### PR TITLE
perf(#30): replace std HashMap with FxHashMap across hot compiler paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "cuda-bindings",
  "cuda-core",
  "futures",
+ "rustc-hash",
  "thiserror",
 ]
 
@@ -740,6 +741,7 @@ dependencies = [
  "once_cell",
  "pliron",
  "pliron-derive",
+ "rustc-hash",
  "thiserror",
 ]
 
@@ -755,6 +757,7 @@ dependencies = [
  "pliron",
  "pliron-derive",
  "reserved-oxide-symbols",
+ "rustc-hash",
  "thiserror",
 ]
 

--- a/crates/cuda-async/Cargo.toml
+++ b/crates/cuda-async/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+rustc-hash = { workspace = true }
 cuda-core = { path = "../cuda-core" }
 cuda-bindings = { path = "../cuda-bindings" }
 futures = "0.3"

--- a/crates/cuda-async/src/device_context.rs
+++ b/crates/cuda-async/src/device_context.rs
@@ -22,8 +22,8 @@
 use crate::error::{DeviceError, device_assert, device_error};
 use crate::scheduling_policies::{GlobalSchedulingPolicy, SchedulingPolicy, StreamPoolRoundRobin};
 use cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream};
-use std::cell::Cell;
 use rustc_hash::FxHashMap;
+use std::cell::Cell;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 

--- a/crates/cuda-async/src/device_context.rs
+++ b/crates/cuda-async/src/device_context.rs
@@ -23,7 +23,7 @@ use crate::error::{DeviceError, device_assert, device_error};
 use crate::scheduling_policies::{GlobalSchedulingPolicy, SchedulingPolicy, StreamPoolRoundRobin};
 use cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream};
 use std::cell::Cell;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
@@ -49,7 +49,7 @@ pub trait FunctionKey: Hash {
 }
 
 /// Cached mapping from function hash keys to loaded `(module, function)` pairs.
-type DeviceFunctions = HashMap<String, (Arc<CudaModule>, Arc<CudaFunction>)>;
+type DeviceFunctions = FxHashMap<String, (Arc<CudaModule>, Arc<CudaFunction>)>;
 
 /// Per-device state: CUDA context, scheduling policy, deallocator stream, and
 /// compiled-kernel cache.
@@ -77,7 +77,7 @@ pub struct AsyncDeviceContexts {
     /// Currently selected default device ordinal.
     default_device: Cell<usize>,
     /// Lazily initialized map of device ordinal to context.
-    devices: Cell<Option<HashMap<usize, AsyncDeviceContext>>>,
+    devices: Cell<Option<FxHashMap<usize, AsyncDeviceContext>>>,
 }
 
 // Thread-local storage for per-device CUDA state.
@@ -114,7 +114,7 @@ pub fn init_device_contexts(
             "Context already initialized.",
         )
     })?;
-    let devices = HashMap::with_capacity(num_devices);
+    let devices = FxHashMap::with_capacity_and_hasher(num_devices, Default::default());
     DEVICE_CONTEXTS.with(|ctx| {
         ctx.default_device.set(default_device_id);
         ctx.devices.set(Some(devices));
@@ -144,14 +144,14 @@ pub fn new_device_context(
         context,
         deallocator_stream,
         policy: Arc::new(policy),
-        functions: HashMap::new(),
+        functions: FxHashMap::default(),
     })
 }
 
 /// Inserts a new device context into `hashmap`. Errors if the device is
 /// already present.
 fn init_device(
-    hashmap: &mut HashMap<usize, AsyncDeviceContext>,
+    hashmap: &mut FxHashMap<usize, AsyncDeviceContext>,
     device_id: usize,
     policy: GlobalSchedulingPolicy,
 ) -> Result<(), DeviceError> {
@@ -162,7 +162,7 @@ fn init_device(
 
 /// Initializes a device with the default round-robin policy.
 fn init_with_default_policy(
-    hashmap: &mut HashMap<usize, AsyncDeviceContext>,
+    hashmap: &mut FxHashMap<usize, AsyncDeviceContext>,
     device_id: usize,
 ) -> Result<(), DeviceError> {
     let policy =

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -9,7 +9,7 @@
 //! textual IR is stable across runs, and the block-argument → PHI-node translation
 //! that bridges pliron's basic-block argument convention to LLVM's PHI-node convention.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fmt::Write;
 
 use pliron::{
@@ -249,7 +249,7 @@ impl<'a> ModuleExportState<'a> {
             self.export_type(ret_ty, output)?;
             write!(output, " @{fixed_func_name}(").unwrap();
 
-            let mut value_names = HashMap::new();
+            let mut value_names = FxHashMap::default();
             let mut next_value_id = 0;
 
             let block = entry_block.deref(self.ctx);
@@ -301,7 +301,7 @@ impl<'a> ModuleExportState<'a> {
             self.convergent_used = true;
 
             // Assign labels to all blocks
-            let mut block_labels = HashMap::new();
+            let mut block_labels = FxHashMap::default();
             let mut next_label_id = 0;
             for (i, block_node) in func
                 .get_operation()
@@ -407,7 +407,7 @@ impl<'a> ModuleExportState<'a> {
             }
 
             // Build predecessor map for PHI generation
-            let mut pred_map: PredecessorMap = HashMap::new();
+            let mut pred_map: PredecessorMap = FxHashMap::default();
             for block in func
                 .get_operation()
                 .deref(self.ctx)
@@ -501,9 +501,9 @@ impl<'a> ModuleExportState<'a> {
     pub(super) fn export_block(
         &mut self,
         block: Ptr<BasicBlock>,
-        value_names: &mut HashMap<Value, String>,
+        value_names: &mut FxHashMap<Value, String>,
         next_value_id: &mut usize,
-        block_labels: &HashMap<Ptr<BasicBlock>, String>,
+        block_labels: &FxHashMap<Ptr<BasicBlock>, String>,
         pred_map: &PredecessorMap,
         is_entry: bool,
         debug_scope: Option<usize>,

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -5,8 +5,8 @@
 
 //! Operation emission for LLVM IR.
 
-use std::cell::Ref;
 use rustc_hash::FxHashMap;
+use std::cell::Ref;
 use std::fmt::Write;
 
 use pliron::r#type::Typed;

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -6,7 +6,7 @@
 //! Operation emission for LLVM IR.
 
 use std::cell::Ref;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fmt::Write;
 
 use pliron::r#type::Typed;
@@ -237,9 +237,9 @@ impl<'a> ModuleExportState<'a> {
     pub(super) fn export_op(
         &mut self,
         op: Ptr<Operation>,
-        value_names: &mut HashMap<Value, String>,
+        value_names: &mut FxHashMap<Value, String>,
         next_value_id: &mut usize,
-        block_labels: &HashMap<Ptr<BasicBlock>, String>,
+        block_labels: &FxHashMap<Ptr<BasicBlock>, String>,
         debug_scope: Option<usize>,
         output: &mut String,
     ) -> Result<(), String> {
@@ -423,7 +423,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_return(
         &mut self,
         op: &ops::ReturnOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -443,7 +443,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_br(
         &self,
         op: &ops::BrOp,
-        block_labels: &HashMap<Ptr<BasicBlock>, String>,
+        block_labels: &FxHashMap<Ptr<BasicBlock>, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -456,8 +456,8 @@ impl<'a> ModuleExportState<'a> {
     fn emit_cond_br(
         &mut self,
         op: &ops::CondBrOp,
-        value_names: &HashMap<Value, String>,
-        block_labels: &HashMap<Ptr<BasicBlock>, String>,
+        value_names: &FxHashMap<Value, String>,
+        block_labels: &FxHashMap<Ptr<BasicBlock>, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -477,7 +477,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_load(
         &mut self,
         op: &ops::LoadOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -505,7 +505,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_store(
         &mut self,
         op: &ops::StoreOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -534,7 +534,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_alloca(
         &mut self,
         op: &ops::AllocaOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -556,7 +556,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_debug_declare_for_alloca(
         &mut self,
         op: &ops::AllocaOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         debug_scope: Option<usize>,
         loc: &pliron::location::Location,
         output: &mut String,
@@ -595,7 +595,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_debug_value(
         &mut self,
         op: &ops::DebugValueOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         debug_scope: Option<usize>,
         loc: &pliron::location::Location,
         output: &mut String,
@@ -634,7 +634,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_gep(
         &mut self,
         op: &ops::GetElementPtrOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -673,7 +673,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_atomic_load(
         &mut self,
         op: &ops::AtomicLoadOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -697,7 +697,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_atomic_store(
         &mut self,
         op: &ops::AtomicStoreOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -721,7 +721,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_atomic_rmw(
         &mut self,
         op: &ops::AtomicRmwOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -748,7 +748,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_atomic_cmpxchg(
         &mut self,
         op: &ops::AtomicCmpxchgOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -791,7 +791,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_fneg(
         &mut self,
         op: &ops::FNegOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -810,7 +810,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_icmp(
         &mut self,
         op: &ops::ICmpOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -844,7 +844,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_fcmp(
         &mut self,
         op: &ops::FCmpOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -884,7 +884,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_select(
         &mut self,
         op: &ops::SelectOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -912,7 +912,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_call(
         &mut self,
         op: &ops::CallOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -974,7 +974,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_inline_asm(
         &mut self,
         op: &ops::InlineAsmOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -1041,7 +1041,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_zext(
         &mut self,
         op: &ops::ZExtOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -1072,7 +1072,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_extract_value(
         &mut self,
         op: &ops::ExtractValueOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -1094,7 +1094,7 @@ impl<'a> ModuleExportState<'a> {
     fn emit_insert_value(
         &mut self,
         op: &ops::InsertValueOp,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
@@ -1118,12 +1118,12 @@ impl<'a> ModuleExportState<'a> {
         Ok(())
     }
 
-    fn emit_undef(&self, op: &ops::UndefOp, value_names: &mut HashMap<Value, String>) {
+    fn emit_undef(&self, op: &ops::UndefOp, value_names: &mut FxHashMap<Value, String>) {
         let res = op.get_operation().deref(self.ctx).get_result(0);
         value_names.insert(res, "undef".to_string());
     }
 
-    fn emit_constant(&self, op: &ops::ConstantOp, value_names: &mut HashMap<Value, String>) {
+    fn emit_constant(&self, op: &ops::ConstantOp, value_names: &mut FxHashMap<Value, String>) {
         let val_attr = op.get_value(self.ctx);
         let const_str = if let Some(int_attr) = val_attr.downcast_ref::<IntegerAttr>() {
             // Use APInt's proper decimal string conversion instead of parsing debug format.
@@ -1147,7 +1147,7 @@ impl<'a> ModuleExportState<'a> {
         value_names.insert(res, const_str);
     }
 
-    fn emit_address_of(&self, op: &ops::AddressOfOp, value_names: &HashMap<Value, String>) {
+    fn emit_address_of(&self, op: &ops::AddressOfOp, value_names: &FxHashMap<Value, String>) {
         // AddressOfOp is virtual in textual LLVM IR: every use site prints the
         // global symbol directly. The naming pre-pass in export_function
         // registers the result as `@<global_name>` before any block is emitted,
@@ -1168,7 +1168,7 @@ impl<'a> ModuleExportState<'a> {
         &self,
         op_name: &str,
         op: Ptr<Operation>,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.deref(self.ctx);
@@ -1206,7 +1206,7 @@ impl<'a> ModuleExportState<'a> {
         &self,
         op_name: &str,
         op: Ptr<Operation>,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.deref(self.ctx);
@@ -1227,7 +1227,7 @@ impl<'a> ModuleExportState<'a> {
     pub(super) fn export_value(
         &self,
         val: Value,
-        value_names: &HashMap<Value, String>,
+        value_names: &FxHashMap<Value, String>,
         output: &mut String,
     ) -> Result<(), String> {
         if let Some(name) = value_names.get(&val) {

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -86,7 +86,8 @@ pub(super) struct ModuleExportState<'a> {
     /// `DIType` nodes keyed by the simple debug type they describe.
     pub(super) debug_types: FxHashMap<DebugLocalTypeKind, usize>,
     /// `DILocalVariable` nodes keyed by scope, source line, and local identity.
-    pub(super) debug_local_variables: FxHashMap<(usize, PathBuf, i32, DebugLocalVariableInfo), usize>,
+    pub(super) debug_local_variables:
+        FxHashMap<(usize, PathBuf, i32, DebugLocalVariableInfo), usize>,
     /// Numbered debug metadata definitions, in allocation order.
     pub(super) debug_nodes: Vec<(usize, String)>,
     /// Whether any function emitted `llvm.dbg.declare`.

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -6,7 +6,8 @@
 //! Exporter state and kernel bookkeeping.
 
 use pliron::{basic_block::BasicBlock, context::Ptr, value::Value};
-use std::{collections::HashMap, path::PathBuf};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
 
 use crate::ops::{DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourceScopeMap};
 
@@ -14,7 +15,7 @@ use super::config::DebugKind;
 
 /// Map from block to its predecessors with the values passed to each predecessor.
 /// Used for PHI node generation when exporting to LLVM IR.
-pub(super) type PredecessorMap = HashMap<Ptr<BasicBlock>, Vec<(Ptr<BasicBlock>, Vec<Value>)>>;
+pub(super) type PredecessorMap = FxHashMap<Ptr<BasicBlock>, Vec<(Ptr<BasicBlock>, Vec<Value>)>>;
 
 /// Cluster dimensions for a kernel (from `#[cluster(x,y,z)]` attribute).
 pub(super) struct KernelClusterConfig {
@@ -63,29 +64,29 @@ pub(super) struct ModuleExportState<'a> {
     /// The single compile unit used for Stage 2 line-table debug info.
     pub(super) debug_compile_unit: Option<usize>,
     /// `DIFile` nodes keyed by the source path they describe.
-    pub(super) debug_files: HashMap<PathBuf, usize>,
+    pub(super) debug_files: FxHashMap<PathBuf, usize>,
     /// Shared empty function type used by all line-table-only subprograms.
     pub(super) debug_subroutine_type: Option<usize>,
     /// `DISubprogram` file paths, used to create file-correct nested scopes.
-    pub(super) debug_subprogram_files: HashMap<usize, PathBuf>,
+    pub(super) debug_subprogram_files: FxHashMap<usize, PathBuf>,
     /// Fallback line/column for calls that LLVM requires to have a location.
-    pub(super) debug_subprogram_fallbacks: HashMap<usize, (i32, i32)>,
+    pub(super) debug_subprogram_fallbacks: FxHashMap<usize, (i32, i32)>,
     /// `DILexicalBlockFile` nodes keyed by `(parent scope, file path)`.
-    pub(super) debug_file_scopes: HashMap<(usize, PathBuf), usize>,
+    pub(super) debug_file_scopes: FxHashMap<(usize, PathBuf), usize>,
     /// `DILexicalBlock` nodes keyed by `(parent scope, file, line, column)`.
-    pub(super) debug_lexical_blocks: HashMap<(usize, PathBuf, i32, i32), usize>,
+    pub(super) debug_lexical_blocks: FxHashMap<(usize, PathBuf, i32, i32), usize>,
     /// Inlined callee `DISubprogram` nodes keyed by `(name, file, line)`.
-    pub(super) debug_inlined_subprograms: HashMap<(String, PathBuf, i32), usize>,
+    pub(super) debug_inlined_subprograms: FxHashMap<(String, PathBuf, i32), usize>,
     /// MIR source-scope tables keyed by the owning function `DISubprogram`.
-    pub(super) debug_source_scope_maps: HashMap<usize, DebugSourceScopeMap>,
+    pub(super) debug_source_scope_maps: FxHashMap<usize, DebugSourceScopeMap>,
     /// Resolved MIR source scopes keyed by `(function DISubprogram, source scope id)`.
-    pub(super) debug_resolved_source_scopes: HashMap<(usize, u32), ResolvedDebugScope>,
+    pub(super) debug_resolved_source_scopes: FxHashMap<(usize, u32), ResolvedDebugScope>,
     /// `DILocation` nodes keyed by `(scope, line, column, inlined-at location)`.
-    pub(super) debug_locations: HashMap<(usize, i32, i32, Option<usize>), usize>,
+    pub(super) debug_locations: FxHashMap<(usize, i32, i32, Option<usize>), usize>,
     /// `DIType` nodes keyed by the simple debug type they describe.
-    pub(super) debug_types: HashMap<DebugLocalTypeKind, usize>,
+    pub(super) debug_types: FxHashMap<DebugLocalTypeKind, usize>,
     /// `DILocalVariable` nodes keyed by scope, source line, and local identity.
-    pub(super) debug_local_variables: HashMap<(usize, PathBuf, i32, DebugLocalVariableInfo), usize>,
+    pub(super) debug_local_variables: FxHashMap<(usize, PathBuf, i32, DebugLocalVariableInfo), usize>,
     /// Numbered debug metadata definitions, in allocation order.
     pub(super) debug_nodes: Vec<(usize, String)>,
     /// Whether any function emitted `llvm.dbg.declare`.
@@ -119,18 +120,18 @@ impl<'a> ModuleExportState<'a> {
             next_metadata_id: 0,
             debug_kind,
             debug_compile_unit: None,
-            debug_files: HashMap::new(),
+            debug_files: FxHashMap::default(),
             debug_subroutine_type: None,
-            debug_subprogram_files: HashMap::new(),
-            debug_subprogram_fallbacks: HashMap::new(),
-            debug_file_scopes: HashMap::new(),
-            debug_lexical_blocks: HashMap::new(),
-            debug_inlined_subprograms: HashMap::new(),
-            debug_source_scope_maps: HashMap::new(),
-            debug_resolved_source_scopes: HashMap::new(),
-            debug_locations: HashMap::new(),
-            debug_types: HashMap::new(),
-            debug_local_variables: HashMap::new(),
+            debug_subprogram_files: FxHashMap::default(),
+            debug_subprogram_fallbacks: FxHashMap::default(),
+            debug_file_scopes: FxHashMap::default(),
+            debug_lexical_blocks: FxHashMap::default(),
+            debug_inlined_subprograms: FxHashMap::default(),
+            debug_source_scope_maps: FxHashMap::default(),
+            debug_resolved_source_scopes: FxHashMap::default(),
+            debug_locations: FxHashMap::default(),
+            debug_types: FxHashMap::default(),
+            debug_local_variables: FxHashMap::default(),
             debug_nodes: Vec::new(),
             debug_declare_used: false,
             debug_value_used: false,

--- a/crates/mir-importer/Cargo.toml
+++ b/crates/mir-importer/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Rust MIR to Pliron IR translation and compilation pipeline"
 
 [dependencies]
+rustc-hash = { workspace = true }
 pliron = { workspace = true }
 pliron-derive = { workspace = true }
 llvm-export = { workspace = true }

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -44,7 +44,7 @@ use rustc_public::CrateDef;
 use rustc_public::mir;
 use rustc_public::mir::mono;
 use rustc_public::ty::{ConstantKind, FloatTy, IntTy, RigidTy, Ty, TyKind, UintTy};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Cluster dimensions extracted from `#[cluster(x,y,z)]` attribute.
 ///
@@ -230,8 +230,8 @@ struct LocalDebugInfo {
 fn collect_debug_locals(
     ctx: &mut Context,
     body: &mir::Body,
-) -> HashMap<mir::Local, LocalDebugInfo> {
-    let mut locals = HashMap::new();
+) -> FxHashMap<mir::Local, LocalDebugInfo> {
+    let mut locals = FxHashMap::default();
 
     for info in &body.var_debug_info {
         if info.composite.is_some() {
@@ -549,7 +549,7 @@ fn emit_entry_allocas(
     let debug_locals = if debug_kind.variables_enabled() {
         collect_debug_locals(ctx, body)
     } else {
-        HashMap::new()
+        FxHashMap::default()
     };
 
     // Pre-scan the body once: for each local whose translated slot type is a

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -40,11 +40,11 @@ use pliron::op::Op;
 use pliron::operation::Operation;
 
 // Re-export rustc_public types for convenience
+use rustc_hash::FxHashMap;
 use rustc_public::CrateDef;
 use rustc_public::mir;
 use rustc_public::mir::mono;
 use rustc_public::ty::{ConstantKind, FloatTy, IntTy, RigidTy, Ty, TyKind, UintTy};
-use rustc_hash::FxHashMap;
 
 /// Cluster dimensions extracted from `#[cluster(x,y,z)]` attribute.
 ///

--- a/crates/mir-lower/Cargo.toml
+++ b/crates/mir-lower/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "dialect-mir to LLVM dialect lowering pass"
 
 [dependencies]
+rustc-hash = { workspace = true }
 pliron = { workspace = true }
 llvm-export = { workspace = true }
 pliron-derive = { workspace = true }

--- a/crates/mir-lower/src/context.rs
+++ b/crates/mir-lower/src/context.rs
@@ -9,20 +9,20 @@
 //! automatically. This module provides the CUDA-specific state types that
 //! certain ops need during conversion.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Map from shared memory allocation keys to their LLVM global symbol names.
 ///
 /// In CUDA kernels, shared memory is declared as module-level globals with
 /// address space 3. When multiple operations reference the same shared allocation
 /// (identified by a key string), they should all refer to the same global.
-pub type SharedGlobalsMap = HashMap<String, pliron::identifier::Identifier>;
+pub type SharedGlobalsMap = FxHashMap<String, pliron::identifier::Identifier>;
 
 /// Map from ordinary device static keys to LLVM global symbol names.
 ///
 /// Ordinary Rust `static` / `static mut` values used from device code live in
 /// CUDA global memory (address space 1), not shared memory.
-pub type DeviceGlobalsMap = HashMap<String, pliron::identifier::Identifier>;
+pub type DeviceGlobalsMap = FxHashMap<String, pliron::identifier::Identifier>;
 
 /// Tracking for dynamic shared memory alignment per kernel.
 ///
@@ -34,4 +34,4 @@ pub type DeviceGlobalsMap = HashMap<String, pliron::identifier::Identifier>;
 /// a function to determine the maximum alignment required by any
 /// `DynamicSharedArray<T, ALIGN>` call, ensuring the global is created
 /// with the correct alignment from the start.
-pub type DynamicSmemAlignmentMap = HashMap<String, (pliron::identifier::Identifier, u64)>;
+pub type DynamicSmemAlignmentMap = FxHashMap<String, (pliron::identifier::Identifier, u64)>;

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -129,7 +129,7 @@ pub mod helpers;
 pub mod lowering;
 pub mod type_conversion_interface;
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use pliron::{
     builtin::types::{IntegerType, Signedness},
@@ -275,9 +275,9 @@ impl DialectConversion for MirToLlvmConversionDriver {
 /// `Ok(())` if all operations were successfully converted.
 pub fn lower_mir_to_llvm(ctx: &mut Context, module_op: Ptr<Operation>) -> Result<()> {
     let mut conversion = MirToLlvmConversionDriver {
-        shared_globals: HashMap::new(),
-        device_globals: HashMap::new(),
-        dynamic_smem_alignments: HashMap::new(),
+        shared_globals: FxHashMap::default(),
+        device_globals: FxHashMap::default(),
+        dynamic_smem_alignments: FxHashMap::default(),
     };
     // pliron's DialectConversion now reports an IRStatus (Changed/Unchanged);
     // lowering only cares about success, so discard it.


### PR DESCRIPTION
## What

Closes #30.

The compiler allocates many short-lived maps keyed by SSA values,
block pointers, and string slices. SipHash (std default) is designed
for adversarial inputs; Fx (a multiplicative hash) is faster for these
trusted internal keys and already used by rustc itself.

## Changes

- `mir-importer`: local value map, debug-info map
- `mir-lower`: shared globals map, lowering context maps
- `llvm-export`: value-name map, block-label map, predecessor map, all
  debug-metadata maps in `ModuleExportState`
- `cuda-async`: device context operation tracking map

`rustc-hash` was already a workspace dependency; only three `Cargo.toml`
files needed the new `rustc-hash = { workspace = true }` entry.

## Test plan

- [ ] `cargo build --workspace` clean
- [ ] smoketest passes (no behavioral change expected; this is a hash-function swap)