### PR TITLE
fix(cargo-oxide): preserve existing LIBRARY_PATH during backend build

### DIFF
--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -162,7 +162,7 @@ pub fn build_backend_from_source(codegen_crate: &Path) {
     cmd.args(["build"]).current_dir(codegen_crate);
 
     if let Some(ref path) = lib_path {
-        cmd.env("LIBRARY_PATH", path);
+        cmd.env("LIBRARY_PATH", build_library_path(path));
         cmd.env("LD_LIBRARY_PATH", build_ld_library_path(path));
     }
 
@@ -262,6 +262,15 @@ pub fn get_rustc_sysroot() -> Option<String> {
         Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
     } else {
         None
+    }
+}
+
+/// Build LIBRARY_PATH preserving existing paths.
+pub fn build_library_path(sysroot_lib: &str) -> String {
+    if let Ok(existing) = std::env::var("LIBRARY_PATH") {
+        format!("{}:{}", existing, sysroot_lib)
+    } else {
+        sysroot_lib.to_string()
     }
 }
 


### PR DESCRIPTION
## Summary

<!-- One paragraph: what does this change and why? -->
This modifies the `backend::build_backend_from_source` in `cargo-oxide` to preserve the existing `LIBRARY_PATH` during the backend build.
This resolves linking errors that occur because the existing `LIBRARY_PATH` is ignored, even when the `libffi` path is explicitly specified in it (Fixes #220).

## Changes

<!-- Bullet list of the main code changes. -->
- Updated `build_backend_from_source` in `backend.rs` to append the `<rustc_sysroot>/lib` to the existing `LIBRARY_PATH`, rather than overwrite.

## Testing

<!-- How did you verify this? Paste relevant `cargo oxide run` / `cargo test` output, or smoketest results. -->
- [x] `cargo oxide run vecadd` passes
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] No files under `cuda-bindings/` modified by an external contributor (see CONTRIBUTING.md)
- [x] SPDX headers on new source files

---
> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/Fua7DeKnm).
