### PR TITLE
Propagate cuda-async synchronization errors

### DIFF
--- a/crates/cuda-async/src/device_box.rs
+++ b/crates/cuda-async/src/device_box.rs
@@ -20,6 +20,7 @@ use crate::error::DeviceError;
 use crate::launch::{AsyncKernelLaunch, KernelArgument};
 use cuda_bindings::CUdeviceptr;
 use cuda_core::memory::free_async;
+use std::io::{self, Write};
 use std::marker::PhantomData;
 
 /// Non-owning, `Copy` handle to a typed device allocation.
@@ -104,7 +105,9 @@ impl<T: Send + ?Sized> Drop for DeviceBox<T> {
         match result {
             Ok(Ok(())) => {}
             Ok(Err(err)) | Err(err) => {
-                eprintln!(
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    stderr,
                     "cuda-async: failed to enqueue async free for device pointer on device_id={}: {}",
                     self.device_id, err
                 );

--- a/crates/cuda-async/src/device_box.rs
+++ b/crates/cuda-async/src/device_box.rs
@@ -16,6 +16,7 @@
 //! streams that reference the allocation before dropping the box.
 
 use crate::device_context::with_deallocator_stream;
+use crate::error::DeviceError;
 use crate::launch::{AsyncKernelLaunch, KernelArgument};
 use cuda_bindings::CUdeviceptr;
 use cuda_core::memory::free_async;
@@ -87,23 +88,27 @@ unsafe impl<T: Send + ?Sized> Send for DeviceBox<T> {}
 /// value, which is safe to read from any thread.
 unsafe impl<T: Send + ?Sized> Sync for DeviceBox<T> {}
 
-/// Enqueues an asynchronous free on the device's deallocator stream.
+/// Best-effort enqueue of an asynchronous free on the device's deallocator
+/// stream.
 ///
-/// # Panics
-///
-/// Panics if the deallocator stream for `self.device_id` is unavailable.
+/// Drop cannot return errors, so failures to access the deallocator stream or
+/// enqueue the free are reported to stderr instead of panicking.
 impl<T: Send + ?Sized> Drop for DeviceBox<T> {
     fn drop(&mut self) {
-        unsafe {
+        let result = unsafe {
             with_deallocator_stream(self.device_id, |stream| {
-                let _ = free_async(self.cudptr, stream.cu_stream());
+                free_async(self.cudptr, stream.cu_stream()).map_err(DeviceError::Driver)
             })
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Failed to free device pointer on device_id={}",
-                    self.device_id
-                )
-            })
+        };
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) | Err(err) => {
+                eprintln!(
+                    "cuda-async: failed to enqueue async free for device pointer on device_id={}: {}",
+                    self.device_id, err
+                );
+            }
         }
     }
 }

--- a/crates/cuda-async/src/device_operation.rs
+++ b/crates/cuda-async/src/device_operation.rs
@@ -236,9 +236,17 @@ pub trait DeviceOperation:
     ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
         let ctx = ExecutionContext::new(Arc::clone(stream));
         let res = unsafe { self.execute(&ctx) };
-        stream.synchronize().expect("Synchronize failed.");
-        res
+        finish_sync(res, stream.synchronize())
     }
+}
+
+fn finish_sync<T>(
+    operation_result: Result<T, DeviceError>,
+    synchronize_result: Result<(), cuda_core::DriverError>,
+) -> Result<T, DeviceError> {
+    let output = operation_result?;
+    synchronize_result.map_err(DeviceError::Driver)?;
+    Ok(output)
 }
 
 // --- Combinators ---
@@ -881,6 +889,45 @@ where
 
 /// Blanket impl: any operation producing `(T0, T1)` is unzippable.
 impl<T0: Send, T1: Send, DI: DeviceOperation<Output = (T0, T1)>> Unzippable2<T0, T1> for DI {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finish_sync_returns_operation_result_after_successful_synchronize() {
+        let result = finish_sync::<u32>(Ok(7), Ok(()));
+
+        assert_eq!(result, Ok(7));
+    }
+
+    #[test]
+    fn finish_sync_preserves_operation_error_after_successful_synchronize() {
+        let operation_error = DeviceError::Launch("launch failed".to_string());
+        let result = finish_sync::<u32>(Err(operation_error.clone()), Ok(()));
+
+        assert_eq!(result, Err(operation_error));
+    }
+
+    #[test]
+    fn finish_sync_propagates_synchronize_error_instead_of_panicking() {
+        let driver_error =
+            cuda_core::DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+        let result = finish_sync::<u32>(Ok(7), Err(driver_error));
+
+        assert_eq!(result, Err(DeviceError::Driver(driver_error)));
+    }
+
+    #[test]
+    fn finish_sync_preserves_operation_error_when_synchronize_also_fails() {
+        let operation_error = DeviceError::Launch("launch failed".to_string());
+        let driver_error =
+            cuda_core::DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+        let result = finish_sync::<u32>(Err(operation_error.clone()), Err(driver_error));
+
+        assert_eq!(result, Err(operation_error));
+    }
+}
 
 /// Splits a tuple-producing [`DeviceOperation`] into per-element operations.
 ///


### PR DESCRIPTION
## Summary

  This PR changes `cuda-async` synchronous execution and async deallocation paths to report CUDA errors instead of panicking.

  - Convert `DeviceOperation::sync_on` stream synchronization failures into `DeviceError::Driver`.
  - Avoid panicking from `DeviceBox::drop` when deallocator stream lookup or `cuMemFreeAsync` enqueue fails.
  ## Motivation

  `DeviceOperation::sync_on` previously called:

  ```rust
  stream.synchronize().expect("Synchronize failed.");
```
  That means a CUDA stream synchronization failure could unwind through a safe API instead of being returned through the existing Result<_, DeviceError> surface.

  Before this change, the failure behavior was effectively:

  thread panicked at 'Synchronize failed.'

  This is especially undesirable because synchronization is where asynchronous CUDA errors are often surfaced.

  DeviceBox::drop also panicked if the async deallocator stream could not be accessed. Drop paths cannot return errors, so they should avoid panicking and report cleanup failures best-effort instead.

  ## Implementation

  - Add a small internal finish_sync helper that combines the operation result with the stream synchronization result.
  - Return Err(DeviceError::Driver(_)) when stream synchronization fails.
  - Preserve the existing behavior of synchronizing after operation execution.
  - Change DeviceBox::drop to log deallocator lookup or async free enqueue failures instead of panicking.

  ## Failure Demonstration

  A regression test covers the synchronization failure path directly:

  let driver_error = cuda_core::DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
  let result = finish_sync::<u32>(Ok(7), Err(driver_error));
  assert_eq!(result, Err(DeviceError::Driver(driver_error)));

  Before the fix, the equivalent sync_on path used .expect("Synchronize failed."), so this error case would panic instead of returning DeviceError.

  ## Testing

  cargo fmt --check
  cargo test -p cuda-async
  cargo clippy -p cuda-async -- -D warnings
  cargo check
