### PR TITLE
fix(docs): Adding missing sphinx-autobuild dependency

### DIFF
--- a/cuda-oxide-book/requirements.txt
+++ b/cuda-oxide-book/requirements.txt
@@ -2,5 +2,6 @@ sphinx>=7.0
 pydata-sphinx-theme>=0.15
 myst-parser>=3.0
 sphinx-copybutton>=0.5
+sphinx-autobuild>=2025.8.25
 sphinx-design>=0.6
 sphinx-sitemap>=2.5


### PR DESCRIPTION
## Description
This change adds `sphinx-autobuild` to requirements.txt

`make livehtml` currently fails with:
```
/bin/sh: sphinx-autobuild: command not found
```

After this update, the live docs server command works in a fresh venv after installing requirements