### PR TITLE
Fix hashmap example unsoundness (#151) with atomic slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ __pycache__/
 
 # Locally-built bench helper (compiled by bench/build.sh)
 crates/rustc-codegen-cuda/examples/gemm_sol/bench/cublaslt_bench
+
+# cargo-oxide layered build cache (large, externally configured target dir)
+/.layer-target/

--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -240,6 +240,37 @@ impl<T> DeviceBuffer<T> {
         let _dealloc_stream = unsafe { std::ptr::read(&this.dealloc_stream) };
         (ptr, len, ctx)
     }
+
+    /// Reinterpret the element type of this buffer as `A`.
+    ///
+    /// `A` must have the same size and alignment as `T` (e.g. `A` is
+    /// `#[repr(transparent)]` over `T`). This is the "atomic-slice launch
+    /// mapping" for issue #151: allocate and initialize a plain
+    /// `DeviceBuffer<u64>`, then hand it to a kernel that takes
+    /// `&[DeviceAtomicU64]`. The pointer, length, and bytes are unchanged;
+    /// only the element type the kernel sees changes to one whose pointee
+    /// permits shared mutation (so rustc does not mark it `readonly`/`noalias`).
+    ///
+    /// Element counts are preserved because `size_of::<A>() == size_of::<T>()`.
+    pub fn cast_elem<A>(self) -> DeviceBuffer<A> {
+        assert_eq!(
+            std::mem::size_of::<A>(),
+            std::mem::size_of::<T>(),
+            "cast_elem requires the same element size"
+        );
+        assert_eq!(
+            std::mem::align_of::<A>(),
+            std::mem::align_of::<T>(),
+            "cast_elem requires the same element alignment"
+        );
+        let (ptr, len, ctx) = self.into_raw_parts();
+        // SAFETY: `ptr` came from a valid `DeviceBuffer<T>` allocation of `len`
+        // elements; `A` has identical size and alignment, so the same allocation
+        // is a valid `DeviceBuffer<A>` of the same length and the same byte
+        // extent. Ownership transfers; the original buffer's `Drop` is
+        // suppressed by `into_raw_parts`.
+        unsafe { DeviceBuffer::<A>::from_raw_parts(ptr, len, ctx) }
+    }
 }
 
 impl<T: DeviceCopy> DeviceBuffer<T> {

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -87,7 +87,14 @@ mod kernels {
     // ============================================================================
 
     /// Test kernel for cluster_sync().
+    ///
+    /// `cluster_sync` only has meaning when the kernel actually runs as a
+    /// thread-block cluster, so this must carry `#[cluster_launch(...)]` like
+    /// the DSMEM tests below. Without it the grid launches as ordinary blocks,
+    /// every block is its own size-1 cluster, `block_rank()` is always 0, and
+    /// only `output[0]` is written.
     #[kernel]
+    #[cluster_launch(4, 1, 1)]
     pub fn test_cluster_sync(mut output: DisjointSlice<u32>) {
         static mut SHMEM: SharedArray<u32, 1> = SharedArray::UNINIT;
 

--- a/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
@@ -96,7 +96,7 @@ mod kernels {
     ///
     /// `table.len()` must be a power of two (host-side invariant).
     #[kernel]
-    pub fn insert_kernel(table: &[u64], keys: &[u32], values: &[u32]) {
+    pub fn insert_kernel(table: &[DeviceAtomicU64], keys: &[u32], values: &[u32]) {
         let tid = thread::index_1d().get();
         if tid >= keys.len() {
             return;
@@ -108,7 +108,7 @@ mod kernels {
         let mut idx = (hash_u32(key) as usize) & mask;
 
         loop {
-            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+            let slot = &table[idx];
 
             match slot.compare_exchange(
                 EMPTY,
@@ -148,7 +148,7 @@ mod kernels {
     /// On a fresh insert it reports `0`.
     #[kernel]
     pub fn try_insert_kernel(
-        table: &[u64],
+        table: &[DeviceAtomicU64],
         keys: &[u32],
         values: &[u32],
         mut out: DisjointSlice<u32>,
@@ -166,7 +166,7 @@ mod kernels {
         let mut idx = (hash_u32(key) as usize) & mask;
 
         loop {
-            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+            let slot = &table[idx];
 
             match slot.compare_exchange(
                 EMPTY,
@@ -196,7 +196,7 @@ mod kernels {
     /// Linear-probe from `hash(key) & mask` and return the value if a key match
     /// is found, or `MISS = u32::MAX` if an EMPTY slot is hit first.
     #[kernel]
-    pub fn find_kernel(table: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+    pub fn find_kernel(table: &[DeviceAtomicU64], keys: &[u32], mut out: DisjointSlice<u32>) {
         let tid = thread::index_1d();
         let tid_raw = tid.get();
         let i = tid_raw;
@@ -209,7 +209,7 @@ mod kernels {
         let mut idx = (hash_u32(key) as usize) & mask;
 
         loop {
-            let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(idx).cast_mut()) };
+            let slot = &table[idx];
             let observed = slot.load(AtomicOrdering::Acquire);
 
             if observed == EMPTY {
@@ -249,7 +249,7 @@ const FORBIDDEN_KEY: u32 = u32::MAX;
 /// inputs/outputs across the host/device boundary on the supplied stream.
 struct GpuHashMap {
     /// Device-side packed `(key, value)` slot array. Length = `capacity`.
-    slots: DeviceBuffer<u64>,
+    slots: DeviceBuffer<DeviceAtomicU64>,
     /// Number of slots. Always a power of two so `hash & (capacity - 1)`
     /// can serve as the probe-position mask.
     capacity: usize,
@@ -279,6 +279,12 @@ impl GpuHashMap {
                 stream.cu_stream(),
             )?;
         }
+
+        // View the storage as atomics so the kernels can soundly mutate it
+        // through a shared `&[DeviceAtomicU64]` (issue #151). `DeviceAtomicU64`
+        // is `#[repr(transparent)]` over `u64`, so the pointer, length, and the
+        // `0xFF`-filled bytes are all unchanged.
+        let slots = slots.cast_elem::<DeviceAtomicU64>();
 
         Ok(Self { slots, capacity })
     }

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
@@ -248,7 +248,12 @@ pub mod kernels {
     ///   4. No FULL(h2) match anywhere in the tile and no EMPTY_TAG to
     ///      claim → triangular advance and repeat.
     #[kernel]
-    pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+    pub fn insert_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        values: &[u32],
+    ) {
         let tid = thread::index_1d().get();
         if tid >= keys.len() {
             return;
@@ -268,17 +273,13 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             insert_overwrite(slot_atomic, observed, key, value);
@@ -294,9 +295,7 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 // Re-read this word: another thread may have mutated it
                 // between Phase 1 and now.
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
@@ -304,9 +303,7 @@ pub mod kernels {
                 while j < GROUP {
                     if get_tag(word, j) == EMPTY_TAG {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         match slot_atomic.compare_exchange(
                             EMPTY_SLOT,
                             pack(key, value),
@@ -345,8 +342,8 @@ pub mod kernels {
     ///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
     #[kernel]
     pub fn try_insert_kernel(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         values: &[u32],
         mut out: DisjointSlice<u32>,
@@ -371,17 +368,13 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             if let Some(o) = out.get_mut(tid) {
@@ -399,17 +392,13 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == EMPTY_TAG {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         match slot_atomic.compare_exchange(
                             EMPTY_SLOT,
                             pack(key, value),
@@ -478,7 +467,12 @@ pub mod kernels {
     /// before Phase 1 of a later launch reads, so cross-launch dedup is
     /// correct.
     #[kernel]
-    pub fn insert_kernel_proto_a(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+    pub fn insert_kernel_proto_a(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        values: &[u32],
+    ) {
         let tid = thread::index_1d().get();
         if tid >= keys.len() {
             return;
@@ -500,17 +494,13 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             insert_overwrite(slot_atomic, observed, key, value);
@@ -529,9 +519,7 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 'word: loop {
                     let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                     let mut j = 0;
@@ -550,11 +538,7 @@ pub mod kernels {
                                     // the slot until we publish FULL(h2), and no
                                     // concurrent inserter can race the byte.
                                     let slot_idx = probe_base + g + j;
-                                    let slot_atomic = unsafe {
-                                        DeviceAtomicU64::from_ptr(
-                                            slots.as_ptr().add(slot_idx).cast_mut(),
-                                        )
-                                    };
+                                    let slot_atomic = &slots[slot_idx];
                                     slot_atomic.store(pack(key, value), AtomicOrdering::Release);
                                     publish_full_tag(ctrl_atomic, claimed, j, h2);
                                     return;
@@ -593,8 +577,8 @@ pub mod kernels {
     /// single-launch first-writer dedup is required.
     #[kernel]
     pub fn try_insert_kernel_proto_a(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         values: &[u32],
         mut out: DisjointSlice<u32>,
@@ -619,17 +603,13 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     if get_tag(word, j) == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             if let Some(o) = out.get_mut(tid) {
@@ -647,9 +627,7 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 'word: loop {
                     let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                     let mut j = 0;
@@ -664,11 +642,7 @@ pub mod kernels {
                             ) {
                                 Ok(_) => {
                                     let slot_idx = probe_base + g + j;
-                                    let slot_atomic = unsafe {
-                                        DeviceAtomicU64::from_ptr(
-                                            slots.as_ptr().add(slot_idx).cast_mut(),
-                                        )
-                                    };
+                                    let slot_atomic = &slots[slot_idx];
                                     slot_atomic.store(pack(key, value), AtomicOrdering::Release);
                                     publish_full_tag(ctrl_atomic, claimed, j, h2);
                                     if let Some(o) = out.get_mut(tid) {
@@ -706,7 +680,12 @@ pub mod kernels {
     ///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
     ///     advance and repeat. DELETED never terminates find.
     #[kernel]
-    pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+    pub fn find_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
         let tid = thread::index_1d();
         let tid_raw = tid.get();
         let i_thread = tid_raw;
@@ -726,18 +705,14 @@ pub mod kernels {
             let mut has_empty = false;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     let tag = get_tag(word, j);
                     if tag == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             if let Some(o) = out.get_mut(tid) {
@@ -787,8 +762,8 @@ pub mod kernels {
     /// probe), same as the single-thread `find_kernel`.
     #[kernel]
     pub fn find_kernel_warp(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         mut out: DisjointSlice<u32>,
     ) {
@@ -811,10 +786,7 @@ pub mod kernels {
             let tag_pos = probe_base + (lane as usize);
             let ctrl_word_idx = tag_pos / GROUP;
             let byte_in_word = tag_pos % GROUP;
-            let word = unsafe {
-                DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                    .load(AtomicOrdering::Acquire)
-            };
+            let word = ctrl[ctrl_word_idx].load(AtomicOrdering::Acquire);
             let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
 
             let mut m_h2 = warp::ballot(tag == h2);
@@ -828,10 +800,7 @@ pub mod kernels {
                 // so all lanes converge on the candidate's slot value.
                 let local_slot: u64 = if lane == cand {
                     let slot_idx = probe_base + (cand as usize);
-                    unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                            .load(AtomicOrdering::Acquire)
-                    }
+                    slots[slot_idx].load(AtomicOrdering::Acquire)
                 } else {
                     0
                 };
@@ -895,8 +864,8 @@ pub mod kernels {
     /// raw kernel.
     #[kernel]
     pub fn find_kernel_warp_typed(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         mut out: DisjointSlice<u32>,
     ) {
@@ -921,10 +890,7 @@ pub mod kernels {
             let tag_pos = probe_base + (lane as usize);
             let ctrl_word_idx = tag_pos / GROUP;
             let byte_in_word = tag_pos % GROUP;
-            let word = unsafe {
-                DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                    .load(AtomicOrdering::Acquire)
-            };
+            let word = ctrl[ctrl_word_idx].load(AtomicOrdering::Acquire);
             let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
 
             let mut m_h2 = tile.ballot(tag == h2);
@@ -934,10 +900,7 @@ pub mod kernels {
                 let cand = m_h2.trailing_zeros();
                 let local_slot: u64 = if lane == cand {
                     let slot_idx = probe_base + (cand as usize);
-                    unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                            .load(AtomicOrdering::Acquire)
-                    }
+                    slots[slot_idx].load(AtomicOrdering::Acquire)
                 } else {
                     0
                 };
@@ -993,7 +956,12 @@ pub mod kernels {
     ///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
     ///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
     #[kernel]
-    pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+    pub fn delete_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
         let tid = thread::index_1d();
         let tid_raw = tid.get();
         let i_thread = tid_raw;
@@ -1013,9 +981,7 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
 
                 // Per-word retry loop: if our CAS to flip a tag to DELETED
                 // fails because someone else mutated this same word, re-read
@@ -1028,9 +994,7 @@ pub mod kernels {
                         let tag = get_tag(word, j);
                         if tag == h2 {
                             let slot_idx = probe_base + g + j;
-                            let slot_atomic = unsafe {
-                                DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                            };
+                            let slot_atomic = &slots[slot_idx];
                             let observed = slot_atomic.load(AtomicOrdering::Acquire);
                             if unpack_key(observed) == key {
                                 let new_word = set_tag(word, j, DELETED_TAG);
@@ -1148,10 +1112,14 @@ pub const FORBIDDEN_KEY: u32 = u32::MAX;
 /// Both buffers are `memset_d8_async(0xFF)` at construction so every tag
 /// reads as `EMPTY_TAG` and every slot reads as `EMPTY_SLOT`.
 pub struct GpuSwissMap {
-    /// Packed tag bytes; 4 tags per `u32` word.
-    pub ctrl: DeviceBuffer<u32>,
-    /// Packed `(key, value)` slots — key in the upper 32 bits.
-    pub slots: DeviceBuffer<u64>,
+    /// Packed tag bytes; 4 tags per `u32` word. Typed as
+    /// `DeviceBuffer<DeviceAtomicU32>` so the kernels can take a
+    /// `&[DeviceAtomicU32]` and mutate it soundly (issue #151:
+    /// mutating through a shared readonly `&[u32]` is UB).
+    pub ctrl: DeviceBuffer<DeviceAtomicU32>,
+    /// Packed `(key, value)` slots — key in the upper 32 bits. Typed as
+    /// `DeviceBuffer<DeviceAtomicU64>` for the same reason as `ctrl`.
+    pub slots: DeviceBuffer<DeviceAtomicU64>,
     /// Number of slots. Power of two, multiple of `GROUP`.
     capacity: usize,
 }
@@ -1186,6 +1154,15 @@ impl GpuSwissMap {
                 stream.cu_stream(),
             )?;
         }
+
+        // Reinterpret the allocations as their atomic element types
+        // (`#[repr(transparent)]`, identical layout). The kernels mutate
+        // these buffers through shared `&[DeviceAtomic*]` slices; a plain
+        // `&[u32]` / `&[u64]` would be readonly+noalias and writing
+        // through it is UB (issue #151). The memset above is byte-level so
+        // it stays valid across the cast.
+        let ctrl = ctrl.cast_elem::<DeviceAtomicU32>();
+        let slots = slots.cast_elem::<DeviceAtomicU64>();
 
         Ok(Self {
             ctrl,

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
@@ -234,7 +234,12 @@ pub mod kernels {
     /// `overwrite = true` (existing values for the same key are replaced
     /// last-writer-wins). Probe and reclaim mechanics live in the helper.
     #[kernel]
-    pub fn insert_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+    pub fn insert_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        values: &[u32],
+    ) {
         let tid = thread::index_1d().get();
         if tid >= keys.len() {
             return;
@@ -252,8 +257,8 @@ pub mod kernels {
     ///   `out[tid] = FLAG_PRESENT (1)`      -> key was already in the table
     #[kernel]
     pub fn try_insert_kernel(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         values: &[u32],
         mut out: DisjointSlice<u32>,
@@ -289,7 +294,12 @@ pub mod kernels {
     /// within a warp" (the highest-rank lane has the largest input index
     /// in that warp, so its value is the most-recent for the warp).
     #[kernel]
-    pub fn insert_kernel_dedup(ctrl: &[u32], slots: &[u64], keys: &[u32], values: &[u32]) {
+    pub fn insert_kernel_dedup(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        values: &[u32],
+    ) {
         let block = this_thread_block();
         let tile = block.tiled_partition::<32>();
         let lane = tile.thread_rank();
@@ -334,21 +344,23 @@ pub mod kernels {
     /// across the old table so the host can bound the launch size without
     /// depending on cooperative-launch residency limits.
     #[kernel]
-    pub fn rehash_kernel(old_ctrl: &[u32], old_slots: &[u64], new_ctrl: &[u32], new_slots: &[u64]) {
+    pub fn rehash_kernel(
+        old_ctrl: &[DeviceAtomicU32],
+        old_slots: &[DeviceAtomicU64],
+        new_ctrl: &[DeviceAtomicU32],
+        new_slots: &[DeviceAtomicU64],
+    ) {
         let mut tid = thread::index_1d().get();
         let stride = (thread::gridDim_x() * thread::blockDim_x()) as usize;
 
         while tid < old_slots.len() {
             let ctrl_word_idx = tid / GROUP;
             let byte_in_word = tid % GROUP;
-            let ctrl_atomic = unsafe {
-                DeviceAtomicU32::from_ptr(old_ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-            };
+            let ctrl_atomic = &old_ctrl[ctrl_word_idx];
             let ctrl_word = ctrl_atomic.load(AtomicOrdering::Acquire);
             let tag = get_tag(ctrl_word, byte_in_word);
             if tag <= 0x7F {
-                let slot_atomic =
-                    unsafe { DeviceAtomicU64::from_ptr(old_slots.as_ptr().add(tid).cast_mut()) };
+                let slot_atomic = &old_slots[tid];
                 let slot = slot_atomic.load(AtomicOrdering::Acquire);
                 let _ = insert_into_table_core(
                     new_ctrl,
@@ -378,7 +390,12 @@ pub mod kernels {
     ///   - Otherwise (tile holds only FULL-mismatch + DELETED), triangular
     ///     advance and repeat. DELETED never terminates find.
     #[kernel]
-    pub fn find_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+    pub fn find_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
         let tid = thread::index_1d();
         let tid_raw = tid.get();
         let i_thread = tid_raw;
@@ -398,18 +415,14 @@ pub mod kernels {
             let mut has_empty = false;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
                 let word = ctrl_atomic.load(AtomicOrdering::Acquire);
                 let mut j = 0;
                 while j < GROUP {
                     let tag = get_tag(word, j);
                     if tag == h2 {
                         let slot_idx = probe_base + g + j;
-                        let slot_atomic = unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                        };
+                        let slot_atomic = &slots[slot_idx];
                         let observed = slot_atomic.load(AtomicOrdering::Acquire);
                         if unpack_key(observed) == key {
                             if let Some(o) = out.get_mut(tid) {
@@ -446,7 +459,12 @@ pub mod kernels {
     ///
     /// Launch with `LaunchConfig::for_num_elems(keys.len() * 32)`.
     #[kernel]
-    pub fn find_kernel_tile_32(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
+    pub fn find_kernel_tile_32(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        out: DisjointSlice<u32>,
+    ) {
         let global_tid = thread::index_1d().get();
         find_tile_impl::<32>(ctrl, slots, keys, out, global_tid);
     }
@@ -467,7 +485,12 @@ pub mod kernels {
     ///
     /// Launch with `LaunchConfig::for_num_elems(keys.len() * 16)`.
     #[kernel]
-    pub fn find_kernel_tile_16(ctrl: &[u32], slots: &[u64], keys: &[u32], out: DisjointSlice<u32>) {
+    pub fn find_kernel_tile_16(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        out: DisjointSlice<u32>,
+    ) {
         let global_tid = thread::index_1d().get();
         find_tile_impl::<16>(ctrl, slots, keys, out, global_tid);
     }
@@ -506,8 +529,8 @@ pub mod kernels {
     /// `N = 16`. The same v3 table is queryable by either kernel.
     #[inline(always)]
     fn find_tile_impl<const N: u32>(
-        ctrl: &[u32],
-        slots: &[u64],
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
         keys: &[u32],
         mut out: DisjointSlice<u32>,
         global_tid: usize,
@@ -534,10 +557,7 @@ pub mod kernels {
                 let tag_pos = probe_base + sub + (lane as usize);
                 let ctrl_word_idx = tag_pos / GROUP;
                 let byte_in_word = tag_pos % GROUP;
-                let word = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                        .load(AtomicOrdering::Acquire)
-                };
+                let word = ctrl[ctrl_word_idx].load(AtomicOrdering::Acquire);
                 let tag: u8 = ((word >> (8 * byte_in_word)) & 0xFF) as u8;
 
                 let mut m_h2 = tile.ballot(tag == h2);
@@ -547,10 +567,7 @@ pub mod kernels {
                     let cand = m_h2.trailing_zeros();
                     let local_slot: u64 = if lane == cand {
                         let slot_idx = probe_base + sub + (cand as usize);
-                        unsafe {
-                            DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                                .load(AtomicOrdering::Acquire)
-                        }
+                        slots[slot_idx].load(AtomicOrdering::Acquire)
                     } else {
                         0
                     };
@@ -609,7 +626,12 @@ pub mod kernels {
     ///   `out[tid] = FLAG_FRESH_OR_OK (0)` -> deleted successfully
     ///   `out[tid] = FLAG_PRESENT (1)`     -> key was not in the table
     #[kernel]
-    pub fn delete_kernel(ctrl: &[u32], slots: &[u64], keys: &[u32], mut out: DisjointSlice<u32>) {
+    pub fn delete_kernel(
+        ctrl: &[DeviceAtomicU32],
+        slots: &[DeviceAtomicU64],
+        keys: &[u32],
+        mut out: DisjointSlice<u32>,
+    ) {
         let tid = thread::index_1d();
         let tid_raw = tid.get();
         let i_thread = tid_raw;
@@ -629,9 +651,7 @@ pub mod kernels {
             let mut g = 0usize;
             while g < PROBE_TILE {
                 let ctrl_word_idx = (probe_base + g) / GROUP;
-                let ctrl_atomic = unsafe {
-                    DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut())
-                };
+                let ctrl_atomic = &ctrl[ctrl_word_idx];
 
                 // Per-word retry loop: if our CAS to flip a tag to DELETED
                 // fails because someone else mutated this same word, re-read
@@ -644,9 +664,7 @@ pub mod kernels {
                         let tag = get_tag(word, j);
                         if tag == h2 {
                             let slot_idx = probe_base + g + j;
-                            let slot_atomic = unsafe {
-                                DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                            };
+                            let slot_atomic = &slots[slot_idx];
                             let observed = slot_atomic.load(AtomicOrdering::Acquire);
                             if unpack_key(observed) == key {
                                 let new_word = set_tag(word, j, DELETED_TAG);
@@ -732,8 +750,8 @@ enum ReclaimOutcome {
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 fn try_reclaim_deleted(
-    ctrl: &[u32],
-    slots: &[u64],
+    ctrl: &[DeviceAtomicU32],
+    slots: &[DeviceAtomicU64],
     del_word_idx: usize,
     del_j: usize,
     key: u32,
@@ -741,10 +759,9 @@ fn try_reclaim_deleted(
     h2: u8,
     overwrite: bool,
 ) -> ReclaimOutcome {
-    let ctrl_atomic =
-        unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(del_word_idx).cast_mut()) };
+    let ctrl_atomic = &ctrl[del_word_idx];
     let slot_idx = del_word_idx * GROUP + del_j;
-    let slot_atomic = unsafe { DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut()) };
+    let slot_atomic = &slots[slot_idx];
 
     loop {
         let cur = ctrl_atomic.load(AtomicOrdering::Acquire);
@@ -827,8 +844,8 @@ fn try_reclaim_deleted(
 ///     and repeat.
 #[inline(always)]
 fn insert_into_table_core(
-    ctrl: &[u32],
-    slots: &[u64],
+    ctrl: &[DeviceAtomicU32],
+    slots: &[DeviceAtomicU64],
     key: u32,
     value: u32,
     overwrite: bool,
@@ -848,17 +865,14 @@ fn insert_into_table_core(
         let mut g = 0usize;
         while g < PROBE_TILE {
             let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
+            let ctrl_atomic = &ctrl[ctrl_word_idx];
             let word = ctrl_atomic.load(AtomicOrdering::Acquire);
             let mut j = 0;
             while j < GROUP {
                 let tag = get_tag(word, j);
                 if tag == h2 {
                     let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
+                    let slot_atomic = &slots[slot_idx];
                     let observed = slot_atomic.load(AtomicOrdering::Acquire);
                     if unpack_key(observed) == key {
                         if overwrite {
@@ -902,17 +916,14 @@ fn insert_into_table_core(
         let mut g = 0usize;
         while g < PROBE_TILE {
             let ctrl_word_idx = (probe_base + g) / GROUP;
-            let ctrl_atomic =
-                unsafe { DeviceAtomicU32::from_ptr(ctrl.as_ptr().add(ctrl_word_idx).cast_mut()) };
+            let ctrl_atomic = &ctrl[ctrl_word_idx];
             let word = ctrl_atomic.load(AtomicOrdering::Acquire);
             let mut j = 0;
             while j < GROUP {
                 let tag = get_tag(word, j);
                 if tag == h2 {
                     let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
+                    let slot_atomic = &slots[slot_idx];
                     let observed = slot_atomic.load(AtomicOrdering::Acquire);
                     if unpack_key(observed) == key {
                         if overwrite {
@@ -922,9 +933,7 @@ fn insert_into_table_core(
                     }
                 } else if tag == EMPTY_TAG {
                     let slot_idx = probe_base + g + j;
-                    let slot_atomic = unsafe {
-                        DeviceAtomicU64::from_ptr(slots.as_ptr().add(slot_idx).cast_mut())
-                    };
+                    let slot_atomic = &slots[slot_idx];
                     match slot_atomic.compare_exchange(
                         EMPTY_SLOT,
                         pack(key, value),
@@ -1026,10 +1035,13 @@ pub const FORBIDDEN_KEY: u32 = u32::MAX;
 /// [`Self::insert_bulk_dedup`]; the bound is correct as a load-factor
 /// trigger but should not be treated as a key count.
 pub struct GpuSwissMap {
-    /// Packed tag bytes; 4 tags per `u32` word.
-    pub ctrl: DeviceBuffer<u32>,
-    /// Packed `(key, value)` slots — key in the upper 32 bits.
-    pub slots: DeviceBuffer<u64>,
+    /// Packed tag bytes; 4 tags per `u32` word. Element type is the
+    /// atomic wrapper so kernels can mutate it through a shared slice
+    /// without violating the `&[u32]` readonly/noalias contract.
+    pub ctrl: DeviceBuffer<DeviceAtomicU32>,
+    /// Packed `(key, value)` slots — key in the upper 32 bits. Atomic
+    /// element type for the same reason as `ctrl`.
+    pub slots: DeviceBuffer<DeviceAtomicU64>,
     /// Number of slots. Power of two, multiple of `GROUP`.
     capacity: usize,
     /// Conservative upper bound on live entries; only updated by
@@ -1069,6 +1081,11 @@ impl GpuSwissMap {
                 stream.cu_stream(),
             )?;
         }
+        // Reinterpret the allocations as slices of the atomic wrapper
+        // (`#[repr(transparent)]`, identical layout). The memset above
+        // is byte-level so it is unaffected by the element type.
+        let ctrl = ctrl.cast_elem::<DeviceAtomicU32>();
+        let slots = slots.cast_elem::<DeviceAtomicU64>();
 
         Ok(Self {
             ctrl,
@@ -1356,6 +1373,8 @@ impl GpuSwissMap {
                 stream.cu_stream(),
             )?;
         }
+        let new_ctrl = new_ctrl.cast_elem::<DeviceAtomicU32>();
+        let new_slots = new_slots.cast_elem::<DeviceAtomicU64>();
 
         let rehash_threads = self.capacity.min(REHASH_MAX_THREADS) as u32;
         let cfg = LaunchConfig::for_num_elems(rehash_threads);


### PR DESCRIPTION
## What and why

The hashmap examples handed a kernel a read-only slice (`&[u64]`) and then wrote
into it with atomic compare-exchange. Rust promises the compiler that a `&[u64]`
never changes (`readonly` + `noalias`), so this is undefined behavior: the GPU
optimizer is free to cache a slot in a register or assume a neighbor thread's
atomic write simply cannot happen.

The fix is to use a type that is *allowed* to change through a shared reference:

```rust
// before (UB): a readonly+noalias slice, mutated via a pointer cast
pub fn insert_kernel(table: &[u64], ...) {
    let slot = unsafe { DeviceAtomicU64::from_ptr(table.as_ptr().add(i).cast_mut()) };
    slot.compare_exchange(EMPTY, packed, AcqRel, Relaxed);
}

// after (sound): a slice of atomics, indexed directly
pub fn insert_kernel(table: &[DeviceAtomicU64], ...) {
    table[i].compare_exchange(EMPTY, packed, AcqRel, Relaxed);
}
```

`DeviceAtomicU64` is `#[repr(transparent)]` over `UnsafeCell<u64>`, so it is
`!Freeze` (rustc drops `readonly`/`noalias`) while keeping the exact same 8-byte
layout. The host buffer does not change shape: a new
`DeviceBuffer::cast_elem::<A>()` helper views the same `u64`/`u32` allocation as
the atomic element type for the launch (same pointer, length, and bytes).

Applied to every atomically-mutated slice in `hashmap`, `hashmap_v2`, and
`hashmap_v3` (`&[u64]` -> `&[DeviceAtomicU64]`, control `&[u32]` ->
`&[DeviceAtomicU32]`). Read-only `keys`/`values` stay plain `&[u32]`.

## Verification

- GPU-verified on an RTX 5090: hashmap v1 (6 tests), v2 (12), v3 (15) all pass.
- Generated IR confirms the slice parameters no longer carry `readonly`/`noalias`.

Closes #151.

## Also in this PR (independent small fixes)

- **Cluster example:** `test_cluster_sync` called `cluster::cluster_sync()` but
  was missing `#[cluster_launch(4,1,1)]`, so it launched as ordinary blocks
  (`block_rank()` always 0) and only `output[0]` was written, failing the test.
  Added the attribute; all cluster + DSMEM tests now pass on GPU.
- **`.gitignore`:** ignore the `.layer-target/` cargo build cache (~4 GB) that
  was showing up as an untracked folder.
