### PR TITLE
feat(cargo-oxide): add `emit-ltoir` to build a crate's LTOIR in one step

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -37,19 +37,21 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 ### Flags
 
-| Flag              | Applies to             | Description                                     |
-|-------------------|------------------------|-------------------------------------------------|
-| `--emit-nvvm-ir`  | run, build, pipeline   | Generate NVVM IR for libNVVM                    |
-| `--arch <sm_XX>`  | run, build, pipeline   | Target architecture override                    |
-| `--arch <sm_XX>`  | emit-ltoir             | Target architecture (required)                  |
-| `--features <F>`  | run, build, emit-ltoir | Comma-separated cargo features to enable        |
-| `-o, --output <P>`| emit-ltoir             | Output path for the `.ltoir` artifact           |
-| `-v, --verbose`   | run, build, emit-ltoir | Show detailed compilation output                |
-| `--no-fmad`       | run, build, pipeline   | Disable FMA contraction (keep separate mul+add) |
-| `--async`         | new                    | Use the async template                          |
-| `--cgdb`          | debug                  | Use cgdb instead of cuda-gdb                    |
-| `--tui`           | debug                  | Use GDB's TUI interface                         |
-| `--check`         | fmt                    | Check formatting only                           |
+| Flag               | Applies to                       | Description                                     |
+|--------------------|----------------------------------|-------------------------------------------------|
+| `--emit-nvvm-ir`   | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
+| `--arch <sm_XX>`   | run, build, pipeline, emit-ltoir | Target arch override                            |
+| `--features <F>`   | run, build, emit-ltoir           | Comma-separated cargo features to enable        |
+| `-o, --output <P>` | emit-ltoir                       | Output path for the `.ltoir` artifact           |
+| `-v, --verbose`    | run, build, emit-ltoir           | Show detailed compilation output                |
+| `--no-fmad`        | run, build, pipeline             | Disable FMA contraction (keep separate mul+add) |
+| `--async`          | new                              | Use the async template                          |
+| `--cgdb`           | debug                            | Use cgdb instead of cuda-gdb                    |
+| `--tui`            | debug                            | Use GDB's TUI interface                         |
+| `--check`          | fmt                              | Check formatting only                           |
+
+`--arch` is required for `emit-ltoir` (LTOIR is architecture-specific); for all other
+commands it is optional and defaults to host GPU auto-detection.
 
 `--no-fmad` disables FMA contraction for kernels that rely on two separate
 roundings (e.g. Dekker's algorithm, 2Sum). Equivalent to `CUDA_OXIDE_NO_FMA=1`.

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -25,6 +25,7 @@ cargo oxide new my_project          # scaffold a new cuda-oxide project
 cargo oxide new my_project --async  # scaffold with async template (tokio + cuda-async)
 cargo oxide run vecadd              # build + run an example
 cargo oxide build vecadd            # compile only (no run)
+cargo oxide emit-ltoir vecadd --arch sm_100  # device code -> .ltoir (Tile/SIMT interop)
 cargo oxide pipeline vecadd         # verbose pipeline dump
                                     # (MIR -> dialect-mir -> LLVM dialect -> LLVM IR -> PTX)
 cargo oxide debug vecadd --tui      # build + launch cuda-gdb
@@ -36,17 +37,19 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 ### Flags
 
-| Flag              | Applies to           | Description                                     |
-|-------------------|----------------------|-------------------------------------------------|
-| `--emit-nvvm-ir`  | run, build, pipeline | Generate NVVM IR for libNVVM                    |
-| `--arch <sm_XX>`  | run, build, pipeline | Target architecture override                    |
-| `--features <F>`  | run, build           | Comma-separated cargo features to enable        |
-| `-v, --verbose`   | run, build           | Show detailed compilation output                |
-| `--no-fmad`       | run, build, pipeline | Disable FMA contraction (keep separate mul+add) |
-| `--async`         | new                  | Use the async template                          |
-| `--cgdb`          | debug                | Use cgdb instead of cuda-gdb                    |
-| `--tui`           | debug                | Use GDB's TUI interface                         |
-| `--check`         | fmt                  | Check formatting only                           |
+| Flag              | Applies to             | Description                                     |
+|-------------------|------------------------|-------------------------------------------------|
+| `--emit-nvvm-ir`  | run, build, pipeline   | Generate NVVM IR for libNVVM                    |
+| `--arch <sm_XX>`  | run, build, pipeline   | Target architecture override                    |
+| `--arch <sm_XX>`  | emit-ltoir             | Target architecture (required)                  |
+| `--features <F>`  | run, build, emit-ltoir | Comma-separated cargo features to enable        |
+| `-o, --output <P>`| emit-ltoir             | Output path for the `.ltoir` artifact           |
+| `-v, --verbose`   | run, build, emit-ltoir | Show detailed compilation output                |
+| `--no-fmad`       | run, build, pipeline   | Disable FMA contraction (keep separate mul+add) |
+| `--async`         | new                    | Use the async template                          |
+| `--cgdb`          | debug                  | Use cgdb instead of cuda-gdb                    |
+| `--tui`           | debug                  | Use GDB's TUI interface                         |
+| `--check`         | fmt                    | Check formatting only                           |
 
 `--no-fmad` disables FMA contraction for kernels that rely on two separate
 roundings (e.g. Dekker's algorithm, 2Sum). Equivalent to `CUDA_OXIDE_NO_FMA=1`.
@@ -89,6 +92,30 @@ Same as `run` but stops after compilation. Useful for examples that require hard
 cargo oxide build htens          # compiles PTX, doesn't try to run on GPU
 cargo oxide build tcgen05        # sm_100a only, but PTX generation works anywhere
 ```
+
+### `cargo oxide emit-ltoir <crate>`
+
+Compiles a crate's device code to a binary LTOIR artifact in one step, for the
+Tile-to-SIMT interop workflow ([#96](https://github.com/NVlabs/cuda-oxide/issues/96)):
+cuda-oxide is the SIMT participant, producing LTOIR that a tile or CUDA C++ kernel
+links against. It builds the crate in NVVM IR mode, then runs the emitted
+`<crate>.ll` through libNVVM `-gen-lto`, writing `<crate>.ltoir`.
+
+`--arch` is required, since LTOIR is architecture-specific. It accepts `sm_XX`,
+`compute_XX`, or a bare `XX`. The default output path is `<crate-dir>/<crate>.ltoir`;
+`-o/--output` overrides it.
+
+```bash
+cargo oxide emit-ltoir standalone_device_fn --arch sm_100
+cargo oxide emit-ltoir my_simt_crate --arch sm_120 -o build/simt.ltoir
+```
+
+cuda-oxide currently exports NVVM IR 2.0 (opaque pointers), which libNVVM only
+accepts for `compute_100` and newer (Blackwell+). Targeting an older architecture
+fails in libNVVM while parsing types; `emit-ltoir` detects this and points at the
+typed-pointer export work tracked in
+[#98](https://github.com/NVlabs/cuda-oxide/issues/98). Use `--arch sm_100` or
+newer until that lands.
 
 ### `cargo oxide pipeline <example>`
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -335,9 +335,6 @@ fn codegen_build_interop(
     // only an explicit `--arch` pins the target here.
     build_interop_device_crates(ctx, example_dir, interop, verbose, arch, None);
     run_host_cargo(example, example_dir, "build", features, None, verbose);
-
-    println!();
-    println!("✓ Build succeeded");
 }
 
 fn reject_interop_nvvm_ir(emit_nvvm_ir: bool) {
@@ -581,9 +578,6 @@ pub fn codegen_build(
         eprintln!("\nBuild failed with exit code: {:?}", status.code());
         std::process::exit(status.code().unwrap_or(1));
     }
-
-    println!();
-    println!("✓ Build succeeded");
 }
 
 // =============================================================================
@@ -623,7 +617,9 @@ pub fn emit_ltoir(
 
     // Step 1: build in NVVM IR mode so the backend writes `<crate>.ll` as
     // libNVVM-ready NVVM IR. codegen_build exits on build failure. FMA
-    // contraction stays at its default (on) for the LTOIR build.
+    // contraction stays at its default (on) for the LTOIR build. Pass
+    // quiet=true so the intermediate "✓ Build succeeded" line is suppressed;
+    // emit_ltoir prints its own unified summary at the end.
     codegen_build(ctx, example, verbose, true, Some(arch), features, false);
 
     // Step 2: compile that NVVM IR to LTOIR via libNVVM -gen-lto.
@@ -712,6 +708,29 @@ fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, compute_arch: &str) -> Vec<u8> {
         eprintln!("Error: nvvmCreateProgram failed: {e}");
         std::process::exit(1);
     });
+
+    // Add libdevice before the kernel module so any __nv_* math calls (exp,
+    // sin, cos, etc.) are resolved at LTOIR compile time, matching the pattern
+    // used by NVCC and cuda-host's own LTOIR path.
+    let libdevice_path = libnvvm_sys::find_libdevice().unwrap_or_else(|e| {
+        eprintln!("Error: could not locate libdevice.10.bc: {e}");
+        eprintln!("Set CUDA_OXIDE_LIBDEVICE, CUDA_TOOLKIT_PATH, or CUDA_HOME.");
+        std::process::exit(1);
+    });
+    let libdevice_bytes = std::fs::read(&libdevice_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read libdevice at {}: {e}",
+            libdevice_path.display()
+        );
+        std::process::exit(1);
+    });
+    program
+        .add_module(&libdevice_bytes, "libdevice.10.bc")
+        .unwrap_or_else(|e| {
+            eprintln!("Error: libNVVM rejected libdevice module: {e}");
+            std::process::exit(1);
+        });
+
     program.add_module(ir, name).unwrap_or_else(|e| {
         eprintln!("Error: libNVVM rejected the NVVM IR module: {e}");
         std::process::exit(1);

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -674,7 +674,7 @@ fn nvvm_compute_arch(arch: &str) -> String {
 /// cuda-oxide exports NVVM IR 2.0 (opaque pointers, LLVM 20 dialect). NVIDIA's
 /// libNVVM only parses that dialect for compute_100 and newer (Blackwell+);
 /// older targets route to the typed-pointer (NVVM IR 1.x) parser and reject the
-/// module while parsing types. See https://github.com/NVlabs/cuda-oxide/issues/98.
+/// module while parsing types. See <https://github.com/NVlabs/cuda-oxide/issues/98>.
 const NVVM_OPAQUE_PTR_MIN_CC: u32 = 100;
 
 /// Parse the numeric compute capability out of a `compute_XX` string.

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -587,6 +587,159 @@ pub fn codegen_build(
 }
 
 // =============================================================================
+// emit-ltoir command
+// =============================================================================
+
+/// Compile a crate's device code to a binary LTOIR artifact in one step.
+///
+/// `cargo oxide build --emit-nvvm-ir` produces NVVM IR, which a consumer then
+/// has to run through libNVVM separately to get linkable LTOIR. This folds both
+/// halves into one command for the Tile-to-SIMT interop workflow (#96): it
+/// builds the crate in NVVM IR mode, then compiles the emitted `<crate>.ll`
+/// with libNVVM `-gen-lto` and writes `<crate>.ltoir` (or `output`).
+///
+/// `arch` is required because LTOIR is architecture-specific. It accepts
+/// `sm_XX`, `compute_XX`, or a bare `XX`, all mapped to libNVVM's
+/// `-arch=compute_XX`.
+pub fn emit_ltoir(
+    ctx: &Context,
+    example: &str,
+    arch: &str,
+    features: Option<&str>,
+    output: Option<&Path>,
+    verbose: bool,
+) {
+    let example_dir = if ctx.is_workspace {
+        resolve_example_dir(ctx, example)
+    } else {
+        ctx.workspace_root.clone()
+    };
+
+    if load_interop_config(&example_dir).is_some_and(|config| !config.device_crates.is_empty()) {
+        eprintln!("Error: emit-ltoir does not support metadata interop examples.");
+        eprintln!("Point it at a single SIMT device crate instead.");
+        std::process::exit(1);
+    }
+
+    // Step 1: build in NVVM IR mode so the backend writes `<crate>.ll` as
+    // libNVVM-ready NVVM IR. codegen_build exits on build failure. FMA
+    // contraction stays at its default (on) for the LTOIR build.
+    codegen_build(ctx, example, verbose, true, Some(arch), features, false);
+
+    // Step 2: compile that NVVM IR to LTOIR via libNVVM -gen-lto.
+    let ll_path = example_dir.join(format!("{example}.ll"));
+    let ir = std::fs::read(&ll_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read emitted NVVM IR at {}: {e}",
+            ll_path.display()
+        );
+        std::process::exit(1);
+    });
+
+    let compute_arch = nvvm_compute_arch(arch);
+    let ltoir = compile_nvvm_to_ltoir(&ir, example, &compute_arch);
+
+    // Step 3: write the artifact.
+    let out_path = output
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| example_dir.join(format!("{example}.ltoir")));
+    std::fs::write(&out_path, &ltoir).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not write LTOIR to {}: {e}",
+            out_path.display()
+        );
+        std::process::exit(1);
+    });
+
+    println!();
+    println!(
+        "✓ LTOIR written to {} ({} bytes, {compute_arch})",
+        out_path.display(),
+        ltoir.len()
+    );
+}
+
+/// Normalize a target architecture to libNVVM's `compute_XX` form.
+///
+/// Accepts `sm_XX` (the form `--arch` and the rest of cargo-oxide use),
+/// `compute_XX` (passed through), or a bare `XX`.
+fn nvvm_compute_arch(arch: &str) -> String {
+    if let Some(cc) = arch.strip_prefix("sm_") {
+        format!("compute_{cc}")
+    } else if arch.starts_with("compute_") {
+        arch.to_string()
+    } else {
+        format!("compute_{arch}")
+    }
+}
+
+/// Lowest compute capability whose libNVVM accepts cuda-oxide's exported dialect.
+///
+/// cuda-oxide exports NVVM IR 2.0 (opaque pointers, LLVM 20 dialect). NVIDIA's
+/// libNVVM only parses that dialect for compute_100 and newer (Blackwell+);
+/// older targets route to the typed-pointer (NVVM IR 1.x) parser and reject the
+/// module while parsing types. See https://github.com/NVlabs/cuda-oxide/issues/98.
+const NVVM_OPAQUE_PTR_MIN_CC: u32 = 100;
+
+/// Parse the numeric compute capability out of a `compute_XX` string.
+///
+/// Reads the leading capability digits and ignores a trailing architecture
+/// variant letter, so `compute_90`, `compute_90a`, and `compute_100f` all yield
+/// their base capability. Returns `None` when there are no leading digits, in
+/// which case the caller skips the capability-floor hint rather than guessing.
+fn compute_capability(compute_arch: &str) -> Option<u32> {
+    let suffix = compute_arch.strip_prefix("compute_")?;
+    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// Compile NVVM IR text to binary LTOIR with libNVVM `-gen-lto`. Exits with a
+/// diagnostic on any libNVVM failure (the program log is attached to the error).
+///
+/// When the target is below [`NVVM_OPAQUE_PTR_MIN_CC`] a compile failure also
+/// prints the issue #98 explanation, since the cryptic libNVVM parse error
+/// otherwise gives no hint that the opaque-pointer dialect is the cause. The
+/// hint is gated on actual failure so it disappears automatically if the floor
+/// ever moves.
+fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, compute_arch: &str) -> Vec<u8> {
+    let nvvm = libnvvm_sys::LibNvvm::load().unwrap_or_else(|e| {
+        eprintln!("Error: could not load libNVVM: {e}");
+        eprintln!("libNVVM ships with the CUDA Toolkit at <CUDA>/nvvm/lib64/libnvvm.so.");
+        eprintln!("Run `cargo oxide doctor` to check your toolkit setup.");
+        std::process::exit(1);
+    });
+    let mut program = libnvvm_sys::Program::new(&nvvm).unwrap_or_else(|e| {
+        eprintln!("Error: nvvmCreateProgram failed: {e}");
+        std::process::exit(1);
+    });
+    program.add_module(ir, name).unwrap_or_else(|e| {
+        eprintln!("Error: libNVVM rejected the NVVM IR module: {e}");
+        std::process::exit(1);
+    });
+    let arch_opt = format!("-arch={compute_arch}");
+    program
+        .compile(&[&arch_opt, "-gen-lto"])
+        .unwrap_or_else(|e| {
+            eprintln!("Error: libNVVM -gen-lto compilation failed: {e}");
+            if compute_capability(compute_arch).is_some_and(|cc| cc < NVVM_OPAQUE_PTR_MIN_CC) {
+                eprintln!();
+                eprintln!(
+                    "{compute_arch} is below compute_{NVVM_OPAQUE_PTR_MIN_CC}. cuda-oxide exports"
+                );
+                eprintln!(
+                    "NVVM IR 2.0 (opaque pointers), which libNVVM only accepts for"
+                );
+                eprintln!(
+                    "compute_{NVVM_OPAQUE_PTR_MIN_CC} and newer (Blackwell+); older targets reject it while"
+                );
+                eprintln!("parsing types. Target sm_100 or newer, or follow the typed-pointer");
+                eprintln!("export work at https://github.com/NVlabs/cuda-oxide/issues/98.");
+            }
+            std::process::exit(1);
+        })
+}
+
+// =============================================================================
 // Pipeline command
 // =============================================================================
 
@@ -2072,6 +2225,36 @@ mod tests {
 
         assert!(rustflags.contains(" -C debuginfo=2"));
         assert!(!rustflags.ends_with(' '));
+    }
+
+    #[test]
+    fn nvvm_compute_arch_normalizes_all_accepted_forms() {
+        // `sm_XX` is the form `--arch` and the rest of cargo-oxide use.
+        assert_eq!(nvvm_compute_arch("sm_120"), "compute_120");
+        assert_eq!(nvvm_compute_arch("sm_90"), "compute_90");
+        // `compute_XX` passes through unchanged.
+        assert_eq!(nvvm_compute_arch("compute_100"), "compute_100");
+        // A bare capability is accepted too.
+        assert_eq!(nvvm_compute_arch("120"), "compute_120");
+    }
+
+    #[test]
+    fn compute_capability_reads_base_through_variants() {
+        // Plain capabilities parse, so the issue #98 floor hint can fire.
+        assert_eq!(compute_capability("compute_90"), Some(90));
+        assert_eq!(compute_capability("compute_100"), Some(100));
+        assert_eq!(compute_capability("compute_120"), Some(120));
+        // Architecture variants resolve to their base capability, so a pre-Blackwell
+        // variant like compute_90a still trips the floor hint.
+        assert_eq!(compute_capability("compute_90a"), Some(90));
+        assert_eq!(compute_capability("compute_100a"), Some(100));
+        assert_eq!(compute_capability("compute_120f"), Some(120));
+        // The floor itself: below 100 is hinted, 100+ is not.
+        assert!(compute_capability("compute_90a").unwrap() < NVVM_OPAQUE_PTR_MIN_CC);
+        assert!(compute_capability("compute_100").unwrap() >= NVVM_OPAQUE_PTR_MIN_CC);
+        // A non-compute string or a missing capability yields no hint.
+        assert_eq!(compute_capability("sm_90"), None);
+        assert_eq!(compute_capability("compute_"), None);
     }
 
     #[test]

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -231,6 +231,8 @@ fn main() {
                 features.as_deref(),
                 no_fmad,
             );
+            println!();
+            println!("✓ Build succeeded");
         }
         Commands::EmitLtoir {
             example,

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -113,7 +113,7 @@ enum Commands {
         /// Comma-separated list of features to enable
         #[arg(long)]
         features: Option<String>,
-        /// Output path for the `.ltoir` file (default: <crate-dir>/<crate>.ltoir)
+        /// Output path for the `.ltoir` file (default: `<crate-dir>/<crate>.ltoir`)
         #[arg(long, short)]
         output: Option<PathBuf>,
         /// Show verbose compilation output

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -23,6 +23,7 @@
 //! ```
 
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 mod backend;
 mod commands;
@@ -96,6 +97,28 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+    },
+    /// Compile a crate's device code to a binary LTOIR artifact in one step.
+    ///
+    /// Produces the SIMT artifact a tile or C++ kernel links against
+    /// (NVVM IR emission followed by libNVVM `-gen-lto`), writing
+    /// `<crate>.ltoir`. See the Tile-to-SIMT interop tracker (#96).
+    EmitLtoir {
+        /// Crate name (required in workspace, optional for standalone projects)
+        example: Option<String>,
+        /// Target architecture (e.g. sm_90, sm_100, sm_120). Required: LTOIR is
+        /// architecture-specific.
+        #[arg(long)]
+        arch: String,
+        /// Comma-separated list of features to enable
+        #[arg(long)]
+        features: Option<String>,
+        /// Output path for the `.ltoir` file (default: <crate-dir>/<crate>.ltoir)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+        /// Show verbose compilation output
+        #[arg(short, long)]
+        verbose: bool,
     },
     /// Show the full compilation pipeline (MIR -> PTX/NVVM IR) with verbose output
     Pipeline {
@@ -207,6 +230,24 @@ fn main() {
                 arch.as_deref(),
                 features.as_deref(),
                 no_fmad,
+            );
+        }
+        Commands::EmitLtoir {
+            example,
+            arch,
+            features,
+            output,
+            verbose,
+        } => {
+            let ctx = commands::resolve_context();
+            let example = resolve_example_name(example, &ctx, "emit-ltoir");
+            commands::emit_ltoir(
+                &ctx,
+                &example,
+                &arch,
+                features.as_deref(),
+                output.as_deref(),
+                verbose,
             );
         }
         Commands::Pipeline {


### PR DESCRIPTION
## What

Adds `cargo oxide emit-ltoir <crate>`, which builds a crate's device code to a
binary **LTOIR** artifact in one step.

`cargo oxide build --emit-nvvm-ir` stops at NVVM IR, leaving the caller to run
libNVVM separately to get linkable LTOIR. `emit-ltoir` folds both halves into a
single command for the **Tile-to-SIMT interop** workflow (#96), where cuda-oxide
is the SIMT participant: it builds the crate in NVVM IR mode, compiles the
emitted `<crate>.ll` with libNVVM `-gen-lto`, and writes `<crate>.ltoir`.

## Details

- `--arch` is **required** (LTOIR is architecture-specific) and accepts `sm_XX`,
  `compute_XX`, or a bare `XX`. `-o/--output` overrides the default
  `<crate>.ltoir` path.
- Reuses the existing `libnvvm-sys` binding and the established NVVM IR build
  path (`codegen_build(.., emit_nvvm_ir=true, ..)`); rejects metadata-interop
  examples (point it at a single SIMT device crate instead).
- cuda-oxide exports NVVM IR 2.0 (opaque pointers), which libNVVM only accepts
  for `compute_100`+ (Blackwell). Below that, libNVVM rejects the module with a
  bare `parse expected type` and no hint at the cause (#98). On a libNVVM
  failure below `compute_100`, `emit-ltoir` appends a short explanation pointing
  at #98 and suggesting `sm_100`+. **The hint is gated on actual failure**, so it
  disappears automatically if the opaque-pointer floor ever moves (e.g. once
  typed-pointer export lands).

## Tests

- Unit tests for the arch normalization (`nvvm_compute_arch`) and the
  capability parse (`compute_capability`).
- Documents the command and the `compute_100` floor in the cargo-oxide README.

`cargo test -p cargo-oxide` (26 passed), `cargo fmt --check`, and
`cargo clippy -p cargo-oxide` are all clean.

Part of #96.
