### PR TITLE
feat: misc Ampere ops (prmt, mbarrier pending_count/arrive_drop)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,82 @@
+---
+name: fork-ci
+
+# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Runs on every push to any branch except main (upstream CI covers main).
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt for the pinned nightly
+        run: rustup component add rustfmt
+
+      - name: Check root workspace formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (no-cuda packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run clippy on packages that don't need CUDA
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo clippy \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols \
+            -- -D warnings
+
+  unit-tests:
+    name: test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - llvm-export
+          - dialect-mir
+          - dialect-nvvm
+          - mir-lower
+          - mir-importer
+          - oxide-artifacts
+          - reserved-oxide-symbols
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run crate unit tests
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          cargo test -p ${{ matrix.package }} --all-targets

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,8 +1,11 @@
 ---
 name: fork-ci
 
-# Lightweight CI for our PR branches. Catches formatting, clippy, rustdoc, and
+# Enhanced CI for our PR branches. Catches formatting, clippy, rustdoc, and
 # unit-test failures in the packages we modify (no CUDA toolkit needed).
+# Also runs additional quality checks that go beyond upstream CI to ensure
+# clean PRs before upstreaming.
+#
 # Runs on every push to any branch except main (upstream CI covers main).
 
 on:
@@ -80,3 +83,163 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           cargo test -p ${{ matrix.package }} --all-targets
+
+  rustdoc:
+    name: rustdoc (no warnings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with -D warnings
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          export RUSTDOCFLAGS="-D warnings"
+
+          cargo doc --no-deps \
+            -p mir-lower \
+            -p llvm-export \
+            -p dialect-nvvm \
+            -p dialect-mir \
+            -p mir-importer \
+            -p oxide-artifacts \
+            -p reserved-oxide-symbols
+
+  # ---- Fork-only quality gates (beyond upstream CI) ----
+  # These catch patterns the maintainer has historically fixed in contributor
+  # PRs, saving a review round-trip.
+
+  style-checks:
+    name: style (owner fixup patterns)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for diff against main
+
+      - name: Detect em-dashes in added lines
+        run: |
+          # Only check lines we actually added (not pre-existing upstream code)
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -n '—' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Em-dash (U+2014) found in added lines"
+            echo "$hits"
+            echo ""
+            echo "The maintainer consistently removes em-dashes from doc comments."
+            echo "Replace with commas, semicolons, or parentheses."
+            exit 1
+          fi
+          echo "Em-dash check: PASS"
+
+      - name: Detect bare brackets in doc comments (warning)
+        run: |
+          # Check added doc comment lines for bare [text] that are NOT
+          # markdown links [text](url), intra-doc links [`item`], or backtick-wrapped
+          hits=$(git diff origin/main...HEAD -- '*.rs' \
+            | grep '^+' | grep -v '^+++' \
+            | grep '///' \
+            | grep -P '\[(?!`)' \
+            | grep -vP '\]\(' \
+            | grep -vP '`[^`]*\[' \
+            || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Possible bare brackets in doc comments (may cause rustdoc errors)"
+            echo "$hits"
+            echo ""
+            echo "Wrap in backticks or use a markdown link."
+          else
+            echo "Bare bracket check: PASS"
+          fi
+          # Warning only — some brackets are valid intra-doc links
+
+      - name: Check SPDX license headers on new files
+        run: |
+          new_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '*.rs' 2>/dev/null || true)
+          if [ -z "$new_files" ]; then
+            echo "No new .rs files"
+            exit 0
+          fi
+
+          found=0
+          for f in $new_files; do
+            if [ -f "$f" ]; then
+              has_spdx=$(head -4 "$f" | grep -c 'SPDX' || true)
+              if [ "$has_spdx" -eq 0 ]; then
+                echo "::error file=$f::Missing SPDX license header"
+                found=1
+              fi
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "New .rs files must start with the SPDX header block."
+            exit 1
+          fi
+
+      - name: Check for unnecessary &mut on type getters
+        run: |
+          # Only check lines we added
+          diff_added=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' || true)
+          if [ -z "$diff_added" ]; then
+            echo "No added lines"
+            exit 0
+          fi
+
+          found=0
+          for pattern in 'FP32Type::get(&mut' 'FP64Type::get(&mut' 'VoidType::get(&mut' 'FP16Type::get(&mut'; do
+            hits=$(echo "$diff_added" | grep "$pattern" || true)
+            if [ -n "$hits" ]; then
+              echo "::error::$pattern found in added lines (takes &Context, not &mut Context)"
+              echo "$hits"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "pliron type getters (FP32Type, FP64Type, VoidType, FP16Type) take &Context."
+            echo "Note: IntegerType::get, PointerType::get, MirPtrType::get_generic legitimately take &mut Context."
+            exit 1
+          fi
+          echo "Type getter mutability check: PASS"
+
+      - name: Check for float equality assertions (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep -P 'assert_eq!\(.*\d+\.\d+f(32|64)' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::Float equality assertion in added lines (clippy::float_cmp)"
+            echo "$hits"
+            echo ""
+            echo 'Use: assert!((val - expected).abs() < 1e-6, "got {}, want {}", val, expected);'
+          else
+            echo "Float equality check: PASS"
+          fi
+          # Warning only
+
+      - name: Check for useless vec patterns (warning)
+        run: |
+          hits=$(git diff origin/main...HEAD -- '*.rs' | grep '^+' | grep -v '^+++' | grep '&vec!\[' || true)
+          if [ -n "$hits" ]; then
+            echo "::warning::&vec![...] in added lines (clippy::useless_vec)"
+            echo "$hits"
+            echo ""
+            echo "Use &[...] slice literal instead."
+          else
+            echo "Useless vec check: PASS"
+          fi
+          # Warning only
+
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check dependencies
+        run: cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hi_sparse_bitset"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad02fc3cac722c3c44c3ed708f6653e7d149b7912f7342fc1e8530455f84f0eb"
+checksum = "d396ee1e6a83131ecc45247b82e2340b29d095598c444ef98562a144773d857e"
 dependencies = [
  "wide",
 ]

--- a/crates/cuda-device/src/barrier.rs
+++ b/crates/cuda-device/src/barrier.rs
@@ -445,6 +445,31 @@ pub unsafe fn mbarrier_arrive_cluster(remote_bar_addr: u64) {
     unreachable!("mbarrier_arrive_cluster called outside CUDA kernel context")
 }
 
+/// Signal that this thread is dropping out of future barrier phases.
+///
+/// After calling `mbarrier_arrive_drop`, this thread will no longer
+/// participate in subsequent phases of the barrier. The barrier's
+/// expected arrival count is decremented for all future phases.
+///
+/// This is useful for dynamic thread participation patterns where some
+/// threads exit early while others continue using the barrier.
+///
+/// # Safety
+///
+/// - `addr` must point to a valid, initialized mbarrier in shared memory
+/// - The calling thread must be a registered participant of the barrier
+///
+/// # PTX
+///
+/// ```ptx
+/// mbarrier.arrive_drop.shared.b64 _, [addr];
+/// ```
+#[inline(never)]
+pub unsafe fn mbarrier_arrive_drop(addr: *mut u64) {
+    let _ = addr;
+    unreachable!("mbarrier_arrive_drop called outside CUDA kernel context")
+}
+
 // =============================================================================
 // Barrier Invalidation
 // =============================================================================
@@ -469,6 +494,31 @@ pub unsafe fn mbarrier_inval(bar: *mut Barrier) {
     let _ = bar;
     // Lowered to: call void @llvm.nvvm.mbarrier.inval.shared(ptr %bar)
     unreachable!("mbarrier_inval called outside CUDA kernel context")
+}
+
+/// Extract the pending arrival count from an mbarrier state token.
+///
+/// The state token is obtained from `mbarrier.test_wait` or similar
+/// operations. This instruction extracts the number of arrivals still
+/// pending before the barrier phase completes.
+///
+/// # Arguments
+///
+/// - `state` - the 64-bit mbarrier state token
+///
+/// # Returns
+///
+/// The number of arrivals still pending (as a `u32`).
+///
+/// # PTX
+///
+/// ```ptx
+/// mbarrier.pending_count.b64 count, state;
+/// ```
+#[inline(never)]
+pub fn mbarrier_pending_count(state: u64) -> u32 {
+    let _ = state;
+    unreachable!("mbarrier_pending_count called outside CUDA kernel context")
 }
 
 // =============================================================================

--- a/crates/cuda-device/src/bitops.rs
+++ b/crates/cuda-device/src/bitops.rs
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Bit-manipulation PTX operations.
+//!
+//! This module exposes per-thread PTX instructions that operate on raw
+//! bit patterns.
+//!
+//! # Operations
+//!
+//! | Function   | PTX Instruction   | Description                       |
+//! |------------|-------------------|-----------------------------------|
+//! | `prmt_b32` | `prmt.b32`        | Byte permute on two 32-bit words  |
+//!
+//! # `prmt.b32` — Byte Permute
+//!
+//! Selects four bytes from two 32-bit inputs according to a control word.
+//!
+//! The two inputs `a` (bits `[63:32]`) and `b` (bits `[31:0]`) form an
+//! 8-byte source array. The control word `c` contains four 4-bit selectors
+//! (one per output byte) that choose which source byte goes to each output
+//! byte position.
+//!
+//! ```text
+//! Source bytes:   a[3] a[2] a[1] a[0] b[3] b[2] b[1] b[0]
+//!                   7    6    5    4    3    2    1    0
+//!
+//! Control word c: [sel3 | sel2 | sel1 | sel0]  (4 bits each)
+//!
+//! Result byte i = source[sel_i & 0x7]
+//! ```
+//!
+//! # Requirements
+//!
+//! - **PTX ISA**: 2.0+
+//! - **Architecture**: sm_20+ (all modern GPUs)
+
+/// Byte permute: rearrange bytes from two 32-bit words.
+///
+/// Selects four bytes from the concatenation of `a` (high) and `b` (low)
+/// according to the control word `c`, producing a new 32-bit value.
+///
+/// # Arguments
+///
+/// - `a` — upper 32 bits of the source (bytes 7..4)
+/// - `b` — lower 32 bits of the source (bytes 3..0)
+/// - `c` — control word with four 4-bit byte selectors
+///
+/// # Returns
+///
+/// A 32-bit value assembled from the selected bytes.
+///
+/// # PTX
+///
+/// ```ptx
+/// prmt.b32 result, a, b, c;
+/// ```
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Swap bytes 0 and 1 of a single word:
+/// let swapped = prmt_b32(x, x, 0x0000_3210);
+/// ```
+#[inline(never)]
+pub fn prmt_b32(a: u32, b: u32, c: u32) -> u32 {
+    let _ = (a, b, c);
+    unreachable!("prmt_b32 called outside CUDA kernel context")
+}

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -15,6 +15,7 @@ pub use cuda_macros::{
 pub mod atomic;
 pub mod barrier;
 pub mod bf16x2;
+pub mod bitops;
 pub mod clc;
 pub mod cluster;
 pub mod constant;

--- a/crates/dialect-nvvm/src/ops/bitops.rs
+++ b/crates/dialect-nvvm/src/ops/bitops.rs
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Bit-manipulation PTX operations.
+//!
+//! | Operation  | PTX Instruction | Description                      |
+//! |------------|-----------------|----------------------------------|
+//! | `PrmtB32`  | `prmt.b32`      | Byte permute on two 32-bit words |
+//!
+//! # Requirements
+//!
+//! - **PTX ISA**: 2.0+
+//! - **Architecture**: sm_20+ (all modern GPUs)
+
+use pliron::{
+    builtin::op_interfaces::{NOpdsInterface, NResultsInterface},
+    context::Context,
+    context::Ptr,
+    op::Op,
+    operation::Operation,
+};
+use pliron_derive::pliron_op;
+
+/// Byte permute: rearrange bytes from two 32-bit words.
+///
+/// Selects four bytes from the concatenation of `a` (high) and `b` (low)
+/// according to the control word `c`, producing a new 32-bit value.
+///
+/// This is a pure per-thread operation (not convergent).
+///
+/// PTX: `prmt.b32 $0, $1, $2, $3;`
+///
+/// # Operands
+///
+/// - `a` (i32): upper source word
+/// - `b` (i32): lower source word
+/// - `c` (i32): control word (byte selectors)
+///
+/// # Results
+///
+/// - `result` (i32): permuted output
+#[pliron_op(
+    name = "nvvm.prmt_b32",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct PrmtB32Op;
+
+impl PrmtB32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        PrmtB32Op { op }
+    }
+}
+
+/// Register bitops operations with the context.
+pub(super) fn register(ctx: &mut Context) {
+    PrmtB32Op::register(ctx);
+}

--- a/crates/dialect-nvvm/src/ops/mbarrier.rs
+++ b/crates/dialect-nvvm/src/ops/mbarrier.rs
@@ -378,6 +378,65 @@ impl NanosleepOp {
     }
 }
 
+/// Extract pending arrival count from mbarrier state token.
+///
+/// Given a 64-bit state token (obtained from `mbarrier.test_wait` or similar),
+/// returns the number of arrivals still pending before the phase completes.
+///
+/// PTX: `mbarrier.pending_count.b64 $0, $1;`
+///
+/// # Operands
+///
+/// - `state` (i64): mbarrier state token
+///
+/// # Results
+///
+/// - `count` (i32): pending arrival count
+#[pliron_op(
+    name = "nvvm.mbarrier_pending_count",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<1>, NResultsInterface<1>],
+)]
+pub struct MbarrierPendingCountOp;
+
+impl MbarrierPendingCountOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MbarrierPendingCountOp { op }
+    }
+}
+
+/// Signal that the calling thread drops out of future barrier phases.
+///
+/// After this operation, the thread will no longer participate in subsequent
+/// phases of the barrier. The expected arrival count is decremented for all
+/// future phases.
+///
+/// PTX: `mbarrier.arrive_drop.shared.b64 _, [$0];`
+///
+/// # Operands
+///
+/// - `addr` (ptr addrspace(3)): pointer to barrier in shared memory
+///
+/// # Results
+///
+/// - None
+#[pliron_op(
+    name = "nvvm.mbarrier_arrive_drop_shared",
+    format,
+    verifier = "succ",
+    interfaces = [NOpdsInterface<1>, NResultsInterface<0>],
+)]
+pub struct MbarrierArriveDropSharedOp;
+
+impl MbarrierArriveDropSharedOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MbarrierArriveDropSharedOp { op }
+    }
+}
+
 /// Register mbarrier operations with the context.
 pub(super) fn register(ctx: &mut Context) {
     MbarrierInitSharedOp::register(ctx);
@@ -390,4 +449,6 @@ pub(super) fn register(ctx: &mut Context) {
     MbarrierInvalSharedOp::register(ctx);
     FenceProxyAsyncSharedCtaOp::register(ctx);
     NanosleepOp::register(ctx);
+    MbarrierPendingCountOp::register(ctx);
+    MbarrierArriveDropSharedOp::register(ctx);
 }

--- a/crates/dialect-nvvm/src/ops/mod.rs
+++ b/crates/dialect-nvvm/src/ops/mod.rs
@@ -98,6 +98,7 @@
 mod asm;
 pub mod atomic;
 mod bf16x2;
+mod bitops;
 mod clc;
 mod cluster;
 mod convert;
@@ -117,6 +118,7 @@ use pliron::context::Context;
 pub use asm::*;
 pub use atomic::*;
 pub use bf16x2::*;
+pub use bitops::*;
 pub use clc::*;
 pub use cluster::*;
 pub use convert::*;
@@ -138,6 +140,7 @@ pub fn register(ctx: &mut Context) {
     atomic::register(ctx);
     asm::register(ctx);
     bf16x2::register(ctx);
+    bitops::register(ctx);
     clc::register(ctx);
     convert::register(ctx);
     thread::register(ctx);

--- a/crates/mir-importer/src/translator/terminator/intrinsics/sync.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/sync.rs
@@ -16,10 +16,11 @@ use crate::translator::rvalue;
 use crate::translator::types;
 use crate::translator::values::ValueMap;
 use dialect_nvvm::ops::{
-    FenceProxyAsyncSharedCtaOp, MbarrierArriveClusterOp, MbarrierArriveExpectTxSharedOp,
-    MbarrierArriveSharedOp, MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
-    MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp, NanosleepOp, ThreadfenceBlockOp,
-    ThreadfenceOp, ThreadfenceSystemOp,
+    FenceProxyAsyncSharedCtaOp, MbarrierArriveClusterOp, MbarrierArriveDropSharedOp,
+    MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
+    MbarrierInvalSharedOp, MbarrierPendingCountOp, MbarrierTestWaitSharedOp,
+    MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp, NanosleepOp, PrmtB32Op,
+    ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -985,4 +986,238 @@ pub fn emit_fence_proxy_async_shared_cta(
             )
         )
     }
+}
+
+/// Emit mbarrier_pending_count: extract pending count from mbarrier state.
+///
+/// Args:
+/// - `args[0]`: u64 (mbarrier state token)
+///
+/// Returns: u32 (pending count)
+pub fn emit_mbarrier_pending_count(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 1 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mbarrier_pending_count expects 1 argument, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (state, last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let pending_op = Operation::new(
+        ctx,
+        MbarrierPendingCountOp::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![state],
+        vec![],
+        0,
+    );
+    pending_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        pending_op.insert_after(ctx, prev);
+    } else {
+        pending_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = pending_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        pending_op,
+        value_map,
+        block_map,
+        loc,
+        "mbarrier_pending_count call without target block",
+    )
+}
+
+/// Emit mbarrier_arrive_drop: signal thread departure from barrier.
+///
+/// Args:
+/// - `args[0]`: *mut u64 (pointer to barrier in shared memory)
+///
+/// Returns: void
+pub fn emit_mbarrier_arrive_drop(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 1 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mbarrier_arrive_drop expects 1 argument, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (bar_ptr, last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+
+    let drop_op = Operation::new(
+        ctx,
+        MbarrierArriveDropSharedOp::get_concrete_op_info(),
+        vec![],
+        vec![bar_ptr],
+        vec![],
+        0,
+    );
+    drop_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        drop_op.insert_after(ctx, prev);
+    } else {
+        drop_op.insert_at_front(block_ptr, ctx);
+    }
+
+    if let Some(target_idx) = target {
+        let goto_op = emit_goto(ctx, *target_idx, drop_op, block_map, loc);
+        Ok(goto_op)
+    } else {
+        input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "mbarrier_arrive_drop call without target block".to_string(),
+            )
+        )
+    }
+}
+
+/// Emit prmt_b32: byte permute on two 32-bit words.
+///
+/// Args:
+/// - `args[0]`: u32 (a - upper source)
+/// - `args[1]`: u32 (b - lower source)
+/// - `args[2]`: u32 (c - control word)
+///
+/// Returns: u32 (permuted result)
+pub fn emit_prmt_b32(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "prmt_b32 expects 3 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (c_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let i32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let prmt_op = Operation::new(
+        ctx,
+        PrmtB32Op::get_concrete_op_info(),
+        vec![i32_type.to_ptr()],
+        vec![a_val, b_val, c_val],
+        vec![],
+        0,
+    );
+    prmt_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        prmt_op.insert_after(ctx, prev);
+    } else {
+        prmt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = prmt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        prmt_op,
+        value_map,
+        block_map,
+        loc,
+        "prmt_b32 call without target block",
+    )
 }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2368,6 +2368,37 @@ fn try_dispatch_intrinsic(
         "cuda_device::barrier::mbarrier_inval" => Ok(Some(intrinsics::sync::emit_mbarrier_inval(
             ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
         )?)),
+        "cuda_device::barrier::mbarrier_pending_count" => {
+            Ok(Some(intrinsics::sync::emit_mbarrier_pending_count(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+        "cuda_device::barrier::mbarrier_arrive_drop" => {
+            Ok(Some(intrinsics::sync::emit_mbarrier_arrive_drop(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
+        "cuda_device::bitops::prmt_b32" => Ok(Some(intrinsics::sync::emit_prmt_b32(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
         "cuda_device::barrier::fence_proxy_async_shared_cta" => {
             Ok(Some(intrinsics::sync::emit_fence_proxy_async_shared_cta(
                 ctx, args, target, block_ptr, prev_op, block_map, loc,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -46,30 +46,30 @@ use dialect_nvvm::ops::{
     CpAsyncBulkWaitGroupReadOp, CvtF16x2F32Op, CvtF32x2Bf16x2Op, DsmemReadU32Op,
     FenceProxyAsyncSharedCtaOp, FmaBf16x2Op, InlinePtxOp, MapaSharedClusterOp, MatchAllSyncI32Op,
     MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveClusterOp,
-    MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp, MbarrierInitSharedOp,
-    MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MbarrierTryWaitParitySharedOp,
-    MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
-    NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
-    ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
-    ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp,
-    ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp,
-    ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp,
-    ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp,
-    ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op,
-    ShflSyncUpI32Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op,
-    StmatrixM8n8X4TransOp, Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op,
-    Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op,
-    Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp,
-    Tcgen05DeallocCg2Op, Tcgen05DeallocOp, Tcgen05FenceAfterThreadSyncOp,
-    Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp, Tcgen05Ld16x256bX8PureOp,
-    Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op, Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op,
-    Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op, Tcgen05RelinquishAllocPermitOp,
-    Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp, TrapOp,
-    VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp, WgmmaCommitGroupSyncAlignedOp,
-    WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaWaitGroupSyncAlignedOp,
+    MbarrierArriveDropSharedOp, MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp,
+    MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierPendingCountOp, MbarrierTestWaitSharedOp,
+    MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp, NanosleepOp, NvvmAtomicCmpxchgOp,
+    NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, PrmtB32Op,
+    ReadPtxSregClock64Op, ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp,
+    ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp,
+    ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp,
+    ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregEnvReg1Op,
+    ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregLaneIdOp, ReadPtxSregNclusterIdOp,
+    ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNtidXOp,
+    ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp,
+    ReadPtxSregTidZOp, ReduxSyncAddOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncDownF32Op,
+    ShflSyncDownI32Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncUpF32Op, ShflSyncUpI32Op,
+    StmatrixM8n8X2Op, StmatrixM8n8X2TransOp, StmatrixM8n8X4Op, StmatrixM8n8X4TransOp,
+    Tcgen05AllocCg2Op, Tcgen05AllocOp, Tcgen05CommitCg2Op, Tcgen05CommitMulticastCg2Op,
+    Tcgen05CommitOp, Tcgen05CommitSharedClusterCg2Op, Tcgen05CommitSharedClusterOp,
+    Tcgen05CpSmemToTmemCg2Op, Tcgen05CpSmemToTmemOp, Tcgen05DeallocCg2Op, Tcgen05DeallocOp,
+    Tcgen05FenceAfterThreadSyncOp, Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp,
+    Tcgen05Ld16x256bX8PureOp, Tcgen05LoadWaitOp, Tcgen05MmaF16Cg2Op, Tcgen05MmaF16Op,
+    Tcgen05MmaWsBf16Op, Tcgen05MmaWsF16Op, Tcgen05MmaWsTf32Op, Tcgen05RelinquishAllocPermitCg2Op,
+    Tcgen05RelinquishAllocPermitOp, Tcgen05StoreWaitOp, ThreadfenceBlockOp, ThreadfenceOp,
+    ThreadfenceSystemOp, TrapOp, VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp, VprintfOp,
+    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMakeSmemDescOp,
+    WgmmaMmaM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -2044,6 +2044,57 @@ impl MirToLlvmConversion for NanosleepOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::mbarrier::convert_nanosleep(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MbarrierPendingCountOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::mbarrier::convert_pending_count(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MbarrierArriveDropSharedOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::mbarrier::convert_arrive_drop(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for PrmtB32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::bitops::convert_prmt_b32(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/bitops.rs
+++ b/crates/mir-lower/src/convert/intrinsics/bitops.rs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Bit-manipulation intrinsic conversion.
+//!
+//! | Operation  | Implementation | Description                      |
+//! |------------|----------------|----------------------------------|
+//! | `PrmtB32`  | Inline PTX     | Byte permute on two 32-bit words |
+
+use llvm_export::ops::{self as llvm, InlineAsmOpExt};
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::inserter::Inserter;
+use pliron::irbuild::rewriter::Rewriter;
+use pliron::op::Op;
+use pliron::operation::Operation;
+use pliron::result::Result;
+
+/// prmt.b32: (a, b, c) -> result (inline PTX, pure)
+pub(crate) fn convert_prmt_b32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 3 {
+        return pliron::input_err_noloc!("prmt_b32 requires 3 operands");
+    }
+
+    let a = operands[0];
+    let b = operands[1];
+    let c = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    // Pure inline asm (per-thread data permutation, not a collective op)
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a, b, c],
+        "prmt.b32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        llvm_export::ops::AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}

--- a/crates/mir-lower/src/convert/intrinsics/mbarrier.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mbarrier.rs
@@ -334,3 +334,59 @@ pub(crate) fn convert_nanosleep(
     rewriter.erase_operation(ctx, op);
     Ok(())
 }
+
+/// mbarrier.pending_count.b64: (state: i64) -> i32 (inline PTX)
+pub(crate) fn convert_pending_count(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 1 {
+        return pliron::input_err_noloc!("mbarrier_pending_count requires 1 operand (state: i64)");
+    }
+    let state = operands[0];
+
+    let asm_template = "mbarrier.pending_count.b64 $0, $1;";
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        i32_ty.into(),
+        vec![state],
+        asm_template,
+        "=r,l",
+    );
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+/// mbarrier.arrive_drop.shared.b64: (addr) -> void (inline PTX)
+pub(crate) fn convert_arrive_drop(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let void_ty = llvm_types::VoidType::get(ctx);
+
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 1 {
+        return pliron::input_err_noloc!("mbarrier_arrive_drop requires 1 operand (addr: ptr)");
+    }
+    let bar_ptr = cast_to_shared_addrspace(ctx, rewriter, operands[0]);
+
+    let asm_template = "mbarrier.arrive_drop.shared.b64 _, [$0];";
+    inline_asm_convergent(
+        ctx,
+        rewriter,
+        void_ty.into(),
+        vec![bar_ptr],
+        asm_template,
+        "l,~{memory}",
+    );
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}

--- a/crates/mir-lower/src/convert/intrinsics/mod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mod.rs
@@ -74,6 +74,7 @@ pub mod asm;
 pub mod atomic;
 pub mod basic;
 pub mod bf16x2;
+pub mod bitops;
 pub mod clc;
 pub mod cluster;
 pub mod common;


### PR DESCRIPTION
## Summary

- Add `prmt.b32` byte permute operation (new `bitops` module across all crates)
- Add `mbarrier.pending_count.b64` to extract pending arrival count from mbarrier state token
- Add `mbarrier.arrive_drop.shared.b64` to signal thread departure from future barrier phases

All three operations span the full pipeline: cuda-device stubs, dialect-nvvm IR ops, mir-importer translation, and mir-lower LLVM conversion.

Closes #51, ref #27.

## Test plan

- [x] `cargo check -p dialect-nvvm` passes
- [x] `cargo check -p mir-lower` passes
- [ ] Verify `prmt.b32` generates correct PTX inline asm with `=r,r,r,r` constraints and `AsmKind::Pure`
- [ ] Verify `mbarrier.pending_count.b64` generates inline asm with `=r,l` constraints
- [ ] Verify `mbarrier.arrive_drop.shared.b64` generates inline asm with `l,~{memory}` constraints and shared addrspace cast