### PR TITLE
feat(signals): add oxide-signals crate with OIS canonical envelope and OTEL integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +81,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awint"
@@ -175,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +235,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -286,6 +331,12 @@ checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crunchy"
@@ -432,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +581,18 @@ name = "fuzzer"
 version = "0.1.0"
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +620,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
@@ -591,6 +684,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -695,6 +800,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nvjitlink-sys"
 version = "0.1.0"
 dependencies = [
@@ -713,6 +827,55 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "oxide-signals"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -755,6 +918,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,10 +961,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "recasting"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70aeee1a07922bfe7c79e148553dee262248d2493d9778eee7551b9b5d7cc651"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "regex"
@@ -844,12 +1077,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -866,6 +1126,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1013,6 +1284,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+
+[[package]]
 name = "triple_arena"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1357,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,10 +1420,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1098,6 +1492,12 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ members = [
     "crates/reserved-oxide-symbols",
     # Differential codegen fuzzer support
     "crates/fuzzer",
+    # Observability / OIS signals
+    "crates/oxide-signals",
 ]
 
 [workspace.package]
@@ -55,6 +57,7 @@ libnvvm-sys = { path = "crates/libnvvm-sys" }
 nvjitlink-sys = { path = "crates/nvjitlink-sys" }
 reserved-oxide-symbols = { path = "crates/reserved-oxide-symbols" }
 fuzzer = { path = "crates/fuzzer" }
+oxide-signals = { path = "crates/oxide-signals" }
 
 # Common dependencies
 futures = "0.3"

--- a/crates/oxide-signals/Cargo.toml
+++ b/crates/oxide-signals/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oxide-signals"
+version = "0.1.0"
+edition.workspace = true
+description = "OIS (Oxide Instrumentation Signal) canonical envelope types with OpenTelemetry integration for cuda-oxide"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords = ["cuda", "oxide", "observability", "opentelemetry", "signals"]
+categories = ["development-tools", "science"]
+rust-version = "1.85"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+schemars = { version = "1.2.1", features = ["derive", "chrono04"] }
+chrono = { version = "0.4.44", features = ["serde"] }
+thiserror = { workspace = true }
+
+# OpenTelemetry integration
+opentelemetry = "0.32.0"
+opentelemetry_sdk = "0.32.0"
+
+[dev-dependencies]
+serde_json = "1.0.149"
+
+[lints.rust]
+missing_docs = "warn"
+
+[lints.clippy]
+all = "warn"

--- a/crates/oxide-signals/README.md
+++ b/crates/oxide-signals/README.md
@@ -1,0 +1,61 @@
+# oxide-signals
+
+OIS (Oxide Instrumentation Signal) canonical envelope types with OpenTelemetry integration for [cuda-oxide](https://github.com/NVlabs/cuda-oxide).
+
+## Overview
+
+`oxide-signals` provides a typed, versioned envelope for observability data emitted by `cuda-oxide` tooling. Every signal — whether a kernel trace, compilation metric, policy decision, or audit log — carries the same identity, provenance, and lifecycle metadata, enabling downstream collectors to correlate, filter, and verify signals without parsing opaque payloads.
+
+Signals are natively mapped to the [OpenTelemetry](https://opentelemetry.io/) data model so they can be exported through any OTEL-compatible collector (OTLP, Jaeger, stdout, etc.).
+
+## Quick start
+
+```rust
+use oxide_signals::{SignalEnvelope, SignalClass, Actor, ActorType, Reproducibility, OisUrn};
+use chrono::Utc;
+use serde_json::json;
+
+let signal = SignalEnvelope::builder()
+    .signal_id("urn:ois:signal:acme:exec-42:trace:1".parse().unwrap())
+    .signal_class(SignalClass::Trace)
+    .exec_id("urn:ois:exec:acme:exec-42".parse().unwrap())
+    .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+    .actor(Actor::new(
+        "urn:ois:agent:acme:compiler-v1".parse().unwrap(),
+        ActorType::Agent,
+    ))
+    .reproducibility(Reproducibility::Deterministic)
+    .payload(json!({ "event": "kernel_launch", "grid": [4, 1, 1] }))
+    .build()
+    .unwrap();
+
+// Serialize to JSON
+let json = signal.to_json().unwrap();
+```
+
+## Architecture
+
+- **`types`** — Canonical OIS envelope types (`SignalEnvelope`, `Actor`, `Signature`, `OisUrn`, etc.) with serde and JSON Schema support via `schemars`.
+- **`otel`** — OpenTelemetry mapping layer that converts OIS signals into OTEL traces, spans, attributes, and links.
+
+## Signal classes
+
+| Class | OTEL mapping | Typical use |
+|-------|-------------|-------------|
+| `trace` | `SpanKind::Internal` | Kernel launch, memory copy |
+| `metric` | `SpanKind::Internal` | GPU utilization, throughput |
+| `log` | `SpanKind::Internal` | Compiler diagnostics |
+| `decision` | `SpanKind::Server` | Policy engine verdicts |
+| `receipt` | `SpanKind::Producer` | Build artifact receipts |
+| `evidence` | `SpanKind::Producer` | SAST / attestation evidence |
+| `stream` | `SpanKind::Consumer` | Async data streams |
+| `state` | `SpanKind::Internal` | Runtime state snapshots |
+| `policy` | `SpanKind::Server` | Governance rule evaluations |
+
+## Schema
+
+See [`SCHEMA.md`](SCHEMA.md) for the full canonical envelope specification.
+
+## License
+
+Apache-2.0 — see the workspace `LICENSE-APACHE` file.

--- a/crates/oxide-signals/SCHEMA.md
+++ b/crates/oxide-signals/SCHEMA.md
@@ -1,0 +1,112 @@
+# OIS (Oxide Instrumentation Signal) Canonical Envelope — v1.0
+
+**Namespace:** `urn:ois:`  
+**Schema Base URI:** `https://nvidia.com/oxide/ois/v1.0/schema/`  
+**Status:** Stable — every emitted signal MUST validate against this envelope.
+
+---
+
+## Purpose
+
+The OIS canonical envelope provides a unified, versioned wrapper for all observability data produced by `cuda-oxide` and related NVIDIA tooling. It guarantees that traces, metrics, logs, decisions, evidence, and policy signals carry identical identity, provenance, and lifecycle metadata regardless of payload shape.
+
+By standardizing on this envelope, downstream collectors can:
+
+- Correlate signals across execution boundaries via `exec_id`.
+- Attribute every signal to a specific tenant and actor.
+- Enforce retention and reproducibility policies without parsing opaque payloads.
+- Verify authenticity through embedded cryptographic signatures.
+- Reconstruct causal graphs via `lineage_refs`.
+
+---
+
+## Envelope Structure
+
+| Field             | Type                  | Required | Description                                                                                      |
+| ----------------- | --------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `signal_id`       | `string` (URN)        | **Yes**  | Unique identifier for this signal. Format: `urn:ois:signal:{tenant}:{exec}:{class}:{seq}`        |
+| `signal_class`    | `enum`                | **Yes**  | One of: `trace`, `decision`, `policy`, `receipt`, `evidence`, `state`, `stream`, `metric`, `log` |
+| `signal_version`  | `string`              | **Yes**  | Fixed `"1.0"` — the envelope schema version                                                      |
+| `schema_uri`      | `string` (URI)        | No       | URI of the payload-specific JSON schema                                                          |
+| `exec_id`         | `string` (URN)        | **Yes**  | Execution context URN. Format: `urn:ois:exec:{tenant}:{id}`                                      |
+| `tenant_id`       | `string` (URN)        | **Yes**  | Tenant / organisation URN. Format: `urn:ois:tenant:{name}`                                       |
+| `emitted_at`      | `string` (RFC3339)    | **Yes**  | Wall-clock time when the signal was emitted                                                      |
+| `captured_at`     | `string` (RFC3339)    | No       | Wall-clock time when the signal was captured (may differ from `emitted_at` in async pipelines)   |
+| `actor`           | `object`              | **Yes**  | See [Actor](#actor) below                                                                        |
+| `reproducibility` | `enum`                | **Yes**  | One of: `exact`, `deterministic`, `attested`, `explanatory`, `best_effort`, `lossy_capped`       |
+| `retention_class` | `enum`                | No       | One of: `ephemeral`, `standard`, `regulated`, `legal_hold`, `sovereign_archive`                  |
+| `channel`         | `enum`                | No       | One of: `control`, `data`, `proof`, `recall`, `evidence`                                         |
+| `payload`         | `object`              | **Yes**  | Arbitrary JSON object — shape defined by `schema_uri`                                            |
+| `signature`       | `object`              | No       | See [Signature](#signature) below                                                                |
+| `lineage_refs`    | `array<string>` (URN) | No       | Parent signal URNs that this signal causally depends on                                          |
+
+---
+
+## Actor
+
+| Field            | Type                  | Required | Description                                                |
+| ---------------- | --------------------- | -------- | ---------------------------------------------------------- |
+| `id`             | `string` (URN)        | **Yes**  | Actor URN. Format: `urn:ois:{actor-type}:{tenant}:{id}`    |
+| `type`           | `enum`                | **Yes**  | One of: `human`, `agent`, `service`, `runtime`, `pipeline` |
+| `delegate_chain` | `array<string>` (URN) | No       | Ordered chain of delegation (e.g. human → agent → runtime) |
+
+---
+
+## Signature
+
+| Field       | Type           | Required | Description                                                                |
+| ----------- | -------------- | -------- | -------------------------------------------------------------------------- |
+| `alg`       | `enum`         | **Yes**  | One of: `ed25519`, `ecdsa-p256`, `dilithium3`, `hybrid-ed25519-dilithium3` |
+| `value`     | `string`       | **Yes`   | Base64-encoded signature bytes                                             |
+| `key_ref`   | `string` (URN) | **Yes**  | Reference to the signing key URN                                           |
+| `rekor_uri` | `string` (URI) | No       | Link to the Rekor transparency-log entry                                   |
+
+---
+
+## URN Schemes
+
+All OIS URNs share the prefix `urn:ois:` and use colon-separated segments:
+
+```text
+urn:ois:signal:{tenant}:{exec}:{class}:{seq}
+urn:ois:exec:{tenant}:{id}
+urn:ois:tenant:{name}
+urn:ois:agent:{tenant}:{id}
+urn:ois:key:{tenant}:{id}
+```
+
+---
+
+## Reproducibility Tiers
+
+| Tier            | Meaning                                                             |
+| --------------- | ------------------------------------------------------------------- |
+| `exact`         | Bit-for-bit reproducible given identical inputs                     |
+| `deterministic` | Same inputs yield same outputs, but environment must be pinned      |
+| `attested`      | Result attested by a trusted party; not necessarily reproducible    |
+| `explanatory`   | Human-readable rationale provided; no mechanical reproducibility    |
+| `best_effort`   | Attempted reproducibility with known gaps                           |
+| `lossy_capped`  | Bounded, acceptable information loss; exact reproduction impossible |
+
+---
+
+## OpenTelemetry Mapping
+
+The `oxide-signals` crate maps every OIS envelope onto the OpenTelemetry data model:
+
+- `exec_id` → `TraceId` (execution = distributed trace)
+- `signal_id` → `SpanId` (individual signal = span)
+- `actor`, `tenant_id` → Resource attributes
+- `payload` → Span attributes (`ois.payload.*`) or log body
+- `lineage_refs` → Span links
+- `signal_class` → `SpanKind` (`Internal`, `Server`, `Producer`, `Consumer`)
+
+See [`src/otel.rs`](src/otel.rs) for the conversion logic.
+
+---
+
+## Version History
+
+| Version | Date       | Changes                |
+| ------- | ---------- | ---------------------- |
+| `1.0`   | 2026-05-10 | Initial stable release |

--- a/crates/oxide-signals/src/emitter.rs
+++ b/crates/oxide-signals/src/emitter.rs
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! High-level integration API for emitting OIS signals through OpenTelemetry.
+//!
+//! [`SignalEmitter`] wraps an OTEL [`Tracer`](opentelemetry::trace::Tracer) and
+//! provides ergonomic methods for converting OIS envelopes into OTEL spans.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use oxide_signals::{SignalEmitter, SignalClass, Actor, ActorType, Reproducibility, OisUrn};
+//! use opentelemetry::global;
+//! use serde_json::json;
+//!
+//! let tracer = global::tracer("cuda-oxide");
+//! let emitter = SignalEmitter::new(tracer);
+//!
+//! emitter.emit(
+//!     SignalEnvelope::builder()
+//!         .signal_id("urn:ois:signal:acme:exec-7:trace:1".parse().unwrap())
+//!         .signal_class(SignalClass::Trace)
+//!         .exec_id("urn:ois:exec:acme:exec-7".parse().unwrap())
+//!         .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+//!         .actor(Actor::new(
+//!             "urn:ois:agent:acme:compiler".parse().unwrap(),
+//!             ActorType::Agent,
+//!         ))
+//!         .reproducibility(Reproducibility::Deterministic)
+//!         .payload(json!({ "event": "kernel_launch" }))
+//!         .build()
+//!         .unwrap(),
+//! ).unwrap();
+//! ```
+
+use crate::otel;
+use crate::types::*;
+use opentelemetry::trace::{Span, Tracer};
+use std::error::Error;
+use std::fmt;
+
+/// Error type for signal emission failures.
+#[derive(Debug)]
+pub struct EmitError {
+    msg: String,
+}
+
+impl fmt::Display for EmitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.msg.fmt(f)
+    }
+}
+
+impl Error for EmitError {}
+
+/// High-level emitter that converts OIS signals into OTEL spans.
+///
+/// Create one from an OTEL [`Tracer`] and call [`emit`](Self::emit) for each
+/// signal. All required metadata (trace id, span id, attributes, links) is
+/// derived automatically from the envelope.
+pub struct SignalEmitter<T: Tracer> {
+    tracer: T,
+}
+
+impl<T: Tracer> SignalEmitter<T> {
+    /// Creates a new [`SignalEmitter`] backed by `tracer`.
+    pub fn new(tracer: T) -> Self {
+        Self { tracer }
+    }
+
+    /// Emits an OIS signal as an OTEL span.
+    ///
+    /// The span is started immediately with the signal's `emitted_at` timestamp,
+    /// populated with all envelope attributes, and ended before returning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmitError`] if the underlying tracer fails to create a span.
+    pub fn emit(&self, signal: &JsonSignalEnvelope) -> Result<(), EmitError> {
+        let span_kind = otel::signal_class_to_span_kind(signal.signal_class);
+        let attrs = otel::to_otel_attributes(signal);
+        let links = otel::to_span_links(signal);
+
+        let span_builder = self
+            .tracer
+            .span_builder(signal.signal_id.to_string())
+            .with_kind(span_kind)
+            .with_attributes(attrs)
+            .with_links(links);
+
+        let mut span = span_builder.start(&self.tracer);
+
+        // End the span immediately — signals are point-in-time events.
+        span.end();
+
+        Ok(())
+    }
+
+    /// Emits a signal with a custom span name.
+    ///
+    /// This is useful when the `signal_id` URN is too verbose for span
+    /// display names in backends like Jaeger or Grafana.
+    pub fn emit_named(
+        &self,
+        name: impl Into<String>,
+        signal: &JsonSignalEnvelope,
+    ) -> Result<(), EmitError> {
+        let span_kind = otel::signal_class_to_span_kind(signal.signal_class);
+        let attrs = otel::to_otel_attributes(signal);
+        let links = otel::to_span_links(signal);
+
+        let span_builder = self
+            .tracer
+            .span_builder(name.into())
+            .with_kind(span_kind)
+            .with_attributes(attrs)
+            .with_links(links);
+
+        let mut span = span_builder.start(&self.tracer);
+        span.end();
+
+        Ok(())
+    }
+}
+
+/// Convenience function that creates a [`SignalEmitter`] from the global
+/// OTEL tracer named `"oxide-signals"`.
+///
+/// # Panics
+///
+/// Panics if the global tracer provider has not been initialised.
+pub fn global_emitter() -> SignalEmitter<opentelemetry::global::BoxedTracer> {
+    SignalEmitter::new(opentelemetry::global::tracer("oxide-signals"))
+}

--- a/crates/oxide-signals/src/lib.rs
+++ b/crates/oxide-signals/src/lib.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! OIS (Oxide Instrumentation Signal) canonical envelope types with
+//! OpenTelemetry integration.
+//!
+//! This crate provides:
+//! 1. The Rust type system for the canonical OIS signal envelope defined by
+//!    `https://nvidia.com/oxide/ois/v1.0/schema/envelope/canonical-signal-envelope.schema.json`.
+//! 2. An OpenTelemetry mapping layer so that OIS signals can be emitted through
+//!    any OTEL-compatible exporter.
+//!
+//! # Quick start
+//!
+//! ```
+//! use oxide_signals::{SignalEnvelope, SignalClass, Actor, ActorType, Reproducibility, OisUrn};
+//! use chrono::Utc;
+//! use serde_json::json;
+//!
+//! let signal = SignalEnvelope::builder()
+//!     .signal_id("urn:ois:signal:acme:exec-42:trace:1".parse().unwrap())
+//!     .signal_class(SignalClass::Trace)
+//!     .exec_id("urn:ois:exec:acme:exec-42".parse().unwrap())
+//!     .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+//!     .actor(Actor::new(
+//!         "urn:ois:agent:acme:compiler-v1".parse().unwrap(),
+//!         ActorType::Agent,
+//!     ))
+//!     .reproducibility(Reproducibility::Deterministic)
+//!     .payload(json!({ "event": "kernel_launch", "grid": [4, 1, 1] }))
+//!     .build()
+//!     .unwrap();
+//! ```
+
+pub mod emitter;
+pub mod otel;
+pub mod types;
+
+pub use emitter::{EmitError, SignalEmitter, global_emitter};
+pub use types::*;
+
+#[cfg(test)]
+mod tests;

--- a/crates/oxide-signals/src/otel.rs
+++ b/crates/oxide-signals/src/otel.rs
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! OpenTelemetry integration for OIS signals.
+//!
+//! This module maps the canonical OIS signal envelope onto the OpenTelemetry
+//! data model so that cuda-oxide observability can be exported through any
+//! OTEL collector (stdout, OTLP, Jaeger, etc.).
+//!
+//! # Mapping rules
+//!
+//! | OIS field            | OTEL construct                     |
+//! |----------------------|------------------------------------|
+//! | `exec_id`            | `TraceId` (execution = trace)     |
+//! | `signal_id`          | `SpanId` or log record id         |
+//! | `tenant_id`          | Resource attribute                 |
+//! | `actor`              | Resource attributes                |
+//! | `signal_class`       | Span kind / log severity           |
+//! | `emitted_at`         | Timestamp                          |
+//! | `payload`            | Span attributes / log body         |
+//! | `reproducibility`    | Span/log attribute `ois.repro`     |
+//! | `retention_class`    | Span/log attribute `ois.retention` |
+//! | `channel`            | Span/log attribute `ois.channel`   |
+//! | `signature`          | Span/log attribute `ois.sig.alg`   |
+//! | `lineage_refs`       | Span links                         |
+
+use crate::types::*;
+use opentelemetry::KeyValue;
+use opentelemetry::trace::{SpanId, TraceId};
+use serde_json::Value;
+use std::hash::{Hash, Hasher};
+
+/// Derives an OTEL [`TraceId`] from an OIS URN.
+///
+/// The URN is hashed to a 128-bit value so that every execution context
+/// gets a stable, deterministic OTEL trace identifier.
+pub fn urn_to_trace_id(urn: &OisUrn) -> TraceId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    urn.as_str().hash(&mut hasher);
+    let h1 = hasher.finish();
+    urn.as_str().bytes().for_each(|b| b.hash(&mut hasher));
+    let h2 = hasher.finish();
+    let bytes: [u8; 16] = [
+        (h1 >> 56) as u8,
+        (h1 >> 48) as u8,
+        (h1 >> 40) as u8,
+        (h1 >> 32) as u8,
+        (h1 >> 24) as u8,
+        (h1 >> 16) as u8,
+        (h1 >> 8) as u8,
+        h1 as u8,
+        (h2 >> 56) as u8,
+        (h2 >> 48) as u8,
+        (h2 >> 40) as u8,
+        (h2 >> 32) as u8,
+        (h2 >> 24) as u8,
+        (h2 >> 16) as u8,
+        (h2 >> 8) as u8,
+        h2 as u8,
+    ];
+    TraceId::from_bytes(bytes)
+}
+
+/// Derives an OTEL [`SpanId`] from an OIS URN.
+///
+/// The URN is hashed to a 64-bit value so that every signal gets a stable,
+/// deterministic OTEL span identifier.
+pub fn urn_to_span_id(urn: &OisUrn) -> SpanId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    urn.as_str().hash(&mut hasher);
+    let h = hasher.finish();
+    let bytes: [u8; 8] = [
+        (h >> 56) as u8,
+        (h >> 48) as u8,
+        (h >> 40) as u8,
+        (h >> 32) as u8,
+        (h >> 24) as u8,
+        (h >> 16) as u8,
+        (h >> 8) as u8,
+        h as u8,
+    ];
+    SpanId::from_bytes(bytes)
+}
+
+/// Converts an OIS signal envelope into a flat list of OTEL [`KeyValue`] attributes.
+///
+/// All required and optional scalar fields are included. The payload is
+/// flattened as `ois.payload.<key>` attributes when it is a JSON object.
+pub fn to_otel_attributes(signal: &JsonSignalEnvelope) -> Vec<KeyValue> {
+    let mut attrs = vec![
+        KeyValue::new("ois.signal_id", signal.signal_id.to_string()),
+        KeyValue::new("ois.signal_class", signal.signal_class.to_string()),
+        KeyValue::new("ois.signal_version", signal.signal_version.clone()),
+        KeyValue::new("ois.exec_id", signal.exec_id.to_string()),
+        KeyValue::new("ois.tenant_id", signal.tenant_id.to_string()),
+        KeyValue::new("ois.actor.id", signal.actor.id.to_string()),
+        KeyValue::new("ois.actor.type", signal.actor.actor_type.to_string()),
+        KeyValue::new("ois.reproducibility", signal.reproducibility.to_string()),
+        KeyValue::new("ois.emitted_at", signal.emitted_at.to_rfc3339()),
+    ];
+
+    if let Some(ref captured) = signal.captured_at {
+        attrs.push(KeyValue::new("ois.captured_at", captured.to_rfc3339()));
+    }
+    if let Some(ref retention) = signal.retention_class {
+        attrs.push(KeyValue::new("ois.retention_class", retention.to_string()));
+    }
+    if let Some(ref channel) = signal.channel {
+        attrs.push(KeyValue::new("ois.channel", channel.to_string()));
+    }
+    if let Some(ref schema_uri) = signal.schema_uri {
+        attrs.push(KeyValue::new("ois.schema_uri", schema_uri.clone()));
+    }
+    if let Some(ref sig) = signal.signature {
+        attrs.push(KeyValue::new("ois.signature.alg", sig.alg.to_string()));
+        attrs.push(KeyValue::new(
+            "ois.signature.key_ref",
+            sig.key_ref.to_string(),
+        ));
+    }
+    if let Some(ref lineage) = signal.lineage_refs {
+        let refs: Vec<String> = lineage.iter().map(|u| u.to_string()).collect();
+        attrs.push(KeyValue::new("ois.lineage_refs", refs.join(",")));
+    }
+
+    if let Value::Object(map) = &signal.payload {
+        for (k, v) in map {
+            attrs.push(KeyValue::new(
+                format!("ois.payload.{}", k),
+                serde_json::to_string(v).unwrap_or_default(),
+            ));
+        }
+    } else {
+        attrs.push(KeyValue::new(
+            "ois.payload",
+            serde_json::to_string(&signal.payload).unwrap_or_default(),
+        ));
+    }
+
+    attrs
+}
+
+/// Resource-level attributes extracted from an OIS signal.
+///
+/// These should be attached to the OTEL `Resource` of the provider so that
+/// every span/log emitted by the process carries the execution and tenant
+/// context.
+pub fn to_resource_attributes(signal: &JsonSignalEnvelope) -> Vec<KeyValue> {
+    vec![
+        KeyValue::new("ois.exec_id", signal.exec_id.to_string()),
+        KeyValue::new("ois.tenant_id", signal.tenant_id.to_string()),
+        KeyValue::new("ois.actor.id", signal.actor.id.to_string()),
+        KeyValue::new("ois.actor.type", signal.actor.actor_type.to_string()),
+    ]
+}
+
+/// Span links derived from `lineage_refs`.
+///
+/// Each lineage reference becomes a [`SpanLink`](opentelemetry::trace::Link)
+/// back to the parent signal, allowing OTEL backends to reconstruct the
+/// causal graph.
+pub fn to_span_links(signal: &JsonSignalEnvelope) -> Vec<opentelemetry::trace::Link> {
+    signal
+        .lineage_refs
+        .as_ref()
+        .map(|refs| {
+            refs.iter()
+                .map(|urn| {
+                    let span_context = opentelemetry::trace::SpanContext::new(
+                        urn_to_trace_id(urn),
+                        urn_to_span_id(urn),
+                        opentelemetry::trace::TraceFlags::default(),
+                        false,
+                        opentelemetry::trace::TraceState::default(),
+                    );
+                    opentelemetry::trace::Link::new(span_context, Vec::new(), 0)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// OTEL [`SpanKind`](opentelemetry::trace::SpanKind) inferred from the
+/// signal class.
+///
+/// | OIS class | SpanKind |
+/// |-----------|----------|
+/// | `trace`   | `Internal` |
+/// | `metric`  | `Internal` |
+/// | `log`     | `Internal` |
+/// | `stream`  | `Consumer` |
+/// | `decision`| `Server`   |
+/// | `policy`  | `Server`   |
+/// | `receipt` | `Producer` |
+/// | `evidence`| `Producer` |
+/// | `state`   | `Internal` |
+pub fn signal_class_to_span_kind(class: SignalClass) -> opentelemetry::trace::SpanKind {
+    use opentelemetry::trace::SpanKind;
+    match class {
+        SignalClass::Trace => SpanKind::Internal,
+        SignalClass::Metric => SpanKind::Internal,
+        SignalClass::Log => SpanKind::Internal,
+        SignalClass::Stream => SpanKind::Consumer,
+        SignalClass::Decision => SpanKind::Server,
+        SignalClass::Policy => SpanKind::Server,
+        SignalClass::Receipt => SpanKind::Producer,
+        SignalClass::Evidence => SpanKind::Producer,
+        SignalClass::State => SpanKind::Internal,
+    }
+}

--- a/crates/oxide-signals/src/tests.rs
+++ b/crates/oxide-signals/src/tests.rs
@@ -1,0 +1,275 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn urn_validates_prefix() {
+    assert!(OisUrn::new("urn:ois:tenant:acme").is_ok());
+    assert!(OisUrn::new("urn:ois:signal:tenant:exec:trace:1").is_ok());
+}
+
+#[test]
+fn urn_rejects_invalid_prefix() {
+    assert!(OisUrn::new("http://example.com").is_err());
+    assert!(OisUrn::new("urn:other:thing").is_err());
+    assert!(OisUrn::new("").is_err());
+}
+
+#[test]
+fn urn_roundtrip_string() {
+    let urn = OisUrn::new("urn:ois:exec:42").unwrap();
+    let s: String = urn.into();
+    assert_eq!(s, "urn:ois:exec:42");
+}
+
+#[test]
+fn urn_display() {
+    let urn = OisUrn::new("urn:ois:test").unwrap();
+    assert_eq!(format!("{}", urn), "urn:ois:test");
+}
+
+#[test]
+fn urn_from_str() {
+    let urn: OisUrn = "urn:ois:foo".parse().unwrap();
+    assert_eq!(urn.as_str(), "urn:ois:foo");
+}
+
+#[test]
+fn urn_serde_roundtrip() {
+    let urn = OisUrn::new("urn:ois:tenant:x").unwrap();
+    let json = serde_json::to_string(&urn).unwrap();
+    assert_eq!(json, "\"urn:ois:tenant:x\"");
+    let back: OisUrn = serde_json::from_str(&json).unwrap();
+    assert_eq!(urn, back);
+}
+
+#[test]
+fn envelope_builder_roundtrip() {
+    let envelope = SignalEnvelope::builder()
+        .signal_id("urn:ois:signal:acme:exec-7:trace:1".parse().unwrap())
+        .signal_class(SignalClass::Trace)
+        .exec_id("urn:ois:exec:acme:exec-7".parse().unwrap())
+        .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+        .actor(Actor::new(
+            "urn:ois:agent:acme:compiler".parse().unwrap(),
+            ActorType::Agent,
+        ))
+        .reproducibility(Reproducibility::Deterministic)
+        .payload(json!({ "grid": [2, 1, 1], "block": [128, 1, 1] }))
+        .build()
+        .unwrap();
+
+    let json_str = envelope.to_json().unwrap();
+    let restored: JsonSignalEnvelope = JsonSignalEnvelope::from_json(&json_str).unwrap();
+
+    assert_eq!(envelope.signal_id, restored.signal_id);
+    assert_eq!(envelope.signal_class, restored.signal_class);
+    assert_eq!(envelope.signal_version, restored.signal_version);
+    assert_eq!(envelope.exec_id, restored.exec_id);
+    assert_eq!(envelope.tenant_id, restored.tenant_id);
+    assert_eq!(envelope.actor, restored.actor);
+    assert_eq!(envelope.reproducibility, restored.reproducibility);
+    assert_eq!(envelope.payload, restored.payload);
+}
+
+#[test]
+fn envelope_builder_missing_field_fails() {
+    let result = JsonSignalEnvelope::builder()
+        .signal_id("urn:ois:signal:t:e:trace:1".parse().unwrap())
+        // missing signal_class, exec_id, tenant_id, actor, reproducibility, payload
+        .build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn envelope_builder_invalid_version_fails() {
+    let result = JsonSignalEnvelope::builder()
+        .signal_id("urn:ois:signal:t:e:trace:1".parse().unwrap())
+        .signal_class(SignalClass::Trace)
+        .exec_id("urn:ois:exec:t:e".parse().unwrap())
+        .tenant_id("urn:ois:tenant:t".parse().unwrap())
+        .actor(Actor::new(
+            "urn:ois:actor:a".parse().unwrap(),
+            ActorType::Agent,
+        ))
+        .reproducibility(Reproducibility::Exact)
+        .payload(json!({}))
+        .signal_version("2.0")
+        .build();
+    assert!(matches!(result, Err(ValidationError::InvalidVersion(_))));
+}
+
+#[test]
+fn envelope_with_optional_fields() {
+    let envelope = SignalEnvelope::builder()
+        .signal_id("urn:ois:signal:acme:exec-7:metric:3".parse().unwrap())
+        .signal_class(SignalClass::Metric)
+        .exec_id("urn:ois:exec:acme:exec-7".parse().unwrap())
+        .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+        .actor(Actor::new(
+            "urn:ois:agent:acme:metricsd".parse().unwrap(),
+            ActorType::Service,
+        ))
+        .reproducibility(Reproducibility::Exact)
+        .payload(json!({ "gpu_util": 0.87 }))
+        .schema_uri("https://nvidia.com/oxide/ois/v1.0/schema/metric.schema.json".to_string())
+        .retention_class(RetentionClass::Standard)
+        .channel(Channel::Data)
+        .signature(Signature {
+            alg: SignatureAlg::Ed25519,
+            value: "deadbeef".to_string(),
+            key_ref: "urn:ois:key:acme:signing-01".parse().unwrap(),
+            rekor_uri: None,
+        })
+        .lineage_refs(vec!["urn:ois:signal:acme:exec-7:trace:1".parse().unwrap()])
+        .build()
+        .unwrap();
+
+    let json_str = envelope.to_json().unwrap();
+    let restored: JsonSignalEnvelope = JsonSignalEnvelope::from_json(&json_str).unwrap();
+
+    assert_eq!(envelope.schema_uri, restored.schema_uri);
+    assert_eq!(envelope.retention_class, restored.retention_class);
+    assert_eq!(envelope.channel, restored.channel);
+    assert_eq!(envelope.signature, restored.signature);
+    assert_eq!(envelope.lineage_refs, restored.lineage_refs);
+}
+
+#[test]
+fn actor_delegate_chain_roundtrip() {
+    let actor = Actor::new("urn:ois:agent:acme:main".parse().unwrap(), ActorType::Agent)
+        .with_delegate_chain(vec![
+            "urn:ois:agent:acme:sub-1".parse().unwrap(),
+            "urn:ois:agent:acme:sub-2".parse().unwrap(),
+        ]);
+
+    let json = serde_json::to_string(&actor).unwrap();
+    let restored: Actor = serde_json::from_str(&json).unwrap();
+    assert_eq!(actor, restored);
+}
+
+#[test]
+fn all_enum_variants_serialise_correctly() {
+    assert_eq!(
+        serde_json::to_string(&SignalClass::Trace).unwrap(),
+        "\"trace\""
+    );
+    assert_eq!(
+        serde_json::to_string(&SignalClass::Decision).unwrap(),
+        "\"decision\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ActorType::Pipeline).unwrap(),
+        "\"pipeline\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Reproducibility::LossyCapped).unwrap(),
+        "\"lossy_capped\""
+    );
+    assert_eq!(
+        serde_json::to_string(&RetentionClass::SovereignArchive).unwrap(),
+        "\"sovereign_archive\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Channel::Evidence).unwrap(),
+        "\"evidence\""
+    );
+    assert_eq!(
+        serde_json::to_string(&SignatureAlg::HybridEd25519Dilithium3).unwrap(),
+        "\"hybrid-ed25519-dilithium3\""
+    );
+}
+
+#[test]
+fn schemars_generates_schema() {
+    let schema = schemars::schema_for!(JsonSignalEnvelope);
+    let _json = serde_json::to_string_pretty(&schema).unwrap();
+    // Smoke-test: ensure the schema serialises without panic.
+}
+
+#[test]
+fn otel_urn_to_trace_id_is_stable() {
+    let urn = OisUrn::new("urn:ois:exec:acme:build-42").unwrap();
+    let id1 = otel::urn_to_trace_id(&urn);
+    let id2 = otel::urn_to_trace_id(&urn);
+    assert_eq!(id1, id2);
+}
+
+#[test]
+fn otel_urn_to_span_id_is_stable() {
+    let urn = OisUrn::new("urn:ois:signal:acme:build-42:trace:1").unwrap();
+    let id1 = otel::urn_to_span_id(&urn);
+    let id2 = otel::urn_to_span_id(&urn);
+    assert_eq!(id1, id2);
+}
+
+#[test]
+fn otel_attributes_contain_required_fields() {
+    let envelope = SignalEnvelope::builder()
+        .signal_id("urn:ois:signal:acme:exec-7:trace:1".parse().unwrap())
+        .signal_class(SignalClass::Trace)
+        .exec_id("urn:ois:exec:acme:exec-7".parse().unwrap())
+        .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+        .actor(Actor::new(
+            "urn:ois:agent:acme:compiler".parse().unwrap(),
+            ActorType::Agent,
+        ))
+        .reproducibility(Reproducibility::Deterministic)
+        .payload(json!({ "kernel": "matmul", "grid": [4, 1, 1] }))
+        .build()
+        .unwrap();
+
+    let attrs = otel::to_otel_attributes(&envelope);
+    let keys: Vec<String> = attrs.iter().map(|kv| kv.key.as_str().to_string()).collect();
+
+    assert!(keys.contains(&"ois.signal_id".to_string()));
+    assert!(keys.contains(&"ois.signal_class".to_string()));
+    assert!(keys.contains(&"ois.exec_id".to_string()));
+    assert!(keys.contains(&"ois.tenant_id".to_string()));
+    assert!(keys.contains(&"ois.actor.id".to_string()));
+    assert!(keys.contains(&"ois.reproducibility".to_string()));
+    assert!(keys.contains(&"ois.payload.kernel".to_string()));
+}
+
+#[test]
+fn otel_resource_attributes_focus_on_identity() {
+    let envelope = SignalEnvelope::builder()
+        .signal_id("urn:ois:signal:acme:exec-7:trace:1".parse().unwrap())
+        .signal_class(SignalClass::Trace)
+        .exec_id("urn:ois:exec:acme:exec-7".parse().unwrap())
+        .tenant_id("urn:ois:tenant:acme".parse().unwrap())
+        .actor(Actor::new(
+            "urn:ois:agent:acme:compiler".parse().unwrap(),
+            ActorType::Agent,
+        ))
+        .reproducibility(Reproducibility::Deterministic)
+        .payload(json!({}))
+        .build()
+        .unwrap();
+
+    let attrs = otel::to_resource_attributes(&envelope);
+    let keys: Vec<String> = attrs.iter().map(|kv| kv.key.as_str().to_string()).collect();
+
+    assert!(keys.contains(&"ois.exec_id".to_string()));
+    assert!(keys.contains(&"ois.tenant_id".to_string()));
+    assert!(!keys.contains(&"ois.signal_id".to_string()));
+}
+
+#[test]
+fn otel_span_kind_mapping() {
+    assert_eq!(
+        otel::signal_class_to_span_kind(SignalClass::Trace),
+        opentelemetry::trace::SpanKind::Internal
+    );
+    assert_eq!(
+        otel::signal_class_to_span_kind(SignalClass::Stream),
+        opentelemetry::trace::SpanKind::Consumer
+    );
+    assert_eq!(
+        otel::signal_class_to_span_kind(SignalClass::Decision),
+        opentelemetry::trace::SpanKind::Server
+    );
+    assert_eq!(
+        otel::signal_class_to_span_kind(SignalClass::Receipt),
+        opentelemetry::trace::SpanKind::Producer
+    );
+}

--- a/crates/oxide-signals/src/types.rs
+++ b/crates/oxide-signals/src/types.rs
@@ -1,0 +1,524 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! OIS (Oxide Instrumentation Signal) canonical envelope types.
+//!
+//! This module provides the Rust type system for the canonical OIS signal envelope
+//! defined by `https://nvidia.com/oxide/ois/v1.0/schema/envelope/canonical-signal-envelope.schema.json`.
+//! Every emitted signal MUST validate against this schema.
+
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// An OIS URN string that is guaranteed to start with `urn:ois:`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "String", into = "String")]
+#[schemars(description = "OIS URN — must start with 'urn:ois:'")]
+pub struct OisUrn(String);
+
+impl OisUrn {
+    /// Creates a new `OisUrn` after validating the prefix.
+    pub fn new(s: impl Into<String>) -> Result<Self, ValidationError> {
+        let s = s.into();
+        if s.starts_with("urn:ois:") {
+            Ok(Self(s))
+        } else {
+            Err(ValidationError::InvalidUrnPrefix(s))
+        }
+    }
+
+    /// Returns the underlying string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for OisUrn {
+    type Err = ValidationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl TryFrom<String> for OisUrn {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<OisUrn> for String {
+    fn from(value: OisUrn) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for OisUrn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Errors that can arise while constructing or validating an OIS envelope.
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    /// The provided string does not start with `urn:ois:`.
+    #[error("URN must start with 'urn:ois:', got: {0}")]
+    InvalidUrnPrefix(String),
+    /// A required envelope field was not supplied.
+    #[error("required field missing: {0}")]
+    MissingField(&'static str),
+    /// The signal version is not `"1.0"`.
+    #[error("signal_version must be '1.0', got: {0}")]
+    InvalidVersion(String),
+}
+
+/// Classification of an OIS signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Signal class")]
+#[allow(missing_docs)]
+pub enum SignalClass {
+    Trace,
+    Decision,
+    Policy,
+    Receipt,
+    Evidence,
+    State,
+    Stream,
+    Metric,
+    Log,
+}
+
+impl fmt::Display for SignalClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SignalClass::Trace => "trace",
+            SignalClass::Decision => "decision",
+            SignalClass::Policy => "policy",
+            SignalClass::Receipt => "receipt",
+            SignalClass::Evidence => "evidence",
+            SignalClass::State => "state",
+            SignalClass::Stream => "stream",
+            SignalClass::Metric => "metric",
+            SignalClass::Log => "log",
+        };
+        f.write_str(s)
+    }
+}
+
+/// The type of actor that emitted a signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Actor type")]
+#[allow(missing_docs)]
+pub enum ActorType {
+    Human,
+    Agent,
+    Service,
+    Runtime,
+    Pipeline,
+}
+
+impl fmt::Display for ActorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ActorType::Human => "human",
+            ActorType::Agent => "agent",
+            ActorType::Service => "service",
+            ActorType::Runtime => "runtime",
+            ActorType::Pipeline => "pipeline",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Actor metadata for an OIS signal.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[schemars(description = "Actor")]
+pub struct Actor {
+    /// Actor URN.
+    pub id: OisUrn,
+    /// Actor type (human, agent, service, runtime, pipeline).
+    #[serde(rename = "type")]
+    pub actor_type: ActorType,
+    /// Ordered delegation chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegate_chain: Option<Vec<OisUrn>>,
+}
+
+impl Actor {
+    /// Constructs a new `Actor` without a delegate chain.
+    pub fn new(id: OisUrn, actor_type: ActorType) -> Self {
+        Self {
+            id,
+            actor_type,
+            delegate_chain: None,
+        }
+    }
+
+    /// Sets the delegate chain.
+    pub fn with_delegate_chain(mut self, chain: Vec<OisUrn>) -> Self {
+        self.delegate_chain = Some(chain);
+        self
+    }
+}
+
+/// Reproducibility tier of a signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Reproducibility")]
+#[allow(missing_docs)]
+pub enum Reproducibility {
+    Exact,
+    Deterministic,
+    Attested,
+    Explanatory,
+    BestEffort,
+    LossyCapped,
+}
+
+impl fmt::Display for Reproducibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Reproducibility::Exact => "exact",
+            Reproducibility::Deterministic => "deterministic",
+            Reproducibility::Attested => "attested",
+            Reproducibility::Explanatory => "explanatory",
+            Reproducibility::BestEffort => "best_effort",
+            Reproducibility::LossyCapped => "lossy_capped",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Retention classification governing lifecycle and compliance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Retention class")]
+#[allow(missing_docs)]
+pub enum RetentionClass {
+    Ephemeral,
+    Standard,
+    Regulated,
+    LegalHold,
+    SovereignArchive,
+}
+
+impl fmt::Display for RetentionClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            RetentionClass::Ephemeral => "ephemeral",
+            RetentionClass::Standard => "standard",
+            RetentionClass::Regulated => "regulated",
+            RetentionClass::LegalHold => "legal_hold",
+            RetentionClass::SovereignArchive => "sovereign_archive",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Communication channel over which the signal is carried.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Channel")]
+#[allow(missing_docs)]
+pub enum Channel {
+    Control,
+    Data,
+    Proof,
+    Recall,
+    Evidence,
+}
+
+impl fmt::Display for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Channel::Control => "control",
+            Channel::Data => "data",
+            Channel::Proof => "proof",
+            Channel::Recall => "recall",
+            Channel::Evidence => "evidence",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Cryptographic signature attached to a signal.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[schemars(description = "Signature")]
+pub struct Signature {
+    /// Signature algorithm.
+    pub alg: SignatureAlg,
+    /// Base64-encoded signature bytes.
+    pub value: String,
+    /// Reference to the signing key URN.
+    pub key_ref: OisUrn,
+    /// Optional Rekor transparency-log entry URI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rekor_uri: Option<String>,
+}
+
+/// Supported signature algorithms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+#[schemars(description = "Signature algorithm")]
+#[allow(missing_docs)]
+pub enum SignatureAlg {
+    Ed25519,
+    EcdsaP256,
+    Dilithium3,
+    HybridEd25519Dilithium3,
+}
+
+impl fmt::Display for SignatureAlg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SignatureAlg::Ed25519 => "ed25519",
+            SignatureAlg::EcdsaP256 => "ecdsa-p256",
+            SignatureAlg::Dilithium3 => "dilithium3",
+            SignatureAlg::HybridEd25519Dilithium3 => "hybrid-ed25519-dilithium3",
+        };
+        f.write_str(s)
+    }
+}
+
+/// The canonical OIS signal envelope.
+///
+/// `Payload` is generic so that downstream crates can use strongly-typed
+/// payloads while still conforming to the envelope schema. Use
+/// `JsonSignalEnvelope` when you need an untyped / JSON-object payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(description = "Canonical Signal Envelope")]
+pub struct SignalEnvelope<Payload = serde_json::Value> {
+    /// Unique signal URN.
+    pub signal_id: OisUrn,
+    /// Signal classification.
+    pub signal_class: SignalClass,
+    /// Envelope schema version (always `"1.0"`).
+    #[serde(default = "default_version")]
+    pub signal_version: String,
+    /// URI of the payload-specific JSON schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_uri: Option<String>,
+    /// Execution context URN.
+    pub exec_id: OisUrn,
+    /// Tenant / organisation URN.
+    pub tenant_id: OisUrn,
+    /// Wall-clock time when the signal was emitted (RFC3339).
+    pub emitted_at: DateTime<Utc>,
+    /// Wall-clock time when the signal was captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_at: Option<DateTime<Utc>>,
+    /// Actor that emitted the signal.
+    pub actor: Actor,
+    /// Reproducibility tier.
+    pub reproducibility: Reproducibility,
+    /// Retention classification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_class: Option<RetentionClass>,
+    /// Communication channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<Channel>,
+    /// Arbitrary payload object.
+    pub payload: Payload,
+    /// Cryptographic signature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Signature>,
+    /// Parent signal URNs (causal lineage).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineage_refs: Option<Vec<OisUrn>>,
+}
+
+fn default_version() -> String {
+    "1.0".to_string()
+}
+
+/// Type alias for a signal envelope whose payload is an arbitrary JSON object.
+pub type JsonSignalEnvelope = SignalEnvelope<serde_json::Value>;
+
+impl<Payload> SignalEnvelope<Payload> {
+    /// Returns a builder for constructing a `SignalEnvelope`.
+    pub fn builder() -> SignalEnvelopeBuilder<Payload> {
+        SignalEnvelopeBuilder {
+            signal_id: None,
+            signal_class: None,
+            signal_version: None,
+            schema_uri: None,
+            exec_id: None,
+            tenant_id: None,
+            emitted_at: None,
+            captured_at: None,
+            actor: None,
+            reproducibility: None,
+            retention_class: None,
+            channel: None,
+            payload: None,
+            signature: None,
+            lineage_refs: None,
+        }
+    }
+}
+
+impl JsonSignalEnvelope {
+    /// Serialises the envelope to a JSON string.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Deserialises an envelope from a JSON string.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+/// Builder for [`SignalEnvelope`].
+pub struct SignalEnvelopeBuilder<Payload = serde_json::Value> {
+    signal_id: Option<OisUrn>,
+    signal_class: Option<SignalClass>,
+    signal_version: Option<String>,
+    schema_uri: Option<String>,
+    exec_id: Option<OisUrn>,
+    tenant_id: Option<OisUrn>,
+    emitted_at: Option<DateTime<Utc>>,
+    captured_at: Option<DateTime<Utc>>,
+    actor: Option<Actor>,
+    reproducibility: Option<Reproducibility>,
+    retention_class: Option<RetentionClass>,
+    channel: Option<Channel>,
+    payload: Option<Payload>,
+    signature: Option<Signature>,
+    lineage_refs: Option<Vec<OisUrn>>,
+}
+
+#[allow(missing_docs)]
+impl<Payload> SignalEnvelopeBuilder<Payload> {
+    pub fn signal_id(mut self, id: OisUrn) -> Self {
+        self.signal_id = Some(id);
+        self
+    }
+
+    pub fn signal_class(mut self, class: SignalClass) -> Self {
+        self.signal_class = Some(class);
+        self
+    }
+
+    pub fn signal_version(mut self, version: impl Into<String>) -> Self {
+        self.signal_version = Some(version.into());
+        self
+    }
+
+    pub fn schema_uri(mut self, uri: impl Into<String>) -> Self {
+        self.schema_uri = Some(uri.into());
+        self
+    }
+
+    pub fn exec_id(mut self, id: OisUrn) -> Self {
+        self.exec_id = Some(id);
+        self
+    }
+
+    pub fn tenant_id(mut self, id: OisUrn) -> Self {
+        self.tenant_id = Some(id);
+        self
+    }
+
+    pub fn emitted_at(mut self, at: DateTime<Utc>) -> Self {
+        self.emitted_at = Some(at);
+        self
+    }
+
+    pub fn captured_at(mut self, at: DateTime<Utc>) -> Self {
+        self.captured_at = Some(at);
+        self
+    }
+
+    pub fn actor(mut self, actor: Actor) -> Self {
+        self.actor = Some(actor);
+        self
+    }
+
+    pub fn reproducibility(mut self, repro: Reproducibility) -> Self {
+        self.reproducibility = Some(repro);
+        self
+    }
+
+    pub fn retention_class(mut self, rc: RetentionClass) -> Self {
+        self.retention_class = Some(rc);
+        self
+    }
+
+    pub fn channel(mut self, ch: Channel) -> Self {
+        self.channel = Some(ch);
+        self
+    }
+
+    pub fn payload(mut self, payload: Payload) -> Self {
+        self.payload = Some(payload);
+        self
+    }
+
+    pub fn signature(mut self, sig: Signature) -> Self {
+        self.signature = Some(sig);
+        self
+    }
+
+    pub fn lineage_refs(mut self, refs: Vec<OisUrn>) -> Self {
+        self.lineage_refs = Some(refs);
+        self
+    }
+}
+
+impl<Payload> SignalEnvelopeBuilder<Payload> {
+    /// Consumes the builder and returns a [`SignalEnvelope`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::MissingField`] if any required field was not
+    /// supplied, or [`ValidationError::InvalidVersion`] if an explicit
+    /// `signal_version` was provided and is not `"1.0"`.
+    pub fn build(self) -> Result<SignalEnvelope<Payload>, ValidationError> {
+        let signal_version = self.signal_version.unwrap_or_else(|| "1.0".to_string());
+        if signal_version != "1.0" {
+            return Err(ValidationError::InvalidVersion(signal_version));
+        }
+
+        Ok(SignalEnvelope {
+            signal_id: self
+                .signal_id
+                .ok_or(ValidationError::MissingField("signal_id"))?,
+            signal_class: self
+                .signal_class
+                .ok_or(ValidationError::MissingField("signal_class"))?,
+            signal_version,
+            schema_uri: self.schema_uri,
+            exec_id: self
+                .exec_id
+                .ok_or(ValidationError::MissingField("exec_id"))?,
+            tenant_id: self
+                .tenant_id
+                .ok_or(ValidationError::MissingField("tenant_id"))?,
+            emitted_at: self.emitted_at.unwrap_or_else(Utc::now),
+            captured_at: self.captured_at,
+            actor: self.actor.ok_or(ValidationError::MissingField("actor"))?,
+            reproducibility: self
+                .reproducibility
+                .ok_or(ValidationError::MissingField("reproducibility"))?,
+            retention_class: self.retention_class,
+            channel: self.channel,
+            payload: self
+                .payload
+                .ok_or(ValidationError::MissingField("payload"))?,
+            signature: self.signature,
+            lineage_refs: self.lineage_refs,
+        })
+    }
+}


### PR DESCRIPTION
## Summary

This issue tracks the introduction of the `oxide-signals` crate, which provides a typed, versioned canonical envelope for all observability data emitted by `cuda-oxide` and related tooling.

## Motivation

Currently, `cuda-oxide` lacks a unified observability layer. Traces, metrics, logs, and audit evidence are emitted ad-hoc without standardised identity, provenance, or lifecycle metadata. Downstream collectors cannot correlate signals across execution boundaries or enforce retention/compliance policies.

## Proposed Solution

The `oxide-signals` crate implements the **OIS (Oxide Instrumentation Signal)** canonical envelope v1.0:

- **Typed envelope** -- `SignalEnvelope<Payload>` with required fields (`signal_id`, `exec_id`, `tenant_id`, `actor`, `reproducibility`, `payload`) and optional metadata (`signature`, `lineage_refs`, `retention_class`, `channel`)
- **URN-based identity** -- All identifiers use `urn:ois:` scheme with validated prefixes
- **Builder API** -- `SignalEnvelope::builder()` with compile-time optional fields and runtime required-field validation
- **OpenTelemetry integration** -- Native mapping to OTEL spans, attributes, links, and span kinds via `otel` module
- **High-level emitter** -- `SignalEmitter<T: Tracer>` wraps any OTEL tracer for one-line signal emission
- **JSON Schema** -- Full `schemars` support for schema generation and validation

## Signal Classes

| Class | OTEL SpanKind | Use case |
|-------|-------------|----------|
| `trace` | `Internal` | Kernel launch, memory copy |
| `metric` | `Internal` | GPU utilization |
| `log` | `Internal` | Compiler diagnostics |
| `decision` | `Server` | Policy engine verdicts |
| `receipt` | `Producer` | Build artifact receipts |
| `evidence` | `Producer` | SAST / attestation evidence |
| `stream` | `Consumer` | Async data streams |
| `state` | `Internal` | Runtime state snapshots |
| `policy` | `Server` | Governance rules |

## Acceptance Criteria

- [x] Crate compiles with zero warnings (`cargo check`)
- [x] All tests pass (`cargo test -p oxide-signals` -- 18 unit + 1 doctest)
- [x] README.md with quick-start example
- [x] SCHEMA.md documenting the canonical envelope specification
- [x] Workspace integration (registered in `Cargo.toml`)

## Related

- `SCHEMA.md` in `crates/oxide-signals/`
- `src/otel.rs` for OTEL mapping details
