### PR TITLE
mir-importer: read closure upvars from generic suffix

### DIFF
--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -67,6 +67,23 @@ pub fn get_usize_type(
     pliron::builtin::types::IntegerType::get(ctx, 64, pliron::builtin::types::Signedness::Unsigned)
 }
 
+/// Returns the tupled-upvars types for a `RigidTy::Closure`.
+///
+/// rustc suffix-encodes closure substitutions as
+/// `[parent_args..., closure_kind, closure_sig, tupled_upvars]`, so the upvars
+/// tuple is the last generic arg, not a fixed index.
+fn closure_upvar_tys(substs: &rustc_public::ty::GenericArgs) -> Option<Vec<rustc_public::ty::Ty>> {
+    let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = substs.0.last()? else {
+        return None;
+    };
+    let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(upvar_tys)) =
+        upvar_tuple_ty.kind()
+    else {
+        return None;
+    };
+    Some(upvar_tys)
+}
+
 /// Returns the 32-bit floating point type.
 pub fn get_f32_type(
     ctx: &mut Context,
@@ -128,15 +145,9 @@ pub fn is_rust_type_zst(rust_ty: &rustc_public::ty::Ty) -> bool {
                 false
             }
         }
-        // Closures with no captures are ZST, closures with captures are not
+        // Closures with no captures are ZST, closures with captures are not.
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Closure(_, substs)) => {
-            // Check substs[2] which is the tuple of upvar types
-            if substs.0.len() >= 3
-                && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
-                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
-                    upvar_tys,
-                )) = upvar_tuple_ty.kind()
-            {
+            if let Some(upvar_tys) = closure_upvar_tys(&substs) {
                 // ZST if no captures
                 return upvar_tys.is_empty();
             }
@@ -858,25 +869,21 @@ pub fn translate_type(
         // Handle Closure types
         // Closures are represented as structs with fields for each captured variable (upvar).
         // The substs for a closure contain:
-        //   [0] Internal marker type (usually i8)
-        //   [1] Function signature
-        //   [2] Tuple of upvar types (the captured variables)
+        //   [parent_args..] Captured parent generics, when the closure appears in a generic item
+        //   [n - 3] Closure kind
+        //   [n - 2] Function signature
+        //   [n - 1] Tuple of upvar types (the captured variables)
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Closure(
             closure_def,
             substs,
         )) => {
             let closure_name = format!("{:?}", closure_def.def_id());
 
-            // Extract upvar types from substs[2] (the tuple of captured types)
+            // Extract upvar types from the tupled-upvars generic arg.
             let mut field_names = Vec::new();
             let mut field_types = Vec::new();
 
-            if substs.0.len() >= 3
-                && let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = &substs.0[2]
-                && let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Tuple(
-                    upvar_tys,
-                )) = upvar_tuple_ty.kind()
-            {
+            if let Some(upvar_tys) = closure_upvar_tys(&substs) {
                 for (i, upvar_ty) in upvar_tys.iter().enumerate() {
                     field_names.push(format!("capture_{}", i));
                     field_types.push(translate_type(ctx, upvar_ty)?);

--- a/crates/rustc-codegen-cuda/examples/generic/README.md
+++ b/crates/rustc-codegen-cuda/examples/generic/README.md
@@ -8,6 +8,7 @@ Tests whether the collector correctly handles monomorphized generic kernels. Thi
 
 - Defines generic kernels `scale<T>` and `add<T>` with trait bounds
 - Host code calls `scale::<f32>` which triggers monomorphization
+- Defines a captured closure inside a generic kernel body
 - Verifies the monomorphized kernel executes correctly
 
 ## Key Concepts Demonstrated

--- a/crates/rustc-codegen-cuda/examples/generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/generic/src/main.rs
@@ -57,6 +57,32 @@ mod kernels {
             *c_elem = a[idx_raw] + b[idx_raw];
         }
     }
+
+    #[inline(never)]
+    fn apply_unary<T, F>(f: F, x: T) -> T
+    where
+        F: FnOnce(T) -> T,
+    {
+        f(x)
+    }
+
+    /// Generic kernel whose body defines a captured closure.
+    ///
+    /// rustc prepends the parent generic args before a closure's fixed
+    /// `[kind, sig, tupled_upvars]` suffix. The importer must read the upvars
+    /// tuple from the suffix, not from a hard-coded substitution index.
+    #[kernel]
+    pub fn closure_capture<T>(bias: T, scale: T, input: &[T], mut out: DisjointSlice<T>)
+    where
+        T: Copy + Add<Output = T> + Mul<Output = T>,
+    {
+        let idx = thread::index_1d();
+        let idx_raw = idx.get();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let transform = move |x: T| (x + bias) * scale;
+            *out_elem = apply_unary(transform, input[idx_raw]);
+        }
+    }
 }
 
 // =============================================================================
@@ -139,5 +165,65 @@ fn main() {
         assert_eq!(errors, 0, "scale::<i32> produced {errors} errors");
     }
 
-    println!("\n✓ SUCCESS: typed generic launches worked for f32 and i32");
+    println!("Launching closure_capture::<f32> kernel...");
+    {
+        let bias: f32 = 1.25;
+        let scale: f32 = 0.5;
+        let input_data: Vec<f32> = (0..N).map(|i| i as f32).collect();
+        let input_dev =
+            DeviceBuffer::from_host(&stream, &input_data).expect("Failed to copy f32 input");
+        let mut output_dev =
+            DeviceBuffer::<f32>::zeroed(&stream, N).expect("Failed to alloc f32 output");
+
+        module
+            .closure_capture::<f32>(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                bias,
+                scale,
+                &input_dev,
+                &mut output_dev,
+            )
+            .expect("closure_capture::<f32> launch failed");
+
+        let output_host = output_dev
+            .to_host_vec(&stream)
+            .expect("Failed to copy f32 output back");
+        let errors = (0..N)
+            .filter(|&i| (output_host[i] - (input_data[i] + bias) * scale).abs() > 1e-5)
+            .count();
+        assert_eq!(errors, 0, "closure_capture::<f32> produced {errors} errors");
+    }
+
+    println!("Launching closure_capture::<i32> kernel...");
+    {
+        let bias: i32 = 7;
+        let scale: i32 = 2;
+        let input_data: Vec<i32> = (0..N as i32).collect();
+        let input_dev =
+            DeviceBuffer::from_host(&stream, &input_data).expect("Failed to copy i32 input");
+        let mut output_dev =
+            DeviceBuffer::<i32>::zeroed(&stream, N).expect("Failed to alloc i32 output");
+
+        module
+            .closure_capture::<i32>(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                bias,
+                scale,
+                &input_dev,
+                &mut output_dev,
+            )
+            .expect("closure_capture::<i32> launch failed");
+
+        let output_host = output_dev
+            .to_host_vec(&stream)
+            .expect("Failed to copy i32 output back");
+        let errors = (0..N)
+            .filter(|&i| output_host[i] != (input_data[i] + bias) * scale)
+            .count();
+        assert_eq!(errors, 0, "closure_capture::<i32> produced {errors} errors");
+    }
+
+    println!("\n✓ SUCCESS: typed generic launches and captured closures worked for f32 and i32");
 }


### PR DESCRIPTION
Closes #211.

## Problem

rustc suffix-encodes closure substitutions as `[parent_args..., closure_kind, closure_sig, tupled_upvars]`. The MIR importer treated `substs[2]` as the upvars tuple, which is only true when there are no parent generic arguments before the closure suffix.

In a generic kernel that constructs a captured closure and passes it through an out-of-line generic helper, the old importer translated the closure environment as a zero-field struct even though closure construction still had two capture operands. On `upstream/main` with only the regression applied:

```text
MirConstructStructOp has 2 operands but struct
'generic::kernels::closure_capture::{closure#0}' has 0 fields
```

## Fix

Add a small `closure_upvar_tys` helper that reads the tupled-upvars type from the last closure generic argument and verifies that it is a tuple. Use that helper in both places that decode closure captures:

- `is_rust_type_zst`, so captured closures in generic contexts are not mistaken for zero-sized closures;
- closure `translate_type`, so the generated MIR struct fields match rustc's closure environment.

This keeps the compiler rule in one place instead of duplicating a fixed-index assumption.

## Diligence

I checked the sibling closure paths for other fixed-index upvar decoding:

- `AggregateKind::Closure` builds the closure value from MIR operands and delegates the closure type to `types::translate_type`.
- closure function ABI handling uses `fn_sig()` and does not inspect upvar substitutions.
- closure call lowering resolves the closure body from the receiver type and substitutions, but does not decode upvars itself.
- collector closure discovery resolves closure bodies from rustc type information and does not build closure environment fields.

The initial direct-call regression was stale because rustc optimized the closure environment away before import. The committed regression keeps the closure as a real value by passing it through `#[inline(never)] apply_unary`.

## Tests

Extended `crates/rustc-codegen-cuda/examples/generic` with `closure_capture<T>`, a generic kernel that captures two generic values in a closure and passes that closure to an out-of-line generic helper:

```rust
let transform = move |x: T| (x + bias) * scale;
*out_elem = apply_unary(transform, input[idx_raw]);
```

The host launches the kernel for both `f32` and `i32`, checking that the captured arithmetic is applied correctly for each monomorphization.

## Validation

Verified the regression fails on `upstream/main` by applying only the example change and running:

```bash
CUDA_OXIDE_SHOW_RUSTC_MIR=1 cargo oxide run generic
```

Verified the patched branch with:

```bash
cargo fmt --all -- --check
cargo check -p mir-importer
cargo clippy -p mir-importer -- -D warnings
(cd crates/rustc-codegen-cuda/examples/generic && cargo fmt --all -- --check)
(cd crates/rustc-codegen-cuda/examples/generic && cargo clippy --all-targets -- -D warnings)
(cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)
(cd crates/rustc-codegen-cuda && cargo clippy --all-targets -- -D warnings)
scripts/smoketest.sh --compile-only --no-color --only '^generic$'
cargo oxide run generic
scripts/smoketest.sh --no-color --only '^generic$'
```
