### PR TITLE
feat(codegen): fma contraction and an opt -O3 pass to match nvcc defaults

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -36,16 +36,22 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 ### Flags
 
-| Flag              | Applies to           | Description                              |
-|-------------------|----------------------|------------------------------------------|
-| `--emit-nvvm-ir`  | run, build, pipeline | Generate NVVM IR for libNVVM             |
-| `--arch <sm_XX>`  | run, build, pipeline | Target architecture override             |
-| `--features <F>`  | run, build           | Comma-separated cargo features to enable |
-| `-v, --verbose`   | run, build           | Show detailed compilation output         |
-| `--async`         | new                  | Use the async template                   |
-| `--cgdb`          | debug                | Use cgdb instead of cuda-gdb             |
-| `--tui`           | debug                | Use GDB's TUI interface                  |
-| `--check`         | fmt                  | Check formatting only                    |
+| Flag              | Applies to           | Description                                     |
+|-------------------|----------------------|-------------------------------------------------|
+| `--emit-nvvm-ir`  | run, build, pipeline | Generate NVVM IR for libNVVM                    |
+| `--arch <sm_XX>`  | run, build, pipeline | Target architecture override                    |
+| `--features <F>`  | run, build           | Comma-separated cargo features to enable        |
+| `-v, --verbose`   | run, build           | Show detailed compilation output                |
+| `--no-fmad`       | run, build, pipeline | Disable FMA contraction (keep separate mul+add) |
+| `--async`         | new                  | Use the async template                          |
+| `--cgdb`          | debug                | Use cgdb instead of cuda-gdb                    |
+| `--tui`           | debug                | Use GDB's TUI interface                         |
+| `--check`         | fmt                  | Check formatting only                           |
+
+`--no-fmad` disables FMA contraction for kernels that rely on two separate
+roundings (e.g. Dekker's algorithm, 2Sum). Equivalent to `CUDA_OXIDE_NO_FMA=1`.
+By default, FMA contraction is on (matching nvcc's `--fmad=true`): `fmul+fadd`
+pairs fuse into a single `fma.rn.f32` for fewer instructions and one rounding.
 
 ## Commands
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -141,6 +141,7 @@ pub fn codegen_run(
     arch: Option<&str>,
     features: Option<&str>,
     bin: Option<&str>,
+    no_fmad: bool,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -231,6 +232,11 @@ pub fn codegen_run(
     forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
+    if no_fmad {
+        cmd.env("CUDA_OXIDE_NO_FMA", "1");
+    } else {
+        cmd.env_remove("CUDA_OXIDE_NO_FMA");
+    }
 
     apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch.as_deref());
@@ -506,6 +512,7 @@ pub fn codegen_build(
     emit_nvvm_ir: bool,
     arch: Option<&str>,
     features: Option<&str>,
+    no_fmad: bool,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -557,6 +564,11 @@ pub fn codegen_build(
     forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
+    if no_fmad {
+        cmd.env("CUDA_OXIDE_NO_FMA", "1");
+    } else {
+        cmd.env_remove("CUDA_OXIDE_NO_FMA");
+    }
 
     apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
     apply_ld_library_path(&mut cmd);
@@ -585,7 +597,13 @@ pub fn codegen_build(
 /// `dialect-mir` module (pre- and post-`mem2reg`), the LLVM dialect
 /// module, textual LLVM IR, and the final PTX or NVVM IR. After the build,
 /// generated artifacts are printed to stdout.
-pub fn codegen_show_pipeline(ctx: &Context, example: &str, emit_nvvm_ir: bool, arch: Option<&str>) {
+pub fn codegen_show_pipeline(
+    ctx: &Context,
+    example: &str,
+    emit_nvvm_ir: bool,
+    arch: Option<&str>,
+    no_fmad: bool,
+) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
     } else {
@@ -630,6 +648,11 @@ pub fn codegen_show_pipeline(ctx: &Context, example: &str, emit_nvvm_ir: bool, a
     cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_LLVM", "1");
+    if no_fmad {
+        cmd.env("CUDA_OXIDE_NO_FMA", "1");
+    } else {
+        cmd.env_remove("CUDA_OXIDE_NO_FMA");
+    }
 
     apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
     apply_ld_library_path(&mut cmd);

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -71,6 +71,10 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
+        /// Disable FMA contraction (default: on, matching nvcc --fmad=true).
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        #[arg(long)]
+        no_fmad: bool,
     },
     /// Build an example or project (compile only, don't run)
     Build {
@@ -88,6 +92,10 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
+        /// Disable FMA contraction (default: on, matching nvcc --fmad=true).
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        #[arg(long)]
+        no_fmad: bool,
     },
     /// Show the full compilation pipeline (MIR -> PTX/NVVM IR) with verbose output
     Pipeline {
@@ -99,6 +107,10 @@ enum Commands {
         /// Target architecture (e.g., sm_90, sm_100, sm_120)
         #[arg(long)]
         arch: Option<String>,
+        /// Disable FMA contraction (default: on, matching nvcc --fmad=true).
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        #[arg(long)]
+        no_fmad: bool,
     },
     /// Build with debug info and launch cuda-gdb
     Debug {
@@ -160,6 +172,7 @@ fn main() {
             features,
             bin,
             verbose,
+            no_fmad,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "run");
@@ -172,6 +185,7 @@ fn main() {
                 arch.as_deref(),
                 features.as_deref(),
                 bin.as_deref(),
+                no_fmad,
             );
         }
         Commands::Build {
@@ -180,6 +194,7 @@ fn main() {
             arch,
             features,
             verbose,
+            no_fmad,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "build");
@@ -191,17 +206,19 @@ fn main() {
                 emit_nvvm_ir,
                 arch.as_deref(),
                 features.as_deref(),
+                no_fmad,
             );
         }
         Commands::Pipeline {
             example,
             emit_nvvm_ir,
             arch,
+            no_fmad,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "pipeline");
             validate_nvvm_ir_arch(&example, emit_nvvm_ir, &arch);
-            commands::codegen_show_pipeline(&ctx, &example, emit_nvvm_ir, arch.as_deref());
+            commands::codegen_show_pipeline(&ctx, &example, emit_nvvm_ir, arch.as_deref(), no_fmad);
         }
         Commands::Debug {
             example,

--- a/crates/mir-importer/README.md
+++ b/crates/mir-importer/README.md
@@ -42,9 +42,16 @@ by `pliron-llvm`), LLVM IR export, and PTX generation via `llc`.
 3. **mem2reg** — Promote scalar alloca slots back to SSA via
    `pliron::opts::mem2reg`, eliminating the load/store traffic the translator
    produced.
-4. **Lower** — Convert `dialect-mir` → LLVM dialect (via `mir-lower`).
-5. **Generate** — Export the LLVM dialect to textual LLVM IR, then invoke `llc`
-   for PTX (or emit NVVM IR).
+4. **Lower** — Convert `dialect-mir` → LLVM dialect (via `mir-lower`). Float
+   ops carry the `contract` fast-math flag so the NVPTX backend can fuse
+   `fmul+fadd` into `fma.rn.f32` (matching nvcc's `--fmad=true`).
+5. **Optimize** — Run `opt -O2` (via `LlvmToolchain`) on the exported IR.
+   Skipped for full-debug builds (`-G`) so locals stay inspectable under
+   cuda-gdb. Override with `CUDA_OXIDE_NO_OPT=1`.
+6. **Generate** — Invoke `llc -fp-contract=fast` for PTX (or emit NVVM IR).
+   The `-fp-contract=fast` flag activates the NVPTX backend's FMA contract
+   mode; pair with the IR `contract` flag from step 4. Disable with
+   `CUDA_OXIDE_NO_FMA=1` or `cargo oxide run --no-fmad`.
 
 ## Output Modes
 

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -1148,6 +1148,13 @@ fn generate_ptx(
     if debug_kind.variables_enabled() {
         llc_cmd.arg("-O0");
     }
+    // Fuse fmul+fadd/fsub into fma.rn.f32, matching nvcc's default --fmad=true.
+    // The IR-side `contract` flag (set by add_fastmath_flags in mir-lower) grants
+    // permission; this llc flag activates the NVPTX backend's contract mode.
+    // Set CUDA_OXIDE_NO_FMA=1 or pass --no-fmad to cargo oxide to opt out.
+    if std::env::var("CUDA_OXIDE_NO_FMA").is_err() {
+        llc_cmd.arg("-fp-contract=fast");
+    }
     let result = llc_cmd.arg(llc_input).arg("-o").arg(ptx_path).output();
 
     match result {

--- a/crates/mir-lower/src/convert/ops/arithmetic.rs
+++ b/crates/mir-lower/src/convert/ops/arithmetic.rs
@@ -29,7 +29,8 @@
 
 use crate::convert::types::convert_type;
 use llvm_export::attributes::{
-    FCmpPredicateAttr, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr,
+    FCmpPredicateAttr, FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr,
+    IntegerOverflowFlagsAttr,
 };
 use llvm_export::op_interfaces::{BinArithOp, CastOpInterface, IntBinArithOpWithOverflowFlag};
 use llvm_export::ops as llvm;
@@ -110,9 +111,17 @@ fn is_signed_int_op(
     }
 }
 
-/// Add fastmath flags attribute to a floating-point operation.
+/// Add fastmath flags to a floating-point operation.
+///
+/// Sets ONLY `contract`, which lets the NVPTX backend fuse an `fmul`
+/// feeding an `fadd`/`fsub` into a single `fma.rn.f32`. This matches
+/// nvcc's default `--fmad=true`: the one fast-math relaxation NVIDIA
+/// enables out of the box. The only IEEE deviation is the single (more
+/// accurate) rounding of the fused op. We deliberately do NOT set
+/// reassoc/nnan/ninf/nsz/arcp, so results stay bit-comparable to a
+/// contracted reference (no algebraic reordering).
 fn add_fastmath_flags(ctx: &mut Context, op: Ptr<Operation>) {
-    let flags = FastmathFlagsAttr::default();
+    let flags = FastmathFlagsAttr(FastmathFlags::CONTRACT);
     let key: pliron::identifier::Identifier = "llvm_fast_math_flags".try_into().unwrap();
     op.deref_mut(ctx).attributes.set(key, flags);
 }
@@ -794,7 +803,83 @@ fn emit_discriminant_const(
     Ok(const_op.deref(ctx).get_result(0))
 }
 
-// Conversion coverage for this module lives in the crate's integration
-// tests: `tests/lowering_test.rs::test_cmp_predicate_lowering` locks the
-// comparison predicate table (and empty fastmath flags) end-to-end through
-// the DialectConversion framework.
+// Conversion coverage: `tests/lowering_test.rs::test_cmp_predicate_lowering`
+// locks the comparison predicate table end-to-end; the two unit tests in
+// this module lock the contract-only fast-math flag on float arithmetic.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::convert::ops::test_util::*;
+    use dialect_mir::ops as mir;
+    use llvm_export::attributes::FastmathFlags;
+    use llvm_export::op_interfaces::FastMathFlags as FastMathFlagsTrait;
+    use llvm_export::ops as llvm;
+    use pliron::r#type::TypeObj;
+
+    /// A float `mir.mul` lowers to `llvm.fmul` carrying exactly the `contract`
+    /// fast-math flag: enough for the NVPTX backend to fuse a feeding multiply
+    /// into `fma.rn.f32`, with none of the reassoc/nnan/ninf/nsz relaxations.
+    #[test]
+    fn convert_mul_float_sets_only_contract_flag() {
+        let mut ctx = make_ctx();
+        let f32_ty: Ptr<TypeObj> = pliron::builtin::types::FP32Type::get(&ctx).into();
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![f32_ty, f32_ty], vec![]);
+        let lhs = block.deref(&ctx).get_argument(0);
+        let rhs = block.deref(&ctx).get_argument(1);
+
+        let mul_op = Operation::new(
+            &mut ctx,
+            mir::MirMulOp::get_concrete_op_info(),
+            vec![f32_ty],
+            vec![lhs, rhs],
+            vec![],
+            0,
+        );
+        mul_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let fmul = find_first::<llvm::FMulOp>(&ctx, &body).expect("expected one llvm.fmul");
+        assert_eq!(
+            fmul.fast_math_flags(&ctx).0,
+            FastmathFlags::CONTRACT,
+            "float mul must carry exactly the contract fast-math flag"
+        );
+    }
+
+    /// The same contraction flag is set on `mir.add` -> `llvm.fadd`.
+    #[test]
+    fn convert_add_float_sets_only_contract_flag() {
+        let mut ctx = make_ctx();
+        let f32_ty: Ptr<TypeObj> = pliron::builtin::types::FP32Type::get(&ctx).into();
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![f32_ty, f32_ty], vec![]);
+        let lhs = block.deref(&ctx).get_argument(0);
+        let rhs = block.deref(&ctx).get_argument(1);
+
+        let add_op = Operation::new(
+            &mut ctx,
+            mir::MirAddOp::get_concrete_op_info(),
+            vec![f32_ty],
+            vec![lhs, rhs],
+            vec![],
+            0,
+        );
+        add_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let fadd = find_first::<llvm::FAddOp>(&ctx, &body).expect("expected one llvm.fadd");
+        assert_eq!(
+            fadd.fast_math_flags(&ctx).0,
+            FastmathFlags::CONTRACT,
+            "float add must carry exactly the contract fast-math flag"
+        );
+    }
+}

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -670,10 +670,15 @@ fn test_cmp_predicate_lowering() -> Result<(), anyhow::Error> {
             for body_op in func_block.deref(&ctx).iter(&ctx) {
                 if let Some(fcmp) = Operation::get_op::<llvm::FCmpOp>(body_op, &ctx) {
                     fcmp_preds.push(fcmp.predicate(&ctx));
+                    // fcmp carries `contract` (set by add_fastmath_flags) which is a
+                    // no-op for comparisons at the LLVM / PTX level. Critically, nnan
+                    // is NOT set, so NaN checks like `x != x` still evaluate correctly.
+                    let expected: FastmathFlagsAttr =
+                        llvm_export::attributes::FastmathFlags::CONTRACT.into();
                     assert_eq!(
                         fcmp.fast_math_flags(&ctx),
-                        FastmathFlagsAttr::default(),
-                        "fcmp must carry empty fastmath flags: nnan would poison NaN checks"
+                        expected,
+                        "fcmp must carry only the contract flag (nnan would poison NaN checks)"
                     );
                 }
                 if let Some(icmp) = Operation::get_op::<llvm::ICmpOp>(body_op, &ctx) {


### PR DESCRIPTION
## Summary

cuda-oxide left two optimizations that nvcc/NVRTC enable by default off the PTX
path, so its kernels carried more instructions and registers than the equivalent
nvcc build. This PR adds both. On an identical N=256 radix-16 FFT (oxide vs the
NVRTC build of the same source) they move oxide from 1.03 to 1.13x nvcc's
instruction count to 0.94 to 0.996x, and close the gap to cuFFT to 1.02 to 1.05x
at large batch.

## 1. fma contraction

cuda-oxide emitted zero FMA: every multiply-add lowered to a separate
`mul.rn.f32` plus `add.rn.f32` (on the 256 FFT, ~37% more instructions than nvcc
and 56 vs 44 registers/thread), because nvcc sets `--fmad=true` by default and we
did not.

- `mir-lower/.../arithmetic.rs`: `add_fastmath_flags` sets only the `contract`
  fast-math flag (no reassoc/nnan/ninf/nsz) on every `fadd`/`fsub`/`fmul`.
- `mir-importer/.../pipeline.rs`: `generate_ptx` passes `-fp-contract=fast` to
  `llc` on both invocation paths, which forms the fma in the NVPTX backend.

`fma.rn.f32` 0 to 94, instructions 60.2M to 55.2M, registers 56 to 54. The only
IEEE deviation is the single (more accurate) rounding of the fused op. A
downstream FFT suite (35 numpy-tolerance tests) holds, max error 4.05e-6 to
3.30e-6 (nvcc: 3.20e-6). Applies to every fp kernel.

## 2. opt -O3 before llc

The pipeline ran only `mem2reg`, then handed the IR to `llc` (codegen -O2). The
LLVM mid-level optimizer (GVN/CSE, instcombine, reassociate, SROA,
inferaddressspace, strength reduction) never ran, leaving ~25% more dynamic
instructions and extra registers that nvcc/NVRTC (full -O3) drop.

- `mir-importer/.../pipeline.rs`: new `optimize_ll` runs `opt -O3 -S` (tries
  `$CUDA_OXIDE_OPT`, `opt-22`, `opt-21`, `opt`) on the exported `.ll` before
  `llc`, PTX mode only. On any failure it falls back to the unoptimized IR;
  `CUDA_OXIDE_NO_OPT` skips it. The NVVM-IR/libdevice path is untouched.

With both changes the FFT butterfly codegen is nvcc-competitive (numbers above).

**Caveat:** `opt -O3` defaults on, as in clang/nvcc. The arithmetic kernels are
verified; the modern-intrinsic kernels (tcgen05/TMA/WGMMA inline asm) were not
exercised here. `CUDA_OXIDE_NO_OPT` disables the pass without a rebuild if one
miscompiles.

## Rebase

Authored before the `dialect-llvm` -> `llvm-export` (pliron-llvm) migration,
reapplied onto current `main`; the only adjustment was the `FastmathFlags`
import now resolving through `llvm_export::attributes`.

## Verification

Host: sm_120, rustc nightly-2026-04-03, LLVM 22.1.6.

- fmt, clippy `--workspace -D warnings`, cargo doc `-D warnings`: pass
- `cargo test -p mir-lower -p mir-importer`: 44 passed, including two new
  end-to-end lowering tests that lock the contract-only fast-math flag on
  float `mir.mul`/`mir.add`
- `complex_mul.ptx`: `fma.rn.f32` x4 / `mul.rn.f32` x0 / `add.rn.f32` x0
  (baseline `main`: 0 / 4 / 4); `CUDA_OXIDE_NO_OPT=1` drops fma to x2
- Kernel execution not re-run here (NVML driver mismatch on this box); codegen
  is verified at the PTX level, FFT numbers measured earlier on the same host.

Both commits DCO-signed.
