### PR TITLE
feat: integer dot products (dp4a, dp2a)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,82 @@
+---
+name: fork-ci
+
+# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Runs on every push to any branch except main (upstream CI covers main).
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt for the pinned nightly
+        run: rustup component add rustfmt
+
+      - name: Check root workspace formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (no-cuda packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clippy on packages that don't need CUDA
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo clippy \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols \
+            -- -D warnings
+
+  unit-tests:
+    name: test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - llvm-export
+          - dialect-mir
+          - dialect-nvvm
+          - mir-lower
+          - mir-importer
+          - oxide-artifacts
+          - reserved-oxide-symbols
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run crate unit tests
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo test -p ${{ matrix.package }} --all-targets

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,8 +1,11 @@
 ---
 name: fork-ci
 
-# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# Enhanced CI for our PR branches. Catches formatting, clippy, rustdoc, and
 # unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Also runs additional quality checks that go beyond upstream CI to ensure
+# clean PRs before upstreaming.
+#
 # Runs on every push to any branch except main (upstream CI covers main).
 
 on:
@@ -80,3 +83,163 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           cargo test -p ${{ matrix.package }} --all-targets
+
+  rustdoc:
+    name: rustdoc (no warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with -D warnings
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          export RUSTDOCFLAGS="-D warnings"
+
+          cargo doc --no-deps \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols
+
+  # ---- Fork-only quality gates (beyond upstream CI) ----
+  # These catch patterns the maintainer has historically fixed in contributor
+  # PRs, saving a review round-trip.
+
+  style-checks:
+    name: style (owner fixup patterns)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for diff against main
+
+      - name: Detect em-dashes in added lines
+        run: |
+          # Only check lines we actually added (not pre-existing upstream code)
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -n '—' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Em-dash (U+2014) found in added lines"
+            echo "$hits"
+            echo ""
+            echo "The maintainer consistently removes em-dashes from doc comments."
+            echo "Replace with commas, semicolons, or parentheses."
+            exit 1
+          fi
+          echo "Em-dash check: PASS"
+
+      - name: Detect bare brackets in doc comments (warning)
+        run: |
+          # Check added doc comment lines for bare [text] that are NOT
+          # markdown links [text](url), intra-doc links [`item`], or backtick-wrapped
+          hits=$(git diff origin/main...HEAD -- '*.rs' \
+            | grep '^+' | grep -v '^+++' \
+            | grep '///' \
+            | grep -P '\[(?!`)' \
+            | grep -vP '\]\(' \
+            | grep -vP '`[^`]*\[' \
+            || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Possible bare brackets in doc comments (may cause rustdoc errors)"
+            echo "$hits"
+            echo ""
+            echo "Wrap in backticks or use a markdown link."
+          else
+            echo "Bare bracket check: PASS"
+          fi
+          # Warning only — some brackets are valid intra-doc links
+
+      - name: Check SPDX license headers on new files
+        run: |
+          new_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '*.rs' 2>/dev/null || true)
+          if [ -z "$new_files" ]; then
+            echo "No new .rs files"
+            exit 0
+          fi
+
+          found=0
+          for f in $new_files; do
+            if [ -f "$f" ]; then
+              has_spdx=$(head -4 "$f" | grep -c 'SPDX' || true)
+              if [ "$has_spdx" -eq 0 ]; then
+                echo "::error file=$f::Missing SPDX license header"
+                found=1
+              fi
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "New .rs files must start with the SPDX header block."
+            exit 1
+          fi
+
+      - name: Check for unnecessary &mut on type getters
+        run: |
+          # Only check lines we added
+          diff_added=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$diff_added" ]; then
+            echo "No added lines"
+            exit 0
+          fi
+
+          found=0
+          for pattern in 'FP32Type::get(&mut' 'FP64Type::get(&mut' 'VoidType::get(&mut' 'FP16Type::get(&mut'; do
+            hits=$(echo "$diff_added" | grep "$pattern" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::$pattern found in added lines (takes &Context, not &mut Context)"
+              echo "$hits"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "pliron type getters (FP32Type, FP64Type, VoidType, FP16Type) take &Context."
+            echo "Note: IntegerType::get, PointerType::get, MirPtrType::get_generic legitimately take &mut Context."
+            exit 1
+          fi
+          echo "Type getter mutability check: PASS"
+
+      - name: Check for float equality assertions (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -P 'assert_eq!\(.*\d+\.\d+f(32|64)' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Float equality assertion in added lines (clippy::float_cmp)"
+            echo "$hits"
+            echo ""
+            echo 'Use: assert!((val - expected).abs() < 1e-6, "got {}, want {}", val, expected);'
+          else
+            echo "Float equality check: PASS"
+          fi
+          # Warning only
+
+      - name: Check for useless vec patterns (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep '&vec!\[' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::&vec![...] in added lines (clippy::useless_vec)"
+            echo "$hits"
+            echo ""
+            echo "Use &[...] slice literal instead."
+          else
+            echo "Useless vec check: PASS"
+          fi
+          # Warning only
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check dependencies
+        run: cargo deny check

--- a/crates/cuda-device/src/dotprod.rs
+++ b/crates/cuda-device/src/dotprod.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integer dot product intrinsics (`dp4a`, `dp2a`).
+//!
+//! These instructions perform packed-byte or packed-half dot products with
+//! accumulation, useful for integer quantised inference on Ampere+ GPUs.
+//!
+//! # `dp4a` — 4-element byte dot product
+//!
+//! Treats `a` and `b` as vectors of 4 packed bytes, multiplies corresponding
+//! elements, sums the products, and adds the scalar accumulator `c`:
+//!
+//! ```text
+//! d = c + a.byte0*b.byte0 + a.byte1*b.byte1 + a.byte2*b.byte2 + a.byte3*b.byte3
+//! ```
+//!
+//! # `dp2a` — 2-element half-word × byte dot product
+//!
+//! Treats `a` as two packed 16-bit values and `b` as packed bytes (lower 2
+//! bytes selected by the `.lo` qualifier):
+//!
+//! ```text
+//! d = c + a.half0*b.byte0 + a.half1*b.byte1
+//! ```
+//!
+//! # Supported on
+//!
+//! - `sm_61+` (`dp4a`, `dp2a`)
+
+/// 4-element signed byte dot product with accumulation.
+///
+/// Interprets `a` and `b` as 4 packed **signed** bytes each, computes the
+/// dot product, and adds the signed 32-bit accumulator `c`.
+///
+/// # PTX
+///
+/// ```ptx
+/// dp4a.s32.s32 %d, %a, %b, %c;
+/// ```
+#[inline(never)]
+pub unsafe fn dp4a_s32(a: u32, b: u32, c: i32) -> i32 {
+    let _ = (a, b, c);
+    unreachable!("dp4a_s32 called outside CUDA kernel context")
+}
+
+/// 4-element unsigned byte dot product with accumulation.
+///
+/// Interprets `a` and `b` as 4 packed **unsigned** bytes each, computes the
+/// dot product, and adds the unsigned 32-bit accumulator `c`.
+///
+/// # PTX
+///
+/// ```ptx
+/// dp4a.u32.u32 %d, %a, %b, %c;
+/// ```
+#[inline(never)]
+pub unsafe fn dp4a_u32(a: u32, b: u32, c: u32) -> u32 {
+    let _ = (a, b, c);
+    unreachable!("dp4a_u32 called outside CUDA kernel context")
+}
+
+/// 2-element signed half-word × byte dot product with accumulation (lower half).
+///
+/// Interprets `a` as 2 packed **signed** 16-bit values and `b`'s lower 2
+/// bytes as signed values. Computes `d = c + a.half0*b.byte0 + a.half1*b.byte1`.
+///
+/// # PTX
+///
+/// ```ptx
+/// dp2a.lo.s32.s32 %d, %a, %b, %c;
+/// ```
+#[inline(never)]
+pub unsafe fn dp2a_s32(a: u32, b: u32, c: i32) -> i32 {
+    let _ = (a, b, c);
+    unreachable!("dp2a_s32 called outside CUDA kernel context")
+}
+
+/// 2-element unsigned half-word × byte dot product with accumulation (lower half).
+///
+/// Interprets `a` as 2 packed **unsigned** 16-bit values and `b`'s lower 2
+/// bytes as unsigned values. Computes `d = c + a.half0*b.byte0 + a.half1*b.byte1`.
+///
+/// # PTX
+///
+/// ```ptx
+/// dp2a.lo.u32.u32 %d, %a, %b, %c;
+/// ```
+#[inline(never)]
+pub unsafe fn dp2a_u32(a: u32, b: u32, c: u32) -> u32 {
+    let _ = (a, b, c);
+    unreachable!("dp2a_u32 called outside CUDA kernel context")
+}

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -23,6 +23,7 @@ pub mod cooperative_groups;
 pub mod cusimd;
 pub mod debug;
 pub mod disjoint;
+pub mod dotprod;
 pub mod fence;
 pub mod grid;
 pub mod ptx;

--- a/crates/dialect-nvvm/src/ops/dotprod.rs
+++ b/crates/dialect-nvvm/src/ops/dotprod.rs
@@ -1,0 +1,144 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integer dot product operations (`dp4a`, `dp2a`).
+//!
+//! These are single-thread, non-convergent packed integer dot product
+//! instructions lowered to inline PTX. Available from `sm_61+`.
+
+use pliron::{
+    builtin::op_interfaces::{NOpdsInterface, NResultsInterface},
+    context::Context,
+    context::Ptr,
+    op::Op,
+    operation::Operation,
+};
+use pliron_derive::pliron_op;
+
+/// Signed 4-element byte dot product with accumulation: `d = c + dot(a, b)`.
+///
+/// `a` and `b` are each 4 packed signed bytes; `c` and `d` are signed 32-bit.
+///
+/// PTX: `dp4a.s32.s32 $0, $1, $2, $3;`  (requires `sm_61+`)
+///
+/// # Operands
+///
+/// - `a` (u32): packed 4×i8
+/// - `b` (u32): packed 4×i8
+/// - `c` (i32): accumulator
+///
+/// # Results
+///
+/// - `d` (i32): accumulated dot product
+#[pliron_op(
+    name = "nvvm.dp4a_s32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct Dp4aS32Op;
+
+impl Dp4aS32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Dp4aS32Op { op }
+    }
+}
+
+/// Unsigned 4-element byte dot product with accumulation: `d = c + dot(a, b)`.
+///
+/// `a` and `b` are each 4 packed unsigned bytes; `c` and `d` are unsigned 32-bit.
+///
+/// PTX: `dp4a.u32.u32 $0, $1, $2, $3;`  (requires `sm_61+`)
+///
+/// # Operands
+///
+/// - `a` (u32): packed 4×u8
+/// - `b` (u32): packed 4×u8
+/// - `c` (u32): accumulator
+///
+/// # Results
+///
+/// - `d` (u32): accumulated dot product
+#[pliron_op(
+    name = "nvvm.dp4a_u32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct Dp4aU32Op;
+
+impl Dp4aU32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Dp4aU32Op { op }
+    }
+}
+
+/// Signed 2-element half-word × byte dot product (lower half): `d = c + dot(a, b)`.
+///
+/// `a` is 2 packed signed 16-bit values; `b`'s lower 2 bytes are used.
+///
+/// PTX: `dp2a.lo.s32.s32 $0, $1, $2, $3;`  (requires `sm_61+`)
+///
+/// # Operands
+///
+/// - `a` (u32): packed 2×i16
+/// - `b` (u32): packed bytes (lower 2 used)
+/// - `c` (i32): accumulator
+///
+/// # Results
+///
+/// - `d` (i32): accumulated dot product
+#[pliron_op(
+    name = "nvvm.dp2a_s32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct Dp2aS32Op;
+
+impl Dp2aS32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Dp2aS32Op { op }
+    }
+}
+
+/// Unsigned 2-element half-word × byte dot product (lower half): `d = c + dot(a, b)`.
+///
+/// `a` is 2 packed unsigned 16-bit values; `b`'s lower 2 bytes are used.
+///
+/// PTX: `dp2a.lo.u32.u32 $0, $1, $2, $3;`  (requires `sm_61+`)
+///
+/// # Operands
+///
+/// - `a` (u32): packed 2×u16
+/// - `b` (u32): packed bytes (lower 2 used)
+/// - `c` (u32): accumulator
+///
+/// # Results
+///
+/// - `d` (u32): accumulated dot product
+#[pliron_op(
+    name = "nvvm.dp2a_u32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct Dp2aU32Op;
+
+impl Dp2aU32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Dp2aU32Op { op }
+    }
+}
+
+/// Register dot product operations with the context.
+pub(super) fn register(ctx: &mut Context) {
+    Dp4aS32Op::register(ctx);
+    Dp4aU32Op::register(ctx);
+    Dp2aS32Op::register(ctx);
+    Dp2aU32Op::register(ctx);
+}

--- a/crates/dialect-nvvm/src/ops/mod.rs
+++ b/crates/dialect-nvvm/src/ops/mod.rs
@@ -102,6 +102,7 @@ mod clc;
 mod cluster;
 mod convert;
 mod debug;
+mod dotprod;
 mod grid;
 mod mbarrier;
 mod stmatrix;
@@ -121,6 +122,7 @@ pub use clc::*;
 pub use cluster::*;
 pub use convert::*;
 pub use debug::*;
+pub use dotprod::*;
 pub use grid::*;
 pub use mbarrier::*;
 pub use stmatrix::*;
@@ -150,4 +152,5 @@ pub fn register(ctx: &mut Context) {
     tcgen05::register(ctx);
     stmatrix::register(ctx);
     debug::register(ctx);
+    dotprod::register(ctx);
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/dotprod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/dotprod.rs
@@ -1,0 +1,393 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integer dot product intrinsics (`dp4a`, `dp2a`).
+//!
+//! Translates `cuda_device::dotprod::*` calls into `dialect-nvvm` dot product
+//! operations.
+
+use super::super::helpers::emit_store_result_and_goto;
+use crate::error::{TranslationErr, TranslationResult};
+use crate::translator::rvalue;
+use crate::translator::values::ValueMap;
+use dialect_nvvm::ops::{Dp2aS32Op, Dp2aU32Op, Dp4aS32Op, Dp4aU32Op};
+use pliron::basic_block::BasicBlock;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::input_err;
+use pliron::location::{Located, Location};
+use pliron::op::Op;
+use pliron::operation::Operation;
+use rustc_public::mir;
+
+/// Emit `dp4a_s32`: signed 4-element byte dot product + accumulate.
+///
+/// Args: `(a: u32, b: u32, c: i32)`. Returns: `i32`.
+pub fn emit_dp4a_s32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "dp4a_s32 expects 3 arguments (a: u32, b: u32, c: i32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (c_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signed);
+
+    let dp_op = Operation::new(
+        ctx,
+        Dp4aS32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    dp_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        dp_op.insert_after(ctx, prev);
+    } else {
+        dp_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = dp_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        dp_op,
+        value_map,
+        block_map,
+        loc,
+        "dp4a_s32 call without target block",
+    )
+}
+
+/// Emit `dp4a_u32`: unsigned 4-element byte dot product + accumulate.
+///
+/// Args: `(a: u32, b: u32, c: u32)`. Returns: `u32`.
+pub fn emit_dp4a_u32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "dp4a_u32 expects 3 arguments (a: u32, b: u32, c: u32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (c_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let dp_op = Operation::new(
+        ctx,
+        Dp4aU32Op::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    dp_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        dp_op.insert_after(ctx, prev);
+    } else {
+        dp_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = dp_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        dp_op,
+        value_map,
+        block_map,
+        loc,
+        "dp4a_u32 call without target block",
+    )
+}
+
+/// Emit `dp2a_s32`: signed 2-element half-word × byte dot product + accumulate.
+///
+/// Args: `(a: u32, b: u32, c: i32)`. Returns: `i32`.
+pub fn emit_dp2a_s32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "dp2a_s32 expects 3 arguments (a: u32, b: u32, c: i32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (c_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signed);
+
+    let dp_op = Operation::new(
+        ctx,
+        Dp2aS32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    dp_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        dp_op.insert_after(ctx, prev);
+    } else {
+        dp_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = dp_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        dp_op,
+        value_map,
+        block_map,
+        loc,
+        "dp2a_s32 call without target block",
+    )
+}
+
+/// Emit `dp2a_u32`: unsigned 2-element half-word × byte dot product + accumulate.
+///
+/// Args: `(a: u32, b: u32, c: u32)`. Returns: `u32`.
+pub fn emit_dp2a_u32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "dp2a_u32 expects 3 arguments (a: u32, b: u32, c: u32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (c_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let dp_op = Operation::new(
+        ctx,
+        Dp2aU32Op::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    dp_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        dp_op.insert_after(ctx, prev);
+    } else {
+        dp_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = dp_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        dp_op,
+        value_map,
+        block_map,
+        loc,
+        "dp2a_u32 call without target block",
+    )
+}

--- a/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
@@ -44,6 +44,7 @@ pub mod clc;
 pub mod cluster;
 pub mod convert;
 pub mod debug;
+pub mod dotprod;
 pub mod float_math;
 pub mod indexing;
 pub mod memory;

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3204,6 +3204,58 @@ fn try_dispatch_intrinsic(
         )?)),
 
         // =================================================================
+        // Integer dot products (from intrinsics::dotprod)
+        // =================================================================
+        "cuda_device::dotprod::dp4a_s32" => Ok(Some(intrinsics::dotprod::emit_dp4a_s32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::dotprod::dp4a_u32" => Ok(Some(intrinsics::dotprod::emit_dp4a_u32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::dotprod::dp2a_s32" => Ok(Some(intrinsics::dotprod::emit_dp2a_s32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::dotprod::dp2a_u32" => Ok(Some(intrinsics::dotprod::emit_dp2a_u32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+
+        // =================================================================
         // CLC - Cluster Launch Control (from intrinsics::clc)
         // =================================================================
         "cuda_device::clc::clc_try_cancel" => Ok(Some(intrinsics::clc::emit_clc_try_cancel(

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -43,23 +43,23 @@ use dialect_nvvm::ops::{
     CpAsyncBulkTensorG2sTile3dOp, CpAsyncBulkTensorG2sTile4dOp, CpAsyncBulkTensorG2sTile5dOp,
     CpAsyncBulkTensorS2gTile1dOp, CpAsyncBulkTensorS2gTile2dOp, CpAsyncBulkTensorS2gTile3dOp,
     CpAsyncBulkTensorS2gTile4dOp, CpAsyncBulkTensorS2gTile5dOp, CpAsyncBulkWaitGroupOp,
-    CpAsyncBulkWaitGroupReadOp, CvtF16x2F32Op, CvtF32x2Bf16x2Op, DsmemReadU32Op,
-    FenceProxyAsyncSharedCtaOp, FmaBf16x2Op, InlinePtxOp, MapaSharedClusterOp, MatchAllSyncI32Op,
-    MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveClusterOp,
-    MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
-    MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MbarrierTryWaitParitySharedOp,
-    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
-    NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
-    ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
-    ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp,
-    ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp,
-    ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp,
-    ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp,
-    ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op,
-    ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
-    StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
+    CpAsyncBulkWaitGroupReadOp, CvtF16x2F32Op, CvtF32x2Bf16x2Op, Dp2aS32Op, Dp2aU32Op, Dp4aS32Op,
+    Dp4aU32Op, DsmemReadU32Op, FenceProxyAsyncSharedCtaOp, FmaBf16x2Op, InlinePtxOp,
+    MapaSharedClusterOp, MatchAllSyncI32Op, MatchAllSyncI64Op, MatchAnySyncI32Op,
+    MatchAnySyncI64Op, MbarrierArriveClusterOp, MbarrierArriveExpectTxSharedOp,
+    MbarrierArriveSharedOp, MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
+    MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp,
+    NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op,
+    ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp,
+    ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp,
+    ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp,
+    ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op,
+    ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp,
+    ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp, ReadPtxSregNtidYOp,
+    ReadPtxSregNtidZOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReduxSyncAddOp,
+    ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op,
+    ShflSyncIdxI32Op, ShflSyncUpF32Op, ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp,
+    StmatrixM8n8X4Op, StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
     Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op,
     Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp,
     Tcgen05DeallocCg2Op, Tcgen05DeallocOp, Tcgen05FenceAfterThreadSyncOp,
@@ -2417,6 +2417,74 @@ impl MirToLlvmConversion for FmaBf16x2Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::bf16x2::convert_fma_bf16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for Dp4aS32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::dotprod::convert_dp4a_s32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for Dp4aU32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::dotprod::convert_dp4a_u32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for Dp2aS32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::dotprod::convert_dp2a_s32(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for Dp2aU32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::dotprod::convert_dp2a_u32(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/dotprod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/dotprod.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integer dot product intrinsic conversions (`dp4a`, `dp2a`).
+//!
+//! Each op is lowered to inline PTX assembly (non-convergent, pure).
+
+use llvm_export::ops::{self as llvm, AsmKind, InlineAsmOpExt};
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::inserter::Inserter;
+use pliron::irbuild::rewriter::Rewriter;
+use pliron::op::Op;
+use pliron::operation::Operation;
+use pliron::result::Result;
+
+/// Convert `nvvm.dp4a_s32` to inline PTX.
+///
+/// `dp4a.s32.s32 %d, %a, %b, %c;` (per-thread arithmetic, non-convergent).
+pub(crate) fn convert_dp4a_s32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!("dp4a_s32 requires 3 operands");
+    }
+
+    let a_val = operands[0];
+    let b_val = operands[1];
+    let c_val = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a_val, b_val, c_val],
+        "dp4a.s32.s32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `nvvm.dp4a_u32` to inline PTX.
+///
+/// `dp4a.u32.u32 %d, %a, %b, %c;` (per-thread arithmetic, non-convergent).
+pub(crate) fn convert_dp4a_u32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!("dp4a_u32 requires 3 operands");
+    }
+
+    let a_val = operands[0];
+    let b_val = operands[1];
+    let c_val = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a_val, b_val, c_val],
+        "dp4a.u32.u32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `nvvm.dp2a_s32` to inline PTX.
+///
+/// `dp2a.lo.s32.s32 %d, %a, %b, %c;` (per-thread arithmetic, non-convergent).
+pub(crate) fn convert_dp2a_s32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!("dp2a_s32 requires 3 operands");
+    }
+
+    let a_val = operands[0];
+    let b_val = operands[1];
+    let c_val = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a_val, b_val, c_val],
+        "dp2a.lo.s32.s32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `nvvm.dp2a_u32` to inline PTX.
+///
+/// `dp2a.lo.u32.u32 %d, %a, %b, %c;` (per-thread arithmetic, non-convergent).
+pub(crate) fn convert_dp2a_u32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!("dp2a_u32 requires 3 operands");
+    }
+
+    let a_val = operands[0];
+    let b_val = operands[1];
+    let c_val = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a_val, b_val, c_val],
+        "dp2a.lo.u32.u32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}

--- a/crates/mir-lower/src/convert/intrinsics/mod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mod.rs
@@ -79,6 +79,7 @@ pub mod cluster;
 pub mod common;
 pub mod convert;
 pub mod debug;
+pub mod dotprod;
 pub mod mbarrier;
 pub mod stmatrix;
 pub mod tcgen05;

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -1337,3 +1337,115 @@ fn test_bool_phi_cmp_lowers_to_unsigned_i1_icmp() -> Result<(), anyhow::Error> {
     );
     Ok(())
 }
+
+// =============================================================================
+// Integer dot product (dp4a / dp2a) lowering tests
+// =============================================================================
+
+#[test]
+fn test_dp4a_s32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
+
+    let a_val = entry.deref(&ctx).get_argument(0);
+    let b_val = entry.deref(&ctx).get_argument(1);
+    let c_val = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::Dp4aS32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "dp4a.s32.s32")
+}
+
+#[test]
+fn test_dp4a_u32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
+
+    let a_val = entry.deref(&ctx).get_argument(0);
+    let b_val = entry.deref(&ctx).get_argument(1);
+    let c_val = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::Dp4aU32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "dp4a.u32.u32")
+}
+
+#[test]
+fn test_dp2a_s32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
+
+    let a_val = entry.deref(&ctx).get_argument(0);
+    let b_val = entry.deref(&ctx).get_argument(1);
+    let c_val = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::Dp2aS32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "dp2a.lo.s32.s32")
+}
+
+#[test]
+fn test_dp2a_u32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) =
+        build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
+
+    let a_val = entry.deref(&ctx).get_argument(0);
+    let b_val = entry.deref(&ctx).get_argument(1);
+    let c_val = entry.deref(&ctx).get_argument(2);
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::Dp2aU32Op::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    assert_inline_asm_lowering(&mut ctx, module_ptr, "dp2a.lo.u32.u32")
+}


### PR DESCRIPTION
## Summary

- Add `dp4a_s32` / `dp4a_u32` (4-element byte dot product + accumulate) and `dp2a_s32` / `dp2a_u32` (2-element half-word x byte dot product + accumulate) intrinsics across the full pipeline: cuda-device stubs, dialect-nvvm ops, mir-importer translation, and mir-lower inline PTX lowering.
- Each operation takes 3 inputs (a, b, c) and produces 1 output (d = c + dot(a, b)), lowered to pure inline PTX assembly (`dp4a.{s32,u32}.{s32,u32}` and `dp2a.lo.{s32,u32}.{s32,u32}`).
- Add 4 lowering tests verifying the inline asm output contains the expected PTX mnemonics.

Closes #48
Ref #27

## Test plan

- [x] `cargo check -p dialect-nvvm -p mir-lower` passes
- [x] `cargo test -p mir-lower --test lowering_test -- dp` passes (4/4 new tests)
- [x] Full `cargo test -p mir-lower --test lowering_test` passes (13/13 tests including 9 existing)