### PR TITLE
feat(cuda-module): #[cooperative_launch] for grid-wide sync on the typed path

### DIFF
--- a/crates/cuda-async/src/launch.rs
+++ b/crates/cuda-async/src/launch.rs
@@ -42,6 +42,10 @@ pub struct AsyncKernelLaunch<'a> {
     cfg: Option<LaunchConfig>,
     /// Optional thread-block cluster dimensions for `cuLaunchKernelEx`.
     cluster_dim: Option<(u32, u32, u32)>,
+    /// When `true`, launch via `cuLaunchKernelEx` with
+    /// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` set, which guarantees the whole grid
+    /// is co-resident on the device (required for `cuda_device::grid::sync()`).
+    cooperative: bool,
     /// Ties borrowed device buffers to the lazy launch operation.
     _borrows: PhantomData<&'a mut ()>,
 }
@@ -93,6 +97,7 @@ impl<'a> AsyncKernelLaunch<'a> {
             args: KernelArgStorage::default(),
             cfg: None,
             cluster_dim: None,
+            cooperative: false,
             _borrows: PhantomData,
         }
     }
@@ -149,7 +154,21 @@ impl<'a> AsyncKernelLaunch<'a> {
         self
     }
 
-    /// Submits the kernel to `stream` via `cuLaunchKernel`.
+    /// Marks this launch as cooperative (`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`).
+    ///
+    /// A cooperative launch guarantees every block in the grid is co-resident
+    /// on the device, which is the precondition for grid-wide barriers like
+    /// `cuda_device::grid::sync()`. May be combined with
+    /// [`set_cluster_dim`](Self::set_cluster_dim); both attributes are then
+    /// passed to `cuLaunchKernelEx` in the same call.
+    pub fn set_cooperative(&mut self, cooperative: bool) -> &mut Self {
+        self.cooperative = cooperative;
+        self
+    }
+
+    /// Submits the kernel to `stream` via `cuLaunchKernel`, or via
+    /// `cuLaunchKernelEx` when cluster dimensions or a cooperative launch
+    /// were requested.
     ///
     /// # Safety
     ///
@@ -169,8 +188,19 @@ impl<'a> AsyncKernelLaunch<'a> {
         let cfg = self
             .cfg
             .ok_or_else(|| DeviceError::Launch("Launch config not set.".to_string()))?;
-        let result = if let Some(cluster_dim) = self.cluster_dim {
-            unsafe {
+        let result = match (self.cluster_dim, self.cooperative) {
+            (Some(cluster_dim), true) => unsafe {
+                cuda_core::launch_kernel_ex_cooperative_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    cluster_dim,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+            (Some(cluster_dim), false) => unsafe {
                 cuda_core::launch_kernel_ex_on_stream(
                     self.func.as_ref(),
                     cfg.grid_dim,
@@ -180,9 +210,18 @@ impl<'a> AsyncKernelLaunch<'a> {
                     stream.as_ref(),
                     self.args.as_mut_slice(),
                 )
-            }
-        } else {
-            unsafe {
+            },
+            (None, true) => unsafe {
+                cuda_core::launch_kernel_cooperative_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+            (None, false) => unsafe {
                 cuda_core::launch_kernel_on_stream(
                     self.func.as_ref(),
                     cfg.grid_dim,
@@ -191,7 +230,7 @@ impl<'a> AsyncKernelLaunch<'a> {
                     stream.as_ref(),
                     self.args.as_mut_slice(),
                 )
-            }
+            },
         };
         result.map_err(DeviceError::Driver)?;
         Ok(())

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -431,3 +431,122 @@ pub unsafe fn launch_kernel_cooperative_on_stream(
         )
     }
 }
+
+/// Low-level wrapper around `cuLaunchKernelEx` with **both** the
+/// `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` and
+/// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` attributes set.
+///
+/// `cuLaunchKernelEx` takes an array of launch attributes, so a single call
+/// can request thread-block clusters ([`launch_kernel_ex`]) and a
+/// cooperative launch ([`launch_kernel_cooperative`]) at the same time.
+/// This is the path used when a `#[cuda_module]` kernel carries both
+/// `#[cluster_launch(...)]` and `#[cooperative_launch]`.
+///
+/// This helper performs **no context binding**. Prefer
+/// [`launch_kernel_ex_cooperative_on_stream`] in normal host-side code so
+/// the correct stream context is made current automatically.
+///
+/// # Safety
+///
+/// The combined preconditions of [`launch_kernel_ex`] (cluster dimensions
+/// must divide the grid, sm_90+) and [`launch_kernel_cooperative`] (the
+/// device must support cooperative launch and the whole grid must be
+/// co-resident).
+///
+/// # Errors
+///
+/// Returns the CUDA driver error produced by `cuLaunchKernelEx` if launch
+/// submission fails.
+#[inline]
+pub unsafe fn launch_kernel_ex_cooperative(
+    func: cuda_bindings::CUfunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: cuda_bindings::CUstream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    // CUlaunchAttribute_st is opaque (see cuda-bindings/build.rs) for CUDA 13.2+
+    // compatibility. C layout: { id: u32 @ 0, pad: [u8;4] @ 4, value: union @ 8 }.
+    // attrs[0]: clusterDim — three u32 fields (x, y, z) at offset 0 of the union.
+    // attrs[1]: cooperative — a single `int` at offset 0 of the union; 1 = enabled.
+    let mut attrs: [cuda_bindings::CUlaunchAttribute_st; 2] = unsafe { std::mem::zeroed() };
+    unsafe {
+        let base = &mut attrs[0] as *mut _ as *mut u8;
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION);
+        let dim_ptr = base.add(8) as *mut u32;
+        dim_ptr.write(cluster_dim.0);
+        dim_ptr.add(1).write(cluster_dim.1);
+        dim_ptr.add(2).write(cluster_dim.2);
+
+        let base = &mut attrs[1] as *mut _ as *mut u8;
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_COOPERATIVE);
+        let val_ptr = base.add(8) as *mut i32;
+        val_ptr.write(1);
+    }
+
+    let config = cuda_bindings::CUlaunchConfig_st {
+        gridDimX: grid_dim.0,
+        gridDimY: grid_dim.1,
+        gridDimZ: grid_dim.2,
+        blockDimX: block_dim.0,
+        blockDimY: block_dim.1,
+        blockDimZ: block_dim.2,
+        sharedMemBytes: shared_mem_bytes,
+        hStream: stream,
+        attrs: attrs.as_mut_ptr(),
+        numAttrs: 2,
+    };
+
+    unsafe {
+        cuda_bindings::cuLaunchKernelEx(
+            &config,
+            func,
+            kernel_params.as_mut_ptr(),
+            std::ptr::null_mut(),
+        )
+    }
+    .result()
+}
+
+/// Launches a cooperative CUDA kernel with cluster dimensions on a specific
+/// stream, binding the stream's owning context first.
+///
+/// This is the cluster-plus-cooperative counterpart to
+/// [`launch_kernel_on_stream`]. It binds `stream.context()` to the calling
+/// thread, then forwards to the raw [`launch_kernel_ex_cooperative`] helper.
+///
+/// # Safety
+///
+/// Same preconditions as [`launch_kernel_ex_cooperative`].
+///
+/// # Errors
+///
+/// Returns an error if binding `stream.context()` fails or if the underlying
+/// `cuLaunchKernelEx` call rejects the launch.
+#[inline]
+pub unsafe fn launch_kernel_ex_cooperative_on_stream(
+    func: &CudaFunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: &CudaStream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    stream.context().bind_to_thread()?;
+    unsafe {
+        launch_kernel_ex_cooperative(
+            func.cu_function(),
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+            cluster_dim,
+            stream.cu_stream(),
+            kernel_params,
+        )
+    }
+}

--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -137,16 +137,17 @@ register reads such as `clock64()` and `globaltimer()`.
 
 These are defined in `cuda-macros` and re-exported from `cuda-device` for convenience:
 
-| Attribute           | Purpose                                       |
-|---------------------|-----------------------------------------------|
-| `#[kernel]`         | Mark a function as a GPU kernel entry point   |
-| `#[device]`         | Mark a helper function or extern block        |
-| `#[launch_bounds]`  | Set max threads / min blocks per SM           |
-| `#[cluster_launch]` | Set compile-time cluster dimensions           |
-| `#[convergent]`     | Mark as convergent (barrier semantics)        |
-| `#[pure]`           | Mark as pure (no side effects)                |
-| `#[readonly]`       | Mark as read-only                             |
-| `gpu_printf!`       | Device-side printf                            |
+| Attribute                | Purpose                                       |
+|--------------------------|-----------------------------------------------|
+| `#[kernel]`              | Mark a function as a GPU kernel entry point   |
+| `#[device]`              | Mark a helper function or extern block        |
+| `#[launch_bounds]`       | Set max threads / min blocks per SM           |
+| `#[cluster_launch]`      | Set compile-time cluster dimensions           |
+| `#[cooperative_launch]`  | Launch as cooperative (for `grid::sync()`)    |
+| `#[convergent]`          | Mark as convergent (barrier semantics)        |
+| `#[pure]`                | Mark as pure (no side effects)                |
+| `#[readonly]`            | Mark as read-only                             |
+| `gpu_printf!`            | Device-side printf                            |
 
 ## Safety Model
 

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -7,8 +7,8 @@
 #![no_std]
 
 pub use cuda_macros::{
-    cluster_launch, constant, convergent, cuda_module, device, gpu_printf, kernel, launch_bounds,
-    pure, readonly,
+    cluster_launch, constant, convergent, cooperative_launch, cuda_module, device, gpu_printf,
+    kernel, launch_bounds, pure, readonly,
 };
 
 // Re-export for convenience

--- a/crates/cuda-host/src/launch.rs
+++ b/crates/cuda-host/src/launch.rs
@@ -287,6 +287,15 @@ pub fn set_async_kernel_cluster_dim(
 
 #[doc(hidden)]
 #[cfg(feature = "async")]
+pub fn set_async_kernel_cooperative(
+    launch: &mut cuda_async::launch::AsyncKernelLaunch<'_>,
+    cooperative: bool,
+) {
+    launch.set_cooperative(cooperative);
+}
+
+#[doc(hidden)]
+#[cfg(feature = "async")]
 pub fn push_async_kernel_scalar<'a, T: KernelScalar + 'a>(
     launch: &mut cuda_async::launch::AsyncKernelLaunch<'a>,
     value: T,

--- a/crates/cuda-host/src/lib.rs
+++ b/crates/cuda-host/src/lib.rs
@@ -93,7 +93,7 @@ pub use launch::{
     KernelSliceArg, KernelSliceArgMut, load_cuda_module_from_async_context,
     load_kernel_module_async, new_async_kernel_launch, new_owned_async_kernel_launch,
     push_async_kernel_scalar, push_async_read_only_device_slice, push_async_writable_device_slice,
-    set_async_kernel_cluster_dim,
+    set_async_kernel_cluster_dim, set_async_kernel_cooperative,
 };
 
 #[cfg(feature = "async")]

--- a/crates/cuda-host/tests/cuda_module_api.rs
+++ b/crates/cuda-host/tests/cuda_module_api.rs
@@ -11,7 +11,7 @@ use cuda_host::cuda_async::device_box::DeviceBox;
 #[cfg(feature = "async")]
 use cuda_host::cuda_async::device_operation::DeviceOperation;
 use cuda_host::cuda_module;
-use cuda_macros::kernel;
+use cuda_macros::{cooperative_launch, kernel};
 
 #[cfg(feature = "async")]
 type TwoF32Buffers = (DeviceBox<[f32]>, DeviceBox<[f32]>);
@@ -46,6 +46,15 @@ mod kernels {
     #[kernel]
     pub unsafe fn unsafe_raw_pointer(raw: *mut f32) {
         let _ = raw;
+    }
+
+    /// `#[cooperative_launch]` routes every generated launch method through
+    /// the cooperative driver entry points; this kernel pins that the
+    /// generated sync, async, and owned-async methods still typecheck.
+    #[kernel]
+    #[cooperative_launch]
+    pub fn cooperative_grid_sync(output: &mut [u32]) {
+        let _ = output;
     }
 }
 
@@ -94,6 +103,8 @@ fn generated_methods_accept_kernel_scalar_types(
         module.unsafe_raw_pointer(stream, config, raw_mut)?;
     }
 
+    module.cooperative_grid_sync(stream, config, output_u32)?;
+
     Ok(())
 }
 
@@ -131,6 +142,9 @@ fn generated_async_methods_accept_borrowed_buffers(
         assert_unit_operation(launch);
     }
 
+    let launch = module.cooperative_grid_sync_async(config, async_output_u32)?;
+    assert_unit_operation(launch);
+
     Ok(())
 }
 
@@ -141,6 +155,7 @@ fn generated_owned_async_methods_accept_owned_buffers(
     async_input: DeviceBox<[f32]>,
     async_output: DeviceBox<[f32]>,
     async_output_u32: DeviceBox<[u32]>,
+    async_coop_output_u32: DeviceBox<[u32]>,
 ) -> Result<(), cuda_core::DriverError> {
     let params = AffineParams {
         scale: 2.0,
@@ -164,6 +179,10 @@ fn generated_owned_async_methods_accept_owned_buffers(
             module.unsafe_raw_pointer_async_owned(config, raw_mut)?;
         assert_owned_unit(launch);
     }
+
+    let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
+        module.cooperative_grid_sync_async_owned(config, async_coop_output_u32)?;
+    assert_owned_u32_buffer(launch);
 
     Ok(())
 }

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -2,8 +2,9 @@
 
 Procedural macros for writing CUDA kernels in Rust. Provides `#[cuda_module]`
 for typed embedded-module loading, `#[kernel]` for GPU entry points,
-`#[device]`, `#[launch_bounds]`, `#[cluster_launch]`, `gpu_printf!`, and the
-lower-level `cuda_launch!` / `cuda_launch_async!` migration macros.
+`#[device]`, `#[launch_bounds]`, `#[cluster_launch]`, `#[cooperative_launch]`,
+`gpu_printf!`, and the lower-level `cuda_launch!` / `cuda_launch_async!`
+migration macros.
 
 ## Attributes
 
@@ -89,6 +90,26 @@ Compile-time thread block cluster dimensions (Hopper+). Must come **after** `#[k
 #[cluster_launch(4, 1, 1)]  // 4 blocks per cluster
 pub fn cluster_kernel(out: DisjointSlice<u32>) { ... }
 // PTX: .entry cluster_kernel .reqnctapercluster 4, 1, 1 { ... }
+```
+
+### `#[cooperative_launch]`
+
+Marks a kernel for cooperative launch, the precondition for grid-wide
+barriers (`cuda_device::grid::sync()`). Must come **after** `#[kernel]`.
+Unlike `#[cluster_launch]` this changes nothing in the PTX: `#[cuda_module]`
+reads the marker and routes every generated launch method through
+`cuLaunchKernelEx` with `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` set. May be
+combined with `#[cluster_launch]`; both attributes then go into the same
+`cuLaunchKernelEx` call.
+
+```rust
+#[kernel]
+#[cooperative_launch]
+pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {
+    // ... per-block work ...
+    grid::sync();
+    // ... grid-wide post-barrier work ...
+}
 ```
 
 ### `#[convergent]`, `#[pure]`, `#[readonly]`

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -180,6 +180,7 @@ struct CudaModuleKernel {
     generics: syn::Generics,
     params: Vec<CudaModuleParam>,
     cluster_dim: Option<(u32, u32, u32)>,
+    cooperative: bool,
     is_generic: bool,
 }
 
@@ -350,6 +351,7 @@ fn collect_cuda_module_kernels(items: &[Item]) -> syn::Result<Vec<CudaModuleKern
             continue;
         }
         let cluster_dim = cuda_module_cluster_dim(&item_fn.attrs)?;
+        let cooperative = cuda_module_cooperative(&item_fn.attrs)?;
         let params = cuda_module_params(item_fn)?;
         let is_generic = item_fn
             .sig
@@ -366,6 +368,7 @@ fn collect_cuda_module_kernels(items: &[Item]) -> syn::Result<Vec<CudaModuleKern
             generics: item_fn.sig.generics.clone(),
             params,
             cluster_dim,
+            cooperative,
             is_generic,
         });
     }
@@ -669,6 +672,21 @@ fn cuda_module_cluster_dim(attrs: &[syn::Attribute]) -> syn::Result<Option<(u32,
     Ok(None)
 }
 
+fn cuda_module_cooperative(attrs: &[syn::Attribute]) -> syn::Result<bool> {
+    for attr in attrs {
+        if attr_path_ends_with(attr, "cooperative_launch") {
+            if !matches!(attr.meta, syn::Meta::Path(_)) {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "cooperative_launch takes no arguments: use a bare #[cooperative_launch]",
+                ));
+            }
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 fn cuda_module_params(item_fn: &ItemFn) -> syn::Result<Vec<CudaModuleParam>> {
     item_fn
         .sig
@@ -845,6 +863,11 @@ fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenS
             ::cuda_host::set_async_kernel_cluster_dim(&mut __launch, #cluster_dim);
         }
     });
+    let set_cooperative = kernel.cooperative.then(|| {
+        quote! {
+            ::cuda_host::set_async_kernel_cooperative(&mut __launch, true);
+        }
+    });
 
     quote! {
         #(#cfg_attrs)*
@@ -860,6 +883,7 @@ fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenS
             #function_binding
             let mut __launch = ::cuda_host::new_async_kernel_launch(__func.clone(), config);
             #set_cluster_dim
+            #set_cooperative
             #(#arg_marshalling)*
             Ok(__launch)
         }
@@ -903,6 +927,11 @@ fn generate_cuda_module_owned_async_launch_method(kernel: &CudaModuleKernel) -> 
             ::cuda_host::set_async_kernel_cluster_dim(&mut __launch, #cluster_dim);
         }
     });
+    let set_cooperative = kernel.cooperative.then(|| {
+        quote! {
+            ::cuda_host::set_async_kernel_cooperative(&mut __launch, true);
+        }
+    });
     let resources_ty = cuda_module_owned_resources_ty(&resources);
     let resource_names = resources.iter().map(|(_, name, _, _)| name);
     let resources_expr = if resources.is_empty() {
@@ -926,6 +955,7 @@ fn generate_cuda_module_owned_async_launch_method(kernel: &CudaModuleKernel) -> 
             let mut __launch: ::cuda_host::AsyncKernelLaunch<'static> =
                 ::cuda_host::new_async_kernel_launch(__func.clone(), config);
             #set_cluster_dim
+            #set_cooperative
             #(#arg_marshalling)*
             Ok(::cuda_host::new_owned_async_kernel_launch(__launch, #resources_expr))
         }
@@ -1160,8 +1190,21 @@ fn cuda_module_function_binding(kernel: &CudaModuleKernel) -> TokenStream2 {
 
 fn cuda_module_launch_call(kernel: &CudaModuleKernel) -> TokenStream2 {
     let cluster_dim = kernel.cluster_dim.map(|(x, y, z)| quote! { (#x, #y, #z) });
-    if let Some(cluster_dim) = cluster_dim {
-        quote! {
+    match (cluster_dim, kernel.cooperative) {
+        (Some(cluster_dim), true) => quote! {
+            unsafe {
+                ::cuda_core::launch_kernel_ex_cooperative_on_stream(
+                    __func,
+                    config.grid_dim,
+                    config.block_dim,
+                    config.shared_mem_bytes,
+                    #cluster_dim,
+                    stream,
+                    &mut __args,
+                )
+            }
+        },
+        (Some(cluster_dim), false) => quote! {
             unsafe {
                 ::cuda_core::launch_kernel_ex_on_stream(
                     __func,
@@ -1173,9 +1216,20 @@ fn cuda_module_launch_call(kernel: &CudaModuleKernel) -> TokenStream2 {
                     &mut __args,
                 )
             }
-        }
-    } else {
-        quote! {
+        },
+        (None, true) => quote! {
+            unsafe {
+                ::cuda_core::launch_kernel_cooperative_on_stream(
+                    __func,
+                    config.grid_dim,
+                    config.block_dim,
+                    config.shared_mem_bytes,
+                    stream,
+                    &mut __args,
+                )
+            }
+        },
+        (None, false) => quote! {
             unsafe {
                 ::cuda_core::launch_kernel_on_stream(
                     __func,
@@ -1186,7 +1240,7 @@ fn cuda_module_launch_call(kernel: &CudaModuleKernel) -> TokenStream2 {
                     &mut __args,
                 )
             }
-        }
+        },
     }
 }
 
@@ -2331,6 +2385,70 @@ impl Parse for ClusterArgs {
             )),
         }
     }
+}
+
+/// Marks a kernel for cooperative launch (`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`).
+///
+/// A cooperative launch guarantees that every block in the grid is
+/// co-resident on the device, which is the precondition for grid-wide
+/// barriers: without it, `cuda_device::grid::sync()` deadlocks (or reads a
+/// null grid-workspace pointer) because blocks that have not been scheduled
+/// yet can never reach the barrier.
+///
+/// Unlike `#[cluster_launch]`, this attribute changes nothing in the
+/// generated PTX. Cooperative-ness is purely a launch-time property: the
+/// `#[cuda_module]` macro reads this marker and routes every generated
+/// launch method through `cuLaunchKernelEx` with the cooperative attribute
+/// set, instead of plain `cuLaunchKernel`.
+///
+/// # Usage
+///
+/// ```ignore
+/// use cuda_device::{cooperative_launch, grid, kernel, DisjointSlice};
+///
+/// #[kernel]
+/// #[cooperative_launch]
+/// pub fn my_grid_sync_kernel(mut out: DisjointSlice<u32>) {
+///     // ... per-block work ...
+///     grid::sync();
+///     // ... grid-wide post-barrier work ...
+/// }
+/// ```
+///
+/// # Requirements
+///
+/// - Must be used WITH `#[kernel]` (not standalone), on a kernel inside a
+///   `#[cuda_module]` module
+/// - The `#[cooperative_launch]` attribute must come AFTER `#[kernel]`
+/// - The device must support cooperative launch
+///   (`CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH`)
+/// - The grid must fit on the device in one wave, otherwise the driver
+///   rejects the launch with `CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE`
+///
+/// May be combined with `#[cluster_launch(x, y, z)]`; both launch
+/// attributes are then passed to `cuLaunchKernelEx` in the same call.
+///
+/// Outside `#[cuda_module]`, the legacy `cuda_launch!` macro offers the
+/// same behaviour through its `cooperative: true` field.
+#[proc_macro_attribute]
+pub fn cooperative_launch(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "cooperative_launch takes no arguments: use a bare #[cooperative_launch]",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // Launch-time only: the marker is consumed by #[cuda_module]; the kernel
+    // body and PTX are unchanged. Parse as a function so misuse on other
+    // items is rejected with a clear error.
+    let input = parse_macro_input!(item as ItemFn);
+    quote! {
+        #input
+    }
+    .into()
 }
 
 /// Marks a function as a CUDA device function.
@@ -3492,4 +3610,127 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Expands a `#[cuda_module]` body and returns the generated tokens as a
+    /// whitespace-free string, so tests can assert on call paths without
+    /// caring how `quote!` spaces out `::` separators.
+    fn expand_to_compact_string(module: ItemMod) -> String {
+        expand_cuda_module(module)
+            .expect("cuda_module expansion failed")
+            .to_string()
+            .replace(' ', "")
+    }
+
+    #[test]
+    fn cooperative_kernel_launches_through_cooperative_driver_call() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[cooperative_launch]
+                pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        // The sync launch method must route through the cooperative driver
+        // entry point (cuLaunchKernelEx + CU_LAUNCH_ATTRIBUTE_COOPERATIVE)
+        // instead of plain cuLaunchKernel.
+        assert!(
+            expanded.contains("launch_kernel_cooperative_on_stream"),
+            "expected cooperative launch call in generated tokens:\n{expanded}"
+        );
+        assert!(
+            !expanded.contains("launch_kernel_on_stream"),
+            "plain launch call should be replaced by the cooperative one:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn plain_kernel_keeps_plain_driver_call() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn plain_kernel(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded.contains("launch_kernel_on_stream"),
+            "expected plain launch call in generated tokens:\n{expanded}"
+        );
+        assert!(
+            !expanded.contains("launch_kernel_cooperative_on_stream"),
+            "cooperative call must not appear without #[cooperative_launch]:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn cooperative_plus_cluster_kernel_uses_combined_driver_call() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[cluster_launch(2, 1, 1)]
+                #[cooperative_launch]
+                pub fn clustered_grid_sync_kernel(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        // cuLaunchKernelEx accepts both attributes in one attrs array, so the
+        // combination is allowed and routes through the combined helper.
+        assert!(
+            expanded.contains("launch_kernel_ex_cooperative_on_stream"),
+            "expected combined cluster+cooperative launch call:\n{expanded}"
+        );
+        assert!(
+            !expanded.contains("launch_kernel_ex_on_stream"),
+            "cluster-only call should be replaced by the combined one:\n{expanded}"
+        );
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn cooperative_kernel_sets_async_builder_knob() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[cooperative_launch]
+                pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        // Both the borrowed-async and owned-async builder methods set the
+        // cooperative knob, exactly like set_async_kernel_cluster_dim is set
+        // for #[cluster_launch].
+        assert_eq!(
+            expanded.matches("set_async_kernel_cooperative").count(),
+            2,
+            "expected the cooperative knob in both async builder methods:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn cooperative_launch_with_arguments_is_rejected() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[cooperative_launch(4)]
+                pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let error = expand_cuda_module(module).expect_err("expected expansion to fail");
+        assert!(
+            error
+                .to_string()
+                .contains("cooperative_launch takes no arguments"),
+            "unexpected error message: {error}"
+        );
+    }
 }

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
@@ -41,7 +41,14 @@ The 21 checks split into three layers:
 | `match_all_sync`    | constant input ⇒ full warp mask                                |
 | `grid_sync`         | every block sees every other block's pre-barrier marker write  |
 
-`grid_sync` runs as a cooperative launch (`cuda_launch! { ..., cooperative: true }`).
+`grid_sync` (and `typed_grid_sync` in Layer 2) run as cooperative
+launches through the typed path: both kernels carry
+`#[cooperative_launch]` inside a `#[cuda_module]` module, so their
+generated launch methods submit via `cuLaunchKernelEx` with
+`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`. The same module also holds a
+compile-only kernel combining `#[cluster_launch(2, 1, 1)]` with
+`#[cooperative_launch]`, pinning that the two attributes are accepted
+together.
 
 ### Layer 2 — typed cooperative-groups handles (5 checks)
 

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
@@ -26,8 +26,10 @@ use cuda_device::cooperative_groups::{
     ops::{BitAnd, BitOr, BitXor, Max, Min, Sum},
     this_grid, this_thread_block, warp_reduce, warp_scan,
 };
-use cuda_device::{DisjointSlice, SharedArray, grid, kernel, thread, warp};
-use cuda_host::cuda_launch;
+use cuda_device::{
+    DisjointSlice, SharedArray, cluster_launch, cooperative_launch, grid, kernel, thread, warp,
+};
+use cuda_host::{cuda_launch, cuda_module};
 
 // =============================================================================
 // KERNELS
@@ -67,35 +69,98 @@ pub fn test_match_all(mut out: DisjointSlice<u32>) {
     }
 }
 
-/// Smoke test for `grid::sync()`. Each block's thread 0 writes a marker
-/// (`blockIdx.x + 1`), the grid synchronises, then thread 0 reads every
-/// other block's marker via the raw base pointer and writes the sum into
-/// `out[blockIdx.x]`. Expected value: `gridDim.x * (gridDim.x + 1) / 2`.
-#[kernel]
-pub fn test_grid_sync(mut markers: DisjointSlice<u32>, mut out: DisjointSlice<u32>) {
-    let block_id = thread::blockIdx_x();
-    let n = thread::gridDim_x();
+// The grid-sync kernels live in a `#[cuda_module]` module so their launches
+// go through the typed path. `#[cooperative_launch]` makes every generated
+// launch method use a cooperative launch (`cuLaunchKernelEx` with
+// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE`), which `grid::sync()` requires.
+#[cuda_module]
+mod grid_sync_kernels {
+    use super::*;
 
-    if thread::threadIdx_x() == 0 {
-        unsafe {
-            *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
+    /// Smoke test for `grid::sync()`. Each block's thread 0 writes a marker
+    /// (`blockIdx.x + 1`), the grid synchronises, then thread 0 reads every
+    /// other block's marker via the raw base pointer and writes the sum into
+    /// `out[blockIdx.x]`. Expected value: `gridDim.x * (gridDim.x + 1) / 2`.
+    #[kernel]
+    #[cooperative_launch]
+    pub fn test_grid_sync(mut markers: DisjointSlice<u32>, mut out: DisjointSlice<u32>) {
+        let block_id = thread::blockIdx_x();
+        let n = thread::gridDim_x();
+
+        if thread::threadIdx_x() == 0 {
+            unsafe {
+                *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
+            }
+        }
+
+        grid::sync();
+
+        if thread::threadIdx_x() == 0 {
+            let base = markers.as_mut_ptr() as *const u32;
+            let mut sum: u32 = 0;
+            let mut i: u32 = 0;
+            while i < n {
+                unsafe {
+                    sum = sum.wrapping_add(*base.add(i as usize));
+                }
+                i += 1;
+            }
+            unsafe {
+                *out.get_unchecked_mut(block_id as usize) = sum;
+            }
         }
     }
 
-    grid::sync();
+    /// `this_grid().sync()` must produce the same observable result as the
+    /// raw `grid::sync()` test above: every block sees every other block's
+    /// pre-barrier marker write.
+    #[kernel]
+    #[cooperative_launch]
+    pub fn test_typed_grid_sync(mut markers: DisjointSlice<u32>, mut out: DisjointSlice<u32>) {
+        let grid_handle = this_grid();
+        let block_id = thread::blockIdx_x();
+        let n = thread::gridDim_x();
 
-    if thread::threadIdx_x() == 0 {
-        let base = markers.as_mut_ptr() as *const u32;
-        let mut sum: u32 = 0;
-        let mut i: u32 = 0;
-        while i < n {
+        if thread::threadIdx_x() == 0 {
             unsafe {
-                sum = sum.wrapping_add(*base.add(i as usize));
+                *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
             }
-            i += 1;
         }
-        unsafe {
-            *out.get_unchecked_mut(block_id as usize) = sum;
+
+        grid_handle.sync();
+
+        if thread::threadIdx_x() == 0 {
+            let base = markers.as_mut_ptr() as *const u32;
+            let mut sum: u32 = 0;
+            let mut i: u32 = 0;
+            while i < n {
+                unsafe {
+                    sum = sum.wrapping_add(*base.add(i as usize));
+                }
+                i += 1;
+            }
+            unsafe {
+                *out.get_unchecked_mut(block_id as usize) = sum;
+            }
+        }
+    }
+
+    /// Compile-only pin: `#[cluster_launch]` and `#[cooperative_launch]` may
+    /// be combined, because `cuLaunchKernelEx` accepts the cluster-dimension
+    /// and cooperative attributes in the same call. The generated launch
+    /// methods route through
+    /// `cuda_core::launch_kernel_ex_cooperative_on_stream`. This kernel is
+    /// never launched at runtime here; it only pins that the combination
+    /// keeps compiling end to end (macro expansion, host launch methods, and
+    /// device PTX).
+    #[kernel]
+    #[cluster_launch(2, 1, 1)]
+    #[cooperative_launch]
+    pub fn test_cluster_coop_compile_only(mut out: DisjointSlice<u32>) {
+        let gid = thread::index_1d();
+        grid::sync();
+        if let Some(slot) = out.get_mut(gid) {
+            *slot = 1;
         }
     }
 }
@@ -144,38 +209,9 @@ pub fn test_typed_warp16_shfl(mut out: DisjointSlice<u32>) {
     }
 }
 
-/// `this_grid().sync()` must produce the same observable result as the
-/// raw `grid::sync()` test above: every block sees every other block's
-/// pre-barrier marker write.
-#[kernel]
-pub fn test_typed_grid_sync(mut markers: DisjointSlice<u32>, mut out: DisjointSlice<u32>) {
-    let grid_handle = this_grid();
-    let block_id = thread::blockIdx_x();
-    let n = thread::gridDim_x();
-
-    if thread::threadIdx_x() == 0 {
-        unsafe {
-            *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
-        }
-    }
-
-    grid_handle.sync();
-
-    if thread::threadIdx_x() == 0 {
-        let base = markers.as_mut_ptr() as *const u32;
-        let mut sum: u32 = 0;
-        let mut i: u32 = 0;
-        while i < n {
-            unsafe {
-                sum = sum.wrapping_add(*base.add(i as usize));
-            }
-            i += 1;
-        }
-        unsafe {
-            *out.get_unchecked_mut(block_id as usize) = sum;
-        }
-    }
-}
+// NOTE: `test_typed_grid_sync` lives in the `grid_sync_kernels` module above,
+// next to its raw `grid::sync()` counterpart, because both need the
+// `#[cooperative_launch]` typed launch path.
 
 /// Probe `Grid::size()` / `Grid::thread_rank()` from every thread.
 /// `out[i]` records `thread_rank()` for the thread whose `index_1d == i`;
@@ -567,6 +603,12 @@ fn main() {
         .load_module_from_file("coop_groups_demo.ptx")
         .expect("Failed to load PTX module");
 
+    // Typed handle for the `#[cuda_module]` grid-sync kernels. Their
+    // `#[cooperative_launch]` attribute makes the generated launch methods
+    // submit cooperative launches, so no per-call flag is needed.
+    let grid_sync_module = grid_sync_kernels::from_module(module.clone())
+        .expect("Failed to initialize typed grid-sync module");
+
     const N: usize = 256;
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),
@@ -642,15 +684,9 @@ fn main() {
     };
     let mut markers = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
     let mut sums = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
-    cuda_launch! {
-        kernel: test_grid_sync,
-        stream: stream,
-        module: module,
-        config: coop_cfg,
-        cooperative: true,
-        args: [slice_mut(markers), slice_mut(sums)]
-    }
-    .expect("test_grid_sync cooperative launch failed");
+    grid_sync_module
+        .test_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums)
+        .expect("test_grid_sync cooperative launch failed");
     let host = sums.to_host_vec(&stream).unwrap();
     let expected: u32 = (1..=BLOCKS).sum();
     let ok = host.iter().all(|&s| s == expected);
@@ -744,15 +780,9 @@ fn main() {
     println!("\n--- this_grid().sync() (cooperative launch) ---");
     let mut markers = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
     let mut sums = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
-    cuda_launch! {
-        kernel: test_typed_grid_sync,
-        stream: stream,
-        module: module,
-        config: coop_cfg,
-        cooperative: true,
-        args: [slice_mut(markers), slice_mut(sums)]
-    }
-    .expect("test_typed_grid_sync cooperative launch failed");
+    grid_sync_module
+        .test_typed_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums)
+        .expect("test_typed_grid_sync cooperative launch failed");
     let host = sums.to_host_vec(&stream).unwrap();
     let expected: u32 = (1..=BLOCKS).sum();
     let ok = host.iter().all(|&s| s == expected);

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -11,7 +11,7 @@ root.
 ### Kernel and Device Attributes
 
 ```rust
-use cuda_device::{kernel, device, launch_bounds, cluster_launch};
+use cuda_device::{kernel, device, launch_bounds, cluster_launch, cooperative_launch};
 
 #[kernel]
 pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) { /* ... */ }
@@ -24,6 +24,10 @@ pub fn tuned_kernel(data: &mut [f32]) { /* ... */ }
 #[cluster_launch(4, 1, 1)]
 pub fn cluster_kernel(data: &mut [f32]) { /* ... */ }
 
+#[kernel]
+#[cooperative_launch]
+pub fn grid_sync_kernel(data: &mut [f32]) { /* ... */ }
+
 #[device]
 fn helper(x: f32) -> f32 { x * x }
 ```
@@ -34,6 +38,7 @@ fn helper(x: f32) -> f32 { x * x }
 | `#[device]`                                 | Mark a helper function or `extern "C"` block for device compilation |
 | `#[launch_bounds(max_threads, min_blocks)]` | Occupancy hints for register allocation                             |
 | `#[cluster_launch(x, y, z)]`                | Set compile-time cluster dimensions (Hopper+)                       |
+| `#[cooperative_launch]`                     | Launch cooperatively via `#[cuda_module]` (enables `grid::sync()`)  |
 | `#[convergent]`                             | Mark as convergent (barrier semantics)                              |
 | `#[pure]`                                   | Mark as side-effect free                                            |
 | `#[readonly]`                               | Mark as read-only                                                   |

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -141,7 +141,7 @@ roadmap, **N/A** = not applicable or no identified need.
 | Warp Collectives | **Full** | `ballot`, `all`, `any`, `shfl`, `shfl_xor`, `shfl_down`, `shfl_up` (`i32` and `f32`); `match_any` / `match_all` (`i32` and `i64`); `active_mask`. |
 | Warp Reductions / Scans | **Full** | `warp_reduce`, `warp_scan` (inclusive). `Sum`/`Min`/`Max` for `u32`/`i32`/`f32`; `BitAnd`/`BitOr`/`BitXor` for `u32`. |
 | Block Reductions / Scans | **Full** | `block_reduce`, `block_scan` (inclusive). Const-generic over `NUM_WARPS`; same op/type matrix as warp variants; uses `__shared__` scratch. |
-| Cooperative Kernel Launch | **Full** | `cuda_launch! { cooperative: true, ... }` enables `Grid::sync()` for grid-wide barriers. |
+| Cooperative Kernel Launch | **Full** | `#[cooperative_launch]` on a `#[cuda_module]` kernel (or `cuda_launch! { cooperative: true, ... }`) enables `Grid::sync()` for grid-wide barriers. |
 
 ## Runtime Library: Debug
 

--- a/cuda-oxide-book/gpu-programming/launching-kernels.md
+++ b/cuda-oxide-book/gpu-programming/launching-kernels.md
@@ -340,6 +340,54 @@ Cluster launch requires **Hopper (sm_90)** or newer. The maximum cluster size is
 typically 16 blocks. Use `cargo oxide build --arch sm_90` to target Hopper.
 :::
 
+## Cooperative launch
+
+Grid-wide barriers (`cuda_device::grid::sync()` or `this_grid().sync()`) only
+work when every block in the grid is resident on the device at the same time.
+A **cooperative launch** asks the driver to guarantee exactly that; without
+it, blocks that have not been scheduled yet can never reach the barrier and
+the kernel deadlocks.
+
+On the typed `#[cuda_module]` path, mark the kernel with
+`#[cooperative_launch]`. Every generated launch method (sync, async, and
+owned-async) then submits through `cuLaunchKernelEx` with the
+`CU_LAUNCH_ATTRIBUTE_COOPERATIVE` attribute set:
+
+```rust
+use cuda_device::{cooperative_launch, grid, kernel, DisjointSlice};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[cooperative_launch]
+    pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {
+        // ... per-block work ...
+        grid::sync();
+        // ... grid-wide post-barrier work ...
+    }
+}
+
+let module = kernels::load(&ctx)?;
+module.grid_sync_kernel(&stream, config, &mut out_dev)?; // cooperative launch
+```
+
+Unlike `#[cluster_launch]`, the attribute changes nothing in the PTX; it only
+changes how the host submits the launch. The two attributes may be combined
+on one kernel, in which case both launch attributes go into the same
+`cuLaunchKernelEx` call.
+
+The legacy `cuda_launch!` macro offers the same behaviour through its
+`cooperative: true` field.
+
+:::{tip}
+The whole grid must fit on the device in a single wave, or the driver rejects
+the launch with `CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE`. Size the grid from
+`cuOccupancyMaxActiveBlocksPerMultiprocessor` (blocks per SM × SM count) when
+in doubt.
+:::
+
 ## Common launch errors
 
 | Error                                  | Likely cause                                           | Fix                                                                  |


### PR DESCRIPTION
## What

Kernels using `grid::sync()` can now launch through the typed `#[cuda_module]` path; previously cooperative launch existed only in the legacy `cuda_launch\!` macro.

```rust
#[kernel]
#[cooperative_launch]                    // mirrors #[cluster_launch(...)]
pub fn my_grid_sync_kernel(...) { ... }

module.my_grid_sync_kernel(stream, cfg, ...)   // launches cooperatively
```

Mirrors the `#[cluster_launch]` precedent at every layer: cuda-core gains `launch_kernel_ex_cooperative[_on_stream]` (one `cuLaunchKernelEx` carrying both the cluster and cooperative attributes when combined), `AsyncKernelLaunch` gains `set_cooperative` next to `set_cluster_dim` with a 4-way dispatch, cuda-host gains the doc-hidden shim, and the macro stores the flag and routes all three generated launch shapes (sync, async, owned-async). Combining with `#[cluster_launch]` is allowed because `cuLaunchKernelEx` expresses both attributes in one array; a never-launched kernel pins that the combination compiles.

## Evidence

- `coop_groups_demo`'s two grid-sync tests now launch through the typed path and PASS on sm_120 (they deadlock or mis-sum if the attribute is not genuinely applied), with kernel bodies byte-identical to before.
- Review independently expanded the generated code (`-Zunpretty=expanded`) to verify the sync path reaches `launch_kernel_cooperative_on_stream` and both async builders set the flag; non-cooperative kernels are unchanged (several untouched examples rebuilt and verified).
- 5 new macro token tests + a cooperative kernel in the cuda-host API test (sync/async/owned-async); book and README sections added.
- Tests/clippy/fmt/doc gates clean; compile-only smoketest green; reviewer's merge probe vs main: zero conflicts.