### PR TITLE
Classify error examples in support status

### DIFF
--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -1,0 +1,27 @@
+---
+name: status-guard
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  error-example-status-guard:
+    name: error-example status guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Verify error* examples are in STATUS.md and smoketest.sh
+        run: bash scripts/check-error-example-status.sh

--- a/Justfile
+++ b/Justfile
@@ -56,3 +56,7 @@ pipeline example:
 # Run every example with GPU-aware gating (see scripts/smoketest.sh --help)
 smoketest *args:
     scripts/smoketest.sh {{args}}
+
+# Verify every error* example is in STATUS.md and smoketest.sh ERROR_EXAMPLES
+check-errors:
+    scripts/check-error-example-status.sh

--- a/crates/rustc-codegen-cuda/README.md
+++ b/crates/rustc-codegen-cuda/README.md
@@ -101,33 +101,36 @@ src/
 
 The `examples/` directory contains standalone kernel crates that exercise different features:
 
-| Example                      | What it covers                                       |
-|------------------------------|------------------------------------------------------|
-| `vecadd`                     | Basic vector addition -- the "hello world" kernel    |
-| `generic`                    | Generic kernels (`scale<T>`)                         |
-| `manual_launch_generic`      | Lower-level generic launch API regression            |
-| `cuda_module_contract`       | Typed launch ABI argument marshalling                |
-| `abi_hmm`                    | HMM pointers, struct layout, closures                |
-| `device_closures`            | Move and non-move closures passed to kernels         |
-| `cross_crate_kernel`         | Kernels defined in a library crate                   |
-| `async_vecadd`               | Async CUDA streams with `cuda-async`                 |
-| `async_mlp`                  | Multi-layer perceptron using async streams           |
-| `sharedmem`                  | Shared memory usage                                  |
-| `dynamic_smem`               | Dynamic shared memory allocation                     |
-| `barrier`                    | `__syncthreads` and barrier semantics                |
-| `atomics`                    | Atomic operations on device                          |
-| `printf`                     | Device-side `printf` via FFI                         |
-| `tma_copy`                   | Tensor Memory Accelerator copies (Hopper+)           |
-| `tma_multicast`              | TMA with multicast across CTAs                       |
-| `wgmma`                      | Warpgroup MMA (Hopper tensor cores)                  |
-| `tcgen05` / `tcgen05_matmul` | 5th-gen tensor cores (Blackwell datacenter)          |
-| `gemm` / `gemm_sol`          | GEMM implementations at various optimization levels  |
-| `cluster`                    | Thread block clusters                                |
-| `clc`                        | Cluster Launch Control                               |
-| `warp_reduce`                | Warp-level reductions                                |
-| `cpp_consumes_rust_device`   | C++ host code consuming Rust-generated PTX           |
+| Example                      | What it covers                                             |
+|------------------------------|------------------------------------------------------------|
+| `vecadd`                     | Basic vector addition -- the "hello world" kernel          |
+| `generic`                    | Generic kernels (`scale<T>`)                               |
+| `manual_launch_generic`      | Lower-level generic launch API regression                  |
+| `cuda_module_contract`       | Typed launch ABI argument marshalling                      |
+| `abi_hmm`                    | HMM pointers, struct layout, closures                      |
+| `device_closures`            | Move and non-move closures passed to kernels               |
+| `cross_crate_kernel`         | Kernels defined in a library crate                         |
+| `async_vecadd`               | Async CUDA streams with `cuda-async`                       |
+| `async_mlp`                  | Multi-layer perceptron using async streams                 |
+| `sharedmem`                  | Shared memory usage                                        |
+| `dynamic_smem`               | Dynamic shared memory allocation                           |
+| `barrier`                    | `__syncthreads` and barrier semantics                      |
+| `atomics`                    | Atomic operations on device                                |
+| `printf`                     | Device-side `printf` via FFI                               |
+| `tma_copy`                   | Tensor Memory Accelerator copies (Hopper+)                 |
+| `tma_multicast`              | TMA with multicast across CTAs                             |
+| `wgmma`                      | Warpgroup MMA (Hopper tensor cores)                        |
+| `tcgen05` / `tcgen05_matmul` | 5th-gen tensor cores (Blackwell datacenter)                |
+| `gemm` / `gemm_sol`          | GEMM implementations at various optimization levels        |
+| `cluster`                    | Thread block clusters                                      |
+| `clc`                        | Cluster Launch Control                                     |
+| `warp_reduce`                | Warp-level reductions                                      |
+| `cpp_consumes_rust_device`   | C++ host code consuming Rust-generated PTX                 |
 | `device_ffi_test`            | Rust kernels calling external C++/CCCL functions via LTOIR |
 | `mathdx_ffi_test`            | MathDx FFI: cuFFTDx thread-level FFT + cuBLASDx block GEMM |
+
+Examples starting with `error_` are expected to fail. See [STATUS.md](STATUS.md)
+for what each one tests and why it fails.
 
 Run any example with:
 

--- a/crates/rustc-codegen-cuda/STATUS.md
+++ b/crates/rustc-codegen-cuda/STATUS.md
@@ -1,0 +1,20 @@
+# rustc-codegen-cuda: error example status
+
+Examples named `error*` fall into two kinds:
+
+- **diagnostics-fixture**: intentional negative test. The compiler is supposed
+  to reject this. It is not a gap.
+- **support-gap**: a real Rust feature that the compiler does not yet handle.
+  Kept as an expected-failure regression test until it is implemented.
+
+When adding a new `error*` example, update this table and the
+`ERROR_EXAMPLES` array in `scripts/smoketest.sh` in the same commit.
+Run `scripts/check-error-example-status.sh` to verify both are in sync.
+
+| Example                               | Kind                | Fails at                            |
+| :------------------------------------ | :------------------ | :---------------------------------- |
+| `error`                               | diagnostics-fixture | `core::fmt` reachable from device   |
+| `error_copy_nonoverlapping_unhandled` | support-gap         | `StatementKind::CopyNonOverlapping` |
+| `error_drop_glue`                     | support-gap         | `TerminatorKind::Drop`              |
+| `error_set_discriminant_unhandled`    | support-gap         | `StatementKind::SetDiscriminant`    |
+| `error_wgmma_mma_unimplemented`       | support-gap         | WGMMA MMA lowering                  |

--- a/scripts/check-error-example-status.sh
+++ b/scripts/check-error-example-status.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Verify every error* example is documented in STATUS.md and listed in
+# the ERROR_EXAMPLES array in smoketest.sh.  Run this after adding or
+# removing an error* example.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# Examples that exist on disk.
+mapfile -t on_disk < <(
+    find crates/rustc-codegen-cuda/examples -mindepth 1 -maxdepth 1 \
+        -type d -name 'error*' -exec basename {} \; | sort
+)
+
+# Examples listed in STATUS.md (backtick-quoted names in the table).
+mapfile -t in_status < <(
+    grep -oP '^\|\s*`\K[^`]+' \
+        crates/rustc-codegen-cuda/STATUS.md | sort
+)
+
+# Examples listed in ERROR_EXAMPLES in smoketest.sh.
+mapfile -t in_smoketest < <(
+    grep -oP 'ERROR_EXAMPLES=\(\K[^)]+' scripts/smoketest.sh \
+        | tr ' ' '\n' | grep -v '^$' | sort
+)
+
+contains() {
+    local needle="$1"; shift
+    printf '%s\n' "$@" | grep -qx "$needle"
+}
+
+for ex in "${on_disk[@]}"; do
+    if ! contains "$ex" "${in_status[@]+"${in_status[@]}"}"; then
+        echo "error: $ex is not in STATUS.md" >&2; fail=1
+    fi
+    if ! contains "$ex" "${in_smoketest[@]+"${in_smoketest[@]}"}"; then
+        echo "error: $ex is not in ERROR_EXAMPLES in smoketest.sh" >&2; fail=1
+    fi
+done
+
+for ex in "${in_status[@]}"; do
+    if [[ ! -d "crates/rustc-codegen-cuda/examples/$ex" ]]; then
+        echo "error: STATUS.md lists '$ex' but no such directory exists" >&2; fail=1
+    fi
+done
+
+[[ $fail -eq 0 ]] && echo "OK: all error* examples are documented and classified."
+exit $fail

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -8,9 +8,10 @@
 # category-specific verdict rule is applied to the cargo output:
 #
 #   standard     -- execution must succeed (SUCCESS/PASS/Complete marker).
-#   error        -- compilation must fail with a recognized diagnostic; the
-#                   example is an intentional negative test of our codegen
-#                   errors. Signal termination (crash) is never accepted.
+#   error        -- compilation must fail with a recognized diagnostic.
+#                   Covers both intentional diagnostic fixtures and known
+#                   support gaps (see STATUS.md). Signal termination is
+#                   never accepted.
 #   tcgen05      -- 5th-gen tensor cores; sm_100 datacenter only. On sm_100
 #                   require full execution; elsewhere PTX compilation is
 #                   sufficient.
@@ -24,8 +25,9 @@
 #                   unset), in which case we require the cuda-oxide
 #                   NVVM IR (`.ll`) to have been generated.
 #
-# The categorization is just a pair of bash arrays at the top of the file.
-# Add/remove examples there when introducing a new example.
+# Categories are bash arrays at the top of this file. When adding an
+# error* example, also update STATUS.md and run
+# scripts/check-error-example-status.sh to verify both are in sync.
 #
 # See --help for runtime flags.
 


### PR DESCRIPTION
Closes #85

## Summary

- add `crates/rustc-codegen-cuda/STATUS.md` to classify current `error*` examples
- distinguish `examples/error/` as a diagnostics fixture from current `error_*` support gaps
- add `scripts/check-error-example-status.sh` to keep `STATUS.md` and `scripts/smoketest.sh` in sync
- point the `rustc-codegen-cuda` README and smoketest comments at the status matrix

## Validation

- `scripts/check-error-example-status.sh`
- `bash -n scripts/check-error-example-status.sh`
- `bash -n scripts/smoketest.sh`
- `git diff --check`
- `cargo fmt --all -- --check`
- `(cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)`