### PR TITLE
fix(cuda-core): use malloc_sync for DeviceBuffer allocations

### DIFF
--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -212,7 +212,7 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         let len = data.len();
         let num_bytes = std::mem::size_of_val(data);
 
-        let ptr = unsafe { crate::memory::malloc_async(stream.cu_stream(), num_bytes)? };
+        let ptr = unsafe { crate::memory::malloc_sync(num_bytes)? };
         unsafe {
             crate::memory::memcpy_htod_async(ptr, data.as_ptr(), num_bytes, stream.cu_stream())?;
         }
@@ -269,7 +269,7 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
         let ctx = stream.context().clone();
         let num_bytes = len * std::mem::size_of::<T>();
 
-        let ptr = unsafe { crate::memory::malloc_async(stream.cu_stream(), num_bytes)? };
+        let ptr = unsafe { crate::memory::malloc_sync(num_bytes)? };
         if num_bytes > 0 {
             unsafe {
                 crate::memory::memset_d8_async(ptr, 0, num_bytes, stream.cu_stream())?;


### PR DESCRIPTION
### **Description**
Pairs `DeviceBuffer` constructors with the correct matching allocation strategy to fix undefined behavior.

**Why:**
I ran into this bug while developing a small game on `cuda-oxide`. As entity buffers were constantly allocated and dropped in the game loop, the game would crash or render corrupted overlapping meshes after a few minutes. 

`DeviceBuffer` was allocating memory via `cuMemAllocAsync` (stream-ordered) but freeing it via `cuMemFree_v2` (legacy synchronous) on drop. Passing a stream-allocated pointer to `cuMemFree_v2` violates the CUDA API contract, causing the driver to silently corrupt the virtual memory pool. This leads to silent memory corruption, premature OOMs, or runtime crashes.

The Impact: It corrupts the graphics card's memory pool. After a few minutes of creating and deleting buffers 
1. Random crashes.
2. Fake "Out of Memory" errors.
3. Silent data corruption (objects overlapping in memory and overwriting each other).

**Changes:**
Switched `malloc_async` to `malloc_sync` in `DeviceBuffer::from_host` and `DeviceBuffer::zeroed` to correctly pair allocations with the `free_sync` call in `Drop`.

PS: CUDA rules state that you must use the same type for both (async-with-async, or sync-with-sync). Mixing them is not allowed.


