### PR TITLE
feat: mma.sync int4 variants (s4/u4, k32/k64)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,82 @@
+---
+name: fork-ci
+
+# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Runs on every push to any branch except main (upstream CI covers main).
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt for the pinned nightly
+        run: rustup component add rustfmt
+
+      - name: Check root workspace formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (no-cuda packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clippy on packages that don't need CUDA
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo clippy \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols \
+            -- -D warnings
+
+  unit-tests:
+    name: test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - llvm-export
+          - dialect-mir
+          - dialect-nvvm
+          - mir-lower
+          - mir-importer
+          - oxide-artifacts
+          - reserved-oxide-symbols
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run crate unit tests
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo test -p ${{ matrix.package }} --all-targets

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,8 +1,11 @@
 ---
 name: fork-ci
 
-# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# Enhanced CI for our PR branches. Catches formatting, clippy, rustdoc, and
 # unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Also runs additional quality checks that go beyond upstream CI to ensure
+# clean PRs before upstreaming.
+#
 # Runs on every push to any branch except main (upstream CI covers main).
 
 on:
@@ -80,3 +83,163 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           cargo test -p ${{ matrix.package }} --all-targets
+
+  rustdoc:
+    name: rustdoc (no warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with -D warnings
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          export RUSTDOCFLAGS="-D warnings"
+
+          cargo doc --no-deps \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols
+
+  # ---- Fork-only quality gates (beyond upstream CI) ----
+  # These catch patterns the maintainer has historically fixed in contributor
+  # PRs, saving a review round-trip.
+
+  style-checks:
+    name: style (owner fixup patterns)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for diff against main
+
+      - name: Detect em-dashes in added lines
+        run: |
+          # Only check lines we actually added (not pre-existing upstream code)
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -n '—' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Em-dash (U+2014) found in added lines"
+            echo "$hits"
+            echo ""
+            echo "The maintainer consistently removes em-dashes from doc comments."
+            echo "Replace with commas, semicolons, or parentheses."
+            exit 1
+          fi
+          echo "Em-dash check: PASS"
+
+      - name: Detect bare brackets in doc comments (warning)
+        run: |
+          # Check added doc comment lines for bare [text] that are NOT
+          # markdown links [text](url), intra-doc links [`item`], or backtick-wrapped
+          hits=$(git diff origin/main...HEAD -- '*.rs' \
+            | grep '^+' | grep -v '^+++' \
+            | grep '///' \
+            | grep -P '\[(?!`)' \
+            | grep -vP '\]\(' \
+            | grep -vP '`[^`]*\[' \
+            || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Possible bare brackets in doc comments (may cause rustdoc errors)"
+            echo "$hits"
+            echo ""
+            echo "Wrap in backticks or use a markdown link."
+          else
+            echo "Bare bracket check: PASS"
+          fi
+          # Warning only — some brackets are valid intra-doc links
+
+      - name: Check SPDX license headers on new files
+        run: |
+          new_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '*.rs' 2>/dev/null || true)
+          if [ -z "$new_files" ]; then
+            echo "No new .rs files"
+            exit 0
+          fi
+
+          found=0
+          for f in $new_files; do
+            if [ -f "$f" ]; then
+              has_spdx=$(head -4 "$f" | grep -c 'SPDX' || true)
+              if [ "$has_spdx" -eq 0 ]; then
+                echo "::error file=$f::Missing SPDX license header"
+                found=1
+              fi
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "New .rs files must start with the SPDX header block."
+            exit 1
+          fi
+
+      - name: Check for unnecessary &mut on type getters
+        run: |
+          # Only check lines we added
+          diff_added=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$diff_added" ]; then
+            echo "No added lines"
+            exit 0
+          fi
+
+          found=0
+          for pattern in 'FP32Type::get(&mut' 'FP64Type::get(&mut' 'VoidType::get(&mut' 'FP16Type::get(&mut'; do
+            hits=$(echo "$diff_added" | grep "$pattern" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::$pattern found in added lines (takes &Context, not &mut Context)"
+              echo "$hits"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "pliron type getters (FP32Type, FP64Type, VoidType, FP16Type) take &Context."
+            echo "Note: IntegerType::get, PointerType::get, MirPtrType::get_generic legitimately take &mut Context."
+            exit 1
+          fi
+          echo "Type getter mutability check: PASS"
+
+      - name: Check for float equality assertions (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -P 'assert_eq!\(.*\d+\.\d+f(32|64)' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Float equality assertion in added lines (clippy::float_cmp)"
+            echo "$hits"
+            echo ""
+            echo 'Use: assert!((val - expected).abs() < 1e-6, "got {}, want {}", val, expected);'
+          else
+            echo "Float equality check: PASS"
+          fi
+          # Warning only
+
+      - name: Check for useless vec patterns (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep '&vec!\[' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::&vec![...] in added lines (clippy::useless_vec)"
+            echo "$hits"
+            echo ""
+            echo "Use &[...] slice literal instead."
+          else
+            echo "Useless vec check: PASS"
+          fi
+          # Warning only
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check dependencies
+        run: cargo deny check

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -32,6 +32,7 @@ pub mod thread;
 pub mod tma;
 pub mod warp;
 pub mod wgmma;
+pub mod wmma;
 
 pub use barrier::{
     // Core type

--- a/crates/cuda-device/src/wmma.rs
+++ b/crates/cuda-device/src/wmma.rs
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! WMMA (Warp Matrix Multiply-Accumulate) device-side stubs.
+//!
+//! These functions are placeholders that get intercepted during MIR import
+//! and replaced with the corresponding `dialect-nvvm` operations.
+
+/// Signed int4 MMA: m16n8k32, accumulates into s32.
+///
+/// PTX: `mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32`
+///
+/// # Safety
+/// Must be called by all threads in a warp.
+#[allow(unused_variables)]
+pub unsafe fn mma_m16n8k32_s32_s4(acc: &mut [i32; 4], a: &[u32; 2], b: &u32) {
+    let _ = (acc, a, b);
+    unreachable!("device stub: lowered to mma.sync PTX by the compiler")
+}
+
+/// Unsigned int4 MMA: m16n8k32, accumulates into s32.
+///
+/// PTX: `mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32`
+///
+/// # Safety
+/// Must be called by all threads in a warp.
+#[allow(unused_variables)]
+pub unsafe fn mma_m16n8k32_s32_u4(acc: &mut [i32; 4], a: &[u32; 2], b: &u32) {
+    let _ = (acc, a, b);
+    unreachable!("device stub: lowered to mma.sync PTX by the compiler")
+}
+
+/// Signed int4 MMA: m16n8k64, accumulates into s32.
+///
+/// PTX: `mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32`
+///
+/// # Safety
+/// Must be called by all threads in a warp.
+#[allow(unused_variables)]
+pub unsafe fn mma_m16n8k64_s32_s4(acc: &mut [i32; 4], a: &[u32; 4], b: &[u32; 2]) {
+    let _ = (acc, a, b);
+    unreachable!("device stub: lowered to mma.sync PTX by the compiler")
+}
+
+/// Unsigned int4 MMA: m16n8k64, accumulates into s32.
+///
+/// PTX: `mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32`
+///
+/// # Safety
+/// Must be called by all threads in a warp.
+#[allow(unused_variables)]
+pub unsafe fn mma_m16n8k64_s32_u4(acc: &mut [i32; 4], a: &[u32; 4], b: &[u32; 2]) {
+    let _ = (acc, a, b);
+    unreachable!("device stub: lowered to mma.sync PTX by the compiler")
+}

--- a/crates/dialect-nvvm/src/ops/mod.rs
+++ b/crates/dialect-nvvm/src/ops/mod.rs
@@ -110,6 +110,7 @@ mod thread;
 mod tma;
 mod warp;
 mod wgmma;
+mod wmma;
 
 use pliron::context::Context;
 
@@ -129,6 +130,7 @@ pub use thread::*;
 pub use tma::*;
 pub use warp::*;
 pub use wgmma::*;
+pub use wmma::*;
 
 /// Register all NVVM dialect operations with the context.
 ///
@@ -150,4 +152,5 @@ pub fn register(ctx: &mut Context) {
     tcgen05::register(ctx);
     stmatrix::register(ctx);
     debug::register(ctx);
+    wmma::register(ctx);
 }

--- a/crates/dialect-nvvm/src/ops/wmma.rs
+++ b/crates/dialect-nvvm/src/ops/wmma.rs
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! WMMA (Warp Matrix Multiply-Accumulate) operations for integer sub-byte types.
+//!
+//! These operations map to PTX `mma.sync.aligned` instructions for int4 types.
+//!
+//! # Operations
+//!
+//! | Operation              | PTX instruction                                          | A frags | B frags |
+//! |------------------------|----------------------------------------------------------|---------|---------|
+//! | `MmaM16N8K32S32S4Op`  | `mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32`       | 2×u32   | 1×u32   |
+//! | `MmaM16N8K32S32U4Op`  | `mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32`       | 2×u32   | 1×u32   |
+//! | `MmaM16N8K64S32S4Op`  | `mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32`       | 4×u32   | 2×u32   |
+//! | `MmaM16N8K64S32U4Op`  | `mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32`       | 4×u32   | 2×u32   |
+//!
+//! All operations take 3 pointer operands: `(acc_ptr, a_ptr, b_ptr)` and produce no results.
+
+use pliron::{
+    builtin::op_interfaces::{NOpdsInterface, NResultsInterface},
+    context::Context,
+    context::Ptr,
+    op::Op,
+    operation::Operation,
+};
+use pliron_derive::pliron_op;
+
+// =============================================================================
+// Signed int4 operations
+// =============================================================================
+
+/// MMA m16n8k32 with signed int4 (s4) operands, s32 accumulator.
+///
+/// PTX: `mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32`
+///
+/// # Operands
+/// - `acc_ptr` (ptr): pointer to 4×i32 accumulator (read-modify-write)
+/// - `a_ptr` (ptr): pointer to 2×u32 A-fragment
+/// - `b_ptr` (ptr): pointer to 1×u32 B-fragment
+#[pliron_op(
+    name = "nvvm.mma_m16n8k32_s32_s4",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<0>],
+)]
+pub struct MmaM16N8K32S32S4Op;
+
+impl MmaM16N8K32S32S4Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K32S32S4Op { op }
+    }
+}
+
+/// MMA m16n8k64 with signed int4 (s4) operands, s32 accumulator.
+///
+/// PTX: `mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32`
+///
+/// # Operands
+/// - `acc_ptr` (ptr): pointer to 4×i32 accumulator (read-modify-write)
+/// - `a_ptr` (ptr): pointer to 4×u32 A-fragment
+/// - `b_ptr` (ptr): pointer to 2×u32 B-fragment
+#[pliron_op(
+    name = "nvvm.mma_m16n8k64_s32_s4",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<0>],
+)]
+pub struct MmaM16N8K64S32S4Op;
+
+impl MmaM16N8K64S32S4Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K64S32S4Op { op }
+    }
+}
+
+// =============================================================================
+// Unsigned int4 operations
+// =============================================================================
+
+/// MMA m16n8k32 with unsigned int4 (u4) operands, s32 accumulator.
+///
+/// PTX: `mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32`
+///
+/// # Operands
+/// - `acc_ptr` (ptr): pointer to 4×i32 accumulator (read-modify-write)
+/// - `a_ptr` (ptr): pointer to 2×u32 A-fragment
+/// - `b_ptr` (ptr): pointer to 1×u32 B-fragment
+#[pliron_op(
+    name = "nvvm.mma_m16n8k32_s32_u4",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<0>],
+)]
+pub struct MmaM16N8K32S32U4Op;
+
+impl MmaM16N8K32S32U4Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K32S32U4Op { op }
+    }
+}
+
+/// MMA m16n8k64 with unsigned int4 (u4) operands, s32 accumulator.
+///
+/// PTX: `mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32`
+///
+/// # Operands
+/// - `acc_ptr` (ptr): pointer to 4×i32 accumulator (read-modify-write)
+/// - `a_ptr` (ptr): pointer to 4×u32 A-fragment
+/// - `b_ptr` (ptr): pointer to 2×u32 B-fragment
+#[pliron_op(
+    name = "nvvm.mma_m16n8k64_s32_u4",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<0>],
+)]
+pub struct MmaM16N8K64S32U4Op;
+
+impl MmaM16N8K64S32U4Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K64S32U4Op { op }
+    }
+}
+
+/// Register all WMMA operations with the context.
+pub(super) fn register(ctx: &mut Context) {
+    MmaM16N8K32S32S4Op::register(ctx);
+    MmaM16N8K32S32U4Op::register(ctx);
+    MmaM16N8K64S32S4Op::register(ctx);
+    MmaM16N8K64S32U4Op::register(ctx);
+}

--- a/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
@@ -53,3 +53,4 @@ pub mod tcgen05;
 pub mod tma;
 pub mod warp;
 pub mod wgmma;
+pub mod wmma;

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
@@ -1,0 +1,275 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! WMMA (Warp Matrix Multiply-Accumulate) intrinsic emission.
+//!
+//! Translates `cuda_device::wmma::*` intrinsic calls into `dialect-nvvm` WMMA operations.
+
+use super::super::helpers::emit_goto;
+use crate::error::{TranslationErr, TranslationResult};
+use crate::translator::rvalue;
+use crate::translator::values::ValueMap;
+use dialect_nvvm::ops::{
+    MmaM16N8K32S32S4Op, MmaM16N8K32S32U4Op, MmaM16N8K64S32S4Op, MmaM16N8K64S32U4Op,
+};
+use pliron::basic_block::BasicBlock;
+use pliron::context::{Context, Ptr};
+use pliron::input_err;
+use pliron::location::{Located, Location};
+use pliron::op::Op;
+use pliron::operation::Operation;
+use rustc_public::mir;
+
+/// Emit `mma_m16n8k32_s32_s4`: signed int4 MMA, k=32.
+///
+/// Args: `(acc: &mut [i32; 4], a: &[u32; 2], b: &u32)`
+/// Returns: void (result written through `acc` pointer)
+pub fn emit_mma_m16n8k32_s32_s4(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k32_s32_s4 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+    let mut operands = Vec::with_capacity(3);
+    for arg in args.iter().take(3) {
+        let (val, last_op_after) =
+            rvalue::translate_operand(ctx, body, arg, value_map, block_ptr, last_op, loc.clone())?;
+        last_op = last_op_after;
+        operands.push(val);
+    }
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K32S32S4Op::get_concrete_op_info(),
+        vec![],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        mma_op.insert_after(ctx, prev);
+    } else {
+        mma_op.insert_at_front(block_ptr, ctx);
+    }
+
+    if let Some(target_idx) = target {
+        let goto_op = emit_goto(ctx, *target_idx, mma_op, block_map, loc);
+        Ok(goto_op)
+    } else {
+        input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "mma_m16n8k32_s32_s4 call without target block".to_string(),
+            )
+        )
+    }
+}
+
+/// Emit `mma_m16n8k32_s32_u4`: unsigned int4 MMA, k=32.
+///
+/// Args: `(acc: &mut [i32; 4], a: &[u32; 2], b: &u32)`
+/// Returns: void (result written through `acc` pointer)
+pub fn emit_mma_m16n8k32_s32_u4(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k32_s32_u4 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+    let mut operands = Vec::with_capacity(3);
+    for arg in args.iter().take(3) {
+        let (val, last_op_after) =
+            rvalue::translate_operand(ctx, body, arg, value_map, block_ptr, last_op, loc.clone())?;
+        last_op = last_op_after;
+        operands.push(val);
+    }
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K32S32U4Op::get_concrete_op_info(),
+        vec![],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        mma_op.insert_after(ctx, prev);
+    } else {
+        mma_op.insert_at_front(block_ptr, ctx);
+    }
+
+    if let Some(target_idx) = target {
+        let goto_op = emit_goto(ctx, *target_idx, mma_op, block_map, loc);
+        Ok(goto_op)
+    } else {
+        input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "mma_m16n8k32_s32_u4 call without target block".to_string(),
+            )
+        )
+    }
+}
+
+/// Emit `mma_m16n8k64_s32_s4`: signed int4 MMA, k=64.
+///
+/// Args: `(acc: &mut [i32; 4], a: &[u32; 4], b: &[u32; 2])`
+/// Returns: void (result written through `acc` pointer)
+pub fn emit_mma_m16n8k64_s32_s4(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k64_s32_s4 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+    let mut operands = Vec::with_capacity(3);
+    for arg in args.iter().take(3) {
+        let (val, last_op_after) =
+            rvalue::translate_operand(ctx, body, arg, value_map, block_ptr, last_op, loc.clone())?;
+        last_op = last_op_after;
+        operands.push(val);
+    }
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K64S32S4Op::get_concrete_op_info(),
+        vec![],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        mma_op.insert_after(ctx, prev);
+    } else {
+        mma_op.insert_at_front(block_ptr, ctx);
+    }
+
+    if let Some(target_idx) = target {
+        let goto_op = emit_goto(ctx, *target_idx, mma_op, block_map, loc);
+        Ok(goto_op)
+    } else {
+        input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "mma_m16n8k64_s32_s4 call without target block".to_string(),
+            )
+        )
+    }
+}
+
+/// Emit `mma_m16n8k64_s32_u4`: unsigned int4 MMA, k=64.
+///
+/// Args: `(acc: &mut [i32; 4], a: &[u32; 4], b: &[u32; 2])`
+/// Returns: void (result written through `acc` pointer)
+pub fn emit_mma_m16n8k64_s32_u4(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k64_s32_u4 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+    let mut operands = Vec::with_capacity(3);
+    for arg in args.iter().take(3) {
+        let (val, last_op_after) =
+            rvalue::translate_operand(ctx, body, arg, value_map, block_ptr, last_op, loc.clone())?;
+        last_op = last_op_after;
+        operands.push(val);
+    }
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K64S32U4Op::get_concrete_op_info(),
+        vec![],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        mma_op.insert_after(ctx, prev);
+    } else {
+        mma_op.insert_at_front(block_ptr, ctx);
+    }
+
+    if let Some(target_idx) = target {
+        let goto_op = emit_goto(ctx, *target_idx, mma_op, block_map, loc);
+        Ok(goto_op)
+    } else {
+        input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "mma_m16n8k64_s32_u4 call without target block".to_string(),
+            )
+        )
+    }
+}

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2915,6 +2915,28 @@ fn try_dispatch_intrinsic(
         // =================================================================
         // WGMMA (from intrinsics::wgmma)
         // =================================================================
+
+        // ---- WMMA int4 MMA ops ----
+        "cuda_device::wmma::mma_m16n8k32_s32_s4" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k32_s32_s4(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
+        "cuda_device::wmma::mma_m16n8k32_s32_u4" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k32_s32_u4(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
+        "cuda_device::wmma::mma_m16n8k64_s32_s4" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k64_s32_s4(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
+        "cuda_device::wmma::mma_m16n8k64_s32_u4" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k64_s32_u4(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
         "cuda_device::wgmma::wgmma_fence" => Ok(Some(intrinsics::wgmma::emit_wgmma_fence(
             ctx, args, target, block_ptr, prev_op, block_map, loc,
         )?)),

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -48,7 +48,8 @@ use dialect_nvvm::ops::{
     MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveClusterOp,
     MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
     MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MbarrierTryWaitParitySharedOp,
-    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
+    MbarrierTryWaitSharedOp, MmaM16N8K32S32S4Op, MmaM16N8K32S32U4Op, MmaM16N8K64S32S4Op,
+    MmaM16N8K64S32U4Op, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
     NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
     ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
     ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
@@ -2126,6 +2127,76 @@ impl MirToLlvmConversion for WgmmaMmaM64N64K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma(ctx, rewriter, self.get_operation(), operands_info)
+    }
+}
+
+// ---- NVVM WMMA int4 ops -----------------------------------------------------
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K32S32S4Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k32_s32_s4(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K32S32U4Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k32_s32_u4(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K64S32S4Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k64_s32_s4(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K64S32U4Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k64_s32_u4(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
     }
 }
 

--- a/crates/mir-lower/src/convert/intrinsics/mod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mod.rs
@@ -85,3 +85,4 @@ pub mod tcgen05;
 pub mod tma;
 pub mod warp;
 pub mod wgmma;
+pub mod wmma;

--- a/crates/mir-lower/src/convert/intrinsics/wmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wmma.rs
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! WMMA (Warp Matrix Multiply-Accumulate) mma.sync intrinsic lowering for SM 80+.
+
+use crate::convert::intrinsics::common::*;
+use llvm_export::types as llvm_types;
+use pliron::context::{Context, Ptr};
+use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::rewriter::Rewriter;
+use pliron::operation::Operation;
+use pliron::result::Result;
+
+/// Convert `mma_m16n8k32_s32_s4` to inline PTX assembly.
+pub(crate) fn convert_mma_m16n8k32_s32_s4(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let void_ty = llvm_types::VoidType::get(ctx);
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k32_s32_s4 requires 3 operands (acc_ptr, a_ptr, b_ptr)"
+        );
+    }
+
+    let asm = "\
+        .reg .b32 c<4>; .reg .b32 d<4>; .reg .b32 a<2>; .reg .b32 b0; \
+        ld.b32 c0, [$0]; ld.b32 c1, [$0+4]; ld.b32 c2, [$0+8]; ld.b32 c3, [$0+12]; \
+        ld.b32 a0, [$1]; ld.b32 a1, [$1+4]; \
+        ld.b32 b0, [$2]; \
+        mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32 {d0, d1, d2, d3}, {a0, a1}, {b0}, {c0, c1, c2, c3}; \
+        st.b32 [$0], d0; st.b32 [$0+4], d1; st.b32 [$0+8], d2; st.b32 [$0+12], d3;";
+
+    inline_asm_convergent(
+        ctx,
+        rewriter,
+        void_ty.into(),
+        operands,
+        asm,
+        "l,l,l,~{memory}",
+    );
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}
+
+/// Convert `mma_m16n8k32_s32_u4` to inline PTX assembly.
+pub(crate) fn convert_mma_m16n8k32_s32_u4(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let void_ty = llvm_types::VoidType::get(ctx);
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k32_s32_u4 requires 3 operands (acc_ptr, a_ptr, b_ptr)"
+        );
+    }
+
+    let asm = "\
+        .reg .b32 c<4>; .reg .b32 d<4>; .reg .b32 a<2>; .reg .b32 b0; \
+        ld.b32 c0, [$0]; ld.b32 c1, [$0+4]; ld.b32 c2, [$0+8]; ld.b32 c3, [$0+12]; \
+        ld.b32 a0, [$1]; ld.b32 a1, [$1+4]; \
+        ld.b32 b0, [$2]; \
+        mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32 {d0, d1, d2, d3}, {a0, a1}, {b0}, {c0, c1, c2, c3}; \
+        st.b32 [$0], d0; st.b32 [$0+4], d1; st.b32 [$0+8], d2; st.b32 [$0+12], d3;";
+
+    inline_asm_convergent(
+        ctx,
+        rewriter,
+        void_ty.into(),
+        operands,
+        asm,
+        "l,l,l,~{memory}",
+    );
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}
+
+/// Convert `mma_m16n8k64_s32_s4` to inline PTX assembly.
+pub(crate) fn convert_mma_m16n8k64_s32_s4(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let void_ty = llvm_types::VoidType::get(ctx);
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k64_s32_s4 requires 3 operands (acc_ptr, a_ptr, b_ptr)"
+        );
+    }
+
+    let asm = "\
+        .reg .b32 c<4>; .reg .b32 d<4>; .reg .b32 a<4>; .reg .b32 b<2>; \
+        ld.b32 c0, [$0]; ld.b32 c1, [$0+4]; ld.b32 c2, [$0+8]; ld.b32 c3, [$0+12]; \
+        ld.b32 a0, [$1]; ld.b32 a1, [$1+4]; ld.b32 a2, [$1+8]; ld.b32 a3, [$1+12]; \
+        ld.b32 b0, [$2]; ld.b32 b1, [$2+4]; \
+        mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32 {d0, d1, d2, d3}, {a0, a1, a2, a3}, {b0, b1}, {c0, c1, c2, c3}; \
+        st.b32 [$0], d0; st.b32 [$0+4], d1; st.b32 [$0+8], d2; st.b32 [$0+12], d3;";
+
+    inline_asm_convergent(
+        ctx,
+        rewriter,
+        void_ty.into(),
+        operands,
+        asm,
+        "l,l,l,~{memory}",
+    );
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}
+
+/// Convert `mma_m16n8k64_s32_u4` to inline PTX assembly.
+pub(crate) fn convert_mma_m16n8k64_s32_u4(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let void_ty = llvm_types::VoidType::get(ctx);
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k64_s32_u4 requires 3 operands (acc_ptr, a_ptr, b_ptr)"
+        );
+    }
+
+    let asm = "\
+        .reg .b32 c<4>; .reg .b32 d<4>; .reg .b32 a<4>; .reg .b32 b<2>; \
+        ld.b32 c0, [$0]; ld.b32 c1, [$0+4]; ld.b32 c2, [$0+8]; ld.b32 c3, [$0+12]; \
+        ld.b32 a0, [$1]; ld.b32 a1, [$1+4]; ld.b32 a2, [$1+8]; ld.b32 a3, [$1+12]; \
+        ld.b32 b0, [$2]; ld.b32 b1, [$2+4]; \
+        mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32 {d0, d1, d2, d3}, {a0, a1, a2, a3}, {b0, b1}, {c0, c1, c2, c3}; \
+        st.b32 [$0], d0; st.b32 [$0+4], d1; st.b32 [$0+8], d2; st.b32 [$0+12], d3;";
+
+    inline_asm_convergent(
+        ctx,
+        rewriter,
+        void_ty.into(),
+        operands,
+        asm,
+        "l,l,l,~{memory}",
+    );
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -1337,3 +1337,135 @@ fn test_bool_phi_cmp_lowers_to_unsigned_i1_icmp() -> Result<(), anyhow::Error> {
     );
     Ok(())
 }
+
+#[test]
+fn test_mma_m16n8k32_s32_s4_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty.into(), true);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![ptr_ty.into(), ptr_ty.into(), ptr_ty.into()]);
+
+    let acc = entry.deref(&ctx).get_argument(0);
+    let a = entry.deref(&ctx).get_argument(1);
+    let b = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K32S32S4Op::get_concrete_op_info(),
+        vec![],
+        vec![acc, a, b],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(
+        &mut ctx,
+        module_ptr,
+        "mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32",
+    )
+}
+
+#[test]
+fn test_mma_m16n8k32_s32_u4_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty.into(), true);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![ptr_ty.into(), ptr_ty.into(), ptr_ty.into()]);
+
+    let acc = entry.deref(&ctx).get_argument(0);
+    let a = entry.deref(&ctx).get_argument(1);
+    let b = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K32S32U4Op::get_concrete_op_info(),
+        vec![],
+        vec![acc, a, b],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(
+        &mut ctx,
+        module_ptr,
+        "mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32",
+    )
+}
+
+#[test]
+fn test_mma_m16n8k64_s32_s4_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty.into(), true);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![ptr_ty.into(), ptr_ty.into(), ptr_ty.into()]);
+
+    let acc = entry.deref(&ctx).get_argument(0);
+    let a = entry.deref(&ctx).get_argument(1);
+    let b = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K64S32S4Op::get_concrete_op_info(),
+        vec![],
+        vec![acc, a, b],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(
+        &mut ctx,
+        module_ptr,
+        "mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32",
+    )
+}
+
+#[test]
+fn test_mma_m16n8k64_s32_u4_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty.into(), true);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![ptr_ty.into(), ptr_ty.into(), ptr_ty.into()]);
+
+    let acc = entry.deref(&ctx).get_argument(0);
+    let a = entry.deref(&ctx).get_argument(1);
+    let b = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K64S32U4Op::get_concrete_op_info(),
+        vec![],
+        vec![acc, a, b],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(
+        &mut ctx,
+        module_ptr,
+        "mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32",
+    )
+}


### PR DESCRIPTION
## Summary

Add four integer-4-bit `mma.sync.aligned` PTX intrinsics (SM 80+), following the same four-layer pattern used for existing MMA operations:

| Variant | PTX instruction | A fragments | B fragments |
|---------|----------------|-------------|-------------|
| `mma_m16n8k32_s32_s4` | `mma.sync.aligned.m16n8k32.row.col.s32.s4.s4.s32` | 2×u32 | 1×u32 |
| `mma_m16n8k32_s32_u4` | `mma.sync.aligned.m16n8k32.row.col.s32.u4.u4.s32` | 2×u32 | 1×u32 |
| `mma_m16n8k64_s32_s4` | `mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32` | 4×u32 | 2×u32 |
| `mma_m16n8k64_s32_u4` | `mma.sync.aligned.m16n8k64.row.col.s32.u4.u4.s32` | 4×u32 | 2×u32 |

### Changes across layers

- **`cuda-device`** — device-side stubs (`wmma.rs`)
- **`dialect-nvvm`** — pliron op definitions (`ops/wmma.rs`)
- **`mir-importer`** — MIR → NVVM translation (`intrinsics/wmma.rs`, match arms in `terminator/mod.rs`)
- **`mir-lower`** — NVVM → LLVM inline-PTX lowering (`intrinsics/wmma.rs`, `interface_impls.rs`)
- **`mir-lower/tests`** — 4 round-trip lowering tests

Closes #37, closes #38, closes #39, closes #40.
Ref #27.

## Test plan

- [x] `cargo check -p cuda-device -p dialect-nvvm -p mir-importer -p mir-lower` passes with no warnings
- [x] `cargo fmt --all` produces no diff
- [ ] `cargo test -p mir-lower` — 4 new `test_mma_m16n8k*` tests verify inline asm strings