### PR TITLE
fix(pipeline): preserve inline always

### DIFF
--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -231,7 +231,9 @@ impl<'a> ModuleExportState<'a> {
         // Emitted as a function attribute keyword between the parameter
         // list and the body open brace.
         let alwaysinline_key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
-        let is_alwaysinline = attrs.0.contains_key(&alwaysinline_key);
+        let is_alwaysinline = attrs
+            .get::<pliron::builtin::attributes::StringAttr>(&alwaysinline_key)
+            .is_some();
 
         if let Some(entry_block) = entry_block_opt {
             let func_loc = func.get_operation().deref(self.ctx).loc();

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -227,6 +227,12 @@ impl<'a> ModuleExportState<'a> {
             .iter(self.ctx)
             .next();
 
+        // Check for alwaysinline attribute (from #[inline(always)]).
+        // Emitted as a function attribute keyword between the parameter
+        // list and the body open brace.
+        let alwaysinline_key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
+        let is_alwaysinline = attrs.0.contains_key(&alwaysinline_key);
+
         if let Some(entry_block) = entry_block_opt {
             let func_loc = func.get_operation().deref(self.ctx).loc();
             let debug_scope = self.debug_subprogram_for_function(&fixed_func_name, &func_loc);
@@ -278,10 +284,14 @@ impl<'a> ModuleExportState<'a> {
             // gets its `bar.sync.aligned` pushed into a `tid`-dependent branch
             // and deadlocks. opt's FunctionAttrs strips `convergent` from
             // functions it proves never reach a convergent op.
+            // alwaysinline (from #[inline(always)]) and !dbg are independent:
+            // either, both, or neither can be present. Emit the inline keyword
+            // before the convergent attr group #0, then the debug scope.
+            let inline_attr = if is_alwaysinline { "alwaysinline " } else { "" };
             if let Some(scope_id) = debug_scope {
-                writeln!(output, ") #0 !dbg !{scope_id} {{").unwrap();
+                writeln!(output, ") {inline_attr}#0 !dbg !{scope_id} {{").unwrap();
             } else {
-                writeln!(output, ") #0 {{").unwrap();
+                writeln!(output, ") {inline_attr}#0 {{").unwrap();
             }
             self.convergent_used = true;
 

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -464,6 +464,89 @@ fn line_table_debug_metadata_emits_function_scope_and_instruction_locations() {
 }
 
 #[test]
+fn export_alwaysinline_function_attribute_uses_llvm_define_syntax() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func = FuncOp::new(&mut ctx, "inline_helper".try_into().unwrap(), func_ty);
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+
+    let key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
+    func.get_operation()
+        .deref_mut(&ctx)
+        .attributes
+        .set(key, StringAttr::new("true".to_string()));
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let ir = export_module_to_string(&ctx, &module).expect("export succeeds");
+    let define_line = ir
+        .lines()
+        .find(|line| line.starts_with("define void @inline_helper("))
+        .expect("inline helper definition");
+    assert_eq!(
+        define_line, "define void @inline_helper() alwaysinline #0 {",
+        "`alwaysinline` must be emitted after the parameter list, before attr group #0:\n{ir}"
+    );
+    assert!(
+        ir.contains("attributes #0 = { convergent }"),
+        "convergent attribute group must still be emitted:\n{ir}"
+    );
+}
+
+#[test]
+fn export_alwaysinline_coexists_with_debug_scope() {
+    // alwaysinline and the !dbg scope are emitted on the same define line and
+    // must not crowd each other out. This guards the 4-way emission: a future
+    // change that drops either one when both are present fails here.
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func = FuncOp::new(&mut ctx, "inline_helper".try_into().unwrap(), func_ty);
+    let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 7, 1);
+    func.get_operation().deref_mut(&ctx).set_loc(func_loc);
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    let ret = ReturnOp::new(&mut ctx, None);
+    let ret_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 8, 5);
+    ret.get_operation().deref_mut(&ctx).set_loc(ret_loc);
+    ret.get_operation().insert_at_back(entry, &ctx);
+
+    let key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
+    func.get_operation()
+        .deref_mut(&ctx)
+        .attributes
+        .set(key, StringAttr::new("true".to_string()));
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = DebugConfig {
+        inner: PtxExportConfig,
+        debug_kind: DebugKind::LineTables,
+    };
+    let ir =
+        export_module_to_string_with_config(&ctx, &module, &config).expect("debug export succeeds");
+    let define_line = ir
+        .lines()
+        .find(|line| line.starts_with("define void @inline_helper("))
+        .expect("inline helper definition");
+    assert!(
+        define_line.contains("alwaysinline"),
+        "alwaysinline must survive when debug info is on:\n{ir}"
+    );
+    assert!(
+        define_line.contains("!dbg !"),
+        "!dbg scope must survive when alwaysinline is present:\n{ir}"
+    );
+}
+
+#[test]
 fn line_table_debug_metadata_uses_file_scope_for_cross_file_locations() {
     let mut ctx = Context::new();
 

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -50,6 +50,19 @@ pub struct CollectedFunction {
     pub is_kernel: bool,
     /// The name to export in PTX. For kernels, this is the user-visible name.
     pub export_name: String,
+    /// True if the function is marked `#[inline(always)]` in rustc's
+    /// `CodegenFnAttrs`. The stable_mir API does not expose inline hints, so
+    /// this is queried via `rustc_middle::TyCtxt::codegen_fn_attrs` in
+    /// `rustc-codegen-cuda` and threaded through.
+    ///
+    /// When true, the LLVM `alwaysinline` attribute is emitted on the
+    /// function definition. The existing matched LLVM middle-end (`opt -O2`),
+    /// when available, can then honor the attribute before PTX generation;
+    /// this flag does not add a separate mandatory inliner pass.
+    ///
+    /// This preserves Rust's inline intent for device helpers and avoids
+    /// making helper boundaries depend entirely on later optimizer heuristics.
+    pub is_inline_always: bool,
 }
 
 /// An external device function declaration (for FFI with external LTOIR).
@@ -266,6 +279,7 @@ pub fn run_pipeline(
             &body,
             &func.instance,
             func.is_kernel,
+            func.is_inline_always,
             Some(&func.export_name),
             &mut legaliser,
             config.debug_kind,
@@ -441,7 +455,6 @@ pub fn run_pipeline(
             target,
         })
     } else {
-        // PTX mode: invoke llc
         if config.verbose {
             eprintln!("\n=== Generating PTX ===");
         }

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -831,8 +831,7 @@ fn set_alwaysinline_attr_from_flag(
             .get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(key, attr.into());
+            .set(key, attr);
     }
 }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -479,12 +479,15 @@ fn emit_entry_allocas(
 /// * `body` - MIR function body
 /// * `instance` - Monomorphized instance (with concrete generic args)
 /// * `is_kernel` - Add `gpu_kernel` attribute for kernel entry points
+/// * `is_inline_always` - Add `alwaysinline` attribute (non-kernel functions
+///   marked `#[inline(always)]` in rustc)
 /// * `override_name` - Custom export name (defaults to instance name)
 pub fn translate_body(
     ctx: &mut Context,
     body: &mir::Body,
     instance: &mono::Instance,
     is_kernel: bool,
+    is_inline_always: bool,
     override_name: Option<&str>,
     legaliser: &mut Legaliser,
     debug_kind: DebugKind,
@@ -710,6 +713,8 @@ pub fn translate_body(
         }
     }
 
+    set_alwaysinline_attr_from_flag(ctx, &mir_func_op, is_kernel, is_inline_always);
+
     // Get the function body region (region 0)
     let region_ptr = op_ptr.deref(ctx).get_region(0);
 
@@ -807,4 +812,106 @@ pub fn translate_body(
     }
 
     Ok(op_ptr)
+}
+
+/// Propagate `#[inline(always)]` as an LLVM `alwaysinline` function
+/// attribute. Kernel entry points are excluded because they're `.entry` in PTX
+/// and never callees, so marking them `alwaysinline` would be a no-op at best
+/// and rejected by LLVM at worst.
+fn set_alwaysinline_attr_from_flag(
+    ctx: &mut Context,
+    mir_func_op: &MirFuncOp,
+    is_kernel: bool,
+    is_inline_always: bool,
+) {
+    if is_inline_always && !is_kernel {
+        let attr = pliron::builtin::attributes::StringAttr::new("true".to_string());
+        let key: Identifier = "alwaysinline".try_into().unwrap();
+        mir_func_op
+            .get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .0
+            .insert(key, attr.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pliron::{
+        basic_block::BasicBlock,
+        builtin::{
+            attributes::TypeAttr, op_interfaces::SymbolOpInterface, ops::ModuleOp,
+            types::FunctionType,
+        },
+        linked_list::ContainsLinkedList,
+        op::Op,
+        operation::Operation,
+    };
+
+    #[test]
+    fn inline_always_flag_reaches_llvm_func_attr_before_export() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+        let module_op = module.get_operation();
+        let module_region = module_op.deref(&ctx).get_region(0);
+        let module_block = {
+            let existing = {
+                let region = module_region.deref(&ctx);
+                region.iter(&ctx).next()
+            };
+            if let Some(block) = existing {
+                block
+            } else {
+                let block = BasicBlock::new(&mut ctx, None, vec![]);
+                block.insert_at_back(module_region, &ctx);
+                block
+            }
+        };
+
+        let func_type = FunctionType::get(&mut ctx, vec![], vec![]);
+        let func_type_attr = TypeAttr::new(func_type.into());
+        let mir_func = {
+            let op = Operation::new(
+                &mut ctx,
+                MirFuncOp::get_concrete_op_info(),
+                vec![],
+                vec![],
+                vec![],
+                1,
+            );
+            let func = MirFuncOp::new(&mut ctx, op, func_type_attr);
+            func.set_symbol_name(&mut ctx, "inline_helper".try_into().unwrap());
+            func
+        };
+
+        set_alwaysinline_attr_from_flag(&mut ctx, &mir_func, false, true);
+        mir_func.get_operation().insert_at_back(module_block, &ctx);
+
+        mir_lower::register(&mut ctx);
+        mir_lower::lower_mir_to_llvm(&mut ctx, module_op).expect("lowering succeeds");
+
+        let llvm_func = {
+            let block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+            block
+                .deref(&ctx)
+                .iter(&ctx)
+                .find_map(|op| Operation::get_op::<llvm_export::ops::FuncOp>(op, &ctx))
+                .expect("lowered LLVM function")
+        };
+
+        let key: Identifier = "alwaysinline".try_into().unwrap();
+        assert!(
+            llvm_func
+                .get_operation()
+                .deref(&ctx)
+                .attributes
+                .0
+                .contains_key(&key),
+            "`is_inline_always` must become an LLVM dialect alwaysinline attribute before export",
+        );
+    }
 }

--- a/crates/mir-importer/src/translator/mod.rs
+++ b/crates/mir-importer/src/translator/mod.rs
@@ -96,12 +96,16 @@ pub fn translate_function(
 ) -> TranslationResult<Ptr<Operation>> {
     register_dialects(ctx);
 
-    // Translate the function body
+    // Translate the function body. This helper is for tests/utilities that
+    // don't have access to rustc's CodegenFnAttrs, so `is_inline_always` is
+    // always false here. The real pipeline call (in `pipeline.rs`) threads
+    // the flag through from `rustc-codegen-cuda`.
     let func_op = body::translate_body(
         ctx,
         body,
         instance,
         is_kernel,
+        /* is_inline_always */ false,
         None,
         legaliser,
         DebugKind::Off,

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -130,6 +130,8 @@ pub fn convert_func(
         propagate_kernel_attrs(ctx, op, &llvm_func, &kernel_key);
     }
 
+    propagate_alwaysinline_attr(ctx, op, &llvm_func);
+
     let llvm_entry = llvm_func.get_or_create_entry_block(ctx);
 
     let mir_region = op.deref(ctx).get_region(0);
@@ -223,6 +225,32 @@ fn propagate_kernel_attrs(
             .deref_mut(ctx)
             .attributes
             .set(key, attr);
+    }
+}
+
+/// Propagate the `alwaysinline` attribute from MIR func to LLVM func.
+///
+/// Set on the MIR func op by `mir-importer` when the source Rust function
+/// carries `#[inline(always)]`. The LLVM exporter then emits the
+/// `alwaysinline` keyword on the `define` line. Existing `opt -O2` runs can
+/// honor that attribute before `llc`, but this propagation is not a mandatory
+/// always-inline pass. The goal is to preserve Rust's inline intent for device
+/// helpers rather than leaving helper boundaries solely to optimizer
+/// heuristics.
+fn propagate_alwaysinline_attr(
+    ctx: &mut Context,
+    mir_op: Ptr<Operation>,
+    llvm_func: &llvm::FuncOp,
+) {
+    let key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
+    let attr_opt = mir_op.deref(ctx).attributes.0.get(&key).cloned();
+    if let Some(attr) = attr_opt {
+        llvm_func
+            .get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .0
+            .insert(key, attr);
     }
 }
 

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -243,14 +243,17 @@ fn propagate_alwaysinline_attr(
     llvm_func: &llvm::FuncOp,
 ) {
     let key: pliron::identifier::Identifier = "alwaysinline".try_into().unwrap();
-    let attr_opt = mir_op.deref(ctx).attributes.0.get(&key).cloned();
+    let attr_opt = mir_op
+        .deref(ctx)
+        .attributes
+        .get::<pliron::builtin::attributes::StringAttr>(&key)
+        .cloned();
     if let Some(attr) = attr_opt {
         llvm_func
             .get_operation()
             .deref_mut(ctx)
             .attributes
-            .0
-            .insert(key, attr);
+            .set(key, attr);
     }
 }
 

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -439,8 +439,7 @@ pub fn generate_device_code<'tcx>(
             let def_id = func.instance.def_id();
             matches!(
                 tcx.codegen_fn_attrs(def_id).inline,
-                rustc_hir::attrs::InlineAttr::Always
-                    | rustc_hir::attrs::InlineAttr::Force { .. }
+                rustc_hir::attrs::InlineAttr::Always | rustc_hir::attrs::InlineAttr::Force { .. }
             )
         })
         .collect();

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -429,12 +429,29 @@ pub fn generate_device_code<'tcx>(
     // 2. Sets up thread-local CompilerCtxt
     // 3. Runs our closure with access to stable() conversion
     // 4. Tears down the context and returns our result
+    // Pre-compute `#[inline(always)]` flags before entering the stable_mir
+    // context, since the query lives on `rustc_middle::TyCtxt` and is not
+    // exposed through stable_mir. Preserving this hint avoids making helper
+    // boundaries depend entirely on later optimizer heuristics.
+    let inline_always_flags: Vec<bool> = functions
+        .iter()
+        .map(|func| {
+            let def_id = func.instance.def_id();
+            matches!(
+                tcx.codegen_fn_attrs(def_id).inline,
+                rustc_hir::attrs::InlineAttr::Always
+                    | rustc_hir::attrs::InlineAttr::Force { .. }
+            )
+        })
+        .collect();
+
     let result = rustc_internal::run(tcx, || {
         // Convert internal Instance<'tcx> to stable_mir Instance
         let stable_functions: Vec<mir_importer::CollectedFunction> = functions
             .iter()
             .zip(export_names.iter())
-            .map(|(func, (export_name, is_kernel))| {
+            .zip(inline_always_flags.iter())
+            .map(|((func, (export_name, is_kernel)), is_inline_always)| {
                 // Use rustc_internal::stable() to convert the Instance.
                 // This is the key bridge between rustc_middle and rustc_public types.
                 let stable_instance = rustc_internal::stable(func.instance);
@@ -443,6 +460,7 @@ pub fn generate_device_code<'tcx>(
                     instance: stable_instance,
                     is_kernel: *is_kernel,
                     export_name: export_name.clone(),
+                    is_inline_always: *is_inline_always,
                 }
             })
             .collect();

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -72,7 +72,7 @@ roadmap, **N/A** = not applicable or no identified need.
 | Feature | Status | Description |
 |:--------|:-------|:------------|
 | `#[kernel]` Attribute | **Full** | Marks functions as GPU kernel entry points (`ptx_kernel` calling convention). Multiple kernels per file. |
-| `#[device]` Helper Functions | **Full** | Device-side helper functions callable from kernels. Inlined aggressively by `llc`. |
+| `#[device]` Helper Functions | **Full** | Device-side helper functions callable from kernels. `#[inline(always)]` is preserved as the LLVM `alwaysinline` attribute (emitted alongside the convergent group and any `!dbg` scope), so `opt` honors the inline intent. |
 | Standalone `#[device]` Functions | **Full** | Device functions compiled without any kernel present. Clean export names for C++ consumption. |
 | Multi-Kernel Modules | **Full** | Multiple `#[kernel]` functions in a single source file compile to a single PTX module. |
 


### PR DESCRIPTION
Closes #188.

## Problem

cuda-oxide drops Rust `#[inline(always)]` before LLVM IR export, so non-kernel
device helper definitions are emitted without LLVM `alwaysinline`. That can
leave helper `.func` boundaries for the existing optimizer/PTX path and
diverges from Rust's codegen intent.

This branch claims attribute preservation only. It does not add a separate
mandatory always-inline pass; the existing matched LLVM middle-end can honor the
attribute when it runs before `llc`.

## Fix

- Read rustc `CodegenFnAttrs::inline` in `rustc-codegen-cuda`.
- Thread an `is_inline_always` flag through `CollectedFunction`.
- Attach an `alwaysinline` attribute during MIR import for non-kernel device
  functions marked `#[inline(always)]`.
- Propagate that attribute during MIR-to-LLVM lowering.
- Emit textual LLVM as `define ... ) alwaysinline #0 {`, preserving the
  existing convergent attribute group.

## Diligence

Checked the collection, MIR import, MIR-to-LLVM lowering, and LLVM export path
for the inline attribute. Kernel entry points are deliberately excluded because
they are PTX `.entry` exports rather than callees.

The pipeline already resolves a matched `opt`/`llc` pair and runs `opt -O2`
when available. This PR does not reintroduce a separate optimizer lookup or a
mandatory inliner pass, avoiding a second toolchain-selection path.

This PR draft is local-only upstreaming metadata and should stay out of the
upstream-facing commit.

## Tests

- Added `export_alwaysinline_function_attribute_uses_llvm_define_syntax` in
  `crates/llvm-export/tests/export_test.rs`.
- The test checks that exported LLVM contains `alwaysinline`.
- The test checks LLVM function-attribute placement by asserting the exact
  `define void @inline_helper() alwaysinline #0 {` line and verifying the
  convergent `#0` attribute group is still emitted.

No actual-inlining regression is included because the PR does not claim to run
a mandatory always-inline pass or guarantee helper removal after optimization.

## Validation

```bash
cargo test -p llvm-export export_alwaysinline_function_attribute_uses_llvm_define_syntax
```