### PR TITLE
Make DeviceBuffer transfers require DeviceCopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/cuda-core/Cargo.toml
+++ b/crates/cuda-core/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 cuda-bindings = { path = "../cuda-bindings" }
 anyhow = { workspace = true }
+half = { workspace = true }
 oxide-artifacts = { workspace = true, features = ["object-read"] }
 
 [dev-dependencies]

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -20,6 +20,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Streams**: `ctx.new_stream()` creates a non-blocking stream. `stream.launch_host_function(f)` enqueues an `FnOnce` callback after all prior stream work completes -- this is the bridge to Rust futures in `cuda-async`.
 - **Modules**: `ctx.load_module_from_file("kernel.ptx")` / `ctx.load_module_from_ptx_src(src)` load compiled GPU code. `module.load_function("kernel_name")` extracts a callable function handle.
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
+- **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`.
 - **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -29,12 +29,88 @@ use crate::context::CudaContext;
 use crate::error::DriverError;
 use crate::stream::CudaStream;
 
+/// Marker trait for values that can be safely copied between host and device
+/// memory as raw bytes.
+///
+/// Types implementing `DeviceCopy` must not contain Rust-owned allocations,
+/// references, or other values whose validity depends on host-side ownership or
+/// drop semantics. This is the device-memory equivalent of a plain-old-data
+/// contract.
+///
+/// # Safety
+///
+/// Implementors must be safe to duplicate with a byte-for-byte copy. Values
+/// copied back from device memory must have a bit pattern that is valid for
+/// `Self`, and the all-zero bit pattern must also be valid because
+/// [`DeviceBuffer::zeroed`] initializes memory with zero bytes.
+pub unsafe trait DeviceCopy: Copy {}
+
+macro_rules! impl_device_copy {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            unsafe impl DeviceCopy for $ty {}
+        )+
+    };
+}
+
+impl_device_copy!(
+    (),
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    f16,
+    f32,
+    f64
+);
+
+unsafe impl<T: DeviceCopy, const N: usize> DeviceCopy for [T; N] {}
+unsafe impl<T: ?Sized> DeviceCopy for *const T {}
+unsafe impl<T: ?Sized> DeviceCopy for *mut T {}
+
+macro_rules! impl_device_copy_tuple {
+    ($($name:ident),+ $(,)?) => {
+        unsafe impl<$($name: DeviceCopy),+> DeviceCopy for ($($name,)+) {}
+    };
+}
+
+impl_device_copy_tuple!(A);
+impl_device_copy_tuple!(A, B);
+impl_device_copy_tuple!(A, B, C);
+impl_device_copy_tuple!(A, B, C, D);
+impl_device_copy_tuple!(A, B, C, D, E);
+impl_device_copy_tuple!(A, B, C, D, E, F);
+impl_device_copy_tuple!(A, B, C, D, E, F, G);
+impl_device_copy_tuple!(A, B, C, D, E, F, G, H);
+
+unsafe impl DeviceCopy for half::bf16 {}
+unsafe impl DeviceCopy for half::f16 {}
+
 /// Owning handle to a contiguous device allocation of `T` elements.
 ///
 /// Holds a raw device pointer, element count, and a reference-counted
 /// context that keeps the CUDA context alive. Dropping the buffer calls
 /// `cuMemFree` (synchronous); for async-sensitive workloads, use
 /// `cuda_async::DeviceBox` which frees via a deallocator stream.
+///
+/// Device buffers may only transfer plain device-copyable values. Owning host
+/// types such as [`String`] are rejected because copying their bytes to and
+/// from device memory would not preserve Rust ownership invariants.
+///
+/// ```compile_fail
+/// # use cuda_core::{CudaStream, DeviceBuffer};
+/// # fn rejects_non_device_copy(stream: &CudaStream) {
+/// let _ = DeviceBuffer::<String>::zeroed(stream, 1);
+/// # }
+/// ```
 pub struct DeviceBuffer<T> {
     ptr: CUdeviceptr,
     len: usize,
@@ -115,7 +191,9 @@ impl<T> DeviceBuffer<T> {
         std::mem::forget(self);
         parts
     }
+}
 
+impl<T: DeviceCopy> DeviceBuffer<T> {
     /// Allocates device memory and copies `data` from the host, enqueued on
     /// `stream`.
     ///

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -43,6 +43,11 @@ use crate::stream::CudaStream;
 /// copied back from device memory must have a bit pattern that is valid for
 /// `Self`, and the all-zero bit pattern must also be valid because
 /// [`DeviceBuffer::zeroed`] initializes memory with zero bytes.
+///
+/// `Copy` alone is not enough: types such as `bool`, `char`, and
+/// `NonZeroU32` are `Copy`, but not every byte pattern is a valid value of
+/// those types. `DeviceCopy` is the stronger promise required when
+/// `DeviceBuffer` turns raw device bytes back into initialized Rust values.
 pub unsafe trait DeviceCopy: Copy {}
 
 macro_rules! impl_device_copy {

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -35,6 +35,8 @@
 //! Raw bindings are available as [`sys`] for any driver entry point not yet
 //! wrapped.
 
+#![feature(f16)]
+
 /// CUDA context management (primary context, RAII).
 pub mod context;
 /// Owning device memory buffer with host-device transfer helpers.
@@ -61,7 +63,7 @@ pub mod vmm;
 pub use context::CudaContext;
 /// Raw CUDA driver bindings re-exported for direct access when needed.
 pub use cuda_bindings as sys;
-pub use device_buffer::DeviceBuffer;
+pub use device_buffer::{DeviceBuffer, DeviceCopy};
 pub use embedded::{EmbeddedModule, EmbeddedModuleError};
 pub use error::{DriverError, IntoResult};
 pub use event::CudaEvent;

--- a/crates/rustc-codegen-cuda/examples/abi_hmm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/abi_hmm/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/array_index/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/array_index/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/async_mlp/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/async_mlp/Cargo.lock
@@ -120,6 +120,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/async_vecadd/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/async_vecadd/Cargo.lock
@@ -120,6 +120,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/atomics/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/atomics/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/barrier/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/barrier/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/cast_tests/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cast_tests/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/clc/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/clc/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/cluster/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cluster/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/compiler_features/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/Cargo.lock
@@ -106,6 +106,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/Cargo.lock
@@ -105,6 +105,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/debug/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/debug/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/device_closures/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_closures/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/device_global/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_global/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/dynamic_smem/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/dynamic_smem/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/error/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/f16_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/f16_stress/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/future_apis/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/future_apis/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/gemm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/generic/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/hashmap/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/Cargo.lock
@@ -128,6 +128,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/Cargo.lock
@@ -128,6 +128,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/hello_constant/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hello_constant/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/helper_fn/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/helper_fn/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/host_closure/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/host_closure/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/index2d_const/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/index2d_const/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/manual_launch_generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/manual_launch_generic/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/Cargo.lock
@@ -117,6 +117,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/mcast_barrier_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mcast_barrier_test/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/numeric_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/numeric_stress/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/primitive_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/primitive_stress/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/printf/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/printf/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/rustlantis-smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/rustlantis-smoke/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/sharedmem/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/sharedmem/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/tcgen05/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/tiled_gemm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tiled_gemm/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/tma_copy/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/vecadd/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/vecadd/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/wgmma/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/wgmma/Cargo.lock
@@ -97,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "half",
  "oxide-artifacts",
 ]
 


### PR DESCRIPTION
 ## Summary

This PR adds an unsafe `DeviceCopy` marker trait for types that can be safely copied between host and device memory as raw bytes, then constrains `DeviceBuffer<T>` transfer APIs to `T: DeviceCopy`.

The change prevents safe Rust code from using `DeviceBuffer` with host-owned or non-POD types such as `String` or `Vec<T>`.

## Motivation

`DeviceBuffer<T>` currently copies raw bytes to and from CUDA device memory. Some APIs then materialize host values from those bytes using `Vec::set_len`.

That is only sound for plain device-copyable data. Before this change, the safe API accepted any `T`, including types with Rust ownership or drop semantics.

For example, this could compile:

```rust
let _ = DeviceBuffer::<String>::zeroed(stream, 1);
```
That is unsound because zeroed or device-written bytes are not a valid String. If such a value is copied back and dropped, Rust may attempt to free an invalid pointer.

## Failure Demonstration

I first added a compile-fail doctest showing that DeviceBuffer<String> should be rejected:

 
```compile_fail
/// # use cuda_core::{CudaStream, DeviceBuffer};
/// # fn rejects_non_device_copy(stream: &CudaStream) {
/// let _ = DeviceBuffer::<String>::zeroed(stream, 1);
/// # }
```

Before the fix, the doctest failed because the invalid code still compiled:
Test compiled successfully, but it's marked `compile_fail`.

After adding the DeviceCopy bound, the same doctest passes because String does not implement DeviceCopy.

## Implementation

  - Add unsafe marker trait DeviceCopy: Copy.
  - Implement DeviceCopy for primitive POD-like numeric types, arrays, tuples, raw pointers, and half-precision float types.
  - Move DeviceBuffer<T> allocation and transfer helpers behind impl<T: DeviceCopy>.
  - Keep raw-parts and metadata accessors available for all T.
  - Document the safety contract, including the requirement that all-zero initialization is valid because DeviceBuffer::zeroed writes zero bytes.
  - Add a compile-fail doctest covering DeviceBuffer<String>.

## Testing

  cargo fmt --check
  cargo clippy -p cuda-core -p cuda-host -p cuda-async -- -D warnings
  cargo test -p cuda-core
  cargo check
  cargo oxide build f16_stress --arch sm_75

