### PR TITLE
fix(docs): clarify that installation requires nightly toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ cargo oxide debug vecadd --tui
 
 #### cargo-oxide
 
-Inside the cuda-oxide repo, `cargo oxide` works out of the box via a workspace alias.
+Inside the cuda-oxide repo, `cargo oxide` works out of the box via a workspace alias, and you must build cuda-oxide in Rust nightly mode.
 
 For use outside the repo (your own projects):
 
 ```bash
-cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
+cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 ```
 
 On first run, `cargo-oxide` will automatically fetch and build the codegen backend.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ cargo oxide debug vecadd --tui
 
 #### cargo-oxide
 
-Inside the cuda-oxide repo, `cargo oxide` works out of the box via a workspace alias, and you must build cuda-oxide in Rust nightly mode.
+Inside the cuda-oxide repo, `cargo oxide` works out of the box via a workspace alias.
 
-For use outside the repo (your own projects):
+For use outside the repo (your own projects), install it with the pinned nightly toolchain:
 
 ```bash
 cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
@@ -247,7 +247,7 @@ cargo oxide run gemm_sol
 | `cuda-host`         | Typed module loading, launch helpers, LTOIR loader                        |
 | `cuda-macros`       | Proc macros (`#[cuda_module]`, `#[kernel]`, `gpu_printf!`)                |
 | `cuda-bindings`     | Raw `bindgen` FFI bindings to `cuda.h`                                    |
-| `cuda-core`         | Safe RAII wrappers (`CudaContext`, `CudaStream`, `DeviceBuffer<T>`, `PinnedHostBuffer<T>`) |
+| `cuda-core`         | Safe RAII wrappers (`CudaContext`, `CudaStream`, `DeviceBuffer<T>`, ...)  |
 | `cuda-async`        | Async execution layer (`DeviceOperation`, `DeviceFuture`, `DeviceBox<T>`) |
 | `libnvvm-sys`       | `dlopen` bindings to libNVVM (used by `cuda-host::ltoir`)                 |
 | `nvjitlink-sys`     | `dlopen` bindings to nvJitLink (used by `cuda-host::ltoir`)               |

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -10,8 +10,10 @@ Replaces the previous `xtask` pattern with a proper cargo subcommand that works 
 
 **External users**:
 
+You must build cuda-oxide in Rust nightly mode.
+
 ```bash
-cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
+cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 ```
 
 On first run, `cargo-oxide` will automatically fetch and build the codegen backend if it's not already available.

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -10,7 +10,7 @@ Replaces the previous `xtask` pattern with a proper cargo subcommand that works 
 
 **External users**:
 
-You must build cuda-oxide in Rust nightly mode.
+Install with the project's pinned nightly toolchain:
 
 ```bash
 cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -124,10 +124,10 @@ build process. `cargo-oxide` handles building it transparently.
 ## Install cargo-oxide
 
 `cargo-oxide` is the cargo subcommand that drives the full compilation
-pipeline. Inside the repo, it works via a workspace alias. For standalone use:
+pipeline. Inside the repo, it works via a workspace alias. And you must build cuda-oxide in Rust nightly mode. For standalone use:
 
 ```bash
-cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
+cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 ```
 
 On first run, `cargo-oxide` automatically fetches and builds the codegen backend

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -124,7 +124,7 @@ build process. `cargo-oxide` handles building it transparently.
 ## Install cargo-oxide
 
 `cargo-oxide` is the cargo subcommand that drives the full compilation
-pipeline. Inside the repo, it works via a workspace alias. And you must build cuda-oxide in Rust nightly mode. For standalone use:
+pipeline. Inside the repo, it works via a workspace alias. For standalone use, install it with the pinned nightly toolchain:
 
 ```bash
 cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -6,7 +6,7 @@ This section walks through installing cuda-oxide, creating a project, writing a 
 
 ## Install cargo-oxide
 
-If you haven't already, install the build tool, and you must build cuda-oxide in Rust nightly mode:
+If you haven't already, install the build tool with the pinned nightly toolchain:
 
 ```bash
 cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -6,10 +6,10 @@ This section walks through installing cuda-oxide, creating a project, writing a 
 
 ## Install cargo-oxide
 
-If you haven't already, install the build tool:
+If you haven't already, install the build tool, and you must build cuda-oxide in Rust nightly mode:
 
 ```bash
-cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
+cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 ```
 
 Verify that your environment is set up correctly:

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -166,8 +166,7 @@ The two extra components are required by the codegen backend:
 
 **Inside the cuda-oxide repo**, it works out of the box via a workspace alias -- no extra install step.
 
-**For use outside the repo** (your own projects):
-You must build cuda-oxide in Rust nightly mode.
+**For use outside the repo** (your own projects), install it with the pinned nightly toolchain:
 
 ```bash
 cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -167,9 +167,10 @@ The two extra components are required by the codegen backend:
 **Inside the cuda-oxide repo**, it works out of the box via a workspace alias -- no extra install step.
 
 **For use outside the repo** (your own projects):
+You must build cuda-oxide in Rust nightly mode.
 
 ```bash
-cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
+cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
 ```
 
 On first run, `cargo-oxide` will automatically fetch and build the codegen backend. Subsequent runs reuse the cached build.


### PR DESCRIPTION
**Description:**
The current installation steps often fail because cargo install defaults to the stable toolchain, causing #![feature] errors. This PR clarifies that cargo-oxide must be built in nightly mode and provides instructions on using the +nightly flag. This approach ensures a successful installation without requiring users to change their global default toolchain.

**Error Messages**

```
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> crates/cuda-core/src/lib.rs:39:1
   |
39 | #![feature(f16)]
   | ^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
error: could not compile `cuda-core` (lib) due to 1 previous error
error: failed to compile `cargo-oxide v0.1.0 (https://github.com/NVlabs/cuda-oxide.git#c8b3103c)`, intermediate artifacts can be found at `/tmp/cargo-installCSlgWm`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
```

**Changes:**
Updated the installation command to enforce the specific nightly toolchain required by the project:

**From** 
```
cargo install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
```

**To**
```
cargo +nightly-2026-04-03 install --git https://github.com/NVlabs/cuda-oxide.git cargo-oxide
```

