### PR TITLE
docs: add LLVM 21 installation guide in Debian/Ubuntu system because default package repositories do not contain LLVM 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ nvcc --version
 # Ubuntu/Debian
 sudo apt install llvm-21
 
+For most Debian-based systems, you can install the official packages from the LLVM repository:
+# Setup the official LLVM repository
+sudo apt-get install -y lsb-release wget software-properties-common gnupg
+wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+sudo ./llvm.sh 21
+
 # Verify NVPTX support
 llc-21 --version | grep nvptx
 ```

--- a/README.md
+++ b/README.md
@@ -155,13 +155,17 @@ nvcc --version
 ```bash
 # Ubuntu/Debian
 sudo apt install llvm-21
+```
 
-For most Debian-based systems, you can install the official packages from the LLVM repository:
-# Setup the official LLVM repository
+If your distro packages do not provide `llvm-21`, use LLVM's apt helper:
+
+```bash
 sudo apt-get install -y lsb-release wget software-properties-common gnupg
 wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
 sudo ./llvm.sh 21
+```
 
+```bash
 # Verify NVPTX support
 llc-21 --version | grep nvptx
 ```

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -68,6 +68,12 @@ intrinsic signatures that cuda-oxide emits. The NVPTX backend must be enabled:
 # Ubuntu / Debian
 sudo apt install llvm-21
 
+For most Debian-based systems, you can install the official packages from the LLVM repository:
+# Setup the official LLVM repository
+sudo apt-get install -y lsb-release wget software-properties-common gnupg
+wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+sudo ./llvm.sh 21
+
 # Verify NVPTX support
 llc-21 --version | grep nvptx
 ```

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -67,13 +67,17 @@ intrinsic signatures that cuda-oxide emits. The NVPTX backend must be enabled:
 ```bash
 # Ubuntu / Debian
 sudo apt install llvm-21
+```
 
-For most Debian-based systems, you can install the official packages from the LLVM repository:
-# Setup the official LLVM repository
+If your distro packages do not provide `llvm-21`, use LLVM's apt helper:
+
+```bash
 sudo apt-get install -y lsb-release wget software-properties-common gnupg
 wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
 sudo ./llvm.sh 21
+```
 
+```bash
 # Verify NVPTX support
 llc-21 --version | grep nvptx
 ```

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -48,9 +48,11 @@ cuda-oxide uses LLVM's NVPTX backend to lower LLVM IR to PTX. Install LLVM 21 or
 ```bash
 # Ubuntu / Debian
 sudo apt install llvm-21
+```
 
-For most Debian-based systems, you can install the official packages from the LLVM repository:
-# Setup the official LLVM repository
+If your distro packages do not provide `llvm-21`, use LLVM's apt helper:
+
+```bash
 sudo apt-get install -y lsb-release wget software-properties-common gnupg
 wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
 sudo ./llvm.sh 21

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -48,6 +48,12 @@ cuda-oxide uses LLVM's NVPTX backend to lower LLVM IR to PTX. Install LLVM 21 or
 ```bash
 # Ubuntu / Debian
 sudo apt install llvm-21
+
+For most Debian-based systems, you can install the official packages from the LLVM repository:
+# Setup the official LLVM repository
+sudo apt-get install -y lsb-release wget software-properties-common gnupg
+wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+sudo ./llvm.sh 21
 ```
 
 Verify that the NVPTX target is present:


### PR DESCRIPTION
The default Ubuntu package repositories do not contain LLVM 21, causing the apt-get install command to fail with a 'no installation candidate' error.

Because some case it shows:
```
/content# sudo apt install llvm-21
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package llvm-21 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'llvm-21' has no installation candidate
/content# llc-21 --version | grep nvptx
-bash: llc-21: command not found
```

and install the official packages from the LLVM repository could solve the problem