### PR TITLE
add missing dependency on llvm-tools component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2026-04-03"
-components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy"]
+components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]


### PR DESCRIPTION
Subtle difference: "${rustc_sysroot}/lib/rustlib/${host_tuple}/lib", which is part of the library search path during linking, will now include links to libLLVM if llvm-tools is a component.

This allows `cargo test -p mir-importer` to pass without further fussing.