### PR TITLE
fix(mir-importer): materialize nested-aggregate and ZST-field constants

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5306,11 +5306,21 @@ fn translate_struct_constant(
                 let field_bytes = if byte_offset + byte_size <= bytes.len() {
                     &bytes[byte_offset..byte_offset + byte_size]
                 } else {
-                    return input_err!(loc, TranslationErr::unsupported(format!(
-                        "Struct constant has insufficient bytes for aggregate field {}", field_idx)));
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(format!(
+                            "Struct constant has insufficient bytes for aggregate field {}",
+                            field_idx
+                        ))
+                    );
                 };
                 let (v, p) = build_const_from_bytes(
-                    ctx, field_ty_ptr, field_bytes, block_ptr, current_prev_op, loc.clone(),
+                    ctx,
+                    field_ty_ptr,
+                    field_bytes,
+                    block_ptr,
+                    current_prev_op,
+                    loc.clone(),
                 )?;
                 current_prev_op = p;
                 field_values.push(v);
@@ -5515,66 +5525,161 @@ fn build_const_from_bytes(
     loc: Location,
 ) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
     use pliron::builtin::types::FP32Type;
-    let is_int = { let t = ty_ptr.deref(ctx); t.downcast_ref::<IntegerType>().map(|i| (i.width(), i.signedness())) };
+    let is_int = {
+        let t = ty_ptr.deref(ctx);
+        t.downcast_ref::<IntegerType>()
+            .map(|i| (i.width(), i.signedness()))
+    };
     let is_f32 = { ty_ptr.deref(ctx).is::<FP32Type>() };
-    let struct_fields = { ty_ptr.deref(ctx).downcast_ref::<dialect_mir::types::MirStructType>().map(|st| st.field_types().to_vec()) };
-    let array_info = { let t = ty_ptr.deref(ctx); t.downcast_ref::<dialect_mir::types::MirArrayType>().map(|a| (a.element_type(), a.size() as usize)) };
+    let struct_fields = {
+        ty_ptr
+            .deref(ctx)
+            .downcast_ref::<dialect_mir::types::MirStructType>()
+            .map(|st| st.field_types().to_vec())
+    };
+    let array_info = {
+        let t = ty_ptr.deref(ctx);
+        t.downcast_ref::<dialect_mir::types::MirArrayType>()
+            .map(|a| (a.element_type(), a.size() as usize))
+    };
 
     if let Some((width, signedness)) = is_int {
         use dialect_mir::ops::MirConstantOp;
         let nbytes = (width as usize).div_ceil(8);
         let mut v: u128 = 0;
-        for (i, &b) in bytes.iter().take(nbytes).enumerate() { v |= (b as u128) << (i*8); }
+        for (i, &b) in bytes.iter().take(nbytes).enumerate() {
+            v |= (b as u128) << (i * 8);
+        }
         let int_ty = IntegerType::get(ctx, width, signedness);
         let apint = APInt::from_u128(v, NonZeroUsize::new(width as usize).unwrap());
-        let op = Operation::new(ctx, MirConstantOp::get_concrete_op_info(), vec![int_ty.into()], vec![], vec![], 0);
+        let op = Operation::new(
+            ctx,
+            MirConstantOp::get_concrete_op_info(),
+            vec![int_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
         op.deref_mut(ctx).set_loc(loc.clone());
-        MirConstantOp::new(op).set_attr_value(ctx, pliron::builtin::attributes::IntegerAttr::new(int_ty, apint));
-        match prev_op { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        MirConstantOp::new(op).set_attr_value(
+            ctx,
+            pliron::builtin::attributes::IntegerAttr::new(int_ty, apint),
+        );
+        match prev_op {
+            Some(p) => op.insert_after(ctx, p),
+            None => op.insert_at_front(block_ptr, ctx),
+        }
         return Ok((op.deref(ctx).get_result(0), Some(op)));
     }
     if is_f32 {
         use dialect_mir::ops::MirFloatConstantOp;
-        let fv = f32::from_le_bytes([bytes[0],bytes[1],bytes[2],bytes[3]]);
-        let op = Operation::new(ctx, MirFloatConstantOp::get_concrete_op_info(), vec![ty_ptr], vec![], vec![], 0);
+        let fv = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let op = Operation::new(
+            ctx,
+            MirFloatConstantOp::get_concrete_op_info(),
+            vec![ty_ptr],
+            vec![],
+            vec![],
+            0,
+        );
         op.deref_mut(ctx).set_loc(loc.clone());
-        MirFloatConstantOp::new(op).set_attr_float_value(ctx, pliron::builtin::attributes::FPSingleAttr::from(fv));
-        match prev_op { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        MirFloatConstantOp::new(op)
+            .set_attr_float_value(ctx, pliron::builtin::attributes::FPSingleAttr::from(fv));
+        match prev_op {
+            Some(p) => op.insert_after(ctx, p),
+            None => op.insert_at_front(block_ptr, ctx),
+        }
         return Ok((op.deref(ctx).get_result(0), Some(op)));
     }
     if let Some(fields) = struct_fields {
         use dialect_mir::ops::MirConstructStructOp;
         let mut vals = Vec::with_capacity(fields.len());
-        let mut prev = prev_op; let mut off = 0usize;
+        let mut prev = prev_op;
+        let mut off = 0usize;
         for fty in fields {
-            let sz = constant_storage_size(ctx, fty).ok_or_else(|| input_error_noloc!(TranslationErr::unsupported("aggregate const: field size".to_string())))?;
+            let sz = constant_storage_size(ctx, fty).ok_or_else(|| {
+                input_error_noloc!(TranslationErr::unsupported(
+                    "aggregate const: field size".to_string()
+                ))
+            })?;
             if sz == 0 {
-                let (v,p)=translate_zero_sized_constant_value(ctx, fty, block_ptr, prev, loc.clone())?; vals.push(v); prev=p; continue;
+                let (v, p) =
+                    translate_zero_sized_constant_value(ctx, fty, block_ptr, prev, loc.clone())?;
+                vals.push(v);
+                prev = p;
+                continue;
             }
-            let (v,p)=build_const_from_bytes(ctx, fty, &bytes[off..off+sz], block_ptr, prev, loc.clone())?;
-            vals.push(v); prev=p; off+=sz;
+            let (v, p) = build_const_from_bytes(
+                ctx,
+                fty,
+                &bytes[off..off + sz],
+                block_ptr,
+                prev,
+                loc.clone(),
+            )?;
+            vals.push(v);
+            prev = p;
+            off += sz;
         }
-        let (cv, pp)=cast_struct_fields_to_expected_types(ctx, vals, ty_ptr, block_ptr, prev, loc.clone());
-        let op = Operation::new(ctx, MirConstructStructOp::get_concrete_op_info(), vec![ty_ptr], cv, vec![], 0);
+        let (cv, pp) =
+            cast_struct_fields_to_expected_types(ctx, vals, ty_ptr, block_ptr, prev, loc.clone());
+        let op = Operation::new(
+            ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![ty_ptr],
+            cv,
+            vec![],
+            0,
+        );
         op.deref_mut(ctx).set_loc(loc.clone());
-        match pp { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        match pp {
+            Some(p) => op.insert_after(ctx, p),
+            None => op.insert_at_front(block_ptr, ctx),
+        }
         return Ok((op.deref(ctx).get_result(0), Some(op)));
     }
     if let Some((elem_ty, n)) = array_info {
         use dialect_mir::ops::MirConstructArrayOp;
-        let sz = constant_storage_size(ctx, elem_ty).ok_or_else(|| input_error_noloc!(TranslationErr::unsupported("aggregate const: array elem size".to_string())))?;
+        let sz = constant_storage_size(ctx, elem_ty).ok_or_else(|| {
+            input_error_noloc!(TranslationErr::unsupported(
+                "aggregate const: array elem size".to_string()
+            ))
+        })?;
         let mut vals = Vec::with_capacity(n);
         let mut prev = prev_op;
         for i in 0..n {
-            let (v,p)=build_const_from_bytes(ctx, elem_ty, &bytes[i*sz..i*sz+sz], block_ptr, prev, loc.clone())?;
-            vals.push(v); prev=p;
+            let (v, p) = build_const_from_bytes(
+                ctx,
+                elem_ty,
+                &bytes[i * sz..i * sz + sz],
+                block_ptr,
+                prev,
+                loc.clone(),
+            )?;
+            vals.push(v);
+            prev = p;
         }
-        let op = Operation::new(ctx, MirConstructArrayOp::get_concrete_op_info(), vec![ty_ptr], vals, vec![], 0);
+        let op = Operation::new(
+            ctx,
+            MirConstructArrayOp::get_concrete_op_info(),
+            vec![ty_ptr],
+            vals,
+            vec![],
+            0,
+        );
         op.deref_mut(ctx).set_loc(loc.clone());
-        match prev { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        match prev {
+            Some(p) => op.insert_after(ctx, p),
+            None => op.insert_at_front(block_ptr, ctx),
+        }
         return Ok((op.deref(ctx).get_result(0), Some(op)));
     }
-    input_err!(loc, TranslationErr::unsupported("build_const_from_bytes: unsupported aggregate field type".to_string()))
+    input_err!(
+        loc,
+        TranslationErr::unsupported(
+            "build_const_from_bytes: unsupported aggregate field type".to_string()
+        )
+    )
 }
 
 /// Translate an enum constant by reconstructing both its active variant and any
@@ -6096,9 +6201,8 @@ fn translate_zero_sized_constant_value(
         let mut operands = Vec::with_capacity(field_types.len());
         let mut cur_prev = prev_op;
         for fty in field_types {
-            let (v, np) = translate_zero_sized_constant_value(
-                ctx, fty, block_ptr, cur_prev, loc.clone(),
-            )?;
+            let (v, np) =
+                translate_zero_sized_constant_value(ctx, fty, block_ptr, cur_prev, loc.clone())?;
             operands.push(v);
             cur_prev = np;
         }

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5295,14 +5295,26 @@ fn translate_struct_constant(
             }
 
             FieldTypeKind::Unsupported => {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "Struct constant field {} has unsupported type. \
-                         Consider using inline construction instead of const.",
+                // Nested aggregate (e.g. a `Vec3` field inside a const `Mat3`):
+                // recursively build it from its byte slice.
+                let byte_size = constant_storage_size(ctx, field_ty_ptr).ok_or_else(|| {
+                    input_error_noloc!(TranslationErr::unsupported(format!(
+                        "Struct constant field {} has unsupported type (no storage size).",
                         field_idx
-                    ))
-                );
+                    )))
+                })?;
+                let field_bytes = if byte_offset + byte_size <= bytes.len() {
+                    &bytes[byte_offset..byte_offset + byte_size]
+                } else {
+                    return input_err!(loc, TranslationErr::unsupported(format!(
+                        "Struct constant has insufficient bytes for aggregate field {}", field_idx)));
+                };
+                let (v, p) = build_const_from_bytes(
+                    ctx, field_ty_ptr, field_bytes, block_ptr, current_prev_op, loc.clone(),
+                )?;
+                current_prev_op = p;
+                field_values.push(v);
+                byte_offset += byte_size;
             }
         }
     }
@@ -5474,9 +5486,95 @@ fn constant_storage_size(ctx: &Context, ty_ptr: Ptr<TypeObj>) -> Option<usize> {
         Some(8)
     } else if ty_ref.is::<dialect_mir::types::MirPtrType>() {
         Some(rustc_public::target::MachineInfo::target_pointer_width().bytes())
+    } else if let Some(st) = ty_ref.downcast_ref::<dialect_mir::types::MirStructType>() {
+        let fields = st.field_types().to_vec();
+        let mut total = 0usize;
+        for f in fields {
+            total += constant_storage_size(ctx, f)?;
+        }
+        Some(total)
+    } else if let Some(at) = ty_ref.downcast_ref::<dialect_mir::types::MirArrayType>() {
+        let elem = at.element_type();
+        let n = at.size() as usize;
+        Some(constant_storage_size(ctx, elem)? * n)
     } else {
         None
     }
+}
+
+/// Recursively build a constant Value of `ty_ptr` from its little-endian
+/// `bytes`, handling primitives AND nested aggregates (struct/array). Used for
+/// const aggregates like glam `Mat3::ZERO` (a struct whose fields are `Vec3`
+/// structs), which the flat per-field path could not translate.
+fn build_const_from_bytes(
+    ctx: &mut Context,
+    ty_ptr: Ptr<TypeObj>,
+    bytes: &[u8],
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
+    use pliron::builtin::types::FP32Type;
+    let is_int = { let t = ty_ptr.deref(ctx); t.downcast_ref::<IntegerType>().map(|i| (i.width(), i.signedness())) };
+    let is_f32 = { ty_ptr.deref(ctx).is::<FP32Type>() };
+    let struct_fields = { ty_ptr.deref(ctx).downcast_ref::<dialect_mir::types::MirStructType>().map(|st| st.field_types().to_vec()) };
+    let array_info = { let t = ty_ptr.deref(ctx); t.downcast_ref::<dialect_mir::types::MirArrayType>().map(|a| (a.element_type(), a.size() as usize)) };
+
+    if let Some((width, signedness)) = is_int {
+        use dialect_mir::ops::MirConstantOp;
+        let nbytes = (width as usize).div_ceil(8);
+        let mut v: u128 = 0;
+        for (i, &b) in bytes.iter().take(nbytes).enumerate() { v |= (b as u128) << (i*8); }
+        let int_ty = IntegerType::get(ctx, width, signedness);
+        let apint = APInt::from_u128(v, NonZeroUsize::new(width as usize).unwrap());
+        let op = Operation::new(ctx, MirConstantOp::get_concrete_op_info(), vec![int_ty.into()], vec![], vec![], 0);
+        op.deref_mut(ctx).set_loc(loc.clone());
+        MirConstantOp::new(op).set_attr_value(ctx, pliron::builtin::attributes::IntegerAttr::new(int_ty, apint));
+        match prev_op { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        return Ok((op.deref(ctx).get_result(0), Some(op)));
+    }
+    if is_f32 {
+        use dialect_mir::ops::MirFloatConstantOp;
+        let fv = f32::from_le_bytes([bytes[0],bytes[1],bytes[2],bytes[3]]);
+        let op = Operation::new(ctx, MirFloatConstantOp::get_concrete_op_info(), vec![ty_ptr], vec![], vec![], 0);
+        op.deref_mut(ctx).set_loc(loc.clone());
+        MirFloatConstantOp::new(op).set_attr_float_value(ctx, pliron::builtin::attributes::FPSingleAttr::from(fv));
+        match prev_op { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        return Ok((op.deref(ctx).get_result(0), Some(op)));
+    }
+    if let Some(fields) = struct_fields {
+        use dialect_mir::ops::MirConstructStructOp;
+        let mut vals = Vec::with_capacity(fields.len());
+        let mut prev = prev_op; let mut off = 0usize;
+        for fty in fields {
+            let sz = constant_storage_size(ctx, fty).ok_or_else(|| input_error_noloc!(TranslationErr::unsupported("aggregate const: field size".to_string())))?;
+            if sz == 0 {
+                let (v,p)=translate_zero_sized_constant_value(ctx, fty, block_ptr, prev, loc.clone())?; vals.push(v); prev=p; continue;
+            }
+            let (v,p)=build_const_from_bytes(ctx, fty, &bytes[off..off+sz], block_ptr, prev, loc.clone())?;
+            vals.push(v); prev=p; off+=sz;
+        }
+        let (cv, pp)=cast_struct_fields_to_expected_types(ctx, vals, ty_ptr, block_ptr, prev, loc.clone());
+        let op = Operation::new(ctx, MirConstructStructOp::get_concrete_op_info(), vec![ty_ptr], cv, vec![], 0);
+        op.deref_mut(ctx).set_loc(loc.clone());
+        match pp { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        return Ok((op.deref(ctx).get_result(0), Some(op)));
+    }
+    if let Some((elem_ty, n)) = array_info {
+        use dialect_mir::ops::MirConstructArrayOp;
+        let sz = constant_storage_size(ctx, elem_ty).ok_or_else(|| input_error_noloc!(TranslationErr::unsupported("aggregate const: array elem size".to_string())))?;
+        let mut vals = Vec::with_capacity(n);
+        let mut prev = prev_op;
+        for i in 0..n {
+            let (v,p)=build_const_from_bytes(ctx, elem_ty, &bytes[i*sz..i*sz+sz], block_ptr, prev, loc.clone())?;
+            vals.push(v); prev=p;
+        }
+        let op = Operation::new(ctx, MirConstructArrayOp::get_concrete_op_info(), vec![ty_ptr], vals, vec![], 0);
+        op.deref_mut(ctx).set_loc(loc.clone());
+        match prev { Some(p)=>op.insert_after(ctx,p), None=>op.insert_at_front(block_ptr,ctx) }
+        return Ok((op.deref(ctx).get_result(0), Some(op)));
+    }
+    input_err!(loc, TranslationErr::unsupported("build_const_from_bytes: unsupported aggregate field type".to_string()))
 }
 
 /// Translate an enum constant by reconstructing both its active variant and any
@@ -5983,15 +6081,46 @@ fn translate_zero_sized_constant_value(
         }
     };
 
-    let op = match zero_sized_kind {
-        ZeroSizedKind::Struct => Operation::new(
+    // A zero-sized struct can still carry (zero-sized) fields in its type, and
+    // `MirConstructStructOp` requires one operand per field. Recursively
+    // synthesize a ZST value for each field type (e.g. `TryFromIntError(())`,
+    // which surfaces when building `core` for nvptx via `-Zbuild-std`).
+    if matches!(zero_sized_kind, ZeroSizedKind::Struct) {
+        let field_types: Vec<Ptr<TypeObj>> = {
+            let ty_ref = ty_ptr.deref(ctx);
+            ty_ref
+                .downcast_ref::<dialect_mir::types::MirStructType>()
+                .map(|st| st.field_types.clone())
+                .unwrap_or_default()
+        };
+        let mut operands = Vec::with_capacity(field_types.len());
+        let mut cur_prev = prev_op;
+        for fty in field_types {
+            let (v, np) = translate_zero_sized_constant_value(
+                ctx, fty, block_ptr, cur_prev, loc.clone(),
+            )?;
+            operands.push(v);
+            cur_prev = np;
+        }
+        let op = Operation::new(
             ctx,
             MirConstructStructOp::get_concrete_op_info(),
             vec![ty_ptr],
-            vec![],
+            operands,
             vec![],
             0,
-        ),
+        );
+        op.deref_mut(ctx).set_loc(loc);
+        if let Some(prev) = cur_prev {
+            op.insert_after(ctx, prev);
+        } else {
+            op.insert_at_front(block_ptr, ctx);
+        }
+        return Ok((op.deref(ctx).get_result(0), Some(op)));
+    }
+
+    let op = match zero_sized_kind {
+        ZeroSizedKind::Struct => unreachable!("handled above"),
         ZeroSizedKind::EmptyTuple => {
             use dialect_mir::ops::MirConstructTupleOp;
             Operation::new(

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "const_aggregate"
+version = "0.1.0"
+edition = "2024"
+authors = ["Nihal Pasham <nihalp@nvidia.com>"]
+license = "Apache-2.0"
+
+# Mark as standalone crate (not part of parent workspace)
+[workspace]
+
+# Regression for nested-aggregate constant materialization.
+# Build/run with:
+#   cargo oxide run const_aggregate
+#
+# Before the fix, a const struct whose field is itself a struct (or an
+# array of structs) failed to compile with
+#   "Struct constant field N has unsupported type".
+
+[dependencies]
+cuda-device = { path = "../../../cuda-device" }
+cuda-host = { path = "../../../cuda-host" }
+cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
@@ -55,17 +55,41 @@ mod kernels {
 
     // struct-of-struct const: the 3x3 identity matrix.
     const IDENTITY: Mat3 = Mat3 {
-        r0: Vec3 { x: 1.0, y: 0.0, z: 0.0 },
-        r1: Vec3 { x: 0.0, y: 1.0, z: 0.0 },
-        r2: Vec3 { x: 0.0, y: 0.0, z: 1.0 },
+        r0: Vec3 {
+            x: 1.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        r1: Vec3 {
+            x: 0.0,
+            y: 1.0,
+            z: 0.0,
+        },
+        r2: Vec3 {
+            x: 0.0,
+            y: 0.0,
+            z: 1.0,
+        },
     };
 
     // struct-of-array-of-struct const.
     const MESH: Mesh = Mesh {
         verts: [
-            Vec3 { x: 1.0, y: 0.0, z: 0.0 },
-            Vec3 { x: 0.0, y: 2.0, z: 0.0 },
-            Vec3 { x: 0.0, y: 0.0, z: 4.0 },
+            Vec3 {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            Vec3 {
+                x: 0.0,
+                y: 2.0,
+                z: 0.0,
+            },
+            Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 4.0,
+            },
         ],
     };
 

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Nested-aggregate constant materialization (regression).
+//!
+//! A `const` whose field is itself an aggregate (a struct, or an array of
+//! structs) used to fail device codegen with
+//! `Unsupported construct: Struct constant field N has unsupported type`.
+//! The fix recursively rebuilds each nested field from its constant bytes.
+//!
+//! Three shapes are exercised:
+//!   - `Mat3` : struct whose fields are `Vec3` structs (struct-of-struct).
+//!   - `Mesh` : struct whose field is a `[Vec3; 3]` (struct-of-array-of-struct).
+//!   - `Marker(())` : zero-sized struct that still carries a (ZST) field.
+//!
+//! Each const is passed by value to an `#[inline(never)]` device fn so rustc
+//! cannot fold the field reads away: the whole aggregate must be materialized
+//! as a `Const` operand, which is the path the fix repairs.
+//!
+//! Run: cargo oxide run const_aggregate
+
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig};
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
+use std::sync::Arc;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    pub struct Vec3 {
+        pub x: f32,
+        pub y: f32,
+        pub z: f32,
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct Mat3 {
+        pub r0: Vec3,
+        pub r1: Vec3,
+        pub r2: Vec3,
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct Mesh {
+        pub verts: [Vec3; 3],
+    }
+
+    /// Zero-sized struct that still has a (zero-sized) field.
+    #[derive(Clone, Copy)]
+    pub struct Marker(pub ());
+
+    // struct-of-struct const: the 3x3 identity matrix.
+    const IDENTITY: Mat3 = Mat3 {
+        r0: Vec3 { x: 1.0, y: 0.0, z: 0.0 },
+        r1: Vec3 { x: 0.0, y: 1.0, z: 0.0 },
+        r2: Vec3 { x: 0.0, y: 0.0, z: 1.0 },
+    };
+
+    // struct-of-array-of-struct const.
+    const MESH: Mesh = Mesh {
+        verts: [
+            Vec3 { x: 1.0, y: 0.0, z: 0.0 },
+            Vec3 { x: 0.0, y: 2.0, z: 0.0 },
+            Vec3 { x: 0.0, y: 0.0, z: 4.0 },
+        ],
+    };
+
+    const MARK: Marker = Marker(());
+
+    /// Sum of the diagonal: 1.0 + 1.0 + 1.0 = 3.0 for the identity.
+    #[inline(never)]
+    fn diag_sum(m: Mat3) -> f32 {
+        m.r0.x + m.r1.y + m.r2.z
+    }
+
+    /// Sum of the per-vertex diagonal: 1.0 + 2.0 + 4.0 = 7.0.
+    #[inline(never)]
+    fn mesh_sum(me: Mesh) -> f32 {
+        me.verts[0].x + me.verts[1].y + me.verts[2].z
+    }
+
+    /// The ZST field carries no data; the call still materializes the const.
+    #[inline(never)]
+    fn marker_value(_m: Marker) -> f32 {
+        100.0
+    }
+
+    /// out[i] = diag_sum(IDENTITY) + mesh_sum(MESH) + marker_value(MARK)
+    ///        = 3.0 + 7.0 + 100.0 = 110.0  for every lane.
+    #[kernel]
+    pub fn const_aggregate(mut out: DisjointSlice<f32>) {
+        let t = thread::index_1d();
+        if let Some(slot) = out.get_mut(t) {
+            *slot = diag_sum(IDENTITY) + mesh_sum(MESH) + marker_value(MARK);
+        }
+    }
+}
+
+const N: usize = 64;
+const EXPECTED: f32 = 110.0;
+
+fn main() {
+    println!("=== Nested-aggregate constant materialization ===\n");
+
+    let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
+    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/const_aggregate.ptx");
+    let module = ctx
+        .load_module_from_file(ptx_path)
+        .expect("Failed to load PTX (device codegen failed?)");
+    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let stream = ctx.default_stream();
+
+    let mut d_out = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    let config = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (N as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    module
+        .const_aggregate(stream.as_ref(), config, &mut d_out)
+        .expect("Kernel launch failed");
+
+    let out = d_out.to_host_vec(&stream).unwrap();
+    let mut bad = None;
+    for (i, v) in out.iter().enumerate() {
+        if (v - EXPECTED).abs() > 1e-6 {
+            bad = Some((i, *v));
+            break;
+        }
+    }
+
+    match bad {
+        None => println!("SUCCESS: all {N} lanes == {EXPECTED} (3.0 + 7.0 + 100.0)"),
+        Some((i, v)) => {
+            println!("FAIL: lane {i} = {v}, expected {EXPECTED}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn _stream_marker(_s: &Arc<CudaStream>) {}


### PR DESCRIPTION
Three constant-translation gaps for real shader code:
- Nested aggregate constants: a const Mat3 (struct of Vec3 structs, e.g. glam Mat3::ZERO) now recursively builds each field from its byte slice instead of failing with "Struct constant field N has unsupported type".
- constant_storage_size is extended to compute the byte size of struct and array constant types (needed for the recursive field slicing above).
- ZST-struct field synthesis: a zero-sized struct still carries (zero-sized) typed fields, and MirConstructStructOp requires one operand per field; synthesize a ZST value per field type (e.g. TryFromIntError(()), hit by step_by under -Zbuild-std) instead of constructing with zero operands.
