### PR TITLE
Fix sm_120 arch selection and a grid::sync deadlock

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -107,17 +107,19 @@ pub fn codegen_run(
 
     let output_format = format_label(emit_nvvm_ir);
     // Target precedence for `cargo oxide run` (highest first):
-    //   1. --arch <sm_XX>           explicit user override
-    //   2. CUDA_OXIDE_TARGET=<sm_XX>  explicit env override (set by parent process)
-    //   3. Host GPU compute capability detected from CUDA device 0
-    //   4. Backend feature-based default (`select_target` in mir-importer)
+    //   1. --arch <sm_XX>            explicit user override   -> CUDA_OXIDE_TARGET
+    //   2. CUDA_OXIDE_TARGET=<sm_XX> explicit env override (from the parent)
+    //   3. detected GPU arch of CUDA device 0 -> CUDA_OXIDE_DEVICE_ARCH (a hint)
+    //   4. backend feature-based default (`select_target` in mir-importer)
     //
-    // (3) is the auto-detect added here so the generated module can load on
-    // the local GPU. We only do it for `run`, not `build`/`pipeline`, because
-    // `run` immediately loads the cubin on device 0 — whereas the other
-    // commands may be cross-compiling for a different machine.
-    let detected_run_arch = detect_run_target_arch(arch, emit_nvvm_ir);
-    let forwarded_arch = arch.or(detected_run_arch.as_deref());
+    // Slot 3 is a HINT, not an override: the backend builds for the detected
+    // GPU only when that GPU can run the kernel. If the kernel needs a newer
+    // arch (tcgen05 needs sm_100a even on a consumer sm_120 GPU), the backend
+    // builds for the required arch and the module simply skips at load time.
+    // We only detect for `run`, not `build`/`pipeline`: `run` loads the cubin
+    // on device 0, whereas those may legitimately cross-compile for another
+    // machine.
+    let detected_device_arch = detect_run_target_arch(arch, emit_nvvm_ir);
 
     if let Some(interop) = interop.filter(|config| !config.device_crates.is_empty()) {
         codegen_run_interop(
@@ -127,8 +129,8 @@ pub fn codegen_run(
             &interop,
             verbose,
             emit_nvvm_ir,
-            forwarded_arch,
-            detected_run_arch.as_deref(),
+            arch,
+            detected_device_arch.as_deref(),
             features,
             bin,
         );
@@ -148,13 +150,12 @@ pub fn codegen_run(
             arch.expect("--emit-nvvm-ir requires --arch")
         );
         println!();
-    } else if detected_run_arch.is_some() {
-        // Surface the auto-detect outcome so it isn't silent magic; users
-        // chasing a JIT/load failure can see exactly which arch was picked.
-        println!(
-            "Target arch: {} (auto-detected from CUDA device 0)",
-            detected_run_arch.as_deref().unwrap()
-        );
+    } else if let Some(dev) = detected_device_arch.as_deref() {
+        // Surface the detected GPU so it isn't silent magic. It is a hint, not
+        // a hard target: the backend builds for it unless a kernel needs a
+        // newer arch (e.g. tcgen05 forces sm_100a even on a consumer sm_120
+        // GPU), so the final PTX target may differ.
+        println!("Detected GPU arch: {dev} (CUDA device 0)");
         println!();
     }
     println!("This is the proper cargo workflow:");
@@ -186,7 +187,8 @@ pub fn codegen_run(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
 
-    apply_output_mode(&mut cmd, emit_nvvm_ir, forwarded_arch);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
+    apply_device_arch_hint(&mut cmd, arch, detected_device_arch.as_deref());
     apply_ld_library_path(&mut cmd);
 
     if let Some(bin) = bin {
@@ -229,7 +231,7 @@ fn codegen_run_interop(
     verbose: bool,
     emit_nvvm_ir: bool,
     arch: Option<&str>,
-    detected_run_arch: Option<&str>,
+    detected_device_arch: Option<&str>,
     features: Option<&str>,
     bin: Option<&str>,
 ) {
@@ -241,15 +243,19 @@ fn codegen_run_interop(
     if let Some(kind) = &interop.kind {
         println!("Interop kind: {}", kind);
     }
-    if let Some(detected) = detected_run_arch {
-        println!(
-            "Target arch: {} (auto-detected from CUDA device 0)",
-            detected
-        );
+    if let Some(dev) = detected_device_arch {
+        println!("Detected GPU arch: {dev} (CUDA device 0)");
     }
     println!();
 
-    build_interop_device_crates(ctx, example_dir, interop, verbose, arch);
+    build_interop_device_crates(
+        ctx,
+        example_dir,
+        interop,
+        verbose,
+        arch,
+        detected_device_arch,
+    );
     run_host_cargo(example, example_dir, "run", features, bin, verbose);
 }
 
@@ -274,7 +280,9 @@ fn codegen_build_interop(
     }
     println!();
 
-    build_interop_device_crates(ctx, example_dir, interop, verbose, arch);
+    // `build` may cross-compile for another machine, so no device-arch hint:
+    // only an explicit `--arch` pins the target here.
+    build_interop_device_crates(ctx, example_dir, interop, verbose, arch, None);
     run_host_cargo(example, example_dir, "build", features, None, verbose);
 
     println!();
@@ -295,9 +303,17 @@ fn build_interop_device_crates(
     interop: &InteropConfig,
     verbose: bool,
     arch: Option<&str>,
+    detected_device_arch: Option<&str>,
 ) {
     for device_crate in &interop.device_crates {
-        build_interop_device_crate(ctx, example_dir, device_crate, verbose, arch);
+        build_interop_device_crate(
+            ctx,
+            example_dir,
+            device_crate,
+            verbose,
+            arch,
+            detected_device_arch,
+        );
     }
 }
 
@@ -307,6 +323,7 @@ fn build_interop_device_crate(
     device_crate: &DeviceCrateConfig,
     verbose: bool,
     arch: Option<&str>,
+    detected_device_arch: Option<&str>,
 ) {
     let manifest_path = example_dir.join(&device_crate.manifest_path);
     let manifest_path = manifest_path.canonicalize().unwrap_or_else(|e| {
@@ -356,6 +373,7 @@ fn build_interop_device_crate(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
     apply_output_mode(&mut cmd, false, arch);
+    apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
     apply_ld_library_path(&mut cmd);
 
     let status = cmd.status().expect("Failed to build interop device crate");
@@ -1276,12 +1294,34 @@ fn build_rustflags_with_existing(
 }
 
 /// Set environment variables for the codegen backend.
+///
+/// `arch` is an explicit pin (`--arch`); it becomes `CUDA_OXIDE_TARGET`, the
+/// hard override the backend honors as-is. The auto-detected GPU arch is *not*
+/// routed here -- see [`apply_device_arch_hint`].
 fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) {
     if let Some(target_arch) = arch {
         cmd.env("CUDA_OXIDE_TARGET", target_arch);
     }
     if emit_nvvm_ir {
         cmd.env("CUDA_OXIDE_EMIT_NVVM_IR", "1");
+    }
+}
+
+/// Forward the auto-detected GPU arch as a *hint* via `CUDA_OXIDE_DEVICE_ARCH`.
+///
+/// Unlike `CUDA_OXIDE_TARGET` (a hard override), this is advisory: the backend
+/// builds for the detected GPU only when that GPU can actually run the kernel.
+/// If the kernel needs a newer arch (e.g. tcgen05 / cta_group TMA multicast
+/// need sm_100a, which a consumer sm_120 GPU lacks), the backend builds for the
+/// required arch instead. Skipped when the user pinned `--arch` (that explicit
+/// choice already went to `CUDA_OXIDE_TARGET`).
+fn apply_device_arch_hint(
+    cmd: &mut Command,
+    explicit_arch: Option<&str>,
+    detected_device_arch: Option<&str>,
+) {
+    if let (None, Some(dev)) = (explicit_arch, detected_device_arch) {
+        cmd.env("CUDA_OXIDE_DEVICE_ARCH", dev);
     }
 }
 
@@ -1293,19 +1333,22 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
 /// `cargo oxide run` resolves the target architecture in this order, highest
 /// priority first:
 ///
-/// 1. `--arch <sm_XX>`            — explicit user override
-/// 2. `CUDA_OXIDE_TARGET=<sm_XX>` — explicit env override (set in the parent
+/// 1. `--arch <sm_XX>`            (explicit user override)
+/// 2. `CUDA_OXIDE_TARGET=<sm_XX>` (explicit env override, set in the parent
 ///    process before invoking `cargo oxide run`)
-/// 3. **This function** — host GPU compute capability of CUDA device 0;
-///    emits the arch-specific `sm_XYa` form for cc ≥ 9.0 (so the backend
-///    can lower WGMMA / tcgen05 / TMA-multicast on the actual host) and the
-///    plain `sm_XY` form for cc < 9.0.
+/// 3. **This function**: the compute capability of the GPU in CUDA device 0,
+///    forwarded as the `CUDA_OXIDE_DEVICE_ARCH` *hint*. Emits the arch-specific
+///    `sm_XYa` form for cc >= 9.0 (so the backend can lower WGMMA / tcgen05 /
+///    TMA-multicast when the GPU supports them) and the plain `sm_XY` form for
+///    cc < 9.0.
 /// 4. Backend feature-based default (`select_target` in
 ///    `mir-importer::pipeline`), which picks the minimum `sm_XX` required by
-///    the IR shape (e.g. `Basic → sm_80`, `Cluster → sm_90`, `Tma → sm_100`).
+///    the IR shape (e.g. `Basic -> sm_80`, `Cluster -> sm_90`, `Tma -> sm_100`).
 ///
-/// This function returns `Some(sm_XY[a])` to fill slot 3, or `None` (falling
-/// through to slot 4) when the host has no usable GPU.
+/// Slot 3 is advisory: the backend builds for the detected GPU only when that
+/// GPU can run the kernel, otherwise it falls back to slot 4 (the arch the
+/// kernel requires). This function returns `Some(sm_XY[a])` to fill slot 3, or
+/// `None` (falling through to slot 4) when the machine has no usable GPU.
 ///
 /// # Why only `run`
 ///
@@ -1320,7 +1363,7 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
 /// The backend's `select_target` picks the minimum `sm_XX` the IR requires.
 /// `Basic → sm_80` is a fine *compilation* baseline, but PTX for `sm_80` will
 /// not load on a Turing (`sm_75`) GPU because the JIT refuses
-/// forward-incompatible PTX. Detecting the host CC in `run` keeps the
+/// forward-incompatible PTX. Detecting the device CC in `run` keeps the
 /// generated module loadable on the actual hardware that will execute it.
 ///
 /// # When this returns `None`
@@ -1329,7 +1372,7 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
 /// - `CUDA_OXIDE_TARGET` is set in the environment (slot 2 wins).
 /// - `--emit-nvvm-ir` is in effect (NVVM IR mode requires explicit `--arch`,
 ///   enforced by the CLI parser).
-/// - No CUDA driver / device 0 is available on the host (CI runners without
+/// - No CUDA driver / device 0 is available on the machine (CI runners without
 ///   GPUs, headless build boxes). The caller falls through to slot 4 and
 ///   the backend's feature-based default applies.
 fn detect_run_target_arch(arch: Option<&str>, emit_nvvm_ir: bool) -> Option<String> {
@@ -1359,11 +1402,11 @@ fn detect_run_target_arch(arch: Option<&str>, emit_nvvm_ir: bool) -> Option<Stri
 /// lineup (there is no consumer Hopper, no non-`a` sm_100, and so on).
 ///
 /// This helper is only used by [`detect_run_target_arch`] in `cargo oxide
-/// run`, where the host GPU is known exactly and no cross-compile is in
+/// run`, where the local GPU is known exactly and no cross-compile is in
 /// flight. Emitting the `a` form there:
 ///
 /// - **No false negatives:** kernels that need `tcgen05` / WGMMA compile and
-///   load on the host (was: silent fallback to `sm_100` / `sm_90` and a
+///   load on that GPU (was: silent fallback to `sm_100` / `sm_90` and a
 ///   `ptxas: 'tcgen05.alloc' not supported on .target 'sm_100'` failure).
 /// - **No false positives:** cc < 9.0 keeps the plain `sm_XY` form, since
 ///   there is no `sm_80a` / `sm_86a` / `sm_89a` target in the PTX ISA.
@@ -1783,6 +1826,40 @@ mod tests {
 
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_TARGET"), None);
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_EMIT_NVVM_IR"), None);
+    }
+
+    #[test]
+    fn apply_device_arch_hint_sets_hint_when_no_explicit_arch() {
+        let mut cmd = Command::new("cargo");
+
+        apply_device_arch_hint(&mut cmd, None, Some("sm_120a"));
+
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_DEVICE_ARCH").as_deref(),
+            Some("sm_120a")
+        );
+        // The hint must never masquerade as the hard override.
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_TARGET"), None);
+    }
+
+    #[test]
+    fn apply_device_arch_hint_skipped_when_arch_explicit() {
+        // An explicit --arch already went to CUDA_OXIDE_TARGET; don't also
+        // emit a competing device hint.
+        let mut cmd = Command::new("cargo");
+
+        apply_device_arch_hint(&mut cmd, Some("sm_90"), Some("sm_120a"));
+
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_DEVICE_ARCH"), None);
+    }
+
+    #[test]
+    fn apply_device_arch_hint_noop_without_detection() {
+        let mut cmd = Command::new("cargo");
+
+        apply_device_arch_hint(&mut cmd, None, None);
+
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_DEVICE_ARCH"), None);
     }
 
     #[test]

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -34,8 +34,9 @@
 //! - **nvJitLink**: same, but at `<root>/lib64/libnvJitLink.so`.
 //! - **libdevice**: `CUDA_OXIDE_LIBDEVICE` env var, then
 //!   `<root>/nvvm/libdevice/libdevice.10.bc` for the same roots.
-//! - **Arch**: `CUDA_OXIDE_TARGET` env var (set by `cargo oxide`'s
-//!   `--arch=<sm_XX>`), defaulting to `sm_120`.
+//! - **Arch**: `CUDA_OXIDE_TARGET` (set by `cargo oxide`'s `--arch=<sm_XX>`),
+//!   then the `CUDA_OXIDE_DEVICE_ARCH` hint (auto-detected GPU arch), then a
+//!   `sm_120` default.
 //!
 //! # Example
 //!
@@ -314,14 +315,19 @@ pub fn find_libdevice() -> Result<PathBuf, LtoirError> {
     })
 }
 
-/// Read the GPU arch (`sm_XX`) from `CUDA_OXIDE_TARGET`, defaulting to
-/// `sm_120` (consumer Blackwell, RTX 5090) when the env var is unset.
+/// Read the GPU arch (`sm_XX`) for the cubin build, defaulting to `sm_120`
+/// (consumer Blackwell, RTX 5090) when nothing else is set.
 ///
-/// `cargo oxide run --arch=<arch>` sets `CUDA_OXIDE_TARGET` for the spawned
-/// binary, so `cargo oxide run --arch=sm_90 my_kernel` causes this helper
-/// to return `"sm_90"`.
+/// Resolution order:
+/// - `CUDA_OXIDE_TARGET` -- an explicit pin. `cargo oxide run --arch=<arch>`
+///   sets it for the spawned binary, so `--arch=sm_90` yields `"sm_90"`.
+/// - `CUDA_OXIDE_DEVICE_ARCH` -- the auto-detected arch of the GPU in this
+///   machine, forwarded by `cargo oxide run` when no `--arch` was given.
+/// - `sm_120` fallback.
 pub fn target_arch() -> String {
-    std::env::var("CUDA_OXIDE_TARGET").unwrap_or_else(|_| "sm_120".to_string())
+    std::env::var("CUDA_OXIDE_TARGET")
+        .or_else(|_| std::env::var("CUDA_OXIDE_DEVICE_ARCH"))
+        .unwrap_or_else(|_| "sm_120".to_string())
 }
 
 /// Directory to search for kernel artifacts (`.cubin` / `.ptx` / `.ll`).

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -280,7 +280,16 @@ impl<'a> ModuleExportState<'a> {
                 write!(output, " {name}").unwrap();
                 next_value_id += 1;
             }
-            writeln!(output, ") {{").unwrap();
+            // Mark every emitted device function `convergent` (attr group #0).
+            // GPU code is convergent-by-default, as in Clang/nvcc: a function
+            // that (transitively) performs a barrier / shuffle / vote must not
+            // have those ops sunk or duplicated into divergent control flow by
+            // `opt -O2`. Without this, an inlined `grid::sync()` / warp collective
+            // gets its `bar.sync.aligned` pushed into a `tid`-dependent branch
+            // and deadlocks. opt's FunctionAttrs strips `convergent` from
+            // functions it proves never reach a convergent op.
+            writeln!(output, ") #0 {{").unwrap();
+            self.convergent_used = true;
 
             // Assign labels to all blocks
             let mut block_labels = HashMap::new();

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -801,7 +801,6 @@ impl<'a> ModuleExportState<'a> {
             self.export_type(ret_ty, output)?;
         }
 
-        let mut is_convergent = false;
         match callee {
             CallOpCallable::Direct(identifier) => {
                 let name = identifier.to_string();
@@ -811,7 +810,6 @@ impl<'a> ModuleExportState<'a> {
                 } else {
                     super::names::strip_device_prefix(&name)
                 };
-                is_convergent = Self::is_convergent_intrinsic(&fixed);
                 write!(output, " @{fixed}(").unwrap();
             }
             CallOpCallable::Indirect(val) => {
@@ -830,12 +828,13 @@ impl<'a> ModuleExportState<'a> {
             self.export_value(arg, value_names, output)?;
         }
 
-        if is_convergent {
-            writeln!(output, ") #0").unwrap();
-            self.convergent_used = true;
-        } else {
-            writeln!(output, ")").unwrap();
-        }
+        // Every device call is emitted `convergent` (attr group #0). GPU code is
+        // convergent-by-default (as in Clang/nvcc): if the callee transitively
+        // performs a barrier / shuffle / vote, `opt -O2` must not sink or
+        // duplicate the call across divergent control flow. opt strips the
+        // attribute from calls it proves never reach a convergent op.
+        writeln!(output, ") #0").unwrap();
+        self.convergent_used = true;
         Ok(())
     }
 

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -780,6 +780,44 @@ fn select_target(features: DetectedFeatures) -> &'static str {
     }
 }
 
+/// Does `arch` (e.g. `"sm_120a"`, `"sm_90"`) support the kernel's detected
+/// features?
+///
+/// tcgen05/TMEM and `cta_group` TMA multicast exist only in the sm_100
+/// datacenter-Blackwell family: consumer Blackwell (sm_120) and Hopper (sm_90)
+/// lack them, so an sm_120 GPU cannot run an sm_100 tcgen05 kernel even though
+/// 120 > 100. WGMMA is Hopper-only. The remaining features are forward
+/// compatible from their floor (TMA / cluster need sm_90+, basic needs sm_80+).
+///
+/// Used to decide whether the GPU in this machine (the `CUDA_OXIDE_DEVICE_ARCH`
+/// hint) can actually run the kernel, or whether we must build for the arch the
+/// IR requires instead.
+fn arch_satisfies(arch: &str, features: DetectedFeatures) -> bool {
+    let Some(major) = arch_major(arch) else {
+        return false;
+    };
+    match features {
+        DetectedFeatures::Blackwell | DetectedFeatures::TmaMulticast => major == 10,
+        DetectedFeatures::Wgmma => major == 9,
+        DetectedFeatures::Tma | DetectedFeatures::Cluster => major >= 9,
+        DetectedFeatures::Basic => major >= 8,
+    }
+}
+
+/// Extract the compute-capability *major* version from an `sm_…` target string.
+///
+/// CUDA concatenates major+minor without a separator, so `"sm_120a"` is cc 12.0
+/// (major 12), `"sm_90"` is cc 9.0, `"sm_103a"` is cc 10.3. We read the digit
+/// run after `sm_` and divide by ten. Returns `None` when there are no digits.
+fn arch_major(arch: &str) -> Option<u32> {
+    let digits: String = arch
+        .trim_start_matches("sm_")
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse::<u32>().ok().map(|n| n / 10)
+}
+
 /// Runs LLVM's middle-end (`opt -O2`) on the emitted IR before `llc`.
 ///
 /// This is what consumes the per-op ABI alignment we emit: the
@@ -865,11 +903,17 @@ fn optimize_ll(ll_path: &Path, verbose: bool) -> Option<std::path::PathBuf> {
 /// group parameter requires LLVM 21). If `CUDA_OXIDE_LLC` is set, it is used
 /// exclusively — power users can point this at an older `llc` at their own
 /// risk (most examples will still compile but modern intrinsics will not).
-/// Auto-detects GPU features to select target, or uses `CUDA_OXIDE_TARGET`
-/// if set.
+///
+/// Target arch resolves (highest priority first) to: an explicit
+/// `CUDA_OXIDE_TARGET` override, else the detected-GPU hint
+/// (`CUDA_OXIDE_DEVICE_ARCH`) when that GPU can run the kernel, else the minimum
+/// arch the IR's features require (`select_target`).
 fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError> {
-    // Check for user-specified target override
-    let target_override = std::env::var("CUDA_OXIDE_TARGET").ok();
+    // Explicit, hard override: `--arch` or a parent-set `CUDA_OXIDE_TARGET`.
+    let explicit_override = std::env::var("CUDA_OXIDE_TARGET").ok();
+    // Advisory hint: the arch of the GPU in this machine, forwarded by
+    // `cargo oxide run`. Used only when that GPU can actually run the kernel.
+    let device_hint = std::env::var("CUDA_OXIDE_DEVICE_ARCH").ok();
 
     // Detect features (order matters: most specific first)
     let detected = match (
@@ -887,18 +931,36 @@ fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError
         _ => DetectedFeatures::Basic,
     };
 
-    // Use override if provided, otherwise auto-detect
-    let target = match &target_override {
-        Some(t) => t.as_str(),
-        None => select_target(detected),
+    // Arch the IR actually requires (the hard floor).
+    let feature_arch = select_target(detected);
+
+    // Resolve the final target:
+    //   1. explicit override -- honored as-is. If it cannot lower the kernel's
+    //      features we warn (otherwise llc aborts with a cryptic backend error).
+    //   2. detected-device hint -- used only if that GPU can run the kernel;
+    //      otherwise we build for `feature_arch`. The resulting PTX will not
+    //      load on this GPU, but feature-gated examples handle that at load time
+    //      (cuModuleLoad reports INVALID_PTX and they skip execution).
+    //   3. neither set -- the feature floor.
+    let (target, target_source): (String, &str) = if let Some(t) = explicit_override {
+        if !arch_satisfies(&t, detected) {
+            eprintln!(
+                "warning: CUDA_OXIDE_TARGET={t} cannot lower the detected feature \
+                 {detected:?} (needs {feature_arch}); PTX generation will likely \
+                 fail. Unset CUDA_OXIDE_TARGET to let cuda-oxide select \
+                 {feature_arch} automatically."
+            );
+        }
+        (t, "CUDA_OXIDE_TARGET")
+    } else if let Some(dev) = device_hint.filter(|d| arch_satisfies(d, detected)) {
+        (dev, "detected GPU")
+    } else {
+        (feature_arch.to_string(), "feature requirement")
     };
 
     // Log target selection
     if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
-        match &target_override {
-            Some(_) => eprintln!("Target: {} (from CUDA_OXIDE_TARGET)", target),
-            None => eprintln!("Target: {} (auto-detected: {:?})", target, detected),
-        }
+        eprintln!("Target: {target} (from {target_source}; detected {detected:?})");
     }
 
     let verbose = std::env::var("CUDA_OXIDE_VERBOSE").is_ok();
@@ -968,13 +1030,13 @@ fn generate_ptx(ll_path: &Path, ptx_path: &Path) -> Result<String, PipelineError
     //   - sm_90a:  Hopper only (WGMMA + TMA) - NOT forward-compatible
     //   - sm_120:  Blackwell consumer (TMA with PTX 8.7)
     //   - sm_80:   Ampere+ (maximum compatibility)
-    let llc_candidates = [("llc-22", target), ("llc-21", target)];
+    let llc_candidates = [("llc-22", target.as_str()), ("llc-21", target.as_str())];
 
     let mut last_error = String::new();
 
     for (llc_cmd, llc_target) in llc_path
         .as_deref()
-        .map(|s| (s, target))
+        .map(|s| (s, target.as_str()))
         .into_iter()
         .chain(llc_candidates)
     {
@@ -1196,6 +1258,57 @@ mod tests {
         assert_eq!(select_target(DetectedFeatures::Tma), "sm_100");
         assert_eq!(select_target(DetectedFeatures::Cluster), "sm_90");
         assert_eq!(select_target(DetectedFeatures::Basic), "sm_80");
+    }
+
+    #[test]
+    fn test_arch_major_parses_cuda_spelling() {
+        assert_eq!(arch_major("sm_75"), Some(7));
+        assert_eq!(arch_major("sm_80"), Some(8));
+        assert_eq!(arch_major("sm_90a"), Some(9));
+        assert_eq!(arch_major("sm_100a"), Some(10));
+        assert_eq!(arch_major("sm_103a"), Some(10));
+        assert_eq!(arch_major("sm_120a"), Some(12));
+        assert_eq!(arch_major("nvvm-ir"), None);
+        assert_eq!(arch_major("sm_"), None);
+    }
+
+    #[test]
+    fn test_arch_satisfies_sm100_only_features() {
+        // tcgen05 and cta_group TMA multicast are sm_100-family only:
+        // consumer Blackwell (sm_120) and Hopper (sm_90) cannot run them, even
+        // though 120 > 100. This is the gemm_sol regression guard.
+        for f in [DetectedFeatures::Blackwell, DetectedFeatures::TmaMulticast] {
+            assert!(arch_satisfies("sm_100a", f), "sm_100a must satisfy {f:?}");
+            assert!(
+                !arch_satisfies("sm_120a", f),
+                "sm_120a must NOT satisfy {f:?}"
+            );
+            assert!(
+                !arch_satisfies("sm_90a", f),
+                "sm_90a must NOT satisfy {f:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_arch_satisfies_wgmma_is_hopper_only() {
+        assert!(arch_satisfies("sm_90a", DetectedFeatures::Wgmma));
+        assert!(!arch_satisfies("sm_100a", DetectedFeatures::Wgmma));
+        assert!(!arch_satisfies("sm_120a", DetectedFeatures::Wgmma));
+    }
+
+    #[test]
+    fn test_arch_satisfies_forward_compatible_features() {
+        // Plain TMA / cluster lower on any sm_90+ device; basic on any sm_80+.
+        // So a consumer sm_120 GPU is a valid target for these (it runs locally
+        // instead of being downgraded to the feature floor).
+        for arch in ["sm_90a", "sm_100a", "sm_120a"] {
+            assert!(arch_satisfies(arch, DetectedFeatures::Tma));
+            assert!(arch_satisfies(arch, DetectedFeatures::Cluster));
+            assert!(arch_satisfies(arch, DetectedFeatures::Basic));
+        }
+        assert!(arch_satisfies("sm_80", DetectedFeatures::Basic));
+        assert!(!arch_satisfies("sm_80", DetectedFeatures::Tma));
     }
 
     /// Build a minimal LLVM dialect module containing a single function


### PR DESCRIPTION
Two codegen fixes that came out of getting `gemm_sol` and `coop_groups_demo` running on a 5090 (sm_120).

### 1. Detected GPU arch is a hint, not a hard target

`cargo oxide run` was forcing the build to the detected arch (sm_120a here). gemm_sol uses `cta_group` TMA multicast, which is sm_100-only, so `llc` couldn't lower it and the build died with no PTX.

Now we use the detected arch only if the GPU can actually run the kernel; otherwise we build for the arch the kernel needs (e.g. sm_100a) and let it skip gracefully at load time, same as `tcgen05`/`tcgen05_matmul` already do. An explicit `--arch` / `CUDA_OXIDE_TARGET` still wins.

### 2. Mark device functions `convergent` (fixes a `grid::sync` deadlock)

`coop_groups_demo` hung at `grid::sync()`. We were only marking the barrier *intrinsics* convergent, not the functions wrapping them. So once `opt -O2` inlined `grid::sync`, it was free to push the `__syncthreads` under an `if (tid.x == 0)`: a blocking block barrier in non-uniform code, which deadlocks (the warp holding thread 0 freezes at one barrier and can never reach the other).

The fix is what Clang/nvcc do for GPU code: mark every device function + call site `convergent`, and let `opt` strip it where it's provably safe.

Heads up: this was latent until #122 (the ABI-alignment work) gave `opt` enough to start inlining these helpers, so that's where it slipped in.

### Tested

- `coop_groups_demo` passes with `-O2` on (was hanging)
- `gemm_sol` compiles + skips on sm_120
- full smoketest 66/67 (the one fail, `cluster` Test 2, is pre-existing)
