### PR TITLE
docs: index_1d/index_2d uniqueness is launch-conditional (#115)

### DIFF
--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -27,8 +27,9 @@
 //!    (`threadIdx`, `blockIdx`, `blockDim`) -- read-only special registers
 //!    assigned by the runtime at kernel launch. The formula
 //!    `outer * stride + inner` combines these into a scalar index per thread.
-//! 3. `index_1d`: unique per thread, unconditionally
-//!    (`threadIdx.x < blockDim.x` is hardware-enforced).
+//! 3. `index_1d`: unique per thread only for a 1D launch
+//!    (`blockDim.y == blockDim.z == 1` and `gridDim.y == gridDim.z == 1`). It
+//!    reads only the X registers, so a 2D/3D launch collides; see issue #115.
 //! 4. `index_2d::<S>()`: unique per thread for const-stride 2D grids.
 //!    The stride lives in the witness type, and `DisjointSlice` only
 //!    accepts indices from the matching index space -- mismatched
@@ -277,6 +278,13 @@ pub mod __internal {
         unsafe { KernelScope::new() }
     }
 
+    /// Real `index_1d` intrinsic the `#[kernel]` / `#[device]` macros call in
+    /// place of the public `super::index_1d` stub. Returns
+    /// `blockIdx.x * blockDim.x + threadIdx.x`.
+    ///
+    /// Unique per thread **only for a 1D launch** (`blockDim.y == blockDim.z ==
+    /// 1` and `gridDim.y == gridDim.z == 1`); a 2D/3D launch collides because
+    /// this reads only the X registers. Tracked in issue #115.
     #[inline(always)]
     pub fn index_1d<'kernel>(
         scope: &'kernel KernelScope<'kernel>,
@@ -287,6 +295,10 @@ pub mod __internal {
         unsafe { ThreadIndex::new(bid * bdim + tid, scope) }
     }
 
+    /// Real `index_2d::<ROW_STRIDE>` intrinsic the macros call in place of the
+    /// public `super::index_2d` stub. `Some(row * ROW_STRIDE + col)` when
+    /// `col < ROW_STRIDE`, else `None`. Unique per thread for a 2D launch
+    /// (`blockDim.z == gridDim.z == 1`); the const stride is in the witness type.
     #[inline(always)]
     pub fn index_2d<'kernel, const ROW_STRIDE: usize>(
         scope: &'kernel KernelScope<'kernel>,
@@ -302,6 +314,10 @@ pub mod __internal {
         }
     }
 
+    /// Real `index_2d_runtime` intrinsic the macros call in place of the public
+    /// `super::index_2d_runtime` stub. Like `index_2d` but the row stride is a
+    /// runtime value, so cross-thread uniqueness is the caller's `unsafe`
+    /// obligation (every thread must pass the same `row_stride`).
     #[inline(always)]
     pub unsafe fn index_2d_runtime<'kernel>(
         scope: &'kernel KernelScope<'kernel>,
@@ -327,15 +343,19 @@ pub mod __internal {
 ///
 /// Computes: `blockIdx.x * blockDim.x + threadIdx.x`
 ///
-/// Designed for **1D grid launches** (grids where only the X dimension is used).
-/// For 2D grids, use [`index_2d`] instead.
+/// Designed for **1D launches** (only the X dimension is used). For 2D grids
+/// use [`index_2d`] instead.
 ///
-/// # Uniqueness Guarantee
+/// # Uniqueness
 ///
-/// This produces a unique index per thread because:
-/// - `threadIdx.x ∈ [0, blockDim.x)` (hardware-guaranteed)
-/// - These are hardware built-in variables (read-only special registers); the formula
-///   `bid * bdim + tid` combines them into non-overlapping ranges per block
+/// This reads only the X dimension, so the index is unique per thread **only
+/// when the launch is 1D**: `blockDim.y == blockDim.z == 1` and
+/// `gridDim.y == gridDim.z == 1`.
+///
+/// Under a 2D or 3D launch, threads that share the same X but differ in Y or Z
+/// get the *same* index, which would alias the same `DisjointSlice` slot. Every
+/// shipped example launches 1D, so nothing hits this today. Tracked in issue
+/// #115 (a fix that makes this sound under any launch is being weighed).
 ///
 /// # Example
 ///
@@ -399,7 +419,11 @@ pub fn index_1d<'kernel>() -> ThreadIndex<'kernel> {
 /// `col_a, col_b ∈ [0, stride)`, so the RHS is in `(-stride, stride)`.
 /// The LHS is a multiple of `stride`, so the only solution is
 /// `row_a == row_b` AND `col_a == col_b`. Distinct hardware threads have
-/// distinct `(row, col)`.
+/// distinct `(row, col)` **for a 2D launch**.
+///
+/// This ignores the Z dimension, so it is unique only when
+/// `blockDim.z == gridDim.z == 1`; a 3D launch would collide on Z. See issue
+/// #115.
 ///
 /// # Parameters
 ///


### PR DESCRIPTION
Corrects the `index_1d` / `index_2d` doc comments to match the actual guarantee, per #115.

## What
- `index_1d`: drop the "unconditionally" claim. It reads only the X registers, so it is unique per thread only for a 1D launch (`blockDim.y == blockDim.z == 1` and `gridDim.y == gridDim.z == 1`).
- `index_2d`: note that its uniqueness proof assumes a 2D launch (`blockDim.z == gridDim.z == 1`); it ignores Z.
- Add doc comments to the `__internal::index_*` intrinsics so IDE hover resolves them (the `#[kernel]` macro rewrites real call sites to that path, which had no docs).

Comment-only change; no formula or codegen change. Every shipped example launches its `index_1d` kernels with fully-1D configs, so nothing races today.

## Scope
This is the documentation half of #115. The actual soundness fix (make `index_1d` unique under any launch, or enforce launch/index geometry at compile time) is still being weighed, so this does **not** close #115.

Refs #115.