### PR TITLE
fix(pipeline): create output_dir before emission

### DIFF
--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -224,6 +224,8 @@ pub fn run_pipeline(
     device_externs: &[DeviceExternDecl],
     config: &PipelineConfig,
 ) -> Result<CompilationResult, PipelineError> {
+    prepare_output_dir(&config.output_dir)?;
+
     let mut ctx = Context::new();
 
     // Step 1: Register dialects
@@ -463,6 +465,21 @@ pub fn run_pipeline(
             target,
         })
     }
+}
+
+/// Ensures the configured output directory exists before any emission step.
+///
+/// The pipeline writes every generated artifact under `PipelineConfig::output_dir`.
+/// Creating the directory at the pipeline boundary lets callers provide fresh
+/// sidecar paths without separately seeding them first.
+fn prepare_output_dir(output_dir: &Path) -> Result<(), PipelineError> {
+    std::fs::create_dir_all(output_dir).map_err(|e| {
+        PipelineError::Export(format!(
+            "failed to create output directory {}: {}",
+            output_dir.display(),
+            e
+        ))
+    })
 }
 
 /// Returns true when lowering emitted CUDA libdevice calls.
@@ -1317,6 +1334,40 @@ mod tests {
         let stripped = strip_target_debug_from_ptx_text(ptx);
 
         assert_eq!(stripped, ".target sm_90a, texmode_independent\n");
+    }
+
+    #[test]
+    fn run_pipeline_creates_missing_output_dir_before_export() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_mir_importer_output_dir_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let output_dir = root.join("fresh").join("nested");
+        fs::remove_dir_all(&root).ok();
+        assert!(!output_dir.exists());
+
+        let config = PipelineConfig {
+            output_dir: output_dir.clone(),
+            output_name: "empty".to_string(),
+            verbose: false,
+            show_mir_dialect: false,
+            show_llvm_dialect: false,
+            emit_nvvm_ir: true,
+        };
+
+        let result = run_pipeline(&[], &[], &config).expect("pipeline run");
+
+        assert!(output_dir.is_dir());
+        assert!(result.ll_path.is_file());
+        assert_eq!(result.artifact_path, result.ll_path);
+        assert_eq!(result.artifact_kind, CompilationArtifactKind::NvvmIr);
+
+        fs::remove_dir_all(&root).expect("clean up temp output dir");
     }
 
     #[test]

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -1358,6 +1358,7 @@ mod tests {
             show_mir_dialect: false,
             show_llvm_dialect: false,
             emit_nvvm_ir: true,
+            debug_kind: DebugKind::Off,
         };
 
         let result = run_pipeline(&[], &[], &config).expect("pipeline run");


### PR DESCRIPTION
Closes #180.

## Problem

`run_pipeline` writes generated artifacts under `PipelineConfig::output_dir`, but previously assumed that directory already existed. Callers that choose a fresh sidecar output directory hit `Export failed: No such file or directory (os error 2)` before the first `.ll` emission.

## Fix

Create `PipelineConfig::output_dir` at the start of `run_pipeline`, before any MIR translation, LLVM export, or PTX/NVVM artifact emission work. Directory creation uses `std::fs::create_dir_all`, so existing directories remain a no-op and nested fresh paths are created in one place.

## Tests

Added a focused `mir-importer` regression that runs the pipeline with an empty function set, NVVM IR emission, and a nested missing output directory. The test avoids invoking `llc`, verifies the fresh directory is created before export, and asserts the `.ll` artifact is written under it.

## Validation

`cargo test -p mir-importer run_pipeline_creates_missing_output_dir_before_export`
