### PR TITLE
Add pinned host buffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The workspace combines:
 - single-source compilation -- host and device code live in the same file, built with one `cargo oxide build`
 - a rustc codegen backend that compiles `#[kernel]` functions to CUDA PTX
 - device-side abstractions (type-safe indexing, shared memory, scoped atomics, barriers, TMA, warp/cluster ops)
-- a host-side runtime for memory management and kernel launching (`cuda-core`, `cuda-async`)
+- a host-side runtime for memory management, pinned host transfers, and kernel launching (`cuda-core`, `cuda-async`)
 - a rust-native compilation pipeline using [Pliron](https://github.com/vaivaswatha/pliron), an MLIR-like IR framework in Rust (Rust → Rust MIR → Pliron IR → LLVM IR → PTX)
 
 ## Project Status
@@ -247,7 +247,7 @@ cargo oxide run gemm_sol
 | `cuda-host`         | Typed module loading, launch helpers, LTOIR loader                        |
 | `cuda-macros`       | Proc macros (`#[cuda_module]`, `#[kernel]`, `gpu_printf!`)                |
 | `cuda-bindings`     | Raw `bindgen` FFI bindings to `cuda.h`                                    |
-| `cuda-core`         | Safe RAII wrappers (`CudaContext`, `CudaStream`, `DeviceBuffer<T>`)       |
+| `cuda-core`         | Safe RAII wrappers (`CudaContext`, `CudaStream`, `DeviceBuffer<T>`, `PinnedHostBuffer<T>`) |
 | `cuda-async`        | Async execution layer (`DeviceOperation`, `DeviceFuture`, `DeviceBox<T>`) |
 | `libnvvm-sys`       | `dlopen` bindings to libNVVM (used by `cuda-host::ltoir`)                 |
 | `nvjitlink-sys`     | `dlopen` bindings to nvJitLink (used by `cuda-host::ltoir`)               |
@@ -289,7 +289,7 @@ cargo oxide run gemm_sol
 - LTOIR generation for Blackwell+ (device-side LTO)
 - Device FFI: Rust <-> C++/CCCL interop via LTOIR
 - MathDx integration: cuFFTDx thread-level FFT, cuBLASDx block-level GEMM
-- Host runtime: `cuda-core` (explicit control) and `cuda-async` (composable async operations)
+- Host runtime: `cuda-core` (explicit control, pinned host transfers) and `cuda-async` (composable async operations)
 - GEMM SoL: 868 TFLOPS (58% cuBLAS SoL) on B200 with cta_group::2, CLC, 4-stage pipeline
 
 ## Documentation

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -22,7 +22,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Modules**: `ctx.load_module_from_file("kernel.ptx")` / `ctx.load_module_from_ptx_src(src)` load compiled GPU code. `module.load_function("kernel_name")` extracts a callable function handle.
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
 - **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`.
-- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. The async transfer helpers (`DeviceBuffer::from_pinned_host`, `copy_to_pinned_host_async`) are `unsafe` because they only enqueue the copy and the caller must keep the pinned buffer alive until `stream.synchronize()`. Use `copy_to_pinned_host` for a blocking DtoH helper that syncs internally.
+- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. The async transfer helpers (`DeviceBuffer::from_pinned_host`, `copy_from_pinned_host_async`, `copy_to_pinned_host_async`) are `unsafe` because they only enqueue the copy and the caller must keep the pinned buffer alive until `stream.synchronize()`. Use `copy_to_pinned_host` for a blocking DtoH helper that syncs internally.
 - **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -6,14 +6,14 @@ Safe RAII wrappers around the CUDA driver API.
 
 This crate turns raw CUDA handles into Rust types with automatic cleanup on drop:
 
-| Type             | Wraps                  | Cleanup call                       |
-|------------------|------------------------|------------------------------------|
-| `CudaContext`    | `CUcontext` (primary)  | `cuDevicePrimaryCtxRelease_v2`     |
-| `CudaStream`     | `CUstream`             | `cuStreamDestroy_v2`               |
-| `CudaEvent`      | `CUevent`              | `cuEventDestroy_v2`                |
-| `CudaModule`     | `CUmodule`             | `cuModuleUnload`                   |
-| `CudaFunction`   | `CUfunction`           | (prevented from outliving module)  |
-| `PinnedHostBuffer<T>` | pinned host memory | `cuMemFreeHost`                    |
+| Type                  | Wraps                  | Cleanup call                       |
+|-----------------------|------------------------|------------------------------------|
+| `CudaContext`         | `CUcontext` (primary)  | `cuDevicePrimaryCtxRelease_v2`     |
+| `CudaStream`          | `CUstream`             | `cuStreamDestroy_v2`               |
+| `CudaEvent`           | `CUevent`              | `cuEventDestroy_v2`                |
+| `CudaModule`          | `CUmodule`             | `cuModuleUnload`                   |
+| `CudaFunction`        | `CUfunction`           | (prevented from outliving module)  |
+| `PinnedHostBuffer<T>` | pinned host memory     | `cuMemFreeHost`                    |
 
 ## Key APIs
 
@@ -22,7 +22,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Modules**: `ctx.load_module_from_file("kernel.ptx")` / `ctx.load_module_from_ptx_src(src)` load compiled GPU code. `module.load_function("kernel_name")` extracts a callable function handle.
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
 - **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`.
-- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. Use `copy_to_pinned_host_async` when device-to-host transfers should overlap with later synchronization.
+- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. The async transfer helpers (`DeviceBuffer::from_pinned_host`, `copy_to_pinned_host_async`) are `unsafe` because they only enqueue the copy and the caller must keep the pinned buffer alive until `stream.synchronize()`. Use `copy_to_pinned_host` for a blocking DtoH helper that syncs internally.
 - **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -13,6 +13,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 | `CudaEvent`      | `CUevent`              | `cuEventDestroy_v2`                |
 | `CudaModule`     | `CUmodule`             | `cuModuleUnload`                   |
 | `CudaFunction`   | `CUfunction`           | (prevented from outliving module)  |
+| `PinnedHostBuffer<T>` | pinned host memory | `cuMemFreeHost`                    |
 
 ## Key APIs
 
@@ -21,6 +22,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Modules**: `ctx.load_module_from_file("kernel.ptx")` / `ctx.load_module_from_ptx_src(src)` load compiled GPU code. `module.load_function("kernel_name")` extracts a callable function handle.
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
 - **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`.
+- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers and true async overlap when used with non-blocking copies.
 - **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -22,7 +22,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Modules**: `ctx.load_module_from_file("kernel.ptx")` / `ctx.load_module_from_ptx_src(src)` load compiled GPU code. `module.load_function("kernel_name")` extracts a callable function handle.
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
 - **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`.
-- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers and true async overlap when used with non-blocking copies.
+- **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. Use `copy_to_pinned_host_async` when device-to-host transfers should overlap with later synchronization.
 - **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -237,7 +237,9 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// share the same [`CudaContext`].
     ///
     /// The device-to-host counterparts are [`Self::copy_to_pinned_host`]
-    /// (blocking) and [`Self::copy_to_pinned_host_async`] (non-blocking).
+    /// (blocking) and [`Self::copy_to_pinned_host_async`] (non-blocking). To
+    /// refill an existing device buffer instead of allocating a new one, use
+    /// [`Self::copy_from_pinned_host_async`].
     ///
     /// # Safety
     ///
@@ -388,4 +390,51 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         }
     }
 
+    /// Enqueues a host-to-device copy from a pinned host buffer into this
+    /// device buffer and returns without synchronizing.
+    ///
+    /// This is the symmetric counterpart of
+    /// [`Self::copy_to_pinned_host_async`]: it refills an existing device
+    /// allocation from rotating pinned host stagers instead of allocating a
+    /// fresh device buffer per refresh, which is the typical shape for
+    /// asynchronous overlap pipelines.
+    ///
+    /// Panics if `src.len() > self.len()`.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `src` and `stream`
+    /// share the same [`CudaContext`].
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy on `stream` and
+    /// returns; CUDA may still be reading from `src`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `src` is not dropped, freed, mutated, or aliased until the enqueued
+    /// copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    /// Dropping `src` before that synchronization point calls
+    /// `cuMemFreeHost` while the in-flight transfer is still reading the
+    /// buffer, which is undefined behavior.
+    pub unsafe fn copy_from_pinned_host_async(
+        &mut self,
+        stream: &CudaStream,
+        src: &PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(src.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
+        assert!(
+            src.len() <= self.len,
+            "source pinned host buffer too large: {} > {}",
+            src.len(),
+            self.len
+        );
+        let num_bytes = src.num_bytes();
+        unsafe {
+            crate::memory::memcpy_htod_async(self.ptr, src.as_ptr(), num_bytes, stream.cu_stream())
+        }
+    }
 }

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -27,6 +27,7 @@ use cuda_bindings::CUdeviceptr;
 
 use crate::context::CudaContext;
 use crate::error::DriverError;
+use crate::pinned_host_buffer::PinnedHostBuffer;
 use crate::stream::CudaStream;
 
 /// Marker trait for values that can be safely copied between host and device
@@ -223,6 +224,18 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         })
     }
 
+    /// Allocates device memory and copies data from a pinned host buffer.
+    ///
+    /// Pinned host memory allows CUDA to avoid the pageable-memory staging
+    /// path and is required when host-device copies need true asynchronous
+    /// overlap with other stream work.
+    pub fn from_pinned_host(
+        stream: &CudaStream,
+        data: &PinnedHostBuffer<T>,
+    ) -> Result<Self, DriverError> {
+        Self::from_host(stream, data.as_slice())
+    }
+
     /// Allocates zero-initialized device memory of `len` elements, enqueued
     /// on `stream`.
     pub fn zeroed(stream: &CudaStream, len: usize) -> Result<Self, DriverError> {
@@ -282,5 +295,19 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
             )?;
         }
         stream.synchronize()
+    }
+
+    /// Copies the buffer contents into an existing pinned host buffer.
+    ///
+    /// Synchronizes on `stream` before returning. Panics if
+    /// `dst.len() < self.len()`. Use pinned destinations when you need the
+    /// transfer to avoid pageable-memory staging; this helper still waits for
+    /// completion before returning, matching [`Self::copy_to_host`].
+    pub fn copy_to_pinned_host(
+        &self,
+        stream: &CudaStream,
+        dst: &mut PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        self.copy_to_host(stream, dst.as_mut_slice())
     }
 }

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -224,7 +224,8 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         })
     }
 
-    /// Allocates device memory and copies data from a pinned host buffer.
+    /// Allocates device memory and enqueues a host-to-device copy from a
+    /// pinned host buffer on `stream`, returning without synchronizing.
     ///
     /// Pinned host memory allows CUDA to avoid the pageable-memory staging
     /// path and is required when host-device copies need true asynchronous
@@ -232,15 +233,24 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     ///
     /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
     /// `PORTABLE` flag, so the allocation is only pinned in the context that
-    /// created it. In debug builds this asserts that `data` and `stream` share
-    /// the same [`CudaContext`].
+    /// created it. In debug builds this asserts that `data` and `stream`
+    /// share the same [`CudaContext`].
     ///
-    /// This method returns after enqueueing the host-to-device copy. It does
-    /// not synchronize `stream`; keep `data` alive and unmodified until the
-    /// copy completes. The blocking device-to-host counterpart is
-    /// [`Self::copy_to_pinned_host`]; use [`Self::copy_to_pinned_host_async`]
-    /// for symmetric non-blocking DtoH behavior.
-    pub fn from_pinned_host(
+    /// The device-to-host counterparts are [`Self::copy_to_pinned_host`]
+    /// (blocking) and [`Self::copy_to_pinned_host_async`] (non-blocking).
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy on `stream` and
+    /// returns; CUDA may still be reading from `data`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `data` is not dropped, freed, mutated, or aliased until the enqueued
+    /// copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    /// Dropping `data` before that synchronization point calls
+    /// `cuMemFreeHost` while the in-flight transfer is still reading the
+    /// buffer, which is undefined behavior.
+    pub unsafe fn from_pinned_host(
         stream: &CudaStream,
         data: &PinnedHostBuffer<T>,
     ) -> Result<Self, DriverError> {
@@ -312,12 +322,12 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         stream.synchronize()
     }
 
-    /// Copies the buffer contents into an existing pinned host buffer.
+    /// Copies the buffer contents into an existing pinned host buffer and
+    /// synchronizes `stream` before returning.
     ///
-    /// Synchronizes on `stream` before returning. Panics if
-    /// `dst.len() < self.len()`. Use pinned destinations when you need the
-    /// transfer to avoid pageable-memory staging; this helper still waits for
-    /// completion before returning, matching [`Self::copy_to_host`].
+    /// Panics if `dst.len() < self.len()`. Use pinned destinations when you
+    /// need the transfer to avoid pageable-memory staging; this helper still
+    /// waits for completion before returning, matching [`Self::copy_to_host`].
     ///
     /// For true DtoH overlap, use [`Self::copy_to_pinned_host_async`] and
     /// synchronize the stream later.
@@ -326,22 +336,34 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         stream: &CudaStream,
         dst: &mut PinnedHostBuffer<T>,
     ) -> Result<(), DriverError> {
-        self.copy_to_pinned_host_async(stream, dst)?;
+        // SAFETY: we synchronize the stream below before returning, so the
+        // pinned destination is no longer being written to by CUDA when the
+        // mutable borrow on `dst` is released to the caller.
+        unsafe { self.copy_to_pinned_host_async(stream, dst)? };
         stream.synchronize()
     }
 
     /// Enqueues a device-to-host copy into an existing pinned host buffer and
     /// returns without synchronizing.
     ///
-    /// Panics if `dst.len() < self.len()`. The destination buffer must not be
-    /// read or mutated until the copy has completed, for example after
-    /// [`CudaStream::synchronize`] or another stream-ordering dependency.
+    /// Panics if `dst.len() < self.len()`.
     ///
     /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
     /// `PORTABLE` flag, so the allocation is only pinned in the context that
-    /// created it. In debug builds this asserts that `dst` and `stream` share
-    /// the same [`CudaContext`].
-    pub fn copy_to_pinned_host_async(
+    /// created it. In debug builds this asserts that `dst` and `stream`
+    /// share the same [`CudaContext`].
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the device-to-host copy on `stream` and
+    /// returns; CUDA may still be writing into `dst`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `dst` is not dropped, freed, read, or aliased until the enqueued copy
+    /// has completed, typically after the next [`CudaStream::synchronize`]
+    /// call or a stream-ordered event wait. Dropping `dst` before that
+    /// synchronization point calls `cuMemFreeHost` while the in-flight
+    /// transfer is still writing the buffer, which is undefined behavior.
+    pub unsafe fn copy_to_pinned_host_async(
         &self,
         stream: &CudaStream,
         dst: &mut PinnedHostBuffer<T>,
@@ -365,4 +387,5 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
             )
         }
     }
+
 }

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -134,7 +134,7 @@ unsafe impl<T: Send + Sync> Sync for DeviceBuffer<T> {}
 impl<T> Drop for DeviceBuffer<T> {
     fn drop(&mut self) {
         if self.ptr != 0 {
-            let _ = self.ctx.bind_to_thread();
+            self.ctx.record_err(self.ctx.bind_to_thread());
             self.ctx
                 .record_err(unsafe { crate::memory::free_sync(self.ptr) });
         }
@@ -229,10 +229,25 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// Pinned host memory allows CUDA to avoid the pageable-memory staging
     /// path and is required when host-device copies need true asynchronous
     /// overlap with other stream work.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `data` and `stream` share
+    /// the same [`CudaContext`].
+    ///
+    /// This method returns after enqueueing the host-to-device copy. It does
+    /// not synchronize `stream`; keep `data` alive and unmodified until the
+    /// copy completes. The blocking device-to-host counterpart is
+    /// [`Self::copy_to_pinned_host`]; use [`Self::copy_to_pinned_host_async`]
+    /// for symmetric non-blocking DtoH behavior.
     pub fn from_pinned_host(
         stream: &CudaStream,
         data: &PinnedHostBuffer<T>,
     ) -> Result<Self, DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(data.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
         Self::from_host(stream, data.as_slice())
     }
 
@@ -303,11 +318,51 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// `dst.len() < self.len()`. Use pinned destinations when you need the
     /// transfer to avoid pageable-memory staging; this helper still waits for
     /// completion before returning, matching [`Self::copy_to_host`].
+    ///
+    /// For true DtoH overlap, use [`Self::copy_to_pinned_host_async`] and
+    /// synchronize the stream later.
     pub fn copy_to_pinned_host(
         &self,
         stream: &CudaStream,
         dst: &mut PinnedHostBuffer<T>,
     ) -> Result<(), DriverError> {
-        self.copy_to_host(stream, dst.as_mut_slice())
+        self.copy_to_pinned_host_async(stream, dst)?;
+        stream.synchronize()
+    }
+
+    /// Enqueues a device-to-host copy into an existing pinned host buffer and
+    /// returns without synchronizing.
+    ///
+    /// Panics if `dst.len() < self.len()`. The destination buffer must not be
+    /// read or mutated until the copy has completed, for example after
+    /// [`CudaStream::synchronize`] or another stream-ordering dependency.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `dst` and `stream` share
+    /// the same [`CudaContext`].
+    pub fn copy_to_pinned_host_async(
+        &self,
+        stream: &CudaStream,
+        dst: &mut PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(dst.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
+        assert!(
+            dst.len() >= self.len,
+            "destination pinned host buffer too small: {} < {}",
+            dst.len(),
+            self.len
+        );
+        unsafe {
+            crate::memory::memcpy_dtoh_async(
+                dst.as_mut_ptr(),
+                self.ptr,
+                self.num_bytes(),
+                stream.cu_stream(),
+            )
+        }
     }
 }

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -20,6 +20,7 @@
 //!   ordering and elapsed-time measurement.
 //! - [`CudaModule`] / [`CudaFunction`] -- PTX/cubin loading and kernel handle
 //!   extraction.
+//! - [`PinnedHostBuffer`] -- page-locked host memory for CUDA transfers.
 //! - [`LaunchConfig`] -- grid/block dimension helper.
 //! - [`memory`] -- free functions for device allocation, transfer, and memset
 //!   (both stream-ordered async and synchronous variants).
@@ -55,6 +56,8 @@ pub mod memory;
 pub mod module;
 /// Peer-to-peer (P2P) access between GPU contexts.
 pub mod peer;
+/// Page-locked host memory for CUDA transfers.
+pub mod pinned_host_buffer;
 /// CUDA stream management (RAII, host callbacks, fork/join).
 pub mod stream;
 /// CUDA Virtual Memory Management (VMM) for physical alloc, VA reservation, and mapping.
@@ -69,6 +72,7 @@ pub use error::{DriverError, IntoResult};
 pub use event::CudaEvent;
 pub use launch::LaunchConfig;
 pub use module::{CudaFunction, CudaModule};
+pub use pinned_host_buffer::PinnedHostBuffer;
 pub use stream::CudaStream;
 
 use std::ffi::c_uint;

--- a/crates/cuda-core/src/memory.rs
+++ b/crates/cuda-core/src/memory.rs
@@ -15,6 +15,7 @@
 
 use crate::error::{DriverError, IntoResult};
 use cuda_bindings::CUdeviceptr;
+use std::ffi::c_void;
 use std::mem::MaybeUninit;
 
 /// Allocates `num_bytes` of device memory on `stream` using the stream-ordered
@@ -166,4 +167,32 @@ pub unsafe fn memset_d8_async(
     stream: cuda_bindings::CUstream,
 ) -> Result<(), DriverError> {
     unsafe { cuda_bindings::cuMemsetD8Async(dptr, value, num_bytes, stream) }.result()
+}
+
+/// Allocates `num_bytes` of page-locked host memory.
+///
+/// Pinned host memory can be used as a staging area for CUDA transfers that
+/// need higher bandwidth or true asynchronous overlap. Pair with [`free_host`].
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `num_bytes` must be greater than zero and must not exceed the host memory
+///   available for page-locked allocations.
+pub unsafe fn malloc_host(num_bytes: usize) -> Result<*mut c_void, DriverError> {
+    let mut host_ptr = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemAllocHost_v2(host_ptr.as_mut_ptr(), num_bytes).result()?;
+        Ok(host_ptr.assume_init())
+    }
+}
+
+/// Frees page-locked host memory previously allocated with [`malloc_host`].
+///
+/// # Safety
+///
+/// - `ptr` must have been returned by [`malloc_host`] and not yet freed.
+/// - No in-flight CUDA transfer or kernel may reference `ptr`.
+pub unsafe fn free_host(ptr: *mut c_void) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemFreeHost(ptr) }.result()
 }

--- a/crates/cuda-core/src/memory.rs
+++ b/crates/cuda-core/src/memory.rs
@@ -172,13 +172,15 @@ pub unsafe fn memset_d8_async(
 /// Allocates `num_bytes` of page-locked host memory.
 ///
 /// Pinned host memory can be used as a staging area for CUDA transfers that
-/// need higher bandwidth or true asynchronous overlap. Pair with [`free_host`].
+/// need higher bandwidth, and is required for host-device copies that are
+/// intended to overlap with GPU work. Pair with [`free_host`].
 ///
 /// # Safety
 ///
 /// - A CUDA context must be bound to the calling thread.
-/// - `num_bytes` must be greater than zero and must not exceed the host memory
-///   available for page-locked allocations.
+/// - `num_bytes` must not exceed the host memory available for page-locked
+///   allocations. Passing zero bytes is not useful and the CUDA driver reports
+///   it as an error.
 pub unsafe fn malloc_host(num_bytes: usize) -> Result<*mut c_void, DriverError> {
     let mut host_ptr = MaybeUninit::uninit();
     unsafe {

--- a/crates/cuda-core/src/pinned_host_buffer.rs
+++ b/crates/cuda-core/src/pinned_host_buffer.rs
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Page-locked host memory for CUDA transfers.
+//!
+//! [`PinnedHostBuffer<T>`] owns CUDA page-locked host memory allocated with
+//! `cuMemAllocHost`. Pinned memory is useful as a staging area for host-device
+//! copies that need higher transfer bandwidth or true asynchronous overlap with
+//! GPU work.
+
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::slice;
+use std::sync::Arc;
+
+use crate::context::CudaContext;
+use crate::device_buffer::DeviceCopy;
+use crate::error::DriverError;
+
+/// Owned page-locked host buffer.
+///
+/// The buffer is initialized and exposes normal Rust slices. The backing
+/// allocation is freed with `cuMemFreeHost` on drop.
+///
+/// Pinned transfer buffers require `T: DeviceCopy`, so host-owned values such
+/// as [`String`] are rejected.
+///
+/// ```compile_fail
+/// # use cuda_core::{CudaContext, PinnedHostBuffer};
+/// # fn rejects_non_device_copy(ctx: &std::sync::Arc<CudaContext>) {
+/// let _ = PinnedHostBuffer::<String>::new(ctx, 1);
+/// # }
+/// ```
+pub struct PinnedHostBuffer<T: DeviceCopy> {
+    ptr: NonNull<T>,
+    len: usize,
+    ctx: Arc<CudaContext>,
+    _marker: PhantomData<T>,
+}
+
+// SAFETY: the allocation is host memory. Moving ownership to another thread is
+// safe when `T` is safe to send.
+unsafe impl<T: DeviceCopy + Send> Send for PinnedHostBuffer<T> {}
+// SAFETY: shared access only exposes `&[T]`.
+unsafe impl<T: DeviceCopy + Sync> Sync for PinnedHostBuffer<T> {}
+
+impl<T: DeviceCopy> PinnedHostBuffer<T> {
+    /// Allocates a pinned host buffer and fills it with `T::default()`.
+    pub fn new(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError>
+    where
+        T: Default,
+    {
+        let buffer = Self::allocate(ctx, len)?;
+
+        for idx in 0..len {
+            unsafe {
+                buffer.ptr.as_ptr().add(idx).write(T::default());
+            }
+        }
+
+        Ok(buffer)
+    }
+
+    /// Allocates a pinned host buffer and copies `data` into it.
+    pub fn from_slice(ctx: &Arc<CudaContext>, data: &[T]) -> Result<Self, DriverError> {
+        let buffer = Self::allocate(ctx, data.len())?;
+        if !data.is_empty() {
+            unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), buffer.ptr.as_ptr(), data.len());
+            }
+        }
+        Ok(buffer)
+    }
+
+    /// Number of elements in the buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the buffer contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Total size in bytes (`len * size_of::<T>()`).
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        self.len * std::mem::size_of::<T>()
+    }
+
+    /// Returns the CUDA context used to allocate this buffer.
+    #[inline]
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Returns the host pointer.
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the mutable host pointer.
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the buffer as a host slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Returns the buffer as a mutable host slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+
+    fn allocate(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError> {
+        let ptr = if len == 0 || std::mem::size_of::<T>() == 0 {
+            NonNull::dangling()
+        } else {
+            ctx.bind_to_thread()?;
+            let num_bytes = allocation_size::<T>(len)?;
+            let ptr = unsafe { crate::memory::malloc_host(num_bytes)? };
+            NonNull::new(ptr.cast::<T>()).ok_or(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            ))?
+        };
+
+        Ok(Self {
+            ptr,
+            len,
+            ctx: ctx.clone(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: DeviceCopy> Drop for PinnedHostBuffer<T> {
+    fn drop(&mut self) {
+        if self.len != 0 && std::mem::size_of::<T>() != 0 {
+            self.ctx.record_err(self.ctx.bind_to_thread());
+            self.ctx
+                .record_err(unsafe { crate::memory::free_host(self.ptr.as_ptr().cast()) });
+        }
+    }
+}
+
+impl<T: DeviceCopy> AsRef<[T]> for PinnedHostBuffer<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T: DeviceCopy> AsMut<[T]> for PinnedHostBuffer<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T: DeviceCopy> Deref for PinnedHostBuffer<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T: DeviceCopy> DerefMut for PinnedHostBuffer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+fn allocation_size<T>(len: usize) -> Result<usize, DriverError> {
+    len.checked_mul(std::mem::size_of::<T>()).ok_or(DriverError(
+        cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+    ))
+}

--- a/crates/cuda-core/src/pinned_host_buffer.rs
+++ b/crates/cuda-core/src/pinned_host_buffer.rs
@@ -7,9 +7,11 @@
 //!
 //! [`PinnedHostBuffer<T>`] owns CUDA page-locked host memory allocated with
 //! `cuMemAllocHost`. Pinned memory is useful as a staging area for host-device
-//! copies that need higher transfer bandwidth or true asynchronous overlap with
-//! GPU work.
+//! copies that need higher transfer bandwidth. Copies only overlap with GPU
+//! work when they are enqueued with non-blocking transfer APIs and synchronized
+//! later by the caller.
 
+use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
@@ -31,12 +33,13 @@ use crate::error::DriverError;
 /// ```compile_fail
 /// # use cuda_core::{CudaContext, PinnedHostBuffer};
 /// # fn rejects_non_device_copy(ctx: &std::sync::Arc<CudaContext>) {
-/// let _ = PinnedHostBuffer::<String>::new(ctx, 1);
+/// let _ = PinnedHostBuffer::<String>::zeroed(ctx, 1);
 /// # }
 /// ```
 pub struct PinnedHostBuffer<T: DeviceCopy> {
     ptr: NonNull<T>,
     len: usize,
+    num_bytes: usize,
     ctx: Arc<CudaContext>,
     _marker: PhantomData<T>,
 }
@@ -48,16 +51,12 @@ unsafe impl<T: DeviceCopy + Send> Send for PinnedHostBuffer<T> {}
 unsafe impl<T: DeviceCopy + Sync> Sync for PinnedHostBuffer<T> {}
 
 impl<T: DeviceCopy> PinnedHostBuffer<T> {
-    /// Allocates a pinned host buffer and fills it with `T::default()`.
-    pub fn new(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError>
-    where
-        T: Default,
-    {
-        let buffer = Self::allocate(ctx, len)?;
-
-        for idx in 0..len {
+    /// Allocates a pinned host buffer and fills it with zero bytes.
+    pub fn zeroed(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError> {
+        let mut buffer = Self::allocate(ctx, len)?;
+        if buffer.num_bytes != 0 {
             unsafe {
-                buffer.ptr.as_ptr().add(idx).write(T::default());
+                std::ptr::write_bytes(buffer.as_mut_ptr().cast::<u8>(), 0, buffer.num_bytes);
             }
         }
 
@@ -90,7 +89,7 @@ impl<T: DeviceCopy> PinnedHostBuffer<T> {
     /// Total size in bytes (`len * size_of::<T>()`).
     #[inline]
     pub fn num_bytes(&self) -> usize {
-        self.len * std::mem::size_of::<T>()
+        self.num_bytes
     }
 
     /// Returns the CUDA context used to allocate this buffer.
@@ -124,11 +123,11 @@ impl<T: DeviceCopy> PinnedHostBuffer<T> {
     }
 
     fn allocate(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError> {
-        let ptr = if len == 0 || std::mem::size_of::<T>() == 0 {
+        let num_bytes = allocation_size::<T>(len)?;
+        let ptr = if num_bytes == 0 {
             NonNull::dangling()
         } else {
             ctx.bind_to_thread()?;
-            let num_bytes = allocation_size::<T>(len)?;
             let ptr = unsafe { crate::memory::malloc_host(num_bytes)? };
             NonNull::new(ptr.cast::<T>()).ok_or(DriverError(
                 cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
@@ -138,6 +137,7 @@ impl<T: DeviceCopy> PinnedHostBuffer<T> {
         Ok(Self {
             ptr,
             len,
+            num_bytes,
             ctx: ctx.clone(),
             _marker: PhantomData,
         })
@@ -146,11 +146,22 @@ impl<T: DeviceCopy> PinnedHostBuffer<T> {
 
 impl<T: DeviceCopy> Drop for PinnedHostBuffer<T> {
     fn drop(&mut self) {
-        if self.len != 0 && std::mem::size_of::<T>() != 0 {
+        if self.num_bytes != 0 {
             self.ctx.record_err(self.ctx.bind_to_thread());
             self.ctx
                 .record_err(unsafe { crate::memory::free_host(self.ptr.as_ptr().cast()) });
         }
+    }
+}
+
+impl<T: DeviceCopy> fmt::Debug for PinnedHostBuffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PinnedHostBuffer")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .field("num_bytes", &self.num_bytes)
+            .field("ctx", &self.ctx)
+            .finish()
     }
 }
 

--- a/crates/cuda-core/tests/pinned_host_buffer.rs
+++ b/crates/cuda-core/tests/pinned_host_buffer.rs
@@ -98,3 +98,30 @@ fn pinned_host_buffer_async_copy_can_be_synchronized_later() {
     assert_eq!(output.as_slice(), input.as_slice());
 }
 
+#[test]
+fn device_buffer_can_be_refilled_from_pinned_host_async() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let mut device =
+        DeviceBuffer::<u32>::zeroed(&stream, 4).expect("failed to allocate device buffer");
+    let mut output =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 4).expect("failed to allocate pinned output buffer");
+
+    for round in 0..3 {
+        let payload = [round * 10, round * 10 + 1, round * 10 + 2, round * 10 + 3];
+        let input =
+            PinnedHostBuffer::from_slice(&ctx, &payload).expect("failed to allocate pinned input");
+
+        // SAFETY: `input` lives until the end of this scope and the
+        // `stream.synchronize()` below completes the in-flight refill before
+        // `input` is dropped. `output` outlives the synchronize call too.
+        unsafe { device.copy_from_pinned_host_async(&stream, &input) }
+            .expect("failed to enqueue refill");
+        unsafe { device.copy_to_pinned_host_async(&stream, &mut output) }
+            .expect("failed to enqueue readback");
+        stream.synchronize().expect("failed to synchronize stream");
+
+        assert_eq!(output.as_slice(), &payload);
+    }
+}

--- a/crates/cuda-core/tests/pinned_host_buffer.rs
+++ b/crates/cuda-core/tests/pinned_host_buffer.rs
@@ -62,8 +62,11 @@ fn pinned_host_buffer_roundtrips_through_device_buffer() {
 
     let input = PinnedHostBuffer::from_slice(&ctx, &[1_u32, 2, 3, 4])
         .expect("failed to allocate pinned input");
-    let device =
-        DeviceBuffer::from_pinned_host(&stream, &input).expect("failed to copy input to device");
+    // SAFETY: `input` is kept alive for the entire roundtrip, and
+    // `copy_to_pinned_host` synchronizes before returning, so both pinned
+    // buffers outlive their in-flight copies.
+    let device = unsafe { DeviceBuffer::from_pinned_host(&stream, &input) }
+        .expect("failed to copy input to device");
     let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
         .expect("failed to allocate pinned output");
 
@@ -81,15 +84,17 @@ fn pinned_host_buffer_async_copy_can_be_synchronized_later() {
 
     let input = PinnedHostBuffer::from_slice(&ctx, &[5_u32, 6, 7, 8])
         .expect("failed to allocate pinned input");
-    let device =
-        DeviceBuffer::from_pinned_host(&stream, &input).expect("failed to copy input to device");
+    // SAFETY: both pinned buffers are kept alive past `stream.synchronize()`
+    // below, satisfying the contract of the async pinned helpers.
+    let device = unsafe { DeviceBuffer::from_pinned_host(&stream, &input) }
+        .expect("failed to copy input to device");
     let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
         .expect("failed to allocate pinned output");
 
-    device
-        .copy_to_pinned_host_async(&stream, &mut output)
+    unsafe { device.copy_to_pinned_host_async(&stream, &mut output) }
         .expect("failed to enqueue output copy");
     stream.synchronize().expect("failed to synchronize stream");
 
     assert_eq!(output.as_slice(), input.as_slice());
 }
+

--- a/crates/cuda-core/tests/pinned_host_buffer.rs
+++ b/crates/cuda-core/tests/pinned_host_buffer.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use cuda_core::{CudaContext, DeviceBuffer, PinnedHostBuffer};
+
+#[test]
+fn pinned_host_buffer_exposes_initialized_slice() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let mut host = PinnedHostBuffer::<u32>::new(&ctx, 4).expect("failed to allocate pinned host");
+
+    assert_eq!(host.len(), 4);
+    assert!(!host.is_empty());
+    assert_eq!(host.as_slice(), &[0, 0, 0, 0]);
+
+    host.as_mut_slice().copy_from_slice(&[1, 2, 3, 4]);
+    assert_eq!(&host[..], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn pinned_host_buffer_supports_empty_allocations() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host = PinnedHostBuffer::<u32>::new(&ctx, 0).expect("failed to create empty pinned host");
+
+    assert_eq!(host.len(), 0);
+    assert!(host.is_empty());
+    assert_eq!(host.as_slice(), &[]);
+}
+
+#[test]
+fn pinned_host_buffer_roundtrips_through_device_buffer() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let input = PinnedHostBuffer::from_slice(&ctx, &[1_u32, 2, 3, 4])
+        .expect("failed to allocate pinned input");
+    let device =
+        DeviceBuffer::from_pinned_host(&stream, &input).expect("failed to copy input to device");
+    let mut output =
+        PinnedHostBuffer::<u32>::new(&ctx, input.len()).expect("failed to allocate pinned output");
+
+    device
+        .copy_to_pinned_host(&stream, &mut output)
+        .expect("failed to copy output to host");
+
+    assert_eq!(output.as_slice(), input.as_slice());
+}

--- a/crates/cuda-core/tests/pinned_host_buffer.rs
+++ b/crates/cuda-core/tests/pinned_host_buffer.rs
@@ -8,11 +8,14 @@ use cuda_core::{CudaContext, DeviceBuffer, PinnedHostBuffer};
 #[test]
 fn pinned_host_buffer_exposes_initialized_slice() {
     let ctx = CudaContext::new(0).expect("failed to create CUDA context");
-    let mut host = PinnedHostBuffer::<u32>::new(&ctx, 4).expect("failed to allocate pinned host");
+    let mut host =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 4).expect("failed to allocate pinned host");
 
     assert_eq!(host.len(), 4);
+    assert_eq!(host.num_bytes(), 16);
     assert!(!host.is_empty());
     assert_eq!(host.as_slice(), &[0, 0, 0, 0]);
+    assert!(format!("{host:?}").contains("PinnedHostBuffer"));
 
     host.as_mut_slice().copy_from_slice(&[1, 2, 3, 4]);
     assert_eq!(&host[..], &[1, 2, 3, 4]);
@@ -21,11 +24,35 @@ fn pinned_host_buffer_exposes_initialized_slice() {
 #[test]
 fn pinned_host_buffer_supports_empty_allocations() {
     let ctx = CudaContext::new(0).expect("failed to create CUDA context");
-    let host = PinnedHostBuffer::<u32>::new(&ctx, 0).expect("failed to create empty pinned host");
+    let host =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 0).expect("failed to create empty pinned host");
 
     assert_eq!(host.len(), 0);
+    assert_eq!(host.num_bytes(), 0);
     assert!(host.is_empty());
     assert_eq!(host.as_slice(), &[]);
+}
+
+#[test]
+fn pinned_host_buffer_from_slice_supports_empty_input() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host = PinnedHostBuffer::<u32>::from_slice(&ctx, &[])
+        .expect("failed to create empty pinned host from slice");
+
+    assert_eq!(host.len(), 0);
+    assert_eq!(host.num_bytes(), 0);
+    assert_eq!(host.as_slice(), &[]);
+}
+
+#[test]
+fn pinned_host_buffer_supports_zero_sized_types() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host = PinnedHostBuffer::<()>::zeroed(&ctx, 8)
+        .expect("failed to create zero-sized pinned host buffer");
+
+    assert_eq!(host.len(), 8);
+    assert_eq!(host.num_bytes(), 0);
+    assert_eq!(host.as_slice(), &[(); 8]);
 }
 
 #[test]
@@ -37,12 +64,32 @@ fn pinned_host_buffer_roundtrips_through_device_buffer() {
         .expect("failed to allocate pinned input");
     let device =
         DeviceBuffer::from_pinned_host(&stream, &input).expect("failed to copy input to device");
-    let mut output =
-        PinnedHostBuffer::<u32>::new(&ctx, input.len()).expect("failed to allocate pinned output");
+    let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
+        .expect("failed to allocate pinned output");
 
     device
         .copy_to_pinned_host(&stream, &mut output)
         .expect("failed to copy output to host");
+
+    assert_eq!(output.as_slice(), input.as_slice());
+}
+
+#[test]
+fn pinned_host_buffer_async_copy_can_be_synchronized_later() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let input = PinnedHostBuffer::from_slice(&ctx, &[5_u32, 6, 7, 8])
+        .expect("failed to allocate pinned input");
+    let device =
+        DeviceBuffer::from_pinned_host(&stream, &input).expect("failed to copy input to device");
+    let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
+        .expect("failed to allocate pinned output");
+
+    device
+        .copy_to_pinned_host_async(&stream, &mut output)
+        .expect("failed to enqueue output copy");
+    stream.synchronize().expect("failed to synchronize stream");
 
     assert_eq!(output.as_slice(), input.as_slice());
 }


### PR DESCRIPTION
 ## Summary

  Add `PinnedHostBuffer<T>` to `cuda-core` for CUDA page-locked host memory.

  This provides a safe RAII wrapper around `cuMemAllocHost` / `cuMemFreeHost` and integrates pinned host buffers with `DeviceBuffer<T>` transfers.

  ## Motivation

  CUDA pinned/page-locked host memory is important for host-device transfer performance and is required when copies need true asynchronous overlap with GPU work.

  `cuda-core` already exposes device allocation and host-device copy helpers, but it did not have a safe owned pinned-host-memory type. This PR adds that missing runtime building block.

  ## Changes

  - Add `PinnedHostBuffer<T: DeviceCopy>`.
  - Allocate pinned host memory with `cuMemAllocHost`.
  - Free pinned host memory on drop with `cuMemFreeHost`.
  - Support initialized buffers via `new` and `from_slice`.
  - Support empty buffers without calling CUDA allocation.
  - Add `DeviceBuffer::from_pinned_host`.
  - Add `DeviceBuffer::copy_to_pinned_host`.
  - Document pinned host memory in the main README and `cuda-core` README.
  - Add tests for pinned allocation, empty allocation, device roundtrip, and non-`DeviceCopy` rejection.

  ## Safety

  `PinnedHostBuffer<T>` requires `T: DeviceCopy`, matching the safety model used by `DeviceBuffer<T>` transfer helpers.

  This rejects host-owned values like `String`, which cannot safely round-trip through raw byte copies.

  Drop follows the existing cuda-core RAII pattern: cleanup errors are recorded on the context instead of panicking.

  ## Testing

  ```bash
  cargo fmt --check
  cargo test -p cuda-core
  cargo clippy -p cuda-core -- -D warnings
  cargo check
  cargo clippy --workspace -- -D warnings
  cargo oxide run vecadd --arch sm_75

  The pinned-memory tests include a real CUDA roundtrip through:

  PinnedHostBuffer::from_slice
  DeviceBuffer::from_pinned_host
  DeviceBuffer::copy_to_pinned_host

  The real vecadd example completed successfully:

  SUCCESS: All 1024 elements correct


