### PR TITLE
during cargo oxide new adjust the name passed to load_kernel_module by converting - to _, to prevent NoArtifact

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -1002,6 +1002,8 @@ cuda-core = {{ git = "{GIT_REPO}" }}
         )
     };
 
+    let adjusted_file_name = name.replace("-", "_");
+
     let main_rs = if async_mode {
         format!(
             r#"use cuda_device::{{kernel, thread, DisjointSlice}};
@@ -1025,10 +1027,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {{
     use std::mem;
 
     init_device_contexts(0, 1)?;
-    // Loads `{name}.ptx` directly when cuda-oxide produced PTX, or builds a
-    // cubin from `{name}.ll` when cuda-oxide auto-detected libdevice math
+    // Loads `{adjusted_file_name}.ptx` directly when cuda-oxide produced PTX, or builds a
+    // cubin from `{adjusted_file_name}.ll` when cuda-oxide auto-detected libdevice math
     // (`sin`, `pow`, `exp`, ...). Requires CUDA Toolkit on the host.
-    let module = load_kernel_module_async("{name}", 0)?;
+    let module = load_kernel_module_async("{adjusted_file_name}", 0)?;
 
     const N: usize = 1024;
     let a_host: Vec<f32> = (0..N).map(|i| i as f32).collect();
@@ -1116,10 +1118,10 @@ fn main() {{
     let b_dev = DeviceBuffer::from_host(&stream, &b_host).unwrap();
     let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-    // Loads `{name}.ptx` directly when cuda-oxide produced PTX, or builds a
-    // cubin from `{name}.ll` when cuda-oxide auto-detected libdevice math
+    // Loads `{adjusted_file_name}.ptx` directly when cuda-oxide produced PTX, or builds a
+    // cubin from `{adjusted_file_name}.ll` when cuda-oxide auto-detected libdevice math
     // (`sin`, `pow`, `exp`, ...). Requires CUDA Toolkit on the host.
-    let module = load_kernel_module(&ctx, "{name}")
+    let module = load_kernel_module(&ctx, "{adjusted_file_name}")
         .expect("Failed to load kernel module");
 
     cuda_launch! {{


### PR DESCRIPTION
`cargo oxide new a-b` generates a main.rs containing the code `load_kernel_module(&ctx, "a-b")` .  This fails at runtime because the generated .ptx file will be named a_b.ptx.

This adjustment seems to solve the problem for me.  I do not know if similar problems exist elsewhere in the code.
