### PR TITLE
fix(mir-importer): lower core::intrinsics::typed_swap_nonoverlapping

### DIFF
--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1637,6 +1637,140 @@ fn extract_func_info(func: &mir::Operand) -> (Option<String>, Option<String>, Op
     }
 }
 
+/// Lower `core::intrinsics::typed_swap_nonoverlapping::<T>(x, y)`, the
+/// primitive behind `core::mem::swap`/`mem::replace`, as load/load/store/store.
+/// The two pointers are guaranteed non-overlapping, so the temp-free crossover
+/// `t0 = *x; t1 = *y; *x = t1; *y = t0` is valid (the loaded SSA values are
+/// captured before either store runs). Returns a unit result + goto target.
+#[allow(clippy::too_many_arguments)]
+fn emit_typed_swap(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    use dialect_mir::ops::{MirConstructTupleOp, MirLoadOp, MirStoreOp};
+    use dialect_mir::types::{MirPtrType, MirTupleType};
+
+    if args.len() != 2 {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(
+                "typed_swap_nonoverlapping requires two pointer operands".to_string()
+            )
+        );
+    }
+
+    let (ptr_x, last) =
+        rvalue::translate_operand(ctx, body, &args[0], value_map, block_ptr, prev_op, loc.clone())?;
+    let (ptr_y, last) =
+        rvalue::translate_operand(ctx, body, &args[1], value_map, block_ptr, last, loc.clone())?;
+
+    let elem_ty = {
+        let t = ptr_x.get_type(ctx);
+        let r = t.deref(ctx);
+        match r.downcast_ref::<MirPtrType>() {
+            Some(p) => p.pointee,
+            None => {
+                return input_err!(
+                    loc,
+                    TranslationErr::unsupported(
+                        "typed_swap_nonoverlapping operand is not a pointer".to_string()
+                    )
+                );
+            }
+        }
+    };
+
+    // t0 = *x
+    let load_x = Operation::new(
+        ctx,
+        MirLoadOp::get_concrete_op_info(),
+        vec![elem_ty],
+        vec![ptr_x],
+        vec![],
+        0,
+    );
+    load_x.deref_mut(ctx).set_loc(loc.clone());
+    match last {
+        Some(p) => load_x.insert_after(ctx, p),
+        None => load_x.insert_at_front(block_ptr, ctx),
+    }
+    let vx = load_x.deref(ctx).get_result(0);
+
+    // t1 = *y
+    let load_y = Operation::new(
+        ctx,
+        MirLoadOp::get_concrete_op_info(),
+        vec![elem_ty],
+        vec![ptr_y],
+        vec![],
+        0,
+    );
+    load_y.deref_mut(ctx).set_loc(loc.clone());
+    load_y.insert_after(ctx, load_x);
+    let vy = load_y.deref(ctx).get_result(0);
+
+    // *x = t1
+    let store_x = Operation::new(
+        ctx,
+        MirStoreOp::get_concrete_op_info(),
+        vec![],
+        vec![ptr_x, vy],
+        vec![],
+        0,
+    );
+    store_x.deref_mut(ctx).set_loc(loc.clone());
+    store_x.insert_after(ctx, load_y);
+
+    // *y = t0
+    let store_y = Operation::new(
+        ctx,
+        MirStoreOp::get_concrete_op_info(),
+        vec![],
+        vec![ptr_y, vx],
+        vec![],
+        0,
+    );
+    store_y.deref_mut(ctx).set_loc(loc.clone());
+    store_y.insert_after(ctx, store_x);
+
+    // unit result
+    let unit_ty = MirTupleType::get(ctx, vec![]);
+    let unit_op = Operation::new(
+        ctx,
+        MirConstructTupleOp::get_concrete_op_info(),
+        vec![unit_ty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    unit_op.deref_mut(ctx).set_loc(loc.clone());
+    unit_op.insert_after(ctx, store_y);
+    let unit_val = unit_op.deref(ctx).get_result(0);
+
+    let goto_prev = value_map
+        .store_local(ctx, destination.local, unit_val, block_ptr, Some(unit_op))
+        .unwrap_or(unit_op);
+
+    if let Some(target_idx) = target {
+        Ok(helpers::emit_goto(ctx, *target_idx, goto_prev, block_map, loc))
+    } else {
+        input_err!(
+            loc,
+            TranslationErr::unsupported(
+                "typed_swap_nonoverlapping call without target not supported".to_string()
+            )
+        )
+    }
+}
+
 /// Dispatches `cuda_device` intrinsic calls to their respective handlers.
 ///
 /// Returns `Ok(Some(op))` if the call was an intrinsic, `Ok(None)` otherwise.
@@ -1682,6 +1816,23 @@ fn try_dispatch_intrinsic(
             block_map,
             loc,
             kind,
+        )?));
+    }
+
+    if name == "core::intrinsics::typed_swap_nonoverlapping"
+        || name == "std::intrinsics::typed_swap_nonoverlapping"
+    {
+        return Ok(Some(emit_typed_swap(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
         )?));
     }
 

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1667,8 +1667,15 @@ fn emit_typed_swap(
         );
     }
 
-    let (ptr_x, last) =
-        rvalue::translate_operand(ctx, body, &args[0], value_map, block_ptr, prev_op, loc.clone())?;
+    let (ptr_x, last) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
     let (ptr_y, last) =
         rvalue::translate_operand(ctx, body, &args[1], value_map, block_ptr, last, loc.clone())?;
 
@@ -1760,7 +1767,13 @@ fn emit_typed_swap(
         .unwrap_or(unit_op);
 
     if let Some(target_idx) = target {
-        Ok(helpers::emit_goto(ctx, *target_idx, goto_prev, block_map, loc))
+        Ok(helpers::emit_goto(
+            ctx,
+            *target_idx,
+            goto_prev,
+            block_map,
+            loc,
+        ))
     } else {
         input_err!(
             loc,

--- a/crates/rustc-codegen-cuda/examples/mem_swap/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mem_swap"
+version = "0.1.0"
+edition = "2024"
+authors = ["Nihal Pasham <nihalp@nvidia.com>"]
+license = "Apache-2.0"
+
+# Mark as standalone crate (not part of parent workspace)
+[workspace]
+
+# Regression for core::mem::swap / mem::replace on the device.
+# Build/run with:
+#   cargo oxide run mem_swap
+#
+# Before the fix, these lowered to the compiler intrinsic
+# `core::intrinsics::typed_swap_nonoverlapping`, which has no MIR body and
+# bailed with "rustc intrinsic ... is not yet supported on the device".
+
+[dependencies]
+cuda-device = { path = "../../../cuda-device" }
+cuda-host = { path = "../../../cuda-host" }
+cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `core::mem::swap` / `mem::replace` on the device (regression).
+//!
+//! `mem::swap`/`mem::replace` lower to the compiler intrinsic
+//! `core::intrinsics::typed_swap_nonoverlapping`, which has no MIR body. Before
+//! the fix this bailed with
+//! `rustc intrinsic core::intrinsics::typed_swap_nonoverlapping is not yet
+//! supported on the device`. The fix lowers it as a temp-free load/load/
+//! store/store crossover.
+//!
+//! Each lane loads `a[i]` and `b[i]` into two locals, `mem::swap`s them, then
+//! `mem::replace`s a sentinel into one. The result is encoded so the host can
+//! verify both operations:
+//!   out[i] = x*1000 + old = b[i]*1000 + a[i]
+//!
+//! Run: cargo oxide run mem_swap
+
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    pub fn swap_kernel(a: &[i32], b: &[i32], mut out: DisjointSlice<i32>) {
+        let t = thread::index_1d();
+        let i = t.get();
+        let mut x = a[i];
+        let mut y = b[i];
+        // mem::swap -> typed_swap_nonoverlapping(&mut x, &mut y)
+        core::mem::swap(&mut x, &mut y); // now x = b[i], y = a[i]
+        // mem::replace also routes through the swap intrinsic:
+        let old = core::mem::replace(&mut y, 7); // old = a[i], y = 7
+        if let Some(slot) = out.get_mut(t) {
+            // encode both: x (= b[i]) and old (= a[i])
+            *slot = x * 1000 + old;
+        }
+    }
+}
+
+const N: usize = 64;
+
+fn main() {
+    println!("=== core::mem::swap / mem::replace on device ===\n");
+
+    let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
+    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/mem_swap.ptx");
+    let module = ctx
+        .load_module_from_file(ptx_path)
+        .expect("Failed to load PTX (device codegen failed?)");
+    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let stream = ctx.default_stream();
+
+    let a_init: Vec<i32> = (0..N as i32).collect(); // a[i] = i
+    let b_init: Vec<i32> = (0..N as i32).map(|i| 100 + i).collect(); // b[i] = 100 + i
+    let d_a = DeviceBuffer::from_host(&stream, &a_init).unwrap();
+    let d_b = DeviceBuffer::from_host(&stream, &b_init).unwrap();
+    let mut d_out = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
+
+    let config = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (N as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    module
+        .swap_kernel(stream.as_ref(), config, &d_a, &d_b, &mut d_out)
+        .expect("Kernel launch failed");
+
+    let out = d_out.to_host_vec(&stream).unwrap();
+    let mut ok = true;
+    for i in 0..N {
+        let want = (100 + i as i32) * 1000 + i as i32; // b[i]*1000 + a[i]
+        if out[i] != want {
+            println!("FAIL: lane {i}: out={} (want {want})", out[i]);
+            ok = false;
+            break;
+        }
+    }
+    if ok {
+        println!("SUCCESS: all {N} lanes swapped+replaced correctly (out = b*1000 + a)");
+    } else {
+        std::process::exit(1);
+    }
+}

--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -74,10 +74,10 @@ fn main() {
 
     let out = d_out.to_host_vec(&stream).unwrap();
     let mut ok = true;
-    for i in 0..N {
+    for (i, got) in out.iter().enumerate() {
         let want = (100 + i as i32) * 1000 + i as i32; // b[i]*1000 + a[i]
-        if out[i] != want {
-            println!("FAIL: lane {i}: out={} (want {want})", out[i]);
+        if *got != want {
+            println!("FAIL: lane {i}: out={got} (want {want})");
             ok = false;
             break;
         }


### PR DESCRIPTION
`typed_swap_nonoverlapping::<T>(x, y)` — the primitive behind `mem::swap` / `mem::replace` — has no MIR body. Lower it as a load/load/store/store crossover; the two pointers are guaranteed non-overlapping, so no temporary is needed. The element type is read off the pointer operand. Dispatched from `try_dispatch_intrinsic`.
