### PR TITLE
feat(cuda-core): derive DeviceCopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,8 +338,10 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "cuda-macros",
  "half",
  "oxide-artifacts",
+ "trybuild",
 ]
 
 [[package]]

--- a/crates/cuda-core/Cargo.toml
+++ b/crates/cuda-core/Cargo.toml
@@ -9,9 +9,11 @@ repository.workspace = true
 
 [dependencies]
 cuda-bindings = { path = "../cuda-bindings" }
+cuda-macros = { path = "../cuda-macros" }
 anyhow = { workspace = true }
 half = { workspace = true }
 oxide-artifacts = { workspace = true, features = ["object-read"] }
 
 [dev-dependencies]
 oxide-artifacts = { workspace = true, features = ["object-write"] }
+trybuild = "1"

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -66,6 +66,9 @@ pub mod vmm;
 pub use context::CudaContext;
 /// Raw CUDA driver bindings re-exported for direct access when needed.
 pub use cuda_bindings as sys;
+/// `#[derive(DeviceCopy)]` macro, re-exported next to the `DeviceCopy` trait so
+/// `use cuda_core::DeviceCopy;` brings both into scope (serde trait+derive pattern).
+pub use cuda_macros::DeviceCopy;
 pub use device_buffer::{DeviceBuffer, DeviceCopy};
 pub use embedded::{EmbeddedModule, EmbeddedModuleError};
 pub use error::{DriverError, IntoResult};

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum.rs
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+// Enums are rejected: a zeroed or device-written buffer could materialize an
+// out-of-range discriminant, which is undefined behavior. Even an enum with a
+// zero-valid first variant is refused, because per-field checking cannot prove
+// every device-produced byte pattern is a valid variant.
+#[derive(Copy, Clone, DeviceCopy)]
+#[repr(u8)]
+enum Tag {
+    A = 1,
+    B = 2,
+}
+
+fn main() {
+    let _ = Tag::A;
+}

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum.stderr
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum.stderr
@@ -1,0 +1,5 @@
+error: `#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires every bit pattern (including the all-zero pattern written by `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant leaves most byte patterns invalid, so a zeroed or device-written buffer could materialize an out-of-range discriminant (undefined behavior). If you can guarantee every device-produced byte pattern is a valid variant, write `unsafe impl DeviceCopy for ... {}` by hand.
+  --> tests/derive_device_copy/fail_enum.rs:12:6
+   |
+12 | enum Tag {
+   |      ^^^

--- a/crates/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.rs
+++ b/crates/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct HostReference {
+    value: &'static u32,
+}
+
+fn main() {}

--- a/crates/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.stderr
+++ b/crates/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `&'static u32: DeviceCopy` is not satisfied
+ --> tests/derive_device_copy/fail_non_device_copy_field.rs:8:12
+  |
+8 |     value: &'static u32,
+  |            ^^^^^^^^^^^^ the trait `DeviceCopy` is not implemented for `&'static u32`
+  |
+note: required by a bound in `assert_impl`
+ --> tests/derive_device_copy/fail_non_device_copy_field.rs:6:23
+  |
+6 | #[derive(Copy, Clone, DeviceCopy)]
+  |                       ^^^^^^^^^^ required by this bound in `assert_impl`
+  = note: this error originates in the derive macro `DeviceCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider removing the leading `&`-reference
+  |
+8 -     value: &'static u32,
+8 +     value: u32,
+  |

--- a/crates/cuda-core/tests/derive_device_copy/pass_enum_union.rs
+++ b/crates/cuda-core/tests/derive_device_copy/pass_enum_union.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+enum Packet {
+    Empty,
+    Scalar(u32),
+    Pair { x: f32, y: [u16; 2] },
+}
+
+#[derive(Copy, Clone, DeviceCopy)]
+union Word {
+    bits: u32,
+    scalar: f32,
+}
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+fn main() {
+    assert_device_copy::<Packet>();
+    assert_device_copy::<Word>();
+}

--- a/crates/cuda-core/tests/derive_device_copy/pass_structs.rs
+++ b/crates/cuda-core/tests/derive_device_copy/pass_structs.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Named {
+    id: u32,
+    values: [f32; 2],
+}
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Tuple(u16, Named);
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Generic<T> {
+    value: T,
+}
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+fn main() {
+    assert_device_copy::<Named>();
+    assert_device_copy::<Tuple>();
+    assert_device_copy::<Generic<Named>>();
+}

--- a/crates/cuda-core/tests/derive_device_copy/pass_union.rs
+++ b/crates/cuda-core/tests/derive_device_copy/pass_union.rs
@@ -3,13 +3,8 @@
 
 use cuda_core::DeviceCopy;
 
-#[derive(Copy, Clone, DeviceCopy)]
-enum Packet {
-    Empty,
-    Scalar(u32),
-    Pair { x: f32, y: [u16; 2] },
-}
-
+// Unions are untagged, so any bit pattern (including all-zero) is valid as
+// long as every field is itself `DeviceCopy`. The derive accepts them.
 #[derive(Copy, Clone, DeviceCopy)]
 union Word {
     bits: u32,
@@ -19,6 +14,5 @@ union Word {
 fn assert_device_copy<T: DeviceCopy>() {}
 
 fn main() {
-    assert_device_copy::<Packet>();
     assert_device_copy::<Word>();
 }

--- a/crates/cuda-core/tests/device_copy_derive.rs
+++ b/crates/cuda-core/tests/device_copy_derive.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test]
+fn device_copy_derive_compile_pass() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive_device_copy/pass_structs.rs");
+    t.pass("tests/derive_device_copy/pass_enum_union.rs");
+    t.compile_fail("tests/derive_device_copy/fail_non_device_copy_field.rs");
+}

--- a/crates/cuda-core/tests/device_copy_derive.rs
+++ b/crates/cuda-core/tests/device_copy_derive.rs
@@ -5,6 +5,7 @@
 fn device_copy_derive_compile_pass() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_device_copy/pass_structs.rs");
-    t.pass("tests/derive_device_copy/pass_enum_union.rs");
+    t.pass("tests/derive_device_copy/pass_union.rs");
     t.compile_fail("tests/derive_device_copy/fail_non_device_copy_field.rs");
+    t.compile_fail("tests/derive_device_copy/fail_enum.rs");
 }

--- a/crates/cuda-macros/src/device_copy.rs
+++ b/crates/cuda-macros/src/device_copy.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `#[derive(DeviceCopy)]` proc-macro.
+//!
+//! Emits the `unsafe impl DeviceCopy` plus a hidden field-type-check function
+//! that fails to compile if any field is not itself `DeviceCopy`.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{
+    Data, DataEnum, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound,
+    parse_str,
+};
+
+pub fn impl_device_copy(input: &DeriveInput, import: TokenStream) -> TokenStream {
+    let input_type = &input.ident;
+
+    // Generate the code to type-check all fields of the derived struct/enum/union. We can't perform
+    // type checking at expansion-time, so instead we generate a dummy nested function with a
+    // type-bound on DeviceCopy and call it with every type that's in the struct/enum/union.
+    // This will fail to compile if any of the nested types doesn't implement DeviceCopy.
+    let check_types_code = match input.data {
+        Data::Struct(ref data_struct) => type_check_struct(data_struct),
+        Data::Enum(ref data_enum) => type_check_enum(data_enum),
+        Data::Union(ref data_union) => type_check_union(data_union),
+    };
+
+    // We need a function for the type-checking code to live in, so generate a complicated and
+    // hopefully-unique name for that
+    let type_test_func_name = format!(
+        "__verify_{}_can_implement_devicecopy",
+        input_type.to_string().to_lowercase()
+    );
+    let type_test_func_ident = Ident::new(&type_test_func_name, Span::call_site());
+
+    // If the struct/enum/union is generic, we need to add the DeviceCopy bound to the generics
+    // when implementing DeviceCopy.
+    let generics = add_bound_to_generics(&input.generics, import.clone());
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    // Finally, generate the unsafe impl and the type-checking function.
+    let generated_code = quote! {
+        unsafe impl #impl_generics #import for #input_type #type_generics #where_clause {}
+
+        #[doc(hidden)]
+        #[allow(non_snake_case, dead_code, unused_variables)]
+        fn #type_test_func_ident #impl_generics(value: &#input_type #type_generics) #where_clause {
+            fn assert_impl<T: #import>() {}
+            #check_types_code
+        }
+    };
+
+    generated_code
+}
+
+fn add_bound_to_generics(generics: &Generics, import: TokenStream) -> Generics {
+    let mut new_generics = generics.clone();
+    let bound: TypeParamBound = parse_str(&quote! {#import}.to_string()).unwrap();
+
+    for type_param in &mut new_generics.type_params_mut() {
+        type_param.bounds.push(bound.clone())
+    }
+
+    new_generics
+}
+
+fn type_check_struct(s: &DataStruct) -> TokenStream {
+    let checks = match s.fields {
+        Fields::Named(ref named_fields) => {
+            let fields: Vec<&Field> = named_fields.named.iter().collect();
+            check_fields(&fields)
+        }
+        Fields::Unnamed(ref unnamed_fields) => {
+            let fields: Vec<&Field> = unnamed_fields.unnamed.iter().collect();
+            check_fields(&fields)
+        }
+        Fields::Unit => vec![],
+    };
+    quote!(
+        #(#checks)*
+    )
+}
+
+fn type_check_enum(s: &DataEnum) -> TokenStream {
+    let mut checks = vec![];
+
+    for variant in &s.variants {
+        match variant.fields {
+            Fields::Named(ref named_fields) => {
+                let fields: Vec<&Field> = named_fields.named.iter().collect();
+                checks.extend(check_fields(&fields));
+            }
+            Fields::Unnamed(ref unnamed_fields) => {
+                let fields: Vec<&Field> = unnamed_fields.unnamed.iter().collect();
+                checks.extend(check_fields(&fields));
+            }
+            Fields::Unit => {}
+        }
+    }
+    quote!(
+        #(#checks)*
+    )
+}
+
+fn type_check_union(s: &DataUnion) -> TokenStream {
+    let fields: Vec<&Field> = s.fields.named.iter().collect();
+    let checks = check_fields(&fields);
+    quote!(
+        #(#checks)*
+    )
+}
+
+fn check_fields(fields: &[&Field]) -> Vec<TokenStream> {
+    fields
+        .iter()
+        .map(|field| {
+            let field_type = &field.ty;
+            quote! {assert_impl::<#field_type>();}
+        })
+        .collect()
+}

--- a/crates/cuda-macros/src/device_copy.rs
+++ b/crates/cuda-macros/src/device_copy.rs
@@ -9,29 +9,49 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
-    Data, DataEnum, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound,
-    parse_str,
+    Data, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound, parse_str,
 };
 
 pub fn impl_device_copy(input: &DeriveInput, import: TokenStream) -> TokenStream {
     let input_type = &input.ident;
 
-    // Generate the code to type-check all fields of the derived struct/enum/union. We can't perform
+    // Generate the code to type-check all fields of the derived struct/union. We can't perform
     // type checking at expansion-time, so instead we generate a dummy nested function with a
-    // type-bound on DeviceCopy and call it with every type that's in the struct/enum/union.
+    // type-bound on DeviceCopy and call it with every type that's in the struct/union.
     // This will fail to compile if any of the nested types doesn't implement DeviceCopy.
+    //
+    // Enums are deliberately rejected: `DeviceCopy`'s safety contract requires
+    // every bit pattern, including the all-zero pattern written by
+    // `DeviceBuffer::zeroed`, to be a valid value of the type. That holds for
+    // product types (structs/unions) when every field is `DeviceCopy`, but NOT
+    // for enums, whose discriminant leaves most byte patterns invalid. A zeroed
+    // or device-written buffer could then materialize an out-of-range
+    // discriminant (undefined behavior). This is the same reason `bool`, `char`,
+    // and `NonZeroU32` are not `DeviceCopy`. Per-field checking is necessary but
+    // not sufficient for enums, so we refuse rather than emit an unsound impl.
     let check_types_code = match input.data {
         Data::Struct(ref data_struct) => type_check_struct(data_struct),
-        Data::Enum(ref data_enum) => type_check_enum(data_enum),
         Data::Union(ref data_union) => type_check_union(data_union),
+        Data::Enum(_) => {
+            return syn::Error::new_spanned(
+                input_type,
+                "`#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires \
+                 every bit pattern (including the all-zero pattern written by \
+                 `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant \
+                 leaves most byte patterns invalid, so a zeroed or device-written buffer \
+                 could materialize an out-of-range discriminant (undefined behavior). If you \
+                 can guarantee every device-produced byte pattern is a valid variant, write \
+                 `unsafe impl DeviceCopy for ... {}` by hand.",
+            )
+            .to_compile_error();
+        }
     };
 
     // We need a function for the type-checking code to live in, so generate a complicated and
-    // hopefully-unique name for that
-    let type_test_func_name = format!(
-        "__verify_{}_can_implement_devicecopy",
-        input_type.to_string().to_lowercase()
-    );
+    // hopefully-unique name for that. The type identifier is used verbatim (not lowercased) so
+    // distinct types differing only in case (e.g. `Foo` and `foo`) get distinct helper names
+    // instead of colliding; the `non_snake_case` allow covers the casing.
+    let type_test_func_name = format!("__verify_{input_type}_can_implement_devicecopy");
     let type_test_func_ident = Ident::new(&type_test_func_name, Span::call_site());
 
     // If the struct/enum/union is generic, we need to add the DeviceCopy bound to the generics
@@ -77,27 +97,6 @@ fn type_check_struct(s: &DataStruct) -> TokenStream {
         }
         Fields::Unit => vec![],
     };
-    quote!(
-        #(#checks)*
-    )
-}
-
-fn type_check_enum(s: &DataEnum) -> TokenStream {
-    let mut checks = vec![];
-
-    for variant in &s.variants {
-        match variant.fields {
-            Fields::Named(ref named_fields) => {
-                let fields: Vec<&Field> = named_fields.named.iter().collect();
-                checks.extend(check_fields(&fields));
-            }
-            Fields::Unnamed(ref unnamed_fields) => {
-                let fields: Vec<&Field> = unnamed_fields.unnamed.iter().collect();
-                checks.extend(check_fields(&fields));
-            }
-            Fields::Unit => {}
-        }
-    }
     quote!(
         #(#checks)*
     )

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+mod device_copy;
 mod printf;
 mod ptx_asm;
 
@@ -84,6 +85,19 @@ pub fn gpu_printf(input: TokenStream) -> TokenStream {
 pub fn ptx_asm(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as ptx_asm::PtxAsmInput);
     ptx_asm::ptx_asm_impl(input).into()
+}
+
+/// Derive `cuda_core::DeviceCopy` for a type whose fields are all themselves
+/// `DeviceCopy`.
+///
+/// Re-exported from `cuda_core` next to the `DeviceCopy` trait so that
+/// `use cuda_core::DeviceCopy;` brings both the trait and this derive into scope
+/// (the serde `Serialize` trait+derive pattern).
+#[proc_macro_derive(DeviceCopy)]
+pub fn device_copy(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    let code = device_copy::impl_device_copy(&ast, quote!(::cuda_core::DeviceCopy));
+    code.into()
 }
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};


### PR DESCRIPTION
Closes #192.

## Problem

`cuda_core::DeviceCopy` marks types that are safe to copy between host and device memory, but users currently have to write `unsafe impl DeviceCopy` manually for application data structs. That is an ergonomics gap and an API safety footgun: a manual impl can omit the field-level check that every contained type is also device-copy-safe.

## Fix

Add a `#[derive(DeviceCopy)]` proc macro in `cuda-macros` and re-export it from `cuda-core` next to the `DeviceCopy` trait. The macro generates the `unsafe impl ::cuda_core::DeviceCopy` and a hidden type-checking helper that requires each field type to implement `DeviceCopy`. Generic type parameters also receive a `DeviceCopy` bound on the generated impl.

## Diligence

This keeps the rule at the marker-trait API boundary: deriving `DeviceCopy` is only valid when every stored field is itself `DeviceCopy`. The derive handles structs, enums, and unions through the same field-check helper, so named and unnamed fields share one enforcement path. The public re-export follows the established trait-plus-derive pattern, so `use cuda_core::DeviceCopy;` brings both the trait and derive macro into scope.

## Tests

Added `cuda-core` trybuild coverage for both accepted and rejected derives:

- compile-pass coverage for named structs with scalar and array fields;
- compile-pass coverage for tuple structs containing another derived `DeviceCopy` type;
- compile-pass coverage for generic structs with the generated bound;
- compile-pass coverage for enum and union forms whose fields are `DeviceCopy`;
- compile-fail coverage proving a copyable host reference field is rejected because the field type is not `DeviceCopy`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cuda-core --all-targets`
- `cargo test -p cuda-macros --all-targets`
- `cargo clippy --workspace -- -D warnings`
