### PR TITLE
deps: bump pliron to master (no_std/hashbrown) + AttributeDict encapsulation sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +569,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -565,6 +577,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -684,6 +701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +815,13 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pliron"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "awint",
  "combine",
  "downcast-rs",
  "dyn-clone",
+ "hashbrown 0.17.1",
  "hi_sparse_bitset",
  "inventory",
  "linkme",
@@ -804,6 +831,7 @@ dependencies = [
  "rustc-hash",
  "rustc_apfloat",
  "slotmap",
+ "spin",
  "thiserror",
  "utf8-chars",
 ]
@@ -811,7 +839,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "combine",
  "convert_case",
@@ -824,7 +852,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "bitflags",
  "log",
@@ -932,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1042,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ repository = "https://github.com/NVlabs/cuda-oxide.git"
 # cuda-oxide consumes the dialect modeling only, not the FFI bridge.
 # `crates/rustc-codegen-cuda/Cargo.toml` MUST stay on this same rev, or pliron
 # resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "fed4e6f848bd726a4f2deb51c5021760ef382aec" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "fed4e6f848bd726a4f2deb51c5021760ef382aec" }
-pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "fed4e6f848bd726a4f2deb51c5021760ef382aec", default-features = false }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
+pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5", default-features = false }
 
 # Internal crates
 llvm-export = { path = "crates/llvm-export" }

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -121,8 +121,10 @@ impl<'a> ModuleExportState<'a> {
 
         // Check for kernel attribute
         let kernel_key: pliron::identifier::Identifier = "gpu_kernel".try_into().unwrap();
-        let attrs = &func.get_operation().deref(self.ctx).attributes.0;
-        let is_kernel = attrs.contains_key(&kernel_key);
+        let attrs = &func.get_operation().deref(self.ctx).attributes;
+        let is_kernel = attrs
+            .get::<pliron::builtin::attributes::StringAttr>(&kernel_key)
+            .is_some();
 
         // Track ALL kernels if backend requires annotations for every kernel
         if is_kernel && self.track_all_kernels {
@@ -141,55 +143,39 @@ impl<'a> ModuleExportState<'a> {
         // Check for cluster dimension attributes (from #[cluster(x,y,z)])
         // These will be emitted as nvvm.annotations metadata
         if is_kernel {
-            let x_key: pliron::identifier::Identifier = "cluster_dim_x".try_into().unwrap();
-            let y_key: pliron::identifier::Identifier = "cluster_dim_y".try_into().unwrap();
-            let z_key: pliron::identifier::Identifier = "cluster_dim_z".try_into().unwrap();
+            let get_int = |key: &str| -> Option<u32> {
+                let key: pliron::identifier::Identifier = key.try_into().unwrap();
+                attrs
+                    .get::<pliron::builtin::attributes::IntegerAttr>(&key)
+                    .map(|int_attr| int_attr.value().to_u32())
+            };
 
-            if let (Some(x_attr), Some(y_attr), Some(z_attr)) =
-                (attrs.get(&x_key), attrs.get(&y_key), attrs.get(&z_key))
-            {
-                use pliron::attribute::AttrObj;
-                let get_int = |attr: &AttrObj| -> Option<u32> {
-                    attr.downcast_ref::<pliron::builtin::attributes::IntegerAttr>()
-                        .map(|int_attr| int_attr.value().to_u32())
-                };
-
-                if let (Some(dim_x), Some(dim_y), Some(dim_z)) =
-                    (get_int(x_attr), get_int(y_attr), get_int(z_attr))
-                {
-                    self.cluster_kernels.push(KernelClusterConfig {
-                        name: fixed_func_name.clone(),
-                        dim_x,
-                        dim_y,
-                        dim_z,
-                    });
-                }
+            if let (Some(dim_x), Some(dim_y), Some(dim_z)) = (
+                get_int("cluster_dim_x"),
+                get_int("cluster_dim_y"),
+                get_int("cluster_dim_z"),
+            ) {
+                self.cluster_kernels.push(KernelClusterConfig {
+                    name: fixed_func_name.clone(),
+                    dim_x,
+                    dim_y,
+                    dim_z,
+                });
             }
 
             // Check for launch bounds attributes (from #[launch_bounds(max, min)])
             // These will be emitted as nvvm.annotations metadata for maxntid and minctasm
-            let maxntid_key: pliron::identifier::Identifier = "maxntid".try_into().unwrap();
-            let minctasm_key: pliron::identifier::Identifier = "minctasm".try_into().unwrap();
-
-            if let Some(max_attr) = attrs.get(&maxntid_key) {
-                use pliron::attribute::AttrObj;
-                let get_int = |attr: &AttrObj| -> Option<u32> {
-                    attr.downcast_ref::<pliron::builtin::attributes::IntegerAttr>()
-                        .map(|int_attr| int_attr.value().to_u32())
-                };
-
-                if let Some(max_threads) = get_int(max_attr) {
-                    let min_blocks = attrs.get(&minctasm_key).and_then(get_int);
-                    self.launch_bounds_kernels.push(KernelLaunchBounds {
-                        name: fixed_func_name.clone(),
-                        max_threads,
-                        min_blocks: if min_blocks == Some(0) {
-                            None
-                        } else {
-                            min_blocks
-                        },
-                    });
-                }
+            if let Some(max_threads) = get_int("maxntid") {
+                let min_blocks = get_int("minctasm");
+                self.launch_bounds_kernels.push(KernelLaunchBounds {
+                    name: fixed_func_name.clone(),
+                    max_threads,
+                    min_blocks: if min_blocks == Some(0) {
+                        None
+                    } else {
+                        min_blocks
+                    },
+                });
             }
         }
 

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -896,16 +896,11 @@ impl<'a> ModuleExportState<'a> {
         let res_name = value_names.get(&res).unwrap();
         let val = op_ref.get_operand(0);
 
-        // Manual attribute access since helper is missing
         let nneg_key: pliron::identifier::Identifier = "llvm_nneg_flag".try_into().unwrap();
         let nneg = op_ref
             .attributes
-            .0
-            .get(&nneg_key)
-            .and_then(|attr| {
-                attr.downcast_ref::<pliron::builtin::attributes::BoolAttr>()
-                    .map(|b| bool::from(b.clone()))
-            })
+            .get::<pliron::builtin::attributes::BoolAttr>(&nneg_key)
+            .map(|b| bool::from(b.clone()))
             .unwrap_or(false);
 
         write!(output, "  {res_name} = zext ").unwrap();

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -449,8 +449,7 @@ pub fn translate_body(
             .get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(key, kernel_attr.into());
+            .set(key, kernel_attr);
 
         // Detect compile-time cluster configuration from #[cluster(x,y,z)] attribute
         if let Some(cluster_dims) = detect_cluster_config(body) {
@@ -478,9 +477,9 @@ pub fn translate_body(
             let z_key: Identifier = "cluster_dim_z".try_into().unwrap();
 
             let mut op_mut = mir_func_op.get_operation().deref_mut(ctx);
-            op_mut.attributes.0.insert(x_key, x_attr.into());
-            op_mut.attributes.0.insert(y_key, y_attr.into());
-            op_mut.attributes.0.insert(z_key, z_attr.into());
+            op_mut.attributes.set(x_key, x_attr);
+            op_mut.attributes.set(y_key, y_attr);
+            op_mut.attributes.set(z_key, z_attr);
 
             if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
                 eprintln!(
@@ -508,14 +507,14 @@ pub fn translate_body(
             let max_key: Identifier = "maxntid".try_into().unwrap();
 
             let mut op_mut = mir_func_op.get_operation().deref_mut(ctx);
-            op_mut.attributes.0.insert(max_key, max_attr.into());
+            op_mut.attributes.set(max_key, max_attr);
 
             // Only add minctasm if it's non-zero (specified)
             if launch_bounds.min_blocks > 0 {
                 let apint_min = APInt::from_u32(launch_bounds.min_blocks, width);
                 let min_attr = IntegerAttr::new(u32_ty, apint_min);
                 let min_key: Identifier = "minctasm".try_into().unwrap();
-                op_mut.attributes.0.insert(min_key, min_attr.into());
+                op_mut.attributes.set(min_key, min_attr);
             }
 
             if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {

--- a/crates/mir-importer/src/translator/terminator/helpers.rs
+++ b/crates/mir-importer/src/translator/terminator/helpers.rs
@@ -160,9 +160,9 @@ pub fn emit_function_call(
     call_op.deref_mut(ctx).set_loc(loc.clone());
 
     let callee_attr = StringAttr::new(callee_name.into());
-    call_op.deref_mut(ctx).attributes.0.insert(
+    call_op.deref_mut(ctx).attributes.set(
         pliron::identifier::Identifier::try_from("callee").unwrap(),
-        callee_attr.into(),
+        callee_attr,
     );
 
     let call_op = if let Some(prev) = last_op {

--- a/crates/mir-importer/src/translator/terminator/intrinsics/float_math.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/float_math.rs
@@ -418,8 +418,7 @@ pub fn emit_sincos(
     sin_op
         .deref_mut(ctx)
         .attributes
-        .0
-        .insert(callee_id.clone(), StringAttr::new(sin_callee.into()).into());
+        .set(callee_id.clone(), StringAttr::new(sin_callee.into()));
     if let Some(prev) = last_op {
         sin_op.insert_after(ctx, prev);
     } else {
@@ -440,8 +439,7 @@ pub fn emit_sincos(
     cos_op
         .deref_mut(ctx)
         .attributes
-        .0
-        .insert(callee_id, StringAttr::new(cos_callee.into()).into());
+        .set(callee_id, StringAttr::new(cos_callee.into()));
     cos_op.insert_after(ctx, sin_op);
     let cos_val = cos_op.deref(ctx).get_result(0);
 

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1336,10 +1336,10 @@ fn translate_closure_call(
         let bool_type = IntegerType::get(ctx, 1, Signedness::Unsigned);
         let mutable_attr =
             IntegerAttr::new(bool_type, APInt::from_i64(1, NonZeroUsize::new(1).unwrap()));
-        ref_op.deref_mut(ctx).attributes.0.insert(
-            Identifier::try_from("mutable").unwrap(),
-            mutable_attr.into(),
-        );
+        ref_op
+            .deref_mut(ctx)
+            .attributes
+            .set(Identifier::try_from("mutable").unwrap(), mutable_attr);
 
         // Insert after previous op
         if let Some(prev) = last_op {
@@ -1417,8 +1417,7 @@ fn translate_closure_call(
     call_op
         .deref_mut(ctx)
         .attributes
-        .0
-        .insert(Identifier::try_from("callee").unwrap(), callee_attr.into());
+        .set(Identifier::try_from("callee").unwrap(), callee_attr);
 
     // Insert the call
     let call_op = if let Some(prev) = last_op {

--- a/crates/mir-lower/src/convert/ops/arithmetic.rs
+++ b/crates/mir-lower/src/convert/ops/arithmetic.rs
@@ -114,7 +114,7 @@ fn is_signed_int_op(
 fn add_fastmath_flags(ctx: &mut Context, op: Ptr<Operation>) {
     let flags = FastmathFlagsAttr::default();
     let key: pliron::identifier::Identifier = "llvm_fast_math_flags".try_into().unwrap();
-    op.deref_mut(ctx).attributes.0.insert(key, flags.into());
+    op.deref_mut(ctx).attributes.set(key, flags);
 }
 
 // ============================================================================
@@ -442,10 +442,10 @@ where
         let cast_op = if lhs_width > rhs_width {
             let zext = llvm::ZExtOp::new(ctx, rhs, lhs_ty);
             let nneg_key: pliron::identifier::Identifier = "llvm_nneg_flag".try_into().unwrap();
-            zext.get_operation().deref_mut(ctx).attributes.0.insert(
-                nneg_key,
-                pliron::builtin::attributes::BoolAttr::new(false).into(),
-            );
+            zext.get_operation()
+                .deref_mut(ctx)
+                .attributes
+                .set(nneg_key, pliron::builtin::attributes::BoolAttr::new(false));
             zext.get_operation()
         } else {
             llvm::TruncOp::new(ctx, rhs, lhs_ty).get_operation()

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -983,10 +983,10 @@ fn cast_integer_value_to_type(
     let cast_op = if source_width < target_width {
         let zext = llvm::ZExtOp::new(ctx, value, target_ty);
         let nneg_key: pliron::identifier::Identifier = "llvm_nneg_flag".try_into().unwrap();
-        zext.get_operation().deref_mut(ctx).attributes.0.insert(
-            nneg_key,
-            pliron::builtin::attributes::BoolAttr::new(false).into(),
-        );
+        zext.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(nneg_key, pliron::builtin::attributes::BoolAttr::new(false));
         zext.get_operation()
     } else {
         llvm::TruncOp::new(ctx, value, target_ty).get_operation()

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -197,10 +197,10 @@ fn convert_int_to_int(
         } else {
             let zext = llvm::ZExtOp::new(ctx, val, llvm_ty);
             let nneg_key: pliron::identifier::Identifier = "llvm_nneg_flag".try_into().unwrap();
-            zext.get_operation().deref_mut(ctx).attributes.0.insert(
-                nneg_key,
-                pliron::builtin::attributes::BoolAttr::new(false).into(),
-            );
+            zext.get_operation()
+                .deref_mut(ctx)
+                .attributes
+                .set(nneg_key, pliron::builtin::attributes::BoolAttr::new(false));
             Ok(zext.get_operation())
         }
     } else if dst_w < src_w {
@@ -234,10 +234,11 @@ fn convert_int_to_float(
     } else {
         let uitofp = llvm::UIToFPOp::new(ctx, val, llvm_ty);
         let nneg_key: pliron::identifier::Identifier = "llvm_nneg_flag".try_into().unwrap();
-        uitofp.get_operation().deref_mut(ctx).attributes.0.insert(
-            nneg_key,
-            pliron::builtin::attributes::BoolAttr::new(false).into(),
-        );
+        uitofp
+            .get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(nneg_key, pliron::builtin::attributes::BoolAttr::new(false));
         Ok(uitofp.get_operation())
     }
 }
@@ -976,16 +977,14 @@ fn convert_float_to_float(
         op.get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(flags_key, flags.into());
+            .set(flags_key, flags);
         Ok(op.get_operation())
     } else if src_width > dst_width {
         let op = llvm::FPTruncOp::new(ctx, val, llvm_ty);
         op.get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(flags_key, flags.into());
+            .set(flags_key, flags);
         Ok(op.get_operation())
     } else {
         Ok(llvm::BitcastOp::new(ctx, val, llvm_ty).get_operation())

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -284,28 +284,22 @@ pub fn convert_shared_alloc_dc(
 
         let elem_type_attr = op_ref
             .attributes
-            .0
-            .get(&"elem_type".try_into().unwrap())
+            .get::<TypeAttr>(&"elem_type".try_into().unwrap())
             .ok_or_else(|| {
                 anyhow_to_pliron(anyhow::anyhow!(
-                    "MirSharedAllocOp missing elem_type attribute"
+                    "MirSharedAllocOp missing elem_type TypeAttr attribute"
                 ))
             })?;
-        let elem_type_attr = elem_type_attr
-            .downcast_ref::<TypeAttr>()
-            .ok_or_else(|| anyhow_to_pliron(anyhow::anyhow!("elem_type is not a TypeAttr")))?;
         let mir_elem_type = elem_type_attr.get_type(ctx);
 
         let size_attr = op_ref
             .attributes
-            .0
-            .get(&"size".try_into().unwrap())
+            .get::<IntegerAttr>(&"size".try_into().unwrap())
             .ok_or_else(|| {
-                anyhow_to_pliron(anyhow::anyhow!("MirSharedAllocOp missing size attribute"))
+                anyhow_to_pliron(anyhow::anyhow!(
+                    "MirSharedAllocOp missing size IntegerAttr attribute"
+                ))
             })?;
-        let size_attr = size_attr
-            .downcast_ref::<IntegerAttr>()
-            .ok_or_else(|| anyhow_to_pliron(anyhow::anyhow!("size is not an IntegerAttr")))?;
         let size = size_attr.value().to_u64();
 
         let alignment = shared_alloc_op.get_alignment_value(ctx).unwrap_or(0);
@@ -417,30 +411,22 @@ pub fn convert_global_alloc_dc(
 
         let global_key_attr = op_ref
             .attributes
-            .0
-            .get(&"global_key".try_into().unwrap())
+            .get::<StringAttr>(&"global_key".try_into().unwrap())
             .ok_or_else(|| {
                 anyhow_to_pliron(anyhow::anyhow!(
-                    "MirGlobalAllocOp missing global_key attribute"
+                    "MirGlobalAllocOp missing global_key StringAttr attribute"
                 ))
             })?;
-        let global_key_attr = global_key_attr
-            .downcast_ref::<StringAttr>()
-            .ok_or_else(|| anyhow_to_pliron(anyhow::anyhow!("global_key is not a StringAttr")))?;
         let global_key = String::from((*global_key_attr).clone());
 
         let global_type_attr = op_ref
             .attributes
-            .0
-            .get(&"global_type".try_into().unwrap())
+            .get::<TypeAttr>(&"global_type".try_into().unwrap())
             .ok_or_else(|| {
                 anyhow_to_pliron(anyhow::anyhow!(
-                    "MirGlobalAllocOp missing global_type attribute"
+                    "MirGlobalAllocOp missing global_type TypeAttr attribute"
                 ))
             })?;
-        let global_type_attr = global_type_attr
-            .downcast_ref::<TypeAttr>()
-            .ok_or_else(|| anyhow_to_pliron(anyhow::anyhow!("global_type is not a TypeAttr")))?;
         let mir_global_type = global_type_attr.get_type(ctx);
 
         let alignment = global_op.get_alignment_value(ctx).unwrap_or(0);

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -1149,11 +1149,7 @@ mod tests {
             let func_op = module_block.deref(&ctx).iter(&ctx).next().unwrap();
             let kernel_attr = StringAttr::new("true".to_string());
             let key: pliron::identifier::Identifier = "gpu_kernel".try_into().unwrap();
-            func_op
-                .deref_mut(&ctx)
-                .attributes
-                .0
-                .insert(key, kernel_attr.into());
+            func_op.deref_mut(&ctx).attributes.set(key, kernel_attr);
         }
 
         // The slot map lowers MultiPayload byte-identically to rustc's
@@ -1206,11 +1202,7 @@ mod tests {
             let func_op = module_block.deref(&ctx).iter(&ctx).next().unwrap();
             let kernel_attr = StringAttr::new("true".to_string());
             let key: pliron::identifier::Identifier = "gpu_kernel".try_into().unwrap();
-            func_op
-                .deref_mut(&ctx)
-                .attributes
-                .0
-                .insert(key, kernel_attr.into());
+            func_op.deref_mut(&ctx).attributes.set(key, kernel_attr);
         }
 
         let err = crate::lower_mir_to_llvm(&mut ctx, module_ptr)

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -133,7 +133,10 @@ fn gpu_kernel_attr() -> pliron::identifier::Identifier {
 /// for that branch and is consumed by both [`convert_function_type`] and
 /// the entry-block prologue in `lowering.rs`.
 pub fn is_kernel_func(ctx: &Context, op: Ptr<Operation>) -> bool {
-    op.deref(ctx).attributes.0.contains_key(&gpu_kernel_attr())
+    op.deref(ctx)
+        .attributes
+        .get::<pliron::builtin::attributes::StringAttr>(&gpu_kernel_attr())
+        .is_some()
 }
 
 // =============================================================================

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -192,19 +192,14 @@ fn propagate_kernel_attrs(
     llvm_func: &llvm::FuncOp,
     kernel_key: &pliron::identifier::Identifier,
 ) {
-    llvm_func
-        .get_operation()
-        .deref_mut(ctx)
-        .attributes
-        .0
-        .insert(
-            kernel_key.clone(),
-            pliron::builtin::attributes::StringAttr::new("true".to_string()).into(),
-        );
+    llvm_func.get_operation().deref_mut(ctx).attributes.set(
+        kernel_key.clone(),
+        pliron::builtin::attributes::StringAttr::new("true".to_string()),
+    );
 
     // Extract MIR attrs first to avoid borrow overlap with deref_mut below
     let attrs_to_copy: Vec<_> = {
-        let mir_attrs = &mir_op.deref(ctx).attributes.0;
+        let mir_attrs = &mir_op.deref(ctx).attributes;
         [
             "cluster_dim_x",
             "cluster_dim_y",
@@ -215,7 +210,9 @@ fn propagate_kernel_attrs(
         .iter()
         .filter_map(|key_str| {
             let key: pliron::identifier::Identifier = (*key_str).try_into().unwrap();
-            mir_attrs.get(&key).map(|attr| (key, attr.clone()))
+            mir_attrs
+                .get::<pliron::builtin::attributes::IntegerAttr>(&key)
+                .map(|attr| (key, attr.clone()))
         })
         .collect()
     };
@@ -225,8 +222,7 @@ fn propagate_kernel_attrs(
             .get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(key, attr);
+            .set(key, attr);
     }
 }
 

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -941,7 +941,7 @@ fn test_bool_phi_cmp_lowers_to_unsigned_i1_icmp() -> Result<(), anyhow::Error> {
     );
     Operation::get_op::<mir::MirCondBranchOp>(cond_br, &ctx)
         .expect("MirCondBranchOp")
-        .set_operand_segment_sizes(&mut ctx, segment_sizes);
+        .set_operand_segment_sizes(&ctx, segment_sizes);
     cond_br.insert_at_back(bb0, &ctx);
 
     // bb1: goto bb2(b).

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,12 +211,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -218,6 +230,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hi_sparse_bitset"
@@ -282,6 +299,15 @@ dependencies = [
  "reserved-oxide-symbols",
  "rustc-hash",
  "thiserror",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -354,12 +380,13 @@ dependencies = [
 [[package]]
 name = "pliron"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "awint",
  "combine",
  "downcast-rs",
  "dyn-clone",
+ "hashbrown 0.17.0",
  "hi_sparse_bitset",
  "inventory",
  "linkme",
@@ -369,6 +396,7 @@ dependencies = [
  "rustc-hash",
  "rustc_apfloat",
  "slotmap",
+ "spin",
  "thiserror",
  "utf8-chars",
 ]
@@ -376,7 +404,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "combine",
  "convert_case",
@@ -389,7 +417,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=fed4e6f848bd726a4f2deb51c5021760ef382aec#fed4e6f848bd726a4f2deb51c5021760ef382aec"
+source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
 dependencies = [
  "bitflags",
  "log",
@@ -506,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +553,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "syn"

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -29,8 +29,8 @@ oxide-artifacts = { path = "../oxide-artifacts", features = ["object-write"] }
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml
 # [workspace.dependencies] section. Source MUST match the root (same git + rev),
 # or pliron resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "fed4e6f848bd726a4f2deb51c5021760ef382aec" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "fed4e6f848bd726a4f2deb51c5021760ef382aec" }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
 linkme = "0.3"            # must match workspace
 combine = "4.6"           # must match workspace
 once_cell = "1.18"        # must match workspace


### PR DESCRIPTION
## deps: bump pliron to master af1b7d0 + AttributeDict encapsulation sweep

Tracks upstream pliron master at `af1b7d07dda9`, picking up:

- [pliron #114](https://github.com/pliron-org/pliron/pull/114): `no_std` support; pliron's maps move to hashbrown
- pliron #121: graph traversals changed from recursive to iterative
- pliron #117: `simplify_cfg` optimizer added to the llvm-opt pipeline

Both the root workspace and the isolated `rustc-codegen-cuda` workspace move to the same rev (required, or pliron resolves to two distinct crates and types stop unifying). Both lockfiles updated together.

### Why the bump broke 4 call sites

hashbrown's `get<Q: Hash + Equivalent<K>>` no longer pins the key type, so call sites that reached into `AttributeDict`'s inner map through the public `.0` field with `"literal".try_into().unwrap()` keys stopped inferring (`E0283: type annotations needed`). Exactly 4 sites broke, all in `mir-lower/src/convert/ops/memory.rs`.

Call sites that already used the wrapper API (`dialect-nvvm` debug ops, `AlignmentAttr` helpers in llvm-export) were untouched by the change. The break only bit code that bypassed the abstraction.

### The encapsulation sweep (the actual point)

Rather than patching the 4 sites with turbofish, this PR routes every keyed `AttributeDict` access through the typed wrapper, so no future map-internals change upstream can reach us:

```text
Before: op.attributes.0.insert(key, attr.into())          // manual AttrObj boxing
After:  op.attributes.set(key, attr)                      // typed

Before: op.attributes.0.get(&key) + downcast_ref::<T>()   // two-step, two error paths
After:  op.attributes.get::<T>(&key)                      // downcasts for you

Before: op.attributes.0.contains_key(&gpu_kernel)
After:  op.attributes.get::<StringAttr>(&gpu_kernel).is_some()
```

Swept sites: callee/mutable stamps in the mir-importer translator, gpu_kernel + cluster-dim + launch-bound stamps and propagation (mir-importer `body.rs`, mir-lower `lowering.rs`), fastmath/nneg/overflow flag stamps (mir-lower arithmetic/cast/call), the nneg read and kernel metadata reads in the llvm-export emitter.

Whole-map operations keep using the public field because the wrapper has no equivalent yet: the MirFuncOp printer in dialect-mir (`retain` + `is_empty` on a `clone_skip_outlined` copy) and a `keys()` introspection in llvm-export's ops_test. Upstream wrapper candidates: `remove`/`retain` and key iteration.

One additional fallout fix: upstream relaxed `set_operand_segment_sizes` to take `&Context`; a mir-lower test passed `&mut ctx` and tripped `clippy::unnecessary_mut_passed` under `-D warnings`.

### Verification

- 4 inference breaks reproduced pre-fix, workspace check clean post-fix
- All 5 compiler-crate test suites pass (101 tests, 0 failed); workspace test binaries compile
- fmt, clippy `-D warnings` (`--all-targets`), doc `-D warnings`, doctests: clean
- Backend rebuilt against the new rev; compile-only builds verified: `vecadd` (sm_90), `tcgen05` (sm_100, 102 tcgen05 instructions in PTX), `wgmma` (sm_90a)
- Rewritten attribute paths verified end-to-end in artifacts: `cluster` emits `cluster_dim_x/y/z` nvvm.annotations; `debug` emits `maxntidx`/`minctasm` metadata and `.maxntid` in PTX

Labels: `build-related`, `refactor`, `IR-lowering`, `llvm-export`
## GPU verification (done)

Full smoketest on a 2x RTX 5090 box (sm_120): compile-only 92/92, execution 91/92. The one execution failure is `cluster` Test 2 (cluster sync), which fails identically on current main on this hardware and is expected for now per the maintainer; not related to this bump.
