### PR TITLE
Fix buffer type in CudaContext::device_name

### DIFF
--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -220,7 +220,7 @@ impl CudaContext {
     /// decoded UTF-8 string with any trailing NULs stripped.
     pub fn device_name(&self) -> Result<String, DriverError> {
         self.bind_to_thread()?;
-        let mut buf = [0i8; 256];
+        let mut buf = [0; 256];
         unsafe {
             cuda_bindings::cuDeviceGetName(buf.as_mut_ptr(), buf.len() as c_int, self.cu_device)
                 .result()?;


### PR DESCRIPTION
Fixes the problem described in https://github.com/NVlabs/cuda-oxide/issues/8, by leaving the type of the array to be inferred by the compiler to the correct type on the target platform.