### PR TITLE
  Auto-detect local GPU target for cargo oxide run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ name = "cargo-oxide"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "cuda-core",
  "cuda-host",
  "libnvvm-sys",
  "nvjitlink-sys",

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4", features = ["derive"] }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
 cuda-host = { workspace = true }
+cuda-core = { workspace = true }

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -51,6 +51,12 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 Builds the codegen backend, compiles the example with the custom backend, and runs it. This is the primary command for day-to-day development.
 
+When neither `--arch` nor `CUDA_OXIDE_TARGET` is set, `run` detects the
+compute capability of CUDA device 0 and targets that architecture so the
+generated PTX can load on the local GPU. Use `--arch <sm_XXX>` or
+`CUDA_OXIDE_TARGET=<sm_XXX>` to override this for a specific device or
+cross-target workflow.
+
 ```bash
 cargo oxide run vecadd
 cargo oxide run gemm_sol

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -106,6 +106,18 @@ pub fn codegen_run(
     clean_generated_files(&example_dir, example);
 
     let output_format = format_label(emit_nvvm_ir);
+    // Target precedence for `cargo oxide run` (highest first):
+    //   1. --arch <sm_XX>           explicit user override
+    //   2. CUDA_OXIDE_TARGET=<sm_XX>  explicit env override (set by parent process)
+    //   3. Host GPU compute capability detected from CUDA device 0
+    //   4. Backend feature-based default (`select_target` in mir-importer)
+    //
+    // (3) is the auto-detect added here so the generated module can load on
+    // the local GPU. We only do it for `run`, not `build`/`pipeline`, because
+    // `run` immediately loads the cubin on device 0 — whereas the other
+    // commands may be cross-compiling for a different machine.
+    let detected_run_arch = detect_run_target_arch(arch, emit_nvvm_ir);
+    let forwarded_arch = arch.or(detected_run_arch.as_deref());
 
     println!("=========================================");
     println!("RUSTC-CODEGEN-CUDA: {}", example);
@@ -148,7 +160,7 @@ pub fn codegen_run(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
 
-    apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, forwarded_arch);
     apply_ld_library_path(&mut cmd);
 
     if let Some(bin) = bin {
@@ -831,6 +843,70 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
     }
 }
 
+/// Pick a runnable target for `cargo oxide run` when the user has not pinned
+/// one explicitly.
+///
+/// # Precedence
+///
+/// `cargo oxide run` resolves the target architecture in this order, highest
+/// priority first:
+///
+/// 1. `--arch <sm_XX>`            — explicit user override
+/// 2. `CUDA_OXIDE_TARGET=<sm_XX>` — explicit env override (set in the parent
+///    process before invoking `cargo oxide run`)
+/// 3. **This function** — host GPU compute capability of CUDA device 0
+/// 4. Backend feature-based default (`select_target` in
+///    `mir-importer::pipeline`), which picks the minimum `sm_XX` required by
+///    the IR shape (e.g. `Basic → sm_80`, `Cluster → sm_90`, `Tma → sm_100`)
+///
+/// This function returns `Some(sm_XY)` to fill slot 3, or `None` (falling
+/// through to slot 4) when the host has no usable GPU.
+///
+/// # Why only `run`
+///
+/// `run` immediately loads the generated module on device 0 and launches the
+/// kernel, so a target older than the local GPU's compute capability is the
+/// only safe default. `build` and `pipeline` may legitimately cross-compile
+/// to a different machine, so they keep the backend's feature-based default
+/// untouched.
+///
+/// # Why this is needed even with the backend default
+///
+/// The backend's `select_target` picks the minimum `sm_XX` the IR requires.
+/// `Basic → sm_80` is a fine *compilation* baseline, but PTX for `sm_80` will
+/// not load on a Turing (`sm_75`) GPU because the JIT refuses
+/// forward-incompatible PTX. Detecting the host CC in `run` keeps the
+/// generated module loadable on the actual hardware that will execute it.
+///
+/// # When this returns `None`
+///
+/// - The user passed `--arch` (slot 1 wins).
+/// - `CUDA_OXIDE_TARGET` is set in the environment (slot 2 wins).
+/// - `--emit-nvvm-ir` is in effect (NVVM IR mode requires explicit `--arch`,
+///   enforced by the CLI parser).
+/// - No CUDA driver / device 0 is available on the host (CI runners without
+///   GPUs, headless build boxes). The caller falls through to slot 4 and
+///   the backend's feature-based default applies.
+fn detect_run_target_arch(arch: Option<&str>, emit_nvvm_ir: bool) -> Option<String> {
+    if arch.is_some() || emit_nvvm_ir || std::env::var_os("CUDA_OXIDE_TARGET").is_some() {
+        return None;
+    }
+
+    cuda_core::CudaContext::new(0)
+        .and_then(|ctx| ctx.compute_capability())
+        .ok()
+        .map(format_sm_arch)
+}
+
+/// Format a `(major, minor)` compute-capability tuple as the `sm_XX` /
+/// `sm_XXX` string the codegen backend expects on `CUDA_OXIDE_TARGET`.
+///
+/// Concatenates without a separator, matching CUDA conventions:
+/// `(7, 5)` → `"sm_75"`, `(12, 0)` → `"sm_120"`.
+fn format_sm_arch((major, minor): (i32, i32)) -> String {
+    format!("sm_{}{}", major, minor)
+}
+
 /// Forward an env var to the child process if it's set in the parent, otherwise remove it.
 fn forward_env_var(cmd: &mut Command, var: &str) {
     if let Ok(val) = std::env::var(var) {
@@ -1236,5 +1312,41 @@ mod tests {
 
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_TARGET"), None);
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_EMIT_NVVM_IR"), None);
+    }
+
+    #[test]
+    fn format_sm_arch_uses_cuda_target_spelling() {
+        assert_eq!(format_sm_arch((7, 5)), "sm_75");
+        assert_eq!(format_sm_arch((12, 0)), "sm_120");
+        // sm_90a / sm_100a etc. are not produced by this helper because
+        // compute_capability() returns plain integers; the `a` suffix is
+        // applied by the backend's feature selector when arch-specific
+        // tcgen05 / wgmma intrinsics are used.
+    }
+
+    #[test]
+    fn detect_run_target_arch_skips_when_arch_explicit() {
+        // --arch wins; never query the GPU.
+        assert_eq!(detect_run_target_arch(Some("sm_120"), false), None);
+    }
+
+    #[test]
+    fn detect_run_target_arch_skips_when_emit_nvvm_ir() {
+        // NVVM IR mode requires explicit --arch; auto-detect must not run.
+        assert_eq!(detect_run_target_arch(None, true), None);
+    }
+
+    #[test]
+    fn detect_run_target_arch_skips_when_env_target_set() {
+        // Test in isolation; the `CUDA_OXIDE_TARGET` env handle is process-wide.
+        // SAFETY: single-threaded test serialised by the cargo test harness.
+        unsafe {
+            std::env::set_var("CUDA_OXIDE_TARGET", "sm_75");
+        }
+        let result = detect_run_target_arch(None, false);
+        unsafe {
+            std::env::remove_var("CUDA_OXIDE_TARGET");
+        }
+        assert_eq!(result, None);
     }
 }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -130,6 +130,14 @@ pub fn codegen_run(
             arch.expect("--emit-nvvm-ir requires --arch")
         );
         println!();
+    } else if detected_run_arch.is_some() {
+        // Surface the auto-detect outcome so it isn't silent magic; users
+        // chasing a JIT/load failure can see exactly which arch was picked.
+        println!(
+            "Target arch: {} (auto-detected from CUDA device 0)",
+            detected_run_arch.as_deref().unwrap()
+        );
+        println!();
     }
     println!("This is the proper cargo workflow:");
     println!("  RUSTFLAGS=\"-Z codegen-backend=...\" cargo run");

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -54,7 +54,10 @@ enum Commands {
         /// Generate NVVM IR (use with libNVVM -gen-lto)
         #[arg(long)]
         emit_nvvm_ir: bool,
-        /// Target architecture (e.g., sm_90, sm_100, sm_120)
+        /// Target architecture (e.g., sm_90, sm_100, sm_120). When omitted,
+        /// `run` auto-detects the compute capability of CUDA device 0 so the
+        /// generated module loads on the local GPU; set `CUDA_OXIDE_TARGET`
+        /// in the environment for a non-interactive override.
         #[arg(long)]
         arch: Option<String>,
         /// Comma-separated list of features to enable

--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -397,6 +397,15 @@ where you need a specific target. For example, `sm_100a` enables
 Blackwell-specific `tcgen05` features that are not available under the generic
 `sm_100` target.
 
+`cargo oxide run` adds a second layer of auto-detection on top of the
+backend's feature-based default: when neither `--arch` nor `CUDA_OXIDE_TARGET`
+is set, it queries the compute capability of CUDA device 0 and forwards that
+to the backend so the generated module is guaranteed to load on the local GPU.
+The full precedence is `--arch` > `CUDA_OXIDE_TARGET` > host CC (for `run`
+only) > backend feature-based default. `cargo oxide build` and
+`cargo oxide pipeline` deliberately skip the host-CC step so they remain
+usable for cross-compilation.
+
 ```{note}
 Why LLVM 21? The 2-D bulk TMA load intrinsic used by `tma_copy`,
 `gemm_sol`, and `tcgen05_matmul` gained a 10-operand form with `addrspace(7)`

--- a/cuda-oxide-book/compiler/rustc-codegen-cuda.md
+++ b/cuda-oxide-book/compiler/rustc-codegen-cuda.md
@@ -406,6 +406,11 @@ The codegen backend receives very limited information from rustc's argument
 parser -- environment variables are the simplest way to pass configuration
 without fighting the compiler driver's flag plumbing.
 
+`CUDA_OXIDE_TARGET` sits in the middle of a precedence chain that
+`cargo oxide` honours: explicit `--arch` wins, then `CUDA_OXIDE_TARGET`,
+then `cargo oxide run`'s host-CC auto-detect (only for `run`, not `build`
+or `pipeline`), and finally the backend's feature-based default.
+
 ```{note}
 `CUDA_OXIDE_VERBOSE=1 cargo oxide build` is your best friend when debugging
 the compiler. It shows exactly which functions were collected, which crates


### PR DESCRIPTION
## Summary

  While investigating #36, I could not reproduce the exact Pliron verifier failure on current `main`.

  However, I found a separate reproducible template runtime issue: `cargo oxide run` can generate PTX for the backend default target even when that target is not runnable on the local GPU.

  On this machine, with an sm_75 GPU and `CUDA_OXIDE_TARGET` unset, the generated template produced `.target sm_80` and failed during module load with:

  ```text
  Failed to load embedded CUDA module: Driver(DriverError(218, "a PTX JIT compilation failed"))
```
  This PR updates cargo oxide run to auto-detect device 0 compute capability and forward it as CUDA_OXIDE_TARGET when no explicit target was provided.

  ## Behavior

  - Keeps explicit --arch behavior unchanged.
  - Keeps explicit CUDA_OXIDE_TARGET behavior unchanged.
  - Keeps normal cargo oxide build behavior unchanged.
  - Only changes cargo oxide run, where the output should be runnable on the local machine by default.

  ## Testing

  cargo fmt --check
  cargo test -p cargo-oxide
  cargo clippy -p cargo-oxide -- -D warnings
  cargo check
  cargo build -p cargo-oxide

  End-to-end generated template test:

  env -u CUDA_OXIDE_TARGET cargo oxide run

  Before this change, the generated PTX targeted sm_80 and failed to load on sm_75 hardware.

  After this change, the generated PTX contains:

  .target sm_75

  and the generated template runs successfully:

  PASSED: all 1024 elements correct

  ## Note on #36

  This came from investigating #36, but I could not reproduce the exact verifier error reported there on current main. This PR fixes the separate target-selection/runtime failure found during that investigation.
