### PR TITLE
Add flake.nix and CI for it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ sign-off will not be merged.
 cuda-oxide requires the Rust nightly toolchain with `rustc_private` support.
 See the [README](README.md) for setup instructions.
 
+The repository includes a `flake.nix` that provides a fully reproducible development
+environment (CUDA 13, LLVM 22, Clang, pinned Rust nightly). If you have Nix with
+flakes enabled, `nix develop` is the quickest way to get everything in place.
+
 ### Formatting and Style
 
 - Run `cargo fmt` before submitting. All code must be formatted with

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 
 On first run, `cargo-oxide` will automatically fetch and build the codegen backend.
 
+#### Nix (alternative)
+
+If you have Nix with flakes enabled, `nix develop` in the repo gives you a reproducible shell with CUDA 13, LLVM 22, Clang, and the pinned Rust nightly — no manual apt installs. The shellHook auto-discovers host NVIDIA drivers on NixOS and non-NixOS systems.
+
+```bash
+nix develop                                       # full dev shell in this repo
+nix run github:NVlabs/cuda-oxide#new my-project   # bootstrap a project
+```
+
 #### Rust
 
 ```bash

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -62,6 +62,37 @@ Rust setup sections below.
 
 ---
 
+## Nix / flake.nix
+
+The repository also ships a `flake.nix` providing a reproducible dev shell
+(CUDA 13, LLVM 22, Clang, pinned Rust nightly). Requires
+[Nix](https://nixos.org/download/) with flakes enabled, an NVIDIA driver on
+the host, and Linux (x86\_64 or aarch64).
+
+Inside the cuda-oxide repo — `cargo-oxide` is included in the shell:
+
+```bash
+nix develop
+cargo oxide run vecadd
+```
+
+To bootstrap a new project without cloning:
+
+```bash
+nix run github:NVlabs/cuda-oxide#new my-project
+cd my-project && nix develop
+```
+
+This scaffolds via `cargo oxide new` and drops in a `flake.nix` that inherits
+this repo's dev shell. The shellHook auto-discovers host NVIDIA driver
+libraries on NixOS and non-NixOS systems; if the host driver is too old,
+update it rather than changing what's inside the Nix shell.
+
+If you use the Nix flake, you can skip the manual CUDA, LLVM, Clang, and
+Rust setup sections below.
+
+---
+
 ## CUDA Toolkit
 
 Install the CUDA Toolkit from the [NVIDIA CUDA Downloads](https://developer.nvidia.com/cuda-downloads) page, then make sure it is on your `PATH`:

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778296574,
+        "narHash": "sha256-DVmg1JCjG0VJTa+FF6tH6tkQChaxzK1EzPL98RiRWU0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1d634a90dffb59ec9ba52652de311b15528c1595",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,109 @@
+{
+  description = "Development shell for cuda-oxide";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config = {
+            allowUnfree = true;
+          };
+        };
+
+        # LLVM
+        llvmPkgs = pkgs.llvmPackages_21;
+
+        # Nightly Rust
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # cuda
+        cudaSymlinked = pkgs.symlinkJoin {
+          name = "cuda-symlinked";
+          paths = with pkgs.cudaPackages_13; [
+            cuda_nvcc
+            cuda_gdb.bin
+            cuda_cudart
+            libnvvm
+            libnvjitlink.lib
+          ];
+        };
+      in
+      {
+        formatter = pkgs.nixfmt;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            rustToolchain
+
+            llvmPkgs.clang
+            llvmPkgs.libclang
+            llvmPkgs.llvm
+
+            cudaSymlinked
+          ];
+
+          CUDA_HOME = cudaSymlinked;
+          LIBCLANG_PATH = "${llvmPkgs.libclang.lib}/lib";
+          CUDA_OXIDE_LLC = "${llvmPkgs.llvm}/bin/llc";
+
+          shellHook = ''
+            # GPU driver setup borrowed from https://github.com/NVlabs/cutile-rs
+            # NixOS provides /run/opengl-driver/lib
+            if [ -d /run/opengl-driver/lib ]; then
+                export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
+            else
+              # Non-NixOS Linux (Ubuntu, Arch, etc. running Nix)
+              # Symlink only the NVIDIA driver to avoid host glibc pollution
+              _nv_drv_dir=$(mktemp -d /tmp/nix-nvidia-driver.XXXXXX)
+
+              for d in /usr/lib/x86_64-linux-gnu \
+                       /lib/x86_64-linux-gnu \
+                       /usr/lib/aarch64-linux-gnu \
+                       /lib/aarch64-linux-gnu \
+                       /usr/lib \
+                       /usr/lib64; do
+                if [ -e "$d/libcuda.so.1" ]; then
+                  for lib in "$d"/libcuda.so* "$d"/libnvidia-ptxjitcompiler.so* "$d"/libnvidia-gpucomp.so*; do
+                    [ -e "$lib" ] && ln -sf "$lib" "$_nv_drv_dir/"
+                  done
+                  break
+              fi
+              done
+
+              if [ -n "$(ls -A "$_nv_drv_dir" 2>/dev/null)" ]; then
+                export LD_LIBRARY_PATH="$_nv_drv_dir:$LD_LIBRARY_PATH"
+                # cleanup when the user exits the nix shell
+                trap 'rm -rf "$_nv_drv_dir"' EXIT
+              else
+                # Clean up immediately if no NVIDIA drivers were found
+                rm -rf "$_nv_drv_dir"
+              fi
+            fi
+
+            echo "🦀 cuda-oxide dev environment loaded"
+            echo " ✓ LLVM $(llc   --version | grep 'LLVM version' | awk '{print $3}')"
+            echo " ✓ CUDA $(nvcc  --version | grep 'release'      | awk '{print $6}' | cut -c 2-)"
+            echo " ✓ Rust $(rustc --version |                       awk '{print $2}')"
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -124,15 +124,37 @@
           name = "cuda-oxide-new";
           runtimeInputs = [ cargo-oxide ];
           text = ''
+            # `cargo oxide new <name> [--async]` takes a single positional
+            # project name. Pick the first non-flag argument as the directory
+            # to drop the template flake into, so flag ordering (e.g. a leading
+            # `--async`) doesn't send the copy to the wrong path.
+            project=""
+            for arg in "$@"; do
+              case "$arg" in
+                -*) ;;
+                *)
+                  project="$arg"
+                  break
+                  ;;
+              esac
+            done
+
             output=$(cargo-oxide new "$@")
-            cp ${userFlake} "$1/flake.nix"
-            chmod +w "$1/flake.nix"
+
+            if [ -n "$project" ] && [ -d "$project" ]; then
+              cp ${userFlake} "$project/flake.nix"
+              chmod +w "$project/flake.nix"
+            fi
+
             echo "Note: run 'nix develop' inside the project directory before using cargo oxide."
             echo ""
             echo "$output"
           '';
         };
 
+        # Packages the `cargo-oxide` CLI. Known impurity: `cargo oxide run`
+        # still builds librustc_codegen_cuda.so on first use and caches it
+        # outside the Nix store, so this derivation is not fully pure yet.
         cargo-oxide = craneLib.buildPackage (
           craneLib.crateNameFromCargoToml { cargoToml = ./crates/cargo-oxide/Cargo.toml; }
           // cargoOxideCommonArgs

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,8 @@
+/*
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
+
 {
   description = "Development shell for cuda-oxide";
 
@@ -8,6 +13,7 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
@@ -15,9 +21,56 @@
       nixpkgs,
       flake-utils,
       rust-overlay,
+      crane,
       ...
     }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+    let
+      # Template flake for user projects. Extends cuda-oxide's devShell via
+      # inputsFrom so users can add their own packages while inheriting the full
+      # CUDA + Rust environment (including the shellHook that wires up the host
+      # NVIDIA driver). nixpkgs and flake-utils are followed from cuda-oxide to
+      # avoid duplicate closures.
+      userFlakeContent = ''
+        {
+          description = "A cuda-oxide project";
+
+          inputs = {
+            cuda-oxide.url = "github:NVlabs/cuda-oxide";
+            nixpkgs.follows = "cuda-oxide/nixpkgs";
+            flake-utils.follows = "cuda-oxide/flake-utils";
+          };
+
+          outputs =
+            {
+              cuda-oxide,
+              nixpkgs,
+              flake-utils,
+              ...
+            }:
+            flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+              system:
+              let
+                pkgs = nixpkgs.legacyPackages.''${system};
+              in
+              {
+                devShells.default = pkgs.mkShell {
+                  inputsFrom = [ cuda-oxide.devShells.''${system}.default ];
+                  packages = [
+                    # add project-specific packages here
+                  ];
+                };
+              }
+            );
+        }
+      '';
+
+      userFlake = builtins.toFile "flake.nix" userFlakeContent;
+
+      # Directory used by `nix flake init -t github:NVlabs/cuda-oxide`.
+      # Content is system-independent; x86_64-linux is chosen arbitrarily.
+      templateSrc = nixpkgs.legacyPackages.x86_64-linux.writeTextDir "flake.nix" userFlakeContent;
+    in
+    (flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
       system:
       let
         overlays = [ (import rust-overlay) ];
@@ -29,7 +82,7 @@
         };
 
         # LLVM
-        llvmPkgs = pkgs.llvmPackages_21;
+        llvmPkgs = pkgs.llvmPackages_22;
 
         # Nightly Rust
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
@@ -45,9 +98,63 @@
             libnvjitlink.lib
           ];
         };
+
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        cargoOxideCommonArgs = {
+          src = ./.;
+          cargoExtraArgs = "-p cargo-oxide";
+          doCheck = false;
+
+          nativeBuildInputs = [
+            llvmPkgs.clang
+            llvmPkgs.libclang
+          ];
+
+          CUDA_HOME = cudaSymlinked;
+          LIBCLANG_PATH = "${llvmPkgs.libclang.lib}/lib";
+        };
+
+        cargoOxideDeps = craneLib.buildDepsOnly (
+          craneLib.crateNameFromCargoToml { cargoToml = ./crates/cargo-oxide/Cargo.toml; }
+          // cargoOxideCommonArgs
+        );
+
+        new-project = pkgs.writeShellApplication {
+          name = "cuda-oxide-new";
+          runtimeInputs = [ cargo-oxide ];
+          text = ''
+            output=$(cargo-oxide new "$@")
+            cp ${userFlake} "$1/flake.nix"
+            chmod +w "$1/flake.nix"
+            echo "Note: run 'nix develop' inside the project directory before using cargo oxide."
+            echo ""
+            echo "$output"
+          '';
+        };
+
+        cargo-oxide = craneLib.buildPackage (
+          craneLib.crateNameFromCargoToml { cargoToml = ./crates/cargo-oxide/Cargo.toml; }
+          // cargoOxideCommonArgs
+          // {
+            cargoArtifacts = cargoOxideDeps;
+          }
+        );
       in
       {
         formatter = pkgs.nixfmt;
+
+        packages.cargo-oxide = cargo-oxide;
+
+        apps.default = {
+          type = "app";
+          program = "${cargo-oxide}/bin/cargo-oxide";
+        };
+
+        apps.new = {
+          type = "app";
+          program = "${new-project}/bin/cuda-oxide-new";
+        };
 
         devShells.default = pkgs.mkShell {
           packages = [
@@ -55,16 +162,16 @@
 
             llvmPkgs.clang
             llvmPkgs.libclang
-            llvmPkgs.llvm
 
             cudaSymlinked
+
+            cargo-oxide
           ];
 
-          CUDA_HOME = cudaSymlinked;
-          LIBCLANG_PATH = "${llvmPkgs.libclang.lib}/lib";
-          CUDA_OXIDE_LLC = "${llvmPkgs.llvm}/bin/llc";
-
           shellHook = ''
+            export CUDA_HOME="${cudaSymlinked}"
+            export LIBCLANG_PATH="${llvmPkgs.libclang.lib}/lib"
+
             # GPU driver setup borrowed from https://github.com/NVlabs/cutile-rs
             # NixOS provides /run/opengl-driver/lib
             if [ -d /run/opengl-driver/lib ]; then
@@ -99,11 +206,16 @@
             fi
 
             echo "🦀 cuda-oxide dev environment loaded"
-            echo " ✓ LLVM $(llc   --version | grep 'LLVM version' | awk '{print $3}')"
             echo " ✓ CUDA $(nvcc  --version | grep 'release'      | awk '{print $6}' | cut -c 2-)"
             echo " ✓ Rust $(rustc --version |                       awk '{print $2}')"
           '';
         };
       }
-    );
+    ))
+    // {
+      templates.default = {
+        path = templateSrc;
+        description = "Reproducible CUDA + Rust dev environment for cuda-oxide projects";
+      };
+    };
 }


### PR DESCRIPTION
### Motivation

Currently, setting up the required environment for `cuda-oxide` (specifically aligning Nightly Rust, LLVM 21, and the correct CUDA toolchain so `CUDA_HOME` resolves properly) can be a bit manual.

This PR introduces a `flake.nix` to provide a fully reproducible development environment for anyone using the Nix package manager. Running `nix develop` drops the user into a shell with the dependencies required to compile the compiler and run the PTX backend.

### What this does

* Uses `symlinkJoin` to pull necessary CUDA 13 packages (`nvcc`, `cudart`, `libnvvm`, `libnvjitlink.lib`).
* LLVM 21 and the pinned Nightly Rust toolchain (via `rust-toolchain.toml`).
* Exports `CUDA_HOME`, `LIBCLANG_PATH`, and `CUDA_OXIDE_LLC`.
* Includes a dynamic `shellHook` (inspired by `cutile-rs`) that symlinks the host machine's NVIDIA driver into the Nix environment. Ensures that drivers works across distros (NixOS or otherwise).
* Supports both `x86_64-linux` and `aarch64-linux`.

### Note on CI and Maintenance

I have included a `.github/workflows/nix-flake.yml` to prove that this environment builds cleanly across both x86_64 and aarch64 Ubuntu runners without issues.

However, I completely understand if you prefer not to officially "support" Nix or add it to your required CI checks to avoid future maintenance burdens. If you'd prefer to just merge the `flake.nix` without the CI, just let me know and I will happily drop the workflow file from this PR!