### PR TITLE
feat: packed atomic add (f16x2, bf16x2)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,82 @@
+---
+name: fork-ci
+
+# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Runs on every push to any branch except main (upstream CI covers main).
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt for the pinned nightly
+        run: rustup component add rustfmt
+
+      - name: Check root workspace formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (no-cuda packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clippy on packages that don't need CUDA
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo clippy \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols \
+            -- -D warnings
+
+  unit-tests:
+    name: test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - llvm-export
+          - dialect-mir
+          - dialect-nvvm
+          - mir-lower
+          - mir-importer
+          - oxide-artifacts
+          - reserved-oxide-symbols
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run crate unit tests
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo test -p ${{ matrix.package }} --all-targets

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,8 +1,11 @@
 ---
 name: fork-ci
 
-# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# Enhanced CI for our PR branches. Catches formatting, clippy, rustdoc, and
 # unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Also runs additional quality checks that go beyond upstream CI to ensure
+# clean PRs before upstreaming.
+#
 # Runs on every push to any branch except main (upstream CI covers main).
 
 on:
@@ -80,3 +83,163 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           cargo test -p ${{ matrix.package }} --all-targets
+
+  rustdoc:
+    name: rustdoc (no warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with -D warnings
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          export RUSTDOCFLAGS="-D warnings"
+
+          cargo doc --no-deps \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols
+
+  # ---- Fork-only quality gates (beyond upstream CI) ----
+  # These catch patterns the maintainer has historically fixed in contributor
+  # PRs, saving a review round-trip.
+
+  style-checks:
+    name: style (owner fixup patterns)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for diff against main
+
+      - name: Detect em-dashes in added lines
+        run: |
+          # Only check lines we actually added (not pre-existing upstream code)
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -n '—' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Em-dash (U+2014) found in added lines"
+            echo "$hits"
+            echo ""
+            echo "The maintainer consistently removes em-dashes from doc comments."
+            echo "Replace with commas, semicolons, or parentheses."
+            exit 1
+          fi
+          echo "Em-dash check: PASS"
+
+      - name: Detect bare brackets in doc comments (warning)
+        run: |
+          # Check added doc comment lines for bare [text] that are NOT
+          # markdown links [text](url), intra-doc links [`item`], or backtick-wrapped
+          hits=$(git diff origin/main...HEAD -- '*.rs' \
+            | grep '^+' | grep -v '^+++' \
+            | grep '///' \
+            | grep -P '\[(?!`)' \
+            | grep -vP '\]\(' \
+            | grep -vP '`[^`]*\[' \
+            || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Possible bare brackets in doc comments (may cause rustdoc errors)"
+            echo "$hits"
+            echo ""
+            echo "Wrap in backticks or use a markdown link."
+          else
+            echo "Bare bracket check: PASS"
+          fi
+          # Warning only — some brackets are valid intra-doc links
+
+      - name: Check SPDX license headers on new files
+        run: |
+          new_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '*.rs' 2>/dev/null || true)
+          if [ -z "$new_files" ]; then
+            echo "No new .rs files"
+            exit 0
+          fi
+
+          found=0
+          for f in $new_files; do
+            if [ -f "$f" ]; then
+              has_spdx=$(head -4 "$f" | grep -c 'SPDX' || true)
+              if [ "$has_spdx" -eq 0 ]; then
+                echo "::error file=$f::Missing SPDX license header"
+                found=1
+              fi
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "New .rs files must start with the SPDX header block."
+            exit 1
+          fi
+
+      - name: Check for unnecessary &mut on type getters
+        run: |
+          # Only check lines we added
+          diff_added=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$diff_added" ]; then
+            echo "No added lines"
+            exit 0
+          fi
+
+          found=0
+          for pattern in 'FP32Type::get(&mut' 'FP64Type::get(&mut' 'VoidType::get(&mut' 'FP16Type::get(&mut'; do
+            hits=$(echo "$diff_added" | grep "$pattern" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::$pattern found in added lines (takes &Context, not &mut Context)"
+              echo "$hits"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "pliron type getters (FP32Type, FP64Type, VoidType, FP16Type) take &Context."
+            echo "Note: IntegerType::get, PointerType::get, MirPtrType::get_generic legitimately take &mut Context."
+            exit 1
+          fi
+          echo "Type getter mutability check: PASS"
+
+      - name: Check for float equality assertions (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -P 'assert_eq!\(.*\d+\.\d+f(32|64)' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Float equality assertion in added lines (clippy::float_cmp)"
+            echo "$hits"
+            echo ""
+            echo 'Use: assert!((val - expected).abs() < 1e-6, "got {}, want {}", val, expected);'
+          else
+            echo "Float equality check: PASS"
+          fi
+          # Warning only
+
+      - name: Check for useless vec patterns (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep '&vec!\[' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::&vec![...] in added lines (clippy::useless_vec)"
+            echo "$hits"
+            echo ""
+            echo "Use &[...] slice literal instead."
+          else
+            echo "Useless vec check: PASS"
+          fi
+          # Warning only
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check dependencies
+        run: cargo deny check

--- a/crates/cuda-device/src/atomic.rs
+++ b/crates/cuda-device/src/atomic.rs
@@ -563,3 +563,69 @@ define_float_atomic! {
     /// 64-bit float atomic, **system scope** (`.sys`).
     pub struct SystemAtomicF64(f64);
 }
+
+// =============================================================================
+// Packed Atomic Add (f16x2, bf16x2)
+//
+// These are standalone functions (not atomic-type methods) because the
+// hardware operates on raw `u32` words carrying two packed 16-bit lanes.
+// They bypass the scoped-type system and use `atom.global` directly.
+// =============================================================================
+
+/// Packed f16x2 atomic add on global memory.
+///
+/// Atomically adds two packed f16 lanes in `val` to the two packed f16 lanes
+/// at `*addr`, stores the element-wise sum, and returns the **previous** value.
+///
+/// Both `val` and the return value are `u32` words carrying two f16 values
+/// (low 16 bits = first lane, high 16 bits = second lane).
+///
+/// # PTX
+///
+/// ```ptx
+/// atom.global.add.noftz.f16x2 %old, [%addr], %val;
+/// ```
+///
+/// `.noftz` = no flush-to-zero: denormalized f16 values are preserved.
+///
+/// # Supported on
+///
+/// - `sm_70+` (Volta onwards).
+///
+/// # Safety
+///
+/// `addr` must point to a valid, naturally-aligned `u32` in global memory.
+#[inline(never)]
+pub fn atom_add_f16x2(addr: *mut u32, val: u32) -> u32 {
+    let _ = (addr, val);
+    unreachable!("atom_add_f16x2 called outside CUDA kernel context")
+}
+
+/// Packed bf16x2 atomic add on global memory.
+///
+/// Atomically adds two packed bf16 lanes in `val` to the two packed bf16 lanes
+/// at `*addr`, stores the element-wise sum, and returns the **previous** value.
+///
+/// Both `val` and the return value are `u32` words carrying two bf16 values
+/// (low 16 bits = first lane, high 16 bits = second lane).
+///
+/// # PTX
+///
+/// ```ptx
+/// atom.global.add.noftz.bf16x2 %old, [%addr], %val;
+/// ```
+///
+/// `.noftz` = no flush-to-zero: denormalized bf16 values are preserved.
+///
+/// # Supported on
+///
+/// - `sm_80+` (Ampere onwards).
+///
+/// # Safety
+///
+/// `addr` must point to a valid, naturally-aligned `u32` in global memory.
+#[inline(never)]
+pub fn atom_add_bf16x2(addr: *mut u32, val: u32) -> u32 {
+    let _ = (addr, val);
+    unreachable!("atom_add_bf16x2 called outside CUDA kernel context")
+}

--- a/crates/dialect-nvvm/src/ops/atomic.rs
+++ b/crates/dialect-nvvm/src/ops/atomic.rs
@@ -513,6 +513,80 @@ impl NvvmAtomicOpInterface for NvvmAtomicCmpxchgOp {
 }
 
 // =============================================================================
+// NvvmAtomAddF16x2Op
+// =============================================================================
+
+/// Packed f16x2 atomic add on global memory.
+///
+/// Atomically adds two packed f16 lanes element-wise, stores the sum, and
+/// returns the **previous** packed value.
+///
+/// Lowered to inline PTX:
+/// ```ptx
+/// atom.global.add.noftz.f16x2 $0, [$1], $2;
+/// ```
+///
+/// # Operands
+///
+/// - `addr` (ptr): pointer to the packed f16x2 value in global memory
+/// - `val`  (u32): packed f16x2 addend
+///
+/// # Results
+///
+/// - `old` (u32): the previous packed f16x2 value at `*addr`
+#[pliron_op(
+    name = "nvvm.atom_add_f16x2",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct NvvmAtomAddF16x2Op;
+
+impl NvvmAtomAddF16x2Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        NvvmAtomAddF16x2Op { op }
+    }
+}
+
+// =============================================================================
+// NvvmAtomAddBf16x2Op
+// =============================================================================
+
+/// Packed bf16x2 atomic add on global memory.
+///
+/// Atomically adds two packed bf16 lanes element-wise, stores the sum, and
+/// returns the **previous** packed value.
+///
+/// Lowered to inline PTX:
+/// ```ptx
+/// atom.global.add.noftz.bf16x2 $0, [$1], $2;
+/// ```
+///
+/// # Operands
+///
+/// - `addr` (ptr): pointer to the packed bf16x2 value in global memory
+/// - `val`  (u32): packed bf16x2 addend
+///
+/// # Results
+///
+/// - `old` (u32): the previous packed bf16x2 value at `*addr`
+#[pliron_op(
+    name = "nvvm.atom_add_bf16x2",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<2>, NResultsInterface<1>],
+)]
+pub struct NvvmAtomAddBf16x2Op;
+
+impl NvvmAtomAddBf16x2Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        NvvmAtomAddBf16x2Op { op }
+    }
+}
+
+// =============================================================================
 // Registration
 // =============================================================================
 
@@ -528,4 +602,6 @@ pub fn register(ctx: &mut Context) {
     NvvmAtomicStoreOp::register(ctx);
     NvvmAtomicRmwOp::register(ctx);
     NvvmAtomicCmpxchgOp::register(ctx);
+    NvvmAtomAddF16x2Op::register(ctx);
+    NvvmAtomAddBf16x2Op::register(ctx);
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -68,8 +68,8 @@ use crate::translator::rvalue;
 use crate::translator::values::ValueMap;
 
 use dialect_nvvm::ops::atomic::{
-    AtomicOrdering, AtomicRmwKind, AtomicScope, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
-    NvvmAtomicRmwOp, NvvmAtomicStoreOp,
+    AtomicOrdering, AtomicRmwKind, AtomicScope, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
+    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp,
 };
 
 use dialect_mir::ops::MirNegOp;
@@ -1327,5 +1327,175 @@ fn emit_core_atomic_cmpxchg(
         block_map,
         loc,
         "core atomic cmpxchg call without target block",
+    )
+}
+
+// =============================================================================
+// Packed Atomic Add (f16x2, bf16x2) — standalone intrinsics
+// =============================================================================
+
+/// Emit `atom_add_f16x2`: packed f16x2 atomic add on global memory.
+///
+/// Args: `(addr: *mut u32, val: u32)`.
+/// Returns: `u32`, the previous packed f16x2 value.
+pub fn emit_atom_add_f16x2(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "atom_add_f16x2 expects 2 arguments (addr: *mut u32, val: u32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (addr_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (val_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let op_ptr = Operation::new(
+        ctx,
+        NvvmAtomAddF16x2Op::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![addr_val, val_val],
+        vec![],
+        0,
+    );
+    op_ptr.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        op_ptr.insert_after(ctx, prev);
+    } else {
+        op_ptr.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = op_ptr.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        op_ptr,
+        value_map,
+        block_map,
+        loc,
+        "atom_add_f16x2 call without target block",
+    )
+}
+
+/// Emit `atom_add_bf16x2`: packed bf16x2 atomic add on global memory.
+///
+/// Args: `(addr: *mut u32, val: u32)`.
+/// Returns: `u32`, the previous packed bf16x2 value.
+pub fn emit_atom_add_bf16x2(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "atom_add_bf16x2 expects 2 arguments (addr: *mut u32, val: u32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (addr_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (val_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let op_ptr = Operation::new(
+        ctx,
+        NvvmAtomAddBf16x2Op::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![addr_val, val_val],
+        vec![],
+        0,
+    );
+    op_ptr.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        op_ptr.insert_after(ctx, prev);
+    } else {
+        op_ptr.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = op_ptr.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        op_ptr,
+        value_map,
+        block_map,
+        loc,
+        "atom_add_bf16x2 call without target block",
     )
 }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2368,6 +2368,37 @@ fn try_dispatch_intrinsic(
         "cuda_device::barrier::mbarrier_inval" => Ok(Some(intrinsics::sync::emit_mbarrier_inval(
             ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
         )?)),
+        "cuda_device::barrier::mbarrier_pending_count" => {
+            Ok(Some(intrinsics::sync::emit_mbarrier_pending_count(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+        "cuda_device::barrier::mbarrier_arrive_drop" => {
+            Ok(Some(intrinsics::sync::emit_mbarrier_arrive_drop(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
+        "cuda_device::bitops::prmt_b32" => Ok(Some(intrinsics::sync::emit_prmt_b32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
         "cuda_device::barrier::fence_proxy_async_shared_cta" => {
             Ok(Some(intrinsics::sync::emit_fence_proxy_async_shared_cta(
                 ctx, args, target, block_ptr, prev_op, block_map, loc,
@@ -3202,6 +3233,36 @@ fn try_dispatch_intrinsic(
             block_map,
             loc,
         )?)),
+
+        // =================================================================
+        // Packed atomic add (from intrinsics::atomic)
+        // =================================================================
+        "cuda_device::atomic::atom_add_f16x2" => Ok(Some(intrinsics::atomic::emit_atom_add_f16x2(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::atomic::atom_add_bf16x2" => {
+            Ok(Some(intrinsics::atomic::emit_atom_add_bf16x2(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
 
         // =================================================================
         // CLC - Cluster Launch Control (from intrinsics::clc)

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -48,28 +48,28 @@ use dialect_nvvm::ops::{
     MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveClusterOp,
     MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
     MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MbarrierTryWaitParitySharedOp,
-    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
-    NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
-    ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
-    ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp,
-    ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp,
-    ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp,
-    ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp,
-    ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op,
-    ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
-    StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
-    Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op,
-    Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp,
-    Tcgen05DeallocCg2Op, Tcgen05DeallocOp, Tcgen05FenceAfterThreadSyncOp,
-    Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp, Tcgen05Ld16x256bX8PureOp,
-    Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op, Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op,
-    Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op, Tcgen05RelinquishAllocPermitOp,
-    Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp, TrapOp,
-    VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp, WgmmaCommitGroupSyncAlignedOp,
-    WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaWaitGroupSyncAlignedOp,
+    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
+    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp,
+    ReadPtxSregClock64Op, ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp,
+    ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp,
+    ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp,
+    ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregEnvReg1Op,
+    ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp,
+    ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp,
+    ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp,
+    ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncDownF32Op,
+    ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op, ShflSyncUpI32Op,
+    StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op, StmatrixM8n8X4TransOp,
+    Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op, Tcgen05CommitMulticastCg2Op,
+    Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op, Tcgen05CommitSharedClusterOp,
+    Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp, Tcgen05DeallocCg2Op, Tcgen05DeallocOp,
+    Tcgen05FenceAfterThreadSyncOp, Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp,
+    Tcgen05Ld16x256bX8PureOp, Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op,
+    Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op, Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op,
+    Tcgen05RelinquishAllocPermitOp, Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp,
+    ThreadfenceSystemOp, TrapOp, VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp,
+    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp,
+    WgmmaMmaM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -2968,6 +2968,40 @@ impl MirToLlvmConversion for NvvmAtomicCmpxchgOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::atomic::convert_atomic_cmpxchg(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for NvvmAtomAddF16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::atomic::convert_atom_add_f16x2(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for NvvmAtomAddBf16x2Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::atomic::convert_atom_add_bf16x2(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/atomic.rs
+++ b/crates/mir-lower/src/convert/intrinsics/atomic.rs
@@ -54,7 +54,9 @@ use dialect_nvvm::ops::atomic::{
 };
 use llvm_export::attributes::{LlvmAtomicOrdering, LlvmAtomicRmwKind, LlvmSyncScope};
 use llvm_export::ops as llvm;
+use llvm_export::ops::{AsmKind, InlineAsmOpExt};
 
+use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
 use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
 use pliron::irbuild::inserter::Inserter;
@@ -269,5 +271,85 @@ pub(crate) fn convert_atomic_cmpxchg(
     rewriter.insert_operation(ctx, extract.get_operation());
     rewriter.replace_operation(ctx, op, extract.get_operation());
 
+    Ok(())
+}
+
+// =============================================================================
+// Packed Atomic Add (f16x2, bf16x2) — inline PTX
+// =============================================================================
+
+/// Convert `nvvm.atom_add_f16x2` to inline PTX.
+///
+/// ```ptx
+/// atom.global.add.noftz.f16x2 $0, [$1], $2;
+/// ```
+///
+/// Constraints: `=r,l,r,~{memory}` — output register, address pointer, input
+/// register, memory clobber.
+///
+/// Uses `SideEffect` (not convergent): atomics are per-thread, not
+/// warp-synchronous.
+pub(crate) fn convert_atom_add_f16x2(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    let addr = operands[0];
+    let val = operands[1];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![addr, val],
+        "atom.global.add.noftz.f16x2 $0, [$1], $2;",
+        "=r,l,r,~{memory}",
+        AsmKind::SideEffect,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// Convert `nvvm.atom_add_bf16x2` to inline PTX.
+///
+/// ```ptx
+/// atom.global.add.noftz.bf16x2 $0, [$1], $2;
+/// ```
+///
+/// Constraints: `=r,l,r,~{memory}` — output register, address pointer, input
+/// register, memory clobber.
+///
+/// Uses `SideEffect` (not convergent): atomics are per-thread, not
+/// warp-synchronous.
+pub(crate) fn convert_atom_add_bf16x2(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    let addr = operands[0];
+    let val = operands[1];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![addr, val],
+        "atom.global.add.noftz.bf16x2 $0, [$1], $2;",
+        "=r,l,r,~{memory}",
+        AsmKind::SideEffect,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `atom_add_f16x2` and `atom_add_bf16x2` packed atomic add intrinsics
- PTX: `atom.global.add.noftz.f16x2` / `atom.global.add.noftz.bf16x2`
- Full pipeline: cuda-device stubs, dialect-nvvm ops, mir-importer emit + dispatch, mir-lower inline PTX lowering

## Details

These operations atomically add packed pairs of half-precision values (f16x2 or bf16x2) element-wise at a global memory address, returning the previous packed value. The `.noftz` (no flush-to-zero) qualifier preserves denormalized values.

| Operation | PTX | Min SM |
|-----------|-----|--------|
| `atom_add_f16x2(addr, val) -> u32` | `atom.global.add.noftz.f16x2` | sm_70 |
| `atom_add_bf16x2(addr, val) -> u32` | `atom.global.add.noftz.bf16x2` | sm_80 |

Lowered via inline PTX with `sideeffect` (not `convergent` — atomics are per-thread, not warp-synchronous). Constraint string: `=r,l,r,~{memory}`.

Closes #50, ref #27.

## Test plan

- [x] `cargo check -p dialect-nvvm -p mir-lower` passes
- [x] `cargo fmt --all` clean
- [ ] End-to-end kernel test with packed f16x2/bf16x2 atomic adds (requires GPU)