### PR TITLE
  Fix CUDA event binding compatibility and arch forwarding

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -149,7 +149,7 @@ pub fn codegen_run(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
 
-    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, target_arch);
+    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, arch, target_arch);
     apply_ld_library_path(&mut cmd);
 
     if let Some(bin) = bin {
@@ -221,7 +221,7 @@ pub fn codegen_build_example(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
 
-    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, target_arch);
+    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, arch, target_arch);
     apply_ld_library_path(&mut cmd);
 
     println!("Building {}...", example);
@@ -292,7 +292,7 @@ pub fn codegen_show_pipeline(
     cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_LLVM", "1");
 
-    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, target_arch);
+    apply_output_mode(&mut cmd, dlto, emit_nvvm_ir, arch, target_arch);
     apply_ld_library_path(&mut cmd);
 
     println!("Building {}...", example);
@@ -813,14 +813,22 @@ fn build_rustflags(backend_so: &Path, debug: bool) -> String {
 
 /// Set environment variables that tell the codegen backend which output
 /// format to produce (LTOIR, NVVM IR) and the target GPU architecture.
-fn apply_output_mode(cmd: &mut Command, dlto: bool, emit_nvvm_ir: bool, target_arch: &str) {
+fn apply_output_mode(
+    cmd: &mut Command,
+    dlto: bool,
+    emit_nvvm_ir: bool,
+    arch: Option<&str>,
+    target_arch: &str,
+) {
     if dlto {
         cmd.env("CUDA_OXIDE_EMIT_LTOIR", "1");
         cmd.env("CUDA_OXIDE_ARCH", target_arch);
     }
+    if emit_nvvm_ir || arch.is_some() {
+        cmd.env("CUDA_OXIDE_TARGET", target_arch);
+    }
     if emit_nvvm_ir {
         cmd.env("CUDA_OXIDE_EMIT_NVVM_IR", "1");
-        cmd.env("CUDA_OXIDE_TARGET", target_arch);
     }
 }
 

--- a/crates/cuda-bindings/build.rs
+++ b/crates/cuda-bindings/build.rs
@@ -25,8 +25,18 @@ fn main() {
 fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_PATH");
+    println!("cargo::rustc-check-cfg=cfg(cuda_has_cuEventElapsedTime_v2)");
 
     let toolkit = cuda_toolkit_dir();
+    let cuda_h = Path::new(&toolkit).join("include/cuda.h");
+    println!("cargo:rerun-if-changed={}", cuda_h.display());
+    if std::fs::read_to_string(&cuda_h)
+        .map(|contents| contents.contains("cuEventElapsedTime_v2"))
+        .unwrap_or(false)
+    {
+        println!("cargo:rustc-cfg=cuda_has_cuEventElapsedTime_v2");
+    }
+
     for path in collect_lib_paths(&toolkit) {
         println!("cargo:rustc-link-search=native={}", path.display());
     }

--- a/crates/cuda-bindings/src/lib.rs
+++ b/crates/cuda-bindings/src/lib.rs
@@ -26,6 +26,31 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 use std::env;
 
+/// Calls the CUDA Driver API event elapsed-time function across toolkit header variants.
+///
+/// CUDA 12.8+ headers expose `cuEventElapsedTime_v2`, while older CUDA 12.x
+/// headers, including CUDA 12.4, expose `cuEventElapsedTime`.
+///
+/// # Safety
+///
+/// `p_milliseconds` must be valid for writes, and `start`/`end` must be valid
+/// CUDA event handles from the active context.
+pub unsafe fn cu_event_elapsed_time(
+    p_milliseconds: *mut f32,
+    start: CUevent,
+    end: CUevent,
+) -> CUresult {
+    #[cfg(cuda_has_cuEventElapsedTime_v2)]
+    {
+        unsafe { cuEventElapsedTime_v2(p_milliseconds, start, end) }
+    }
+
+    #[cfg(not(cuda_has_cuEventElapsedTime_v2))]
+    {
+        unsafe { cuEventElapsedTime(p_milliseconds, start, end) }
+    }
+}
+
 /// Root directory of the CUDA toolkit used for this build, for host code that must agree with
 /// compile-time include and link paths (e.g. loading companion libraries or probing layout).
 ///

--- a/crates/cuda-core/src/event.rs
+++ b/crates/cuda-core/src/event.rs
@@ -121,7 +121,7 @@ impl CudaEvent {
         end.synchronize()?;
         let mut ms: f32 = 0.0;
         unsafe {
-            cuda_bindings::cuEventElapsedTime_v2(&mut ms as *mut _, self.cu_event, end.cu_event)
+            cuda_bindings::cu_event_elapsed_time(&mut ms as *mut _, self.cu_event, end.cu_event)
                 .result()?;
         }
         Ok(ms)


### PR DESCRIPTION
## Summary

This PR fixes two setup/runtime issues found while validating cuda-oxide on a CUDA 12.4 system with an sm_75 NVIDIA T1200 GPU.

  - Add a CUDA Driver API compatibility wrapper for event elapsed timing.
  - Use `cuEventElapsedTime_v2` when the installed CUDA headers expose it.
  - Fall back to `cuEventElapsedTime` for older CUDA 12.x headers such as CUDA 12.4.
  - Forward explicit `cargo oxide --arch` values to the normal PTX generation path through `CUDA_OXIDE_TARGET`, while preserving backend auto-target selection when `--arch` is omitted.

## Motivation
CUDA 12.4 headers generate a `cuEventElapsedTime` binding, not `cuEventElapsedTime_v2`, which caused `cuda-core` to fail to compile.

Also, `cargo oxide run vecadd --arch sm_75` accepted the `--arch` flag but did not apply it for normal PTX output. The generated PTX still targeted the auto-selected architecture, causing PTX JIT failures on sm_75 hardware. With this change, `--arch sm_75` correctly generates `.target sm_75`.

The change preserves the existing default behavior when `--arch` is omitted: the backend still performs auto-target selection.

## Testing

  ```bash
  cargo fmt --check
  cargo check
  cargo clippy -p cuda-bindings -p cuda-core -p cargo-oxide -- -D warnings
  cargo test -p cuda-bindings -p cuda-core -p cargo-oxide
  cargo oxide doctor
  unset CUDA_OXIDE_TARGET && cargo oxide build vecadd
  unset CUDA_OXIDE_TARGET && cargo oxide run vecadd --arch sm_75

  When --arch is omitted, the generated vecadd.ptx keeps the backend-selected default:

  .target sm_80

  With --arch sm_75, the generated vecadd.ptx contains:

  .target sm_75

  and the example prints:

  SUCCESS: All 1024 elements correct!
