### PR TITLE
ci(examples): GPU-less examples-compile job + smoketest --compile-only

### DIFF
--- a/.github/workflows/examples-compile.yml
+++ b/.github/workflows/examples-compile.yml
@@ -1,0 +1,105 @@
+---
+name: examples-compile
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  examples-compile:
+    name: compile all examples (device pipeline, GPU-less)
+    runs-on: ubuntu-latest
+    # ~85 example crates: backend build + shared dep tree + per-example
+    # device codegen. Typically well under an hour with the shared
+    # CARGO_TARGET_DIR; the timeout leaves headroom for cold runners.
+    timeout-minutes: 60
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # Needed for cuda.h (bindgen in cuda-bindings) and the link-time
+      # libcuda.so stub. Same shape as unit-tests.yml / clippy.yml.
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
+        id: cuda-toolkit
+        with:
+          cuda: "13.1.1"
+          method: network
+          sub-packages: '["nvcc", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcurand-dev"]'
+
+      # The device pipeline shells out to LLVM's llc/opt for PTX
+      # generation. LLVM 21 is the documented floor for the intrinsics we
+      # emit (TMA / tcgen05 / WGMMA need llc-21+), so CI pins exactly 21:
+      # if someone lands IR that needs a newer llc, this job is where the
+      # floor bump becomes visible instead of on contributors' machines.
+      # If a future ubuntu-latest codename has no llvm-toolchain-*-21
+      # suite, apt-get update fails loudly; recover by pinning runs-on to
+      # the previous image or bumping the LLVM major here.
+      - name: Install LLVM 21 (llc/opt for the NVPTX backend)
+        run: |
+          set -euo pipefail
+          source /etc/os-release
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/keyrings/apt-llvm-org.asc >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/apt-llvm-org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-21 main" \
+            | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends llvm-21
+          llc-21 --version | head -2
+          opt-21 --version | head -2
+
+      - name: Compile every example (smoketest --compile-only)
+        # Step-level timeout, below the job's 60: a job-level timeout
+        # CANCELS the job and `if: failure()` never fires, losing the
+        # logs. A step timeout fails the step, so the upload still runs.
+        timeout-minutes: 50
+        env:
+          CUDA_TOOLKIT_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
+          CUDA_OXIDE_LLC: /usr/bin/llc-21
+          # Each example is its own cargo workspace; without a shared
+          # target dir the dep tree rebuilds ~85 times and blows the
+          # runner's ~14 GB disk (same trick as clippy.yml). smoketest.sh
+          # honours an externally-set CARGO_TARGET_DIR and still builds
+          # the backend .so at its fixed discovery path.
+          CARGO_TARGET_DIR: ${{ runner.temp }}/examples-shared-target
+          SMOKETEST_LOG_DIR: ${{ runner.temp }}/smoketest-logs
+        run: |
+          set -euo pipefail
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          # cargo-oxide itself links libcuda (it can query the GPU arch in
+          # `run` mode), so its DT_NEEDED carries libcuda.so.1. The dev
+          # sub-packages only ship the link-time stub named libcuda.so;
+          # shadow it under the soname so the binary loads on a GPU-less
+          # runner. Compile-only never makes a real driver call. Same
+          # trick as unit-tests.yml.
+          if [ -f "${CUDA_TOOLKIT_PATH}/lib64/stubs/libcuda.so" ]; then
+            stub_shadow="${RUNNER_TEMP}/libcuda-stub"
+            mkdir -p "${stub_shadow}"
+            ln -sf "${CUDA_TOOLKIT_PATH}/lib64/stubs/libcuda.so" "${stub_shadow}/libcuda.so.1"
+            export LD_LIBRARY_PATH="${stub_shadow}:${LD_LIBRARY_PATH}"
+          fi
+
+          scripts/smoketest.sh --compile-only --no-color
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoketest-compile-logs
+          path: ${{ runner.temp }}/smoketest-logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -385,7 +385,7 @@ fn build_interop_device_crate(
         std::process::exit(status.code().unwrap_or(1));
     }
 
-    let ptx_path = ptx_dir.join(format!("{}.ptx", artifact_name));
+    let ptx_path = ptx_dir.join(format!("{}.ptx", artifact_stem(&artifact_name)));
     if !ptx_path.exists() {
         eprintln!(
             "Error: device crate build succeeded but did not produce {}",
@@ -1468,11 +1468,21 @@ fn touch_main_rs(example_dir: &Path) {
     }
 }
 
+/// Artifacts are named after the crate, and cargo normalizes hyphens in
+/// package names to underscores (`rustlantis-smoke` emits
+/// `rustlantis_smoke.ptx`). Always go through this when deriving an
+/// artifact filename from an example name, or hyphenated examples keep
+/// stale artifacts forever.
+fn artifact_stem(example: &str) -> String {
+    example.replace('-', "_")
+}
+
 /// Remove stale generated artifacts (`.ptx`, `.ll`, `.ltoir`, `.cubin`) from a
 /// previous run so we can verify the build produces fresh output.
 fn clean_generated_files(example_dir: &Path, example: &str) {
-    for ext in &["ptx", "ll", "ltoir", "cubin"] {
-        let file = example_dir.join(format!("{}.{}", example, ext));
+    let stem = artifact_stem(example);
+    for ext in &["ptx", "ll", "opt.ll", "ltoir", "cubin"] {
+        let file = example_dir.join(format!("{}.{}", stem, ext));
         if file.exists() {
             let _ = std::fs::remove_file(&file);
         }
@@ -1486,13 +1496,14 @@ fn format_label(emit_nvvm_ir: bool) -> &'static str {
 
 /// Print generated artifacts (LLVM IR or PTX) to stdout after a pipeline build.
 fn show_generated_artifacts(example_dir: &Path, example: &str) {
-    let ll_file = example_dir.join(format!("{}.ll", example));
-    let ptx_file = example_dir.join(format!("{}.ptx", example));
+    let stem = artifact_stem(example);
+    let ll_file = example_dir.join(format!("{}.ll", stem));
+    let ptx_file = example_dir.join(format!("{}.ptx", stem));
 
     if ll_file.exists() {
         println!();
         println!("=========================================");
-        println!("LLVM IR ({}.ll)", example);
+        println!("LLVM IR ({}.ll)", stem);
         println!("=========================================");
         if let Ok(content) = std::fs::read_to_string(&ll_file) {
             println!("{}", content);
@@ -1502,7 +1513,7 @@ fn show_generated_artifacts(example_dir: &Path, example: &str) {
     if ptx_file.exists() {
         println!();
         println!("=========================================");
-        println!("PTX ({}.ptx)", example);
+        println!("PTX ({}.ptx)", stem);
         println!("=========================================");
         if let Ok(content) = std::fs::read_to_string(&ptx_file) {
             println!("{}", content);
@@ -1760,6 +1771,12 @@ mod tests {
         cmd.get_envs()
             .find(|(name, _)| *name == OsStr::new(key))
             .and_then(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
+    }
+
+    #[test]
+    fn artifact_stem_normalizes_hyphens_like_cargo() {
+        assert_eq!(artifact_stem("rustlantis-smoke"), "rustlantis_smoke");
+        assert_eq!(artifact_stem("vecadd"), "vecadd");
     }
 
     #[test]

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -62,6 +62,11 @@ OPTIONS
   -o, --only PATTERN   Run only examples whose name matches the bash regex
                        PATTERN (e.g. -o 'tcgen05|wgmma').
   -s, --skip PATTERN   Skip examples whose name matches PATTERN.
+  -c, --compile-only   Build each example instead of running it (cargo
+                       oxide build). Non-error categories must exit 0 and
+                       leave a device artifact ({ex}.ptx or {ex}.ll);
+                       error examples must still fail to compile. Works
+                       on GPU-less machines (CI).
   -x, --fail-fast      Stop at the first failure.
   -v, --verbose        Stream cargo output live (instead of capturing to
                        a per-example log file). Verdict is printed at the
@@ -83,6 +88,7 @@ EXAMPLES
   scripts/smoketest.sh -o '^vecadd$'   # exact-match form
   scripts/smoketest.sh -s 'wgmma|tma'  # skip wgmma and tma examples
   scripts/smoketest.sh -x -v vecadd    # stop on first fail, stream output
+  scripts/smoketest.sh --compile-only  # GPU-less compile gate (used by CI)
 
 Per-example logs live under .smoketest-logs/ by default. Set
 SMOKETEST_LOG_DIR to override this path.
@@ -95,12 +101,14 @@ FAIL_FAST=0
 VERBOSE=0
 KEEP_LOGS=0
 FORCE_NO_COLOR=0
+COMPILE_ONLY=0
 declare -a POSITIONAL=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -o|--only)      [[ $# -lt 2 ]] && { echo "error: $1 requires a pattern" >&2; exit 2; }; ONLY="$2"; shift 2;;
         -s|--skip)      [[ $# -lt 2 ]] && { echo "error: $1 requires a pattern" >&2; exit 2; }; SKIP="$2"; shift 2;;
+        -c|--compile-only) COMPILE_ONLY=1; shift;;
         -x|--fail-fast) FAIL_FAST=1; shift;;
         -v|--verbose)   VERBOSE=1; shift;;
         --keep-logs)    KEEP_LOGS=1; shift;;
@@ -159,24 +167,36 @@ fi
 
 git_head="$(git rev-parse --short HEAD 2>/dev/null || echo '?')"
 git_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
-gpu_info="$(nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader 2>/dev/null | head -1 || echo 'no GPU detected')"
+# nvidia-smi can be present yet broken (driver mismatch, sandboxes,
+# containers) and it prints its failure text to STDOUT, so trust it only
+# when it exits 0 AND the compute capability parses. One probe feeds both
+# the banner and the LTOIR arch so they can never disagree.
+host_cc=""
+if gpu_query="$(nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader 2>/dev/null)"; then
+    gpu_info="$(head -1 <<<"${gpu_query}")"
+    host_cc="$(awk -F', *' '{print $2}' <<<"${gpu_info}" | tr -d '[:space:]')"
+else
+    gpu_info='no GPU detected'
+fi
 
 # Detect host compute capability for the ltoir category: the cubin produced
 # by the LTOIR linker must match the GPU's arch or it refuses to load.
-# nvidia-smi returns something like "12.0" → sm_120, "10.0" → sm_100.
-host_cc="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:]' || true)"
-if [[ -n "${host_cc}" ]]; then
+# nvidia-smi reports something like "12.0" → sm_120, "10.0" → sm_100.
+if [[ "${host_cc}" =~ ^[0-9]+\.[0-9]+$ ]]; then
     # Strip the dot: 12.0 -> 120
     LTOIR_ARCH="sm_${host_cc//./}"
 else
-    # No GPU detected. ltoir examples will likely fail, but pick a sensible
-    # floor so the cuda-oxide side still compiles.
+    # No working GPU detected. ltoir examples will likely fail to execute,
+    # but pick a sensible floor so the cuda-oxide side still compiles.
     LTOIR_ARCH="sm_90"
 fi
 
 printf "%scuda-oxide smoketest%s @ %s%s%s (%s)\n" "${C_BOLD}" "${C_RESET}" "${C_BOLD}" "${git_head}" "${C_RESET}" "${git_branch}"
 printf "GPU: %s\n" "${gpu_info}"
 printf "LTOIR arch: %s\n" "${LTOIR_ARCH}"
+if [[ ${COMPILE_ONLY} -eq 1 ]]; then
+    printf "Mode: compile-only (cargo oxide build; nothing is executed)\n"
+fi
 if [[ -n "${ONLY}" ]]; then printf "Filter --only: %s\n" "${ONLY}"; fi
 if [[ -n "${SKIP}" ]]; then printf "Filter --skip: %s\n" "${SKIP}"; fi
 echo ""
@@ -190,6 +210,17 @@ mapfile -t ALL_EXAMPLES < <(
         echo "${manifest%/Cargo.toml}"
     done | sort
 )
+
+# An example dir without a top-level Cargo.toml would be skipped by the
+# glob above and silently shrink coverage (e.g. a restructure that nests
+# the manifest one level down). Fail loudly instead.
+for dir in crates/rustc-codegen-cuda/examples/*/; do
+    if [[ ! -f "${dir}Cargo.toml" ]]; then
+        echo "error: ${dir} has no top-level Cargo.toml; every directory under" >&2
+        echo "       crates/rustc-codegen-cuda/examples/ must be an example crate" >&2
+        exit 2
+    fi
+done
 
 selected=()
 for ex in "${ALL_EXAMPLES[@]}"; do
@@ -316,7 +347,9 @@ verdict_wgmma() {
 
 verdict_ltoir() {
     local ex="$1" log="$2" ec="$3"
-    local ll_file="crates/rustc-codegen-cuda/examples/${ex}/${ex}.ll"
+    # Hyphens in example names become underscores in the crate-named
+    # artifact (see verdict_compile).
+    local ll_file="crates/rustc-codegen-cuda/examples/${ex}/${ex//-/_}.ll"
     if [[ ${ec} -gt 128 ]]; then echo "FAIL (crashed, signal $((ec - 128)))"; return 1; fi
     # `skipping:` marker -- the example opted out (e.g. mathdx_ffi_test with
     # MATHDX_ROOT unset). Accept as pass so long as the cuda-oxide side
@@ -342,13 +375,60 @@ verdict_ltoir() {
     return 1
 }
 
+# Compile-only verdict, used for every non-error category when
+# --compile-only is set. Two requirements:
+#   1. `cargo oxide build` exited 0. Device codegen failures are rustc
+#      fatals (see rustc-codegen-cuda/src/lib.rs join on device results),
+#      so a broken device pipeline cannot exit 0.
+#   2. A fresh device artifact exists: {ex}.ptx, or {ex}.ll for the
+#      NVVM-IR path. cargo-oxide deletes stale ones before building
+#      (clean_generated_files), so presence proves this build emitted it.
+#      This catches collector regressions where the build "succeeds"
+#      because no #[kernel] was found and device codegen never ran.
+# Interop examples write PTX into their configured ptx_dir instead, and
+# cargo-oxide itself verifies that file exists (exits non-zero if not),
+# so the exit code alone is trusted for them.
+verdict_compile() {
+    local ex="$1" log="$2" ec="$3"
+    local ex_dir="crates/rustc-codegen-cuda/examples/${ex}"
+    # Artifacts are named after the crate, and cargo normalizes hyphens
+    # to underscores (rustlantis-smoke emits rustlantis_smoke.ptx). This
+    # assumes dir name == package name, which holds for every example and
+    # is equally assumed by cargo-oxide's clean_generated_files; a renamed
+    # package fails here loudly rather than passing on a stale artifact.
+    local artifact="${ex//-/_}"
+    if [[ ${ec} -gt 128 ]]; then echo "FAIL (crashed, signal $((ec - 128)))"; return 1; fi
+    if [[ ${ec} -ne 0 ]]; then   echo "FAIL (exit=${ec})";                    return 1; fi
+    if [[ -s "${ex_dir}/${artifact}.ptx" || -s "${ex_dir}/${artifact}.ll" ]]; then
+        echo "PASS (compiled)"
+        return 0
+    fi
+    # Match only the real interop config shapes ([[package.metadata.
+    # cuda-oxide.device-crates]] tables or a device-crates = [...] key),
+    # not the substring anywhere: a stray comment must not silently
+    # exempt an example from the artifact check.
+    if grep -qE '^[[:space:]]*(\[\[package\.metadata\.cuda-oxide\.device-crates\]\]|device-crates[[:space:]]*=)' \
+        "${ex_dir}/Cargo.toml" 2>/dev/null; then
+        echo "PASS (compiled, interop)"
+        return 0
+    fi
+    echo "FAIL (built, but no device artifact emitted)"
+    return 1
+}
+
 # ---- Runner --------------------------------------------------------------
 
 # Run cargo oxide for ${ex} in category ${cat}. Writes to ${log}. Returns
 # the cargo process exit code via the global ${CARGO_EC}.
 run_cargo() {
     local ex="$1" log="$2" cat="$3"
-    local -a args=("run" "${ex}")
+    # Compile-only mode swaps `run` for `build`: the full device pipeline
+    # (MIR -> dialect-mir -> LLVM dialect -> llc -> PTX) still executes at
+    # build time, only host execution is skipped. The ltoir flags are kept:
+    # `--emit-nvvm-ir` is supported by `build` for non-interop examples.
+    local verb="run"
+    if [[ ${COMPILE_ONLY} -eq 1 ]]; then verb="build"; fi
+    local -a args=("${verb}" "${ex}")
     if [[ "${cat}" == "ltoir" ]]; then
         args+=("--emit-nvvm-ir" "--arch=${LTOIR_ARCH}")
     fi
@@ -420,6 +500,11 @@ for ex in "${selected[@]}"; do
     if [[ ! -f "${log}" ]]; then
         verdict="FAIL (log missing: ${log})"
         status=1
+    elif [[ ${COMPILE_ONLY} -eq 1 && "${cat}" != "error" ]]; then
+        # Compile-only collapses the GPU-gated categories: with nothing
+        # executed, "PTX (or NVVM IR) compiled" is the bar for everything
+        # except error examples, which must still fail with a diagnostic.
+        verdict="$(verdict_compile "${ex}" "${log}" "${ec}")" && status=0 || status=$?
     else
         case "${cat}" in
             error)       verdict="$(verdict_error       "${log}" "${ec}")"        && status=0 || status=$? ;;


### PR DESCRIPTION
## What

A new `examples-compile` CI job that builds every example through the full device pipeline (MIR -> dialect-mir -> LLVM dialect -> llc -> PTX) on a GPU-less runner, on every PR.

```text
Before: clippy lints examples, but the codegen backend never runs in CI
After:  every PR compiles all ~75 examples to PTX; device-pipeline breaks fail the check
```

Motivation: the #119 + #156 composition break. Each PR was green alone; together, #119's divergent-enum guard rejected #156's `enum_array_match` example, and nothing in CI could see it because no job runs device codegen over the examples.

## How

- `scripts/smoketest.sh --compile-only`: swaps `cargo oxide run` for `cargo oxide build`. Non-error categories must exit 0 **and** leave a fresh, non-empty `{crate}.ptx` or `{crate}.ll` (cargo-oxide deletes stale ones pre-build, artifacts are gitignored, so presence proves this build emitted it; this also catches collector regressions where no kernel is found and the build "succeeds" with no PTX). `error` examples must still fail with a diagnostic. The GPU-gated categories (tcgen05 / wgmma / ltoir) collapse to "PTX (or NVVM IR) compiled".
- `.github/workflows/examples-compile.yml`: CUDA headers via the same Jimver action as sibling jobs (bindgen + link-time libcuda stub), LLVM 21 from apt.llvm.org (the documented `llc` floor, now enforced by CI), a `libcuda.so.1` stub shadow so the cargo-oxide binary loads on a GPU-less runner, shared `CARGO_TARGET_DIR` (same disk trick as clippy.yml), failure-log artifact upload with a step-level timeout so logs survive a hang.
- cargo-oxide fix riding along: artifact filenames are crate-named and cargo maps hyphens to underscores (`rustlantis-smoke` emits `rustlantis_smoke.ptx`). `clean_generated_files` / `show_generated_artifacts` / the interop PTX check now normalize through a shared `artifact_stem` helper; `.opt.ll` is cleaned too. Previously, hyphenated examples kept stale artifacts forever.
- smoketest hardening: `nvidia-smi` failure text (printed to stdout) no longer corrupts `LTOIR_ARCH`; a single probe feeds both the banner and the arch; example enumeration fails loudly if a dir under `examples/` lacks a top-level `Cargo.toml` (silent coverage shrinkage).

## Evidence

- 75/75 tracked examples pass `--compile-only` locally with `llc-21` pinned (CI-equivalent env).
- Prove-it-bites: in a worktree at the historical breaking merge `14747f7`, this exact script fails `enum_array_match` with the divergent-enum fatal (`Load of enum 'E' is not supported: ... not yet field-faithful ...`). The job would have caught the break.
- `cargo test -p cargo-oxide --bins`: 16/16; clippy clean.

## Maintainer follow-ups (repo settings, not in this diff)

- Add the check `compile all examples (device pipeline, GPU-less)` to branch protection required checks; the name is matched on the job's `name:` field.
- The #119+#156 class is compositional: two stale-green PRs merged in sequence can still land a break. Closing that fully needs "Require branches to be up to date before merging" (or a merge queue).

## Known non-goals

Execution-only break classes stay with the GPU smoketest: semantic miscompiles with valid PTX, sync/hang regressions, driver JIT rejection, host/device ABI drift, LTOIR link+load. Possible future hardening: per-example expected-diagnostic pins for the `error` category, and a kernel-count floor on emitted PTX.