### PR TITLE
Respect nvcc host compiler overrides in FFI examples

### DIFF
--- a/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/README.md
+++ b/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/README.md
@@ -95,6 +95,13 @@ Device: NVIDIA GeForce RTX 5090 (sm_120)
 - LTOIR tools from `device_ffi_test/tools/` (built automatically by `run_test.sh`)
 - Blackwell+ GPU (sm_100+) — LTOIR requires NVVM 20 dialect
 
+If your default host compiler is newer than the CUDA Toolkit supports, set
+`NVCC_CCBIN` or `CUDAHOSTCXX` before running the example:
+
+```bash
+NVCC_CCBIN=/usr/bin/g++-15 cargo oxide run cpp_consumes_rust_device --emit-nvvm-ir --arch=sm_120
+```
+
 ## File Structure
 
 ```text

--- a/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/cuda-caller/run_test.sh
+++ b/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/cuda-caller/run_test.sh
@@ -25,6 +25,11 @@ set -e
 
 ARCH="${1:-sm_120}"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+NVCC_CCBIN="${NVCC_CCBIN:-${CUDAHOSTCXX:-}}"
+NVCC_FLAGS=()
+if [[ -n "$NVCC_CCBIN" ]]; then
+    NVCC_FLAGS+=("-ccbin=$NVCC_CCBIN")
+fi
 
 # Paths
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -38,6 +43,9 @@ MERGED_CUBIN="$EXAMPLE_DIR/merged.cubin"
 
 echo "=== Phase 2: C++ calling Rust device functions via LTOIR ==="
 echo "Arch: $ARCH"
+if [[ -n "$NVCC_CCBIN" ]]; then
+    echo "nvcc host compiler: $NVCC_CCBIN"
+fi
 echo ""
 
 # ---- Step 0: Check prerequisites ----
@@ -64,7 +72,8 @@ echo ""
 # ---- Step 3: Compile C++ caller kernel → LTOIR ----
 echo "--- Compiling C++ caller kernel → LTOIR (nvcc) ---"
 COMPUTE="compute_${ARCH#sm_}"
-nvcc -dc \
+nvcc "${NVCC_FLAGS[@]}" \
+     -dc \
      --keep \
      -gencode "arch=${COMPUTE},code=lto_${ARCH#sm_}" \
      "$SCRIPT_DIR/caller_kernel.cu" \
@@ -83,7 +92,7 @@ echo ""
 
 # ---- Step 5: Build test runner ----
 echo "--- Building C++ test runner ---"
-nvcc -o "$SCRIPT_DIR/test_runner" "$SCRIPT_DIR/test_runner.cu" -lcuda
+nvcc "${NVCC_FLAGS[@]}" -o "$SCRIPT_DIR/test_runner" "$SCRIPT_DIR/test_runner.cu" -lcuda
 echo "  ✓ test_runner built"
 echo ""
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
@@ -14,6 +14,15 @@ code through LTOIR linking to GPU execution is fully working.
 cargo oxide run device_ffi_test --emit-nvvm-ir --arch=<your_arch>  # e.g., sm_120
 ```
 
+If your default host compiler is newer than the CUDA Toolkit supports, choose
+one explicitly for the `nvcc` steps:
+
+```bash
+NVCC_CCBIN=/usr/bin/g++-15 cargo oxide run device_ffi_test --emit-nvvm-ir --arch=sm_120
+```
+
+`CUDAHOSTCXX` is also honored as a fallback when `NVCC_CCBIN` is unset.
+
 > **Note:** The `--emit-nvvm-ir` and `--arch=<your_arch>` flags are **required** for this example.
 > Running without these flags will result in a compilation error because device FFI
 > requires LTOIR linking which needs NVVM IR output. A proper error message for this

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/build_ltoir.sh
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/build_ltoir.sh
@@ -21,7 +21,17 @@ set -e  # Exit on any error
 
 # Parse architecture argument (default: sm_120 for Blackwell)
 ARCH="${1:-sm_120}"
+CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+NVCC_CCBIN="${NVCC_CCBIN:-${CUDAHOSTCXX:-}}"
+NVCC_FLAGS=()
+if [[ -n "$NVCC_CCBIN" ]]; then
+    NVCC_FLAGS+=("-ccbin=$NVCC_CCBIN")
+fi
+
 echo "Building for architecture: $ARCH"
+if [[ -n "$NVCC_CCBIN" ]]; then
+    echo "nvcc host compiler: $NVCC_CCBIN"
+fi
 echo ""
 
 # Setup nvvm-tools path for nvvm-dis (converts binary LTOIR to text)
@@ -50,7 +60,7 @@ compile_ltoir() {
 
     echo "=== Compiling $src ==="
     # -dc: relocatable device code, -dlto: device LTO, --keep: retain .ltoir
-    nvcc -arch=$ARCH -dc -dlto --keep $extra_flags "$src" -o "${base}.o" 2>&1
+    nvcc "${NVCC_FLAGS[@]}" -arch=$ARCH -dc -dlto --keep $extra_flags "$src" -o "${base}.o" 2>&1
 
     if [ -f "${base}.ltoir" ]; then
         echo "  Binary LTOIR: ${base}.ltoir ($(wc -c < ${base}.ltoir) bytes)"
@@ -72,7 +82,7 @@ compile_ltoir "external_device_funcs.cu"
 
 # Compile CCCL wrappers (needs CCCL include path)
 if [ -f "cccl_wrappers.cu" ]; then
-    compile_ltoir "cccl_wrappers.cu" "-I/usr/local/cuda/include/cccl"
+    compile_ltoir "cccl_wrappers.cu" "-I${CUDA_HOME}/include/cccl"
 fi
 
 # Clean up intermediate files

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/build_tools.sh
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/build_tools.sh
@@ -11,9 +11,17 @@
 set -e
 
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+NVCC_CCBIN="${NVCC_CCBIN:-${CUDAHOSTCXX:-}}"
+NVCC_FLAGS=()
+if [[ -n "$NVCC_CCBIN" ]]; then
+    NVCC_FLAGS+=("-ccbin=$NVCC_CCBIN")
+fi
 
 echo "=== Building Device FFI Tools ==="
 echo "CUDA_HOME: $CUDA_HOME"
+if [[ -n "$NVCC_CCBIN" ]]; then
+    echo "nvcc host compiler: $NVCC_CCBIN"
+fi
 echo ""
 
 # Build compile_ltoir (libNVVM)
@@ -34,7 +42,7 @@ echo "  ✓ link_ltoir"
 
 # Build launch_cubin (CUDA Driver API)
 echo "Building launch_cubin..."
-nvcc -o launch_cubin launch_cubin.cu -lcuda
+nvcc "${NVCC_FLAGS[@]}" -o launch_cubin launch_cubin.cu -lcuda
 echo "  ✓ launch_cubin"
 
 echo ""

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/README.md
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/README.md
@@ -19,6 +19,13 @@ compiles them to LTOIR, and links them with cuda-oxide generated code.
 2. **MathDx Library** - Download from: https://developer.nvidia.com/cublasdx-downloads
 3. **cuda-oxide compiler** toolchain
 
+If your default host compiler is newer than the CUDA Toolkit supports, set
+`NVCC_CCBIN` or `CUDAHOSTCXX` before running the example:
+
+```bash
+NVCC_CCBIN=/usr/bin/g++-15 cargo oxide run mathdx_ffi_test --emit-nvvm-ir --arch=sm_120
+```
+
 ## Directory Structure
 
 ```text

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/extern-libs/build.sh
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/extern-libs/build.sh
@@ -77,6 +77,14 @@ echo "Architecture: $ARCH"
 echo "Build test:   $BUILD_TEST"
 echo ""
 
+NVCC_CCBIN="${NVCC_CCBIN:-${CUDAHOSTCXX:-}}"
+NVCC_FLAGS=()
+if [[ -n "$NVCC_CCBIN" ]]; then
+    NVCC_FLAGS+=("-ccbin=$NVCC_CCBIN")
+    echo "nvcc host compiler: $NVCC_CCBIN"
+    echo ""
+fi
+
 # =============================================================================
 # Clean if requested
 # =============================================================================
@@ -141,7 +149,7 @@ compile_ltoir() {
     # -dc: relocatable device code, -dlto: device LTO, --keep: retain .ltoir
     # --expt-relaxed-constexpr: REQUIRED for cuBLASDx - enables constexpr in device code
     # -Wno-deprecated-declarations: suppress MathDx deprecation warnings
-    nvcc -arch=$ARCH -dc -dlto --keep -std=c++17 --expt-relaxed-constexpr \
+    nvcc "${NVCC_FLAGS[@]}" -arch=$ARCH -dc -dlto --keep -std=c++17 --expt-relaxed-constexpr \
         -Wno-deprecated-declarations \
         -I"${MATHDX_INCLUDE}" -I"${CUTLASS_INCLUDE}" \
         $extra_flags "$src" -o "${base}.o" 2>&1
@@ -219,7 +227,7 @@ if [ "$BUILD_TEST" = true ]; then
         if [ -f "test_separate.cu" ]; then
             echo ""
             echo "=== Building test_separate host program ==="
-            nvcc -arch=$ARCH test_separate.cu -o test_separate -lcuda
+            nvcc "${NVCC_FLAGS[@]}" -arch=$ARCH test_separate.cu -o test_separate -lcuda
             echo "  Created: test_separate"
             echo ""
             echo "Run './test_separate' to validate CUDA C++ extern calls"


### PR DESCRIPTION
## Summary

Some FFI examples call `nvcc` directly from shell helper scripts. On systems where the default host compiler is newer than the installed CUDA Toolkit supports, those examples fail unless users know to rely on `nvcc`-specific escape hatches like `NVCC_PREPEND_FLAGS`.

This makes the FFI scripts honor `NVCC_CCBIN`, falling back to `CUDAHOSTCXX`, and passes the selected compiler to `nvcc` as `-ccbin=...`. The selected compiler is printed when set, so the build log makes it clear which host compiler `nvcc` is using.

This updates the direct `nvcc` call sites in:

- `device_ffi_test`
- `cpp_consumes_rust_device`
- `mathdx_ffi_test`

It also documents the override in the matching READMEs and uses `CUDA_HOME` for `device_ffi_test`'s CCCL include path instead of hardcoding `/usr/local/cuda`.

## Test plan

Tested on RTX 5080 (`sm_120`), CUDA 13.2, Fedora 44, with `NVCC_CCBIN=/usr/bin/g++-15`.

- `NVCC_CCBIN=/usr/bin/g++-15 scripts/smoketest.sh --keep-logs -o '^(device_ffi_test|cpp_consumes_rust_device|mathdx_ffi_test)$'`
- Force rebuilt `device_ffi_test/tools`, then:
  `NVCC_CCBIN=/usr/bin/g++-15 cargo oxide run device_ffi_test --emit-nvvm-ir --arch=sm_120`
- `cd crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/cuda-caller && NVCC_CCBIN=/usr/bin/g++-15 ./run_test.sh sm_120`
- `bash -n` on all edited scripts
- `cargo fmt --check`
