### PR TITLE
fix(cuda-bindings): resolve build failure by checking CUDA_HOME

### DIFF
--- a/crates/cuda-bindings/build.rs
+++ b/crates/cuda-bindings/build.rs
@@ -5,10 +5,13 @@
 
 use std::{env, error::Error, path::Path, path::PathBuf, process::exit};
 
-/// Returns the CUDA toolkit install root: `CUDA_TOOLKIT_PATH` if set, otherwise `/usr/local/cuda`.
-/// Used for include paths, library search paths, and bindgen’s Clang configuration.
+/// Returns the CUDA toolkit install root: `CUDA_TOOLKIT_PATH` or `CUDA_HOME` if set,
+/// otherwise `/usr/local/cuda`. Used for include paths, library search paths,
+/// and bindgen’s Clang configuration.
 fn cuda_toolkit_dir() -> String {
-    env::var("CUDA_TOOLKIT_PATH").unwrap_or_else(|_| "/usr/local/cuda".to_string())
+    env::var("CUDA_TOOLKIT_PATH")
+        .or_else(|_| env::var("CUDA_HOME"))
+        .unwrap_or_else(|_| "/usr/local/cuda".to_string())
 }
 
 /// Runs [`run`]; on error, prints the message and exits with status 1.
@@ -25,16 +28,26 @@ fn main() {
 fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_PATH");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
     println!("cargo::rustc-check-cfg=cfg(cuda_has_cuEventElapsedTime_v2)");
 
     let toolkit = cuda_toolkit_dir();
     let cuda_h = Path::new(&toolkit).join("include/cuda.h");
     println!("cargo:rerun-if-changed={}", cuda_h.display());
-    if std::fs::read_to_string(&cuda_h)
-        .map(|contents| contents.contains("cuEventElapsedTime_v2"))
-        .unwrap_or(false)
-    {
-        println!("cargo:rustc-cfg=cuda_has_cuEventElapsedTime_v2");
+
+    match std::fs::read_to_string(&cuda_h) {
+        Ok(contents) => {
+            if contents.contains("cuEventElapsedTime_v2") {
+                println!("cargo:rustc-cfg=cuda_has_cuEventElapsedTime_v2");
+            }
+        }
+        Err(err) => {
+            println!(
+                "cargo:warning=cuda-bindings: Could not read cuda.h at {}: {}",
+                cuda_h.display(),
+                err
+            );
+        }
     }
 
     for path in collect_lib_paths(&toolkit) {


### PR DESCRIPTION
Resolves #16 

### Problem
In environments where `CUDA_TOOLKIT_PATH` is not explicitly set but standard environment variables like `CUDA_HOME` are, `build.rs` silently falls back to `/usr/local/cuda`. If this directory doesn't exist or contains a different CUDA version, `std::fs::read_to_string` silently fails. 

This causes the build script to skip enabling the `cuda_has_cuEventElapsedTime_v2` feature flag, resulting in a cryptic `cannot find function` compilation error downstream on CUDA 13 (when CUDA_HOME is the correct location).

### Changes
- `cuda_toolkit_dir()` now checks `CUDA_HOME before falling back to `/usr/local/cuda`.
- Added `cargo:rerun-if-env-changed=CUDA_HOME`
- Replaced the silent `.unwrap_or(false)` with a `cargo:warning`. If the script cannot read `cuda.h`, it now emits a visible warning during `cargo build` explaining exactly which path failed.

### Checklist
- [x] I have signed my commits (DCO).
- [x] Code is formatted with `cargo fmt`.
- [x] Checked with `cargo clippy`.