### PR TITLE
feat(codegen): pass ABI alignment to LLVM load/store/alloca ops

### DIFF
--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -291,7 +291,7 @@ impl Verify for MirDisjointSliceType {
 /// * Field types must be valid.
 #[pliron_type(
     name = "mir.struct",
-    format = "`<` $name `,` `[` vec($field_names, CharSpace(`,`)) `]` `,` `[` vec($field_types, CharSpace(`,`)) `]` `,` `[` vec($mem_to_decl, CharSpace(`,`)) `]` `,` `[` vec($field_offsets, CharSpace(`,`)) `]` `,` $total_size `>`"
+    format = "`<` $name `,` `[` vec($field_names, CharSpace(`,`)) `]` `,` `[` vec($field_types, CharSpace(`,`)) `]` `,` `[` vec($mem_to_decl, CharSpace(`,`)) `]` `,` `[` vec($field_offsets, CharSpace(`,`)) `]` `,` $total_size `,` $abi_align `>`"
 )]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirStructType {
@@ -310,6 +310,12 @@ pub struct MirStructType {
     /// Total struct size in bytes (including trailing padding).
     /// 0 means size is not known (fallback to LLVM layout).
     pub total_size: u64,
+    /// ABI alignment in bytes, from rustc layout. 0 means unknown.
+    ///
+    /// Captures `repr(align(N))` raises: over-alignment is an operation
+    /// property in LLVM, so this is carried here and stamped as `align N`
+    /// on loads/stores/allocas during lowering.
+    pub abi_align: u64,
 }
 
 impl MirStructType {
@@ -334,7 +340,16 @@ impl MirStructType {
         field_types: Vec<Ptr<TypeObj>>,
         mem_to_decl: Vec<usize>,
     ) -> TypePtr<Self> {
-        Self::get_with_full_layout(ctx, name, field_names, field_types, mem_to_decl, vec![], 0)
+        Self::get_with_full_layout(
+            ctx,
+            name,
+            field_names,
+            field_types,
+            mem_to_decl,
+            vec![],
+            0,
+            0,
+        )
     }
 
     /// Create a new struct type with complete layout information from rustc.
@@ -346,6 +361,8 @@ impl MirStructType {
     /// * `mem_to_decl` - Memory order mapping (empty = identity)
     /// * `field_offsets` - Byte offset of each field in declaration order (empty = unknown)
     /// * `total_size` - Total struct size in bytes (0 = unknown)
+    /// * `abi_align` - ABI alignment in bytes (0 = unknown)
+    #[allow(clippy::too_many_arguments)]
     pub fn get_with_full_layout(
         ctx: &mut Context,
         name: String,
@@ -354,6 +371,7 @@ impl MirStructType {
         mem_to_decl: Vec<usize>,
         field_offsets: Vec<u64>,
         total_size: u64,
+        abi_align: u64,
     ) -> TypePtr<Self> {
         Type::register_instance(
             MirStructType {
@@ -363,6 +381,7 @@ impl MirStructType {
                 mem_to_decl,
                 field_offsets,
                 total_size,
+                abi_align,
             },
             ctx,
         )
@@ -383,6 +402,7 @@ impl MirStructType {
                 mem_to_decl: vec![],
                 field_offsets: vec![],
                 total_size: 0,
+                abi_align: 0,
             },
             ctx,
         )

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -446,7 +446,9 @@ impl<'a> ModuleExportState<'a> {
         self.export_type(ty, output)?;
         write!(output, ", {}", ptr_qualifier(addrspace)).unwrap();
         self.export_value(ptr, value_names, output)?;
-        writeln!(output).unwrap();
+        let align = crate::ops::op_alignment(self.ctx, op.get_operation())
+            .unwrap_or_else(|| self.natural_alignment(ty));
+        writeln!(output, ", align {align}").unwrap();
         Ok(())
     }
 
@@ -459,15 +461,18 @@ impl<'a> ModuleExportState<'a> {
         let op_ref = op.get_operation().deref(self.ctx);
         let val = op_ref.get_operand(0);
         let ptr = op_ref.get_operand(1);
+        let val_ty = val.get_type(self.ctx);
         let addrspace = addrspace_of(ptr.get_type(self.ctx), self.ctx);
 
         write!(output, "  store ").unwrap();
-        self.export_type(val.get_type(self.ctx), output)?;
+        self.export_type(val_ty, output)?;
         write!(output, " ").unwrap();
         self.export_value(val, value_names, output)?;
         write!(output, ", {}", ptr_qualifier(addrspace)).unwrap();
         self.export_value(ptr, value_names, output)?;
-        writeln!(output).unwrap();
+        let align = crate::ops::op_alignment(self.ctx, op.get_operation())
+            .unwrap_or_else(|| self.natural_alignment(val_ty));
+        writeln!(output, ", align {align}").unwrap();
         Ok(())
     }
 
@@ -484,9 +489,12 @@ impl<'a> ModuleExportState<'a> {
             .get_attr_alloca_element_type(self.ctx)
             .expect("Missing alloca_element_type");
 
+        let elem_llvm_ty = elem_ty.get_type(self.ctx);
         write!(output, "  {res_name} = alloca ").unwrap();
-        self.export_type(elem_ty.get_type(self.ctx), output)?;
-        writeln!(output).unwrap();
+        self.export_type(elem_llvm_ty, output)?;
+        let align = crate::ops::op_alignment(self.ctx, op.get_operation())
+            .unwrap_or_else(|| self.natural_alignment(elem_llvm_ty));
+        writeln!(output, ", align {align}").unwrap();
         Ok(())
     }
 

--- a/crates/llvm-export/src/export/types.rs
+++ b/crates/llvm-export/src/export/types.rs
@@ -60,20 +60,46 @@ impl<'a> ModuleExportState<'a> {
         Ok(())
     }
 
-    /// Compute natural alignment (in bytes) for a type.
-    /// Used for atomic load/store which require explicit alignment in LLVM IR.
+    /// Compute conservative ABI alignment (bytes) for a type.
+    ///
+    /// Used as the fallback when no explicit alignment is stamped on a
+    /// load/store/alloca op. Required for atomic loads/stores (LLVM IR
+    /// mandates explicit alignment) and for vectorization hints.
     pub(super) fn natural_alignment(&self, ty: Ptr<TypeObj>) -> u32 {
         let ty_ref = ty.deref(self.ctx);
         if let Some(int_ty) = ty_ref.downcast_ref::<IntegerType>() {
-            let width = int_ty.width();
-            // Alignment = ceil(width / 8), minimum 1
-            std::cmp::max(1, width / 8)
-        } else if ty_ref.is::<pliron::builtin::types::FP32Type>() {
+            // ceil(width / 8), minimum 1.
+            std::cmp::max(1, int_ty.width() / 8)
+        } else if ty_ref.is::<FP32Type>() {
             4
-        } else if ty_ref.is::<pliron::builtin::types::FP64Type>() {
+        } else if ty_ref.is::<FP64Type>() {
             8
+        } else if ty_ref.is::<HalfType>() {
+            2
+        } else if ty_ref.is::<PointerType>() {
+            8
+        } else if let Some(array_ty) = ty_ref.downcast_ref::<crate::types::ArrayType>() {
+            // ABI alignment of `[N x T]` matches elem alignment.
+            self.natural_alignment(array_ty.elem_type())
+        } else if let Some(vec_ty) = ty_ref.downcast_ref::<crate::types::VectorType>() {
+            // ABI alignment of an LLVM vector: power-of-2-rounded total width.
+            let elem = self.natural_alignment(vec_ty.elem_type());
+            let total = elem.saturating_mul(vec_ty.num_elements());
+            let mut a = 1u32;
+            while a.saturating_mul(2) <= total && a < 128 {
+                a *= 2;
+            }
+            a
+        } else if let Some(struct_ty) = ty_ref.downcast_ref::<StructType>() {
+            // Max field alignment (1 if empty). May under-state a repr(align)
+            // raise; the true alignment is carried on the op, not the type.
+            struct_ty
+                .fields()
+                .map(|f| self.natural_alignment(f))
+                .max()
+                .unwrap_or(1)
         } else {
-            // Default: 8 bytes (conservative for pointers, etc.)
+            // Conservative fallback for pointers and unknown types.
             8
         }
     }

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -141,6 +141,7 @@ pub mod ops {
         context::{Context, Ptr},
         identifier::Identifier,
         op::Op,
+        operation::Operation,
         r#type::TypeObj,
         value::Value,
     };
@@ -174,9 +175,29 @@ pub mod ops {
         }
     }
 
-    /// Generic op-attribute key under which a `GlobalOp`'s explicit alignment is
-    /// stashed (pliron-llvm's `GlobalOp` has no native alignment attribute).
+    /// Op-attribute key for a `GlobalOp`'s explicit alignment.
     const GLOBAL_ALIGNMENT_KEY: &str = "cuda_oxide_global_alignment";
+
+    /// Op-attribute key under which a memory op's (`load` / `store` / `alloca`)
+    /// explicit ABI alignment is stashed. Stamped by the mir-lower alignment
+    /// pre-pass (while types are still MIR, so `repr(align(N))` is visible)
+    /// and emitted as `align N` during export.
+    const OP_ALIGNMENT_KEY: &str = "cuda_oxide_op_alignment";
+
+    /// Stamp the ABI alignment (bytes) onto a memory op.
+    pub fn set_op_alignment(ctx: &mut Context, op: Ptr<Operation>, align: u32) {
+        let key = Identifier::try_new(OP_ALIGNMENT_KEY.to_string()).expect("valid identifier");
+        op.deref_mut(ctx).attributes.set(key, AlignmentAttr(align));
+    }
+
+    /// Read the ABI alignment (bytes) stamped on a memory op, if any.
+    pub fn op_alignment(ctx: &Context, op: Ptr<Operation>) -> Option<u32> {
+        let key = Identifier::try_new(OP_ALIGNMENT_KEY.to_string()).expect("valid identifier");
+        op.deref(ctx)
+            .attributes
+            .get::<AlignmentAttr>(&key)
+            .map(|a| a.0)
+    }
 
     /// Alignment helpers re-homed from the pre-migration local `GlobalOp`.
     /// Upstream `GlobalOp` carries type/linkage/addrspace but no alignment, so

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -780,6 +780,82 @@ fn select_target(features: DetectedFeatures) -> &'static str {
     }
 }
 
+/// Runs LLVM's middle-end (`opt -O2`) on the emitted IR before `llc`.
+///
+/// This is what consumes the per-op ABI alignment we emit: the
+/// LoadStoreVectorizer fuses aligned aggregate/element accesses, SROA
+/// scalarizes stack aggregates, and InferAddressSpaces promotes generic
+/// pointers to `.global` (LDG/STG). Gated on alignment — fusion only fires
+/// when loads/stores carry matching `align N` hints.
+///
+/// Set `CUDA_OXIDE_NO_OPT=1` to skip and feed the unoptimised IR straight to
+/// `llc`. Returns the optimised `.ll` path, or `None` if opt is disabled or
+/// unavailable (caller falls back to the original `ll_path`).
+fn optimize_ll(ll_path: &Path, verbose: bool) -> Option<std::path::PathBuf> {
+    if std::env::var("CUDA_OXIDE_NO_OPT").is_ok() {
+        return None;
+    }
+
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(p) = std::env::var("CUDA_OXIDE_OPT") {
+        candidates.push(p);
+    }
+    if let Some(p) = std::process::Command::new("rustc")
+        .args(["--print", "sysroot", "--print", "host-tuple"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .split('\n')
+                .zip([["lib", "rustlib"], ["bin", "opt"]])
+                .flat_map(|(a, b)| [a].into_iter().chain(b))
+                .collect::<std::path::PathBuf>()
+                .to_str()
+                .map(str::to_string)
+        })
+    {
+        candidates.push(p);
+    }
+    for name in ["opt-22", "opt-21", "opt"] {
+        candidates.push(name.to_string());
+    }
+
+    let opt_ll = ll_path.with_extension("opt.ll");
+    for opt_cmd in candidates {
+        match std::process::Command::new(&opt_cmd)
+            .arg("-O2")
+            .arg(ll_path)
+            .arg("-S")
+            .arg("-o")
+            .arg(&opt_ll)
+            .output()
+        {
+            Ok(o) if o.status.success() => {
+                if verbose {
+                    eprintln!("opt -O2 via {opt_cmd}: {}", opt_ll.display());
+                }
+                return Some(opt_ll);
+            }
+            Ok(o) => {
+                if verbose {
+                    eprintln!(
+                        "opt ({opt_cmd}) failed: {}",
+                        String::from_utf8_lossy(&o.stderr).trim()
+                    );
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                if verbose {
+                    eprintln!("opt ({opt_cmd}): {e}");
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Generates PTX from LLVM IR using `llc`.
 ///
 /// LLVM 21+ is the minimum supported version:
@@ -827,6 +903,12 @@ fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError
 
     let verbose = std::env::var("CUDA_OXIDE_VERBOSE").is_ok();
 
+    // Run the middle-end (opt -O2) before llc. Feature detection above
+    // intentionally reads the original (pre-opt) IR so the target is
+    // determined by what the source actually needs, not what opt elides.
+    let optimized = optimize_ll(ll_path, verbose);
+    let llc_input: &Path = optimized.as_deref().unwrap_or(ll_path);
+
     // Check for user-specified llc path override
     if let Ok(llc_path) = std::env::var("CUDA_OXIDE_LLC") {
         if verbose {
@@ -835,7 +917,7 @@ fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError
         let result = std::process::Command::new(&llc_path)
             .arg("-march=nvptx64")
             .arg(format!("-mcpu={}", target))
-            .arg(ll_path)
+            .arg(llc_input)
             .arg("-o")
             .arg(ptx_path)
             .output();
@@ -899,7 +981,7 @@ fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError
         let result = std::process::Command::new(llc_cmd)
             .arg("-march=nvptx64")
             .arg(format!("-mcpu={}", llc_target))
-            .arg(ll_path)
+            .arg(llc_input)
             .arg("-o")
             .arg(ptx_path)
             .output();

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -479,7 +479,7 @@ pub fn translate_type(
                     }
 
                     // Query rustc for complete memory layout info
-                    let (mem_to_decl, field_offsets, total_size) =
+                    let (mem_to_decl, field_offsets, total_size, abi_align) =
                         if let Ok(layout) = rust_ty.layout() {
                             let shape = layout.shape();
 
@@ -496,10 +496,12 @@ pub fn translate_type(
 
                             // Total struct size (bytes)
                             let size: u64 = shape.size.bytes() as u64;
+                            // True ABI alignment (captures repr(align(N)) raises)
+                            let align: u64 = shape.abi_align as u64;
 
-                            (mem_order, offsets, size)
+                            (mem_order, offsets, size, align)
                         } else {
-                            (vec![], vec![], 0u64)
+                            (vec![], vec![], 0u64, 0u64)
                         };
 
                     // Create the struct type with full layout info
@@ -511,6 +513,7 @@ pub fn translate_type(
                         mem_to_decl,
                         field_offsets,
                         total_size,
+                        abi_align,
                     )
                     .into())
                 } else {
@@ -582,19 +585,25 @@ pub fn translate_type(
                 }
             }
 
-            let (mem_to_decl, field_offsets, total_size) = if let Ok(layout) = rust_ty.layout() {
-                let shape = layout.shape();
-                let mem_to_decl = shape.fields.fields_by_offset_order();
-                let field_offsets = match &shape.fields {
-                    rustc_public::abi::FieldsShape::Arbitrary { offsets } => {
-                        offsets.iter().map(|offset| offset.bytes() as u64).collect()
-                    }
-                    _ => vec![],
+            let (mem_to_decl, field_offsets, total_size, abi_align) =
+                if let Ok(layout) = rust_ty.layout() {
+                    let shape = layout.shape();
+                    let mem_to_decl = shape.fields.fields_by_offset_order();
+                    let field_offsets = match &shape.fields {
+                        rustc_public::abi::FieldsShape::Arbitrary { offsets } => {
+                            offsets.iter().map(|offset| offset.bytes() as u64).collect()
+                        }
+                        _ => vec![],
+                    };
+                    (
+                        mem_to_decl,
+                        field_offsets,
+                        shape.size.bytes() as u64,
+                        shape.abi_align as u64,
+                    )
+                } else {
+                    (vec![], vec![], 0, 0)
                 };
-                (mem_to_decl, field_offsets, shape.size.bytes() as u64)
-            } else {
-                (vec![], vec![], 0)
-            };
 
             Ok(dialect_mir::types::MirStructType::get_with_full_layout(
                 ctx,
@@ -604,6 +613,7 @@ pub fn translate_type(
                 mem_to_decl,
                 field_offsets,
                 total_size,
+                abi_align,
             )
             .into())
         }

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -496,10 +496,7 @@ pub fn translate_type(
 
                             // Total struct size (bytes)
                             let size: u64 = shape.size.bytes() as u64;
-                            // True ABI alignment (captures repr(align(N)) raises)
-                            let align: u64 = shape.abi_align as u64;
-
-                            (mem_order, offsets, size, align)
+                            (mem_order, offsets, size, shape.abi_align)
                         } else {
                             (vec![], vec![], 0u64, 0u64)
                         };
@@ -599,7 +596,7 @@ pub fn translate_type(
                         mem_to_decl,
                         field_offsets,
                         shape.size.bytes() as u64,
-                        shape.abi_align as u64,
+                        shape.abi_align,
                     )
                 } else {
                     (vec![], vec![], 0, 0)

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -94,9 +94,21 @@ pub(crate) fn convert_store(
     };
 
     let llvm_store = llvm::StoreOp::new(ctx, val, ptr);
+    copy_alignment(ctx, op, llvm_store.get_operation());
     rewriter.insert_operation(ctx, llvm_store.get_operation());
     rewriter.erase_operation(ctx, op);
     Ok(())
+}
+
+/// Copy the ABI alignment stamped on a MIR memory op onto its lowered LLVM op.
+///
+/// The alignment is stamped by the pre-pass in `lowering.rs` while types are
+/// still MIR; this helper transfers it to the newly created LLVM op so the
+/// exporter can emit `align N`.
+fn copy_alignment(ctx: &mut Context, mir_op: Ptr<Operation>, llvm_op: Ptr<Operation>) {
+    if let Some(align) = llvm_export::ops::op_alignment(ctx, mir_op) {
+        llvm_export::ops::set_op_alignment(ctx, llvm_op, align);
+    }
 }
 
 /// Convert `mir.load` to `llvm.load`.
@@ -114,6 +126,7 @@ pub(crate) fn convert_load(
     let llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
 
     let llvm_load = llvm::LoadOp::new(ctx, ptr, llvm_ty);
+    copy_alignment(ctx, op, llvm_load.get_operation());
     rewriter.insert_operation(ctx, llvm_load.get_operation());
     rewriter.replace_operation(ctx, op, llvm_load.get_operation());
 
@@ -157,6 +170,7 @@ pub(crate) fn convert_alloca(
     let one_val = one_const.get_operation().deref(ctx).get_result(0);
 
     let alloca = llvm::AllocaOp::new(ctx, llvm_pointee, one_val);
+    copy_alignment(ctx, op, alloca.get_operation());
     rewriter.insert_operation(ctx, alloca.get_operation());
     rewriter.replace_operation(ctx, op, alloca.get_operation());
 
@@ -187,10 +201,15 @@ pub(crate) fn convert_ref(
     let one_val = one_const.get_operation().deref(ctx).get_result(0);
 
     let alloca = llvm::AllocaOp::new(ctx, operand_ty, one_val);
+    // Propagate alignment stamped by the pre-pass (covers repr(align(N))
+    // structs). Without this, the synthesised alloca would be under-aligned
+    // relative to any loads/stores that claim the struct's true alignment.
+    copy_alignment(ctx, op, alloca.get_operation());
     rewriter.insert_operation(ctx, alloca.get_operation());
     let alloca_ptr = alloca.get_operation().deref(ctx).get_result(0);
 
     let store = llvm::StoreOp::new(ctx, operand, alloca_ptr);
+    copy_alignment(ctx, op, store.get_operation());
     rewriter.insert_operation(ctx, store.get_operation());
 
     rewriter.replace_operation_with_values(ctx, op, vec![alloca_ptr]);

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -33,7 +33,7 @@ use crate::convert::types::{
 };
 
 use dialect_mir::ops::MirFuncOp;
-use dialect_mir::types::{MirDisjointSliceType, MirSliceType, MirStructType};
+use dialect_mir::types::{MirDisjointSliceType, MirPtrType, MirSliceType, MirStructType};
 use llvm_export::ops as llvm;
 use pliron::{
     basic_block::BasicBlock,
@@ -48,7 +48,7 @@ use pliron::{
     op::Op,
     operation::Operation,
     result::Result,
-    r#type::TypeObj,
+    r#type::{TypeObj, Typed},
     value::Value,
 };
 
@@ -98,6 +98,11 @@ pub fn convert_func(
         // Must happen BEFORE inline_region empties the MIR region.
         let mir_blocks: Vec<_> = mir_region.deref(ctx).iter(ctx).collect();
         let max_align = compute_max_dynamic_smem_alignment(ctx, &mir_blocks);
+
+        // Stamp ABI alignment onto load/store/alloca/ref ops while types are
+        // still MIR — repr(align(N)) is visible on MirStructType but lost after
+        // type conversion (LLVM struct types carry no over-alignment).
+        stamp_memory_op_alignment(ctx, &mir_blocks);
 
         if let Some(align) = max_align {
             let symbol_name: pliron::identifier::Identifier =
@@ -454,6 +459,72 @@ fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
         pliron::result::ErrorKind::VerificationFailed,
         pliron::result::StringError(e.to_string())
     )
+}
+
+// ============================================================================
+// Alignment Pre-Pass
+// ============================================================================
+
+/// Returns the over-alignment (bytes) carried by `ty` if it is a
+/// `MirStructType` with a known `repr(align)`-raised alignment, else `None`.
+fn struct_over_align(ctx: &Context, ty: Ptr<TypeObj>) -> Option<u64> {
+    ty.deref(ctx)
+        .downcast_ref::<MirStructType>()
+        .map(|s| s.abi_align)
+        .filter(|a| *a > 0)
+}
+
+/// Stamp the true ABI alignment onto every `mir.load`, `mir.store`,
+/// `mir.alloca`, and `mir.ref` whose accessed/allocated type carries a
+/// `repr(align(N))` raise in `MirStructType.abi_align`.
+///
+/// Must run BEFORE `inline_region` moves the blocks and BEFORE dialect
+/// conversion replaces MIR types with LLVM types, since the alignment
+/// information lives on `MirStructType` and is not expressible on LLVM
+/// struct types.
+fn stamp_memory_op_alignment(ctx: &mut Context, mir_blocks: &[Ptr<BasicBlock>]) {
+    let load_id = dialect_mir::ops::MirLoadOp::get_opid_static();
+    let store_id = dialect_mir::ops::MirStoreOp::get_opid_static();
+    let alloca_id = dialect_mir::ops::MirAllocaOp::get_opid_static();
+    let ref_id = dialect_mir::ops::MirRefOp::get_opid_static();
+
+    // Collect (op, align) first (read-only pass), then stamp (write pass).
+    let mut to_stamp: Vec<(Ptr<Operation>, u64)> = Vec::new();
+    for mir_block in mir_blocks {
+        let ops: Vec<_> = mir_block.deref(ctx).iter(ctx).collect();
+        for op in ops {
+            let op_id = Operation::get_opid(op, ctx);
+            let align = if op_id == load_id {
+                // load: result(0) is the loaded value.
+                struct_over_align(ctx, op.deref(ctx).get_result(0).get_type(ctx))
+            } else if op_id == store_id {
+                // store: operand(1) is the stored value.
+                struct_over_align(ctx, op.deref(ctx).get_operand(1).get_type(ctx))
+            } else if op_id == alloca_id {
+                // alloca: pointee type lives inside the MirPtrType result.
+                let res_ty = op.deref(ctx).get_result(0).get_type(ctx);
+                res_ty
+                    .deref(ctx)
+                    .downcast_ref::<MirPtrType>()
+                    .map(|p| p.pointee)
+                    .and_then(|pointee| struct_over_align(ctx, pointee))
+            } else if op_id == ref_id {
+                // ref: operand(0) is the value being referenced (spilled to
+                // stack). If it is an over-aligned struct, the synthesised
+                // alloca+store in convert_ref must honour that alignment.
+                struct_over_align(ctx, op.deref(ctx).get_operand(0).get_type(ctx))
+            } else {
+                None
+            };
+            if let Some(a) = align {
+                to_stamp.push((op, a));
+            }
+        }
+    }
+
+    for (op, align) in to_stamp {
+        llvm_export::ops::set_op_alignment(ctx, op, align as u32);
+    }
 }
 
 // ============================================================================

--- a/crates/rustc-codegen-cuda/examples/vectorization/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/vectorization/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vectorization"
+version = "0.2.0"
+edition = "2024"
+license = "Apache-2.0"
+
+# Mark as standalone crate (not part of parent workspace)
+[workspace]
+
+# This example demonstrates alignment-driven vectorization with rustc-codegen-cuda.
+# Build with:
+#   cargo oxide run vectorization
+# Or manually:
+#   RUSTFLAGS="-Z codegen-backend=path/to/librustc_codegen_cuda.so" cargo build --release
+
+[dependencies]
+# Device-side intrinsics (thread indexing, barriers, etc.)
+cuda-device = { path = "../../../cuda-device" }
+
+# Host-side utilities (CudaKernel trait, etc.)
+cuda-host = { path = "../../../cuda-host" }
+
+# Host-side CUDA runtime
+cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/vectorization/LICENSE
+++ b/crates/rustc-codegen-cuda/examples/vectorization/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2026 NVIDIA CORPORATION
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Alignment-driven vectorization across the CUDA built-in vector types.
+//!
+//! Each type is the Rust equivalent of a CUDA vector type (e.g. `f32x4` =
+//! `float4`), with its exact CUDA size and alignment. A per-type copy kernel
+//! (`output[i] = input[i]`) shows how alignment governs whether the whole-
+//! element load/store fuses into a vectorized `ld/st.global.v*` or stays
+//! scalar. For every type, `main` checks the Rust layout matches CUDA, the
+//! round-trip copy is bit-correct on the GPU, and reports/asserts the codegen.
+//!
+//! Run: `cargo oxide run vectorization`
+
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::cuda_module;
+
+/// One row of the per-type report.
+struct Row {
+    name: &'static str,
+    cuda: &'static str,
+    size: usize,
+    align: usize,
+    kernel: &'static str,
+    copy_ok: bool,
+}
+
+/// Generate, from a single table, the CUDA-style vector types, the
+/// `#[cuda_module]` of per-type copy kernels, and `run_all` (launch + verify
+/// each). The macro emits the *whole* `#[cuda_module]` so the kernel repetition
+/// expands before the attribute macro runs (a `macro_rules!` *inside* the
+/// module would be invisible to it).
+macro_rules! vector_suite {
+    ($($ty:ident: $base:ty; $n:literal; align $align:literal; size $size:literal; $cuda:literal,)*) => {
+        $(
+            #[repr(C, align($align))]
+            #[derive(Clone, Copy, PartialEq, Debug)]
+            pub struct $ty([$base; $n]);
+            // Plain POD aggregate, no pointers: safe to memcpy to/from the device.
+            unsafe impl cuda_core::DeviceCopy for $ty {}
+        )*
+
+        #[cuda_module]
+        mod kernels {
+            use cuda_device::{kernel, thread, DisjointSlice};
+            $(
+                #[kernel]
+                pub fn $ty(input: &[super::$ty], mut output: DisjointSlice<super::$ty>) {
+                    let idx = thread::index_1d();
+                    let i = idx.get();
+                    if let Some(o) = output.get_mut(idx) {
+                        *o = input[i];
+                    }
+                }
+            )*
+        }
+
+        /// Launch every kernel, asserting each type's Rust layout matches CUDA
+        /// and its copy round-trips.
+        fn run_all(
+            module: &kernels::LoadedModule,
+            stream: &cuda_core::CudaStream,
+            cfg: LaunchConfig,
+            n: usize,
+        ) -> Vec<Row> {
+            let mut rows = Vec::new();
+            $(
+                {
+                    assert_eq!(core::mem::size_of::<$ty>(), $size, concat!(stringify!($ty), " size"));
+                    assert_eq!(core::mem::align_of::<$ty>(), $align, concat!(stringify!($ty), " align"));
+                    let input: Vec<$ty> = (0..n)
+                        .map(|i| $ty(core::array::from_fn(|j| (i * $n + j + 1) as $base)))
+                        .collect();
+                    let in_dev = DeviceBuffer::from_host(stream, &input).unwrap();
+                    let mut out_dev = DeviceBuffer::<$ty>::zeroed(stream, n).unwrap();
+                    module
+                        .$ty(stream, cfg, &in_dev, &mut out_dev)
+                        .expect(concat!(stringify!($ty), " launch"));
+                    let out = out_dev.to_host_vec(stream).unwrap();
+                    rows.push(Row {
+                        name: stringify!($ty),
+                        cuda: $cuda,
+                        size: $size,
+                        align: $align,
+                        kernel: stringify!($ty),
+                        copy_ok: out == input,
+                    });
+                }
+            )*
+            rows
+        }
+    };
+}
+
+vector_suite! {
+    i8x1: i8; 1; align 1; size 1; "char1",
+    i8x2: i8; 2; align 2; size 2; "char2",
+    i8x3: i8; 3; align 1; size 3; "char3",
+    i8x4: i8; 4; align 4; size 4; "char4",
+    i16x1: i16; 1; align 2; size 2; "short1",
+    i16x2: i16; 2; align 4; size 4; "short2",
+    i16x3: i16; 3; align 2; size 6; "short3",
+    i16x4: i16; 4; align 8; size 8; "short4",
+    i32x1: i32; 1; align 4; size 4; "int1",
+    i32x2: i32; 2; align 8; size 8; "int2",
+    i32x3: i32; 3; align 4; size 12; "int3",
+    i32x4: i32; 4; align 16; size 16; "int4",
+    i64x1: i64; 1; align 8; size 8; "longlong1",
+    i64x2: i64; 2; align 16; size 16; "longlong2",
+    i64x3: i64; 3; align 8; size 24; "longlong3",
+    i64x4: i64; 4; align 16; size 32; "longlong4",
+    i64x4_a32: i64; 4; align 32; size 32; "longlong4_32a",
+    f32x1: f32; 1; align 4; size 4; "float1",
+    f32x2: f32; 2; align 8; size 8; "float2",
+    f32x3: f32; 3; align 4; size 12; "float3",
+    f32x4: f32; 4; align 16; size 16; "float4",
+    f64x1: f64; 1; align 8; size 8; "double1",
+    f64x2: f64; 2; align 16; size 16; "double2",
+    f64x3: f64; 3; align 8; size 24; "double3",
+    f64x4: f64; 4; align 16; size 32; "double4",
+    f64x4_a32: f64; 4; align 32; size 32; "double4_32a",
+}
+
+fn main() {
+    let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
+    let stream = ctx.default_stream();
+    const N: usize = 256;
+    let cfg = LaunchConfig::for_num_elems(N as u32);
+
+    let module = ctx
+        .load_module_from_file("vectorization.ptx")
+        .expect("Failed to load vectorization.ptx");
+    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+
+    let rows = run_all(&module, &stream, cfg, N);
+
+    // Inspect the PTX we just launched to report/assert the codegen shape.
+    let ptx = std::fs::read_to_string("vectorization.ptx")
+        .expect("vectorization.ptx not found (run with `cargo oxide run vectorization`)");
+
+    println!(
+        "{:<11} {:<14} {:>4} {:>5}  {:<22} vectorized",
+        "rust", "cuda", "size", "align", "ptx load"
+    );
+    let mut errors = 0;
+    for r in &rows {
+        let body = kernel_body(&ptx, r.kernel);
+        let load = first_mem_op(body);
+        let vectorized = load.contains(".v2.") || load.contains(".v4.") || load.contains(".v8.");
+        if !r.copy_ok {
+            errors += 1;
+            println!("  !! {} round-trip copy mismatch", r.name);
+        }
+        // The robust, alignment-gated invariant this example exists to show: a
+        // type aligned to the 128-bit vector width (or wider) always fuses into
+        // a vector `ld/st.global.v*`. (Some smaller types also vectorize, and
+        // the 8-byte ones coalesce into a single `b64` -- reported, not asserted.)
+        let expect_vec = r.align >= 16;
+        if expect_vec && !vectorized {
+            errors += 1;
+            println!("  !! {} expected to vectorize but did not", r.name);
+        }
+        println!(
+            "{:<11} {:<14} {:>4} {:>5}  {:<22} {}",
+            r.name,
+            r.cuda,
+            r.size,
+            r.align,
+            load,
+            if vectorized { "yes" } else { "no" }
+        );
+    }
+
+    if errors == 0 {
+        println!(
+            "\n\u{2713} SUCCESS: {} CUDA vector types -- layout, copy, and codegen all correct",
+            rows.len()
+        );
+    } else {
+        println!("\n\u{2717} FAILED: {} problem(s)", errors);
+        std::process::exit(1);
+    }
+}
+
+/// PTX text of a `.visible .entry <name>` kernel, header to closing `}`.
+fn kernel_body<'a>(ptx: &'a str, name: &str) -> &'a str {
+    let start = ptx
+        .find(&format!(".visible .entry {name}("))
+        .unwrap_or_else(|| panic!("kernel `{name}` not found in PTX"));
+    let body = &ptx[start..];
+    let end = body.find("\n}").map_or(body.len(), |e| e + 2);
+    &body[..end]
+}
+
+/// First global memory op mnemonic in a kernel body (e.g. `ld.global.v2.b64`).
+fn first_mem_op(body: &str) -> String {
+    for line in body.lines() {
+        let t = line.trim();
+        if let Some(rest) = t
+            .strip_prefix("ld.global.")
+            .or_else(|| t.strip_prefix("st.global."))
+        {
+            let mnem: String = rest.split_whitespace().next().unwrap_or("").to_string();
+            let kind = if t.starts_with("ld") {
+                "ld.global."
+            } else {
+                "st.global."
+            };
+            return format!("{kind}{mnem}");
+        }
+    }
+    "(none)".to_string()
+}


### PR DESCRIPTION
## Summary

Threads `repr(align(N))` alignment from rustc layout through the full pipeline so LLVM emits `align N` on every `load`/`store`/`alloca`, enabling the LoadStoreVectorizer to fuse adjacent accesses into `v2`/`v4` ops in PTX.

Before → After (for a `#[repr(C, align(16))]` float4 struct):
```
Before: ld.global.b32  %f1, [%rd1];       # 4 separate scalar loads
        ld.global.b32  %f2, [%rd1+4];
        ld.global.b32  %f3, [%rd1+8];
        ld.global.b32  %f4, [%rd1+12];

After:  ld.global.v2.b64  {%f1,%f2,%f3,%f4}, [%rd1];  # 1 vector load
```

Ports and fixes PR #113 by @paulzhng.

## Changes beyond the original PR

1. **`convert_ref` gap fixed**: the synthesised `alloca+store` inside `convert_ref` now propagates the pre-pass alignment, preventing a latent miscompile where an over-aligned struct taken by reference received an under-aligned stack slot
2. **`CUDA_OXIDE_NO_OPT=1` implemented**: the env var was documented in a comment but never actually checked; now properly gates the `opt -O2` step
3. **`OP_ALIGNMENT_KEY` as `const &str`**: matches the adjacent `GLOBAL_ALIGNMENT_KEY` pattern (no per-call `String` allocation)
4. **`natural_alignment` extended**: fallback alignment now covers `half`, `ptr`, arrays, vectors, and structs (previously only `i*`, `f32`, `f64`)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p dialect-mir -p llvm-export -p mir-lower --lib --tests -- -D warnings` clean
- [x] `cargo test -p dialect-mir -p llvm-export -p mir-lower --lib --tests` — 27 tests pass

## Co-authoring details

- Co-authored-by: @paulzhng (Paul Zhang <paul@studio-vaai.com>)