### PR TITLE
fix(docs): improve clang/bindgen installation troubleshooting

### DIFF
--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -129,6 +129,14 @@ sudo apt install libclang-21-dev libclang-cpp21-dev libclang-common-21-dev
 
 `cargo oxide doctor` catches this up front; the symptom otherwise is `'stddef.h' file not found` during the host build.
 
+:::{tip}
+**If doctor still reports clang not found:**
+The issue may be that the versioned binary (e.g., clang-21) is installed but not mapped to the unversioned clang command required by bindgen. You can fix this by installing the clang meta-package, which manages these dependencies automatically:
+
+```bash
+sudo apt install clang libclang-dev
+```
+
 :::{note}
 **Fresh Ubuntu 24.04 / DGX-OS:** after installing LLVM 21 via `apt.llvm.org/llvm.sh` as shown above, the versioned `clang-21` / `clang++-21` binaries are present but the unversioned aliases `cargo oxide doctor` looks for are not. Add them with `update-alternatives`:
 


### PR DESCRIPTION
**Description:**

**Error Messages after install clang:**

```
sudo apt install libclang-21-dev libclang-cpp21-dev libclang-common-21-dev

cargo oxide doctor
warning: user-defined alias `oxide` is shadowing an external subcommand found at `/home/vito/.cargo/bin/cargo-oxide`
  |
  = note: this was previously accepted but will become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/10049>
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/cargo-oxide doctor`
Building rustc-codegen-cuda backend...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
✓ Backend built: /home/vito/Desktop/cuda-oxide/crates/rustc-codegen-cuda/target/debug/librustc_codegen_cuda.so
cargo-oxide environment check
==============================

Rust nightly toolchain... ✓ rustc 1.96.0-nightly (55e86c996 2026-04-02)
rust-toolchain.toml... ✓ present
Codegen backend... ✓ /home/vito/Desktop/cuda-oxide/crates/rustc-codegen-cuda/target/debug/librustc_codegen_cuda.so
CUDA toolkit (nvcc)... ✓ Cuda compilation tools, release 12.0, V12.0.140
libNVVM (libnvvm.so)... ✓ libNVVM 2.0
nvJitLink (libnvJitLink.so)... ✓ nvJitLink 13.2
libdevice (libdevice.10.bc)... ✓ /usr/local/cuda/nvvm/libdevice/libdevice.10.bc
llc (LLVM)... ✗ llc not found
  Install LLVM 21+: sudo apt install llvm-21
  (cuda-oxide probes llc-22 then llc-21 on PATH;
   older versions reject modern TMA/tcgen05 intrinsics)
clang / libclang resource dir... ✗ clang not found
  Host `cuda-bindings` uses bindgen, which needs clang + its resource headers.
  Install with: sudo apt install clang-21
  (or at minimum `libclang-common-21-dev` alongside your libclang)
cuda-gdb (optional)... ✓ NVIDIA (R) CUDA Debugger

❌ Some checks failed. Fix the issues above and re-run `cargo oxide doctor`.
```

**Changes:**
Install with `sudo apt install clang-21`
```bash
sudo apt install clang libclang-dev
```

**Result:**

```
~/.../cuda-oxide$ cargo oxide doctor
warning: user-defined alias `oxide` is shadowing an external subcommand found at `/home/vito/.cargo/bin/cargo-oxide`
  |
  = note: this was previously accepted but will become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/10049>
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/cargo-oxide doctor`
Building rustc-codegen-cuda backend...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
✓ Backend built: /home/vito/Desktop/cuda-oxide/crates/rustc-codegen-cuda/target/debug/librustc_codegen_cuda.so
cargo-oxide environment check
==============================

Rust nightly toolchain... ✓ rustc 1.96.0-nightly (55e86c996 2026-04-02)
rust-toolchain.toml... ✓ present
Codegen backend... ✓ /home/vito/Desktop/cuda-oxide/crates/rustc-codegen-cuda/target/debug/librustc_codegen_cuda.so
CUDA toolkit (nvcc)... ✓ Cuda compilation tools, release 12.0, V12.0.140
libNVVM (libnvvm.so)... ✓ libNVVM 2.0
nvJitLink (libnvJitLink.so)... ✓ nvJitLink 13.2
libdevice (libdevice.10.bc)... ✓ /usr/local/cuda/nvvm/libdevice/libdevice.10.bc
llc (LLVM)... ✓ Ubuntu LLVM version 21.1.8 (llc-21)
clang / libclang resource dir... ✓ /usr/lib/llvm-18/lib/clang/18
cuda-gdb (optional)... ✓ NVIDIA (R) CUDA Debugger

✅ Environment looks good!
```