### PR TITLE
Fix hashmap_v3 resize on cooperative launch limits

### DIFF
--- a/crates/rustc-codegen-cuda/examples/hashmap/README.md
+++ b/crates/rustc-codegen-cuda/examples/hashmap/README.md
@@ -146,8 +146,8 @@ What test 6 does **not** cover:
 ## Intentionally Out of Scope for v1
 
 - **Deletion** — `hashmap_v2` and `hashmap_v3` introduce tombstone tags.
-- **Resize / rehash** — `hashmap_v3` adds a single-kernel `grid.sync()`
-  rehash.
+- **Resize / rehash** — `hashmap_v3` adds a single-kernel strided
+  two-buffer rehash.
 - **Generic `<K, V>`** — deferred for API design reasons (sentinel
   selection, slot-packing atomicity, hasher choice), not because of any
   cuda-oxide compiler limitation. `#[kernel]` already supports generics.
@@ -168,7 +168,7 @@ this one stays a clean, minimal reference:
 - **`hashmap_v3`** — keeps v2's storage layout and probe shape, drops
   the second insert protocol, and adds 16-lane sub-warp find tiles
   (`WarpTile<16>`), intra-warp insert dedup via `tile.match_any`,
-  `DELETED`-slot reclaim on insert, and a single-kernel `grid.sync()`
-  rehash with auto-resize.
+  `DELETED`-slot reclaim on insert, and a strided two-buffer rehash
+  with auto-resize.
 
 None of that retrofits onto v1; v1 stands on its own.

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/README.md
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/README.md
@@ -335,8 +335,8 @@ Default capacity is `1 << 14` slots.
 - **DELETED slot reclaim on insert** — v2 leaves tombstones in place;
   with enough delete-insert churn the table fragments and effective
   capacity shrinks. Reclaim and rehash ship in `hashmap_v3`.
-- **Resize / rehash** — v2 has no resize path. Cooperative-launch
-  grid-wide rehash ships in `hashmap_v3`.
+- **Resize / rehash** — v2 has no resize path. Strided two-buffer
+  rehash ships in `hashmap_v3`.
 - **Generic `<K, V>`** — deferred for API design reasons.
 - **Float keys** — PTX has no `compare_exchange` for floats.
 - **Single-launch dedup under Protocol A** — best-effort by design;
@@ -390,8 +390,8 @@ faster, find ratios are tighter on misses than hits — stays the same.
 - **`hashmap_v3`** — the next iteration of this design. Same SwissTable
   storage layout and probe shape; adds 16-lane sub-warp find tiles via
   `WarpTile<16>`, intra-warp insert dedup via `tile.match_any`,
-  `DELETED`-slot reclaim on insert, and a single-kernel `grid.sync()`
-  rehash with auto-resize. v2 stays in tree as the frozen baseline.
+  `DELETED`-slot reclaim on insert, and a strided two-buffer rehash
+  with auto-resize. v2 stays in tree as the frozen baseline.
 
 ## What v2 Ships in One Crate
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/README.md
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/README.md
@@ -13,7 +13,7 @@ capabilities that v2 did not have:
 | Sub-warp find tile            | `find_bulk_tile_16`      | Two queries per warp    |
 | Intra-warp insert dedup       | `insert_bulk_dedup`      | Duplicate-heavy inputs  |
 | `DELETED`-slot reclaim        | Every insert path        | Churn at high load      |
-| Single-kernel rehash + resize | `resize_to` / grow path  | Cooperative auto-resize |
+| Single-kernel rehash + resize | `resize_to` / grow path  | Strided auto-resize |
 
 - `WarpTile<16>` is 1.2-1.3x faster than the full-warp tile at
   moderate load.
@@ -78,7 +78,7 @@ let by_subwarp = map.find_bulk_tile_16(&query, &module, &stream)?;     // 2 keys
 // Tombstone delete (FULL(h2) -> DELETED). Subsequent inserts may reclaim.
 let deleted = map.delete_bulk(&keys, &module, &stream)?;       // Vec<bool>
 
-// Resize: cooperative-launch rehash kernel into freshly memset'd buffers.
+// Resize: strided rehash kernel into freshly memset'd buffers.
 map.resize_to(new_capacity, &module, &stream)?;
 
 // Auto-resize wrapper: doubles capacity in a loop until projected load
@@ -163,27 +163,21 @@ insert may reclaim the slot via the handshake above.
 
 1. Allocate fresh `ctrl` and `slots` for `new_capacity`,
    `memset_d8_async(0xFF, ...)` so they read all-`EMPTY`.
-2. Cooperative-launch `rehash_kernel(old_ctrl, old_slots, new_ctrl, new_slots)`
-   with one thread per old slot.
-3. Phase 1 of `rehash_kernel`: each thread reads its old slot. If
-   `FULL(h2)`, hold `(key, value)` in registers; otherwise mark "not
-   live".
-4. `grid.sync()` — every read happens before any new-table write.
-5. Phase 2: each "live" thread re-inserts `(key, value)` into the new
-   table via the standard `insert_into_table_core`.
-6. Replace `self.ctrl` / `self.slots` / `self.capacity` with the new
+2. Launch `rehash_kernel(old_ctrl, old_slots, new_ctrl, new_slots)`.
+   The launch is capped, and each thread walks old slots in a grid-stride loop.
+3. Each thread reads a live old slot and immediately re-inserts `(key, value)`
+   into the new table via the standard `insert_into_table_core`.
+4. Replace `self.ctrl` / `self.slots` / `self.capacity` with the new
    buffers; old buffers drop.
+
+Because resize always rehashes into separate freshly cleared buffers, no
+cooperative grid-wide barrier is needed: the old table is read-only while the
+new table is being populated.
 
 `insert_bulk_grow` is a thin wrapper: doubles `capacity` (in a loop)
 until the projected post-insert load would stay under 7/8, then runs
 `insert_bulk`. Each doubling increments `resize_count` so stress tests
 can verify the trigger.
-
-Cooperative-launch caveat: `rehash_kernel` runs with one thread per
-old slot, so `capacity()` must fit the GPU's cooperative-launch
-resident-block budget. On modern GPUs this comfortably covers tables
-up to ~1 M slots; larger tables need a strided variant (each thread
-handles multiple slots in a chunked loop) — out of scope for v3.
 
 ## Bench Snapshot — RTX 5090, sm\_120
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
 
 use cuda_core::{CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
 use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU32, DeviceAtomicU64};
-use cuda_device::cooperative_groups::{ThreadGroup, WarpCollective, this_grid, this_thread_block};
+use cuda_device::cooperative_groups::{ThreadGroup, WarpCollective, this_thread_block};
 use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_launch;
 
@@ -91,6 +91,14 @@ pub const GROUP: usize = 4;
 /// consecutive 16-byte sub-tiles before the triangular advance, so the
 /// same table is queryable by either tile size.
 pub const PROBE_TILE: usize = 32;
+
+/// Maximum number of threads used by the non-cooperative rehash launch.
+///
+/// Resize walks the old table with a grid-stride loop, so correctness does
+/// not depend on launching one thread per slot. Keeping the launch bounded
+/// avoids cooperative-launch resident-block limits while still giving enough
+/// parallelism for large tables.
+pub const REHASH_MAX_THREADS: usize = 65_536;
 
 /// Tag byte = "this slot is free". All slots start as `EMPTY_TAG`. The
 /// initial all-`0xFF` ctrl array gives us this for free via
@@ -311,37 +319,21 @@ pub fn insert_kernel_dedup(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[
     }
 }
 
-/// `rehash_kernel` — single-kernel rehash via `grid.sync()`.
-///
-/// Cooperative-launch only. Phase 1: each thread reads its assigned
-/// slot in the old table and stashes the `(key, value)` pair (or a
-/// "not live" marker) into registers. After `grid.sync()`, Phase 2:
-/// each thread that read a `FULL(h2)` slot re-inserts its pair into
-/// the new table via [`insert_into_table_core`].
-///
-/// The grid barrier costs a single `cudaCGSync()` and lets one kernel
-/// invocation replace the "two launches plus a stream sync" pattern
-/// that would otherwise be needed: it sequences the entire read
-/// phase before any write into the destination buffer with no
-/// host-side coordination.
+/// `rehash_kernel` — single-kernel two-buffer rehash.
 ///
 /// v3 ships the two-buffer mode only (`old != new`); the new buffer
-/// is `memset`-cleared by the host before launch. In-place
-/// compaction (`old == new`, which would also need a clear step
-/// between read and re-insert) is a future extension; the grid
-/// barrier is in place so that extension can land without rewriting
-/// the kernel.
-///
-/// Launch with one thread per old slot:
-/// `LaunchConfig::for_num_elems(old_capacity as u32)`. The host
-/// wrapper [`GpuSwissMap::resize_to`] passes `cooperative: true` to
-/// `cuda_launch!`.
+/// is `memset`-cleared by the host before launch, and the old buffer
+/// remains read-only for the duration of the kernel. That means no
+/// grid-wide barrier is required: each thread can read a live old
+/// slot and immediately insert it into the new table. Threads stride
+/// across the old table so the host can bound the launch size without
+/// depending on cooperative-launch residency limits.
 #[kernel]
 pub fn rehash_kernel(old_ctrl: &[u32], old_slots: &[u64], new_ctrl: &[u32], new_slots: &[u64]) {
-    let grid = this_grid();
-    let tid = thread::index_1d().get();
+    let mut tid = thread::index_1d().get();
+    let stride = (thread::gridDim_x() * thread::blockDim_x()) as usize;
 
-    let (live, key, value) = if tid < old_slots.len() {
+    while tid < old_slots.len() {
         let ctrl_word_idx = tid / GROUP;
         let byte_in_word = tid % GROUP;
         let ctrl_atomic =
@@ -352,18 +344,16 @@ pub fn rehash_kernel(old_ctrl: &[u32], old_slots: &[u64], new_ctrl: &[u32], new_
             let slot_atomic =
                 unsafe { DeviceAtomicU64::from_ptr(old_slots.as_ptr().add(tid).cast_mut()) };
             let slot = slot_atomic.load(AtomicOrdering::Acquire);
-            (true, unpack_key(slot), unpack_value(slot))
-        } else {
-            (false, 0u32, 0u32)
+            let _ = insert_into_table_core(
+                new_ctrl,
+                new_slots,
+                unpack_key(slot),
+                unpack_value(slot),
+                true,
+            );
         }
-    } else {
-        (false, 0u32, 0u32)
-    };
 
-    grid.sync();
-
-    if live {
-        let _ = insert_into_table_core(new_ctrl, new_slots, key, value, true);
+        tid += stride;
     }
 }
 
@@ -1317,20 +1307,18 @@ impl GpuSwissMap {
 
     /// Reallocate `ctrl` and `slots` to `new_capacity` slots and
     /// rehash all live entries from the old buffers into the new
-    /// via the cooperative-launch [`rehash_kernel`] (one thread per
-    /// old slot, single grid barrier between read and re-insert).
+    /// via the strided two-buffer [`rehash_kernel`].
     ///
     /// Both growing and shrinking are supported. `new_capacity` must
     /// be a power of two and at least `PROBE_TILE`. After this call,
     /// the old buffers are dropped (freed once the launch completes
     /// and the borrowed device pointers go out of scope).
     ///
-    /// Cooperative launch caveat: the kernel runs with one thread per
-    /// old slot, so `self.capacity()` must fit the GPU's cooperative-
-    /// launch resident-block budget. On modern GPUs this comfortably
-    /// covers tables up to ~1 M slots. Larger tables would need a
-    /// strided variant (each thread handles multiple slots in a
-    /// chunked loop) — out of scope for v3.
+    /// The old buffers are read-only and the new buffers start empty,
+    /// so rehash does not require a cooperative grid-wide barrier.
+    /// The launch size is capped and each thread handles a strided
+    /// subset of old slots, which keeps resize portable across GPUs
+    /// with smaller cooperative-launch residency budgets.
     pub fn resize_to(
         &mut self,
         new_capacity: usize,
@@ -1363,13 +1351,13 @@ impl GpuSwissMap {
             )?;
         }
 
-        let cfg = LaunchConfig::for_num_elems(self.capacity as u32);
+        let rehash_threads = self.capacity.min(REHASH_MAX_THREADS) as u32;
+        let cfg = LaunchConfig::for_num_elems(rehash_threads);
         cuda_launch! {
             kernel: rehash_kernel,
             stream: stream,
             module: module,
             config: cfg,
-            cooperative: true,
             args: [
                 slice(self.ctrl), slice(self.slots),
                 slice(new_ctrl), slice(new_slots)


### PR DESCRIPTION
## Summary

`hashmap_v3` currently rehashes during `resize_to` with a cooperative kernel that launches one thread per old table slot. On an RTX 5080 (`sm_120`), the resize correctness test can exceed the cooperative-launch resident-block limit and fail with:

```text
DriverError(720, "too many blocks in cooperative launch")
```

The current resize path is always two-buffer: it allocates fresh `ctrl` and `slots` buffers, clears them, reads from the old table, inserts live entries into the new table, then swaps the buffers. Since old-table reads and new-table writes do not alias, the `grid.sync()` is not needed for correctness here.

This changes rehash to a normal bounded grid-stride kernel and documents the resize path as strided two-buffer rehash. That keeps the single-kernel rehash path while avoiding cooperative-launch residency limits.

## Test plan

Tested on RTX 5080 (`sm_120`), CUDA 13.2, Fedora 44. For CUDA 13.2 host compiler compatibility, `nvcc` was pinned to `g++-15`.

- `cargo oxide run hashmap_v3`
- `NVCC_PREPEND_FLAGS='-ccbin=/usr/bin/g++-15' cargo oxide run device_ffi_test --emit-nvvm-ir --arch=sm_120`
- `NVCC_PREPEND_FLAGS='-ccbin=/usr/bin/g++-15' scripts/smoketest.sh --keep-logs`

Full smoketest result: 46/46 pass.
