### PR TITLE
mir-importer: index slice data pointers by element

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -3465,6 +3465,15 @@ fn translate_place_addr_from_slot(
     let mut current_is_slice_data = false;
 
     for (proj_idx, elem) in projection.iter().enumerate() {
+        // The slice-data provenance bit only describes the pointer produced by
+        // the immediately-preceding `Deref` of a fat slice (index it by
+        // element, not as a pointer to one array object). Capture it for this
+        // iteration and clear it up front, so the invariant stays local: it is
+        // true only when the previous step handed us a slice DATA pointer, and
+        // no later projection arm can accidentally leak it forward.
+        let entered_as_slice_data = current_is_slice_data;
+        current_is_slice_data = false;
+
         match elem {
             // `*place` -- the place walked so far holds a pointer; the
             // address of the dereferenced place is that pointer VALUE, so a
@@ -3664,7 +3673,6 @@ fn translate_place_addr_from_slot(
                             // the field arm below.
                             mir::ProjectionElem::Field(..) => {
                                 current = data_ptr;
-                                current_is_slice_data = false;
                                 continue;
                             }
                             // Element access through a slice data pointer is
@@ -3724,7 +3732,6 @@ fn translate_place_addr_from_slot(
             }
 
             mir::ProjectionElem::Field(field_idx, field_ty) => {
-                current_is_slice_data = false;
                 let field_type = types::translate_type(ctx, field_ty)?;
                 let result_ptr_ty =
                     dialect_mir::types::MirPtrType::get_generic(ctx, field_type, is_mutable);
@@ -3761,7 +3768,7 @@ fn translate_place_addr_from_slot(
                     Some(kind) => kind,
                     None => return Ok(None),
                 };
-                if current_is_slice_data {
+                if entered_as_slice_data {
                     pointee_kind = PointeeKind::Direct;
                 }
 
@@ -3798,7 +3805,6 @@ fn translate_place_addr_from_slot(
                 );
                 current = next_current;
                 current_prev_op = Some(addr_op);
-                current_is_slice_data = false;
             }
 
             // Runtime `arr[i]` indexing. Without this arm, a place like
@@ -3810,7 +3816,7 @@ fn translate_place_addr_from_slot(
                     Some(kind) => kind,
                     None => return Ok(None),
                 };
-                if current_is_slice_data {
+                if entered_as_slice_data {
                     pointee_kind = PointeeKind::Direct;
                 }
 
@@ -3842,7 +3848,6 @@ fn translate_place_addr_from_slot(
                 );
                 current = next_current;
                 current_prev_op = Some(addr_op);
-                current_is_slice_data = false;
             }
 
             // Enum-variant downcast (`(x as Variant).field`). Addressing an

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -3462,6 +3462,7 @@ fn translate_place_addr_from_slot(
 
     let mut current = slot;
     let mut current_prev_op = prev_op;
+    let mut current_is_slice_data = false;
 
     for (proj_idx, elem) in projection.iter().enumerate() {
         match elem {
@@ -3659,17 +3660,26 @@ fn translate_place_addr_from_slot(
                         }
 
                         match &projection[proj_idx + 1] {
-                            // Sized field or element access: hand the data
-                            // pointer to the matching arm of this loop. The
-                            // following `Index` / `ConstantIndex` offsets it
-                            // directly (its pointee is the element type, not
-                            // an array), see `emit_indexed_element_addr`.
-                            mir::ProjectionElem::Field(..)
-                            | mir::ProjectionElem::Index(_)
+                            // Sized field access: hand the data pointer to
+                            // the field arm below.
+                            mir::ProjectionElem::Field(..) => {
+                                current = data_ptr;
+                                current_is_slice_data = false;
+                                continue;
+                            }
+                            // Element access through a slice data pointer is
+                            // pointer arithmetic over the slice element type.
+                            // That remains true when the element type is
+                            // itself an array (`&[[T; N]][i]`), where a
+                            // type-only check would otherwise mistake the
+                            // data pointer for a pointer to one array object
+                            // and index inside row 0.
+                            mir::ProjectionElem::Index(_)
                             | mir::ProjectionElem::ConstantIndex {
                                 from_end: false, ..
                             } => {
                                 current = data_ptr;
+                                current_is_slice_data = true;
                                 continue;
                             }
                             // Unknown continuation: keep the conservative
@@ -3714,6 +3724,7 @@ fn translate_place_addr_from_slot(
             }
 
             mir::ProjectionElem::Field(field_idx, field_ty) => {
+                current_is_slice_data = false;
                 let field_type = types::translate_type(ctx, field_ty)?;
                 let result_ptr_ty =
                     dialect_mir::types::MirPtrType::get_generic(ctx, field_type, is_mutable);
@@ -3746,10 +3757,13 @@ fn translate_place_addr_from_slot(
                 if *from_end {
                     return Ok(None);
                 }
-                let (pointee_kind, addr_space) = match pointer_pointee_kind(ctx, current) {
+                let (mut pointee_kind, addr_space) = match pointer_pointee_kind(ctx, current) {
                     Some(kind) => kind,
                     None => return Ok(None),
                 };
+                if current_is_slice_data {
+                    pointee_kind = PointeeKind::Direct;
+                }
 
                 let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
                 let index_apint = APInt::from_i64(*offset as i64, NonZeroUsize::new(64).unwrap());
@@ -3784,6 +3798,7 @@ fn translate_place_addr_from_slot(
                 );
                 current = next_current;
                 current_prev_op = Some(addr_op);
+                current_is_slice_data = false;
             }
 
             // Runtime `arr[i]` indexing. Without this arm, a place like
@@ -3791,10 +3806,13 @@ fn translate_place_addr_from_slot(
             // and return a pointer to the array's first slot, miscompiling
             // every load through the reference into a load of element 0.
             mir::ProjectionElem::Index(index_local) => {
-                let (pointee_kind, addr_space) = match pointer_pointee_kind(ctx, current) {
+                let (mut pointee_kind, addr_space) = match pointer_pointee_kind(ctx, current) {
                     Some(kind) => kind,
                     None => return Ok(None),
                 };
+                if current_is_slice_data {
+                    pointee_kind = PointeeKind::Direct;
+                }
 
                 let index_place = mir::Place {
                     local: *index_local,
@@ -3824,6 +3842,7 @@ fn translate_place_addr_from_slot(
                 );
                 current = next_current;
                 current_prev_op = Some(addr_op);
+                current_is_slice_data = false;
             }
 
             // Enum-variant downcast (`(x as Variant).field`). Addressing an

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/README.md
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/README.md
@@ -46,6 +46,7 @@ and a direct projected assignment, including runtime and literal row indices.
 | `write_nested_slice_row_ref` | `let e = &mut rows[row][0]; *e = v` through fat `&mut [[f32; 2]]` |
 | `write_nested_slice_const_row_ref` | `let e = &mut rows[1][0]; *e = v` through fat `&mut [[f32; 2]]` |
 | `write_nested_slice_row_assign` | `rows[row][0] = v` through fat `&mut [[f32; 2]]` |
+| `write_nested_slice_wide_nonzero_col` | `rows[row][2] = v` through fat `&mut [[f32; 3]]` (wider element, non-zero column) |
 
 Each kernel writes a distinct, index-dependent pattern into a zeroed
 buffer; the host reads everything back and checks every lane, so a write

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/README.md
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/README.md
@@ -26,6 +26,13 @@ pointer, which addresses the ORIGINAL elements), and continues the
 projection walk with a plain pointer offset, so both shared and mutable
 borrows stay sound.
 
+When the slice element is itself an array, the first index after the fat
+slice deref must still offset by one whole slice element. For
+`&mut [[f32; 2]]`, `rows[row][0]` must write row `row`, column 0; treating
+the extracted data pointer as a pointer to one array object writes inside
+row 0 instead. The example covers both a mutable reference to that place
+and a direct projected assignment, including runtime and literal row indices.
+
 ## Kernels
 
 | Kernel                       | Shape pinned                                |
@@ -36,6 +43,9 @@ borrows stay sound.
 | `write_slice_index_assign`   | `s[i] = v` through fat `&mut [f32]`         |
 | `write_mut_ref_index`        | `&mut a[i]` write (pre-existing guard)      |
 | `write_struct_field_get_mut` | `get_mut` on `[Cell; 2]`, then field write  |
+| `write_nested_slice_row_ref` | `let e = &mut rows[row][0]; *e = v` through fat `&mut [[f32; 2]]` |
+| `write_nested_slice_const_row_ref` | `let e = &mut rows[1][0]; *e = v` through fat `&mut [[f32; 2]]` |
+| `write_nested_slice_row_assign` | `rows[row][0] = v` through fat `&mut [[f32; 2]]` |
 
 Each kernel writes a distinct, index-dependent pattern into a zeroed
 buffer; the host reads everything back and checks every lane, so a write

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
@@ -226,6 +226,33 @@ mod kernels {
         let row = ((rows[0][0] as usize) & 1) + 1;
         rows[row][0] = 52.0 + lane as f32;
     }
+
+    /// Nested fat-slice element that is a WIDER array (`[f32; 3]`) written at a
+    /// NON-ZERO inner column. The row index must stride by one whole `[f32; 3]`
+    /// row (3 floats, not 2), then the column index must select column 2 inside
+    /// that row. This pins both the per-element stride and the inner
+    /// array-aware index away from the leading element, the case a
+    /// column-`[0]`-only test would miss.
+    #[kernel]
+    pub fn write_nested_slice_wide_nonzero_col(mut out: DisjointSlice<[[f32; 3]; 2]>) {
+        let idx = thread::index_1d();
+        let lane = idx.get();
+        let matrix = match out.get_mut(idx) {
+            Some(m) => m,
+            None => return,
+        };
+
+        matrix[0][0] = 10.0;
+        matrix[0][1] = 11.0;
+        matrix[0][2] = 12.0;
+        matrix[1][0] = 20.0;
+        matrix[1][1] = 21.0;
+        matrix[1][2] = 22.0;
+
+        let rows: &mut [[f32; 3]] = matrix;
+        let row = ((rows[0][0] as usize) & 1) + 1; // 10 & 1 == 0 -> runtime row 1
+        rows[row][2] = 70.0 + lane as f32; // write row 1, column 2
+    }
 }
 
 /// Launches one `[f32; SIZE]`-shaped kernel on a zeroed buffer and checks
@@ -372,6 +399,35 @@ fn main() {
                 .expect("launch")
         },
     );
+
+    // Wider nested element (`[f32; 3]`) with a non-zero inner column: the row
+    // index must stride by a whole `[f32; 3]` and the column index must land in
+    // column 2, not column 0.
+    {
+        let mut dev = DeviceBuffer::<[[f32; 3]; 2]>::zeroed(&stream, N).unwrap();
+        module
+            .write_nested_slice_wide_nonzero_col(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                &mut dev,
+            )
+            .expect("launch");
+        let host = dev.to_host_vec(&stream).unwrap();
+        let ok = host.iter().enumerate().all(|(lane, m)| {
+            (m[0][0] - 10.0).abs() < 1e-6
+                && (m[0][1] - 11.0).abs() < 1e-6
+                && (m[0][2] - 12.0).abs() < 1e-6
+                && (m[1][0] - 20.0).abs() < 1e-6
+                && (m[1][1] - 21.0).abs() < 1e-6
+                && (m[1][2] - (70.0 + lane as f32)).abs() < 1e-6
+        });
+        let verdict = if ok { "PASS" } else { "FAIL" };
+        println!(
+            "  {:<30} {verdict}    (elem[0] = {:?})",
+            "write_nested_slice_wide_nonzero_col", host[0]
+        );
+        all_pass &= ok;
+    }
 
     if all_pass {
         println!("\nSUCCESS: all kernels passed");

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
@@ -26,6 +26,9 @@
  *     let e = &mut a[i]; *e = v         // pre-existing working shape
  *     cells.get_mut(i) -> &mut Cell,    // fat walk composed with the
  *     then c.lo = v                     // (Deref, Field) field write
+ *     let e = &mut rows[row][0]; *e = v // fat slice element is an array
+ *     let e = &mut rows[1][0]; *e = v   // same, with ConstantIndex row
+ *     rows[row][0] = v                  // same shape as projected assignment
  *
  * Each kernel writes a distinct, index-dependent pattern; the host reads
  * the buffer back and checks every lane, so a write that lands in a
@@ -157,6 +160,72 @@ mod kernels {
             }
         }
     }
+
+    /// Mutable write through a fat slice whose element type is itself an
+    /// array. The row index must step by one `[f32; 2]` row, then the
+    /// column index selects inside that row.
+    #[kernel]
+    pub fn write_nested_slice_row_ref(mut out: DisjointSlice<[[f32; 2]; 2]>) {
+        let idx = thread::index_1d();
+        let lane = idx.get();
+        let matrix = match out.get_mut(idx) {
+            Some(m) => m,
+            None => return,
+        };
+
+        matrix[0][0] = 10.0;
+        matrix[0][1] = 77.0;
+        matrix[1][0] = 0.0;
+        matrix[1][1] = 99.0;
+
+        let rows: &mut [[f32; 2]] = matrix;
+        let row = ((rows[0][0] as usize) & 1) + 1;
+        let elem = &mut rows[row][0];
+        *elem = 42.0 + lane as f32;
+    }
+
+    /// Same nested-array fat-slice reference shape, but with a literal row
+    /// index. This covers the forward `ConstantIndex` address-walker arm.
+    #[kernel]
+    pub fn write_nested_slice_const_row_ref(mut out: DisjointSlice<[[f32; 2]; 2]>) {
+        let idx = thread::index_1d();
+        let lane = idx.get();
+        let matrix = match out.get_mut(idx) {
+            Some(m) => m,
+            None => return,
+        };
+
+        matrix[0][0] = 10.0;
+        matrix[0][1] = 77.0;
+        matrix[1][0] = 0.0;
+        matrix[1][1] = 99.0;
+
+        let rows: &mut [[f32; 2]] = matrix;
+        let elem = &mut rows[1][0];
+        *elem = 62.0 + lane as f32;
+    }
+
+    /// Same nested-array fat-slice shape as `write_nested_slice_row_ref`,
+    /// but as a direct projected assignment. This exercises the
+    /// statement-level store path that reuses the same address walker.
+    #[kernel]
+    pub fn write_nested_slice_row_assign(mut out: DisjointSlice<[[f32; 2]; 2]>) {
+        let idx = thread::index_1d();
+        let lane = idx.get();
+        let matrix = match out.get_mut(idx) {
+            Some(m) => m,
+            None => return,
+        };
+
+        matrix[0][0] = 10.0;
+        matrix[0][1] = 77.0;
+        matrix[1][0] = 0.0;
+        matrix[1][1] = 99.0;
+
+        let rows: &mut [[f32; 2]] = matrix;
+        let row = ((rows[0][0] as usize) & 1) + 1;
+        rows[row][0] = 52.0 + lane as f32;
+    }
 }
 
 /// Launches one `[f32; SIZE]`-shaped kernel on a zeroed buffer and checks
@@ -179,6 +248,31 @@ where
         .all(|elem| (0..SIZE).all(|i| (elem[i] - expected(i)).abs() < 1e-6));
     let verdict = if ok { "PASS" } else { "FAIL" };
     println!("  {name:<30} {verdict}    (elem[0] = {:?})", host_out[0]);
+    ok
+}
+
+/// Launches one nested-array fat-slice kernel and checks that the write
+/// reaches row 1 column 0 rather than row 0 column 1.
+fn run_nested_matrix_check<F>(
+    name: &str,
+    stream: &Arc<CudaStream>,
+    expected_base: f32,
+    launch: F,
+) -> bool
+where
+    F: FnOnce(&Arc<CudaStream>, LaunchConfig, &mut DeviceBuffer<[[f32; 2]; 2]>),
+{
+    let mut dev_mats = DeviceBuffer::<[[f32; 2]; 2]>::zeroed(stream, N).unwrap();
+    launch(stream, LaunchConfig::for_num_elems(N as u32), &mut dev_mats);
+    let host_mats = dev_mats.to_host_vec(stream).unwrap();
+    let ok = host_mats.iter().enumerate().all(|(lane, mat)| {
+        (mat[0][0] - 10.0).abs() < 1e-6
+            && (mat[0][1] - 77.0).abs() < 1e-6
+            && (mat[1][0] - (expected_base + lane as f32)).abs() < 1e-6
+            && (mat[1][1] - 99.0).abs() < 1e-6
+    });
+    let verdict = if ok { "PASS" } else { "FAIL" };
+    println!("  {name:<30} {verdict}    (elem[0] = {:?})", host_mats[0]);
     ok
 }
 
@@ -249,6 +343,35 @@ fn main() {
         );
         all_pass &= ok;
     }
+
+    // Nested-array slice element variants: catch row/column stride mixups
+    // when a fat slice's element type is itself an array.
+    all_pass &=
+        run_nested_matrix_check("write_nested_slice_row_ref", &stream, 42.0, |s, cfg, o| {
+            module
+                .write_nested_slice_row_ref(s, cfg, o)
+                .expect("launch")
+        });
+    all_pass &= run_nested_matrix_check(
+        "write_nested_slice_const_row_ref",
+        &stream,
+        62.0,
+        |s, cfg, o| {
+            module
+                .write_nested_slice_const_row_ref(s, cfg, o)
+                .expect("launch")
+        },
+    );
+    all_pass &= run_nested_matrix_check(
+        "write_nested_slice_row_assign",
+        &stream,
+        52.0,
+        |s, cfg, o| {
+            module
+                .write_nested_slice_row_assign(s, cfg, o)
+                .expect("launch")
+        },
+    );
 
     if all_pass {
         println!("\nSUCCESS: all kernels passed");


### PR DESCRIPTION
Closes #209.

## Problem

The place-address walker extracts field 0 from fat slice values so it can continue indexing through the original backing storage. When the slice element type is itself an array, such as `&mut [[f32; 2]]`, that extracted data pointer has type `ptr<[f32; 2]>`.

The compiler rule is that this pointer addresses slice elements. Therefore the first `Index` or forward `ConstantIndex` after the fat-slice deref must use pointer arithmetic over `[f32; 2]` rows. It must not be reclassified as a pointer to one array object and indexed inside row 0.

## Fix

Track when the current address is the data pointer just extracted from a fat slice. For the immediately following `Index` or forward `ConstantIndex`, force the address walker to use the direct pointer-offset path. Clear the marker after consuming that indexed projection, and also clear it for ordinary sized field access.

This keeps ordinary array-object indexing unchanged: a true pointer to `[T; N]` still uses `mir.array_element_addr`; only a pointer known to originate as fat-slice data uses element-sized `mir.ptr_offset` for the first index.

## Diligence

I checked the sibling lowering paths that decide between pointer offset and array-element address:

- `translate_place_addr_from_slot`, which serves `Rvalue::Ref`, `Rvalue::AddressOf`, and projected assignment destinations;
- `emit_indexed_element_addr`, the shared dispatch point for runtime and forward constant indices;
- `MirPtrOffsetOp` lowering, which scales by the pointer pointee type;
- `MirArrayElementAddrOp` lowering, which is correct for indexing inside one array object.

## Tests

Extended `crates/rustc-codegen-cuda/examples/slice_get_mut` with three nested-array fat-slice cases:

- `write_nested_slice_row_ref`: takes `let elem = &mut rows[row][0]` and writes through the reference;
- `write_nested_slice_const_row_ref`: takes `let elem = &mut rows[1][0]` and writes through the reference;
- `write_nested_slice_row_assign`: writes through direct projected assignment `rows[row][0] = value`.

The runtime-row cases prove the `Index` path, the literal-row case proves the forward `ConstantIndex` path, and the assignment case proves the statement-level destination path that reuses the same address walker.
I also checked the raw Rust MIR dump for the literal-row kernel; the relevant projection is emitted as `(*_9)[1 of 2][0 of 1]`, so this is covering the forward constant-index arm rather than another runtime-index lowering.

All three cases initialize row 0 column 1 to a sentinel and row 1 column 0 to zero. On `upstream/main` with only the regression applied, they write the sentinel column in row 0:

```text
write_nested_slice_row_ref     FAIL    (elem[0] = [[10.0, 42.0], [0.0, 99.0]])
write_nested_slice_const_row_ref FAIL    (elem[0] = [[10.0, 62.0], [0.0, 99.0]])
write_nested_slice_row_assign  FAIL    (elem[0] = [[10.0, 52.0], [0.0, 99.0]])
```

On this branch, they write row 1 column 0:

```text
write_nested_slice_row_ref     PASS    (elem[0] = [[10.0, 77.0], [42.0, 99.0]])
write_nested_slice_const_row_ref PASS    (elem[0] = [[10.0, 77.0], [62.0, 99.0]])
write_nested_slice_row_assign  PASS    (elem[0] = [[10.0, 77.0], [52.0, 99.0]])
```

## Validation

```bash
cargo fmt --all -- --check
(cd crates/rustc-codegen-cuda/examples/slice_get_mut && cargo fmt --all -- --check)
cargo check -p mir-importer
cargo clippy -p mir-importer -- -D warnings
(cd crates/rustc-codegen-cuda/examples/slice_get_mut && cargo clippy --all-targets -- -D warnings)
scripts/smoketest.sh --compile-only --no-color --only '^slice_get_mut$'
cargo oxide run slice_get_mut
scripts/smoketest.sh --no-color --only '^slice_get_mut$'
```
