### PR TITLE
intrinsics: add globaltimer

### DIFF
--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -129,7 +129,9 @@ pub fn debug_kernel(data: &[f32]) {
 }
 ```
 
-`gpu_printf!` compiles to device-side `vprintf` with C vararg promotion. `gpu_assert!` traps on failure.
+`gpu_printf!` compiles to device-side `vprintf` with C vararg promotion.
+`gpu_assert!` traps on failure. The `debug` module also exposes GPU timing
+register reads such as `clock64()` and `globaltimer()`.
 
 ## Proc-Macro Re-exports
 

--- a/crates/cuda-device/src/debug.rs
+++ b/crates/cuda-device/src/debug.rs
@@ -11,6 +11,7 @@
 //! |--------------------|-------------------------------|---------------------|
 //! | [`clock()`]        | Read 32-bit GPU clock counter | `clock()`           |
 //! | [`clock64()`]      | Read 64-bit GPU clock counter | `clock64()`         |
+//! | [`globaltimer()`]  | Read GPU global timer         | `%globaltimer`      |
 //! | [`trap()`]         | Abort kernel execution        | `__trap()`          |
 //! | [`breakpoint()`]   | Insert cuda-gdb breakpoint    | `__brkpt()`         |
 //! | [`prof_trigger()`] | Signal NVIDIA profiler        | `__prof_trigger(N)` |
@@ -101,6 +102,28 @@ pub fn clock() -> u32 {
 pub fn clock64() -> u64 {
     // Lowered to: call i64 @llvm.nvvm.read.ptx.sreg.clock64()
     unreachable!("clock64 called outside CUDA kernel context")
+}
+
+/// Read the GPU global timer.
+///
+/// Returns a 64-bit timer value from PTX `%globaltimer`. Unlike [`clock64()`],
+/// this is a global timer source, so it is preferable when measuring interactions
+/// that may span multiple SMs.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use cuda_device::debug;
+///
+/// let start = debug::globaltimer();
+/// // ... operation to measure ...
+/// let end = debug::globaltimer();
+/// let ticks = end.wrapping_sub(start);
+/// ```
+#[inline(never)]
+pub fn globaltimer() -> u64 {
+    // Lowered to: inline PTX "mov.u64 ..., %globaltimer;"
+    unreachable!("globaltimer called outside CUDA kernel context")
 }
 
 // =============================================================================

--- a/crates/cuda-device/src/debug.rs
+++ b/crates/cuda-device/src/debug.rs
@@ -122,7 +122,7 @@ pub fn clock64() -> u64 {
 /// ```
 #[inline(never)]
 pub fn globaltimer() -> u64 {
-    // Lowered to: inline PTX "mov.u64 ..., %globaltimer;"
+    // Lowered to: call i64 @llvm.nvvm.read.ptx.sreg.globaltimer()
     unreachable!("globaltimer called outside CUDA kernel context")
 }
 

--- a/crates/dialect-nvvm/README.md
+++ b/crates/dialect-nvvm/README.md
@@ -14,16 +14,16 @@ dialect-nvvm ops
 
 ## Operations by GPU Generation
 
-123 operations across 12 modules, spanning three GPU generations:
+124 operations across 12 modules, spanning three GPU generations:
 
 ### Universal (all GPUs)
 
-| Module   | Ops | Highlights                                                                                |
-|----------|-----|-------------------------------------------------------------------------------------------|
-| `thread` | 18  | tid/ctaid/ntid/nctaid for x/y/z, env_reg{1,2}, barrier0, threadfence{,_block,_system}     |
-| `warp`   | 18  | shfl (idx/bfly/down/up, i32 and f32), lane_id, vote (all/any/ballot), match_any/match_all |
-| `grid`   | 1   | grid_sync (cooperative kernel launches only)                                              |
-| `debug`  | 6   | clock/clock64, trap, breakpoint, pm_event, vprintf                                        |
+| Module   | Ops | Highlights                                                                                         |
+|----------|-----|----------------------------------------------------------------------------------------------------|
+| `thread` | 18  | tid/ctaid/ntid/nctaid for x/y/z, env_reg{1,2}, barrier0, threadfence{,_block,_system}              |
+| `warp`   | 18  | shfl (idx/bfly/down/up, i32 and f32), lane_id, vote (all/any/ballot), match_any/match_all          |
+| `grid`   | 1   | grid_sync (cooperative kernel launches only)                                                       |
+| `debug`  | 7   | clock/clock64/globaltimer, trap, breakpoint, pm_event, vprintf                                     |
 
 ### Volta+ (sm_70)
 
@@ -52,11 +52,11 @@ dialect-nvvm ops
 
 Three attributes defined for atomic operations:
 
-| Attribute        | Values                                     |
-|------------------|--------------------------------------------|
-| `AtomicOrdering` | relaxed, acquire, release, acq_rel, seq_cst|
-| `AtomicScope`    | cta, gpu, sys                              |
-| `AtomicRmwKind`  | xchg, add, sub, and, or, xor, max, min     |
+| Attribute        | Values                                      |
+|------------------|---------------------------------------------|
+| `AtomicOrdering` | relaxed, acquire, release, acq_rel, seq_cst |
+| `AtomicScope`    | cta, gpu, sys                               |
+| `AtomicRmwKind`  | xchg, add, sub, and, or, xor, max, min      |
 
 ## Verification
 
@@ -83,7 +83,7 @@ src/
     ├── warp.rs      # Shuffle, vote, match operations
     ├── grid.rs      # Cooperative grid_sync
     ├── atomic.rs    # Atomic ops + ordering/scope/kind attributes
-    ├── debug.rs     # Clock, trap, printf
+    ├── debug.rs     # Clock/timer, trap, printf
     ├── cluster.rs   # Thread block clusters, DSMEM
     ├── mbarrier.rs  # Async barriers for TMA
     ├── tma.rs       # Tensor Memory Accelerator copies

--- a/crates/dialect-nvvm/src/ops/debug.rs
+++ b/crates/dialect-nvvm/src/ops/debug.rs
@@ -8,15 +8,16 @@
 //! This module provides operations for debugging and profiling GPU kernels:
 //!
 //! ```text
-//! ┌─────────────────────────┬──────────────────────────────┬─────────────────────────┐
-//! │ Operation               │ PTX / LLVM Intrinsic         │ Description             │
-//! ├─────────────────────────┼──────────────────────────────┼─────────────────────────┤
-//! │ ReadPtxSregClockOp      │ %clock / read.ptx.sreg.clock │ 32-bit clock counter    │
-//! │ ReadPtxSregClock64Op    │ %clock64 / ...clock64        │ 64-bit clock counter    │
-//! │ TrapOp                  │ trap / llvm.nvvm.trap        │ Abort kernel execution  │
-//! │ BreakpointOp            │ brkpt / llvm.nvvm.brkpt      │ cuda-gdb breakpoint     │
-//! │ VprintfOp               │ vprintf / call @vprintf      │ Formatted output        │
-//! └─────────────────────────┴──────────────────────────────┴─────────────────────────┘
+//! ┌──────────────────────────┬──────────────────────────────┬─────────────────────────┐
+//! │ Operation                │ PTX / LLVM Intrinsic         │ Description             │
+//! ├──────────────────────────┼──────────────────────────────┼─────────────────────────┤
+//! │ ReadPtxSregClockOp       │ %clock / read.ptx.sreg.clock │ 32-bit clock counter    │
+//! │ ReadPtxSregClock64Op     │ %clock64 / ...clock64        │ 64-bit clock counter    │
+//! │ ReadPtxSregGlobaltimerOp │ %globaltimer                 │ Global timer counter    │
+//! │ TrapOp                   │ trap / llvm.nvvm.trap        │ Abort kernel execution  │
+//! │ BreakpointOp             │ brkpt / llvm.nvvm.brkpt      │ cuda-gdb breakpoint     │
+//! │ VprintfOp                │ vprintf / call @vprintf      │ Formatted output        │
+//! └──────────────────────────┴──────────────────────────────┴─────────────────────────┘
 //! ```
 
 use pliron::{
@@ -127,6 +128,55 @@ impl Verify for ReadPtxSregClock64Op {
             return verify_err!(
                 op.loc(),
                 "nvvm.read_ptx_sreg_clock64 result must be 64-bit integer"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Read the 64-bit GPU global timer.
+///
+/// Corresponds to PTX `%globaltimer`.
+///
+/// # Verification
+///
+/// - Must have 0 operands
+/// - Must have 1 result of type `i64`
+#[pliron_op(
+    name = "nvvm.read_ptx_sreg_globaltimer",
+    format,
+    interfaces = [NOpdsInterface<0>, NResultsInterface<1>],
+)]
+pub struct ReadPtxSregGlobaltimerOp;
+
+impl ReadPtxSregGlobaltimerOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        ReadPtxSregGlobaltimerOp { op }
+    }
+}
+
+impl Verify for ReadPtxSregGlobaltimerOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = &*self.get_operation().deref(ctx);
+        let res = op.get_result(0);
+        let ty = res.get_type(ctx);
+
+        let ty_obj = ty.deref(ctx);
+        let int_ty = match ty_obj.downcast_ref::<IntegerType>() {
+            Some(ty) => ty,
+            None => {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.read_ptx_sreg_globaltimer result must be integer"
+                );
+            }
+        };
+
+        if int_ty.width() != 64 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.read_ptx_sreg_globaltimer result must be 64-bit integer"
             );
         }
         Ok(())
@@ -343,6 +393,7 @@ pub(super) fn register(ctx: &mut Context) {
     // Clock/Timing
     ReadPtxSregClockOp::register(ctx);
     ReadPtxSregClock64Op::register(ctx);
+    ReadPtxSregGlobaltimerOp::register(ctx);
     // Trap
     TrapOp::register(ctx);
     // Debugging

--- a/crates/dialect-nvvm/src/ops/debug.rs
+++ b/crates/dialect-nvvm/src/ops/debug.rs
@@ -13,7 +13,7 @@
 //! ├──────────────────────────┼──────────────────────────────┼─────────────────────────┤
 //! │ ReadPtxSregClockOp       │ %clock / read.ptx.sreg.clock │ 32-bit clock counter    │
 //! │ ReadPtxSregClock64Op     │ %clock64 / ...clock64        │ 64-bit clock counter    │
-//! │ ReadPtxSregGlobaltimerOp │ %globaltimer                 │ Global timer counter    │
+//! │ ReadPtxSregGlobaltimerOp │ %globaltimer / ...globaltimer│ Global timer counter    │
 //! │ TrapOp                   │ trap / llvm.nvvm.trap        │ Abort kernel execution  │
 //! │ BreakpointOp             │ brkpt / llvm.nvvm.brkpt      │ cuda-gdb breakpoint     │
 //! │ VprintfOp                │ vprintf / call @vprintf      │ Formatted output        │

--- a/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
@@ -8,6 +8,7 @@
 //! Handles translation of debug/profiling primitives including:
 //! - `clock()` - 32-bit GPU clock counter
 //! - `clock64()` - 64-bit GPU clock counter
+//! - `globaltimer()` - 64-bit GPU global timer
 //! - `trap()` - Abort kernel execution
 //! - `breakpoint()` - cuda-gdb breakpoint
 //! - `prof_trigger()` - Profiler event trigger
@@ -17,7 +18,8 @@ use super::super::helpers::{emit_goto, emit_store_result_and_goto};
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::values::ValueMap;
 use dialect_nvvm::ops::{
-    BreakpointOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp, TrapOp, VprintfOp,
+    BreakpointOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp, ReadPtxSregGlobaltimerOp,
+    TrapOp, VprintfOp,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -134,6 +136,58 @@ pub fn emit_clock64(
         block_map,
         loc,
         "clock64 call without target block",
+    )
+}
+
+/// Emits `globaltimer()`: Read 64-bit GPU global timer.
+///
+/// # Generated Operation
+///
+/// `nvvm.read_ptx_sreg_globaltimer` - Maps to PTX `mov.u64 %rd, %globaltimer;`
+///
+/// # Returns
+///
+/// u64 global timer tick count
+pub fn emit_globaltimer(
+    ctx: &mut Context,
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    let i64_type = IntegerType::get(ctx, 64, Signedness::Unsigned);
+
+    let timer_op = Operation::new(
+        ctx,
+        ReadPtxSregGlobaltimerOp::get_concrete_op_info(),
+        vec![i64_type.to_ptr()],
+        vec![],
+        vec![],
+        0,
+    );
+    timer_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = prev_op {
+        timer_op.insert_after(ctx, prev);
+    } else {
+        timer_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = timer_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        timer_op,
+        value_map,
+        block_map,
+        loc,
+        "globaltimer call without target block",
     )
 }
 

--- a/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
@@ -8,17 +8,17 @@
 //! This module handles the translation of `cuda_device` intrinsic calls into
 //! `dialect-nvvm` operations. Intrinsics are organized by functional category:
 //!
-//! | Module      | Intrinsics                                          |
-//! |-------------|-----------------------------------------------------|
+//! | Module      | Intrinsics                                                                   |
+//! |-------------|------------------------------------------------------------------------------|
 //! | `indexing`  | `threadIdx_*`, `blockIdx_*`, `index_1d`, `index_2d::<S>`, `index_2d_runtime` |
-//! | `sync`      | `sync_threads`, `mbarrier_*`, `fence_*`             |
-//! | `cluster`   | `cluster_ctaidX`, `cluster_sync`, `map_shared_rank` |
-//! | `warp`      | `shuffle_*`, `vote_*`, `lane_id`                    |
-//! | `wgmma`     | Hopper WGMMA matrix operations                      |
-//! | `tcgen05`   | Blackwell tensor core (tcgen05) operations          |
-//! | `tma`       | Tensor Memory Access (TMA) operations               |
-//! | `memory`    | `SharedArray`, `stmatrix_*`, type conversions       |
-//! | `debug`     | `clock`, `clock64`, `trap`, `breakpoint`            |
+//! | `sync`      | `sync_threads`, `mbarrier_*`, `fence_*`                                      |
+//! | `cluster`   | `cluster_ctaidX`, `cluster_sync`, `map_shared_rank`                          |
+//! | `warp`      | `shuffle_*`, `vote_*`, `lane_id`                                             |
+//! | `wgmma`     | Hopper WGMMA matrix operations                                               |
+//! | `tcgen05`   | Blackwell tensor core (tcgen05) operations                                   |
+//! | `tma`       | Tensor Memory Access (TMA) operations                                        |
+//! | `memory`    | `SharedArray`, `stmatrix_*`, type conversions                                |
+//! | `debug`     | `clock`, `clock64`, `globaltimer`, `trap`, `breakpoint`                      |
 //!
 //! # Architecture
 //!

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1946,6 +1946,16 @@ fn try_dispatch_intrinsic(
             block_map,
             loc,
         )?)),
+        "cuda_device::debug::globaltimer" => Ok(Some(intrinsics::debug::emit_globaltimer(
+            ctx,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
         "cuda_device::debug::trap" => Ok(Some(intrinsics::debug::emit_trap(
             ctx, target, block_ptr, prev_op, block_map, loc,
         )?)),

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -52,11 +52,11 @@ use dialect_nvvm::ops::{
     ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp,
     ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp,
     ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op,
-    ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp,
-    ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp,
-    ReadPtxSregTidXOp, ReadPtxSregTidYOp, ReadPtxSregTidZOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op,
-    ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
+    ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp,
+    ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp, ReadPtxSregNtidYOp,
+    ReadPtxSregNtidZOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp, ReadPtxSregTidZOp, ShflSyncBflyF32Op,
+    ShflSyncBflyI32Op, ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op,
+    ShflSyncUpF32Op, ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
     StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
     Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op,
     Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp,
@@ -1167,6 +1167,23 @@ impl MirToLlvmConversion for ReadPtxSregClock64Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::debug::convert_clock64(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for ReadPtxSregGlobaltimerOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::debug::convert_globaltimer(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/debug.rs
+++ b/crates/mir-lower/src/convert/intrinsics/debug.rs
@@ -5,14 +5,15 @@
 
 //! Debug and profiling intrinsic conversion.
 //!
-//! | Operation     | Lowering                            | PTX Output         |
-//! |---------------|-------------------------------------|--------------------|
-//! | `Clock`       | `llvm_nvvm_read_ptx_sreg_clock`     | `mov %r, %clock`   |
-//! | `Clock64`     | `llvm_nvvm_read_ptx_sreg_clock64`   | `mov %rd, %clock64`|
-//! | `Trap`        | inline PTX `trap;`                  | `trap;`            |
-//! | `Breakpoint`  | inline PTX `brkpt;`                 | `brkpt;`           |
-//! | `PmEvent`     | inline PTX `pmevent N;`             | `pmevent N;`       |
-//! | `Vprintf`     | `call @vprintf`                     | `call vprintf`     |
+//! | Operation      | Lowering                            | PTX Output              |
+//! |----------------|-------------------------------------|-------------------------|
+//! | `Clock`        | `llvm_nvvm_read_ptx_sreg_clock`     | `mov %r, %clock`        |
+//! | `Clock64`      | `llvm_nvvm_read_ptx_sreg_clock64`   | `mov %rd, %clock64`     |
+//! | `Globaltimer`  | inline PTX `%globaltimer`           | `mov %rd, %globaltimer` |
+//! | `Trap`         | inline PTX `trap;`                  | `trap;`                 |
+//! | `Breakpoint`   | inline PTX `brkpt;`                 | `brkpt;`                |
+//! | `PmEvent`      | inline PTX `pmevent N;`             | `pmevent N;`            |
+//! | `Vprintf`      | `call @vprintf`                     | `call vprintf`          |
 
 use crate::convert::intrinsics::common::*;
 use crate::helpers;
@@ -69,6 +70,25 @@ pub(crate) fn convert_clock64(
     )?;
     rewriter.replace_operation(ctx, op, call_op);
 
+    Ok(())
+}
+
+pub(crate) fn convert_globaltimer(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        i64_ty.into(),
+        vec![],
+        "mov.u64 $0, %globaltimer;",
+        "=l",
+    );
+    rewriter.replace_operation(ctx, op, asm_op);
     Ok(())
 }
 

--- a/crates/mir-lower/src/convert/intrinsics/debug.rs
+++ b/crates/mir-lower/src/convert/intrinsics/debug.rs
@@ -5,15 +5,15 @@
 
 //! Debug and profiling intrinsic conversion.
 //!
-//! | Operation      | Lowering                            | PTX Output              |
-//! |----------------|-------------------------------------|-------------------------|
-//! | `Clock`        | `llvm_nvvm_read_ptx_sreg_clock`     | `mov %r, %clock`        |
-//! | `Clock64`      | `llvm_nvvm_read_ptx_sreg_clock64`   | `mov %rd, %clock64`     |
-//! | `Globaltimer`  | inline PTX `%globaltimer`           | `mov %rd, %globaltimer` |
-//! | `Trap`         | inline PTX `trap;`                  | `trap;`                 |
-//! | `Breakpoint`   | inline PTX `brkpt;`                 | `brkpt;`                |
-//! | `PmEvent`      | inline PTX `pmevent N;`             | `pmevent N;`            |
-//! | `Vprintf`      | `call @vprintf`                     | `call vprintf`          |
+//! | Operation      | Lowering                                | PTX Output              |
+//! |----------------|-----------------------------------------|-------------------------|
+//! | `Clock`        | `llvm_nvvm_read_ptx_sreg_clock`         | `mov %r, %clock`        |
+//! | `Clock64`      | `llvm_nvvm_read_ptx_sreg_clock64`       | `mov %rd, %clock64`     |
+//! | `Globaltimer`  | `llvm_nvvm_read_ptx_sreg_globaltimer`   | `mov %rd, %globaltimer` |
+//! | `Trap`         | inline PTX `trap;`                      | `trap;`                 |
+//! | `Breakpoint`   | inline PTX `brkpt;`                     | `brkpt;`                |
+//! | `PmEvent`      | inline PTX `pmevent N;`                 | `pmevent N;`            |
+//! | `Vprintf`      | `call @vprintf`                         | `call vprintf`          |
 
 use crate::convert::intrinsics::common::*;
 use crate::helpers;
@@ -80,15 +80,18 @@ pub(crate) fn convert_globaltimer(
     _operands_info: &OperandsInfo,
 ) -> Result<()> {
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
-    let asm_op = inline_asm_convergent(
+    let func_ty = llvm_types::FuncType::get(ctx, i64_ty.into(), vec![], false);
+
+    let call_op = call_intrinsic(
         ctx,
         rewriter,
-        i64_ty.into(),
+        op,
+        "llvm_nvvm_read_ptx_sreg_globaltimer",
+        func_ty,
         vec![],
-        "mov.u64 $0, %globaltimer;",
-        "=l",
-    );
-    rewriter.replace_operation(ctx, op, asm_op);
+    )?;
+    rewriter.replace_operation(ctx, op, call_op);
+
     Ok(())
 }
 

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -142,6 +142,103 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn test_globaltimer_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    let mut ctx = Context::new();
+    dialect_llvm::register(&mut ctx);
+    dialect_mir::register(&mut ctx);
+    dialect_nvvm::register(&mut ctx);
+    mir_lower::register(&mut ctx);
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_ptr = module.get_operation();
+
+    let func_name = "kernel_func";
+    let func_ty = pliron::builtin::types::FunctionType::get(&mut ctx, vec![], vec![]);
+
+    let func_op_ptr = Operation::new(
+        &mut ctx,
+        mir::MirFuncOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        1,
+    );
+    let func_ty_attr = pliron::builtin::attributes::TypeAttr::new(func_ty.into());
+    let func = mir::MirFuncOp::new(&mut ctx, func_op_ptr, func_ty_attr);
+    func.set_symbol_name(&mut ctx, func_name.try_into().unwrap());
+
+    let region = func.get_operation().deref(&ctx).get_region(0);
+    let block = {
+        let b = pliron::basic_block::BasicBlock::new(&mut ctx, None, vec![]);
+        b.insert_at_back(region, &ctx);
+        b
+    };
+
+    let i64_ty = pliron::builtin::types::IntegerType::get(
+        &mut ctx,
+        64,
+        pliron::builtin::types::Signedness::Signless,
+    );
+    let timer_op = Operation::new(
+        &mut ctx,
+        nvvm::ReadPtxSregGlobaltimerOp::get_concrete_op_info(),
+        vec![i64_ty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    timer_op.insert_at_back(block, &ctx);
+
+    let ret_op_ptr = Operation::new(
+        &mut ctx,
+        mir::MirReturnOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        0,
+    );
+    let ret_op = mir::MirReturnOp::new(ret_op_ptr);
+    ret_op.get_operation().insert_at_back(block, &ctx);
+
+    let module_region = module.get_operation().deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let mut found_inline_asm = false;
+    let module_op = module_ptr.deref(&ctx);
+    let region = module_op.get_region(0);
+    let block = region.deref(&ctx).iter(&ctx).next().unwrap();
+
+    for op in block.deref(&ctx).iter(&ctx) {
+        if let Some(func_op) = Operation::get_op::<dialect_llvm::ops::FuncOp>(op, &ctx) {
+            if func_op.get_symbol_name(&ctx).to_string() != func_name {
+                continue;
+            }
+
+            let func_region = func_op.get_operation().deref(&ctx).get_region(0);
+            for func_block in func_region.deref(&ctx).iter(&ctx) {
+                for body_op in func_block.deref(&ctx).iter(&ctx) {
+                    if let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(body_op, &ctx)
+                        && inline_asm.asm_template(&ctx) == "mov.u64 $0, %globaltimer;"
+                    {
+                        found_inline_asm = true;
+                        assert!(inline_asm.is_convergent(&ctx));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        found_inline_asm,
+        "Expected globaltimer inline asm in lowered kernel"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_threadfence_system_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     let mut ctx = Context::new();
     dialect_llvm::register(&mut ctx);

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -6,7 +6,7 @@
 use dialect_llvm::ops as llvm;
 use dialect_mir::ops as mir;
 use dialect_nvvm::ops as nvvm;
-use pliron::builtin::op_interfaces::SymbolOpInterface;
+use pliron::builtin::op_interfaces::{CallOpCallable, CallOpInterface, SymbolOpInterface};
 use pliron::builtin::ops::ModuleOp;
 use pliron::context::Context;
 use pliron::linked_list::ContainsLinkedList;
@@ -142,7 +142,7 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
 }
 
 #[test]
-fn test_globaltimer_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+fn test_globaltimer_lowers_to_intrinsic_call() -> Result<(), anyhow::Error> {
     let mut ctx = Context::new();
     dialect_llvm::register(&mut ctx);
     dialect_mir::register(&mut ctx);
@@ -206,34 +206,63 @@ fn test_globaltimer_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
 
     mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let mut found_inline_asm = false;
+    const INTRINSIC: &str = "llvm_nvvm_read_ptx_sreg_globaltimer";
+
+    let mut found_decl = false;
+    let mut found_call = false;
     let module_op = module_ptr.deref(&ctx);
     let region = module_op.get_region(0);
     let block = region.deref(&ctx).iter(&ctx).next().unwrap();
 
     for op in block.deref(&ctx).iter(&ctx) {
-        if let Some(func_op) = Operation::get_op::<dialect_llvm::ops::FuncOp>(op, &ctx) {
-            if func_op.get_symbol_name(&ctx).to_string() != func_name {
-                continue;
-            }
+        let Some(func_op) = Operation::get_op::<dialect_llvm::ops::FuncOp>(op, &ctx) else {
+            continue;
+        };
+        let name = func_op.get_symbol_name(&ctx).to_string();
 
+        if name == INTRINSIC {
+            // Intrinsic declaration: present with empty body.
+            found_decl = true;
+            let num_regions = func_op.get_operation().deref(&ctx).regions().count();
+            if num_regions > 0 {
+                assert!(
+                    func_op
+                        .get_operation()
+                        .deref(&ctx)
+                        .get_region(0)
+                        .deref(&ctx)
+                        .iter(&ctx)
+                        .next()
+                        .is_none(),
+                    "intrinsic declaration must have empty body"
+                );
+            }
+        } else if name == func_name {
             let func_region = func_op.get_operation().deref(&ctx).get_region(0);
             for func_block in func_region.deref(&ctx).iter(&ctx) {
                 for body_op in func_block.deref(&ctx).iter(&ctx) {
-                    if let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(body_op, &ctx)
-                        && inline_asm.asm_template(&ctx) == "mov.u64 $0, %globaltimer;"
+                    if let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx)
+                        && let CallOpCallable::Direct(sym) = call.callee(&ctx)
+                        && sym.to_string() == INTRINSIC
                     {
-                        found_inline_asm = true;
-                        assert!(inline_asm.is_convergent(&ctx));
+                        found_call = true;
                     }
+                    assert!(
+                        Operation::get_op::<llvm::InlineAsmOp>(body_op, &ctx).is_none(),
+                        "globaltimer must not lower to inline asm"
+                    );
                 }
             }
         }
     }
 
     assert!(
-        found_inline_asm,
-        "Expected globaltimer inline asm in lowered kernel"
+        found_decl,
+        "Expected `{INTRINSIC}` declaration in lowered module"
+    );
+    assert!(
+        found_call,
+        "Expected call to `{INTRINSIC}` in lowered kernel body"
     );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/debug/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/debug/src/main.rs
@@ -9,6 +9,7 @@
 //!
 //! Tests GPU debug/utility features:
 //! - `clock64()` - Read GPU clock cycles
+//! - `globaltimer()` - Read the GPU global timer
 //! - `trap()` - Abort kernel execution
 //! - `gpu_assert!()` - Runtime assertion
 //! - `breakpoint()` - cuda-gdb breakpoint
@@ -27,13 +28,14 @@ use cuda_host::cuda_module;
 mod kernels {
     use super::*;
 
-    /// Test kernel: measures clock cycles for a simple operation
+    /// Test kernel: measures clock and global timer ticks for a simple operation.
     #[kernel]
     #[launch_bounds(256, 2)] // Max 256 threads/block, min 2 blocks/SM
     pub fn clock_test(mut output: DisjointSlice<u64>) {
         let idx = thread::index_1d();
         if let Some(output_elem) = output.get_mut(idx) {
-            let start = debug::clock64();
+            let start_cycles = debug::clock64();
+            let start_timer = debug::globaltimer();
 
             // Some work to measure
             let mut sum: u64 = 0;
@@ -41,10 +43,14 @@ mod kernels {
                 sum = sum.wrapping_add(i);
             }
 
-            let end = debug::clock64();
+            let end_timer = debug::globaltimer();
+            let end_cycles = debug::clock64();
 
-            // Write elapsed cycles (use sum to prevent optimization)
-            *output_elem = (end - start) + (sum & 0);
+            // Write elapsed ticks (use sum to prevent optimization)
+            *output_elem = end_cycles
+                .wrapping_sub(start_cycles)
+                .wrapping_add(end_timer.wrapping_sub(start_timer))
+                .wrapping_add(sum & 0);
         }
     }
 
@@ -146,7 +152,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ====================================================================
     // Test 1: Clock cycles measurement
     // ====================================================================
-    println!("--- Test 1: clock64() cycle measurement ---");
+    println!("--- Test 1: clock64() / globaltimer() measurement ---");
     {
         const N: usize = 256;
         let mut output_dev = DeviceBuffer::<u64>::zeroed(&stream, N)?;


### PR DESCRIPTION
## Summary

Adds a CUDA device-side `globaltimer()` debug intrinsic that reads PTX `%globaltimer` as a 64-bit timer value. This complements `clock64()` with a global timer source that is better suited for measurements that may span multiple SMs.

## Example

```rust
use cuda_device::debug;

let start = debug::globaltimer();

// ... operation to measure ...

let end = debug::globaltimer();
let ticks = debug::elapsed_ticks(start, end);
```

## Implementation

- Adds `cuda_device::debug::globaltimer() -> u64` and `cuda_device::debug::elapsed_ticks(start, end) -> u64`.
- Adds the `nvvm.read_ptx_sreg_globaltimer` op to `dialect-nvvm`, including registration and result-type verification.
- Wires `cuda_device::debug::globaltimer` through MIR intrinsic dispatch.
- Lowers the NVVM op to convergent inline asm:

```text
mov.u64 $0, %globaltimer;
```

- Updates debug and dialect documentation to include the new timer intrinsic.
- Updates the debug example to exercise `globaltimer()` alongside `clock64()`.

## Validation

- Adds `test_globaltimer_lowers_to_inline_asm`, which verifies that `ReadPtxSregGlobaltimerOp` lowers to the expected inline asm template and is marked convergent