### PR TITLE
Add sphinx-autobuild dependency

### DIFF
--- a/cuda-oxide-book/requirements.txt
+++ b/cuda-oxide-book/requirements.txt
@@ -4,3 +4,4 @@ myst-parser>=3.0
 sphinx-copybutton>=0.5
 sphinx-design>=0.6
 sphinx-sitemap>=2.5
+sphinx-autobuild>=2024.10


### PR DESCRIPTION
Add sphinx-autobuild dependency for cuda-oxide-book requirements.txt. This is needed for 'make livehtml' as per issue: https://github.com/NVlabs/cuda-oxide/issues/68