### PR TITLE
evaluate unevaluated array length constant for code generation

### DIFF
--- a/crates/mir-importer/src/lib.rs
+++ b/crates/mir-importer/src/lib.rs
@@ -87,3 +87,29 @@ pub use pipeline::{
     CollectedFunction, CompilationArtifactKind, CompilationResult, DeviceExternAttrs,
     DeviceExternDecl, PipelineConfig, PipelineError, run_pipeline,
 };
+
+// ── Array-length const evaluation bridge ─────────────────────────────────────
+// The type translator must turn `[T; N]` array lengths into concrete values,
+// but stable_mir cannot *evaluate* an `Unevaluated` length const (e.g. a `const
+// SUB_LEN: usize = 2` reference) at the type-translation layer. The codegen
+// backend (which holds `TyCtxt`) installs a lifetime-erased eval callback here
+// for the duration of one `rustc_internal::run` scope, while tcx is alive.
+type ArrayLenEval = Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64>>;
+thread_local! {
+    static ARRAY_LEN_EVAL: std::cell::RefCell<Option<ArrayLenEval>> =
+        const { std::cell::RefCell::new(None) };
+}
+/// Install the array-length eval callback. SAFETY CONTRACT: `f` borrows the
+/// compiler `TyCtxt`; the caller MUST `clear_array_len_eval()` before that tcx
+/// is released (i.e. within the same `rustc_internal::run` scope).
+pub fn install_array_len_eval(f: ArrayLenEval) {
+    ARRAY_LEN_EVAL.with(|c| *c.borrow_mut() = Some(f));
+}
+/// Remove the array-length eval callback.
+pub fn clear_array_len_eval() {
+    ARRAY_LEN_EVAL.with(|c| *c.borrow_mut() = None);
+}
+/// Evaluate an array-length const via the installed callback (if any).
+pub(crate) fn eval_array_len(tc: &rustc_public::ty::TyConst) -> Option<u64> {
+    ARRAY_LEN_EVAL.with(|c| c.borrow().as_ref().and_then(|f| f(tc)))
+}

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -475,30 +475,19 @@ pub fn translate_type(
             // Translate the element type
             let elem = translate_type(ctx, &elem_ty)?;
 
-            // Extract the array length from the const
-            let len = match &len_const.kind() {
-                rustc_public::ty::TyConstKind::Value(_, alloc) => {
-                    // The allocation contains the length as bytes
-                    // For usize, it's 8 bytes on 64-bit systems
-                    let bytes = &alloc.bytes;
-                    if bytes.len() >= 8 {
-                        let mut arr = [0u8; 8];
-                        for (i, b) in bytes.iter().take(8).enumerate() {
-                            arr[i] = b.unwrap_or(0);
-                        }
-                        u64::from_le_bytes(arr)
-                    } else {
-                        return input_err_noloc!(TranslationErr::unsupported(
-                            "Array length constant has unexpected size"
-                        ));
-                    }
-                }
-                _ => {
-                    return input_err_noloc!(TranslationErr::unsupported(format!(
-                        "Array length must be a value constant, got: {:?}",
-                        len_const.kind()
-                    )));
-                }
+            // Array length: evaluate the const (handles both already-evaluated
+            // `Value` consts and `Unevaluated` const exprs like
+            // `[T; some_const_fn()]`).
+            let len = match len_const.eval_target_usize() {
+                Ok(n) => n,
+                // stable_mir cannot evaluate an `Unevaluated` length const
+                // (e.g. a `const SUB_LEN` reference) -> use the backend-installed
+                // TyCtxt eval bridge.
+                Err(_) => crate::eval_array_len(&len_const).ok_or_else(|| {
+                    input_error_noloc!(TranslationErr::unsupported(
+                        "Array length const could not be evaluated (no TyCtxt bridge)".to_string()
+                    ))
+                })?,
             };
 
             Ok(dialect_mir::types::MirArrayType::get(ctx, elem, len).into())

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -589,8 +589,15 @@ pub fn generate_device_code<'tcx>(
         // Install a TyCtxt-backed array-length const evaluator for the type
         // translator (stable_mir can't evaluate `Unevaluated` length consts).
         // The closure borrows `tcx`; we erase its lifetime to store it in a
-        // thread-local and CLEAR it before this `run` scope ends (tcx alive
-        // throughout). Sound because install/use/clear all happen here.
+        // thread-local. The RAII guard below calls clear_array_len_eval() on
+        // drop, guaranteeing cleanup even if run_pipeline panics.
+        struct ArrayLenEvalGuard;
+        impl Drop for ArrayLenEvalGuard {
+            fn drop(&mut self) {
+                mir_importer::clear_array_len_eval();
+            }
+        }
+
         {
             use rustc_public::rustc_internal;
             let eval = move |tc: &rustc_public::ty::TyConst| -> Option<u64> {
@@ -608,10 +615,8 @@ pub fn generate_device_code<'tcx>(
             };
             mir_importer::install_array_len_eval(boxed);
         }
-        let __pipeline_result =
-            mir_importer::run_pipeline(&stable_functions, &stable_device_externs, &pipeline_config);
-        mir_importer::clear_array_len_eval();
-        __pipeline_result
+        let _guard = ArrayLenEvalGuard;
+        mir_importer::run_pipeline(&stable_functions, &stable_device_externs, &pipeline_config)
     });
 
     // Handle the result from rustc_internal::run.

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -586,7 +586,32 @@ pub fn generate_device_code<'tcx>(
         // Run the cuda-oxide pipeline!
         // Rust MIR → `dialect-mir` → mem2reg → LLVM dialect → LLVM IR → PTX.
         // Device externs are emitted as `declare` statements in LLVM IR
-        mir_importer::run_pipeline(&stable_functions, &stable_device_externs, &pipeline_config)
+        // Install a TyCtxt-backed array-length const evaluator for the type
+        // translator (stable_mir can't evaluate `Unevaluated` length consts).
+        // The closure borrows `tcx`; we erase its lifetime to store it in a
+        // thread-local and CLEAR it before this `run` scope ends (tcx alive
+        // throughout). Sound because install/use/clear all happen here.
+        {
+            use rustc_public::rustc_internal;
+            let eval = move |tc: &rustc_public::ty::TyConst| -> Option<u64> {
+                let internal: rustc_middle::ty::Const<'_> =
+                    rustc_internal::internal(tcx, tc.clone());
+                let env = rustc_middle::ty::TypingEnv::fully_monomorphized();
+                tcx.normalize_erasing_regions(env, internal)
+                    .try_to_target_usize(tcx)
+            };
+            let boxed: Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + 'static> = unsafe {
+                std::mem::transmute::<
+                    Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + '_>,
+                    Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + 'static>,
+                >(Box::new(eval))
+            };
+            mir_importer::install_array_len_eval(boxed);
+        }
+        let __pipeline_result =
+            mir_importer::run_pipeline(&stable_functions, &stable_device_externs, &pipeline_config);
+        mir_importer::clear_array_len_eval();
+        __pipeline_result
     });
 
     // Handle the result from rustc_internal::run.

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -600,6 +600,10 @@ pub fn generate_device_code<'tcx>(
 
         {
             use rustc_public::rustc_internal;
+            // Boxed array-length evaluator, factored into an alias so the
+            // lifetime-erasing transmute below does not trip
+            // clippy::type_complexity.
+            type EvalFn<'a> = dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + 'a;
             let eval = move |tc: &rustc_public::ty::TyConst| -> Option<u64> {
                 let internal: rustc_middle::ty::Const<'_> =
                     rustc_internal::internal(tcx, tc.clone());
@@ -607,11 +611,8 @@ pub fn generate_device_code<'tcx>(
                 tcx.normalize_erasing_regions(env, internal)
                     .try_to_target_usize(tcx)
             };
-            let boxed: Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + 'static> = unsafe {
-                std::mem::transmute::<
-                    Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + '_>,
-                    Box<dyn Fn(&rustc_public::ty::TyConst) -> Option<u64> + 'static>,
-                >(Box::new(eval))
+            let boxed: Box<EvalFn<'static>> = unsafe {
+                std::mem::transmute::<Box<EvalFn<'_>>, Box<EvalFn<'static>>>(Box::new(eval))
             };
             mir_importer::install_array_len_eval(boxed);
         }


### PR DESCRIPTION
## Summary

Here's the core constraint: by the time you're in codegen, array length consts should be fully monomorphized and evaluatable. But stable_mir's TyConst::eval_target_usize() fails on TyConstKind::Unevaluated — it can't reduce those to a u64 through stable_mir's API alone.

The TyCtxt bridge is necessary because:

- TyCtxt::normalize_erasing_regions(fully_monomorphized, const) is the actual rustc mechanism to force-evaluate an unevaluated const in a monomorphized context
- That API is only available through rustc internals (rustc_middle), not through stable_mir
- The type translator lives in mir-importer, which intentionally has no direct TyCtxt dependency — hence the callback bridge rather than passing tcx directly
- The alternative would be to pass tcx directly into run_pipeline and down to the type translator, but that would couple mir-importer tightly to rustc internals, defeating its design goal of being stable_mir-only.

So the bridge is a pragmatic workaround for a gap in stable_mir's const evaluation API. If stable_mir ever exposes a way to evaluate Unevaluated consts in a fully-monomorphized context, the whole bridge could be deleted.

