### PR TITLE
Fix buffer type in CudaContext::device_name

### DIFF
--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -220,7 +220,7 @@ impl CudaContext {
     /// decoded UTF-8 string with any trailing NULs stripped.
     pub fn device_name(&self) -> Result<String, DriverError> {
         self.bind_to_thread()?;
-        let mut buf = [0i8; 256];
+        let mut buf = [0; 256];
         unsafe {
             cuda_bindings::cuDeviceGetName(buf.as_mut_ptr(), buf.len() as c_int, self.cu_device)
                 .result()?;


### PR DESCRIPTION
Let Rust infer the device-name buffer element type from cuDeviceGetName so it matches the target-specific c_char alias. This fixes builds on platforms where c_char is unsigned, such as aarch64 Linux.

Fixes #8.