### PR TITLE
feat: packed type conversions (rz, relu for f16x2/bf16x2)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,82 @@
+---
+name: fork-ci
+
+# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Runs on every push to any branch except main (upstream CI covers main).
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt for the pinned nightly
+        run: rustup component add rustfmt
+
+      - name: Check root workspace formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (no-cuda packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clippy on packages that don't need CUDA
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo clippy \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols \
+            -- -D warnings
+
+  unit-tests:
+    name: test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - llvm-export
+          - dialect-mir
+          - dialect-nvvm
+          - mir-lower
+          - mir-importer
+          - oxide-artifacts
+          - reserved-oxide-symbols
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run crate unit tests
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo test -p ${{ matrix.package }} --all-targets

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,8 +1,11 @@
 ---
 name: fork-ci
 
-# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# Enhanced CI for our PR branches. Catches formatting, clippy, rustdoc, and
 # unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Also runs additional quality checks that go beyond upstream CI to ensure
+# clean PRs before upstreaming.
+#
 # Runs on every push to any branch except main (upstream CI covers main).
 
 on:
@@ -80,3 +83,163 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           cargo test -p ${{ matrix.package }} --all-targets
+
+  rustdoc:
+    name: rustdoc (no warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with -D warnings
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          export RUSTDOCFLAGS="-D warnings"
+
+          cargo doc --no-deps \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols
+
+  # ---- Fork-only quality gates (beyond upstream CI) ----
+  # These catch patterns the maintainer has historically fixed in contributor
+  # PRs, saving a review round-trip.
+
+  style-checks:
+    name: style (owner fixup patterns)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for diff against main
+
+      - name: Detect em-dashes in added lines
+        run: |
+          # Only check lines we actually added (not pre-existing upstream code)
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -n '—' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Em-dash (U+2014) found in added lines"
+            echo "$hits"
+            echo ""
+            echo "The maintainer consistently removes em-dashes from doc comments."
+            echo "Replace with commas, semicolons, or parentheses."
+            exit 1
+          fi
+          echo "Em-dash check: PASS"
+
+      - name: Detect bare brackets in doc comments (warning)
+        run: |
+          # Check added doc comment lines for bare [text] that are NOT
+          # markdown links [text](url), intra-doc links [`item`], or backtick-wrapped
+          hits=$(git diff origin/main...HEAD -- '*.rs' \
+            | grep '^+' | grep -v '^+++' \
+            | grep '///' \
+            | grep -P '\[(?!`)' \
+            | grep -vP '\]\(' \
+            | grep -vP '`[^`]*\[' \
+            || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Possible bare brackets in doc comments (may cause rustdoc errors)"
+            echo "$hits"
+            echo ""
+            echo "Wrap in backticks or use a markdown link."
+          else
+            echo "Bare bracket check: PASS"
+          fi
+          # Warning only — some brackets are valid intra-doc links
+
+      - name: Check SPDX license headers on new files
+        run: |
+          new_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '*.rs' 2>/dev/null || true)
+          if [ -z "$new_files" ]; then
+            echo "No new .rs files"
+            exit 0
+          fi
+
+          found=0
+          for f in $new_files; do
+            if [ -f "$f" ]; then
+              has_spdx=$(head -4 "$f" | grep -c 'SPDX' || true)
+              if [ "$has_spdx" -eq 0 ]; then
+                echo "::error file=$f::Missing SPDX license header"
+                found=1
+              fi
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "New .rs files must start with the SPDX header block."
+            exit 1
+          fi
+
+      - name: Check for unnecessary &mut on type getters
+        run: |
+          # Only check lines we added
+          diff_added=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$diff_added" ]; then
+            echo "No added lines"
+            exit 0
+          fi
+
+          found=0
+          for pattern in 'FP32Type::get(&mut' 'FP64Type::get(&mut' 'VoidType::get(&mut' 'FP16Type::get(&mut'; do
+            hits=$(echo "$diff_added" | grep "$pattern" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::$pattern found in added lines (takes &Context, not &mut Context)"
+              echo "$hits"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "pliron type getters (FP32Type, FP64Type, VoidType, FP16Type) take &Context."
+            echo "Note: IntegerType::get, PointerType::get, MirPtrType::get_generic legitimately take &mut Context."
+            exit 1
+          fi
+          echo "Type getter mutability check: PASS"
+
+      - name: Check for float equality assertions (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -P 'assert_eq!\(.*\d+\.\d+f(32|64)' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Float equality assertion in added lines (clippy::float_cmp)"
+            echo "$hits"
+            echo ""
+            echo 'Use: assert!((val - expected).abs() < 1e-6, "got {}, want {}", val, expected);'
+          else
+            echo "Float equality check: PASS"
+          fi
+          # Warning only
+
+      - name: Check for useless vec patterns (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep '&vec!\[' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::&vec![...] in added lines (clippy::useless_vec)"
+            echo "$hits"
+            echo ""
+            echo "Use &[...] slice literal instead."
+          else
+            echo "Useless vec check: PASS"
+          fi
+          # Warning only
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check dependencies
+        run: cargo deny check

--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -37,3 +37,77 @@ pub fn cvt_f16x2_f32(lo: f32, hi: f32) -> u32 {
     let _ = (lo, hi);
     unreachable!("cvt_f16x2_f32 called outside CUDA kernel context")
 }
+
+/// Convert two f32 values to a packed f16x2 (u32) with truncation rounding.
+///
+/// Uses round-toward-zero (truncation) instead of the default
+/// round-to-nearest-even mode.
+///
+/// Maps to PTX: `cvt.rz.f16x2.f32 d, hi, lo;`
+///
+/// # Arguments
+/// - `lo`: f32 value for the low 16 bits (bits `[15:0]`)
+/// - `hi`: f32 value for the high 16 bits (bits `[31:16]`)
+///
+/// # Returns
+/// A u32 containing two packed f16 values (truncation rounded).
+#[inline(never)]
+pub fn cvt_rz_f16x2_f32(lo: f32, hi: f32) -> u32 {
+    let _ = (lo, hi);
+    unreachable!("cvt_rz_f16x2_f32 called outside CUDA kernel context")
+}
+
+/// Convert two f32 values to a packed f16x2 (u32) with fused ReLU.
+///
+/// Negative values are clamped to zero before packing.
+///
+/// Maps to PTX: `cvt.rn.relu.f16x2.f32 d, hi, lo;`
+///
+/// # Arguments
+/// - `lo`: f32 value for the low 16 bits (bits `[15:0]`)
+/// - `hi`: f32 value for the high 16 bits (bits `[31:16]`)
+///
+/// # Returns
+/// A u32 containing two packed f16 values (ReLU applied).
+#[inline(never)]
+pub fn cvt_rn_relu_f16x2_f32(lo: f32, hi: f32) -> u32 {
+    let _ = (lo, hi);
+    unreachable!("cvt_rn_relu_f16x2_f32 called outside CUDA kernel context")
+}
+
+/// Convert two f32 values to a packed bf16x2 (u32) with fused ReLU.
+///
+/// Negative values are clamped to zero before packing.
+///
+/// Maps to PTX: `cvt.rn.relu.bf16x2.f32 d, hi, lo;`
+///
+/// # Arguments
+/// - `lo`: f32 value for the low 16 bits (bits `[15:0]`)
+/// - `hi`: f32 value for the high 16 bits (bits `[31:16]`)
+///
+/// # Returns
+/// A u32 containing two packed bf16 values (ReLU applied).
+#[inline(never)]
+pub fn cvt_rn_relu_bf16x2_f32(lo: f32, hi: f32) -> u32 {
+    let _ = (lo, hi);
+    unreachable!("cvt_rn_relu_bf16x2_f32 called outside CUDA kernel context")
+}
+
+/// Convert two f32 values to a packed bf16x2 (u32) with truncation rounding.
+///
+/// Uses round-toward-zero (truncation) instead of the default
+/// round-to-nearest-even mode.
+///
+/// Maps to PTX: `cvt.rz.bf16x2.f32 d, hi, lo;`
+///
+/// # Arguments
+/// - `lo`: f32 value for the low 16 bits (bits `[15:0]`)
+/// - `hi`: f32 value for the high 16 bits (bits `[31:16]`)
+///
+/// # Returns
+/// A u32 containing two packed bf16 values (truncation rounded).
+#[inline(never)]
+pub fn cvt_rz_bf16x2_f32(lo: f32, hi: f32) -> u32 {
+    let _ = (lo, hi);
+    unreachable!("cvt_rz_bf16x2_f32 called outside CUDA kernel context")
+}

--- a/crates/dialect-nvvm/src/ops/convert.rs
+++ b/crates/dialect-nvvm/src/ops/convert.rs
@@ -40,7 +40,115 @@ impl CvtF16x2F32Op {
     }
 }
 
+/// Convert two f32 values to packed f16x2 (u32) with truncation rounding.
+///
+/// Maps to PTX: `cvt.rz.f16x2.f32 d, hi, lo;`
+///
+/// # Operands
+///
+/// - `lo` (f32): value for bits `[15:0]`
+/// - `hi` (f32): value for bits `[31:16]`
+///
+/// # Results
+///
+/// - packed f16x2 as u32
+#[pliron_op(
+    name = "nvvm.cvt_rz_f16x2_f32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct CvtRzF16x2F32Op;
+
+impl CvtRzF16x2F32Op {
+    pub fn new(op: Ptr<Operation>) -> Self {
+        CvtRzF16x2F32Op { op }
+    }
+}
+
+/// Convert two f32 values to packed f16x2 (u32) with fused ReLU.
+///
+/// Maps to PTX: `cvt.rn.relu.f16x2.f32 d, hi, lo;`
+///
+/// # Operands
+///
+/// - `lo` (f32): value for bits `[15:0]`
+/// - `hi` (f32): value for bits `[31:16]`
+///
+/// # Results
+///
+/// - packed f16x2 as u32 (ReLU applied)
+#[pliron_op(
+    name = "nvvm.cvt_rn_relu_f16x2_f32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct CvtRnReluF16x2F32Op;
+
+impl CvtRnReluF16x2F32Op {
+    pub fn new(op: Ptr<Operation>) -> Self {
+        CvtRnReluF16x2F32Op { op }
+    }
+}
+
+/// Convert two f32 values to packed bf16x2 (u32) with fused ReLU.
+///
+/// Maps to PTX: `cvt.rn.relu.bf16x2.f32 d, hi, lo;`
+///
+/// # Operands
+///
+/// - `lo` (f32): value for bits `[15:0]`
+/// - `hi` (f32): value for bits `[31:16]`
+///
+/// # Results
+///
+/// - packed bf16x2 as u32 (ReLU applied)
+#[pliron_op(
+    name = "nvvm.cvt_rn_relu_bf16x2_f32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct CvtRnReluBf16x2F32Op;
+
+impl CvtRnReluBf16x2F32Op {
+    pub fn new(op: Ptr<Operation>) -> Self {
+        CvtRnReluBf16x2F32Op { op }
+    }
+}
+
+/// Convert two f32 values to packed bf16x2 (u32) with truncation rounding.
+///
+/// Maps to PTX: `cvt.rz.bf16x2.f32 d, hi, lo;`
+///
+/// # Operands
+///
+/// - `lo` (f32): value for bits `[15:0]`
+/// - `hi` (f32): value for bits `[31:16]`
+///
+/// # Results
+///
+/// - packed bf16x2 as u32
+#[pliron_op(
+    name = "nvvm.cvt_rz_bf16x2_f32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct CvtRzBf16x2F32Op;
+
+impl CvtRzBf16x2F32Op {
+    pub fn new(op: Ptr<Operation>) -> Self {
+        CvtRzBf16x2F32Op { op }
+    }
+}
+
 /// Register convert operations with the context.
 pub(super) fn register(ctx: &mut Context) {
     CvtF16x2F32Op::register(ctx);
+    CvtRzF16x2F32Op::register(ctx);
+    CvtRnReluF16x2F32Op::register(ctx);
+    CvtRnReluBf16x2F32Op::register(ctx);
+    CvtRzBf16x2F32Op::register(ctx);
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/convert.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/convert.rs
@@ -12,7 +12,9 @@ use super::super::helpers::emit_store_result_and_goto;
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::rvalue;
 use crate::translator::values::ValueMap;
-use dialect_nvvm::ops::CvtF16x2F32Op;
+use dialect_nvvm::ops::{
+    CvtF16x2F32Op, CvtRnReluBf16x2F32Op, CvtRnReluF16x2F32Op, CvtRzBf16x2F32Op, CvtRzF16x2F32Op,
+};
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -102,5 +104,305 @@ pub fn emit_cvt_f16x2_f32(
         block_map,
         loc,
         "cvt_f16x2_f32 call without target block",
+    )
+}
+
+/// Emit cvt_rz_f16x2_f32: convert two f32 values to packed f16x2 (u32)
+/// with truncation rounding.
+pub fn emit_cvt_rz_f16x2_f32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "cvt_rz_f16x2_f32 expects 2 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (lo_val, mut last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (hi_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+    let cvt_op = Operation::new(
+        ctx,
+        CvtRzF16x2F32Op::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    cvt_op.deref_mut(ctx).set_loc(loc.clone());
+    if let Some(prev) = last_op {
+        cvt_op.insert_after(ctx, prev);
+    } else {
+        cvt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = cvt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        cvt_op,
+        value_map,
+        block_map,
+        loc,
+        "cvt_rz_f16x2_f32 call without target block",
+    )
+}
+
+/// Emit cvt_rn_relu_f16x2_f32: convert two f32 values to packed f16x2 (u32)
+/// with fused ReLU.
+pub fn emit_cvt_rn_relu_f16x2_f32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "cvt_rn_relu_f16x2_f32 expects 2 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (lo_val, mut last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (hi_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+    let cvt_op = Operation::new(
+        ctx,
+        CvtRnReluF16x2F32Op::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    cvt_op.deref_mut(ctx).set_loc(loc.clone());
+    if let Some(prev) = last_op {
+        cvt_op.insert_after(ctx, prev);
+    } else {
+        cvt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = cvt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        cvt_op,
+        value_map,
+        block_map,
+        loc,
+        "cvt_rn_relu_f16x2_f32 call without target block",
+    )
+}
+
+/// Emit cvt_rn_relu_bf16x2_f32: convert two f32 values to packed bf16x2 (u32)
+/// with fused ReLU.
+pub fn emit_cvt_rn_relu_bf16x2_f32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "cvt_rn_relu_bf16x2_f32 expects 2 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (lo_val, mut last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (hi_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+    let cvt_op = Operation::new(
+        ctx,
+        CvtRnReluBf16x2F32Op::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    cvt_op.deref_mut(ctx).set_loc(loc.clone());
+    if let Some(prev) = last_op {
+        cvt_op.insert_after(ctx, prev);
+    } else {
+        cvt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = cvt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        cvt_op,
+        value_map,
+        block_map,
+        loc,
+        "cvt_rn_relu_bf16x2_f32 call without target block",
+    )
+}
+
+/// Emit cvt_rz_bf16x2_f32: convert two f32 values to packed bf16x2 (u32)
+/// with truncation rounding.
+pub fn emit_cvt_rz_bf16x2_f32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "cvt_rz_bf16x2_f32 expects 2 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (lo_val, mut last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (hi_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+    let cvt_op = Operation::new(
+        ctx,
+        CvtRzBf16x2F32Op::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    cvt_op.deref_mut(ctx).set_loc(loc.clone());
+    if let Some(prev) = last_op {
+        cvt_op.insert_after(ctx, prev);
+    } else {
+        cvt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = cvt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        cvt_op,
+        value_map,
+        block_map,
+        loc,
+        "cvt_rz_bf16x2_f32 call without target block",
     )
 }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2389,6 +2389,62 @@ fn try_dispatch_intrinsic(
             block_map,
             loc,
         )?)),
+        "cuda_device::convert::cvt_rz_f16x2_f32" => {
+            Ok(Some(intrinsics::convert::emit_cvt_rz_f16x2_f32(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+        "cuda_device::convert::cvt_rn_relu_f16x2_f32" => {
+            Ok(Some(intrinsics::convert::emit_cvt_rn_relu_f16x2_f32(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+        "cuda_device::convert::cvt_rn_relu_bf16x2_f32" => {
+            Ok(Some(intrinsics::convert::emit_cvt_rn_relu_bf16x2_f32(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+        "cuda_device::convert::cvt_rz_bf16x2_f32" => {
+            Ok(Some(intrinsics::convert::emit_cvt_rz_bf16x2_f32(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
 
         // =================================================================
         // Debug & Profiling (from intrinsics::debug)
@@ -3191,6 +3247,90 @@ fn try_dispatch_intrinsic(
         // bf16x2 packed arithmetic (from intrinsics::bf16x2)
         // =================================================================
         "cuda_device::bf16x2::fma_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_fma_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::add_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_add_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::sub_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_sub_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::mul_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_mul_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::min_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_min_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::max_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_max_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::neg_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_neg_bf16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::bf16x2::abs_bf16x2" => Ok(Some(intrinsics::bf16x2::emit_abs_bf16x2(
             ctx,
             body,
             args,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -35,41 +35,42 @@ use dialect_mir::ops::{
     MirUndefOp, MirUnreachableOp,
 };
 use dialect_nvvm::ops::{
-    ActiveMaskOp, BarWarpSyncOp, Barrier0Op, BreakpointOp, ClcQueryGetFirstCtaidXOp,
-    ClcQueryGetFirstCtaidYOp, ClcQueryGetFirstCtaidZOp, ClcQueryIsCanceledOp,
-    ClcTryCancelMulticastOp, ClcTryCancelOp, ClusterSyncOp, CpAsyncBulkCommitGroupOp,
-    CpAsyncBulkTensorG2sTile1dOp, CpAsyncBulkTensorG2sTile2dMulticastCg2Op,
-    CpAsyncBulkTensorG2sTile2dMulticastOp, CpAsyncBulkTensorG2sTile2dOp,
-    CpAsyncBulkTensorG2sTile3dOp, CpAsyncBulkTensorG2sTile4dOp, CpAsyncBulkTensorG2sTile5dOp,
-    CpAsyncBulkTensorS2gTile1dOp, CpAsyncBulkTensorS2gTile2dOp, CpAsyncBulkTensorS2gTile3dOp,
-    CpAsyncBulkTensorS2gTile4dOp, CpAsyncBulkTensorS2gTile5dOp, CpAsyncBulkWaitGroupOp,
-    CpAsyncBulkWaitGroupReadOp, CvtF16x2F32Op, CvtF32x2Bf16x2Op, DsmemReadU32Op,
+    AbsBf16x2Op, ActiveMaskOp, AddBf16x2Op, BarWarpSyncOp, Barrier0Op, BreakpointOp,
+    ClcQueryGetFirstCtaidXOp, ClcQueryGetFirstCtaidYOp, ClcQueryGetFirstCtaidZOp,
+    ClcQueryIsCanceledOp, ClcTryCancelMulticastOp, ClcTryCancelOp, ClusterSyncOp,
+    CpAsyncBulkCommitGroupOp, CpAsyncBulkTensorG2sTile1dOp,
+    CpAsyncBulkTensorG2sTile2dMulticastCg2Op, CpAsyncBulkTensorG2sTile2dMulticastOp,
+    CpAsyncBulkTensorG2sTile2dOp, CpAsyncBulkTensorG2sTile3dOp, CpAsyncBulkTensorG2sTile4dOp,
+    CpAsyncBulkTensorG2sTile5dOp, CpAsyncBulkTensorS2gTile1dOp, CpAsyncBulkTensorS2gTile2dOp,
+    CpAsyncBulkTensorS2gTile3dOp, CpAsyncBulkTensorS2gTile4dOp, CpAsyncBulkTensorS2gTile5dOp,
+    CpAsyncBulkWaitGroupOp, CpAsyncBulkWaitGroupReadOp, CvtF16x2F32Op, CvtF32x2Bf16x2Op,
+    CvtRnReluBf16x2F32Op, CvtRnReluF16x2F32Op, CvtRzBf16x2F32Op, CvtRzF16x2F32Op, DsmemReadU32Op,
     FenceProxyAsyncSharedCtaOp, FmaBf16x2Op, InlinePtxOp, MapaSharedClusterOp, MatchAllSyncI32Op,
-    MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveClusterOp,
+    MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MaxBf16x2Op, MbarrierArriveClusterOp,
     MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
     MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MbarrierTryWaitParitySharedOp,
-    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
-    NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
-    ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
-    ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp,
-    ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp,
-    ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp,
-    ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp,
-    ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op,
-    ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
-    StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
-    Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op,
-    Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp,
-    Tcgen05DeallocCg2Op, Tcgen05DeallocOp, Tcgen05FenceAfterThreadSyncOp,
-    Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp, Tcgen05Ld16x256bX8PureOp,
-    Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op, Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op,
-    Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op, Tcgen05RelinquishAllocPermitOp,
-    Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp, TrapOp,
-    VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp, WgmmaCommitGroupSyncAlignedOp,
-    WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaWaitGroupSyncAlignedOp,
+    MbarrierTryWaitSharedOp, MinBf16x2Op, MulBf16x2Op, NanosleepOp, NegBf16x2Op,
+    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp,
+    ReadPtxSregClock64Op, ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp,
+    ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp,
+    ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp,
+    ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregEnvReg1Op,
+    ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp,
+    ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp,
+    ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp,
+    ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncDownF32Op,
+    ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op, ShflSyncUpI32Op,
+    StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op, StmatrixM8n8X4TransOp, SubBf16x2Op,
+    Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op, Tcgen05CommitMulticastCg2Op,
+    Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op, Tcgen05CommitSharedClusterOp,
+    Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp, Tcgen05DeallocCg2Op, Tcgen05DeallocOp,
+    Tcgen05FenceAfterThreadSyncOp, Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp,
+    Tcgen05Ld16x256bX8PureOp, Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op,
+    Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op, Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op,
+    Tcgen05RelinquishAllocPermitOp, Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp,
+    ThreadfenceSystemOp, TrapOp, VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp,
+    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp,
+    WgmmaMmaM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -2148,6 +2149,74 @@ impl MirToLlvmConversion for CvtF16x2F32Op {
     }
 }
 
+#[op_interface_impl]
+impl MirToLlvmConversion for CvtRzF16x2F32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::convert::convert_cvt_rz_f16x2_f32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for CvtRnReluF16x2F32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::convert::convert_cvt_rn_relu_f16x2_f32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for CvtRnReluBf16x2F32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::convert::convert_cvt_rn_relu_bf16x2_f32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for CvtRzBf16x2F32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::convert::convert_cvt_rz_bf16x2_f32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
 // ---- NVVM Tcgen05 ops ------------------------------------------------------
 
 #[op_interface_impl]
@@ -2417,6 +2486,125 @@ impl MirToLlvmConversion for FmaBf16x2Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::bf16x2::convert_fma_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for AddBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_add_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for SubBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_sub_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MulBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_mul_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MinBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_min_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MaxBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_max_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for NegBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_neg_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for AbsBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bf16x2::convert_abs_bf16x2(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/convert.rs
+++ b/crates/mir-lower/src/convert/intrinsics/convert.rs
@@ -5,9 +5,13 @@
 
 //! Type conversion intrinsic lowering.
 //!
-//! | Operation     | PTX                           |
-//! |---------------|-------------------------------|
-//! | `CvtF16x2F32` | `cvt.rn.f16x2.f32 d, hi, lo;` |
+//! | Operation              | PTX                                    |
+//! |------------------------|----------------------------------------|
+//! | `CvtF16x2F32`         | `cvt.rn.f16x2.f32 d, hi, lo;`         |
+//! | `CvtRzF16x2F32`       | `cvt.rz.f16x2.f32 d, hi, lo;`         |
+//! | `CvtRnReluF16x2F32`   | `cvt.rn.relu.f16x2.f32 d, hi, lo;`    |
+//! | `CvtRnReluBf16x2F32`  | `cvt.rn.relu.bf16x2.f32 d, hi, lo;`   |
+//! | `CvtRzBf16x2F32`      | `cvt.rz.bf16x2.f32 d, hi, lo;`        |
 
 use llvm_export::ops::{self as llvm, InlineAsmOpExt};
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -49,6 +53,134 @@ pub(crate) fn convert_cvt_f16x2_f32(
         i32_ty.into(),
         vec![lo_val, hi_val],
         "cvt.rn.f16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        llvm_export::ops::AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `cvt.rz.f16x2.f32`: pack two f32 values into f16x2 (u32)
+/// with truncation rounding.
+pub(crate) fn convert_cvt_rz_f16x2_f32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 2 {
+        return pliron::input_err_noloc!("cvt_rz_f16x2_f32 requires 2 operands");
+    }
+
+    let lo_val = operands[0];
+    let hi_val = operands[1];
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![lo_val, hi_val],
+        "cvt.rz.f16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        llvm_export::ops::AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `cvt.rn.relu.f16x2.f32`: pack two f32 values into f16x2 (u32)
+/// with fused ReLU.
+pub(crate) fn convert_cvt_rn_relu_f16x2_f32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 2 {
+        return pliron::input_err_noloc!("cvt_rn_relu_f16x2_f32 requires 2 operands");
+    }
+
+    let lo_val = operands[0];
+    let hi_val = operands[1];
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![lo_val, hi_val],
+        "cvt.rn.relu.f16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        llvm_export::ops::AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `cvt.rn.relu.bf16x2.f32`: pack two f32 values into bf16x2 (u32)
+/// with fused ReLU.
+pub(crate) fn convert_cvt_rn_relu_bf16x2_f32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 2 {
+        return pliron::input_err_noloc!("cvt_rn_relu_bf16x2_f32 requires 2 operands");
+    }
+
+    let lo_val = operands[0];
+    let hi_val = operands[1];
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![lo_val, hi_val],
+        "cvt.rn.relu.bf16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        llvm_export::ops::AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `cvt.rz.bf16x2.f32`: pack two f32 values into bf16x2 (u32)
+/// with truncation rounding.
+pub(crate) fn convert_cvt_rz_bf16x2_f32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 2 {
+        return pliron::input_err_noloc!("cvt_rz_bf16x2_f32 requires 2 operands");
+    }
+
+    let lo_val = operands[0];
+    let hi_val = operands[1];
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![lo_val, hi_val],
+        "cvt.rz.bf16x2.f32 $0, $2, $1;",
         "=r,f,f",
         llvm_export::ops::AsmKind::Pure,
     );

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -1039,6 +1039,110 @@ fn test_cvt_f16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn test_cvt_rz_f16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
+
+    let lo_val = entry.deref(&ctx).get_argument(0);
+    let hi_val = entry.deref(&ctx).get_argument(1);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::CvtRzF16x2F32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "cvt.rz.f16x2.f32")
+}
+
+#[test]
+fn test_cvt_rn_relu_f16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
+
+    let lo_val = entry.deref(&ctx).get_argument(0);
+    let hi_val = entry.deref(&ctx).get_argument(1);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::CvtRnReluF16x2F32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "cvt.rn.relu.f16x2.f32")
+}
+
+#[test]
+fn test_cvt_rn_relu_bf16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
+
+    let lo_val = entry.deref(&ctx).get_argument(0);
+    let hi_val = entry.deref(&ctx).get_argument(1);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::CvtRnReluBf16x2F32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "cvt.rn.relu.bf16x2.f32")
+}
+
+#[test]
+fn test_cvt_rz_bf16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
+
+    let lo_val = entry.deref(&ctx).get_argument(0);
+    let hi_val = entry.deref(&ctx).get_argument(1);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::CvtRzBf16x2F32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![lo_val, hi_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "cvt.rz.bf16x2.f32")
+}
+
+#[test]
 fn test_inline_ptx_op_lowers_to_inline_asm_attrs() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 


### PR DESCRIPTION
## Summary
- Add four new packed type conversion intrinsics: `cvt_rz_f16x2_f32`, `cvt_rn_relu_f16x2_f32`, `cvt_rn_relu_bf16x2_f32`, and `cvt_rz_bf16x2_f32`
- Each takes two `f32` inputs and returns a `u32` (packed f16x2 or bf16x2), mapping to their respective PTX `cvt` instructions via pure inline asm
- Full pipeline wired: cuda-device stubs, dialect-nvvm ops, mir-importer translation, mir-lower inline-asm lowering, and lowering tests

Closes #47
Related to #27

## Test plan
- [x] `cargo check -p dialect-nvvm -p mir-lower` passes
- [x] `cargo check -p mir-lower --tests` passes (lowering tests compile)
- [x] `cargo fmt --all` applied
- [ ] CI passes