### PR TITLE
chore: cleaner alloc_key usage

### DIFF
--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -293,20 +293,10 @@ pub fn convert_shared_alloc_dc(
         (alloc_key, mir_elem_type, size, alignment)
     };
 
-    let global_name = if let Some(key) = &alloc_key {
-        if let Some(existing_name) = shared_globals.get(key) {
-            existing_name.clone()
-        } else {
-            create_shared_global(
-                ctx,
-                op,
-                shared_globals,
-                mir_elem_type,
-                size,
-                alignment,
-                Some(key),
-            )?
-        }
+    let global_name = if alloc_key.is_some()
+        && let Some(existing_name) = shared_globals.get(alloc_key.as_deref().unwrap())
+    {
+        existing_name.clone()
     } else {
         create_shared_global(
             ctx,
@@ -315,7 +305,7 @@ pub fn convert_shared_alloc_dc(
             mir_elem_type,
             size,
             alignment,
-            None,
+            alloc_key,
         )?
     };
 
@@ -343,7 +333,7 @@ fn create_shared_global(
     mir_elem_type: Ptr<TypeObj>,
     size: u64,
     alignment: u64,
-    alloc_key: Option<&String>,
+    alloc_key: Option<String>,
 ) -> Result<pliron::identifier::Identifier> {
     let llvm_elem_type = convert_type(ctx, mir_elem_type).map_err(anyhow_to_pliron)?;
     let array_type = ArrayType::get(ctx, llvm_elem_type, size);
@@ -375,7 +365,7 @@ fn create_shared_global(
     global_op.get_operation().insert_at_front(module_block, ctx);
 
     if let Some(key) = alloc_key {
-        shared_globals.insert(key.clone(), name.clone());
+        shared_globals.insert(key, name.clone());
     }
 
     Ok(name)

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -293,8 +293,12 @@ pub fn convert_shared_alloc_dc(
         (alloc_key, mir_elem_type, size, alignment)
     };
 
-    let global_name = if alloc_key.is_some()
-        && let Some(existing_name) = shared_globals.get(alloc_key.as_deref().unwrap())
+    // Cache hit only when the op carries a key AND that key is already in
+    // `shared_globals`. `as_ref()` borrows for the if-let scope so the else
+    // branch can still move `alloc_key` into `create_shared_global` (which
+    // takes ownership and inserts it into the cache).
+    let global_name = if let Some(key) = alloc_key.as_ref()
+        && let Some(existing_name) = shared_globals.get(key)
     {
         existing_name.clone()
     } else {
@@ -324,8 +328,10 @@ pub fn convert_shared_alloc_dc(
 /// - Optional alignment
 /// - Unique generated name (`__shared_mem_N`)
 ///
-/// The global is inserted at the front of the module block.
-/// If `alloc_key` is provided, the name is cached for deduplication.
+/// The global is inserted at the front of the module block. When
+/// `alloc_key` is `Some`, the key is moved into `shared_globals` so that
+/// later allocations with the same key reuse this global (caller is
+/// expected to have already checked the cache for a hit).
 fn create_shared_global(
     ctx: &mut Context,
     op: Ptr<Operation>,


### PR DESCRIPTION
## What this PR does.

While reading https://github.com/NVlabs/cuda-oxide/issues/30, i found that the usage of `alloc_key` could be simplified by more rusty grammar