### PR TITLE
Preserve async free metadata across DeviceBuffer::cast_elem

### DIFF
--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -213,11 +213,22 @@ impl<T> DeviceBuffer<T> {
     ///   freed with the synchronous `cuMemFree` on drop. Do not pass a
     ///   stream-ordered (`cuMemAllocAsync`) pointer here.
     pub unsafe fn from_raw_parts(ptr: CUdeviceptr, len: usize, ctx: Arc<CudaContext>) -> Self {
+        // SAFETY: `from_raw_parts` has the same raw-allocation safety contract,
+        // with no stream-ordered deallocation metadata attached.
+        unsafe { Self::from_raw_parts_with_dealloc_stream(ptr, len, ctx, None) }
+    }
+
+    unsafe fn from_raw_parts_with_dealloc_stream(
+        ptr: CUdeviceptr,
+        len: usize,
+        ctx: Arc<CudaContext>,
+        dealloc_stream: Option<Arc<CudaStream>>,
+    ) -> Self {
         Self {
             ptr,
             len,
             ctx,
-            dealloc_stream: None,
+            dealloc_stream,
             _marker: PhantomData,
         }
     }
@@ -225,20 +236,33 @@ impl<T> DeviceBuffer<T> {
     /// Consumes the buffer and returns the raw parts without freeing.
     ///
     /// The caller is responsible for eventually freeing `ptr` with the
-    /// allocator that matches how it was created.
+    /// allocator that matches how it was created. For stream-ordered
+    /// allocations, this does not return the stored deallocation stream; the
+    /// caller must already know which stream to use for `cuMemFreeAsync`.
     pub fn into_raw_parts(self) -> (CUdeviceptr, usize, Arc<CudaContext>) {
+        let (ptr, len, ctx, _dealloc_stream) = self.into_all_raw_parts();
+        (ptr, len, ctx)
+    }
+
+    fn into_all_raw_parts(
+        self,
+    ) -> (
+        CUdeviceptr,
+        usize,
+        Arc<CudaContext>,
+        Option<Arc<CudaStream>>,
+    ) {
         // Suppress the buffer's `Drop` (which would free `ptr`) while still
-        // dropping the heap-owned fields (`ctx` is moved out and returned;
-        // `dealloc_stream`'s `Arc` is dropped here so its strong count is not
-        // leaked).
+        // moving out the heap-owned fields. Callers that do not need
+        // `dealloc_stream` can drop it after this helper returns.
         let this = std::mem::ManuallyDrop::new(self);
         let ptr = this.ptr;
         let len = this.len;
         // SAFETY: `this` is `ManuallyDrop` and is never used again, so reading
         // out its non-`Copy` fields takes ownership without a double drop.
         let ctx = unsafe { std::ptr::read(&this.ctx) };
-        let _dealloc_stream = unsafe { std::ptr::read(&this.dealloc_stream) };
-        (ptr, len, ctx)
+        let dealloc_stream = unsafe { std::ptr::read(&this.dealloc_stream) };
+        (ptr, len, ctx, dealloc_stream)
     }
 
     /// Reinterpret the element type of this buffer as `A`.
@@ -263,13 +287,16 @@ impl<T> DeviceBuffer<T> {
             std::mem::align_of::<T>(),
             "cast_elem requires the same element alignment"
         );
-        let (ptr, len, ctx) = self.into_raw_parts();
+        let (ptr, len, ctx, dealloc_stream) = self.into_all_raw_parts();
         // SAFETY: `ptr` came from a valid `DeviceBuffer<T>` allocation of `len`
         // elements; `A` has identical size and alignment, so the same allocation
         // is a valid `DeviceBuffer<A>` of the same length and the same byte
         // extent. Ownership transfers; the original buffer's `Drop` is
-        // suppressed by `into_raw_parts`.
-        unsafe { DeviceBuffer::<A>::from_raw_parts(ptr, len, ctx) }
+        // suppressed by `into_all_raw_parts`, and the allocation metadata is
+        // preserved for the new element type.
+        unsafe {
+            DeviceBuffer::<A>::from_raw_parts_with_dealloc_stream(ptr, len, ctx, dealloc_stream)
+        }
     }
 }
 

--- a/crates/cuda-core/tests/device_buffer.rs
+++ b/crates/cuda-core/tests/device_buffer.rs
@@ -131,3 +131,21 @@ fn uninitialized_async_implicit_drop_is_stream_ordered() {
     }
     stream.synchronize().expect("stream sync failed");
 }
+
+#[test]
+fn uninitialized_async_cast_elem_implicit_drop_is_stream_ordered() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let n = 1 << 20; // 4 MiB of u32
+    let src = DeviceBuffer::<u32>::zeroed(&stream, n).expect("failed to allocate source buffer");
+    for _ in 0..64 {
+        let mut dst = unsafe { DeviceBuffer::<u32>::uninitialized_async(&stream, n) }
+            .expect("failed to allocate uninitialized device buffer");
+        dst.copy_from_device_async(&src, &stream)
+            .expect("failed to enqueue device-to-device copy");
+        let dst = dst.cast_elem::<std::num::Wrapping<u32>>();
+        drop(dst);
+    }
+    stream.synchronize().expect("stream sync failed");
+}


### PR DESCRIPTION
## Summary

- preserve `DeviceBuffer` deallocation-stream metadata when `cast_elem` reinterprets the element type
- keep the public `into_raw_parts` API unchanged, with an internal all-parts path for ownership-preserving conversions
- add a regression test for async allocation + `cast_elem` + implicit drop while stream work is still in flight

## Why

`cast_elem` consumed a buffer with `into_raw_parts` and rebuilt it through `from_raw_parts`, which always marks the allocation as synchronous. For buffers allocated by `cuMemAllocAsync`, that stripped the stored deallocation stream and could make the reinterpreted buffer drop through `cuMemFree` instead of stream-ordered `cuMemFreeAsync`.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p cuda-core --test device_buffer --no-run` blocked locally because `cuda-bindings` cannot find `cuda.h`; `CUDA_TOOLKIT_PATH`/`CUDA_HOME` are unset and `/usr/local/cuda` is missing
