### PR TITLE
Add debug information to the generated PTX code

### DIFF
--- a/crates/dialect-llvm/src/export/debug.rs
+++ b/crates/dialect-llvm/src/export/debug.rs
@@ -53,11 +53,18 @@ pub enum DebugOp {
         file: DebugOpScopeRef,
         line: i32,
         unit: DebugOpScopeRef,
+        r#type: DebugOpScopeRef,
     },
     DILocation {
         line: i32,
         column: i32,
         scope: DebugOpScopeRef,
+    },
+    DISubroutineType {
+        types: DebugOpScopeRef,
+    },
+    DIRefList {
+        list: Vec<DebugOpScopeRef>,
     },
     Raw(String),
 }
@@ -88,8 +95,9 @@ impl DebugOp {
                 file,
                 line,
                 unit,
+                r#type,
             } => {
-                write!(output, r#"distinct !DISubprogram(name: "{name}", scope: !{scope}, file: !{file}, line: {line}, unit: !{unit})"#).unwrap();
+                write!(output, r#"distinct !DISubprogram(name: "{name}", scope: !{scope}, file: !{file}, line: {line}, unit: !{unit}, type: !{})"#, r#type).unwrap();
             }
             DebugOp::DILocation {
                 line,
@@ -104,6 +112,22 @@ impl DebugOp {
             }
             DebugOp::Raw(raw_str) => {
                 write!(output, "{}", raw_str).unwrap();
+            }
+            DebugOp::DISubroutineType { types } => {
+                write!(output, "!DISubroutineType(types: !{types})").unwrap();
+            }
+            DebugOp::DIRefList { list } => {
+                write!(output, "!{{").unwrap();
+
+                let mut refs = list.iter().peekable();
+                while let Some(r) = refs.next() {
+                    write!(output, "!{r}").unwrap();
+                    if refs.peek().is_some() {
+                        write!(output, ", ").unwrap();
+                    }
+                }
+
+                write!(output, "}}").unwrap();
             }
         }
     }

--- a/crates/dialect-llvm/src/export/debug.rs
+++ b/crates/dialect-llvm/src/export/debug.rs
@@ -1,0 +1,110 @@
+use std::fmt::{Display, Formatter, Write};
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub struct DebugOpScopeRef(usize);
+impl Display for DebugOpScopeRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+pub struct DebugOpRegistry {
+    pub(crate) ops: Vec<DebugOp>,
+}
+
+impl DebugOpRegistry {
+    pub fn new() -> Self {
+        Self { ops: Vec::new() }
+    }
+
+    pub fn get_or_create(&mut self, op: DebugOp) -> DebugOpScopeRef {
+        if let Some((index, _)) = self.ops.iter().enumerate().find(|(_, o)| o == &&op) {
+            DebugOpScopeRef(index)
+        } else {
+            self.ops.push(op);
+            DebugOpScopeRef(self.ops.len() - 1)
+        }
+    }
+}
+
+impl DebugOpRegistry {
+    pub fn emit(&self, output: &mut String) {
+        writeln!(output).unwrap();
+
+        for (index, op) in self.ops.iter().enumerate() {
+            write!(output, "!{} = ", index).unwrap();
+            op.emit(output);
+            writeln!(output).unwrap();
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone)]
+pub enum DebugOp {
+    DIFile {
+        filename: String,
+        directory: String,
+    },
+    DICompileUnit {
+        file: DebugOpScopeRef,
+    },
+    DISubprogram {
+        name: String,
+        scope: DebugOpScopeRef,
+        file: DebugOpScopeRef,
+        line: i32,
+        unit: DebugOpScopeRef,
+    },
+    DILocation {
+        line: i32,
+        column: i32,
+        scope: DebugOpScopeRef,
+    },
+    Raw(String),
+}
+
+impl DebugOp {
+    pub fn emit(&self, output: &mut String) {
+        match self {
+            DebugOp::DIFile {
+                filename,
+                directory,
+            } => {
+                write!(
+                    output,
+                    "!DIFile(filename: \"{filename}\", directory: \"{directory}\")",
+                )
+                .unwrap();
+            }
+            DebugOp::DICompileUnit { file } => {
+                write!(
+                    output,
+                    "distinct !DICompileUnit(language: DW_LANG_Rust, file: !{file}, emissionKind: FullDebug)"
+                )
+                .unwrap();
+            }
+            DebugOp::DISubprogram {
+                name,
+                scope,
+                file,
+                line,
+                unit,
+            } => {
+                write!(output, r#"distinct !DISubprogram(name: "{name}", scope: !{scope}, file: !{file}, line: {line}, unit: !{unit})"#).unwrap();
+            }
+            DebugOp::DILocation {
+                line,
+                column,
+                scope,
+            } => {
+                write!(
+                    output,
+                    r#"!DILocation(line: {line}, column: {column}, scope: !{scope})"#
+                )
+                .unwrap();
+            }
+            DebugOp::Raw(raw_str) => {
+                write!(output, "{}", raw_str).unwrap();
+            }
+        }
+    }
+}

--- a/crates/dialect-llvm/src/export/function.rs
+++ b/crates/dialect-llvm/src/export/function.rs
@@ -32,7 +32,7 @@ use crate::{
     ops::{self, FuncOp},
     types::FuncType,
 };
-
+use crate::export::debug::{DebugOpRegistry, DebugOpScopeRef};
 use super::{
     literals::{format_float_literal, format_half_literal},
     names::{has_device_prefix, strip_device_prefix},
@@ -105,7 +105,9 @@ impl<'a> ModuleExportState<'a> {
     pub(super) fn export_function(
         &mut self,
         func: &FuncOp,
+        debug_reference: DebugOpScopeRef,
         output: &mut String,
+        debug_op_registry: &mut DebugOpRegistry
     ) -> Result<(), String> {
         let func_name = func.get_symbol_name(self.ctx);
         // LLVM intrinsics (NVVM and standard, e.g. llvm.fptosi.sat) use dots in IR
@@ -280,7 +282,7 @@ impl<'a> ModuleExportState<'a> {
                 write!(output, " {name}").unwrap();
                 next_value_id += 1;
             }
-            writeln!(output, ") {{").unwrap();
+            writeln!(output, ") !dbg !{debug_reference} {{").unwrap();
 
             // Assign labels to all blocks
             let mut block_labels = HashMap::new();
@@ -452,6 +454,8 @@ impl<'a> ModuleExportState<'a> {
                     &block_labels,
                     &pred_map,
                     i == 0,
+                    debug_reference,
+                    debug_op_registry,
                     output,
                 )?;
             }
@@ -487,6 +491,8 @@ impl<'a> ModuleExportState<'a> {
         block_labels: &HashMap<Ptr<BasicBlock>, String>,
         pred_map: &PredecessorMap,
         is_entry: bool,
+        scope_reference: DebugOpScopeRef,
+        debug_op_registry: &mut DebugOpRegistry,
         output: &mut String,
     ) -> Result<(), String> {
         // Always print label to ensure it can be referenced by PHI nodes
@@ -540,7 +546,7 @@ impl<'a> ModuleExportState<'a> {
         }
 
         for op in block.deref(self.ctx).iter(self.ctx) {
-            self.export_op(op, value_names, next_value_id, block_labels, output)?;
+            self.export_op(op, value_names, next_value_id, block_labels, scope_reference, debug_op_registry,  output)?;
         }
         Ok(())
     }

--- a/crates/dialect-llvm/src/export/mod.rs
+++ b/crates/dialect-llvm/src/export/mod.rs
@@ -35,8 +35,10 @@
 //! - [`types`] — LLVM type printing
 //! - [`literals`] — constant/literal formatting
 //! - [`metadata`] — nvvm annotations and version, llvm.used
+//! - [`debug`] - debugging information (DWARF)
 
 mod config;
+mod debug;
 mod externs;
 mod function;
 mod literals;
@@ -56,6 +58,7 @@ use pliron::{builtin::ops::ModuleOp, context::Context};
 ///
 /// Uses default PTX export mode. For alternate backends, use [`export_module_to_string_with_config`].
 pub fn export_module_to_string(ctx: &Context, module: &ModuleOp) -> Result<String, String> {
+    eprintln!("export_module_to_string");
     module::export_module_to_string_with_config(ctx, module, &config::PtxExportConfig)
 }
 
@@ -73,6 +76,7 @@ pub fn export_module_with_externs<T: AsDeviceExtern>(
     device_externs: &[T],
     config: &dyn ExportBackendConfig,
 ) -> Result<String, String> {
+    eprintln!("export_module_with_externs");
     let externs: Vec<DeviceExternDecl> = device_externs
         .iter()
         .map(|e| e.as_device_extern())
@@ -89,5 +93,6 @@ pub fn export_module_to_string_with_config(
     module: &ModuleOp,
     config: &dyn ExportBackendConfig,
 ) -> Result<String, String> {
+    eprintln!("export_module_to_string_with_config");
     module::export_module_to_string_with_config(ctx, module, config)
 }

--- a/crates/dialect-llvm/src/export/module.rs
+++ b/crates/dialect-llvm/src/export/module.rs
@@ -5,8 +5,13 @@
 
 //! Module-level export flow.
 
+use std::ffi::OsStr;
 use std::fmt::Write;
 
+use crate::export::debug::{DebugOp, DebugOpRegistry};
+use crate::ops;
+use pliron::location::{Location, Source};
+use pliron::uniqued_any::get;
 use pliron::{
     builtin::{
         op_interfaces::{OneRegionInterface, SymbolOpInterface},
@@ -17,8 +22,6 @@ use pliron::{
     op::Op,
     operation::Operation,
 };
-
-use crate::ops;
 
 use super::{
     config::ExportBackendConfig,
@@ -89,6 +92,13 @@ pub(super) fn export_module_with_externs_impl(
 
     // 3. Process Globals and Functions (including intrinsic declarations)
     // Skip device extern declarations - they were already emitted in section 2 with proper attributes
+    let mut debug_op_registry = DebugOpRegistry::new();
+    let dwarf_version =
+        debug_op_registry.get_or_create(DebugOp::Raw("!{i32 7, !\"Dwarf Version\", i32 2}".into()));
+    let debug_info_version = debug_op_registry.get_or_create(DebugOp::Raw(
+        "!{i32 2, !\"Debug Info Version\", i32 3}".into(),
+    ));
+
     let device_extern_names: std::collections::HashSet<&str> = device_externs
         .iter()
         .map(|d| d.export_name.as_str())
@@ -111,7 +121,21 @@ pub(super) fn export_module_with_externs_impl(
                     writeln!(&mut output).unwrap();
                 }
 
-                state.export_function(&func, &mut output)?;
+                let file_ref = debug_op_registry.get_or_create(DebugOp::DIFile {
+                    filename: filename_from_loc(&func.loc(ctx), ctx),
+                    directory: directory_from_loc(&func.loc(ctx), ctx),
+                });
+                let compile_unit = debug_op_registry.get_or_create(DebugOp::DICompileUnit {
+                    file: file_ref,
+                });
+                let function_ref = debug_op_registry.get_or_create(DebugOp::DISubprogram {
+                    name: func_name.into(),
+                    scope: file_ref,
+                    file: file_ref,
+                    line: line_from_loc(&func.loc(ctx)),
+                    unit: compile_unit,
+                });
+                state.export_function(&func, function_ref, &mut output, &mut debug_op_registry)?;
                 last_was_decl = is_decl;
             } else if let Some(global) = Operation::get_op::<ops::GlobalOp>(op, ctx) {
                 state.export_global(&global, &mut output)?;
@@ -127,6 +151,28 @@ pub(super) fn export_module_with_externs_impl(
             }
         }
     }
+
+    // 3.5 Dump debug info
+    writeln!(
+        &mut output,
+        "!llvm.module.flags = !{{!{dwarf_version}, !{debug_info_version}}}"
+    )
+    .unwrap();
+
+    write!(&mut output, "!llvm.dbg.cu = !{{").unwrap();
+    let mut cu_iter = debug_op_registry.ops.iter()
+        .enumerate().filter(|d| matches!(d.1, DebugOp::DICompileUnit { .. }))
+        .peekable();
+    while let Some((index, _)) = cu_iter.next() {
+        write!(&mut output, "!{index}").unwrap();
+        if cu_iter.peek().is_some() {
+            write!(&mut output, ", ").unwrap();
+        }
+    }
+    writeln!(&mut output, "}}").unwrap();
+
+
+    debug_op_registry.emit(&mut output);
 
     // 4. @llvm.used — preserve kernels and/or standalone device functions from DCE
     //
@@ -246,8 +292,8 @@ pub(super) fn export_module_to_string_with_config(
                 if !is_decl && last_was_decl {
                     writeln!(&mut output).unwrap();
                 }
-
-                state.export_function(&func, &mut output)?;
+                todo!();
+                //state.export_function(&func, &mut output)?;
                 last_was_decl = is_decl;
             } else if let Some(global) = Operation::get_op::<ops::GlobalOp>(op, ctx) {
                 // Export global variable (typically shared memory)
@@ -354,7 +400,7 @@ pub(super) fn export_module_to_string_with_config(
                 "!{} = !{{ptr @{}, !\"kernel\", i32 1, !\"cluster_dim_x\", i32 {}, !\"cluster_dim_y\", i32 {}, !\"cluster_dim_z\", i32 {}}}",
                 md_id, cfg.name, cfg.dim_x, cfg.dim_y, cfg.dim_z
             )
-            .unwrap();
+                .unwrap();
             metadata_refs.push(format!("!{}", md_id));
             md_id += 1;
         }
@@ -438,4 +484,64 @@ pub(super) fn export_module_to_string_with_config(
     }
 
     Ok(output)
+}
+
+pub fn line_from_loc(location: &Location) -> i32 {
+    match location {
+        Location::SrcPos { src: _src, pos } => pos.line,
+        Location::Fused {
+            metadata: _metadata,
+            locations,
+        } => locations.get(0).map(|l| line_from_loc(l)).unwrap_or(0),
+        Location::Named {
+            name: _name,
+            child_loc,
+        } => line_from_loc(child_loc),
+        Location::CallSite { callee, caller } => line_from_loc(callee),
+        Location::Unknown => 0,
+    }
+}
+
+pub fn col_from_loc(location: &Location) -> i32 {
+    match location {
+        Location::SrcPos { src: _src, pos } => pos.column,
+        Location::Fused {
+            metadata: _metadata,
+            locations,
+        } => locations.get(0).map(|l| line_from_loc(l)).unwrap_or(0),
+        Location::Named {
+            name: _name,
+            child_loc,
+        } => line_from_loc(child_loc),
+        Location::CallSite { callee, caller } => line_from_loc(callee),
+        Location::Unknown => 0,
+    }
+}
+
+pub fn filename_from_loc(location: &Location, ctx: &Context) -> String {
+    match location {
+        Location::SrcPos {
+            src: Source::File(src),
+            pos: _pos,
+        } => get(ctx, *src)
+            .file_name()
+            .unwrap_or(OsStr::new("<unknown>"))
+            .display()
+            .to_string(),
+        _ => "<unknown>".into(),
+    }
+}
+
+pub fn directory_from_loc(location: &Location, ctx: &Context) -> String {
+    match location {
+        Location::SrcPos {
+            src: Source::File(src),
+            pos: _pos,
+        } => {
+            let mut p = get(ctx, *src).clone();
+            p.pop();
+            p.display().to_string()
+        }
+        _ => "<unknown>".into(),
+    }
 }

--- a/crates/dialect-llvm/src/export/module.rs
+++ b/crates/dialect-llvm/src/export/module.rs
@@ -125,8 +125,12 @@ pub(super) fn export_module_with_externs_impl(
                     filename: filename_from_loc(&func.loc(ctx), ctx),
                     directory: directory_from_loc(&func.loc(ctx), ctx),
                 });
-                let compile_unit = debug_op_registry.get_or_create(DebugOp::DICompileUnit {
-                    file: file_ref,
+                let compile_unit =
+                    debug_op_registry.get_or_create(DebugOp::DICompileUnit { file: file_ref });
+                // TODO: Use actual args
+                let empty_type = debug_op_registry.get_or_create(DebugOp::Raw("!{}".into()));
+                let program_type = debug_op_registry.get_or_create(DebugOp::DISubroutineType {
+                    types: empty_type,
                 });
                 let function_ref = debug_op_registry.get_or_create(DebugOp::DISubprogram {
                     name: func_name.into(),
@@ -134,6 +138,7 @@ pub(super) fn export_module_with_externs_impl(
                     file: file_ref,
                     line: line_from_loc(&func.loc(ctx)),
                     unit: compile_unit,
+                    r#type: program_type,
                 });
                 state.export_function(&func, function_ref, &mut output, &mut debug_op_registry)?;
                 last_was_decl = is_decl;
@@ -160,8 +165,11 @@ pub(super) fn export_module_with_externs_impl(
     .unwrap();
 
     write!(&mut output, "!llvm.dbg.cu = !{{").unwrap();
-    let mut cu_iter = debug_op_registry.ops.iter()
-        .enumerate().filter(|d| matches!(d.1, DebugOp::DICompileUnit { .. }))
+    let mut cu_iter = debug_op_registry
+        .ops
+        .iter()
+        .enumerate()
+        .filter(|d| matches!(d.1, DebugOp::DICompileUnit { .. }))
         .peekable();
     while let Some((index, _)) = cu_iter.next() {
         write!(&mut output, "!{index}").unwrap();
@@ -170,7 +178,6 @@ pub(super) fn export_module_with_externs_impl(
         }
     }
     writeln!(&mut output, "}}").unwrap();
-
 
     debug_op_registry.emit(&mut output);
 

--- a/crates/dialect-llvm/src/export/ops.rs
+++ b/crates/dialect-llvm/src/export/ops.rs
@@ -8,6 +8,18 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
+use super::{
+    literals::{format_float_literal, format_half_literal},
+    state::ModuleExportState,
+};
+use crate::export::debug::{DebugOp, DebugOpRegistry, DebugOpScopeRef};
+use crate::export::module::{col_from_loc, line_from_loc};
+use crate::{
+    attributes::{FCmpPredicateAttr, FPHalfAttr, GepIndexAttr, ICmpPredicateAttr},
+    ops::{self, LlvmAtomicOpInterface},
+    types::{FuncType, VoidType},
+};
+use pliron::location::Located;
 use pliron::r#type::Typed;
 use pliron::{
     basic_block::BasicBlock,
@@ -20,17 +32,7 @@ use pliron::{
     operation::Operation,
     value::Value,
 };
-
-use crate::{
-    attributes::{FCmpPredicateAttr, FPHalfAttr, GepIndexAttr, ICmpPredicateAttr},
-    ops::{self, LlvmAtomicOpInterface},
-    types::{FuncType, VoidType},
-};
-
-use super::{
-    literals::{format_float_literal, format_half_literal},
-    state::ModuleExportState,
-};
+use pliron::printable::Printable;
 
 /// Typed view of a dispatched LLVM dialect operation.
 ///
@@ -221,10 +223,13 @@ impl<'a> ModuleExportState<'a> {
         value_names: &mut HashMap<Value, String>,
         next_value_id: &mut usize,
         block_labels: &HashMap<Ptr<BasicBlock>, String>,
+        scope_reference: DebugOpScopeRef,
+        debug_op_registry: &mut DebugOpRegistry,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.deref(self.ctx);
         let op_obj = Operation::get_op_dyn(op, self.ctx);
+        eprintln!("op: {:#?}", op_ref.loc());
 
         // Register result names (skip if already named in pre-pass)
         for res in op_ref.results() {
@@ -235,6 +240,8 @@ impl<'a> ModuleExportState<'a> {
             });
         }
 
+        // TODO: this is ugly AF
+        let output_before = output.clone();
         match LlvmOp::try_from(op_obj.as_ref()).ok() {
             // Terminators
             Some(LlvmOp::Return(op)) => self.emit_return(op, value_names, output)?,
@@ -372,6 +379,15 @@ impl<'a> ModuleExportState<'a> {
             )
             .unwrap(),
         }
+        if &output_before != output {
+            *output = output.trim_end().into();
+            let debug_ref = debug_op_registry.get_or_create(DebugOp::DILocation {
+                scope: scope_reference,
+                line: line_from_loc(&op_ref.loc()),
+                column: col_from_loc(&op_ref.loc()),
+            });
+            writeln!(output, ", !dbg !{debug_ref}").unwrap();
+        }
 
         Ok(())
     }
@@ -392,7 +408,7 @@ impl<'a> ModuleExportState<'a> {
             write!(output, " ").unwrap();
             self.export_value(val, value_names, output)?;
         }
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -447,7 +463,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_type(ty, output)?;
         write!(output, ", {}", ptr_qualifier(addrspace)).unwrap();
         self.export_value(ptr, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -468,7 +484,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(val, value_names, output)?;
         write!(output, ", {}", ptr_qualifier(addrspace)).unwrap();
         self.export_value(ptr, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -487,7 +503,7 @@ impl<'a> ModuleExportState<'a> {
 
         write!(output, "  {res_name} = alloca ").unwrap();
         self.export_type(elem_ty.get_type(self.ctx), output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -526,7 +542,7 @@ impl<'a> ModuleExportState<'a> {
                 }
             }
         }
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -667,7 +683,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_type(arg.get_type(self.ctx), output)?;
         write!(output, " ").unwrap();
         self.export_value(arg, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -701,7 +717,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(lhs, value_names, output)?;
         write!(output, ", ").unwrap();
         self.export_value(rhs, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -741,7 +757,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(lhs, value_names, output)?;
         write!(output, ", ").unwrap();
         self.export_value(rhs, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -769,7 +785,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_type(val_ty, output)?;
         write!(output, " ").unwrap();
         self.export_value(false_val, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -995,7 +1011,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(val, value_names, output)?;
         write!(output, " to ").unwrap();
         self.export_type(res.get_type(self.ctx), output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -1017,7 +1033,7 @@ impl<'a> ModuleExportState<'a> {
         for idx in op.indices(self.ctx) {
             write!(output, ", {idx}").unwrap();
         }
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -1044,7 +1060,7 @@ impl<'a> ModuleExportState<'a> {
         for idx in op.indices(self.ctx) {
             write!(output, ", {idx}").unwrap();
         }
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -1113,7 +1129,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(lhs, value_names, output)?;
         write!(output, ", ").unwrap();
         self.export_value(rhs, value_names, output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 
@@ -1136,7 +1152,7 @@ impl<'a> ModuleExportState<'a> {
         self.export_value(val, value_names, output)?;
         write!(output, " to ").unwrap();
         self.export_type(res.get_type(self.ctx), output)?;
-        writeln!(output).unwrap();
+
         Ok(())
     }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -23,6 +23,7 @@ use super::block;
 use super::types;
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::values::{self, SlotAddrSpaceMap, ValueMap};
+use combine::stream::position::SourcePosition;
 use dialect_mir::ops::MirFuncOp;
 use dialect_mir::types::address_space;
 use pliron::basic_block::BasicBlock;
@@ -30,10 +31,10 @@ use pliron::builtin::op_interfaces::SymbolOpInterface;
 use pliron::context::{Context, Ptr};
 use pliron::identifier::{Identifier, Legaliser};
 use pliron::input_err_noloc;
-use pliron::location::{Located, Location};
+use pliron::location::{Located, Location, Source};
 use pliron::op::Op;
 use pliron::operation::Operation;
-
+use std::path::PathBuf;
 // Re-export rustc_public types for convenience
 use rustc_public::CrateDef;
 use rustc_public::mir;
@@ -422,9 +423,12 @@ pub fn translate_body(
 
     // Set function location
     // Use body span for location
-    let loc = Location::Named {
-        name: format!("{:?}", body.span),
-        child_loc: Box::new(Location::Unknown),
+    let loc = Location::SrcPos {
+        src: Source::new_from_file(ctx, PathBuf::from(body.span.get_filename()).canonicalize().unwrap()),
+        pos: SourcePosition {
+            line: body.span.get_lines().start_line as i32,
+            column: body.span.get_lines().start_col as i32,
+        },
     };
     op_ptr.deref_mut(ctx).set_loc(loc);
 

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -30,12 +30,13 @@ use super::types;
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::rvalue;
 use crate::translator::values::ValueMap;
+use combine::stream::position::SourcePosition;
 use dialect_mir::ops::{MirStorageDeadOp, MirStorageLiveOp, MirStoreOp};
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
 use pliron::input_err;
-use pliron::location::{Located, Location};
+use pliron::location::{Located, Location, Source};
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::r#type::Typed;
@@ -43,6 +44,7 @@ use pliron::utils::apint::APInt;
 use pliron::value::Value;
 use rustc_public::mir;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 
 /// Translates a MIR statement to one or more `dialect-mir` operations.
 ///
@@ -59,9 +61,12 @@ pub fn translate_statement(
     prev_op: Option<Ptr<Operation>>,
 ) -> TranslationResult<Option<Ptr<Operation>>> {
     // Use Debug representation of the span as location
-    let loc = Location::Named {
-        name: format!("{:?}", stmt.span),
-        child_loc: Box::new(Location::Unknown),
+    let loc = Location::SrcPos {
+        src: Source::new_from_file(ctx, PathBuf::from(stmt.span.get_filename()).canonicalize().unwrap()),
+        pos: SourcePosition {
+            line: stmt.span.get_lines().start_line as i32,
+            column: stmt.span.get_lines().start_col as i32,
+        },
     };
 
     match &stmt.kind {


### PR DESCRIPTION
As mentioned in https://github.com/NVlabs/cuda-oxide/issues/105, currently there is no debug information related to the generated device code by rustc_codegen_cuda. This PR aims to introduce basic debug information to help the debugging of GPU code. 

This is not a final solution, just my attempt to make my life a bit easier.