### PR TITLE
chore(examples): port nine legacy cuda_launch\! examples to #[cuda_module]

### DIFF
--- a/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
@@ -10,23 +10,28 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::kernel;
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
 static mut DEVICE_COUNTER: u64 = 0;
 static mut DEVICE_MARKER: u32 = 0;
 
-/// # Safety
-///
-/// `out` must point to a writable `u64` in device-accessible memory.
-/// The static globals `DEVICE_COUNTER` and `DEVICE_MARKER` are mutated
-/// without synchronisation; the test launches a single thread to dodge
-/// the race.
-#[kernel]
-pub unsafe fn device_global(out: *mut u64) {
-    unsafe {
-        DEVICE_COUNTER += 1;
-        DEVICE_MARKER = 0x00C0_FFEE;
-        *out = DEVICE_COUNTER ^ (DEVICE_MARKER as u64);
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// # Safety
+    ///
+    /// `out` must point to a writable `u64` in device-accessible memory.
+    /// The static globals `DEVICE_COUNTER` and `DEVICE_MARKER` are mutated
+    /// without synchronisation; the test launches a single thread to dodge
+    /// the race.
+    #[kernel]
+    pub unsafe fn device_global(out: *mut u64) {
+        unsafe {
+            DEVICE_COUNTER += 1;
+            DEVICE_MARKER = 0x00C0_FFEE;
+            *out = DEVICE_COUNTER ^ (DEVICE_MARKER as u64);
+        }
     }
 }
 
@@ -40,14 +45,15 @@ fn main() {
     let module = ctx
         .load_module_from_file("device_global.ptx")
         .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     for launch_idx in 1..=2 {
-        cuda_launch! {
-            kernel: device_global,
-            stream: stream,
-            module: module,
-            config: LaunchConfig::for_num_elems(1),
-            args: [out_dev.cu_deviceptr() as *mut u64]
+        unsafe {
+            module.device_global(
+                &stream,
+                LaunchConfig::for_num_elems(1),
+                out_dev.cu_deviceptr() as *mut u64,
+            )
         }
         .expect("Kernel launch failed");
 

--- a/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
@@ -14,37 +14,42 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
-/// Stores one `f16` value so we cover constants and device memory traffic.
-#[kernel]
-pub fn test_f16_store(mut out: DisjointSlice<f16>) {
-    if thread::index_1d().get() == 0 {
-        unsafe {
-            *out.get_unchecked_mut(0) = f16::from_bits(0x3e00); // 1.5
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Stores one `f16` value so we cover constants and device memory traffic.
+    #[kernel]
+    pub fn test_f16_store(mut out: DisjointSlice<f16>) {
+        if thread::index_1d().get() == 0 {
+            unsafe {
+                *out.get_unchecked_mut(0) = f16::from_bits(0x3e00); // 1.5
+            }
         }
     }
-}
 
-/// Exercises basic `f16` arithmetic, comparison, and casts through `f32`.
-#[kernel]
-pub fn test_f16_ops(mut out: DisjointSlice<u32>) {
-    if thread::index_1d().get() == 0 {
-        let one = f16::from_bits(0x3c00);
-        let two = f16::from_bits(0x4000);
-        let half = f16::from_bits(0x3800);
+    /// Exercises basic `f16` arithmetic, comparison, and casts through `f32`.
+    #[kernel]
+    pub fn test_f16_ops(mut out: DisjointSlice<u32>) {
+        if thread::index_1d().get() == 0 {
+            let one = f16::from_bits(0x3c00);
+            let two = f16::from_bits(0x4000);
+            let half = f16::from_bits(0x3800);
 
-        let sum = one + two;
-        let product = sum * half;
-        let is_gt = if product > one { 1u32 } else { 0u32 };
-        let widened = product as f32;
-        let narrowed = (widened + 1.0_f32) as f16;
+            let sum = one + two;
+            let product = sum * half;
+            let is_gt = if product > one { 1u32 } else { 0u32 };
+            let widened = product as f32;
+            let narrowed = (widened + 1.0_f32) as f16;
 
-        unsafe {
-            *out.get_unchecked_mut(0) = sum.to_bits() as u32;
-            *out.get_unchecked_mut(1) = product.to_bits() as u32;
-            *out.get_unchecked_mut(2) = is_gt;
-            *out.get_unchecked_mut(3) = narrowed.to_bits() as u32;
+            unsafe {
+                *out.get_unchecked_mut(0) = sum.to_bits() as u32;
+                *out.get_unchecked_mut(1) = product.to_bits() as u32;
+                *out.get_unchecked_mut(2) = is_gt;
+                *out.get_unchecked_mut(3) = narrowed.to_bits() as u32;
+            }
         }
     }
 }
@@ -55,6 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
     let module = ctx.load_module_from_file("f16_stress.ptx")?;
+    let module = kernels::from_module(module)?;
     let cfg = LaunchConfig::for_num_elems(1);
 
     let mut passed = 0u32;
@@ -62,11 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let mut out = DeviceBuffer::<f16>::zeroed(&stream, 1)?;
-        cuda_launch! {
-            kernel: test_f16_store,
-            stream: stream, module: module, config: cfg,
-            args: [slice_mut(out)]
-        }?;
+        module.test_f16_store(&stream, cfg, &mut out)?;
         let got = out.to_host_vec(&stream)?[0].to_bits();
         let expected = f16::from_bits(0x3e00).to_bits();
         check("f16 load/store", got, expected, &mut passed, &mut failed);
@@ -74,11 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
-        cuda_launch! {
-            kernel: test_f16_ops,
-            stream: stream, module: module, config: cfg,
-            args: [slice_mut(out)]
-        }?;
+        module.test_f16_ops(&stream, cfg, &mut out)?;
         let got = out.to_host_vec(&stream)?;
 
         let one = f16::from_bits(0x3c00);

--- a/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
@@ -31,37 +31,42 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::{cuda_launch, ltoir};
+use cuda_host::{cuda_module, ltoir};
 
 // =============================================================================
 // KERNELS
 // =============================================================================
 
-/// Writes `f32::max(a, b)` and `f32::min(a, b)` to `out[0..2]`, and then
-/// `f32::max(nan_arg, b)` and `f32::min(nan_arg, b)` to `out[2..4]` so the
-/// host can exercise the maxNum / minNum NaN-suppression rule by passing
-/// a NaN through `nan_arg`.
-#[kernel]
-pub fn fmaxmin_f32_kernel(a: f32, b: f32, nan_arg: f32, mut out: DisjointSlice<u32>) {
-    if thread::index_1d().get() == 0 {
-        unsafe {
-            *out.get_unchecked_mut(0) = a.max(b).to_bits();
-            *out.get_unchecked_mut(1) = a.min(b).to_bits();
-            *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
-            *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Writes `f32::max(a, b)` and `f32::min(a, b)` to `out[0..2]`, and then
+    /// `f32::max(nan_arg, b)` and `f32::min(nan_arg, b)` to `out[2..4]` so the
+    /// host can exercise the maxNum / minNum NaN-suppression rule by passing
+    /// a NaN through `nan_arg`.
+    #[kernel]
+    pub fn fmaxmin_f32_kernel(a: f32, b: f32, nan_arg: f32, mut out: DisjointSlice<u32>) {
+        if thread::index_1d().get() == 0 {
+            unsafe {
+                *out.get_unchecked_mut(0) = a.max(b).to_bits();
+                *out.get_unchecked_mut(1) = a.min(b).to_bits();
+                *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
+                *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+            }
         }
     }
-}
 
-/// Same as `fmaxmin_f32_kernel` for `f64::max` / `f64::min`.
-#[kernel]
-pub fn fmaxmin_f64_kernel(a: f64, b: f64, nan_arg: f64, mut out: DisjointSlice<u64>) {
-    if thread::index_1d().get() == 0 {
-        unsafe {
-            *out.get_unchecked_mut(0) = a.max(b).to_bits();
-            *out.get_unchecked_mut(1) = a.min(b).to_bits();
-            *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
-            *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+    /// Same as `fmaxmin_f32_kernel` for `f64::max` / `f64::min`.
+    #[kernel]
+    pub fn fmaxmin_f64_kernel(a: f64, b: f64, nan_arg: f64, mut out: DisjointSlice<u64>) {
+        if thread::index_1d().get() == 0 {
+            unsafe {
+                *out.get_unchecked_mut(0) = a.max(b).to_bits();
+                *out.get_unchecked_mut(1) = a.min(b).to_bits();
+                *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
+                *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+            }
         }
     }
 }
@@ -80,6 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // IR rather than PTX and `ltoir::load_kernel_module` finishes the build
     // through libNVVM + nvJitLink, just like `primitive_stress`.
     let module = ltoir::load_kernel_module(&ctx, "fmaxmin_smoke")?;
+    let module = kernels::from_module(module)?;
     let cfg = LaunchConfig::for_num_elems(1);
 
     let mut passed = 0u32;
@@ -91,11 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = -2.5_f32;
         let nan_arg = f32::NAN;
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
-        cuda_launch! {
-            kernel: fmaxmin_f32_kernel,
-            stream: stream, module: module, config: cfg,
-            args: [a, b, nan_arg, slice_mut(out)]
-        }?;
+        module.fmaxmin_f32_kernel(&stream, cfg, a, b, nan_arg, &mut out)?;
         let result = out.to_host_vec(&stream)?;
         let expected: [u32; 4] = [
             a.max(b).to_bits(), // f32::max finite
@@ -118,11 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = -2.5e10_f64;
         let nan_arg = f64::NAN;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 4)?;
-        cuda_launch! {
-            kernel: fmaxmin_f64_kernel,
-            stream: stream, module: module, config: cfg,
-            args: [a, b, nan_arg, slice_mut(out)]
-        }?;
+        module.fmaxmin_f64_kernel(&stream, cfg, a, b, nan_arg, &mut out)?;
         let result = out.to_host_vec(&stream)?;
         let expected: [u64; 4] = [
             a.max(b).to_bits(),

--- a/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
@@ -29,36 +29,41 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::{cuda_launch, ltoir};
+use cuda_host::{cuda_module, ltoir};
 
 // =============================================================================
 // KERNELS
 // =============================================================================
 
-/// Stores `f32::NAN`, `f32::INFINITY`, `f32::NEG_INFINITY`, and a finite
-/// control value so the constants reach `format_float_literal` as `float`
-/// SSA values.
-#[kernel]
-pub fn fp_special_literal_f32_kernel(mut out: DisjointSlice<f32>) {
-    if thread::index_1d().get() == 0 {
-        unsafe {
-            *out.get_unchecked_mut(0) = f32::NAN;
-            *out.get_unchecked_mut(1) = f32::INFINITY;
-            *out.get_unchecked_mut(2) = f32::NEG_INFINITY;
-            *out.get_unchecked_mut(3) = 1.5_f32;
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Stores `f32::NAN`, `f32::INFINITY`, `f32::NEG_INFINITY`, and a finite
+    /// control value so the constants reach `format_float_literal` as `float`
+    /// SSA values.
+    #[kernel]
+    pub fn fp_special_literal_f32_kernel(mut out: DisjointSlice<f32>) {
+        if thread::index_1d().get() == 0 {
+            unsafe {
+                *out.get_unchecked_mut(0) = f32::NAN;
+                *out.get_unchecked_mut(1) = f32::INFINITY;
+                *out.get_unchecked_mut(2) = f32::NEG_INFINITY;
+                *out.get_unchecked_mut(3) = 1.5_f32;
+            }
         }
     }
-}
 
-/// Same as `fp_special_literal_f32_kernel` for `f64`.
-#[kernel]
-pub fn fp_special_literal_f64_kernel(mut out: DisjointSlice<f64>) {
-    if thread::index_1d().get() == 0 {
-        unsafe {
-            *out.get_unchecked_mut(0) = f64::NAN;
-            *out.get_unchecked_mut(1) = f64::INFINITY;
-            *out.get_unchecked_mut(2) = f64::NEG_INFINITY;
-            *out.get_unchecked_mut(3) = 1.5_f64;
+    /// Same as `fp_special_literal_f32_kernel` for `f64`.
+    #[kernel]
+    pub fn fp_special_literal_f64_kernel(mut out: DisjointSlice<f64>) {
+        if thread::index_1d().get() == 0 {
+            unsafe {
+                *out.get_unchecked_mut(0) = f64::NAN;
+                *out.get_unchecked_mut(1) = f64::INFINITY;
+                *out.get_unchecked_mut(2) = f64::NEG_INFINITY;
+                *out.get_unchecked_mut(3) = 1.5_f64;
+            }
         }
     }
 }
@@ -74,6 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream = ctx.default_stream();
 
     let module = ltoir::load_kernel_module(&ctx, "fp_special_literal_smoke")?;
+    let module = kernels::from_module(module)?;
     let cfg = LaunchConfig::for_num_elems(1);
 
     let mut passed = 0u32;
@@ -82,11 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------- f32 ----------
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
-        cuda_launch! {
-            kernel: fp_special_literal_f32_kernel,
-            stream: stream, module: module, config: cfg,
-            args: [slice_mut(out)]
-        }?;
+        module.fp_special_literal_f32_kernel(&stream, cfg, &mut out)?;
         let got = out.to_host_vec(&stream)?;
         check_f32_specials(&got, &mut passed, &mut failed);
     }
@@ -94,11 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------- f64 ----------
     {
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, 4)?;
-        cuda_launch! {
-            kernel: fp_special_literal_f64_kernel,
-            stream: stream, module: module, config: cfg,
-            args: [slice_mut(out)]
-        }?;
+        module.fp_special_literal_f64_kernel(&stream, cfg, &mut out)?;
         let got = out.to_host_vec(&stream)?;
         check_f64_specials(&got, &mut passed, &mut failed);
     }

--- a/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
@@ -27,10 +27,10 @@
 
 use std::sync::Arc;
 
-use cuda_core::{CudaContext, CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig};
 use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU64};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
 // =============================================================================
 // SHARED CONSTANTS AND HELPERS (compiled both host- and device-side)
@@ -84,138 +84,148 @@ fn unpack_value(slot: u64) -> u32 {
 // KERNELS
 // =============================================================================
 
-/// `insert_kernel` — last-writer-wins.
-///
-/// One thread per input key. Linear-probes from `hash(key) & mask` until it
-/// either CAS-claims an EMPTY slot or finds the key already present, in
-/// which case it overwrites the value via an inner CAS loop.
-///
-/// `table.len()` must be a power of two (host-side invariant).
-#[kernel]
-pub fn insert_kernel(table: &[u64], keys: &[u32], values: &[u32]) {
-    let tid = thread::index_1d().get();
-    if tid >= keys.len() {
-        return;
-    }
+#[cuda_module]
+mod kernels {
+    use super::*;
 
-    let key = keys[tid];
-    let value = values[tid];
-    let mask = table.len() - 1;
-    let mut idx = (hash_u32(key) as usize) & mask;
+    /// `insert_kernel` — last-writer-wins.
+    ///
+    /// One thread per input key. Linear-probes from `hash(key) & mask` until it
+    /// either CAS-claims an EMPTY slot or finds the key already present, in
+    /// which case it overwrites the value via an inner CAS loop.
+    ///
+    /// `table.len()` must be a power of two (host-side invariant).
+    #[kernel]
+    pub fn insert_kernel(table: &[u64], keys: &[u32], values: &[u32]) {
+        let tid = thread::index_1d().get();
+        if tid >= keys.len() {
+            return;
+        }
 
-    loop {
-        let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+        let key = keys[tid];
+        let value = values[tid];
+        let mask = table.len() - 1;
+        let mut idx = (hash_u32(key) as usize) & mask;
 
-        match slot.compare_exchange(
-            EMPTY,
-            pack(key, value),
-            AtomicOrdering::AcqRel,
-            AtomicOrdering::Relaxed,
-        ) {
-            Ok(_) => return,
-            Err(observed) if unpack_key(observed) == key => {
-                let mut expected = observed;
-                let desired = pack(key, value);
-                loop {
-                    match slot.compare_exchange(
-                        expected,
-                        desired,
-                        AtomicOrdering::AcqRel,
-                        AtomicOrdering::Relaxed,
-                    ) {
-                        Ok(_) => return,
-                        // Fires only when another thread in this same
-                        // batch holds the same key and CAS'd in first.
-                        // Re-read its value and retry so last-writer-wins.
-                        Err(actual) => expected = actual,
+        loop {
+            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+
+            match slot.compare_exchange(
+                EMPTY,
+                pack(key, value),
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) if unpack_key(observed) == key => {
+                    let mut expected = observed;
+                    let desired = pack(key, value);
+                    loop {
+                        match slot.compare_exchange(
+                            expected,
+                            desired,
+                            AtomicOrdering::AcqRel,
+                            AtomicOrdering::Relaxed,
+                        ) {
+                            Ok(_) => return,
+                            // Fires only when another thread in this same
+                            // batch holds the same key and CAS'd in first.
+                            // Re-read its value and retry so last-writer-wins.
+                            Err(actual) => expected = actual,
+                        }
                     }
                 }
+                // Hash collision: different key already lives here. Probe forward.
+                Err(_) => idx = (idx + 1) & mask,
             }
-            // Hash collision: different key already lives here. Probe forward.
-            Err(_) => idx = (idx + 1) & mask,
         }
     }
-}
 
-/// `try_insert_kernel` — first-writer-wins.
-///
-/// Same outer probe as `insert_kernel`, but on duplicate it leaves the
-/// existing slot untouched and reports `1 = already present` via `out`.
-/// On a fresh insert it reports `0`.
-#[kernel]
-pub fn try_insert_kernel(table: &[u64], keys: &[u32], values: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i = tid_raw;
-    if i >= keys.len() {
-        return;
+    /// `try_insert_kernel` — first-writer-wins.
+    ///
+    /// Same outer probe as `insert_kernel`, but on duplicate it leaves the
+    /// existing slot untouched and reports `1 = already present` via `out`.
+    /// On a fresh insert it reports `0`.
+    #[kernel]
+    pub fn try_insert_kernel(
+        table: &[u64],
+        keys: &[u32],
+        values: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i = tid_raw;
+        if i >= keys.len() {
+            return;
+        }
+
+        let key = keys[i];
+        let value = values[i];
+        let mask = table.len() - 1;
+        let mut idx = (hash_u32(key) as usize) & mask;
+
+        loop {
+            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+
+            match slot.compare_exchange(
+                EMPTY,
+                pack(key, value),
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Relaxed,
+            ) {
+                Ok(_) => {
+                    if let Some(o) = out.get_mut(tid) {
+                        *o = 0;
+                    }
+                    return;
+                }
+                Err(observed) if unpack_key(observed) == key => {
+                    if let Some(o) = out.get_mut(tid) {
+                        *o = 1;
+                    }
+                    return;
+                }
+                Err(_) => idx = (idx + 1) & mask,
+            }
+        }
     }
 
-    let key = keys[i];
-    let value = values[i];
-    let mask = table.len() - 1;
-    let mut idx = (hash_u32(key) as usize) & mask;
+    /// `find_kernel` — one key per thread.
+    ///
+    /// Linear-probe from `hash(key) & mask` and return the value if a key match
+    /// is found, or `MISS = u32::MAX` if an EMPTY slot is hit first.
+    #[kernel]
+    pub fn find_kernel(table: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i = tid_raw;
+        if i >= keys.len() {
+            return;
+        }
 
-    loop {
-        let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+        let key = keys[i];
+        let mask = table.len() - 1;
+        let mut idx = (hash_u32(key) as usize) & mask;
 
-        match slot.compare_exchange(
-            EMPTY,
-            pack(key, value),
-            AtomicOrdering::AcqRel,
-            AtomicOrdering::Relaxed,
-        ) {
-            Ok(_) => {
+        loop {
+            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+            let observed = slot.load(AtomicOrdering::Acquire);
+
+            if observed == EMPTY {
                 if let Some(o) = out.get_mut(tid) {
-                    *o = 0;
+                    *o = MISS;
                 }
                 return;
             }
-            Err(observed) if unpack_key(observed) == key => {
+            if unpack_key(observed) == key {
                 if let Some(o) = out.get_mut(tid) {
-                    *o = 1;
+                    *o = unpack_value(observed);
                 }
                 return;
             }
-            Err(_) => idx = (idx + 1) & mask,
+            idx = (idx + 1) & mask;
         }
-    }
-}
-
-/// `find_kernel` — one key per thread.
-///
-/// Linear-probe from `hash(key) & mask` and return the value if a key match
-/// is found, or `MISS = u32::MAX` if an EMPTY slot is hit first.
-#[kernel]
-pub fn find_kernel(table: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i = tid_raw;
-    if i >= keys.len() {
-        return;
-    }
-
-    let key = keys[i];
-    let mask = table.len() - 1;
-    let mut idx = (hash_u32(key) as usize) & mask;
-
-    loop {
-        let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
-        let observed = slot.load(AtomicOrdering::Acquire);
-
-        if observed == EMPTY {
-            if let Some(o) = out.get_mut(tid) {
-                *o = MISS;
-            }
-            return;
-        }
-        if unpack_key(observed) == key {
-            if let Some(o) = out.get_mut(tid) {
-                *o = unpack_value(observed);
-            }
-            return;
-        }
-        idx = (idx + 1) & mask;
     }
 }
 
@@ -283,7 +293,7 @@ impl GpuHashMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -299,13 +309,7 @@ impl GpuHashMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel(stream, cfg, &self.slots, &keys_dev, &values_dev)?;
 
         Ok(())
     }
@@ -318,7 +322,7 @@ impl GpuHashMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -335,13 +339,14 @@ impl GpuHashMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: try_insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.slots), slice(keys_dev), slice(values_dev), slice_mut(out_dev)]
-        }?;
+        module.try_insert_kernel(
+            stream,
+            cfg,
+            &self.slots,
+            &keys_dev,
+            &values_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == 0).collect())
@@ -352,7 +357,7 @@ impl GpuHashMap {
     fn find_bulk(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -363,13 +368,7 @@ impl GpuHashMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: find_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel(stream, cfg, &self.slots, &keys_dev, &mut out_dev)?;
 
         let out = out_dev.to_host_vec(stream)?;
         Ok(out)
@@ -414,6 +413,7 @@ fn main() {
     let module = ctx
         .load_module_from_file("hashmap.ptx")
         .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
@@ -36,8 +36,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use cuda_core::{CudaContext, CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
-use cuda_host::cuda_launch;
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig};
 use hashbrown::HashMap as HbMap;
 use hashmap_v2::*;
 use rayon::prelude::*;
@@ -262,7 +261,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module: Arc<CudaModule> = ctx.load_module_from_file("hashmap_v2.ptx")?;
+    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v2.ptx")?)?;
 
     print_environment_banner(&ctx)?;
 
@@ -320,38 +319,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = LaunchConfig::for_num_elems(n_keys as u32);
         row_b_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             })?;
 
         // ---- GPU INSERT — Protocol A -----------------------------------
         row_a_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel_proto_a,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel_proto_a(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             })?;
 
         // ---- Build a final B-protocol map for the find benches ----------
         unsafe { reset_table_async(&map, &stream)? };
-        cuda_launch! {
-            kernel: insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(map.ctrl), slice(map.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)?;
         stream.synchronize()?;
 
         let cfg_warp = LaunchConfig::for_num_elems((n_keys * PROBE_TILE) as u32);
@@ -359,39 +340,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // ---- GPU LOOKUP (hits) — single-thread --------------------------
         row_single_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — warp-cooperative -----------------------
         row_warp_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_warp,
-                    stream: stream,
-                    module: module,
-                    config: cfg_warp,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — warp-cooperative, typed CG API ---------
         row_warp_typed_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_warp_typed,
-                    stream: stream,
-                    module: module,
-                    config: cfg_warp,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
@@ -403,13 +366,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;
@@ -422,13 +379,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_warp,
-                    stream: stream,
-                    module: module,
-                    config: cfg_warp,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;
@@ -441,13 +392,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_warp_typed,
-                    stream: stream,
-                    module: module,
-                    config: cfg_warp,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
@@ -61,11 +61,11 @@
 
 use std::sync::Arc;
 
-use cuda_core::{CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaStream, DeviceBuffer, LaunchConfig};
 use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU32, DeviceAtomicU64};
 use cuda_device::cooperative_groups::{ThreadGroup, WarpCollective, this_thread_block};
 use cuda_device::{DisjointSlice, kernel, thread, warp};
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
 // =============================================================================
 // SHARED CONSTANTS AND HELPERS (compiled both host- and device-side)
@@ -211,800 +211,526 @@ pub fn unpack_value(slot: u64) -> u32 {
 // KERNELS
 // =============================================================================
 
-/// `insert_kernel` — last-writer-wins, one thread per input key.
-///
-/// Storage:
-///   - `ctrl[g]` is the `u32` packing tags for slots `g*GROUP .. g*GROUP+GROUP`.
-///   - `slots[s]` is the packed `(key, value)` for slot `s`.
-///
-/// Probe shape: triangular in `PROBE_TILE`-byte tiles. Each step
-/// examines `PROBE_TILE` consecutive tag bytes (= `PROBE_TILE / GROUP`
-/// ctrl words) starting at `probe_base`, and advances by `stride *
-/// PROBE_TILE` (with `stride += 1` per step). All four kernels — and
-/// the warp-cooperative find — share this exact shape so they walk
-/// the same sequence and EMPTY-termination remains correct.
-///
-/// Insert protocol (Protocol B, payload-first):
-///   1. Phase 1 — walk the tile ctrl word by ctrl word looking for any
-///      `FULL(h2)` tag whose slot holds our key. On match, slot-CAS
-///      overwrite the value (last-writer-wins) and return.
-///   2. Phase 2 — re-walk the tile looking for any `EMPTY_TAG` byte.
-///      For each one, try the slot CAS `EMPTY_SLOT -> pack(k, v)`.
-///      The slot CAS is the serialization point: concurrent inserts of
-///      the same key see `Err(actual)` with a matching key and
-///      degenerate to the overwrite path; concurrent inserts of
-///      *different* keys see `Err(actual)` with a mismatched key and
-///      skip past.
-///   3. After a successful slot CAS, publish via a ctrl-word CAS retry
-///      loop: `set_tag(current_word, j, FULL(h2))` on the specific
-///      ctrl word containing byte `j`. Other bytes in that word may
-///      have changed concurrently, so the loop re-reads on failure;
-///      byte `j` itself cannot change under us because no other thread
-///      can claim a slot we already own.
-///   4. No FULL(h2) match anywhere in the tile and no EMPTY_TAG to
-///      claim → triangular advance and repeat.
-#[kernel]
-pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
-    let tid = thread::index_1d().get();
-    if tid >= keys.len() {
-        return;
-    }
+#[cuda_module]
+pub mod kernels {
+    use super::*;
 
-    let key = keys[tid];
-    let value = values[tid];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        // Phase 1: walk the entire 32-byte tile, ctrl word by ctrl word,
-        // checking for an already-published FULL(h2) entry holding our key.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        insert_overwrite(slot_atomic, observed, key, value);
-                        return;
-                    }
-                }
-                j += 1;
-            }
-            g += GROUP;
+    /// `insert_kernel` — last-writer-wins, one thread per input key.
+    ///
+    /// Storage:
+    ///   - `ctrl[g]` is the `u32` packing tags for slots `g*GROUP .. g*GROUP+GROUP`.
+    ///   - `slots[s]` is the packed `(key, value)` for slot `s`.
+    ///
+    /// Probe shape: triangular in `PROBE_TILE`-byte tiles. Each step
+    /// examines `PROBE_TILE` consecutive tag bytes (= `PROBE_TILE / GROUP`
+    /// ctrl words) starting at `probe_base`, and advances by `stride *
+    /// PROBE_TILE` (with `stride += 1` per step). All four kernels — and
+    /// the warp-cooperative find — share this exact shape so they walk
+    /// the same sequence and EMPTY-termination remains correct.
+    ///
+    /// Insert protocol (Protocol B, payload-first):
+    ///   1. Phase 1 — walk the tile ctrl word by ctrl word looking for any
+    ///      `FULL(h2)` tag whose slot holds our key. On match, slot-CAS
+    ///      overwrite the value (last-writer-wins) and return.
+    ///   2. Phase 2 — re-walk the tile looking for any `EMPTY_TAG` byte.
+    ///      For each one, try the slot CAS `EMPTY_SLOT -> pack(k, v)`.
+    ///      The slot CAS is the serialization point: concurrent inserts of
+    ///      the same key see `Err(actual)` with a matching key and
+    ///      degenerate to the overwrite path; concurrent inserts of
+    ///      *different* keys see `Err(actual)` with a mismatched key and
+    ///      skip past.
+    ///   3. After a successful slot CAS, publish via a ctrl-word CAS retry
+    ///      loop: `set_tag(current_word, j, FULL(h2))` on the specific
+    ///      ctrl word containing byte `j`. Other bytes in that word may
+    ///      have changed concurrently, so the loop re-reads on failure;
+    ///      byte `j` itself cannot change under us because no other thread
+    ///      can claim a slot we already own.
+    ///   4. No FULL(h2) match anywhere in the tile and no EMPTY_TAG to
+    ///      claim → triangular advance and repeat.
+    #[kernel]
+    pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+        let tid = thread::index_1d().get();
+        if tid >= keys.len() {
+            return;
         }
 
-        // Phase 2: try to claim an EMPTY tag anywhere in this tile.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            // Re-read this word: another thread may have mutated it
-            // between Phase 1 and now.
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == EMPTY_TAG {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    match slot_atomic.compare_exchange(
-                        EMPTY_SLOT,
-                        pack(key, value),
-                        AtomicOrdering::AcqRel,
-                        AtomicOrdering::Relaxed,
-                    ) {
-                        Ok(_) => {
-                            publish_full_tag(ctrl_atomic, word, j, h2);
+        let key = keys[tid];
+        let value = values[tid];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            // Phase 1: walk the entire 32-byte tile, ctrl word by ctrl word,
+            // checking for an already-published FULL(h2) entry holding our key.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                let mut j = 0;
+                while j < GROUP {
+                    if get_tag(word, j) == h2 {
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                        if unpack_key(observed) == key {
+                            insert_overwrite(slot_atomic, observed, key, value);
                             return;
                         }
-                        Err(actual) => {
-                            if unpack_key(actual) == key {
-                                insert_overwrite(slot_atomic, actual, key, value);
-                                return;
-                            }
-                            // Different key already in this slot; skip.
-                        }
                     }
+                    j += 1;
                 }
-                j += 1;
+                g += GROUP;
             }
-            g += GROUP;
-        }
 
-        // No FULL(h2) match and no claimable EMPTY in this tile: advance.
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `try_insert_kernel` — first-writer-wins variant.
-///
-/// Same probe / claim shape as `insert_kernel`, but on duplicate it leaves
-/// the existing slot untouched and writes per-thread output:
-///   `out[tid] = FLAG_FRESH_OR_OK (0)`  -> we claimed a fresh slot
-///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
-#[kernel]
-pub fn try_insert_kernel(
-    ctrl: &[u32],
-    slots: &[u64],
-    keys: &[u32],
-    values: &[u32],
-    mut out: DisjointSlice<u32>,
-) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
-    }
-
-    let key = keys[i_thread];
-    let value = values[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        // Phase 1: published-FULL duplicate detection across the tile.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        if let Some(o) = out.get_mut(tid) {
-                            *o = FLAG_PRESENT;
-                        }
-                        return;
-                    }
-                }
-                j += 1;
-            }
-            g += GROUP;
-        }
-
-        // Phase 2: claim an EMPTY slot.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == EMPTY_TAG {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    match slot_atomic.compare_exchange(
-                        EMPTY_SLOT,
-                        pack(key, value),
-                        AtomicOrdering::AcqRel,
-                        AtomicOrdering::Relaxed,
-                    ) {
-                        Ok(_) => {
-                            publish_full_tag(ctrl_atomic, word, j, h2);
-                            if let Some(o) = out.get_mut(tid) {
-                                *o = FLAG_FRESH_OR_OK;
-                            }
-                            return;
-                        }
-                        Err(actual) => {
-                            if unpack_key(actual) == key {
-                                // Same-key race; some other thread is the
-                                // first-writer. Report PRESENT, leave slot.
-                                if let Some(o) = out.get_mut(tid) {
-                                    *o = FLAG_PRESENT;
-                                }
-                                return;
-                            }
-                        }
-                    }
-                }
-                j += 1;
-            }
-            g += GROUP;
-        }
-
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `insert_kernel_proto_a` — last-writer-wins, Protocol A
-/// (ctrl-first / RESERVED handshake), one thread per input key.
-///
-/// Probe shape is identical to Protocol B (`PROBE_TILE = 32`,
-/// triangular advance). The protocol differs only in how a slot is
-/// claimed:
-///   1. **Phase 1** — walk the tile looking for `FULL(h2)` whose slot
-///      already holds our key; on match, take the same overwrite path
-///      as Protocol B (`insert_overwrite`).
-///   2. **Phase 2 — handshake claim**. For each `EMPTY_TAG` byte in
-///      the tile, attempt a ctrl-word CAS `EMPTY_TAG -> RESERVED_TAG`
-///      at byte `j`. On success: the slot is exclusively ours.
-///   3. **Plain release store** of `pack(k, v)` into the slot — no
-///      slot CAS needed; observers can't peek a RESERVED slot, and no
-///      other insert can claim this byte.
-///   4. **Publish** with a ctrl-word CAS retry loop
-///      `RESERVED_TAG -> FULL(h2)` at byte `j`. Same `publish_full_tag`
-///      helper as Protocol B; byte `j` is owned by us so it cannot
-///      change under the loop.
-///
-/// On a CAS collision in step 2 (someone mutated a different byte of
-/// the same word), re-read the word and re-scan it before moving on.
-///
-/// Duplicate-key races within a single launch: two threads inserting
-/// the same key in the same launch may each win the handshake at
-/// different bytes and publish two slots holding that key. The
-/// resulting state is internally consistent (every find walks the
-/// probe in the same order and returns the first published slot it
-/// hits), but it is NOT single-occurrence. Across kernel launches
-/// the stream-sync release-acquire boundary publishes earlier inserts
-/// before Phase 1 of a later launch reads, so cross-launch dedup is
-/// correct.
-#[kernel]
-pub fn insert_kernel_proto_a(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
-    let tid = thread::index_1d().get();
-    if tid >= keys.len() {
-        return;
-    }
-
-    let key = keys[tid];
-    let value = values[tid];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        // Phase 1: scan the tile for an already-published FULL(h2)
-        // entry whose slot key matches ours. If found, take the
-        // overwrite path. RESERVED bytes naturally fall through here
-        // (top bit set, won't equal h2).
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        insert_overwrite(slot_atomic, observed, key, value);
-                        return;
-                    }
-                }
-                j += 1;
-            }
-            g += GROUP;
-        }
-
-        // Phase 2: walk the tile word by word; for each word, try to
-        // claim the first EMPTY byte via EMPTY_TAG -> RESERVED_TAG CAS.
-        // CAS collisions on a different byte of the same word force a
-        // re-read of that word.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            'word: loop {
+            // Phase 2: try to claim an EMPTY tag anywhere in this tile.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                // Re-read this word: another thread may have mutated it
+                // between Phase 1 and now.
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == EMPTY_TAG {
-                        let claimed = set_tag(word, j, RESERVED_TAG);
-                        match ctrl_atomic.compare_exchange(
-                            word,
-                            claimed,
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        match slot_atomic.compare_exchange(
+                            EMPTY_SLOT,
+                            pack(key, value),
                             AtomicOrdering::AcqRel,
                             AtomicOrdering::Relaxed,
                         ) {
                             Ok(_) => {
-                                // We exclusively own slot (probe_base + g + j).
-                                // Plain release store: no observer can load
-                                // the slot until we publish FULL(h2), and no
-                                // concurrent inserter can race the byte.
-                                let slot_idx = probe_base + g + j;
-                                let slot_atomic = unsafe {
-                                    DeviceAtomicU64::from_ptr(
-                                        slots.as_ptr().add(slot_idx).cast_mut(),
-                                    )
-                                };
-                                slot_atomic.store(pack(key, value), AtomicOrdering::Release);
-                                publish_full_tag(ctrl_atomic, claimed, j, h2);
+                                publish_full_tag(ctrl_atomic, word, j, h2);
                                 return;
                             }
-                            Err(_) => {
-                                continue 'word;
+                            Err(actual) => {
+                                if unpack_key(actual) == key {
+                                    insert_overwrite(slot_atomic, actual, key, value);
+                                    return;
+                                }
+                                // Different key already in this slot; skip.
                             }
                         }
                     }
                     j += 1;
                 }
-                // Word fully scanned, no EMPTY remains. Move on.
-                break 'word;
+                g += GROUP;
             }
-            g += GROUP;
+
+            // No FULL(h2) match and no claimable EMPTY in this tile: advance.
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `try_insert_kernel` — first-writer-wins variant.
+    ///
+    /// Same probe / claim shape as `insert_kernel`, but on duplicate it leaves
+    /// the existing slot untouched and writes per-thread output:
+    ///   `out[tid] = FLAG_FRESH_OR_OK (0)`  -> we claimed a fresh slot
+    ///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
+    #[kernel]
+    pub fn try_insert_kernel(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        values: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
+        let key = keys[i_thread];
+        let value = values[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
 
-/// `try_insert_kernel_proto_a` — first-writer-wins, Protocol A.
-///
-/// Same probe / claim shape as `insert_kernel_proto_a`. Differences:
-///   - On Phase 1 hit (key already published), writes
-///     `FLAG_PRESENT (1)` and returns without touching the slot.
-///   - On successful handshake claim and publish, writes
-///     `FLAG_FRESH_OR_OK (0)`.
-///
-/// Same single-launch duplicate-key caveat as `insert_kernel_proto_a`:
-/// two threads racing on the same key in the same launch may each
-/// publish a slot. The first slot encountered in probe order then
-/// shadows the second; both threads will report `FRESH` (each thinks
-/// it claimed first). Use `insert_kernel` (Protocol B) when strict
-/// single-launch first-writer dedup is required.
-#[kernel]
-pub fn try_insert_kernel_proto_a(
-    ctrl: &[u32],
-    slots: &[u64],
-    keys: &[u32],
-    values: &[u32],
-    mut out: DisjointSlice<u32>,
-) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
-    }
-
-    let key = keys[i_thread];
-    let value = values[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        // Phase 1: published-FULL duplicate detection across the tile.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                if get_tag(word, j) == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        if let Some(o) = out.get_mut(tid) {
-                            *o = FLAG_PRESENT;
+        loop {
+            // Phase 1: published-FULL duplicate detection across the tile.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                let mut j = 0;
+                while j < GROUP {
+                    if get_tag(word, j) == h2 {
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                        if unpack_key(observed) == key {
+                            if let Some(o) = out.get_mut(tid) {
+                                *o = FLAG_PRESENT;
+                            }
+                            return;
                         }
-                        return;
                     }
+                    j += 1;
                 }
-                j += 1;
+                g += GROUP;
             }
-            g += GROUP;
-        }
 
-        // Phase 2: handshake claim with per-word retry.
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            'word: loop {
+            // Phase 2: claim an EMPTY slot.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == EMPTY_TAG {
-                        let claimed = set_tag(word, j, RESERVED_TAG);
-                        match ctrl_atomic.compare_exchange(
-                            word,
-                            claimed,
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        match slot_atomic.compare_exchange(
+                            EMPTY_SLOT,
+                            pack(key, value),
                             AtomicOrdering::AcqRel,
                             AtomicOrdering::Relaxed,
                         ) {
                             Ok(_) => {
-                                let slot_idx = probe_base + g + j;
-                                let slot_atomic = unsafe {
-                                    DeviceAtomicU64::from_ptr(
-                                        slots.as_ptr().add(slot_idx).cast_mut(),
-                                    )
-                                };
-                                slot_atomic.store(pack(key, value), AtomicOrdering::Release);
-                                publish_full_tag(ctrl_atomic, claimed, j, h2);
+                                publish_full_tag(ctrl_atomic, word, j, h2);
                                 if let Some(o) = out.get_mut(tid) {
                                     *o = FLAG_FRESH_OR_OK;
                                 }
                                 return;
                             }
-                            Err(_) => continue 'word,
+                            Err(actual) => {
+                                if unpack_key(actual) == key {
+                                    // Same-key race; some other thread is the
+                                    // first-writer. Report PRESENT, leave slot.
+                                    if let Some(o) = out.get_mut(tid) {
+                                        *o = FLAG_PRESENT;
+                                    }
+                                    return;
+                                }
+                            }
                         }
                     }
                     j += 1;
                 }
-                break 'word;
+                g += GROUP;
             }
-            g += GROUP;
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
         }
-
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `find_kernel` — single-thread find, one thread per key.
-///
-/// Walks the same triangular probe sequence as the insert kernels (same
-/// `PROBE_TILE = 32` width), so EMPTY-termination is sound — see
-/// `find_kernel_warp` below for why probe-width coherence matters.
-///
-/// At each tile (32 consecutive tag bytes):
-///   - For every byte tagged `FULL(h2)` matching our key's fingerprint,
-///     load the slot and key-compare; on match return the value.
-///   - If any byte in the tile is `EMPTY_TAG`, the key cannot live past
-///     this point in its triangular chain (insert would have stopped
-///     at this same EMPTY), so return `MISS`.
-///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
-///     advance and repeat. DELETED never terminates find.
-#[kernel]
-pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
     }
 
-    let key = keys[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        let mut g = 0usize;
-        let mut has_empty = false;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                let tag = get_tag(word, j);
-                if tag == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        if let Some(o) = out.get_mut(tid) {
-                            *o = unpack_value(observed);
-                        }
-                        return;
-                    }
-                } else if tag == EMPTY_TAG {
-                    has_empty = true;
-                }
-                j += 1;
-            }
-            g += GROUP;
-        }
-
-        if has_empty {
-            if let Some(o) = out.get_mut(tid) {
-                *o = MISS;
-            }
+    /// `insert_kernel_proto_a` — last-writer-wins, Protocol A
+    /// (ctrl-first / RESERVED handshake), one thread per input key.
+    ///
+    /// Probe shape is identical to Protocol B (`PROBE_TILE = 32`,
+    /// triangular advance). The protocol differs only in how a slot is
+    /// claimed:
+    ///   1. **Phase 1** — walk the tile looking for `FULL(h2)` whose slot
+    ///      already holds our key; on match, take the same overwrite path
+    ///      as Protocol B (`insert_overwrite`).
+    ///   2. **Phase 2 — handshake claim**. For each `EMPTY_TAG` byte in
+    ///      the tile, attempt a ctrl-word CAS `EMPTY_TAG -> RESERVED_TAG`
+    ///      at byte `j`. On success: the slot is exclusively ours.
+    ///   3. **Plain release store** of `pack(k, v)` into the slot — no
+    ///      slot CAS needed; observers can't peek a RESERVED slot, and no
+    ///      other insert can claim this byte.
+    ///   4. **Publish** with a ctrl-word CAS retry loop
+    ///      `RESERVED_TAG -> FULL(h2)` at byte `j`. Same `publish_full_tag`
+    ///      helper as Protocol B; byte `j` is owned by us so it cannot
+    ///      change under the loop.
+    ///
+    /// On a CAS collision in step 2 (someone mutated a different byte of
+    /// the same word), re-read the word and re-scan it before moving on.
+    ///
+    /// Duplicate-key races within a single launch: two threads inserting
+    /// the same key in the same launch may each win the handshake at
+    /// different bytes and publish two slots holding that key. The
+    /// resulting state is internally consistent (every find walks the
+    /// probe in the same order and returns the first published slot it
+    /// hits), but it is NOT single-occurrence. Across kernel launches
+    /// the stream-sync release-acquire boundary publishes earlier inserts
+    /// before Phase 1 of a later launch reads, so cross-launch dedup is
+    /// correct.
+    #[kernel]
+    pub fn insert_kernel_proto_a(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+        let tid = thread::index_1d().get();
+        if tid >= keys.len() {
             return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
+        let key = keys[tid];
+        let value = values[tid];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
 
-/// `find_kernel_warp` — warp-cooperative find, one warp (32 lanes) per key.
-///
-/// Each probe step pulls 32 tag bytes (= `PROBE_TILE`) into the warp via a
-/// single coalesced ctrl load: lanes 0..3 share `ctrl[probe_base/4 + 0]`,
-/// lanes 4..7 share `+1`, ..., lanes 28..31 share `+7`. Each lane then
-/// extracts its byte and the warp uses ballot/shuffle to:
-///   1. `m_h2 = ballot(tag == h2)` — a 32-bit fingerprint match mask.
-///   2. For each set bit in `m_h2` (lowest first), the matching lane
-///      loads its slot, broadcasts the packed `(key, value)` via two
-///      `shuffle`s (one per `u32` half), and all lanes key-compare.
-///      On hit, lane 0 writes `out[warp_idx] = value` and the warp returns.
-///   3. `m_empty = ballot(tag == EMPTY_TAG)` — if non-zero, the key
-///      cannot live past an EMPTY in this hash chain; lane 0 writes MISS.
-///   4. Otherwise, triangular advance `probe_base` by `stride * PROBE_TILE`
-///      and repeat.
-///
-/// Launch with `blockDim.x` a multiple of 32; the host driver does
-/// `LaunchConfig::for_num_elems(keys.len() * 32)` so each warp receives
-/// exactly one key. DELETED tags are skipped (they don't terminate the
-/// probe), same as the single-thread `find_kernel`.
-#[kernel]
-pub fn find_kernel_warp(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let lane = warp::lane_id();
-    let global_tid = thread::index_1d().get();
-    let warp_idx = global_tid / PROBE_TILE;
-    if warp_idx >= keys.len() {
-        return;
-    }
-
-    let key = keys[warp_idx];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        // Each lane owns exactly one tag byte at (probe_base + lane).
-        let tag_pos = probe_base + (lane as usize);
-        let ctrl_word_idx = tag_pos / GROUP;
-        let byte_in_word = tag_pos % GROUP;
-        let word = unsafe {
-            DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                .load(AtomicOrdering::Acquire)
-        };
-        let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
-
-        let mut m_h2 = warp::ballot(tag == h2);
-        let m_empty = warp::ballot(tag == EMPTY_TAG);
-
-        // Walk h2 candidates lowest-bit-first.
-        while m_h2 != 0 {
-            let cand = m_h2.trailing_zeros();
-            // Only the candidate lane materializes the slot; others feed
-            // a dummy value into shuffle. The shuffle's source is `cand`
-            // so all lanes converge on the candidate's slot value.
-            let local_slot: u64 = if lane == cand {
-                let slot_idx = probe_base + (cand as usize);
-                unsafe {
-                    DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        .load(AtomicOrdering::Acquire)
-                }
-            } else {
-                0
-            };
-            // cuda-oxide's warp::shuffle is u32-only, so broadcast the
-            // packed slot in two halves and reassemble.
-            let lo = warp::shuffle(local_slot as u32, cand);
-            let hi = warp::shuffle((local_slot >> 32) as u32, cand);
-            let observed: u64 = ((hi as u64) << 32) | (lo as u64);
-
-            if unpack_key(observed) == key {
-                if lane == 0 {
-                    // SAFETY: warp_idx < keys.len() == out.len(), and
-                    // each warp has a unique warp_idx so writes by lane
-                    // 0 across warps are disjoint.
-                    unsafe {
-                        *out.get_unchecked_mut(warp_idx) = unpack_value(observed);
-                    }
-                }
-                return;
-            }
-            m_h2 &= m_h2 - 1;
-        }
-
-        if m_empty != 0 {
-            if lane == 0 {
-                // SAFETY: same uniqueness argument as above.
-                unsafe {
-                    *out.get_unchecked_mut(warp_idx) = MISS;
-                }
-            }
-            return;
-        }
-
-        // Triangular advance in tile units. Both operands are
-        // PROBE_TILE-aligned, so the sum stays aligned and `& mask`
-        // keeps it in [0, N).
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `find_kernel_warp_typed` — `find_kernel_warp` rewritten on the typed
-/// cooperative-groups API.
-///
-/// Identical algorithm to `find_kernel_warp`; the only differences are:
-///
-/// - `warp::lane_id()`               -> `tile.thread_rank()`
-/// - `warp::ballot(p)`               -> `tile.ballot(p)`
-/// - `warp::shuffle(v, src)`         -> `tile.shfl(v, src)`
-///
-/// where `tile = this_thread_block().tiled_partition::<32>()`.
-///
-/// The emitted *instruction* under each typed call is byte-identical
-/// to the raw form (one `vote.sync.ballot.b32` or one
-/// `shfl.sync.idx.b32`), but at the time of writing each typed
-/// wrapper is large enough to clear rustc's MIR `Inline` cost
-/// threshold and ends up as its own `.visible .func`. The four typed
-/// sites in the inner probe loop (`tile.ballot ×2`, `tile.shfl ×2`)
-/// therefore add four `call.uni` round-trips per probe step, which
-/// the bench binary measures at ~12–17 % runtime overhead vs the
-/// raw kernel.
-#[kernel]
-pub fn find_kernel_warp_typed(
-    ctrl: &[u32],
-    slots: &[u64],
-    keys: &[u32],
-    mut out: DisjointSlice<u32>,
-) {
-    let block = this_thread_block();
-    let tile = block.tiled_partition::<32>();
-
-    let lane = tile.thread_rank();
-    let global_tid = thread::index_1d().get();
-    let warp_idx = global_tid / PROBE_TILE;
-    if warp_idx >= keys.len() {
-        return;
-    }
-
-    let key = keys[warp_idx];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        let tag_pos = probe_base + (lane as usize);
-        let ctrl_word_idx = tag_pos / GROUP;
-        let byte_in_word = tag_pos % GROUP;
-        let word = unsafe {
-            DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                .load(AtomicOrdering::Acquire)
-        };
-        let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
-
-        let mut m_h2 = tile.ballot(tag == h2);
-        let m_empty = tile.ballot(tag == EMPTY_TAG);
-
-        while m_h2 != 0 {
-            let cand = m_h2.trailing_zeros();
-            let local_slot: u64 = if lane == cand {
-                let slot_idx = probe_base + (cand as usize);
-                unsafe {
-                    DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        .load(AtomicOrdering::Acquire)
-                }
-            } else {
-                0
-            };
-            let lo = tile.shfl(local_slot as u32, cand);
-            let hi = tile.shfl((local_slot >> 32) as u32, cand);
-            let observed: u64 = ((hi as u64) << 32) | (lo as u64);
-
-            if unpack_key(observed) == key {
-                if lane == 0 {
-                    // SAFETY: warp_idx < keys.len() == out.len(), and
-                    // each warp has a unique warp_idx so writes by lane
-                    // 0 across warps are disjoint.
-                    unsafe {
-                        *out.get_unchecked_mut(warp_idx) = unpack_value(observed);
-                    }
-                }
-                return;
-            }
-            m_h2 &= m_h2 - 1;
-        }
-
-        if m_empty != 0 {
-            if lane == 0 {
-                // SAFETY: same uniqueness argument as above.
-                unsafe {
-                    *out.get_unchecked_mut(warp_idx) = MISS;
-                }
-            }
-            return;
-        }
-
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `delete_kernel` — tombstone the slot for each input key.
-///
-/// One thread per key. Probes the same `PROBE_TILE`-wide triangular
-/// sequence as insert and find. When it locates the key it CAS-flips
-/// the byte in the containing ctrl word from `FULL(h2)` to
-/// `DELETED_TAG`. The `(key, value)` payload is **not** cleared:
-/// readers only ever materialize slots whose tag is `FULL(h2)`, so a
-/// stale slot under a `DELETED` tag is unreachable.
-///
-/// The CAS targets the specific ctrl word containing the matching tag
-/// byte (not "the group's word" — there are now `PROBE_TILE / GROUP`
-/// ctrl words per tile). On CAS failure (some other thread mutated
-/// this word), the inner loop re-reads and re-scans this word before
-/// moving on to the next word in the tile.
-///
-/// Output:
-///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
-///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
-#[kernel]
-pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
-    }
-
-    let key = keys[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    'tile: loop {
-        let mut has_empty = false;
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-
-            // Per-word retry loop: if our CAS to flip a tag to DELETED
-            // fails because someone else mutated this same word, re-read
-            // and re-scan this word.
-            loop {
+        loop {
+            // Phase 1: scan the tile for an already-published FULL(h2)
+            // entry whose slot key matches ours. If found, take the
+            // overwrite path. RESERVED bytes naturally fall through here
+            // (top bit set, won't equal h2).
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
-                let mut cas_collided = false;
+                while j < GROUP {
+                    if get_tag(word, j) == h2 {
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                        if unpack_key(observed) == key {
+                            insert_overwrite(slot_atomic, observed, key, value);
+                            return;
+                        }
+                    }
+                    j += 1;
+                }
+                g += GROUP;
+            }
+
+            // Phase 2: walk the tile word by word; for each word, try to
+            // claim the first EMPTY byte via EMPTY_TAG -> RESERVED_TAG CAS.
+            // CAS collisions on a different byte of the same word force a
+            // re-read of that word.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                'word: loop {
+                    let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                    let mut j = 0;
+                    while j < GROUP {
+                        if get_tag(word, j) == EMPTY_TAG {
+                            let claimed = set_tag(word, j, RESERVED_TAG);
+                            match ctrl_atomic.compare_exchange(
+                                word,
+                                claimed,
+                                AtomicOrdering::AcqRel,
+                                AtomicOrdering::Relaxed,
+                            ) {
+                                Ok(_) => {
+                                    // We exclusively own slot (probe_base + g + j).
+                                    // Plain release store: no observer can load
+                                    // the slot until we publish FULL(h2), and no
+                                    // concurrent inserter can race the byte.
+                                    let slot_idx = probe_base + g + j;
+                                    let slot_atomic = unsafe {
+                                        DeviceAtomicU64::from_ptr(
+                                            slots.as_ptr().add(slot_idx).cast_mut(),
+                                        )
+                                    };
+                                    slot_atomic.store(pack(key, value), AtomicOrdering::Release);
+                                    publish_full_tag(ctrl_atomic, claimed, j, h2);
+                                    return;
+                                }
+                                Err(_) => {
+                                    continue 'word;
+                                }
+                            }
+                        }
+                        j += 1;
+                    }
+                    // Word fully scanned, no EMPTY remains. Move on.
+                    break 'word;
+                }
+                g += GROUP;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `try_insert_kernel_proto_a` — first-writer-wins, Protocol A.
+    ///
+    /// Same probe / claim shape as `insert_kernel_proto_a`. Differences:
+    ///   - On Phase 1 hit (key already published), writes
+    ///     `FLAG_PRESENT (1)` and returns without touching the slot.
+    ///   - On successful handshake claim and publish, writes
+    ///     `FLAG_FRESH_OR_OK (0)`.
+    ///
+    /// Same single-launch duplicate-key caveat as `insert_kernel_proto_a`:
+    /// two threads racing on the same key in the same launch may each
+    /// publish a slot. The first slot encountered in probe order then
+    /// shadows the second; both threads will report `FRESH` (each thinks
+    /// it claimed first). Use `insert_kernel` (Protocol B) when strict
+    /// single-launch first-writer dedup is required.
+    #[kernel]
+    pub fn try_insert_kernel_proto_a(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        values: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
+        }
+
+        let key = keys[i_thread];
+        let value = values[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            // Phase 1: published-FULL duplicate detection across the tile.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                let mut j = 0;
+                while j < GROUP {
+                    if get_tag(word, j) == h2 {
+                        let slot_idx = probe_base + g + j;
+                        let slot_atomic = unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                        };
+                        let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                        if unpack_key(observed) == key {
+                            if let Some(o) = out.get_mut(tid) {
+                                *o = FLAG_PRESENT;
+                            }
+                            return;
+                        }
+                    }
+                    j += 1;
+                }
+                g += GROUP;
+            }
+
+            // Phase 2: handshake claim with per-word retry.
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                'word: loop {
+                    let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                    let mut j = 0;
+                    while j < GROUP {
+                        if get_tag(word, j) == EMPTY_TAG {
+                            let claimed = set_tag(word, j, RESERVED_TAG);
+                            match ctrl_atomic.compare_exchange(
+                                word,
+                                claimed,
+                                AtomicOrdering::AcqRel,
+                                AtomicOrdering::Relaxed,
+                            ) {
+                                Ok(_) => {
+                                    let slot_idx = probe_base + g + j;
+                                    let slot_atomic = unsafe {
+                                        DeviceAtomicU64::from_ptr(
+                                            slots.as_ptr().add(slot_idx).cast_mut(),
+                                        )
+                                    };
+                                    slot_atomic.store(pack(key, value), AtomicOrdering::Release);
+                                    publish_full_tag(ctrl_atomic, claimed, j, h2);
+                                    if let Some(o) = out.get_mut(tid) {
+                                        *o = FLAG_FRESH_OR_OK;
+                                    }
+                                    return;
+                                }
+                                Err(_) => continue 'word,
+                            }
+                        }
+                        j += 1;
+                    }
+                    break 'word;
+                }
+                g += GROUP;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `find_kernel` — single-thread find, one thread per key.
+    ///
+    /// Walks the same triangular probe sequence as the insert kernels (same
+    /// `PROBE_TILE = 32` width), so EMPTY-termination is sound — see
+    /// `find_kernel_warp` below for why probe-width coherence matters.
+    ///
+    /// At each tile (32 consecutive tag bytes):
+    ///   - For every byte tagged `FULL(h2)` matching our key's fingerprint,
+    ///     load the slot and key-compare; on match return the value.
+    ///   - If any byte in the tile is `EMPTY_TAG`, the key cannot live past
+    ///     this point in its triangular chain (insert would have stopped
+    ///     at this same EMPTY), so return `MISS`.
+    ///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
+    ///     advance and repeat. DELETED never terminates find.
+    #[kernel]
+    pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
+        }
+
+        let key = keys[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            let mut g = 0usize;
+            let mut has_empty = false;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+                let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                let mut j = 0;
                 while j < GROUP {
                     let tag = get_tag(word, j);
                     if tag == h2 {
@@ -1014,48 +740,342 @@ pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: Disjoin
                         };
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
-                            let new_word = set_tag(word, j, DELETED_TAG);
-                            match ctrl_atomic.compare_exchange(
-                                word,
-                                new_word,
-                                AtomicOrdering::AcqRel,
-                                AtomicOrdering::Relaxed,
-                            ) {
-                                Ok(_) => {
-                                    if let Some(o) = out.get_mut(tid) {
-                                        *o = FLAG_FRESH_OR_OK;
-                                    }
-                                    return;
-                                }
-                                Err(_) => {
-                                    cas_collided = true;
-                                    break;
-                                }
+                            if let Some(o) = out.get_mut(tid) {
+                                *o = unpack_value(observed);
                             }
+                            return;
                         }
                     } else if tag == EMPTY_TAG {
                         has_empty = true;
                     }
                     j += 1;
                 }
-                if !cas_collided {
-                    break; // word fully scanned; move to next word in the tile
-                }
-                // else: retry this same word with a freshly-loaded view.
+                g += GROUP;
             }
-            g += GROUP;
-        }
 
-        if has_empty {
-            if let Some(o) = out.get_mut(tid) {
-                *o = FLAG_PRESENT;
+            if has_empty {
+                if let Some(o) = out.get_mut(tid) {
+                    *o = MISS;
+                }
+                return;
             }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `find_kernel_warp` — warp-cooperative find, one warp (32 lanes) per key.
+    ///
+    /// Each probe step pulls 32 tag bytes (= `PROBE_TILE`) into the warp via a
+    /// single coalesced ctrl load: lanes 0..3 share `ctrl[probe_base/4 + 0]`,
+    /// lanes 4..7 share `+1`, ..., lanes 28..31 share `+7`. Each lane then
+    /// extracts its byte and the warp uses ballot/shuffle to:
+    ///   1. `m_h2 = ballot(tag == h2)` — a 32-bit fingerprint match mask.
+    ///   2. For each set bit in `m_h2` (lowest first), the matching lane
+    ///      loads its slot, broadcasts the packed `(key, value)` via two
+    ///      `shuffle`s (one per `u32` half), and all lanes key-compare.
+    ///      On hit, lane 0 writes `out[warp_idx] = value` and the warp returns.
+    ///   3. `m_empty = ballot(tag == EMPTY_TAG)` — if non-zero, the key
+    ///      cannot live past an EMPTY in this hash chain; lane 0 writes MISS.
+    ///   4. Otherwise, triangular advance `probe_base` by `stride * PROBE_TILE`
+    ///      and repeat.
+    ///
+    /// Launch with `blockDim.x` a multiple of 32; the host driver does
+    /// `LaunchConfig::for_num_elems(keys.len() * 32)` so each warp receives
+    /// exactly one key. DELETED tags are skipped (they don't terminate the
+    /// probe), same as the single-thread `find_kernel`.
+    #[kernel]
+    pub fn find_kernel_warp(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let lane = warp::lane_id();
+        let global_tid = thread::index_1d().get();
+        let warp_idx = global_tid / PROBE_TILE;
+        if warp_idx >= keys.len() {
             return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-        continue 'tile;
+        let key = keys[warp_idx];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            // Each lane owns exactly one tag byte at (probe_base + lane).
+            let tag_pos = probe_base + (lane as usize);
+            let ctrl_word_idx = tag_pos / GROUP;
+            let byte_in_word = tag_pos % GROUP;
+            let word = unsafe {
+                DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                    .load(AtomicOrdering::Acquire)
+            };
+            let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
+
+            let mut m_h2 = warp::ballot(tag == h2);
+            let m_empty = warp::ballot(tag == EMPTY_TAG);
+
+            // Walk h2 candidates lowest-bit-first.
+            while m_h2 != 0 {
+                let cand = m_h2.trailing_zeros();
+                // Only the candidate lane materializes the slot; others feed
+                // a dummy value into shuffle. The shuffle's source is `cand`
+                // so all lanes converge on the candidate's slot value.
+                let local_slot: u64 = if lane == cand {
+                    let slot_idx = probe_base + (cand as usize);
+                    unsafe {
+                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                            .load(AtomicOrdering::Acquire)
+                    }
+                } else {
+                    0
+                };
+                // cuda-oxide's warp::shuffle is u32-only, so broadcast the
+                // packed slot in two halves and reassemble.
+                let lo = warp::shuffle(local_slot as u32, cand);
+                let hi = warp::shuffle((local_slot >> 32) as u32, cand);
+                let observed: u64 = ((hi as u64) << 32) | (lo as u64);
+
+                if unpack_key(observed) == key {
+                    if lane == 0 {
+                        // SAFETY: warp_idx < keys.len() == out.len(), and
+                        // each warp has a unique warp_idx so writes by lane
+                        // 0 across warps are disjoint.
+                        unsafe {
+                            *out.get_unchecked_mut(warp_idx) = unpack_value(observed);
+                        }
+                    }
+                    return;
+                }
+                m_h2 &= m_h2 - 1;
+            }
+
+            if m_empty != 0 {
+                if lane == 0 {
+                    // SAFETY: same uniqueness argument as above.
+                    unsafe {
+                        *out.get_unchecked_mut(warp_idx) = MISS;
+                    }
+                }
+                return;
+            }
+
+            // Triangular advance in tile units. Both operands are
+            // PROBE_TILE-aligned, so the sum stays aligned and `& mask`
+            // keeps it in [0, N).
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `find_kernel_warp_typed` — `find_kernel_warp` rewritten on the typed
+    /// cooperative-groups API.
+    ///
+    /// Identical algorithm to `find_kernel_warp`; the only differences are:
+    ///
+    /// - `warp::lane_id()`               -> `tile.thread_rank()`
+    /// - `warp::ballot(p)`               -> `tile.ballot(p)`
+    /// - `warp::shuffle(v, src)`         -> `tile.shfl(v, src)`
+    ///
+    /// where `tile = this_thread_block().tiled_partition::<32>()`.
+    ///
+    /// The emitted *instruction* under each typed call is byte-identical
+    /// to the raw form (one `vote.sync.ballot.b32` or one
+    /// `shfl.sync.idx.b32`), but at the time of writing each typed
+    /// wrapper is large enough to clear rustc's MIR `Inline` cost
+    /// threshold and ends up as its own `.visible .func`. The four typed
+    /// sites in the inner probe loop (`tile.ballot ×2`, `tile.shfl ×2`)
+    /// therefore add four `call.uni` round-trips per probe step, which
+    /// the bench binary measures at ~12–17 % runtime overhead vs the
+    /// raw kernel.
+    #[kernel]
+    pub fn find_kernel_warp_typed(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let block = this_thread_block();
+        let tile = block.tiled_partition::<32>();
+
+        let lane = tile.thread_rank();
+        let global_tid = thread::index_1d().get();
+        let warp_idx = global_tid / PROBE_TILE;
+        if warp_idx >= keys.len() {
+            return;
+        }
+
+        let key = keys[warp_idx];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            let tag_pos = probe_base + (lane as usize);
+            let ctrl_word_idx = tag_pos / GROUP;
+            let byte_in_word = tag_pos % GROUP;
+            let word = unsafe {
+                DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                    .load(AtomicOrdering::Acquire)
+            };
+            let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
+
+            let mut m_h2 = tile.ballot(tag == h2);
+            let m_empty = tile.ballot(tag == EMPTY_TAG);
+
+            while m_h2 != 0 {
+                let cand = m_h2.trailing_zeros();
+                let local_slot: u64 = if lane == cand {
+                    let slot_idx = probe_base + (cand as usize);
+                    unsafe {
+                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                            .load(AtomicOrdering::Acquire)
+                    }
+                } else {
+                    0
+                };
+                let lo = tile.shfl(local_slot as u32, cand);
+                let hi = tile.shfl((local_slot >> 32) as u32, cand);
+                let observed: u64 = ((hi as u64) << 32) | (lo as u64);
+
+                if unpack_key(observed) == key {
+                    if lane == 0 {
+                        // SAFETY: warp_idx < keys.len() == out.len(), and
+                        // each warp has a unique warp_idx so writes by lane
+                        // 0 across warps are disjoint.
+                        unsafe {
+                            *out.get_unchecked_mut(warp_idx) = unpack_value(observed);
+                        }
+                    }
+                    return;
+                }
+                m_h2 &= m_h2 - 1;
+            }
+
+            if m_empty != 0 {
+                if lane == 0 {
+                    // SAFETY: same uniqueness argument as above.
+                    unsafe {
+                        *out.get_unchecked_mut(warp_idx) = MISS;
+                    }
+                }
+                return;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `delete_kernel` — tombstone the slot for each input key.
+    ///
+    /// One thread per key. Probes the same `PROBE_TILE`-wide triangular
+    /// sequence as insert and find. When it locates the key it CAS-flips
+    /// the byte in the containing ctrl word from `FULL(h2)` to
+    /// `DELETED_TAG`. The `(key, value)` payload is **not** cleared:
+    /// readers only ever materialize slots whose tag is `FULL(h2)`, so a
+    /// stale slot under a `DELETED` tag is unreachable.
+    ///
+    /// The CAS targets the specific ctrl word containing the matching tag
+    /// byte (not "the group's word" — there are now `PROBE_TILE / GROUP`
+    /// ctrl words per tile). On CAS failure (some other thread mutated
+    /// this word), the inner loop re-reads and re-scans this word before
+    /// moving on to the next word in the tile.
+    ///
+    /// Output:
+    ///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
+    ///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
+    #[kernel]
+    pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
+        }
+
+        let key = keys[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        'tile: loop {
+            let mut has_empty = false;
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+
+                // Per-word retry loop: if our CAS to flip a tag to DELETED
+                // fails because someone else mutated this same word, re-read
+                // and re-scan this word.
+                loop {
+                    let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                    let mut j = 0;
+                    let mut cas_collided = false;
+                    while j < GROUP {
+                        let tag = get_tag(word, j);
+                        if tag == h2 {
+                            let slot_idx = probe_base + g + j;
+                            let slot_atomic = unsafe {
+                                DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                            };
+                            let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                            if unpack_key(observed) == key {
+                                let new_word = set_tag(word, j, DELETED_TAG);
+                                match ctrl_atomic.compare_exchange(
+                                    word,
+                                    new_word,
+                                    AtomicOrdering::AcqRel,
+                                    AtomicOrdering::Relaxed,
+                                ) {
+                                    Ok(_) => {
+                                        if let Some(o) = out.get_mut(tid) {
+                                            *o = FLAG_FRESH_OR_OK;
+                                        }
+                                        return;
+                                    }
+                                    Err(_) => {
+                                        cas_collided = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        } else if tag == EMPTY_TAG {
+                            has_empty = true;
+                        }
+                        j += 1;
+                    }
+                    if !cas_collided {
+                        break; // word fully scanned; move to next word in the tile
+                    }
+                    // else: retry this same word with a freshly-loaded view.
+                }
+                g += GROUP;
+            }
+
+            if has_empty {
+                if let Some(o) = out.get_mut(tid) {
+                    *o = FLAG_PRESENT;
+                }
+                return;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+            continue 'tile;
+        }
     }
 }
 
@@ -1184,7 +1204,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1200,13 +1220,7 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
 
         Ok(())
     }
@@ -1219,7 +1233,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1236,13 +1250,15 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: try_insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev), slice_mut(out_dev)]
-        }?;
+        module.try_insert_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &values_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1257,7 +1273,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1273,13 +1289,14 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: insert_kernel_proto_a,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel_proto_a(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &values_dev,
+        )?;
 
         Ok(())
     }
@@ -1291,7 +1308,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1308,13 +1325,15 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: try_insert_kernel_proto_a,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev), slice_mut(out_dev)]
-        }?;
+        module.try_insert_kernel_proto_a(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &values_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1325,7 +1344,7 @@ impl GpuSwissMap {
     pub fn find_bulk(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1336,13 +1355,14 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: find_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1356,7 +1376,7 @@ impl GpuSwissMap {
     pub fn find_bulk_warp(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1374,13 +1394,14 @@ impl GpuSwissMap {
         // 256 means 8 warps per block, 8 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(PROBE_TILE as u32);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        cuda_launch! {
-            kernel: find_kernel_warp,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel_warp(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1391,7 +1412,7 @@ impl GpuSwissMap {
     pub fn delete_bulk(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1402,13 +1423,14 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: delete_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.delete_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let module = ctx
         .load_module_from_file("hashmap_v2.ptx")
         .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
@@ -41,8 +41,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use cuda_core::{CudaContext, CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
-use cuda_host::cuda_launch;
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig};
 use hashbrown::HashMap as HbMap;
 use hashmap_v3::*;
 use rayon::prelude::*;
@@ -267,7 +266,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module: Arc<CudaModule> = ctx.load_module_from_file("hashmap_v3.ptx")?;
+    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v3.ptx")?)?;
 
     print_environment_banner(&ctx)?;
 
@@ -325,13 +324,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = LaunchConfig::for_num_elems(n_keys as u32);
         row_b_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             })?;
 
@@ -341,25 +334,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // to collapse. Should be within a few percent of `insert_kernel`.
         row_b_insert_dedup[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel_dedup,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             })?;
 
         // ---- Build a fresh map for the find benches ---------------------
         unsafe { reset_table_async(&map, &stream)? };
-        cuda_launch! {
-            kernel: insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(map.ctrl), slice(map.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)?;
         stream.synchronize()?;
 
         let cfg_tile_32 = LaunchConfig::for_num_elems((n_keys * 32) as u32);
@@ -368,39 +349,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // ---- GPU LOOKUP (hits) — single-thread --------------------------
         row_single_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — tile_32 (full-warp, 1 query/warp) ------
         row_tile_32_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_tile_32,
-                    stream: stream,
-                    module: module,
-                    config: cfg_tile_32,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — tile_16 (sub-warp, 2 queries/warp) -----
         row_tile_16_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_tile_16,
-                    stream: stream,
-                    module: module,
-                    config: cfg_tile_16,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             })?;
 
@@ -412,13 +375,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;
@@ -431,13 +388,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_tile_32,
-                    stream: stream,
-                    module: module,
-                    config: cfg_tile_32,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;
@@ -450,13 +401,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                cuda_launch! {
-                    kernel: find_kernel_tile_16,
-                    stream: stream,
-                    module: module,
-                    config: cfg_tile_16,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice_mut(*o)]
-                }?;
+                module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)?;
                 Ok(())
             },
         )?;
@@ -598,13 +543,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             DEDUP_INPUT,
             &stream,
             |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             },
         )?;
@@ -616,13 +555,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             DEDUP_INPUT,
             &stream,
             |m, k, v| {
-                cuda_launch! {
-                    kernel: insert_kernel_dedup,
-                    stream: stream,
-                    module: module,
-                    config: cfg,
-                    args: [slice(m.ctrl), slice(m.slots), slice(*k), slice(*v)]
-                }?;
+                module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
                 Ok(())
             },
         )?;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
@@ -57,11 +57,11 @@
 
 use std::sync::Arc;
 
-use cuda_core::{CudaModule, CudaStream, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaStream, DeviceBuffer, LaunchConfig};
 use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU32, DeviceAtomicU64};
 use cuda_device::cooperative_groups::{ThreadGroup, WarpCollective, this_thread_block};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
 // =============================================================================
 // SHARED CONSTANTS AND HELPERS (compiled both host- and device-side)
@@ -219,420 +219,190 @@ pub fn unpack_value(slot: u64) -> u32 {
 // KERNELS
 // =============================================================================
 
-/// `insert_kernel` — last-writer-wins, one thread per input key.
-///
-/// Storage:
-///   - `ctrl[g]` is the `u32` packing tags for slots `g*GROUP .. g*GROUP+GROUP`.
-///   - `slots[s]` is the packed `(key, value)` for slot `s`.
-///
-/// Thin wrapper around [`insert_into_table_core`]: bounds-check the
-/// thread, look up its `(key, value)`, and dispatch with
-/// `overwrite = true` (existing values for the same key are replaced
-/// last-writer-wins). Probe and reclaim mechanics live in the helper.
-#[kernel]
-pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
-    let tid = thread::index_1d().get();
-    if tid >= keys.len() {
-        return;
-    }
-    let _ = insert_into_table_core(ctrl, slots, keys[tid], values[tid], true);
-}
+#[cuda_module]
+pub mod kernels {
+    use super::*;
 
-/// `try_insert_kernel` — first-writer-wins variant.
-///
-/// Same probe / claim mechanics as [`insert_kernel`] (delegates to
-/// [`insert_into_table_core`] with `overwrite = false`), but writes
-/// per-thread output reflecting whether the slot was fresh:
-///   `out[tid] = FLAG_FRESH_OR_OK (0)`  -> we claimed a fresh slot
-///                                         (or reclaimed a `DELETED` one)
-///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
-#[kernel]
-pub fn try_insert_kernel(
-    ctrl: &[u32],
-    slots: &[u64],
-    keys: &[u32],
-    values: &[u32],
-    mut out: DisjointSlice<u32>,
-) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
+    /// `insert_kernel` — last-writer-wins, one thread per input key.
+    ///
+    /// Storage:
+    ///   - `ctrl[g]` is the `u32` packing tags for slots `g*GROUP .. g*GROUP+GROUP`.
+    ///   - `slots[s]` is the packed `(key, value)` for slot `s`.
+    ///
+    /// Thin wrapper around [`insert_into_table_core`]: bounds-check the
+    /// thread, look up its `(key, value)`, and dispatch with
+    /// `overwrite = true` (existing values for the same key are replaced
+    /// last-writer-wins). Probe and reclaim mechanics live in the helper.
+    #[kernel]
+    pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+        let tid = thread::index_1d().get();
+        if tid >= keys.len() {
+            return;
+        }
+        let _ = insert_into_table_core(ctrl, slots, keys[tid], values[tid], true);
     }
-    let fresh = insert_into_table_core(ctrl, slots, keys[i_thread], values[i_thread], false);
-    if let Some(o) = out.get_mut(tid) {
-        *o = if fresh {
-            FLAG_FRESH_OR_OK
+
+    /// `try_insert_kernel` — first-writer-wins variant.
+    ///
+    /// Same probe / claim mechanics as [`insert_kernel`] (delegates to
+    /// [`insert_into_table_core`] with `overwrite = false`), but writes
+    /// per-thread output reflecting whether the slot was fresh:
+    ///   `out[tid] = FLAG_FRESH_OR_OK (0)`  -> we claimed a fresh slot
+    ///                                         (or reclaimed a `DELETED` one)
+    ///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
+    #[kernel]
+    pub fn try_insert_kernel(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        values: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
+        }
+        let fresh = insert_into_table_core(ctrl, slots, keys[i_thread], values[i_thread], false);
+        if let Some(o) = out.get_mut(tid) {
+            *o = if fresh {
+                FLAG_FRESH_OR_OK
+            } else {
+                FLAG_PRESENT
+            };
+        }
+    }
+
+    /// `insert_kernel_dedup` — bulk insert with intra-warp duplicate
+    /// detection via `tile.match_any(my_key)`.
+    ///
+    /// One thread per input. Each warp tile partitions its 32 lanes into
+    /// duplicate-groups (by key) using `match_any`; only the highest-rank
+    /// lane in each group performs the global insert via
+    /// [`insert_into_table_core`]. Other lanes in the group drop their
+    /// duplicate insert silently. Cross-warp duplicates still race on the
+    /// global path and are arbitrated by the slot CAS plus the Phase 2
+    /// `FULL(h2)+key` re-check.
+    ///
+    /// Picking the highest-rank lane per group gives "last-writer-wins
+    /// within a warp" (the highest-rank lane has the largest input index
+    /// in that warp, so its value is the most-recent for the warp).
+    #[kernel]
+    pub fn insert_kernel_dedup(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+        let block = this_thread_block();
+        let tile = block.tiled_partition::<32>();
+        let lane = tile.thread_rank();
+        let global_tid = thread::index_1d().get();
+
+        // Tail lanes (past keys.len()) must still participate in `match_any`
+        // — `WarpCollective::match_any` is a sync collective and requires
+        // all lanes in the tile to call it. Inactive lanes contribute the
+        // sentinel `FORBIDDEN_KEY` (= `u32::MAX`), which user keys are
+        // forbidden from using, so they form their own dup group disjoint
+        // from any active key.
+        let active = global_tid < keys.len();
+        let key = if active {
+            keys[global_tid]
         } else {
-            FLAG_PRESENT
+            FORBIDDEN_KEY
         };
-    }
-}
+        let value = if active { values[global_tid] } else { 0 };
 
-/// `insert_kernel_dedup` — bulk insert with intra-warp duplicate
-/// detection via `tile.match_any(my_key)`.
-///
-/// One thread per input. Each warp tile partitions its 32 lanes into
-/// duplicate-groups (by key) using `match_any`; only the highest-rank
-/// lane in each group performs the global insert via
-/// [`insert_into_table_core`]. Other lanes in the group drop their
-/// duplicate insert silently. Cross-warp duplicates still race on the
-/// global path and are arbitrated by the slot CAS plus the Phase 2
-/// `FULL(h2)+key` re-check.
-///
-/// Picking the highest-rank lane per group gives "last-writer-wins
-/// within a warp" (the highest-rank lane has the largest input index
-/// in that warp, so its value is the most-recent for the warp).
-#[kernel]
-pub fn insert_kernel_dedup(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
-    let block = this_thread_block();
-    let tile = block.tiled_partition::<32>();
-    let lane = tile.thread_rank();
-    let global_tid = thread::index_1d().get();
+        let dup_mask = tile.match_any(key);
 
-    // Tail lanes (past keys.len()) must still participate in `match_any`
-    // — `WarpCollective::match_any` is a sync collective and requires
-    // all lanes in the tile to call it. Inactive lanes contribute the
-    // sentinel `FORBIDDEN_KEY` (= `u32::MAX`), which user keys are
-    // forbidden from using, so they form their own dup group disjoint
-    // from any active key.
-    let active = global_tid < keys.len();
-    let key = if active {
-        keys[global_tid]
-    } else {
-        FORBIDDEN_KEY
-    };
-    let value = if active { values[global_tid] } else { 0 };
-
-    let dup_mask = tile.match_any(key);
-
-    if !active {
-        return;
-    }
-
-    // Highest set bit in the dup mask is the in-warp leader for this
-    // duplicate group. All lanes in the group agree on the same
-    // leader because they all see the same dup_mask.
-    let leader = 31u32 - dup_mask.leading_zeros();
-    if lane == leader {
-        let _ = insert_into_table_core(ctrl, slots, key, value, true);
-    }
-}
-
-/// `rehash_kernel` — single-kernel two-buffer rehash.
-///
-/// v3 ships the two-buffer mode only (`old != new`); the new buffer
-/// is `memset`-cleared by the host before launch, and the old buffer
-/// remains read-only for the duration of the kernel. That means no
-/// grid-wide barrier is required: each thread can read a live old
-/// slot and immediately insert it into the new table. Threads stride
-/// across the old table so the host can bound the launch size without
-/// depending on cooperative-launch residency limits.
-#[kernel]
-pub fn rehash_kernel(old_ctrl: &[u32], old_slots: &[u64], new_ctrl: &[u32], new_slots: &[u64]) {
-    let mut tid = thread::index_1d().get();
-    let stride = (thread::gridDim_x() * thread::blockDim_x()) as usize;
-
-    while tid < old_slots.len() {
-        let ctrl_word_idx = tid / GROUP;
-        let byte_in_word = tid % GROUP;
-        let ctrl_atomic =
-            unsafe { DeviceAtomicU32::from_ptr(old_ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-        let ctrl_word = ctrl_atomic.load(AtomicOrdering::Acquire);
-        let tag = get_tag(ctrl_word, byte_in_word);
-        if tag <= 0x7F {
-            let slot_atomic =
-                unsafe { DeviceAtomicU64::from_ptr(old_slots.as_ptr().add(tid).cast_mut()) };
-            let slot = slot_atomic.load(AtomicOrdering::Acquire);
-            let _ = insert_into_table_core(
-                new_ctrl,
-                new_slots,
-                unpack_key(slot),
-                unpack_value(slot),
-                true,
-            );
-        }
-
-        tid += stride;
-    }
-}
-
-/// `find_kernel` — single-thread find, one thread per key.
-///
-/// Walks the same triangular probe sequence as the insert kernels
-/// (same `PROBE_TILE = 32` width), so EMPTY-termination is sound —
-/// see `find_tile_impl` below for why probe-width coherence matters.
-///
-/// At each tile (32 consecutive tag bytes):
-///   - For every byte tagged `FULL(h2)` matching our key's fingerprint,
-///     load the slot and key-compare; on match return the value.
-///   - If any byte in the tile is `EMPTY_TAG`, the key cannot live past
-///     this point in its triangular chain (insert would have stopped
-///     at this same EMPTY), so return `MISS`.
-///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
-///     advance and repeat. DELETED never terminates find.
-#[kernel]
-pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
-    }
-
-    let key = keys[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    loop {
-        let mut g = 0usize;
-        let mut has_empty = false;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-            let word = ctrl_atomic.load(AtomicOrdering::Acquire);
-            let mut j = 0;
-            while j < GROUP {
-                let tag = get_tag(word, j);
-                if tag == h2 {
-                    let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
-                    let observed = slot_atomic.load(AtomicOrdering::Acquire);
-                    if unpack_key(observed) == key {
-                        if let Some(o) = out.get_mut(tid) {
-                            *o = unpack_value(observed);
-                        }
-                        return;
-                    }
-                } else if tag == EMPTY_TAG {
-                    has_empty = true;
-                }
-                j += 1;
-            }
-            g += GROUP;
-        }
-
-        if has_empty {
-            if let Some(o) = out.get_mut(tid) {
-                *o = MISS;
-            }
+        if !active {
             return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
-
-/// `find_kernel_tile_32` — full-warp find (32-lane tile per query).
-///
-/// One concrete instantiation of [`find_tile_impl`] at `N = 32`. Each
-/// warp partitions into a single 32-lane tile that scans one
-/// `PROBE_TILE`-byte insert tile per `tile.ballot` round, identical
-/// to v2's `find_kernel_warp_typed`.
-///
-/// Launch with `LaunchConfig::for_num_elems(keys.len() * 32)`.
-#[kernel]
-pub fn find_kernel_tile_32(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
-    let global_tid = thread::index_1d().get();
-    find_tile_impl::<32>(ctrl, slots, keys, out, global_tid);
-}
-
-/// `find_kernel_tile_16` — sub-warp find (16-lane tile per query).
-///
-/// One concrete instantiation of [`find_tile_impl`] at `N = 16`. Each
-/// warp partitions into two 16-lane tiles, each handling one query.
-/// Two queries per warp instead of one; each query scans
-/// `PROBE_TILE = 32` insert-tile bytes in **two** 16-byte ballot
-/// rounds rather than one 32-byte round, before triangular advance.
-///
-/// The motivating regime is moderate load (75 % is the bench
-/// crossover): probe chains long enough that single-thread loses on
-/// per-key serialization, but short enough that a full-warp 32-lane
-/// scan per key is over-provisioned and leaves throughput on the
-/// table. Two queries per warp recover the headroom.
-///
-/// Launch with `LaunchConfig::for_num_elems(keys.len() * 16)`.
-#[kernel]
-pub fn find_kernel_tile_16(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
-    let global_tid = thread::index_1d().get();
-    find_tile_impl::<16>(ctrl, slots, keys, out, global_tid);
-}
-
-/// Const-generic warp-cooperative find body, parameterised over the
-/// `N`-lane tile size. The two `find_kernel_tile_*` kernels above are
-/// the only callers; both inline this body via `#[inline(always)]`,
-/// so the const-generic monomorphises to two distinct PTX symbols
-/// with `N` folded as an integer literal.
-///
-/// Algorithm (one tile per query):
-///   1. Walk the `PROBE_TILE`-byte insert tile in `N`-byte sub-tiles.
-///   2. Each sub-tile pulls `N` tag bytes into the tile via a single
-///      coalesced ctrl load (lane `l` reads byte at `probe_base + sub
-///      + l`).
-///   3. `m_h2 = tile.ballot(tag == h2)` — N-bit fingerprint match
-///      mask. For each set bit (lowest first) the matching lane
-///      loads its slot and broadcasts the packed `(key, value)` via
-///      two `shfl`s; on key match, lane 0 writes `out[tile_idx]` and
-///      the tile returns.
-///   4. `m_empty = tile.ballot(tag == EMPTY_TAG)` — if non-zero, the
-///      key cannot live past an `EMPTY` in this hash chain; lane 0
-///      writes `MISS` and the tile returns.
-///   5. Else advance to the next `N`-byte sub-tile within the same
-///      `PROBE_TILE` insert tile. After `PROBE_TILE / N` sub-tiles,
-///      triangular-advance `probe_base` by `stride * PROBE_TILE` and
-///      repeat.
-///
-/// `N = 32` collapses the inner sub-tile loop to one iteration per
-/// probe step (identical to v2's `find_kernel_warp_typed`). `N = 16`
-/// runs two iterations per probe step but doubles the number of
-/// queries per warp.
-///
-/// Insert and find share `PROBE_TILE`-aligned probe sequences; only
-/// the *granularity* of the find ballot changes between `N = 32` and
-/// `N = 16`. The same v3 table is queryable by either kernel.
-#[inline(always)]
-fn find_tile_impl<const N: u32>(
-    ctrl: &[u32],
-    slots: &[u64],
-    keys: &[u32],
-    mut out: DisjointSlice<u32>,
-    global_tid: usize,
-) {
-    let block = this_thread_block();
-    let tile = block.tiled_partition::<N>();
-
-    let lane = tile.thread_rank();
-    let tile_idx = global_tid / (N as usize);
-    if tile_idx >= keys.len() {
-        return;
+        // Highest set bit in the dup mask is the in-warp leader for this
+        // duplicate group. All lanes in the group agree on the same
+        // leader because they all see the same dup_mask.
+        let leader = 31u32 - dup_mask.leading_zeros();
+        if lane == leader {
+            let _ = insert_into_table_core(ctrl, slots, key, value, true);
+        }
     }
 
-    let key = keys[tile_idx];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
+    /// `rehash_kernel` — single-kernel two-buffer rehash.
+    ///
+    /// v3 ships the two-buffer mode only (`old != new`); the new buffer
+    /// is `memset`-cleared by the host before launch, and the old buffer
+    /// remains read-only for the duration of the kernel. That means no
+    /// grid-wide barrier is required: each thread can read a live old
+    /// slot and immediately insert it into the new table. Threads stride
+    /// across the old table so the host can bound the launch size without
+    /// depending on cooperative-launch residency limits.
+    #[kernel]
+    pub fn rehash_kernel(old_ctrl: &[u32], old_slots: &[u64], new_ctrl: &[u32], new_slots: &[u64]) {
+        let mut tid = thread::index_1d().get();
+        let stride = (thread::gridDim_x() * thread::blockDim_x()) as usize;
 
-    loop {
-        let mut sub = 0usize;
-        while sub < PROBE_TILE {
-            let tag_pos = probe_base + sub + (lane as usize);
-            let ctrl_word_idx = tag_pos / GROUP;
-            let byte_in_word = tag_pos % GROUP;
-            let word = unsafe {
-                DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                    .load(AtomicOrdering::Acquire)
+        while tid < old_slots.len() {
+            let ctrl_word_idx = tid / GROUP;
+            let byte_in_word = tid % GROUP;
+            let ctrl_atomic = unsafe {
+                DeviceAtomicU32::from_ptr(old_ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
             };
-            let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
-
-            let mut m_h2 = tile.ballot(tag == h2);
-            let m_empty = tile.ballot(tag == EMPTY_TAG);
-
-            while m_h2 != 0 {
-                let cand = m_h2.trailing_zeros();
-                let local_slot: u64 = if lane == cand {
-                    let slot_idx = probe_base + sub + (cand as usize);
-                    unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                            .load(AtomicOrdering::Acquire)
-                    }
-                } else {
-                    0
-                };
-                let lo = tile.shfl(local_slot as u32, cand);
-                let hi = tile.shfl((local_slot >> 32) as u32, cand);
-                let observed: u64 = ((hi as u64) << 32) | (lo as u64);
-
-                if unpack_key(observed) == key {
-                    if lane == 0 {
-                        // SAFETY: tile_idx < keys.len() == out.len(),
-                        // and each tile has a unique tile_idx so
-                        // writes by lane 0 across tiles are disjoint.
-                        unsafe {
-                            *out.get_unchecked_mut(tile_idx) = unpack_value(observed);
-                        }
-                    }
-                    return;
-                }
-                m_h2 &= m_h2 - 1;
+            let ctrl_word = ctrl_atomic.load(AtomicOrdering::Acquire);
+            let tag = get_tag(ctrl_word, byte_in_word);
+            if tag <= 0x7F {
+                let slot_atomic =
+                    unsafe { DeviceAtomicU64::from_ptr(old_slots.as_ptr().add(tid).cast_mut()) };
+                let slot = slot_atomic.load(AtomicOrdering::Acquire);
+                let _ = insert_into_table_core(
+                    new_ctrl,
+                    new_slots,
+                    unpack_key(slot),
+                    unpack_value(slot),
+                    true,
+                );
             }
 
-            if m_empty != 0 {
-                if lane == 0 {
-                    // SAFETY: same uniqueness argument as above.
-                    unsafe {
-                        *out.get_unchecked_mut(tile_idx) = MISS;
-                    }
-                }
-                return;
-            }
+            tid += stride;
+        }
+    }
 
-            sub += N as usize;
+    /// `find_kernel` — single-thread find, one thread per key.
+    ///
+    /// Walks the same triangular probe sequence as the insert kernels
+    /// (same `PROBE_TILE = 32` width), so EMPTY-termination is sound —
+    /// see `find_tile_impl` below for why probe-width coherence matters.
+    ///
+    /// At each tile (32 consecutive tag bytes):
+    ///   - For every byte tagged `FULL(h2)` matching our key's fingerprint,
+    ///     load the slot and key-compare; on match return the value.
+    ///   - If any byte in the tile is `EMPTY_TAG`, the key cannot live past
+    ///     this point in its triangular chain (insert would have stopped
+    ///     at this same EMPTY), so return `MISS`.
+    ///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
+    ///     advance and repeat. DELETED never terminates find.
+    #[kernel]
+    pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-    }
-}
+        let key = keys[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
 
-/// `delete_kernel` — tombstone the slot for each input key.
-///
-/// One thread per key. Probes the same `PROBE_TILE`-wide triangular
-/// sequence as insert and find. When it locates the key it CAS-flips
-/// the byte in the containing ctrl word from `FULL(h2)` to
-/// `DELETED_TAG`. The `(key, value)` payload is **not** cleared:
-/// readers only ever materialize slots whose tag is `FULL(h2)`, so a
-/// stale slot under a `DELETED` tag is unreachable.
-///
-/// The CAS targets the specific ctrl word containing the matching tag
-/// byte (not "the group's word" — there are now `PROBE_TILE / GROUP`
-/// ctrl words per tile). On CAS failure (some other thread mutated
-/// this word), the inner loop re-reads and re-scans this word before
-/// moving on to the next word in the tile.
-///
-/// Output:
-///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
-///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
-#[kernel]
-pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
-    let tid = thread::index_1d();
-    let tid_raw = tid.get();
-    let i_thread = tid_raw;
-    if i_thread >= keys.len() {
-        return;
-    }
-
-    let key = keys[i_thread];
-    let hash = hash_u32(key);
-    let h2 = h2_from_hash(hash);
-    let mask = slots.len() - 1;
-    let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
-    let mut stride = 0usize;
-
-    'tile: loop {
-        let mut has_empty = false;
-        let mut g = 0usize;
-        while g < PROBE_TILE {
-            let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
-
-            // Per-word retry loop: if our CAS to flip a tag to DELETED
-            // fails because someone else mutated this same word, re-read
-            // and re-scan this word.
-            loop {
+        loop {
+            let mut g = 0usize;
+            let mut has_empty = false;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
-                let mut cas_collided = false;
                 while j < GROUP {
                     let tag = get_tag(word, j);
                     if tag == h2 {
@@ -642,48 +412,286 @@ pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: Disjoin
                         };
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
-                            let new_word = set_tag(word, j, DELETED_TAG);
-                            match ctrl_atomic.compare_exchange(
-                                word,
-                                new_word,
-                                AtomicOrdering::AcqRel,
-                                AtomicOrdering::Relaxed,
-                            ) {
-                                Ok(_) => {
-                                    if let Some(o) = out.get_mut(tid) {
-                                        *o = FLAG_FRESH_OR_OK;
-                                    }
-                                    return;
-                                }
-                                Err(_) => {
-                                    cas_collided = true;
-                                    break;
-                                }
+                            if let Some(o) = out.get_mut(tid) {
+                                *o = unpack_value(observed);
                             }
+                            return;
                         }
                     } else if tag == EMPTY_TAG {
                         has_empty = true;
                     }
                     j += 1;
                 }
-                if !cas_collided {
-                    break; // word fully scanned; move to next word in the tile
-                }
-                // else: retry this same word with a freshly-loaded view.
+                g += GROUP;
             }
-            g += GROUP;
-        }
 
-        if has_empty {
-            if let Some(o) = out.get_mut(tid) {
-                *o = FLAG_PRESENT;
+            if has_empty {
+                if let Some(o) = out.get_mut(tid) {
+                    *o = MISS;
+                }
+                return;
             }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `find_kernel_tile_32` — full-warp find (32-lane tile per query).
+    ///
+    /// One concrete instantiation of [`find_tile_impl`] at `N = 32`. Each
+    /// warp partitions into a single 32-lane tile that scans one
+    /// `PROBE_TILE`-byte insert tile per `tile.ballot` round, identical
+    /// to v2's `find_kernel_warp_typed`.
+    ///
+    /// Launch with `LaunchConfig::for_num_elems(keys.len() * 32)`.
+    #[kernel]
+    pub fn find_kernel_tile_32(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
+        let global_tid = thread::index_1d().get();
+        find_tile_impl::<32>(ctrl, slots, keys, out, global_tid);
+    }
+
+    /// `find_kernel_tile_16` — sub-warp find (16-lane tile per query).
+    ///
+    /// One concrete instantiation of [`find_tile_impl`] at `N = 16`. Each
+    /// warp partitions into two 16-lane tiles, each handling one query.
+    /// Two queries per warp instead of one; each query scans
+    /// `PROBE_TILE = 32` insert-tile bytes in **two** 16-byte ballot
+    /// rounds rather than one 32-byte round, before triangular advance.
+    ///
+    /// The motivating regime is moderate load (75 % is the bench
+    /// crossover): probe chains long enough that single-thread loses on
+    /// per-key serialization, but short enough that a full-warp 32-lane
+    /// scan per key is over-provisioned and leaves throughput on the
+    /// table. Two queries per warp recover the headroom.
+    ///
+    /// Launch with `LaunchConfig::for_num_elems(keys.len() * 16)`.
+    #[kernel]
+    pub fn find_kernel_tile_16(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
+        let global_tid = thread::index_1d().get();
+        find_tile_impl::<16>(ctrl, slots, keys, out, global_tid);
+    }
+
+    /// Const-generic warp-cooperative find body, parameterised over the
+    /// `N`-lane tile size. The two `find_kernel_tile_*` kernels above are
+    /// the only callers; both inline this body via `#[inline(always)]`,
+    /// so the const-generic monomorphises to two distinct PTX symbols
+    /// with `N` folded as an integer literal.
+    ///
+    /// Algorithm (one tile per query):
+    ///   1. Walk the `PROBE_TILE`-byte insert tile in `N`-byte sub-tiles.
+    ///   2. Each sub-tile pulls `N` tag bytes into the tile via a single
+    ///      coalesced ctrl load (lane `l` reads byte at `probe_base + sub
+    ///      + l`).
+    ///   3. `m_h2 = tile.ballot(tag == h2)` — N-bit fingerprint match
+    ///      mask. For each set bit (lowest first) the matching lane
+    ///      loads its slot and broadcasts the packed `(key, value)` via
+    ///      two `shfl`s; on key match, lane 0 writes `out[tile_idx]` and
+    ///      the tile returns.
+    ///   4. `m_empty = tile.ballot(tag == EMPTY_TAG)` — if non-zero, the
+    ///      key cannot live past an `EMPTY` in this hash chain; lane 0
+    ///      writes `MISS` and the tile returns.
+    ///   5. Else advance to the next `N`-byte sub-tile within the same
+    ///      `PROBE_TILE` insert tile. After `PROBE_TILE / N` sub-tiles,
+    ///      triangular-advance `probe_base` by `stride * PROBE_TILE` and
+    ///      repeat.
+    ///
+    /// `N = 32` collapses the inner sub-tile loop to one iteration per
+    /// probe step (identical to v2's `find_kernel_warp_typed`). `N = 16`
+    /// runs two iterations per probe step but doubles the number of
+    /// queries per warp.
+    ///
+    /// Insert and find share `PROBE_TILE`-aligned probe sequences; only
+    /// the *granularity* of the find ballot changes between `N = 32` and
+    /// `N = 16`. The same v3 table is queryable by either kernel.
+    #[inline(always)]
+    fn find_tile_impl<const N: u32>(
+        ctrl: &[u32],
+        slots: &[u64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+        global_tid: usize,
+    ) {
+        let block = this_thread_block();
+        let tile = block.tiled_partition::<N>();
+
+        let lane = tile.thread_rank();
+        let tile_idx = global_tid / (N as usize);
+        if tile_idx >= keys.len() {
             return;
         }
 
-        stride += 1;
-        probe_base = (probe_base + stride * PROBE_TILE) & mask;
-        continue 'tile;
+        let key = keys[tile_idx];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        loop {
+            let mut sub = 0usize;
+            while sub < PROBE_TILE {
+                let tag_pos = probe_base + sub + (lane as usize);
+                let ctrl_word_idx = tag_pos / GROUP;
+                let byte_in_word = tag_pos % GROUP;
+                let word = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                        .load(AtomicOrdering::Acquire)
+                };
+                let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
+
+                let mut m_h2 = tile.ballot(tag == h2);
+                let m_empty = tile.ballot(tag == EMPTY_TAG);
+
+                while m_h2 != 0 {
+                    let cand = m_h2.trailing_zeros();
+                    let local_slot: u64 = if lane == cand {
+                        let slot_idx = probe_base + sub + (cand as usize);
+                        unsafe {
+                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                                .load(AtomicOrdering::Acquire)
+                        }
+                    } else {
+                        0
+                    };
+                    let lo = tile.shfl(local_slot as u32, cand);
+                    let hi = tile.shfl((local_slot >> 32) as u32, cand);
+                    let observed: u64 = ((hi as u64) << 32) | (lo as u64);
+
+                    if unpack_key(observed) == key {
+                        if lane == 0 {
+                            // SAFETY: tile_idx < keys.len() == out.len(),
+                            // and each tile has a unique tile_idx so
+                            // writes by lane 0 across tiles are disjoint.
+                            unsafe {
+                                *out.get_unchecked_mut(tile_idx) = unpack_value(observed);
+                            }
+                        }
+                        return;
+                    }
+                    m_h2 &= m_h2 - 1;
+                }
+
+                if m_empty != 0 {
+                    if lane == 0 {
+                        // SAFETY: same uniqueness argument as above.
+                        unsafe {
+                            *out.get_unchecked_mut(tile_idx) = MISS;
+                        }
+                    }
+                    return;
+                }
+
+                sub += N as usize;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+        }
+    }
+
+    /// `delete_kernel` — tombstone the slot for each input key.
+    ///
+    /// One thread per key. Probes the same `PROBE_TILE`-wide triangular
+    /// sequence as insert and find. When it locates the key it CAS-flips
+    /// the byte in the containing ctrl word from `FULL(h2)` to
+    /// `DELETED_TAG`. The `(key, value)` payload is **not** cleared:
+    /// readers only ever materialize slots whose tag is `FULL(h2)`, so a
+    /// stale slot under a `DELETED` tag is unreachable.
+    ///
+    /// The CAS targets the specific ctrl word containing the matching tag
+    /// byte (not "the group's word" — there are now `PROBE_TILE / GROUP`
+    /// ctrl words per tile). On CAS failure (some other thread mutated
+    /// this word), the inner loop re-reads and re-scans this word before
+    /// moving on to the next word in the tile.
+    ///
+    /// Output:
+    ///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
+    ///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
+    #[kernel]
+    pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let tid_raw = tid.get();
+        let i_thread = tid_raw;
+        if i_thread >= keys.len() {
+            return;
+        }
+
+        let key = keys[i_thread];
+        let hash = hash_u32(key);
+        let h2 = h2_from_hash(hash);
+        let mask = slots.len() - 1;
+        let mut probe_base = (hash as usize) & mask & !(PROBE_TILE - 1);
+        let mut stride = 0usize;
+
+        'tile: loop {
+            let mut has_empty = false;
+            let mut g = 0usize;
+            while g < PROBE_TILE {
+                let ctrl_word_idx = (probe_base + g) / GROUP;
+                let ctrl_atomic = unsafe {
+                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
+                };
+
+                // Per-word retry loop: if our CAS to flip a tag to DELETED
+                // fails because someone else mutated this same word, re-read
+                // and re-scan this word.
+                loop {
+                    let word = ctrl_atomic.load(AtomicOrdering::Acquire);
+                    let mut j = 0;
+                    let mut cas_collided = false;
+                    while j < GROUP {
+                        let tag = get_tag(word, j);
+                        if tag == h2 {
+                            let slot_idx = probe_base + g + j;
+                            let slot_atomic = unsafe {
+                                DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
+                            };
+                            let observed = slot_atomic.load(AtomicOrdering::Acquire);
+                            if unpack_key(observed) == key {
+                                let new_word = set_tag(word, j, DELETED_TAG);
+                                match ctrl_atomic.compare_exchange(
+                                    word,
+                                    new_word,
+                                    AtomicOrdering::AcqRel,
+                                    AtomicOrdering::Relaxed,
+                                ) {
+                                    Ok(_) => {
+                                        if let Some(o) = out.get_mut(tid) {
+                                            *o = FLAG_FRESH_OR_OK;
+                                        }
+                                        return;
+                                    }
+                                    Err(_) => {
+                                        cas_collided = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        } else if tag == EMPTY_TAG {
+                            has_empty = true;
+                        }
+                        j += 1;
+                    }
+                    if !cas_collided {
+                        break; // word fully scanned; move to next word in the tile
+                    }
+                    // else: retry this same word with a freshly-loaded view.
+                }
+                g += GROUP;
+            }
+
+            if has_empty {
+                if let Some(o) = out.get_mut(tid) {
+                    *o = FLAG_PRESENT;
+                }
+                return;
+            }
+
+            stride += 1;
+            probe_base = (probe_base + stride * PROBE_TILE) & mask;
+            continue 'tile;
+        }
     }
 }
 
@@ -1095,7 +1103,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1111,13 +1119,7 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
 
         Ok(())
     }
@@ -1140,7 +1142,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1156,13 +1158,7 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: insert_kernel_dedup,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev)]
-        }?;
+        module.insert_kernel_dedup(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
 
         Ok(())
     }
@@ -1175,7 +1171,7 @@ impl GpuSwissMap {
         &self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1192,13 +1188,15 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: try_insert_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice(values_dev), slice_mut(out_dev)]
-        }?;
+        module.try_insert_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &values_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1209,7 +1207,7 @@ impl GpuSwissMap {
     pub fn find_bulk(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1220,13 +1218,14 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: find_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1240,7 +1239,7 @@ impl GpuSwissMap {
     pub fn find_bulk_tile_32(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1258,13 +1257,14 @@ impl GpuSwissMap {
         // block size 256 means 8 tiles per block, 8 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(32);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        cuda_launch! {
-            kernel: find_kernel_tile_32,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel_tile_32(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1281,7 +1281,7 @@ impl GpuSwissMap {
     pub fn find_bulk_tile_16(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1299,13 +1299,14 @@ impl GpuSwissMap {
         // block size 256 means 16 tiles per block, 16 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(16);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        cuda_launch! {
-            kernel: find_kernel_tile_16,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.find_kernel_tile_16(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1327,7 +1328,7 @@ impl GpuSwissMap {
     pub fn resize_to(
         &mut self,
         new_capacity: usize,
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert!(
@@ -1358,16 +1359,7 @@ impl GpuSwissMap {
 
         let rehash_threads = self.capacity.min(REHASH_MAX_THREADS) as u32;
         let cfg = LaunchConfig::for_num_elems(rehash_threads);
-        cuda_launch! {
-            kernel: rehash_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [
-                slice(self.ctrl), slice(self.slots),
-                slice(new_ctrl), slice(new_slots)
-            ]
-        }?;
+        module.rehash_kernel(stream, cfg, &self.ctrl, &self.slots, &new_ctrl, &new_slots)?;
 
         self.ctrl = new_ctrl;
         self.slots = new_slots;
@@ -1394,7 +1386,7 @@ impl GpuSwissMap {
         &mut self,
         keys: &[u32],
         values: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(keys.len(), values.len());
@@ -1417,7 +1409,7 @@ impl GpuSwissMap {
     pub fn delete_bulk(
         &self,
         keys: &[u32],
-        module: &Arc<CudaModule>,
+        module: &kernels::LoadedModule,
         stream: &Arc<CudaStream>,
     ) -> Result<Vec<bool>, Box<dyn std::error::Error>> {
         if keys.is_empty() {
@@ -1428,13 +1420,14 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        cuda_launch! {
-            kernel: delete_kernel,
-            stream: stream,
-            module: module,
-            config: cfg,
-            args: [slice(self.ctrl), slice(self.slots), slice(keys_dev), slice_mut(out_dev)]
-        }?;
+        module.delete_kernel(
+            stream,
+            cfg,
+            &self.ctrl,
+            &self.slots,
+            &keys_dev,
+            &mut out_dev,
+        )?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let module = ctx
         .load_module_from_file("hashmap_v3.ptx")
         .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;

--- a/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
@@ -5,25 +5,30 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::cuda_launch;
+use cuda_host::cuda_module;
 
 const WIDTH: usize = 16;
 const HEIGHT: usize = 8;
 
-#[kernel]
-pub fn copy_2d_const_width(
-    input: &[f32],
-    mut output: DisjointSlice<f32, thread::Index2D<WIDTH>>,
-    height: u32,
-) {
-    let row = thread::index_2d_row();
+#[cuda_module]
+mod kernels {
+    use super::*;
 
-    if let Some(idx) = thread::index_2d::<WIDTH>()
-        && row < height as usize
-    {
-        let i = idx.get();
-        if let Some(out_elem) = output.get_mut(idx) {
-            *out_elem = input[i];
+    #[kernel]
+    pub fn copy_2d_const_width(
+        input: &[f32],
+        mut output: DisjointSlice<f32, thread::Index2D<WIDTH>>,
+        height: u32,
+    ) {
+        let row = thread::index_2d_row();
+
+        if let Some(idx) = thread::index_2d::<WIDTH>()
+            && row < height as usize
+        {
+            let i = idx.get();
+            if let Some(out_elem) = output.get_mut(idx) {
+                *out_elem = input[i];
+            }
         }
     }
 }
@@ -42,19 +47,21 @@ fn main() {
     let module = ctx
         .load_module_from_file("index2d_const.ptx")
         .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
-    cuda_launch! {
-        kernel: copy_2d_const_width,
-        stream: stream,
-        module: module,
-        config: LaunchConfig {
-            grid_dim: (1, HEIGHT as u32, 1),
-            block_dim: (WIDTH as u32, 1, 1),
-            shared_mem_bytes: 0,
-        },
-        args: [slice(input_dev), slice_mut(output_dev), HEIGHT as u32]
-    }
-    .expect("Kernel launch failed");
+    module
+        .copy_2d_const_width(
+            &stream,
+            LaunchConfig {
+                grid_dim: (1, HEIGHT as u32, 1),
+                block_dim: (WIDTH as u32, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            &input_dev,
+            &mut output_dev,
+            HEIGHT as u32,
+        )
+        .expect("Kernel launch failed");
 
     let output_host = output_dev.to_host_vec(&stream).unwrap();
     for i in 0..(WIDTH * HEIGHT) {

--- a/crates/rustc-codegen-cuda/examples/math_atan/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/math_atan/src/main.rs
@@ -17,49 +17,54 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
-use cuda_host::{cuda_launch, ltoir};
+use cuda_host::{cuda_module, ltoir};
 
-#[kernel]
-pub fn atan2_f32(ys: &[f32], xs: &[f32], mut out: DisjointSlice<f32>) {
-    let idx = thread::index_1d();
-    let i = idx.get();
-    if i < ys.len()
-        && let Some(slot) = out.get_mut(idx)
-    {
-        *slot = ys[i].atan2(xs[i]);
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    pub fn atan2_f32(ys: &[f32], xs: &[f32], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i < ys.len()
+            && let Some(slot) = out.get_mut(idx)
+        {
+            *slot = ys[i].atan2(xs[i]);
+        }
     }
-}
 
-#[kernel]
-pub fn atan_f32(ys: &[f32], mut out: DisjointSlice<f32>) {
-    let idx = thread::index_1d();
-    let i = idx.get();
-    if i < ys.len()
-        && let Some(slot) = out.get_mut(idx)
-    {
-        *slot = ys[i].atan();
+    #[kernel]
+    pub fn atan_f32(ys: &[f32], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i < ys.len()
+            && let Some(slot) = out.get_mut(idx)
+        {
+            *slot = ys[i].atan();
+        }
     }
-}
 
-#[kernel]
-pub fn atan2_f64(ys: &[f64], xs: &[f64], mut out: DisjointSlice<f64>) {
-    let idx = thread::index_1d();
-    let i = idx.get();
-    if i < ys.len()
-        && let Some(slot) = out.get_mut(idx)
-    {
-        *slot = ys[i].atan2(xs[i]);
+    #[kernel]
+    pub fn atan2_f64(ys: &[f64], xs: &[f64], mut out: DisjointSlice<f64>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i < ys.len()
+            && let Some(slot) = out.get_mut(idx)
+        {
+            *slot = ys[i].atan2(xs[i]);
+        }
     }
-}
 
-#[kernel]
-pub fn atan_f64(ys: &[f64], mut out: DisjointSlice<f64>) {
-    let idx = thread::index_1d();
-    let i = idx.get();
-    if i < ys.len()
-        && let Some(slot) = out.get_mut(idx)
-    {
-        *slot = ys[i].atan();
+    #[kernel]
+    pub fn atan_f64(ys: &[f64], mut out: DisjointSlice<f64>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i < ys.len()
+            && let Some(slot) = out.get_mut(idx)
+        {
+            *slot = ys[i].atan();
+        }
     }
 }
 
@@ -103,6 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `__nv_*` calls in the kernel force the NVVM-IR output flavor; the
     // first launch builds a cubin via libNVVM + nvJitLink.
     let module = ltoir::load_kernel_module(&ctx, "math_atan")?;
+    let module = kernels::from_module(module)?;
 
     // All four atan2 quadrants plus small / large / mixed-sign magnitudes.
     // Values are f32-representable so the same arrays double as f64 inputs
@@ -120,8 +126,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let n = ys_f32.len();
     let cfg = LaunchConfig::for_num_elems(n as u32);
 
-    // Single upload per input; `slice(...)` borrows, so the same buffer is
-    // reused by both `atan` and `atan2` launches of its width.
+    // Single upload per input; the typed launch methods borrow the device
+    // buffers, so the same buffer is reused by both `atan` and `atan2`
+    // launches of its width.
     let ys32 = DeviceBuffer::from_host(&stream, &ys_f32)?;
     let xs32 = DeviceBuffer::from_host(&stream, &xs_f32)?;
     let ys64 = DeviceBuffer::from_host(&stream, &ys_f64)?;
@@ -132,26 +139,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_atan2_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
     let mut out_atan_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
 
-    cuda_launch! {
-        kernel: atan2_f32,
-        stream: stream, module: module, config: cfg,
-        args: [slice(ys32), slice(xs32), slice_mut(out_atan2_f32)]
-    }?;
-    cuda_launch! {
-        kernel: atan_f32,
-        stream: stream, module: module, config: cfg,
-        args: [slice(ys32), slice_mut(out_atan_f32)]
-    }?;
-    cuda_launch! {
-        kernel: atan2_f64,
-        stream: stream, module: module, config: cfg,
-        args: [slice(ys64), slice(xs64), slice_mut(out_atan2_f64)]
-    }?;
-    cuda_launch! {
-        kernel: atan_f64,
-        stream: stream, module: module, config: cfg,
-        args: [slice(ys64), slice_mut(out_atan_f64)]
-    }?;
+    module.atan2_f32(&stream, cfg, &ys32, &xs32, &mut out_atan2_f32)?;
+    module.atan_f32(&stream, cfg, &ys32, &mut out_atan_f32)?;
+    module.atan2_f64(&stream, cfg, &ys64, &xs64, &mut out_atan2_f64)?;
+    module.atan_f64(&stream, cfg, &ys64, &mut out_atan_f64)?;
 
     let got_atan2_f32 = out_atan2_f32.to_host_vec(&stream)?;
     let got_atan_f32 = out_atan_f32.to_host_vec(&stream)?;


### PR DESCRIPTION
## What

Nine examples move from the legacy untyped `cuda_launch\!` macro to the typed `#[cuda_module]` path: `hashmap`, `hashmap_v2`, `hashmap_v3` (both bins each), `f16_stress`, `fmaxmin_smoke`, `fp_special_literal_smoke`, `device_global`, `index2d_const`, `math_atan`.

Kernel bodies, host checks, and printed success markers are byte-identical; only the launch plumbing changes. The tenth candidate, `host_closure`, turned out to already use the typed path as its primary mechanism.

No typed-path gaps surfaced: every parameter shape in these examples (read-only slices, `DisjointSlice` with and without `Index2D`, scalars, raw pointers on an unsafe kernel, f16 buffers) marshals identically.

This narrows the remaining `cuda_launch\!` surface to: the two deliberate low-level API regression examples (`manual_launch_generic`, `manual_launch_libdevice`), the fuzzer harness, `host_closure`'s secondary variant, and `coop_groups_demo`'s non-cooperative calls — the prelude to demoting the macro to an explicitly `unsafe` niche API for runtime-loaded kernels.

## Evidence

- All nine ported examples executed on sm_120 with their original success markers.
- Review mechanically diffed old vs new (behavior-identical), confirmed no example was force-ported around a typed-path gap.
- fmt (edition-aware per example)/compile-only smoketest green.