### PR TITLE
fix(#219): remove dead/wrong get_mut and get_unchecked_mut arms from DisjointSlice dispatch

### DIFF
--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3362,20 +3362,18 @@ fn try_dispatch_intrinsic(
         path if path.starts_with("cuda_device::DisjointSlice::") => {
             if let Some(method) = path.rsplit("::").next() {
                 match method {
-                    "get_thread_local" => {
-                        Ok(Some(intrinsics::indexing::emit_get_thread_local(
-                            ctx,
-                            body,
-                            args,
-                            destination,
-                            target,
-                            block_ptr,
-                            prev_op,
-                            value_map,
-                            block_map,
-                            loc,
-                        )?))
-                    }
+                    "get_thread_local" => Ok(Some(intrinsics::indexing::emit_get_thread_local(
+                        ctx,
+                        body,
+                        args,
+                        destination,
+                        target,
+                        block_ptr,
+                        prev_op,
+                        value_map,
+                        block_map,
+                        loc,
+                    )?)),
                     "len" => Ok(Some(intrinsics::indexing::emit_len(
                         ctx,
                         body,

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3352,11 +3352,17 @@ fn try_dispatch_intrinsic(
             )?))
         }
 
-        // DisjointSlice methods using prefix matching
+        // DisjointSlice methods using prefix matching (covers generic
+        // instantiations whose full path includes type parameters).
+        // Note: `get_mut` and `get_unchecked_mut` are `#[inline]` in
+        // cuda-device and are always inlined by rustc before MIR reaches the
+        // translator. Routing them here would produce a type mismatch
+        // (`emit_get_thread_local` returns `*mut T` but `get_mut` returns
+        // `Option<&mut T>`). They are intentionally absent from this match.
         path if path.starts_with("cuda_device::DisjointSlice::") => {
             if let Some(method) = path.rsplit("::").next() {
                 match method {
-                    "get_mut" | "get_unchecked_mut" | "get_thread_local" => {
+                    "get_thread_local" => {
                         Ok(Some(intrinsics::indexing::emit_get_thread_local(
                             ctx,
                             body,


### PR DESCRIPTION
## What

Closes #219.

The DisjointSlice method dispatch in `terminator/mod.rs` included
`get_mut` and `get_unchecked_mut` as candidates to route to
`emit_get_thread_local`. Both of these are bugs:

1. **Dead code.** Both methods are `#[inline]` in cuda-device; rustc
   inlines them before the translator sees them. The arms were
   unreachable in practice.
2. **Wrong return type.** `emit_get_thread_local` returns a raw
   `*mut T` pointer, but `get_mut` and `get_unchecked_mut` return
   `Option<&mut T>`. Any call that did reach this path would produce
   a type mismatch.

## Fix

Remove `"get_mut" | "get_unchecked_mut"` from the match. `get_thread_local`
and `len` are the only methods that actually need translation-time dispatch.
A comment explains why the two inlined methods are intentionally absent.

## Test plan

- [ ] `cargo oxide run vecadd` (no regression in baseline kernel)
- [ ] `cargo test -p mir-importer`
- [ ] smoketest passes