### PR TITLE
docs: clang dev packages + update-alternatives for Ubuntu 24.04 / DGX-OS

### DIFF
--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -72,13 +72,31 @@ A stock LLVM build without the NVPTX backend will not work. The `llvm-21` Ubuntu
 
 ## Clang (host `cuda-bindings`)
 
-The host `cuda-bindings` crate runs [`bindgen`](https://github.com/rust-lang/rust-bindgen), which loads libclang and needs clang's own resource-dir `stddef.h` — a bare `libclang1-*` runtime is not enough.
+The host `cuda-bindings` crate runs [`bindgen`](https://github.com/rust-lang/rust-bindgen), which loads `libclang.so` at runtime and needs clang's own resource-dir `stddef.h` — a bare `libclang1-*` runtime is not enough. Three packages cover both halves:
 
 ```bash
-sudo apt install clang-21   # or libclang-common-21-dev
+sudo apt install libclang-21-dev libclang-cpp21-dev libclang-common-21-dev
 ```
 
 `cargo oxide doctor` catches this up front; the symptom otherwise is `'stddef.h' file not found` during the host build.
+
+:::{note}
+**Fresh Ubuntu 24.04 / DGX-OS:** `clang-21` and friends aren't in the default apt sources, and `apt.llvm.org/llvm.sh` installs the versioned `clang-21` / `clang++-21` binaries without registering the unversioned aliases that `cargo oxide doctor` looks for. Three steps cover both gaps:
+
+```bash
+# 1. LLVM 21 from upstream (adds the apt.llvm.org repo + installs clang-21 etc.)
+wget -q https://apt.llvm.org/llvm.sh && sudo bash llvm.sh 21
+
+# 2. The bindgen-side dev headers (llvm.sh doesn't pull these)
+sudo apt install -y libclang-21-dev libclang-cpp21-dev libclang-common-21-dev
+
+# 3. Unversioned aliases so `clang` / `clang++` resolve
+sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-21   100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
+```
+
+Validated end-to-end on Asus GX10 / NVIDIA DGX Spark (GB10, sm_121, Ubuntu 24.04.4 / DGX-OS kernel 6.17, CUDA 13.0, LLVM 21.1.8).
+:::
 
 ---
 

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -81,21 +81,14 @@ sudo apt install libclang-21-dev libclang-cpp21-dev libclang-common-21-dev
 `cargo oxide doctor` catches this up front; the symptom otherwise is `'stddef.h' file not found` during the host build.
 
 :::{note}
-**Fresh Ubuntu 24.04 / DGX-OS:** `clang-21` and friends aren't in the default apt sources, and `apt.llvm.org/llvm.sh` installs the versioned `clang-21` / `clang++-21` binaries without registering the unversioned aliases that `cargo oxide doctor` looks for. Three steps cover both gaps:
+**Fresh Ubuntu 24.04 / DGX-OS:** after installing LLVM 21 via `apt.llvm.org/llvm.sh` as shown above, the versioned `clang-21` / `clang++-21` binaries are present but the unversioned aliases `cargo oxide doctor` looks for are not. Add them with `update-alternatives`:
 
 ```bash
-# 1. LLVM 21 from upstream (adds the apt.llvm.org repo + installs clang-21 etc.)
-wget -q https://apt.llvm.org/llvm.sh && sudo bash llvm.sh 21
-
-# 2. The bindgen-side dev headers (llvm.sh doesn't pull these)
-sudo apt install -y libclang-21-dev libclang-cpp21-dev libclang-common-21-dev
-
-# 3. Unversioned aliases so `clang` / `clang++` resolve
 sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-21   100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
 ```
 
-Validated end-to-end on Asus GX10 / NVIDIA DGX Spark (GB10, sm_121, Ubuntu 24.04.4 / DGX-OS kernel 6.17, CUDA 13.0, LLVM 21.1.8).
+Validated on Asus GX10 / NVIDIA DGX Spark.
 :::
 
 ---


### PR DESCRIPTION
## Summary

Updates `cuda-oxide-book/getting-started/installation.md` to document the apt-deps + alternatives gap we hit when bringing cuda-oxide up on a fresh Ubuntu 24.04 / DGX-OS image. Single-file docs change.

### What fails today

1. **Bindgen `libclang.so` discovery.** The current `sudo apt install clang-21   # or libclang-common-21-dev` is insufficient. `bindgen` (used by `cuda-bindings`) loads `libclang.so` from `libclang-21-dev`; `libclang-common-21-dev` ships only the resource-dir headers; both are needed, alongside `libclang-cpp21-dev` for the C++ surface.
2. **Unversioned aliases.** `apt.llvm.org/llvm.sh` installs `clang-21` / `clang++-21` without registering the unversioned `clang` / `clang++` aliases that `cargo oxide doctor` probes for. `update-alternatives` has to be set up explicitly.

### What this PR adds

- Updates the existing **"Clang (host `cuda-bindings`)"** section in `installation.md` to list all three required packages.
- Adds a small `:::{note}` callout under that section with the apt.llvm.org bootstrap + the three-step recipe (LLVM repo → dev headers → `update-alternatives`).
- One-line "validated on Asus GX10 / NVIDIA DGX Spark (GB10, sm_121, …)" footnote in the callout for adopters on that hardware tier.

No new pages. No toctree changes.

### Scope changes from the earlier version of this PR

The previous version added `cuda-oxide-book/appendix/asus-gx10.md` + `cuda-oxide-book/getting-started/ubuntu-24-04-bring-up.md` as new pages, with the full validation footprint (vecadd / async_mlp / pipeline / gemm_sol / WGMMA-canary on sm_121, plus a paired cuBLAS bf16 GEMM benchmark). Per @nihalpasham's feedback the validation data — benchmark numbers, toolchain pins, platform-specific compiler limitations — is hard to keep current as the compiler evolves, so it doesn't belong in committed docs. Those two pages and the `index.md` toctree entries are dropped here. The validation results are preserved as a follow-up comment on this PR so they stay searchable as snapshot-in-time context.

james@chronara
