### PR TITLE
Fix CVE-2026-25541, resolve all clippy warnings, add clippy CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,31 @@
+---
+name: clippy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install nightly toolchain with clippy
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -802,11 +802,10 @@ fn apply_ld_library_path(cmd: &mut Command) {
 /// Touch main.rs to force recompilation (faster than cargo clean).
 fn touch_main_rs(example_dir: &Path) {
     let main_rs = example_dir.join("src/main.rs");
-    if main_rs.exists() {
-        if let Ok(content) = std::fs::read(&main_rs) {
+    if main_rs.exists()
+        && let Ok(content) = std::fs::read(&main_rs) {
             let _ = std::fs::write(&main_rs, content);
         }
-    }
 }
 
 /// Remove stale generated artifacts (`.ptx`, `.ll`, `.ltoir`) from a
@@ -1088,14 +1087,13 @@ fn main() {{
 /// Locate an executable by name, first via `which` (PATH lookup), then by
 /// checking a list of common fallback absolute paths.
 fn find_executable(name: &str, fallback_paths: &[&str]) -> Option<PathBuf> {
-    if let Ok(output) = Command::new("which").arg(name).output() {
-        if output.status.success() {
+    if let Ok(output) = Command::new("which").arg(name).output()
+        && output.status.success() {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !path.is_empty() {
                 return Some(PathBuf::from(path));
             }
         }
-    }
     for path in fallback_paths {
         let p = PathBuf::from(path);
         if p.exists() {

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -803,9 +803,10 @@ fn apply_ld_library_path(cmd: &mut Command) {
 fn touch_main_rs(example_dir: &Path) {
     let main_rs = example_dir.join("src/main.rs");
     if main_rs.exists()
-        && let Ok(content) = std::fs::read(&main_rs) {
-            let _ = std::fs::write(&main_rs, content);
-        }
+        && let Ok(content) = std::fs::read(&main_rs)
+    {
+        let _ = std::fs::write(&main_rs, content);
+    }
 }
 
 /// Remove stale generated artifacts (`.ptx`, `.ll`, `.ltoir`) from a
@@ -1088,12 +1089,13 @@ fn main() {{
 /// checking a list of common fallback absolute paths.
 fn find_executable(name: &str, fallback_paths: &[&str]) -> Option<PathBuf> {
     if let Ok(output) = Command::new("which").arg(name).output()
-        && output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return Some(PathBuf::from(path));
-            }
+        && output.status.success()
+    {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
         }
+    }
     for path in fallback_paths {
         let p = PathBuf::from(path);
         if p.exists() {

--- a/crates/cuda-async/src/launch.rs
+++ b/crates/cuda-async/src/launch.rs
@@ -142,7 +142,7 @@ impl AsyncKernelLaunch {
                 &mut self.args,
             )
         }
-        .map_err(|e| DeviceError::Driver(e))?;
+        .map_err(DeviceError::Driver)?;
         Ok(())
     }
 }

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -126,7 +126,7 @@ impl<T> DeviceBuffer<T> {
     pub fn from_host(stream: &CudaStream, data: &[T]) -> Result<Self, DriverError> {
         let ctx = stream.context().clone();
         let len = data.len();
-        let num_bytes = len * std::mem::size_of::<T>();
+        let num_bytes = std::mem::size_of_val(data);
 
         let ptr = unsafe { crate::memory::malloc_async(stream.cu_stream(), num_bytes)? };
         unsafe {

--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -35,7 +35,7 @@ impl LaunchConfig {
     /// directly to element index.
     pub fn for_num_elems(n: u32) -> Self {
         const DEFAULT_BLOCK_SIZE: u32 = 256;
-        let grid_x = (n + DEFAULT_BLOCK_SIZE - 1) / DEFAULT_BLOCK_SIZE;
+        let grid_x = n.div_ceil(DEFAULT_BLOCK_SIZE);
         LaunchConfig {
             grid_dim: (grid_x, 1, 1),
             block_dim: (DEFAULT_BLOCK_SIZE, 1, 1),

--- a/crates/cuda-core/src/vmm.rs
+++ b/crates/cuda-core/src/vmm.rs
@@ -33,7 +33,7 @@ unsafe fn set_mem_location_device(
     loc.type_ = cuda_bindings::CUmemLocationType_enum_CU_MEM_LOCATION_TYPE_DEVICE;
     unsafe {
         let base = loc as *mut _ as *mut u8;
-        (base.add(4) as *mut i32).write(device as i32);
+        (base.add(4) as *mut i32).write(device);
     }
 }
 

--- a/crates/cuda-device/src/clc.rs
+++ b/crates/cuda-device/src/clc.rs
@@ -169,6 +169,11 @@ pub unsafe fn clc_query_is_canceled(resp_lo: u64, resp_hi: u64) -> u32 {
 ///
 /// Only valid when `clc_query_is_canceled` returned 0 (work available).
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context. The response pair must
+/// originate from a prior `clc_query_cancel` call.
+///
 /// # PTX
 ///
 /// ```ptx
@@ -184,6 +189,11 @@ pub unsafe fn clc_query_get_first_ctaid_x(resp_lo: u64, resp_hi: u64) -> u32 {
 ///
 /// Only valid when `clc_query_is_canceled` returned 0 (work available).
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context. The response pair must
+/// originate from a prior `clc_query_cancel` call.
+///
 /// # PTX
 ///
 /// ```ptx
@@ -198,6 +208,11 @@ pub unsafe fn clc_query_get_first_ctaid_y(resp_lo: u64, resp_hi: u64) -> u32 {
 /// Get the Z coordinate of the canceled CTA's grid position.
 ///
 /// Only valid when `clc_query_is_canceled` returned 0 (work available).
+///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context. The response pair must
+/// originate from a prior `clc_query_cancel` call.
 ///
 /// # PTX
 ///

--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -2122,6 +2122,12 @@ pub fn f32_pair_to_packed_bf16(a: f32, b: f32) -> u32 {
 /// Identical to [`tcgen05_alloc`] but emits `cta_group::2`.
 /// Both CTAs in the pair must call this together.
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `dst_smem` must be a valid shared-memory pointer. Both CTAs in the
+/// pair must execute this cooperatively.
+///
 /// # PTX
 ///
 /// ```ptx
@@ -2136,6 +2142,11 @@ pub unsafe fn tcgen05_alloc_cg2(dst_smem: *mut u32, n_cols: u32) {
 /// Deallocate Tensor Memory for a CTA pair (`cta_group::2`).
 ///
 /// Identical to [`tcgen05_dealloc`] but emits `cta_group::2`.
+///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `tmem_addr` must be a previously allocated TMEM address.
 ///
 /// # PTX
 ///
@@ -2166,6 +2177,12 @@ pub fn tcgen05_relinquish_alloc_permit_cg2() {
 /// pair cooperate on a larger tile (e.g., 256×128 with each SM contributing
 /// half the rows).
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// Descriptors must reference valid SMEM regions. `d_tmem` must be a
+/// valid TMEM address. Both CTAs must participate.
+///
 /// # PTX
 ///
 /// ```ptx
@@ -2185,6 +2202,11 @@ pub unsafe fn tcgen05_mma_f16_cg2(
 
 /// Commit pending CTA-pair tcgen05 operations to an mbarrier (`cta_group::2`).
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `mbar` must point to a valid mbarrier object in shared memory.
+///
 /// # PTX
 ///
 /// ```ptx
@@ -2197,6 +2219,11 @@ pub unsafe fn tcgen05_commit_cg2(mbar: *mut u64) {
 }
 
 /// Commit CTA-pair tcgen05 operations via `.shared::cluster` (`cta_group::2`).
+///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `mbar` must point to a valid mbarrier in cluster-accessible shared memory.
 ///
 /// # PTX
 ///
@@ -2216,6 +2243,12 @@ pub unsafe fn tcgen05_commit_shared_cluster_cg2(mbar: *mut u64) {
 /// Mojo's `mma_arrive_multicast` works — the MMA warp signals both its
 /// own and its partner CTA's barrier in one instruction.
 ///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `mbar` must point to a valid mbarrier in cluster-accessible shared memory.
+/// `cta_mask` must only reference valid CTA ranks within the cluster.
+///
 /// # Parameters
 ///
 /// - `mbar`: pointer to mbarrier in shared memory
@@ -2233,6 +2266,12 @@ pub unsafe fn tcgen05_commit_multicast_cg2(mbar: *mut u64, cta_mask: u16) {
 }
 
 /// Copy SMEM to TMEM for a CTA pair (`cta_group::2`).
+///
+/// # Safety
+///
+/// Must be called from a CUDA kernel context on sm_100a+.
+/// `tmem_addr` must be a valid TMEM address and `smem_desc` must be a
+/// valid SMEM descriptor. Both CTAs must participate.
 ///
 /// # PTX
 ///

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -155,14 +155,13 @@ fn find_closure_generic(generics: &syn::Generics) -> Option<syn::Ident> {
     for param in &generics.params {
         if let syn::GenericParam::Type(type_param) = param {
             for bound in &type_param.bounds {
-                if let syn::TypeParamBound::Trait(trait_bound) = bound {
-                    if let Some(segment) = trait_bound.path.segments.last() {
+                if let syn::TypeParamBound::Trait(trait_bound) = bound
+                    && let Some(segment) = trait_bound.path.segments.last() {
                         let name = segment.ident.to_string();
                         if name == "Fn" || name == "FnMut" || name == "FnOnce" {
                             return Some(type_param.ident.clone());
                         }
                     }
-                }
             }
         }
     }
@@ -177,15 +176,12 @@ fn find_closure_param<'a>(
 ) -> Option<(usize, &'a (&'a Ident, &'a Type))> {
     for (idx, (_name, ty)) in args_info.iter().enumerate() {
         // Check if the type is a simple path matching our closure generic
-        if let Type::Path(type_path) = *ty {
-            if type_path.qself.is_none() {
-                if let Some(segment) = type_path.path.segments.first() {
-                    if type_path.path.segments.len() == 1 && segment.ident == *closure_type_name {
+        if let Type::Path(type_path) = *ty
+            && type_path.qself.is_none()
+                && let Some(segment) = type_path.path.segments.first()
+                    && type_path.path.segments.len() == 1 && segment.ident == *closure_type_name {
                         return Some((idx, &args_info[idx]));
                     }
-                }
-            }
-        }
     }
     None
 }
@@ -203,8 +199,8 @@ fn strip_mut_from_inputs(
             match arg {
                 FnArg::Typed(pat_type) => {
                     let mut new_pat_type = pat_type.clone();
-                    if let Pat::Ident(pat_ident) = &*pat_type.pat {
-                        if pat_ident.mutability.is_some() {
+                    if let Pat::Ident(pat_ident) = &*pat_type.pat
+                        && pat_ident.mutability.is_some() {
                             // Create new PatIdent without mut
                             let new_pat_ident = syn::PatIdent {
                                 attrs: pat_ident.attrs.clone(),
@@ -215,7 +211,6 @@ fn strip_mut_from_inputs(
                             };
                             new_pat_type.pat = Box::new(Pat::Ident(new_pat_ident));
                         }
-                    }
                     FnArg::Typed(new_pat_type)
                 }
                 other => other.clone(),
@@ -250,11 +245,10 @@ fn generate_generic_kernel_no_instantiation(input: ItemFn) -> TokenStream {
         .inputs
         .iter()
         .filter_map(|arg| {
-            if let FnArg::Typed(pat_type) = arg {
-                if let Pat::Ident(pat_ident) = &*pat_type.pat {
+            if let FnArg::Typed(pat_type) = arg
+                && let Pat::Ident(pat_ident) = &*pat_type.pat {
                     return Some((&pat_ident.ident, &*pat_type.ty));
                 }
-            }
             None
         })
         .collect();
@@ -543,11 +537,10 @@ fn generate_generic_kernel(input: ItemFn, instantiate_types: Vec<Type>) -> Token
     let arg_names: Vec<TokenStream2> = args
         .iter()
         .filter_map(|arg| {
-            if let FnArg::Typed(pat_type) = arg {
-                if let Pat::Ident(pat_ident) = &*pat_type.pat {
+            if let FnArg::Typed(pat_type) = arg
+                && let Pat::Ident(pat_ident) = &*pat_type.pat {
                     return Some(quote! { #pat_ident });
                 }
-            }
             None
         })
         .collect();
@@ -957,11 +950,10 @@ fn generate_device_function(mut input: ItemFn) -> TokenStream {
         .inputs
         .iter()
         .filter_map(|arg| {
-            if let FnArg::Typed(pat_type) = arg {
-                if let Pat::Ident(pat_ident) = &*pat_type.pat {
+            if let FnArg::Typed(pat_type) = arg
+                && let Pat::Ident(pat_ident) = &*pat_type.pat {
                     return Some(pat_ident.ident.clone());
                 }
-            }
             None
         })
         .collect();
@@ -1074,11 +1066,10 @@ fn generate_device_extern_block(mut input: ItemForeignMod) -> TokenStream {
                 .inputs
                 .iter()
                 .filter_map(|arg| {
-                    if let syn::FnArg::Typed(pat_type) = arg {
-                        if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                    if let syn::FnArg::Typed(pat_type) = arg
+                        && let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
                             return Some(pat_ident.ident.clone());
                         }
-                    }
                     None
                 })
                 .collect();
@@ -1254,11 +1245,10 @@ impl<'ast> Visit<'ast> for IdentCollector {
         // Track local `let` bindings - they shadow outer variables
         if let syn::Pat::Ident(pat_ident) = &node.pat {
             self.local_bindings.insert(pat_ident.ident.to_string());
-        } else if let syn::Pat::Type(pat_type) = &node.pat {
-            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+        } else if let syn::Pat::Type(pat_type) = &node.pat
+            && let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
                 self.local_bindings.insert(pat_ident.ident.to_string());
             }
-        }
         // Still visit the initializer and body
         syn::visit::visit_local(self, node);
     }

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -156,12 +156,13 @@ fn find_closure_generic(generics: &syn::Generics) -> Option<syn::Ident> {
         if let syn::GenericParam::Type(type_param) = param {
             for bound in &type_param.bounds {
                 if let syn::TypeParamBound::Trait(trait_bound) = bound
-                    && let Some(segment) = trait_bound.path.segments.last() {
-                        let name = segment.ident.to_string();
-                        if name == "Fn" || name == "FnMut" || name == "FnOnce" {
-                            return Some(type_param.ident.clone());
-                        }
+                    && let Some(segment) = trait_bound.path.segments.last()
+                {
+                    let name = segment.ident.to_string();
+                    if name == "Fn" || name == "FnMut" || name == "FnOnce" {
+                        return Some(type_param.ident.clone());
                     }
+                }
             }
         }
     }
@@ -178,10 +179,12 @@ fn find_closure_param<'a>(
         // Check if the type is a simple path matching our closure generic
         if let Type::Path(type_path) = *ty
             && type_path.qself.is_none()
-                && let Some(segment) = type_path.path.segments.first()
-                    && type_path.path.segments.len() == 1 && segment.ident == *closure_type_name {
-                        return Some((idx, &args_info[idx]));
-                    }
+            && let Some(segment) = type_path.path.segments.first()
+            && type_path.path.segments.len() == 1
+            && segment.ident == *closure_type_name
+        {
+            return Some((idx, &args_info[idx]));
+        }
     }
     None
 }
@@ -200,17 +203,18 @@ fn strip_mut_from_inputs(
                 FnArg::Typed(pat_type) => {
                     let mut new_pat_type = pat_type.clone();
                     if let Pat::Ident(pat_ident) = &*pat_type.pat
-                        && pat_ident.mutability.is_some() {
-                            // Create new PatIdent without mut
-                            let new_pat_ident = syn::PatIdent {
-                                attrs: pat_ident.attrs.clone(),
-                                by_ref: pat_ident.by_ref,
-                                mutability: None, // Strip mut
-                                ident: pat_ident.ident.clone(),
-                                subpat: pat_ident.subpat.clone(),
-                            };
-                            new_pat_type.pat = Box::new(Pat::Ident(new_pat_ident));
-                        }
+                        && pat_ident.mutability.is_some()
+                    {
+                        // Create new PatIdent without mut
+                        let new_pat_ident = syn::PatIdent {
+                            attrs: pat_ident.attrs.clone(),
+                            by_ref: pat_ident.by_ref,
+                            mutability: None, // Strip mut
+                            ident: pat_ident.ident.clone(),
+                            subpat: pat_ident.subpat.clone(),
+                        };
+                        new_pat_type.pat = Box::new(Pat::Ident(new_pat_ident));
+                    }
                     FnArg::Typed(new_pat_type)
                 }
                 other => other.clone(),
@@ -246,9 +250,10 @@ fn generate_generic_kernel_no_instantiation(input: ItemFn) -> TokenStream {
         .iter()
         .filter_map(|arg| {
             if let FnArg::Typed(pat_type) = arg
-                && let Pat::Ident(pat_ident) = &*pat_type.pat {
-                    return Some((&pat_ident.ident, &*pat_type.ty));
-                }
+                && let Pat::Ident(pat_ident) = &*pat_type.pat
+            {
+                return Some((&pat_ident.ident, &*pat_type.ty));
+            }
             None
         })
         .collect();
@@ -538,9 +543,10 @@ fn generate_generic_kernel(input: ItemFn, instantiate_types: Vec<Type>) -> Token
         .iter()
         .filter_map(|arg| {
             if let FnArg::Typed(pat_type) = arg
-                && let Pat::Ident(pat_ident) = &*pat_type.pat {
-                    return Some(quote! { #pat_ident });
-                }
+                && let Pat::Ident(pat_ident) = &*pat_type.pat
+            {
+                return Some(quote! { #pat_ident });
+            }
             None
         })
         .collect();
@@ -951,9 +957,10 @@ fn generate_device_function(mut input: ItemFn) -> TokenStream {
         .iter()
         .filter_map(|arg| {
             if let FnArg::Typed(pat_type) = arg
-                && let Pat::Ident(pat_ident) = &*pat_type.pat {
-                    return Some(pat_ident.ident.clone());
-                }
+                && let Pat::Ident(pat_ident) = &*pat_type.pat
+            {
+                return Some(pat_ident.ident.clone());
+            }
             None
         })
         .collect();
@@ -1067,9 +1074,10 @@ fn generate_device_extern_block(mut input: ItemForeignMod) -> TokenStream {
                 .iter()
                 .filter_map(|arg| {
                     if let syn::FnArg::Typed(pat_type) = arg
-                        && let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
-                            return Some(pat_ident.ident.clone());
-                        }
+                        && let syn::Pat::Ident(pat_ident) = &*pat_type.pat
+                    {
+                        return Some(pat_ident.ident.clone());
+                    }
                     None
                 })
                 .collect();
@@ -1246,9 +1254,10 @@ impl<'ast> Visit<'ast> for IdentCollector {
         if let syn::Pat::Ident(pat_ident) = &node.pat {
             self.local_bindings.insert(pat_ident.ident.to_string());
         } else if let syn::Pat::Type(pat_type) = &node.pat
-            && let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
-                self.local_bindings.insert(pat_ident.ident.to_string());
-            }
+            && let syn::Pat::Ident(pat_ident) = &*pat_type.pat
+        {
+            self.local_bindings.insert(pat_ident.ident.to_string());
+        }
         // Still visit the initializer and body
         syn::visit::visit_local(self, node);
     }

--- a/crates/dialect-llvm/src/export.rs
+++ b/crates/dialect-llvm/src/export.rs
@@ -816,8 +816,8 @@ fn strip_device_prefix(name: &str) -> String {
     if let Some(pos) = name.find(FQDN_DEVICE_PREFIX) {
         return name[pos + FQDN_DEVICE_PREFIX.len()..].to_string();
     }
-    if name.starts_with(DEVICE_PREFIX) {
-        return name[DEVICE_PREFIX.len()..].to_string();
+    if let Some(stripped) = name.strip_prefix(DEVICE_PREFIX) {
+        return stripped.to_string();
     }
     name.to_string()
 }

--- a/crates/dialect-llvm/src/ops/atomic.rs
+++ b/crates/dialect-llvm/src/ops/atomic.rs
@@ -230,6 +230,7 @@ pub struct AtomicCmpxchgOp;
 
 impl AtomicCmpxchgOp {
     /// Create a new `cmpxchg` op.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: &mut Context,
         ptr: Value,

--- a/crates/dialect-nvvm/src/ops/atomic.rs
+++ b/crates/dialect-nvvm/src/ops/atomic.rs
@@ -438,6 +438,7 @@ impl NvvmAtomicCmpxchgOp {
     }
 
     /// Create a new cmpxchg from scratch.
+    #[allow(clippy::too_many_arguments)]
     pub fn build(
         ctx: &mut Context,
         ptr: Value,

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -377,12 +377,12 @@ pub fn run_pipeline(
 
     // Step 8: Generate PTX or LTOIR
     if config.emit_ltoir {
-        return Err(PipelineError::Export(
+        Err(PipelineError::Export(
             "LTOIR container generation (--dlto) is not supported. \
              Use --emit-nvvm-ir instead, which produces NVVM-compatible LLVM IR \
              that can be compiled to LTOIR via libNVVM."
                 .to_string(),
-        ));
+        ))
     } else {
         // PTX mode: invoke llc
         if config.verbose {

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -655,8 +655,8 @@ pub fn translate_rvalue(
 
             // Case 1: For Ref(*ptr), just want the pointer itself - no load needed.
             // This is because &*ptr = ptr in terms of address.
-            if place.projection.len() == 1 {
-                if let mir::ProjectionElem::Deref = &place.projection[0] {
+            if place.projection.len() == 1
+                && let mir::ProjectionElem::Deref = &place.projection[0] {
                     // For &(*ptr), just return ptr directly without loading
                     let base_place = mir::Place {
                         local: place.local,
@@ -673,7 +673,6 @@ pub fn translate_rvalue(
                     )?;
                     return Ok((None, base_val, last_inserted));
                 }
-            }
 
             // ═══════════════════════════════════════════════════════════════════════
             // Case 2: &(*ptr).field - Reference to nested struct field
@@ -708,9 +707,9 @@ pub fn translate_rvalue(
             //
             // Pattern: Deref followed by Field projection(s)
             // ═══════════════════════════════════════════════════════════════════════
-            if place.projection.len() >= 2 {
-                if let mir::ProjectionElem::Deref = &place.projection[0] {
-                    if let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
+            if place.projection.len() >= 2
+                && let mir::ProjectionElem::Deref = &place.projection[0]
+                    && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
                         // Get the base pointer (the local variable holding the pointer)
                         let base_place = mir::Place {
                             local: place.local,
@@ -825,8 +824,6 @@ pub fn translate_rvalue(
 
                         return Ok((None, result_val, last_inserted));
                     }
-                }
-            }
 
             // Case 3: bare local reference `&local` / `&mut local`.
             //
@@ -894,8 +891,8 @@ pub fn translate_rvalue(
             // This is the "correct-refs" path: we lean on the alloca slot
             // rather than `MirRefOp`, so a caller mutating through the
             // reference affects the original local.
-            if let Some(slot) = value_map.get_slot(place.local) {
-                if let Some((result_val, last_inserted)) = translate_place_addr_from_slot(
+            if let Some(slot) = value_map.get_slot(place.local)
+                && let Some((result_val, last_inserted)) = translate_place_addr_from_slot(
                     ctx,
                     slot,
                     &place.projection,
@@ -906,7 +903,6 @@ pub fn translate_rvalue(
                 )? {
                     return Ok((None, result_val, last_inserted));
                 }
-            }
 
             // Case 5: Fallback -- reference to a computed value that has no
             // backing slot (e.g. the result of an rvalue expression). Emit
@@ -939,8 +935,8 @@ pub fn translate_rvalue(
             // For other places, we must materialize an address (mir.ref or mir.field_addr).
 
             // Check if the place is a simple Deref: *local
-            if place.projection.len() == 1 {
-                if let mir::ProjectionElem::Deref = &place.projection[0] {
+            if place.projection.len() == 1
+                && let mir::ProjectionElem::Deref = &place.projection[0] {
                     // For &raw mut (*ptr) or &raw const (*ptr), just return ptr directly
                     let base_place = mir::Place {
                         local: place.local,
@@ -957,12 +953,11 @@ pub fn translate_rvalue(
                     )?;
                     return Ok((None, base_val, last_inserted));
                 }
-            }
 
             // Pattern: Deref followed by Field projection(s) - compute field address
-            if place.projection.len() >= 2 {
-                if let mir::ProjectionElem::Deref = &place.projection[0] {
-                    if let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
+            if place.projection.len() >= 2
+                && let mir::ProjectionElem::Deref = &place.projection[0]
+                    && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
                         let base_place = mir::Place {
                             local: place.local,
                             projection: vec![],
@@ -1055,8 +1050,6 @@ pub fn translate_rvalue(
 
                         return Ok((None, result_val, last_inserted));
                     }
-                }
-            }
 
             // For other places, translate to a value and materialize an address.
             let (val, last_inserted) =
@@ -1939,11 +1932,9 @@ pub fn translate_operand(
                                 if let Some(num_str) = b_str
                                     .strip_prefix("Some(")
                                     .and_then(|s| s.strip_suffix(')'))
-                                {
-                                    if let Ok(byte) = num_str.parse::<u8>() {
+                                    && let Ok(byte) = num_str.parse::<u8>() {
                                         bytes[i] = byte;
                                     }
-                                }
                             }
                             f64::from_le_bytes(bytes)
                         } else {
@@ -2002,11 +1993,9 @@ pub fn translate_operand(
                                 if let Some(num_str) = b_str
                                     .strip_prefix("Some(")
                                     .and_then(|s| s.strip_suffix(')'))
-                                {
-                                    if let Ok(byte) = num_str.parse::<u8>() {
+                                    && let Ok(byte) = num_str.parse::<u8>() {
                                         bytes[i] = byte;
                                     }
-                                }
                             }
                             f32::from_le_bytes(bytes)
                         } else {
@@ -2173,11 +2162,9 @@ pub fn translate_operand(
                             if let Some(num_str) = b_str
                                 .strip_prefix("Some(")
                                 .and_then(|s| s.strip_suffix(')'))
-                            {
-                                if let Ok(byte) = num_str.parse::<u8>() {
+                                && let Ok(byte) = num_str.parse::<u8>() {
                                     bytes.push(byte);
                                 }
-                            }
                         }
                         let mut res: u64 = 0;
                         for (i, byte) in bytes.iter().enumerate() {
@@ -2260,11 +2247,9 @@ pub fn translate_operand(
                             if let Some(num_str) = b_str
                                 .strip_prefix("Some(")
                                 .and_then(|s| s.strip_suffix(')'))
-                            {
-                                if let Ok(byte) = num_str.parse::<u8>() {
+                                && let Ok(byte) = num_str.parse::<u8>() {
                                     bytes.push(byte);
                                 }
-                            }
                         }
 
                         let mut res: u64 = 0;
@@ -2452,13 +2437,13 @@ pub fn translate_place(
             let val = Value::OpResult { op, res_idx: 0 };
             return Ok((val, Some(op)));
         }
-        return input_err!(
+        input_err!(
             loc,
             TranslationErr::unsupported(format!(
                 "Local {} has no alloca slot and is not a ZST",
                 Into::<usize>::into(local)
             ))
-        );
+        )
     } else {
         // Handle projections (place.field, place[index], etc.)
         // For now, handle tuple field projections (_3.0, _3.1, etc.)
@@ -2969,14 +2954,9 @@ fn apply_deref_projection(
                 .downcast_ref::<dialect_mir::types::MirTupleType>()
                 .is_some_and(|tt| tt.get_types().is_empty());
             Some(DerefKind::Ptr { pointee, is_zst })
-        } else if let Some(slice_ty) = ptr_ty_ref.downcast_ref::<dialect_mir::types::MirSliceType>()
-        {
-            Some(DerefKind::Slice {
+        } else { ptr_ty_ref.downcast_ref::<dialect_mir::types::MirSliceType>().map(|slice_ty| DerefKind::Slice {
                 element_ty: slice_ty.element_type(),
-            })
-        } else {
-            None
-        }
+            }) }
     };
 
     let deref_kind = deref_kind.ok_or_else(|| {
@@ -3182,7 +3162,7 @@ fn apply_enum_field_projection(
 /// - `ConstantIndex {offset, from_end: false, ..}` → `MirConstantOp` + [`MirArrayElementAddrOp`]
 /// - `Index(local)`    → `load_local(local)` + [`MirArrayElementAddrOp`]
 /// - `Deref`           → load the pointer; subsequent projections apply to
-///                       the pointee.
+///   the pointee.
 ///
 /// Returns `Ok(Some((addr, last_op)))` on success, `Ok(None)` if the
 /// projection chain contains an element this helper doesn't know how to
@@ -3806,7 +3786,7 @@ fn translate_ptr_to_array_constant(
     let element_byte_size: usize = {
         let elem_obj = element_ty_ptr.deref(ctx);
         if let Some(int_ty) = elem_obj.downcast_ref::<IntegerType>() {
-            (int_ty.width() as usize + 7) / 8
+            (int_ty.width() as usize).div_ceil(8)
         } else if elem_obj.is::<FP32Type>() {
             4
         } else if elem_obj.is::<FP64Type>() {
@@ -5351,7 +5331,7 @@ fn enum_variant_field_offsets(
                 rustc_public::abi::FieldsShape::Primitive => Ok(vec![]),
                 rustc_public::abi::FieldsShape::Arbitrary { offsets } => Ok(offsets
                     .iter()
-                    .map(|offset| offset.bytes() as usize)
+                    .map(|offset| offset.bytes())
                     .collect()),
                 other => input_err!(
                     loc,
@@ -5368,7 +5348,7 @@ fn enum_variant_field_offsets(
                 variant
                     .offsets
                     .iter()
-                    .map(|offset| offset.bytes() as usize)
+                    .map(|offset| offset.bytes())
                     .collect()
             })
             .ok_or_else(|| {
@@ -5413,7 +5393,7 @@ fn read_enum_tag_value(
         }
         rustc_public::abi::FieldsShape::Arbitrary { offsets } => offsets
             .get(tag_field)
-            .map(|offset| offset.bytes() as usize)
+            .map(|offset| offset.bytes())
             .ok_or_else(|| {
                 input_error_noloc!(TranslationErr::unsupported(format!(
                     "Enum tag field {} out of bounds for {} layout fields",
@@ -5524,8 +5504,8 @@ pub(crate) fn extract_enum_discriminant(
                 return val as usize;
             }
             // If read_uint fails, try raw_bytes
-            if let Ok(bytes) = alloc.raw_bytes() {
-                if !bytes.is_empty() {
+            if let Ok(bytes) = alloc.raw_bytes()
+                && !bytes.is_empty() {
                     // Convert bytes to usize (little-endian)
                     let mut value: usize = 0;
                     for (i, &byte) in bytes.iter().take(8).enumerate() {
@@ -5533,7 +5513,6 @@ pub(crate) fn extract_enum_discriminant(
                     }
                     return value;
                 }
-            }
             // Last resort: bytes field directly
             if !alloc.bytes.is_empty() {
                 let mut value: usize = 0;
@@ -5649,8 +5628,8 @@ fn extract_shared_array_info(
     fn parse_const_value(c: &rustc_public::ty::TyConst) -> Option<usize> {
         let const_str = format!("{:?}", c);
         // Parse the bytes from the debug string
-        if let Some(bytes_part) = const_str.split("bytes: [").nth(1) {
-            if let Some(bytes_end) = bytes_part.split(']').next() {
+        if let Some(bytes_part) = const_str.split("bytes: [").nth(1)
+            && let Some(bytes_end) = bytes_part.split(']').next() {
                 let mut bytes = Vec::new();
                 for byte_str in bytes_end.split(',') {
                     if bytes.len() >= 8 {
@@ -5660,11 +5639,9 @@ fn extract_shared_array_info(
                     if let Some(num_str) = b_str
                         .strip_prefix("Some(")
                         .and_then(|s| s.strip_suffix(')'))
-                    {
-                        if let Ok(byte) = num_str.parse::<u8>() {
+                        && let Ok(byte) = num_str.parse::<u8>() {
                             bytes.push(byte);
                         }
-                    }
                 }
                 // Convert bytes to usize (little-endian)
                 let mut value: usize = 0;
@@ -5673,7 +5650,6 @@ fn extract_shared_array_info(
                 }
                 return Some(value);
             }
-        }
         None
     }
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -656,23 +656,17 @@ pub fn translate_rvalue(
             // Case 1: For Ref(*ptr), just want the pointer itself - no load needed.
             // This is because &*ptr = ptr in terms of address.
             if place.projection.len() == 1
-                && let mir::ProjectionElem::Deref = &place.projection[0] {
-                    // For &(*ptr), just return ptr directly without loading
-                    let base_place = mir::Place {
-                        local: place.local,
-                        projection: vec![],
-                    };
-                    let (base_val, last_inserted) = translate_place(
-                        ctx,
-                        body,
-                        &base_place,
-                        value_map,
-                        block_ptr,
-                        prev_op,
-                        loc,
-                    )?;
-                    return Ok((None, base_val, last_inserted));
-                }
+                && let mir::ProjectionElem::Deref = &place.projection[0]
+            {
+                // For &(*ptr), just return ptr directly without loading
+                let base_place = mir::Place {
+                    local: place.local,
+                    projection: vec![],
+                };
+                let (base_val, last_inserted) =
+                    translate_place(ctx, body, &base_place, value_map, block_ptr, prev_op, loc)?;
+                return Ok((None, base_val, last_inserted));
+            }
 
             // ═══════════════════════════════════════════════════════════════════════
             // Case 2: &(*ptr).field - Reference to nested struct field
@@ -709,121 +703,116 @@ pub fn translate_rvalue(
             // ═══════════════════════════════════════════════════════════════════════
             if place.projection.len() >= 2
                 && let mir::ProjectionElem::Deref = &place.projection[0]
-                    && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
-                        // Get the base pointer (the local variable holding the pointer)
-                        let base_place = mir::Place {
-                            local: place.local,
-                            projection: vec![],
-                        };
-                        let (ptr_val, mut last_inserted) = translate_place(
-                            ctx,
-                            body,
-                            &base_place,
-                            value_map,
-                            block_ptr,
-                            prev_op,
-                            loc.clone(),
-                        )?;
+                && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1]
+            {
+                // Get the base pointer (the local variable holding the pointer)
+                let base_place = mir::Place {
+                    local: place.local,
+                    projection: vec![],
+                };
+                let (ptr_val, mut last_inserted) = translate_place(
+                    ctx,
+                    body,
+                    &base_place,
+                    value_map,
+                    block_ptr,
+                    prev_op,
+                    loc.clone(),
+                )?;
 
-                        // Get the field type
-                        let field_type = super::types::translate_type(ctx, field_ty)?;
+                // Get the field type
+                let field_type = super::types::translate_type(ctx, field_ty)?;
 
-                        // Determine if this is a mutable reference
-                        let is_mutable = matches!(borrow_kind, mir::BorrowKind::Mut { .. });
+                // Determine if this is a mutable reference
+                let is_mutable = matches!(borrow_kind, mir::BorrowKind::Mut { .. });
 
-                        // Create result pointer type
-                        let result_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
-                            ctx, field_type, is_mutable,
-                        );
+                // Create result pointer type
+                let result_ptr_ty =
+                    dialect_mir::types::MirPtrType::get_generic(ctx, field_type, is_mutable);
 
-                        use dialect_mir::ops::MirFieldAddrOp;
-                        let field_addr_op = Operation::new(
-                            ctx,
-                            MirFieldAddrOp::get_concrete_op_info(),
-                            vec![result_ptr_ty.into()],
-                            vec![ptr_val],
-                            vec![],
-                            0,
-                        );
-                        field_addr_op.deref_mut(ctx).set_loc(loc.clone());
+                use dialect_mir::ops::MirFieldAddrOp;
+                let field_addr_op = Operation::new(
+                    ctx,
+                    MirFieldAddrOp::get_concrete_op_info(),
+                    vec![result_ptr_ty.into()],
+                    vec![ptr_val],
+                    vec![],
+                    0,
+                );
+                field_addr_op.deref_mut(ctx).set_loc(loc.clone());
 
-                        let mir_field_addr_op = MirFieldAddrOp::new(field_addr_op);
-                        mir_field_addr_op.set_attr_field_index(
-                            ctx,
-                            dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
-                        );
+                let mir_field_addr_op = MirFieldAddrOp::new(field_addr_op);
+                mir_field_addr_op.set_attr_field_index(
+                    ctx,
+                    dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                );
 
-                        // Insert the operation
-                        if let Some(prev) = last_inserted {
-                            field_addr_op.insert_after(ctx, prev);
-                        } else if let Some(prev) = prev_op {
-                            field_addr_op.insert_after(ctx, prev);
-                        } else {
-                            field_addr_op.insert_at_front(block_ptr, ctx);
-                        }
-                        last_inserted = Some(field_addr_op);
+                // Insert the operation
+                if let Some(prev) = last_inserted {
+                    field_addr_op.insert_after(ctx, prev);
+                } else if let Some(prev) = prev_op {
+                    field_addr_op.insert_after(ctx, prev);
+                } else {
+                    field_addr_op.insert_at_front(block_ptr, ctx);
+                }
+                last_inserted = Some(field_addr_op);
 
-                        // Get the result value
-                        let mut result_val = field_addr_op.deref(ctx).get_result(0);
+                // Get the result value
+                let mut result_val = field_addr_op.deref(ctx).get_result(0);
 
-                        // Handle additional projections after the first field
-                        // e.g., &(*ptr).field1.field2
-                        if place.projection.len() > 2 {
-                            for proj in &place.projection[2..] {
-                                match proj {
-                                    mir::ProjectionElem::Field(
-                                        nested_field_idx,
-                                        nested_field_ty,
-                                    ) => {
-                                        // Get the nested field type
-                                        let nested_field_type =
-                                            super::types::translate_type(ctx, nested_field_ty)?;
+                // Handle additional projections after the first field
+                // e.g., &(*ptr).field1.field2
+                if place.projection.len() > 2 {
+                    for proj in &place.projection[2..] {
+                        match proj {
+                            mir::ProjectionElem::Field(nested_field_idx, nested_field_ty) => {
+                                // Get the nested field type
+                                let nested_field_type =
+                                    super::types::translate_type(ctx, nested_field_ty)?;
 
-                                        // Create result pointer type for nested field
-                                        let nested_ptr_ty =
-                                            dialect_mir::types::MirPtrType::get_generic(
-                                                ctx,
-                                                nested_field_type,
-                                                is_mutable,
-                                            );
+                                // Create result pointer type for nested field
+                                let nested_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
+                                    ctx,
+                                    nested_field_type,
+                                    is_mutable,
+                                );
 
-                                        let nested_field_addr_op = Operation::new(
-                                            ctx,
-                                            MirFieldAddrOp::get_concrete_op_info(),
-                                            vec![nested_ptr_ty.into()],
-                                            vec![result_val],
-                                            vec![],
-                                            0,
-                                        );
-                                        nested_field_addr_op.deref_mut(ctx).set_loc(loc.clone());
+                                let nested_field_addr_op = Operation::new(
+                                    ctx,
+                                    MirFieldAddrOp::get_concrete_op_info(),
+                                    vec![nested_ptr_ty.into()],
+                                    vec![result_val],
+                                    vec![],
+                                    0,
+                                );
+                                nested_field_addr_op.deref_mut(ctx).set_loc(loc.clone());
 
-                                        let mir_nested_op =
-                                            MirFieldAddrOp::new(nested_field_addr_op);
-                                        mir_nested_op.set_attr_field_index(
-                                            ctx,
-                                            dialect_mir::attributes::FieldIndexAttr(
-                                                *nested_field_idx as u32,
-                                            ),
-                                        );
+                                let mir_nested_op = MirFieldAddrOp::new(nested_field_addr_op);
+                                mir_nested_op.set_attr_field_index(
+                                    ctx,
+                                    dialect_mir::attributes::FieldIndexAttr(
+                                        *nested_field_idx as u32,
+                                    ),
+                                );
 
-                                        if let Some(prev) = last_inserted {
-                                            nested_field_addr_op.insert_after(ctx, prev);
-                                        }
-                                        last_inserted = Some(nested_field_addr_op);
-                                        result_val = nested_field_addr_op.deref(ctx).get_result(0);
-                                    }
-                                    _ => {
-                                        // For other projections (Index, etc.), fall through to general case
-                                        // This is a simplification - complex paths like &(*ptr).field[i]
-                                        // would need more handling
-                                        break;
-                                    }
+                                if let Some(prev) = last_inserted {
+                                    nested_field_addr_op.insert_after(ctx, prev);
                                 }
+                                last_inserted = Some(nested_field_addr_op);
+                                result_val = nested_field_addr_op.deref(ctx).get_result(0);
+                            }
+                            _ => {
+                                // For other projections (Index, etc.), fall through to general case
+                                // This is a simplification - complex paths like &(*ptr).field[i]
+                                // would need more handling
+                                break;
                             }
                         }
-
-                        return Ok((None, result_val, last_inserted));
                     }
+                }
+
+                return Ok((None, result_val, last_inserted));
+            }
 
             // Case 3: bare local reference `&local` / `&mut local`.
             //
@@ -900,9 +889,10 @@ pub fn translate_rvalue(
                     block_ptr,
                     prev_op,
                     loc.clone(),
-                )? {
-                    return Ok((None, result_val, last_inserted));
-                }
+                )?
+            {
+                return Ok((None, result_val, last_inserted));
+            }
 
             // Case 5: Fallback -- reference to a computed value that has no
             // backing slot (e.g. the result of an rvalue expression). Emit
@@ -936,120 +926,109 @@ pub fn translate_rvalue(
 
             // Check if the place is a simple Deref: *local
             if place.projection.len() == 1
-                && let mir::ProjectionElem::Deref = &place.projection[0] {
-                    // For &raw mut (*ptr) or &raw const (*ptr), just return ptr directly
-                    let base_place = mir::Place {
-                        local: place.local,
-                        projection: vec![],
-                    };
-                    let (base_val, last_inserted) = translate_place(
-                        ctx,
-                        body,
-                        &base_place,
-                        value_map,
-                        block_ptr,
-                        prev_op,
-                        loc,
-                    )?;
-                    return Ok((None, base_val, last_inserted));
-                }
+                && let mir::ProjectionElem::Deref = &place.projection[0]
+            {
+                // For &raw mut (*ptr) or &raw const (*ptr), just return ptr directly
+                let base_place = mir::Place {
+                    local: place.local,
+                    projection: vec![],
+                };
+                let (base_val, last_inserted) =
+                    translate_place(ctx, body, &base_place, value_map, block_ptr, prev_op, loc)?;
+                return Ok((None, base_val, last_inserted));
+            }
 
             // Pattern: Deref followed by Field projection(s) - compute field address
             if place.projection.len() >= 2
                 && let mir::ProjectionElem::Deref = &place.projection[0]
-                    && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1] {
-                        let base_place = mir::Place {
-                            local: place.local,
-                            projection: vec![],
-                        };
-                        let (ptr_val, mut last_inserted) = translate_place(
-                            ctx,
-                            body,
-                            &base_place,
-                            value_map,
-                            block_ptr,
-                            prev_op,
-                            loc.clone(),
-                        )?;
+                && let mir::ProjectionElem::Field(field_idx, field_ty) = &place.projection[1]
+            {
+                let base_place = mir::Place {
+                    local: place.local,
+                    projection: vec![],
+                };
+                let (ptr_val, mut last_inserted) = translate_place(
+                    ctx,
+                    body,
+                    &base_place,
+                    value_map,
+                    block_ptr,
+                    prev_op,
+                    loc.clone(),
+                )?;
 
-                        let field_type = super::types::translate_type(ctx, field_ty)?;
-                        let is_mutable = matches!(mutability, mir::RawPtrKind::Mut);
-                        let result_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
-                            ctx, field_type, is_mutable,
-                        );
+                let field_type = super::types::translate_type(ctx, field_ty)?;
+                let is_mutable = matches!(mutability, mir::RawPtrKind::Mut);
+                let result_ptr_ty =
+                    dialect_mir::types::MirPtrType::get_generic(ctx, field_type, is_mutable);
 
-                        use dialect_mir::ops::MirFieldAddrOp;
-                        let field_addr_op = Operation::new(
-                            ctx,
-                            MirFieldAddrOp::get_concrete_op_info(),
-                            vec![result_ptr_ty.into()],
-                            vec![ptr_val],
-                            vec![],
-                            0,
-                        );
-                        field_addr_op.deref_mut(ctx).set_loc(loc.clone());
+                use dialect_mir::ops::MirFieldAddrOp;
+                let field_addr_op = Operation::new(
+                    ctx,
+                    MirFieldAddrOp::get_concrete_op_info(),
+                    vec![result_ptr_ty.into()],
+                    vec![ptr_val],
+                    vec![],
+                    0,
+                );
+                field_addr_op.deref_mut(ctx).set_loc(loc.clone());
 
-                        let mir_field_addr_op = MirFieldAddrOp::new(field_addr_op);
-                        mir_field_addr_op.set_attr_field_index(
-                            ctx,
-                            dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
-                        );
+                let mir_field_addr_op = MirFieldAddrOp::new(field_addr_op);
+                mir_field_addr_op.set_attr_field_index(
+                    ctx,
+                    dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                );
 
-                        if let Some(prev) = last_inserted {
-                            field_addr_op.insert_after(ctx, prev);
-                        } else if let Some(prev) = prev_op {
-                            field_addr_op.insert_after(ctx, prev);
-                        } else {
-                            field_addr_op.insert_at_front(block_ptr, ctx);
-                        }
-                        last_inserted = Some(field_addr_op);
+                if let Some(prev) = last_inserted {
+                    field_addr_op.insert_after(ctx, prev);
+                } else if let Some(prev) = prev_op {
+                    field_addr_op.insert_after(ctx, prev);
+                } else {
+                    field_addr_op.insert_at_front(block_ptr, ctx);
+                }
+                last_inserted = Some(field_addr_op);
 
-                        let mut result_val = field_addr_op.deref(ctx).get_result(0);
+                let mut result_val = field_addr_op.deref(ctx).get_result(0);
 
-                        if place.projection.len() > 2 {
-                            for proj in &place.projection[2..] {
-                                if let mir::ProjectionElem::Field(
-                                    nested_field_idx,
-                                    nested_field_ty,
-                                ) = proj
-                                {
-                                    let nested_field_type =
-                                        super::types::translate_type(ctx, nested_field_ty)?;
-                                    let nested_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
-                                        ctx,
-                                        nested_field_type,
-                                        is_mutable,
-                                    );
-                                    let nested_field_addr_op = Operation::new(
-                                        ctx,
-                                        MirFieldAddrOp::get_concrete_op_info(),
-                                        vec![nested_ptr_ty.into()],
-                                        vec![result_val],
-                                        vec![],
-                                        0,
-                                    );
-                                    nested_field_addr_op.deref_mut(ctx).set_loc(loc.clone());
-                                    let mir_nested_op = MirFieldAddrOp::new(nested_field_addr_op);
-                                    mir_nested_op.set_attr_field_index(
-                                        ctx,
-                                        dialect_mir::attributes::FieldIndexAttr(
-                                            *nested_field_idx as u32,
-                                        ),
-                                    );
+                if place.projection.len() > 2 {
+                    for proj in &place.projection[2..] {
+                        if let mir::ProjectionElem::Field(nested_field_idx, nested_field_ty) = proj
+                        {
+                            let nested_field_type =
+                                super::types::translate_type(ctx, nested_field_ty)?;
+                            let nested_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
+                                ctx,
+                                nested_field_type,
+                                is_mutable,
+                            );
+                            let nested_field_addr_op = Operation::new(
+                                ctx,
+                                MirFieldAddrOp::get_concrete_op_info(),
+                                vec![nested_ptr_ty.into()],
+                                vec![result_val],
+                                vec![],
+                                0,
+                            );
+                            nested_field_addr_op.deref_mut(ctx).set_loc(loc.clone());
+                            let mir_nested_op = MirFieldAddrOp::new(nested_field_addr_op);
+                            mir_nested_op.set_attr_field_index(
+                                ctx,
+                                dialect_mir::attributes::FieldIndexAttr(*nested_field_idx as u32),
+                            );
 
-                                    if let Some(prev) = last_inserted {
-                                        nested_field_addr_op.insert_after(ctx, prev);
-                                    }
-                                    last_inserted = Some(nested_field_addr_op);
-                                    result_val = nested_field_addr_op.deref(ctx).get_result(0);
-                                } else {
-                                    break;
-                                }
+                            if let Some(prev) = last_inserted {
+                                nested_field_addr_op.insert_after(ctx, prev);
                             }
+                            last_inserted = Some(nested_field_addr_op);
+                            result_val = nested_field_addr_op.deref(ctx).get_result(0);
+                        } else {
+                            break;
                         }
-
-                        return Ok((None, result_val, last_inserted));
                     }
+                }
+
+                return Ok((None, result_val, last_inserted));
+            }
 
             // For other places, translate to a value and materialize an address.
             let (val, last_inserted) =
@@ -1932,9 +1911,10 @@ pub fn translate_operand(
                                 if let Some(num_str) = b_str
                                     .strip_prefix("Some(")
                                     .and_then(|s| s.strip_suffix(')'))
-                                    && let Ok(byte) = num_str.parse::<u8>() {
-                                        bytes[i] = byte;
-                                    }
+                                    && let Ok(byte) = num_str.parse::<u8>()
+                                {
+                                    bytes[i] = byte;
+                                }
                             }
                             f64::from_le_bytes(bytes)
                         } else {
@@ -1993,9 +1973,10 @@ pub fn translate_operand(
                                 if let Some(num_str) = b_str
                                     .strip_prefix("Some(")
                                     .and_then(|s| s.strip_suffix(')'))
-                                    && let Ok(byte) = num_str.parse::<u8>() {
-                                        bytes[i] = byte;
-                                    }
+                                    && let Ok(byte) = num_str.parse::<u8>()
+                                {
+                                    bytes[i] = byte;
+                                }
                             }
                             f32::from_le_bytes(bytes)
                         } else {
@@ -2162,9 +2143,10 @@ pub fn translate_operand(
                             if let Some(num_str) = b_str
                                 .strip_prefix("Some(")
                                 .and_then(|s| s.strip_suffix(')'))
-                                && let Ok(byte) = num_str.parse::<u8>() {
-                                    bytes.push(byte);
-                                }
+                                && let Ok(byte) = num_str.parse::<u8>()
+                            {
+                                bytes.push(byte);
+                            }
                         }
                         let mut res: u64 = 0;
                         for (i, byte) in bytes.iter().enumerate() {
@@ -2247,9 +2229,10 @@ pub fn translate_operand(
                             if let Some(num_str) = b_str
                                 .strip_prefix("Some(")
                                 .and_then(|s| s.strip_suffix(')'))
-                                && let Ok(byte) = num_str.parse::<u8>() {
-                                    bytes.push(byte);
-                                }
+                                && let Ok(byte) = num_str.parse::<u8>()
+                            {
+                                bytes.push(byte);
+                            }
                         }
 
                         let mut res: u64 = 0;
@@ -2954,9 +2937,13 @@ fn apply_deref_projection(
                 .downcast_ref::<dialect_mir::types::MirTupleType>()
                 .is_some_and(|tt| tt.get_types().is_empty());
             Some(DerefKind::Ptr { pointee, is_zst })
-        } else { ptr_ty_ref.downcast_ref::<dialect_mir::types::MirSliceType>().map(|slice_ty| DerefKind::Slice {
-                element_ty: slice_ty.element_type(),
-            }) }
+        } else {
+            ptr_ty_ref
+                .downcast_ref::<dialect_mir::types::MirSliceType>()
+                .map(|slice_ty| DerefKind::Slice {
+                    element_ty: slice_ty.element_type(),
+                })
+        }
     };
 
     let deref_kind = deref_kind.ok_or_else(|| {
@@ -5329,10 +5316,9 @@ fn enum_variant_field_offsets(
 
             match &layout.fields {
                 rustc_public::abi::FieldsShape::Primitive => Ok(vec![]),
-                rustc_public::abi::FieldsShape::Arbitrary { offsets } => Ok(offsets
-                    .iter()
-                    .map(|offset| offset.bytes())
-                    .collect()),
+                rustc_public::abi::FieldsShape::Arbitrary { offsets } => {
+                    Ok(offsets.iter().map(|offset| offset.bytes()).collect())
+                }
                 other => input_err!(
                     loc,
                     TranslationErr::unsupported(format!(
@@ -5505,14 +5491,15 @@ pub(crate) fn extract_enum_discriminant(
             }
             // If read_uint fails, try raw_bytes
             if let Ok(bytes) = alloc.raw_bytes()
-                && !bytes.is_empty() {
-                    // Convert bytes to usize (little-endian)
-                    let mut value: usize = 0;
-                    for (i, &byte) in bytes.iter().take(8).enumerate() {
-                        value |= (byte as usize) << (i * 8);
-                    }
-                    return value;
+                && !bytes.is_empty()
+            {
+                // Convert bytes to usize (little-endian)
+                let mut value: usize = 0;
+                for (i, &byte) in bytes.iter().take(8).enumerate() {
+                    value |= (byte as usize) << (i * 8);
                 }
+                return value;
+            }
             // Last resort: bytes field directly
             if !alloc.bytes.is_empty() {
                 let mut value: usize = 0;
@@ -5629,27 +5616,29 @@ fn extract_shared_array_info(
         let const_str = format!("{:?}", c);
         // Parse the bytes from the debug string
         if let Some(bytes_part) = const_str.split("bytes: [").nth(1)
-            && let Some(bytes_end) = bytes_part.split(']').next() {
-                let mut bytes = Vec::new();
-                for byte_str in bytes_end.split(',') {
-                    if bytes.len() >= 8 {
-                        break;
-                    }
-                    let b_str = byte_str.trim();
-                    if let Some(num_str) = b_str
-                        .strip_prefix("Some(")
-                        .and_then(|s| s.strip_suffix(')'))
-                        && let Ok(byte) = num_str.parse::<u8>() {
-                            bytes.push(byte);
-                        }
+            && let Some(bytes_end) = bytes_part.split(']').next()
+        {
+            let mut bytes = Vec::new();
+            for byte_str in bytes_end.split(',') {
+                if bytes.len() >= 8 {
+                    break;
                 }
-                // Convert bytes to usize (little-endian)
-                let mut value: usize = 0;
-                for (i, byte) in bytes.iter().enumerate() {
-                    value |= (*byte as usize) << (i * 8);
+                let b_str = byte_str.trim();
+                if let Some(num_str) = b_str
+                    .strip_prefix("Some(")
+                    .and_then(|s| s.strip_suffix(')'))
+                    && let Ok(byte) = num_str.parse::<u8>()
+                {
+                    bytes.push(byte);
                 }
-                return Some(value);
             }
+            // Convert bytes to usize (little-endian)
+            let mut value: usize = 0;
+            for (i, byte) in bytes.iter().enumerate() {
+                value |= (*byte as usize) << (i * 8);
+            }
+            return Some(value);
+        }
         None
     }
 

--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -833,7 +833,7 @@ fn extract_ordering_from_generics(substs: &rustc_public::ty::GenericArgs) -> Ato
     if let Some(GenericArgKind::Const(c)) = substs.0.get(2) {
         let discr = match c.kind() {
             TyConstKind::Value(_, alloc) => alloc.read_uint().unwrap_or(4) as u64,
-            _ => c.eval_target_usize().unwrap_or(4) as u64,
+            _ => c.eval_target_usize().unwrap_or(4),
         };
         intrinsic_ordering_from_discriminant(discr)
     } else {
@@ -953,8 +953,8 @@ fn extract_core_intrinsic_generics(
     func: &mir::Operand,
     loc: &Location,
 ) -> TranslationResult<(AtomicTypeInfo, AtomicOrdering)> {
-    if let mir::Operand::Constant(const_op) = func {
-        if let TyKind::RigidTy(RigidTy::FnDef(_, substs)) = const_op.const_.ty().kind() {
+    if let mir::Operand::Constant(const_op) = func
+        && let TyKind::RigidTy(RigidTy::FnDef(_, substs)) = const_op.const_.ty().kind() {
             if let Some(type_info) = extract_type_info_from_generics(&substs) {
                 // PTX has no 8-bit atomics; 16-bit is partial (sm_70+). Reject both for now.
                 // See docs/atomics/atomic-width-support.md.
@@ -986,7 +986,6 @@ fn extract_core_intrinsic_generics(
                 )
             );
         }
-    }
     input_err!(
         loc.clone(),
         TranslationErr::unsupported(

--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -954,38 +954,39 @@ fn extract_core_intrinsic_generics(
     loc: &Location,
 ) -> TranslationResult<(AtomicTypeInfo, AtomicOrdering)> {
     if let mir::Operand::Constant(const_op) = func
-        && let TyKind::RigidTy(RigidTy::FnDef(_, substs)) = const_op.const_.ty().kind() {
-            if let Some(type_info) = extract_type_info_from_generics(&substs) {
-                // PTX has no 8-bit atomics; 16-bit is partial (sm_70+). Reject both for now.
-                // See docs/atomics/atomic-width-support.md.
-                if type_info.bit_width == 8 {
-                    return input_err!(
-                        loc.clone(),
-                        TranslationErr::unsupported(
-                            "8-bit atomics are not supported by PTX; use 32-bit or 64-bit. \
+        && let TyKind::RigidTy(RigidTy::FnDef(_, substs)) = const_op.const_.ty().kind()
+    {
+        if let Some(type_info) = extract_type_info_from_generics(&substs) {
+            // PTX has no 8-bit atomics; 16-bit is partial (sm_70+). Reject both for now.
+            // See docs/atomics/atomic-width-support.md.
+            if type_info.bit_width == 8 {
+                return input_err!(
+                    loc.clone(),
+                    TranslationErr::unsupported(
+                        "8-bit atomics are not supported by PTX; use 32-bit or 64-bit. \
                              See docs/atomics/atomic-width-support.md"
-                        )
-                    );
-                }
-                if type_info.bit_width == 16 {
-                    return input_err!(
-                        loc.clone(),
-                        TranslationErr::unsupported(
-                            "16-bit atomics are not yet supported; use 32-bit or 64-bit. \
-                             See docs/atomics/atomic-width-support.md"
-                        )
-                    );
-                }
-                let ordering = extract_ordering_from_generics(&substs);
-                return Ok((type_info, ordering));
+                    )
+                );
             }
-            return input_err!(
-                loc.clone(),
-                TranslationErr::unsupported(
-                    "could not extract element type from core atomic intrinsic generics"
-                )
-            );
+            if type_info.bit_width == 16 {
+                return input_err!(
+                    loc.clone(),
+                    TranslationErr::unsupported(
+                        "16-bit atomics are not yet supported; use 32-bit or 64-bit. \
+                             See docs/atomics/atomic-width-support.md"
+                    )
+                );
+            }
+            let ordering = extract_ordering_from_generics(&substs);
+            return Ok((type_info, ordering));
         }
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "could not extract element type from core atomic intrinsic generics"
+            )
+        );
+    }
     input_err!(
         loc.clone(),
         TranslationErr::unsupported(

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -839,43 +839,44 @@ fn translate_call(
     // dead code because we return false for RuntimeChecks(UbChecks).
     // The MIR still contains these calls, but they're in dead branches.
     if let Some(ref name) = pattern_name
-        && name.contains("precondition_check") {
-            // Just emit a goto to the target block, skipping the call entirely
-            if let Some(target_idx) = target_usize {
-                let actual_prev_op = if let Some(p) = prev_op {
-                    p
-                } else {
-                    // Create a dummy i1 constant (false) as a placeholder operation
-                    use pliron::builtin::attributes::IntegerAttr;
-                    use pliron::utils::apint::APInt;
-                    use std::num::NonZeroUsize;
+        && name.contains("precondition_check")
+    {
+        // Just emit a goto to the target block, skipping the call entirely
+        if let Some(target_idx) = target_usize {
+            let actual_prev_op = if let Some(p) = prev_op {
+                p
+            } else {
+                // Create a dummy i1 constant (false) as a placeholder operation
+                use pliron::builtin::attributes::IntegerAttr;
+                use pliron::utils::apint::APInt;
+                use std::num::NonZeroUsize;
 
-                    let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
-                    let dummy = Operation::new(
-                        ctx,
-                        MirConstantOp::get_concrete_op_info(),
-                        vec![bool_ty.into()],
-                        vec![],
-                        vec![],
-                        0,
-                    );
-                    dummy.deref_mut(ctx).set_loc(loc.clone());
-                    let const_op = MirConstantOp::new(dummy);
-                    let false_val = APInt::from_u64(0, NonZeroUsize::new(1).unwrap());
-                    const_op.set_attr_value(ctx, IntegerAttr::new(bool_ty, false_val));
-                    let dummy = const_op.get_operation();
-                    dummy.insert_at_front(block_ptr, ctx);
-                    dummy
-                };
-                return Ok(helpers::emit_goto(
+                let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+                let dummy = Operation::new(
                     ctx,
-                    target_idx,
-                    actual_prev_op,
-                    block_map,
-                    loc,
-                ));
-            }
+                    MirConstantOp::get_concrete_op_info(),
+                    vec![bool_ty.into()],
+                    vec![],
+                    vec![],
+                    0,
+                );
+                dummy.deref_mut(ctx).set_loc(loc.clone());
+                let const_op = MirConstantOp::new(dummy);
+                let false_val = APInt::from_u64(0, NonZeroUsize::new(1).unwrap());
+                const_op.set_attr_value(ctx, IntegerAttr::new(bool_ty, false_val));
+                let dummy = const_op.get_operation();
+                dummy.insert_at_front(block_ptr, ctx);
+                dummy
+            };
+            return Ok(helpers::emit_goto(
+                ctx,
+                target_idx,
+                actual_prev_op,
+                block_map,
+                loc,
+            ));
         }
+    }
 
     // Handle closure trait method calls (FnOnce::call_once, FnMut::call_mut, Fn::call)
     // These calls pass arguments as a tuple, but the closure body expects unpacked args.
@@ -885,13 +886,95 @@ fn translate_call(
     // But the closure body expects: fn(self_ref, unpacked_arg1, unpacked_arg2, ...)
     if let Some(ref name) = pattern_name
         && (name.contains("call_once") || name.contains("call_mut") || name.ends_with("::call"))
-            && substs_contains("Closure")
+        && substs_contains("Closure")
+    {
+        return translate_closure_call(
+            ctx,
+            body,
+            &call_name,
+            &func_ret_ty,
+            args,
+            destination,
+            &target_usize,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+            legaliser,
+        );
+    }
+
+    // Handle prof_trigger specially to extract const generic N
+    if let Some(ref name) = pattern_name
+        && name == "cuda_device::debug::prof_trigger"
+    {
+        // Extract the const generic N from the function type
+        if let mir::Operand::Constant(const_op) = func
+            && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(_, substs)) =
+                const_op.const_.ty().kind()
         {
-            return translate_closure_call(
+            // The const generic N is the first generic argument
+            if let Some(rustc_public::ty::GenericArgKind::Const(c)) = substs.0.first() {
+                use rustc_public::ty::TyConstKind;
+
+                let event_id = match c.kind() {
+                    TyConstKind::Value(_, alloc) => {
+                        // Read the allocation bytes (little-endian u32)
+                        alloc.read_uint().unwrap_or(0) as u32
+                    }
+                    _ => {
+                        // Try eval_target_usize as fallback
+                        c.eval_target_usize().unwrap_or(0) as u32
+                    }
+                };
+                return intrinsics::debug::emit_prof_trigger(
+                    ctx,
+                    event_id,
+                    &target_usize,
+                    block_ptr,
+                    prev_op,
+                    block_map,
+                    loc,
+                );
+            }
+        }
+    }
+
+    // Handle DynamicSharedArray specially to extract the ALIGN const generic
+    if let Some(ref name) = pattern_name
+        && name.contains("DynamicSharedArray")
+        && (name.contains("::get") || name.contains("::offset"))
+    {
+        // Extract the ALIGN const generic from the function type
+        // DynamicSharedArray<T, ALIGN> has T as first generic, ALIGN as second
+        let alignment = if let mir::Operand::Constant(const_op) = func {
+            if let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(_, substs)) =
+                const_op.const_.ty().kind()
+            {
+                // The ALIGN const generic is the second generic argument (index 1)
+                // First is T (type), second is ALIGN (const)
+                if let Some(rustc_public::ty::GenericArgKind::Const(c)) = substs.0.get(1) {
+                    use rustc_public::ty::TyConstKind;
+                    match c.kind() {
+                        TyConstKind::Value(_, alloc) => alloc.read_uint().unwrap_or(16) as u64,
+                        _ => c.eval_target_usize().unwrap_or(16),
+                    }
+                } else {
+                    16 // Default alignment (matches nvcc)
+                }
+            } else {
+                16
+            }
+        } else {
+            16
+        };
+
+        if name.contains("::get") {
+            // Both get() and get_raw() use the same handler with offset 0
+            return intrinsics::memory::emit_dynamic_shared_get(
                 ctx,
                 body,
-                &call_name,
-                &func_ret_ty,
                 args,
                 destination,
                 &target_usize,
@@ -900,132 +983,48 @@ fn translate_call(
                 value_map,
                 block_map,
                 loc,
-                legaliser,
+                0,         // byte_offset = 0 for get() and get_raw()
+                alignment, // User-specified or default alignment
+            );
+        } else if name.contains("::offset") {
+            // DynamicSharedArray::offset(byte_offset) - get pointer at byte offset
+            return intrinsics::memory::emit_dynamic_shared_offset(
+                ctx,
+                body,
+                args,
+                destination,
+                &target_usize,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+                alignment, // User-specified or default alignment
             );
         }
-
-    // Handle prof_trigger specially to extract const generic N
-    if let Some(ref name) = pattern_name
-        && name == "cuda_device::debug::prof_trigger" {
-            // Extract the const generic N from the function type
-            if let mir::Operand::Constant(const_op) = func
-                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(
-                    _,
-                    substs,
-                )) = const_op.const_.ty().kind()
-                {
-                    // The const generic N is the first generic argument
-                    if let Some(rustc_public::ty::GenericArgKind::Const(c)) = substs.0.first() {
-                        use rustc_public::ty::TyConstKind;
-
-                        let event_id = match c.kind() {
-                            TyConstKind::Value(_, alloc) => {
-                                // Read the allocation bytes (little-endian u32)
-                                alloc.read_uint().unwrap_or(0) as u32
-                            }
-                            _ => {
-                                // Try eval_target_usize as fallback
-                                c.eval_target_usize().unwrap_or(0) as u32
-                            }
-                        };
-                        return intrinsics::debug::emit_prof_trigger(
-                            ctx,
-                            event_id,
-                            &target_usize,
-                            block_ptr,
-                            prev_op,
-                            block_map,
-                            loc,
-                        );
-                    }
-                }
-        }
-
-    // Handle DynamicSharedArray specially to extract the ALIGN const generic
-    if let Some(ref name) = pattern_name
-        && name.contains("DynamicSharedArray")
-            && (name.contains("::get") || name.contains("::offset"))
-        {
-            // Extract the ALIGN const generic from the function type
-            // DynamicSharedArray<T, ALIGN> has T as first generic, ALIGN as second
-            let alignment = if let mir::Operand::Constant(const_op) = func {
-                if let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(
-                    _,
-                    substs,
-                )) = const_op.const_.ty().kind()
-                {
-                    // The ALIGN const generic is the second generic argument (index 1)
-                    // First is T (type), second is ALIGN (const)
-                    if let Some(rustc_public::ty::GenericArgKind::Const(c)) = substs.0.get(1) {
-                        use rustc_public::ty::TyConstKind;
-                        match c.kind() {
-                            TyConstKind::Value(_, alloc) => alloc.read_uint().unwrap_or(16) as u64,
-                            _ => c.eval_target_usize().unwrap_or(16),
-                        }
-                    } else {
-                        16 // Default alignment (matches nvcc)
-                    }
-                } else {
-                    16
-                }
-            } else {
-                16
-            };
-
-            if name.contains("::get") {
-                // Both get() and get_raw() use the same handler with offset 0
-                return intrinsics::memory::emit_dynamic_shared_get(
-                    ctx,
-                    body,
-                    args,
-                    destination,
-                    &target_usize,
-                    block_ptr,
-                    prev_op,
-                    value_map,
-                    block_map,
-                    loc,
-                    0,         // byte_offset = 0 for get() and get_raw()
-                    alignment, // User-specified or default alignment
-                );
-            } else if name.contains("::offset") {
-                // DynamicSharedArray::offset(byte_offset) - get pointer at byte offset
-                return intrinsics::memory::emit_dynamic_shared_offset(
-                    ctx,
-                    body,
-                    args,
-                    destination,
-                    &target_usize,
-                    block_ptr,
-                    prev_op,
-                    value_map,
-                    block_map,
-                    loc,
-                    alignment, // User-specified or default alignment
-                );
-            }
-        }
+    }
 
     // Try to dispatch core::sync::atomic intrinsics (std::intrinsics::atomic_*)
     // These use const generics for ordering, so we intercept them here before
     // the regular intrinsic dispatch and extract generics from the func operand.
     if let Some(ref name) = pattern_name
-        && intrinsics::atomic::is_core_atomic_intrinsic(name) {
-            return intrinsics::atomic::dispatch_core_intrinsic(
-                ctx,
-                body,
-                func,
-                args,
-                destination,
-                &target_usize,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-                name,
-            );
-        }
+        && intrinsics::atomic::is_core_atomic_intrinsic(name)
+    {
+        return intrinsics::atomic::dispatch_core_intrinsic(
+            ctx,
+            body,
+            func,
+            args,
+            destination,
+            &target_usize,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+            name,
+        );
+    }
 
     // Try to dispatch as intrinsic
     if let Some(ref name) = pattern_name
@@ -1042,9 +1041,10 @@ fn translate_call(
             block_map,
             loc.clone(),
             &substs_contains,
-        )? {
-            return Ok(result);
-        }
+        )?
+    {
+        return Ok(result);
+    }
 
     // Handle diverging calls (calls that never return, like unwrap_failed, panic, etc.)
     // These have no target block because the function never returns.

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -838,8 +838,8 @@ fn translate_call(
     // Skip precondition_check calls - these are UB check assertions that are
     // dead code because we return false for RuntimeChecks(UbChecks).
     // The MIR still contains these calls, but they're in dead branches.
-    if let Some(ref name) = pattern_name {
-        if name.contains("precondition_check") {
+    if let Some(ref name) = pattern_name
+        && name.contains("precondition_check") {
             // Just emit a goto to the target block, skipping the call entirely
             if let Some(target_idx) = target_usize {
                 let actual_prev_op = if let Some(p) = prev_op {
@@ -876,7 +876,6 @@ fn translate_call(
                 ));
             }
         }
-    }
 
     // Handle closure trait method calls (FnOnce::call_once, FnMut::call_mut, Fn::call)
     // These calls pass arguments as a tuple, but the closure body expects unpacked args.
@@ -884,8 +883,8 @@ fn translate_call(
     //
     // MIR shows: <{closure} as FnMut<(u32,)>>::call_mut(self_ref, tuple_args)
     // But the closure body expects: fn(self_ref, unpacked_arg1, unpacked_arg2, ...)
-    if let Some(ref name) = pattern_name {
-        if (name.contains("call_once") || name.contains("call_mut") || name.ends_with("::call"))
+    if let Some(ref name) = pattern_name
+        && (name.contains("call_once") || name.contains("call_mut") || name.ends_with("::call"))
             && substs_contains("Closure")
         {
             return translate_closure_call(
@@ -904,14 +903,13 @@ fn translate_call(
                 legaliser,
             );
         }
-    }
 
     // Handle prof_trigger specially to extract const generic N
-    if let Some(ref name) = pattern_name {
-        if name == "cuda_device::debug::prof_trigger" {
+    if let Some(ref name) = pattern_name
+        && name == "cuda_device::debug::prof_trigger" {
             // Extract the const generic N from the function type
-            if let mir::Operand::Constant(const_op) = func {
-                if let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(
+            if let mir::Operand::Constant(const_op) = func
+                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::FnDef(
                     _,
                     substs,
                 )) = const_op.const_.ty().kind()
@@ -941,13 +939,11 @@ fn translate_call(
                         );
                     }
                 }
-            }
         }
-    }
 
     // Handle DynamicSharedArray specially to extract the ALIGN const generic
-    if let Some(ref name) = pattern_name {
-        if name.contains("DynamicSharedArray")
+    if let Some(ref name) = pattern_name
+        && name.contains("DynamicSharedArray")
             && (name.contains("::get") || name.contains("::offset"))
         {
             // Extract the ALIGN const generic from the function type
@@ -1009,13 +1005,12 @@ fn translate_call(
                 );
             }
         }
-    }
 
     // Try to dispatch core::sync::atomic intrinsics (std::intrinsics::atomic_*)
     // These use const generics for ordering, so we intercept them here before
     // the regular intrinsic dispatch and extract generics from the func operand.
-    if let Some(ref name) = pattern_name {
-        if intrinsics::atomic::is_core_atomic_intrinsic(name) {
+    if let Some(ref name) = pattern_name
+        && intrinsics::atomic::is_core_atomic_intrinsic(name) {
             return intrinsics::atomic::dispatch_core_intrinsic(
                 ctx,
                 body,
@@ -1031,11 +1026,10 @@ fn translate_call(
                 name,
             );
         }
-    }
 
     // Try to dispatch as intrinsic
-    if let Some(ref name) = pattern_name {
-        if let Some(result) = try_dispatch_intrinsic(
+    if let Some(ref name) = pattern_name
+        && let Some(result) = try_dispatch_intrinsic(
             ctx,
             body,
             name,
@@ -1051,7 +1045,6 @@ fn translate_call(
         )? {
             return Ok(result);
         }
-    }
 
     // Handle diverging calls (calls that never return, like unwrap_failed, panic, etc.)
     // These have no target block because the function never returns.

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -133,13 +133,13 @@ pub fn is_rust_type_zst(rust_ty: &rustc_public::ty::Ty) -> bool {
             // Check substs[2] which is the tuple of upvar types
             if substs.0.len() >= 3
                 && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
-                    && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
-                        upvar_tys,
-                    )) = upvar_tuple_ty.kind()
-                    {
-                        // ZST if no captures
-                        return upvar_tys.is_empty();
-                    }
+                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
+                    upvar_tys,
+                )) = upvar_tuple_ty.kind()
+            {
+                // ZST if no captures
+                return upvar_tys.is_empty();
+            }
             // Default to ZST if we can't determine
             true
         }
@@ -567,15 +567,15 @@ pub fn translate_type(
 
             if substs.0.len() >= 3
                 && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
-                    && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
-                        upvar_tys,
-                    )) = upvar_tuple_ty.kind()
-                    {
-                        for (i, upvar_ty) in upvar_tys.iter().enumerate() {
-                            field_names.push(format!("capture_{}", i));
-                            field_types.push(translate_type(ctx, upvar_ty)?);
-                        }
-                    }
+                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
+                    upvar_tys,
+                )) = upvar_tuple_ty.kind()
+            {
+                for (i, upvar_ty) in upvar_tys.iter().enumerate() {
+                    field_names.push(format!("capture_{}", i));
+                    field_types.push(translate_type(ctx, upvar_ty)?);
+                }
+            }
 
             Ok(
                 dialect_mir::types::MirStructType::get(ctx, closure_name, field_names, field_types)

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -131,17 +131,15 @@ pub fn is_rust_type_zst(rust_ty: &rustc_public::ty::Ty) -> bool {
         // Closures with no captures are ZST, closures with captures are not
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Closure(_, substs)) => {
             // Check substs[2] which is the tuple of upvar types
-            if substs.0.len() >= 3 {
-                if let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2] {
-                    if let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
+            if substs.0.len() >= 3
+                && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
+                    && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
                         upvar_tys,
                     )) = upvar_tuple_ty.kind()
                     {
                         // ZST if no captures
                         return upvar_tys.is_empty();
                     }
-                }
-            }
             // Default to ZST if we can't determine
             true
         }
@@ -567,9 +565,9 @@ pub fn translate_type(
             let mut field_names = Vec::new();
             let mut field_types = Vec::new();
 
-            if substs.0.len() >= 3 {
-                if let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2] {
-                    if let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
+            if substs.0.len() >= 3
+                && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
+                    && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
                         upvar_tys,
                     )) = upvar_tuple_ty.kind()
                     {
@@ -578,8 +576,6 @@ pub fn translate_type(
                             field_types.push(translate_type(ctx, upvar_ty)?);
                         }
                     }
-                }
-            }
 
             Ok(
                 dialect_mir::types::MirStructType::get(ctx, closure_name, field_names, field_types)

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -256,13 +256,14 @@ fn cast_pointer_to_generic_if_needed(
     };
 
     if let Some(addrspace) = maybe_addrspace
-        && addrspace != ADDRSPACE_GENERIC {
-            let cast_op = llvm::AddrSpaceCastOp::new(ctx, arg, ADDRSPACE_GENERIC);
-            rewriter.insert_operation(ctx, cast_op.get_operation());
-            let casted_val = cast_op.get_operation().deref(ctx).get_result(0);
-            let generic_ptr_ty = llvm_types::PointerType::get_generic(ctx);
-            return Ok((casted_val, generic_ptr_ty.into()));
-        }
+        && addrspace != ADDRSPACE_GENERIC
+    {
+        let cast_op = llvm::AddrSpaceCastOp::new(ctx, arg, ADDRSPACE_GENERIC);
+        rewriter.insert_operation(ctx, cast_op.get_operation());
+        let casted_val = cast_op.get_operation().deref(ctx).get_result(0);
+        let generic_ptr_ty = llvm_types::PointerType::get_generic(ctx);
+        return Ok((casted_val, generic_ptr_ty.into()));
+    }
 
     Ok((arg, arg_ty))
 }

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -255,15 +255,14 @@ fn cast_pointer_to_generic_if_needed(
             .map(|ptr_ty| ptr_ty.address_space())
     };
 
-    if let Some(addrspace) = maybe_addrspace {
-        if addrspace != ADDRSPACE_GENERIC {
+    if let Some(addrspace) = maybe_addrspace
+        && addrspace != ADDRSPACE_GENERIC {
             let cast_op = llvm::AddrSpaceCastOp::new(ctx, arg, ADDRSPACE_GENERIC);
             rewriter.insert_operation(ctx, cast_op.get_operation());
             let casted_val = cast_op.get_operation().deref(ctx).get_result(0);
             let generic_ptr_ty = llvm_types::PointerType::get_generic(ctx);
             return Ok((casted_val, generic_ptr_ty.into()));
         }
-    }
 
     Ok((arg, arg_ty))
 }

--- a/crates/mir-lower/src/helpers.rs
+++ b/crates/mir-lower/src/helpers.rs
@@ -329,12 +329,10 @@ pub fn ensure_intrinsic_declared(
     for existing_op in module_block.deref(ctx).iter(ctx) {
         if let Some(existing_func) =
             pliron::operation::Operation::get_op::<llvm::FuncOp>(existing_op, ctx)
-        {
-            if existing_func.get_symbol_name(ctx) == sym_name {
+            && existing_func.get_symbol_name(ctx) == sym_name {
                 already_declared = true;
                 break;
             }
-        }
     }
 
     // If not declared, create a function declaration (no body)

--- a/crates/mir-lower/src/helpers.rs
+++ b/crates/mir-lower/src/helpers.rs
@@ -329,10 +329,11 @@ pub fn ensure_intrinsic_declared(
     for existing_op in module_block.deref(ctx).iter(ctx) {
         if let Some(existing_func) =
             pliron::operation::Operation::get_op::<llvm::FuncOp>(existing_op, ctx)
-            && existing_func.get_symbol_name(ctx) == sym_name {
-                already_declared = true;
-                break;
-            }
+            && existing_func.get_symbol_name(ctx) == sym_name
+        {
+            already_declared = true;
+            break;
+        }
     }
 
     // If not declared, create a function declaration (no body)

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "combine"


### PR DESCRIPTION
## Summary
- Update bytes 1.11.0 → 1.11.1 in rustc-codegen-cuda/Cargo.lock to fix CVE-2026-25541
- Resolve all 66 clippy warnings across the workspace
- Add # Safety docs to 10 unsafe intrinsic stubs in cuda-device
- Add clippy GitHub Actions workflow (-D warnings on push/PR)

## Test plan
- [x] cargo clippy --workspace reports zero warnings
- [x] Full smoketest passes: 38/38 examples on RTX 5090 (sm_120)