### PR TITLE
Preserve device contexts when duplicate init fails

### DIFF
--- a/crates/cuda-async/src/device_context.rs
+++ b/crates/cuda-async/src/device_context.rs
@@ -105,9 +105,12 @@ pub fn init_device_contexts(
     num_devices: usize,
 ) -> Result<(), DeviceError> {
     DEVICE_CONTEXTS.with(|ctx| {
+        let devices = ctx.devices.take();
+        let is_uninitialized = devices.is_none();
+        ctx.devices.set(devices);
         device_assert(
             default_device_id,
-            ctx.devices.replace(None).is_none(),
+            is_uninitialized,
             "Context already initialized.",
         )
     })?;
@@ -326,4 +329,31 @@ pub fn get_cuda_function(
             .ok_or_else(|| device_error(device_id, "Failed to get cuda function."))?;
         Ok(Arc::clone(function))
     })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_duplicate_init_error(result: Result<(), DeviceError>) {
+        assert!(matches!(
+            result,
+            Err(DeviceError::Context {
+                device_id: 0,
+                message,
+            }) if message == "Context already initialized."
+        ));
+    }
+
+    #[test]
+    fn duplicate_init_preserves_existing_device_contexts() {
+        std::thread::spawn(|| {
+            init_device_contexts(0, 1).expect("initial context initialization should succeed");
+
+            assert_duplicate_init_error(init_device_contexts(0, 1));
+            assert_duplicate_init_error(init_device_contexts(0, 1));
+        })
+        .join()
+        .expect("test thread should not panic");
+    }
 }


### PR DESCRIPTION
## Summary
- keep `init_device_contexts` from clearing the thread-local device map while checking for duplicate initialization
- add a regression test showing duplicate init continues to fail after the first duplicate error

## Why
`ctx.devices.replace(None).is_none()` used the duplicate-init predicate itself to replace the existing map with `None`. That made the first duplicate call return `Context already initialized`, but it also dropped the initialized state, so a later call could initialize again.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p cuda-async duplicate_init_preserves_existing_device_contexts` *(blocked locally: CUDA toolkit headers are not installed; `cuda-bindings` could not find `cuda.h` under `/usr/local/cuda`)*
