### PR TITLE
chore(deps): bump pliron to master, migrate to TypeHandle API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "awint"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +798,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "once_vec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6298074a1742b584aaca148a6c61ecb27f0b55fdf237c235939c84924377a1"
+
+[[package]]
 name = "oxide-artifacts"
 version = "0.2.1"
 dependencies = [
@@ -818,8 +818,8 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pliron"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "awint",
  "combine",
@@ -830,6 +830,7 @@ dependencies = [
  "inventory",
  "linkme",
  "log",
+ "once_vec",
  "pliron-derive",
  "regex",
  "rustc-hash",
@@ -837,13 +838,12 @@ dependencies = [
  "slotmap",
  "spin",
  "thiserror",
- "utf8-chars",
 ]
 
 [[package]]
 name = "pliron-derive"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "combine",
  "convert_case",
@@ -855,8 +855,8 @@ dependencies = [
 
 [[package]]
 name = "pliron-llvm"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "bitflags",
  "log",
@@ -1182,15 +1182,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "utf8-chars"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe49e006d6df172d7f14794568a90fe41e05a1fa9e03dc276fa6da4bb747ec3"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ repository = "https://github.com/NVlabs/cuda-oxide.git"
 # cuda-oxide consumes the dialect modeling only, not the FFI bridge.
 # `crates/rustc-codegen-cuda/Cargo.toml` MUST stay on this same rev, or pliron
 # resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
-pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5", default-features = false }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "847561916b34649ba944d4eb7db50d02cf9ddf30" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "847561916b34649ba944d4eb7db50d02cf9ddf30" }
+pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "847561916b34649ba944d4eb7db50d02cf9ddf30", default-features = false }
 
 # Internal crates
 llvm-export = { path = "crates/llvm-export" }

--- a/crates/dialect-mir/src/attributes.rs
+++ b/crates/dialect-mir/src/attributes.rs
@@ -9,9 +9,9 @@ use std::hash::{Hash, Hasher};
 
 use pliron::attribute::Attribute;
 use pliron::builtin::attr_interfaces::{FloatAttr, TypedAttrInterface};
-use pliron::context::{Context, Ptr};
+use pliron::context::Context;
 use pliron::derive::{attr_interface_impl, pliron_attr};
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::utils::apfloat::{self, Float, GetSemantics};
 
 use crate::types::MirFP16Type;
@@ -112,14 +112,14 @@ impl Hash for MirFP16Attr {
 }
 
 impl Typed for MirFP16Attr {
-    fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
+    fn get_type(&self, ctx: &Context) -> TypeHandle {
         MirFP16Type::get(ctx).into()
     }
 }
 
 #[attr_interface_impl]
 impl TypedAttrInterface for MirFP16Attr {
-    fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
+    fn get_type(&self, ctx: &Context) -> TypeHandle {
         MirFP16Type::get(ctx).into()
     }
 }

--- a/crates/dialect-mir/src/ops/aggregate.rs
+++ b/crates/dialect-mir/src/ops/aggregate.rs
@@ -109,7 +109,7 @@ impl Verify for MirExtractFieldOp {
                 return verify_err!(op.loc(), "MirExtractFieldOp index out of bounds for tuple");
             }
             let expected_ty = types[index];
-            // Types are Ptr<TypeObj>, can compare directly
+            // Types are TypeHandle, can compare directly
             if res_ty != expected_ty {
                 return verify_err!(
                     op.loc(),

--- a/crates/dialect-mir/src/ops/cast.rs
+++ b/crates/dialect-mir/src/ops/cast.rs
@@ -115,12 +115,12 @@ impl Verify for MirCastOp {
                 if opd_ty_obj.downcast_ref::<IntegerType>().is_none() {
                     return verify_err!(loc, "IntToFloat cast requires integer operand type");
                 }
-                if !type_impls::<dyn FloatTypeInterface>(&**res_ty_obj) {
+                if !type_impls::<dyn FloatTypeInterface>(&*res_ty_obj) {
                     return verify_err!(loc, "IntToFloat cast requires float result type");
                 }
             }
             MirCastKindAttr::FloatToInt => {
-                if !type_impls::<dyn FloatTypeInterface>(&**opd_ty_obj) {
+                if !type_impls::<dyn FloatTypeInterface>(&*opd_ty_obj) {
                     return verify_err!(loc, "FloatToInt cast requires float operand type");
                 }
                 if res_ty_obj.downcast_ref::<IntegerType>().is_none() {
@@ -128,10 +128,10 @@ impl Verify for MirCastOp {
                 }
             }
             MirCastKindAttr::FloatToFloat => {
-                if !type_impls::<dyn FloatTypeInterface>(&**opd_ty_obj) {
+                if !type_impls::<dyn FloatTypeInterface>(&*opd_ty_obj) {
                     return verify_err!(loc, "FloatToFloat cast requires float operand type");
                 }
-                if !type_impls::<dyn FloatTypeInterface>(&**res_ty_obj) {
+                if !type_impls::<dyn FloatTypeInterface>(&*res_ty_obj) {
                     return verify_err!(loc, "FloatToFloat cast requires float result type");
                 }
             }

--- a/crates/dialect-mir/src/ops/constants.rs
+++ b/crates/dialect-mir/src/ops/constants.rs
@@ -20,7 +20,7 @@ use pliron::{
     op::Op,
     operation::Operation,
     result::Error,
-    r#type::{TypeObj, Typed},
+    r#type::{TypeHandle, Typed},
     verify_err,
 };
 use pliron_derive::pliron_op;
@@ -212,7 +212,7 @@ pub struct MirUndefOp;
 
 impl MirUndefOp {
     /// Create a new `MirUndefOp` producing a single result of `result_ty`.
-    pub fn new(ctx: &mut Context, result_ty: Ptr<TypeObj>) -> Self {
+    pub fn new(ctx: &mut Context, result_ty: TypeHandle) -> Self {
         MirUndefOp {
             op: Operation::new(
                 ctx,

--- a/crates/dialect-mir/src/ops/function.rs
+++ b/crates/dialect-mir/src/ops/function.rs
@@ -38,7 +38,7 @@ use pliron::{
     printable::{Printable, State, indented_nl},
     region::Region,
     result::Error,
-    r#type::{TypePtr, Typed, type_cast},
+    r#type::{TypeHandle, Typed, TypedHandle, type_cast},
     verify_err,
 };
 use pliron_derive::pliron_op;
@@ -94,16 +94,16 @@ impl MirFuncOp {
     }
 
     /// Get the function type.
-    pub fn get_type(&self, ctx: &Context) -> TypePtr<FunctionType> {
+    pub fn get_type(&self, ctx: &Context) -> TypedHandle<FunctionType> {
         let ty = attr_cast::<dyn TypedAttrInterface>(&*self.get_attr_mir_func_type(ctx).unwrap())
             .unwrap()
             .get_type(ctx);
-        TypePtr::from_ptr(ty, ctx).unwrap()
+        TypedHandle::from_handle(ty, ctx).unwrap()
     }
 }
 
 impl Typed for MirFuncOp {
-    fn get_type(&self, ctx: &Context) -> Ptr<pliron::r#type::TypeObj> {
+    fn get_type(&self, ctx: &Context) -> TypeHandle {
         self.get_type(ctx).into()
     }
 }

--- a/crates/dialect-mir/src/ops/memory.rs
+++ b/crates/dialect-mir/src/ops/memory.rs
@@ -24,7 +24,7 @@ use pliron::{
         AllocInfo, PromotableAllocationInterface, PromotableOpInterface, PromotableOpKind,
     },
     result::Error,
-    r#type::{TypeObj, Typed},
+    r#type::{TypeHandle, Typed},
     value::Value,
     verify_err,
 };
@@ -93,7 +93,7 @@ impl MirAllocaOp {
     }
 
     /// Return the pointee (element) type carried by the result pointer.
-    pub fn pointee_type(&self, ctx: &Context) -> Ptr<TypeObj> {
+    pub fn pointee_type(&self, ctx: &Context) -> TypeHandle {
         let res_ty = self.get_operation().deref(ctx).get_result(0).get_type(ctx);
         let ty_ref = res_ty.deref(ctx);
         ty_ref

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -7,11 +7,10 @@
 
 use pliron::builtin::type_interfaces::FloatTypeInterface;
 use pliron::context::Context;
-use pliron::context::Ptr;
 use pliron::derive::{pliron_type, type_interface_impl};
 use pliron::location::Location;
 use pliron::result::Error;
-use pliron::r#type::{Type, TypeObj, TypePtr};
+use pliron::r#type::{Type, TypeHandle, TypedHandle};
 use pliron::utils::apfloat::{self, GetSemantics, Semantics};
 use pliron::{common_traits::Verify, verify_err};
 
@@ -38,19 +37,19 @@ impl FloatTypeInterface for MirFP16Type {
 #[pliron_type(name = "mir.tuple", format = "`<` vec($types, CharSpace(`,`)) `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirTupleType {
-    pub types: Vec<Ptr<TypeObj>>,
+    pub types: Vec<TypeHandle>,
 }
 
 impl MirTupleType {
-    pub fn get(ctx: &mut Context, types: Vec<Ptr<TypeObj>>) -> TypePtr<Self> {
+    pub fn get(ctx: &mut Context, types: Vec<TypeHandle>) -> TypedHandle<Self> {
         Type::register_instance(MirTupleType { types }, ctx)
     }
 
-    pub fn get_existing(ctx: &Context, types: Vec<Ptr<TypeObj>>) -> Option<TypePtr<Self>> {
+    pub fn get_existing(ctx: &Context, types: Vec<TypeHandle>) -> Option<TypedHandle<Self>> {
         Type::get_instance(MirTupleType { types }, ctx)
     }
 
-    pub fn get_types(&self) -> &[Ptr<TypeObj>] {
+    pub fn get_types(&self) -> &[TypeHandle] {
         &self.types
     }
 }
@@ -100,7 +99,7 @@ pub mod address_space {
 )]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirPtrType {
-    pub pointee: Ptr<TypeObj>,
+    pub pointee: TypeHandle,
     pub is_mutable: bool,
     pub address_space: u32,
 }
@@ -109,10 +108,10 @@ impl MirPtrType {
     /// Create a pointer type with explicit address space.
     pub fn get(
         ctx: &mut Context,
-        pointee: Ptr<TypeObj>,
+        pointee: TypeHandle,
         is_mutable: bool,
         address_space: u32,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Type::register_instance(
             MirPtrType {
                 pointee,
@@ -126,42 +125,50 @@ impl MirPtrType {
     /// Create a pointer in generic address space (0).
     pub fn get_generic(
         ctx: &mut Context,
-        pointee: Ptr<TypeObj>,
+        pointee: TypeHandle,
         is_mutable: bool,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::GENERIC)
     }
 
     /// Create a pointer in shared memory address space (3).
-    pub fn get_shared(ctx: &mut Context, pointee: Ptr<TypeObj>, is_mutable: bool) -> TypePtr<Self> {
+    pub fn get_shared(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+    ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::SHARED)
     }
 
     /// Create a pointer in global memory address space (1).
-    pub fn get_global(ctx: &mut Context, pointee: Ptr<TypeObj>, is_mutable: bool) -> TypePtr<Self> {
+    pub fn get_global(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+    ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::GLOBAL)
     }
 
     /// Create a pointer in constant memory address space (4).
     pub fn get_constant(
         ctx: &mut Context,
-        pointee: Ptr<TypeObj>,
+        pointee: TypeHandle,
         is_mutable: bool,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::CONSTANT)
     }
 
     /// Create a pointer in tensor memory address space (6) - Blackwell+ tcgen05.
-    pub fn get_tmem(ctx: &mut Context, pointee: Ptr<TypeObj>, is_mutable: bool) -> TypePtr<Self> {
+    pub fn get_tmem(ctx: &mut Context, pointee: TypeHandle, is_mutable: bool) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::TMEM)
     }
 
     pub fn get_existing(
         ctx: &Context,
-        pointee: Ptr<TypeObj>,
+        pointee: TypeHandle,
         is_mutable: bool,
         address_space: u32,
-    ) -> Option<TypePtr<Self>> {
+    ) -> Option<TypedHandle<Self>> {
         Type::get_instance(
             MirPtrType {
                 pointee,
@@ -208,19 +215,19 @@ impl Verify for MirPtrType {
 #[pliron_type(name = "mir.slice", format = "`<` $element_ty `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirSliceType {
-    pub element_ty: Ptr<TypeObj>,
+    pub element_ty: TypeHandle,
 }
 
 impl MirSliceType {
-    pub fn get(ctx: &mut Context, element_ty: Ptr<TypeObj>) -> TypePtr<Self> {
+    pub fn get(ctx: &mut Context, element_ty: TypeHandle) -> TypedHandle<Self> {
         Type::register_instance(MirSliceType { element_ty }, ctx)
     }
 
-    pub fn get_existing(ctx: &Context, element_ty: Ptr<TypeObj>) -> Option<TypePtr<Self>> {
+    pub fn get_existing(ctx: &Context, element_ty: TypeHandle) -> Option<TypedHandle<Self>> {
         Type::get_instance(MirSliceType { element_ty }, ctx)
     }
 
-    pub fn element_type(&self) -> Ptr<TypeObj> {
+    pub fn element_type(&self) -> TypeHandle {
         self.element_ty
     }
 }
@@ -241,19 +248,19 @@ impl Verify for MirSliceType {
 #[pliron_type(name = "mir.disjoint_slice", format = "`<` $element_ty `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirDisjointSliceType {
-    pub element_ty: Ptr<TypeObj>,
+    pub element_ty: TypeHandle,
 }
 
 impl MirDisjointSliceType {
-    pub fn get(ctx: &mut Context, element_ty: Ptr<TypeObj>) -> TypePtr<Self> {
+    pub fn get(ctx: &mut Context, element_ty: TypeHandle) -> TypedHandle<Self> {
         Type::register_instance(MirDisjointSliceType { element_ty }, ctx)
     }
 
-    pub fn get_existing(ctx: &Context, element_ty: Ptr<TypeObj>) -> Option<TypePtr<Self>> {
+    pub fn get_existing(ctx: &Context, element_ty: TypeHandle) -> Option<TypedHandle<Self>> {
         Type::get_instance(MirDisjointSliceType { element_ty }, ctx)
     }
 
-    pub fn element_type(&self) -> Ptr<TypeObj> {
+    pub fn element_type(&self) -> TypeHandle {
         self.element_ty
     }
 }
@@ -300,7 +307,7 @@ pub struct MirStructType {
     /// Field names in declaration order
     pub field_names: Vec<String>,
     /// Field types in declaration order (parallel to field_names)
-    pub field_types: Vec<Ptr<TypeObj>>,
+    pub field_types: Vec<TypeHandle>,
     /// Memory order mapping: `mem_to_decl[mem_idx] = decl_idx`.
     /// Empty means identity (no reordering).
     pub mem_to_decl: Vec<usize>,
@@ -324,8 +331,8 @@ impl MirStructType {
         ctx: &mut Context,
         name: String,
         field_names: Vec<String>,
-        field_types: Vec<Ptr<TypeObj>>,
-    ) -> TypePtr<Self> {
+        field_types: Vec<TypeHandle>,
+    ) -> TypedHandle<Self> {
         Self::get_with_layout(ctx, name, field_names, field_types, vec![])
     }
 
@@ -337,9 +344,9 @@ impl MirStructType {
         ctx: &mut Context,
         name: String,
         field_names: Vec<String>,
-        field_types: Vec<Ptr<TypeObj>>,
+        field_types: Vec<TypeHandle>,
         mem_to_decl: Vec<usize>,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Self::get_with_full_layout(
             ctx,
             name,
@@ -367,12 +374,12 @@ impl MirStructType {
         ctx: &mut Context,
         name: String,
         field_names: Vec<String>,
-        field_types: Vec<Ptr<TypeObj>>,
+        field_types: Vec<TypeHandle>,
         mem_to_decl: Vec<usize>,
         field_offsets: Vec<u64>,
         total_size: u64,
         abi_align: u64,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Type::register_instance(
             MirStructType {
                 name,
@@ -392,8 +399,8 @@ impl MirStructType {
         ctx: &Context,
         name: String,
         field_names: Vec<String>,
-        field_types: Vec<Ptr<TypeObj>>,
-    ) -> Option<TypePtr<Self>> {
+        field_types: Vec<TypeHandle>,
+    ) -> Option<TypedHandle<Self>> {
         Type::get_instance(
             MirStructType {
                 name,
@@ -424,7 +431,7 @@ impl MirStructType {
     }
 
     /// Get field types.
-    pub fn field_types(&self) -> &[Ptr<TypeObj>] {
+    pub fn field_types(&self) -> &[TypeHandle] {
         &self.field_types
     }
 
@@ -466,12 +473,12 @@ impl MirStructType {
     }
 
     /// Get the type of a field by index.
-    pub fn get_field_type(&self, index: usize) -> Option<Ptr<TypeObj>> {
+    pub fn get_field_type(&self, index: usize) -> Option<TypeHandle> {
         self.field_types.get(index).copied()
     }
 
     /// Get the type of a field by name.
-    pub fn get_field_type_by_name(&self, name: &str) -> Option<Ptr<TypeObj>> {
+    pub fn get_field_type_by_name(&self, name: &str) -> Option<TypeHandle> {
         self.get_field_index(name)
             .and_then(|idx| self.get_field_type(idx))
     }
@@ -497,27 +504,27 @@ impl Verify for MirStructType {
 #[pliron_type(name = "mir.array", format = "`<` $element_ty `,` $size `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirArrayType {
-    pub element_ty: Ptr<TypeObj>,
+    pub element_ty: TypeHandle,
     pub size: u64,
 }
 
 impl MirArrayType {
     /// Create a new array type.
-    pub fn get(ctx: &mut Context, element_ty: Ptr<TypeObj>, size: u64) -> TypePtr<Self> {
+    pub fn get(ctx: &mut Context, element_ty: TypeHandle, size: u64) -> TypedHandle<Self> {
         Type::register_instance(MirArrayType { element_ty, size }, ctx)
     }
 
     /// Get an existing array type if it exists.
     pub fn get_existing(
         ctx: &Context,
-        element_ty: Ptr<TypeObj>,
+        element_ty: TypeHandle,
         size: u64,
-    ) -> Option<TypePtr<Self>> {
+    ) -> Option<TypedHandle<Self>> {
         Type::get_instance(MirArrayType { element_ty, size }, ctx)
     }
 
     /// Get the element type.
-    pub fn element_type(&self) -> Ptr<TypeObj> {
+    pub fn element_type(&self) -> TypeHandle {
         self.element_ty
     }
 
@@ -541,7 +548,7 @@ pub struct EnumVariant {
     /// Variant name (e.g., "Some", "None", "Ok", "Err")
     pub name: String,
     /// Field types for this variant (empty for unit variants like None)
-    pub field_types: Vec<Ptr<TypeObj>>,
+    pub field_types: Vec<TypeHandle>,
     /// Where each field lives, as a byte position inside the ENUM (not
     /// inside the variant), from rustc's layout. Same order as
     /// `field_types`. Different variants reuse the same positions because
@@ -551,7 +558,7 @@ pub struct EnumVariant {
 
 impl EnumVariant {
     /// Create a new enum variant with unknown field offsets.
-    pub fn new(name: String, field_types: Vec<Ptr<TypeObj>>) -> Self {
+    pub fn new(name: String, field_types: Vec<TypeHandle>) -> Self {
         EnumVariant {
             name,
             field_types,
@@ -563,7 +570,7 @@ impl EnumVariant {
     /// each field (parallel to `field_types`).
     pub fn new_with_offsets(
         name: String,
-        field_types: Vec<Ptr<TypeObj>>,
+        field_types: Vec<TypeHandle>,
         field_offsets: Vec<u64>,
     ) -> Self {
         EnumVariant {
@@ -639,7 +646,7 @@ pub struct MirEnumType {
     /// width and signedness for Direct-tag enums (so `#[repr(uN/iN)]`,
     /// `#[repr(C)]`, sparse and negative discriminants are all honoured); a
     /// variant-count fallback for the niched / single-variant models.
-    pub discriminant_ty: Ptr<TypeObj>,
+    pub discriminant_ty: TypeHandle,
     /// Variant names in order
     pub variant_names: Vec<String>,
     /// Declared discriminant VALUES in variant order, as the unsigned bit
@@ -649,7 +656,7 @@ pub struct MirEnumType {
     /// Number of fields for each variant (parallel to variant_names)
     pub variant_field_counts: Vec<u32>,
     /// All field types concatenated (use variant_field_counts to split)
-    pub all_field_types: Vec<Ptr<TypeObj>>,
+    pub all_field_types: Vec<TypeHandle>,
     /// Where each field lives, as a byte position inside the enum, from
     /// rustc's layout (same order as `all_field_types`). Positions repeat
     /// across variants because variants share bytes. Empty when the
@@ -679,10 +686,10 @@ impl MirEnumType {
     pub fn get(
         ctx: &mut Context,
         name: String,
-        discriminant_ty: Ptr<TypeObj>,
+        discriminant_ty: TypeHandle,
         variant_discriminants: Vec<u64>,
         variants: Vec<EnumVariant>,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         Self::get_with_layout(
             ctx,
             name,
@@ -705,13 +712,13 @@ impl MirEnumType {
     pub fn get_with_layout(
         ctx: &mut Context,
         name: String,
-        discriminant_ty: Ptr<TypeObj>,
+        discriminant_ty: TypeHandle,
         variant_discriminants: Vec<u64>,
         variants: Vec<EnumVariant>,
         tag_offset: u64,
         total_size: u64,
         abi_align: u64,
-    ) -> TypePtr<Self> {
+    ) -> TypedHandle<Self> {
         // Flatten variants into parallel vectors
         let mut variant_names = Vec::with_capacity(variants.len());
         let mut variant_field_counts = Vec::with_capacity(variants.len());
@@ -748,7 +755,7 @@ impl MirEnumType {
     }
 
     /// Get the discriminant type.
-    pub fn discriminant_type(&self) -> Ptr<TypeObj> {
+    pub fn discriminant_type(&self) -> TypeHandle {
         self.discriminant_ty
     }
 

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -963,7 +963,7 @@ fn test_mir_global_alloc_verify() {
 
     // Helper: build a MirGlobalAllocOp whose result pointer is in `ptr_ty`
     // address space, with valid attributes.
-    let build = |ctx: &mut Context, ptr_ty: pliron::r#type::TypePtr<MirPtrType>| {
+    let build = |ctx: &mut Context, ptr_ty: pliron::r#type::TypedHandle<MirPtrType>| {
         let op = Operation::new(
             ctx,
             MirGlobalAllocOp::get_concrete_op_info(),

--- a/crates/dialect-nvvm/src/ops/asm.rs
+++ b/crates/dialect-nvvm/src/ops/asm.rs
@@ -13,7 +13,7 @@ use pliron::{
     op::Op,
     operation::Operation,
     result::Error,
-    r#type::TypeObj,
+    r#type::TypeHandle,
     value::Value,
     verify_err,
 };
@@ -44,7 +44,7 @@ impl InlinePtxOp {
     /// Build an inline PTX operation with zero or one result.
     pub fn build(
         ctx: &mut Context,
-        result_tys: Vec<Ptr<TypeObj>>,
+        result_tys: Vec<TypeHandle>,
         inputs: Vec<Value>,
         template: &str,
         constraints: &str,

--- a/crates/dialect-nvvm/src/ops/atomic.rs
+++ b/crates/dialect-nvvm/src/ops/atomic.rs
@@ -167,7 +167,7 @@ impl NvvmAtomicLoadOp {
     pub fn build(
         ctx: &mut Context,
         ptr: Value,
-        result_ty: Ptr<pliron::r#type::TypeObj>,
+        result_ty: pliron::r#type::TypeHandle,
         ordering: AtomicOrdering,
         scope: AtomicScope,
     ) -> Self {
@@ -337,7 +337,7 @@ impl NvvmAtomicRmwOp {
         ctx: &mut Context,
         ptr: Value,
         val: Value,
-        result_ty: Ptr<pliron::r#type::TypeObj>,
+        result_ty: pliron::r#type::TypeHandle,
         rmw_kind: AtomicRmwKind,
         ordering: AtomicOrdering,
         scope: AtomicScope,
@@ -444,7 +444,7 @@ impl NvvmAtomicCmpxchgOp {
         ptr: Value,
         cmp: Value,
         new: Value,
-        result_ty: Ptr<pliron::r#type::TypeObj>,
+        result_ty: pliron::r#type::TypeHandle,
         success_ordering: AtomicOrdering,
         failure_ordering: AtomicOrdering,
         scope: AtomicScope,

--- a/crates/dialect-nvvm/src/ops/debug.rs
+++ b/crates/dialect-nvvm/src/ops/debug.rs
@@ -359,7 +359,7 @@ impl VprintfOp {
         Operation::new(
             ctx,
             Self::get_concrete_op_info(),
-            vec![i32_ty.to_ptr()],      // Result: i32
+            vec![i32_ty.to_handle()],   // Result: i32
             vec![format_ptr, args_ptr], // Operands: format_ptr, args_ptr
             vec![],
             0,

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -180,9 +180,7 @@ impl<'a> ModuleExportState<'a> {
             }
         }
 
-        use pliron::r#type::TypeObj;
-        let func_type = func.get_type(self.ctx);
-        let ft = Ptr::<TypeObj>::from(func_type);
+        let ft: pliron::r#type::TypeHandle = func.get_type(self.ctx).into();
         let ft_ref = ft.deref(self.ctx);
         let func_ty = ft_ref
             .downcast_ref::<FuncType>()

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -1274,7 +1274,7 @@ fn fastmath_keywords(flags: FastmathFlags) -> String {
 }
 
 /// Return the address space of a pointer type, or 0 for non-pointer types.
-fn addrspace_of(ty: Ptr<pliron::r#type::TypeObj>, ctx: &pliron::context::Context) -> u32 {
+fn addrspace_of(ty: pliron::r#type::TypeHandle, ctx: &pliron::context::Context) -> u32 {
     ty.deref(ctx)
         .downcast_ref::<crate::types::PointerType>()
         .map_or(0, crate::types::PointerType::address_space)

--- a/crates/llvm-export/src/export/types.rs
+++ b/crates/llvm-export/src/export/types.rs
@@ -9,8 +9,7 @@ use std::fmt::Write;
 
 use pliron::{
     builtin::types::{FP32Type, FP64Type, IntegerType},
-    context::Ptr,
-    r#type::TypeObj,
+    r#type::TypeHandle,
 };
 
 use crate::types::{HalfType, PointerType, StructType, VoidType};
@@ -18,7 +17,7 @@ use crate::types::{HalfType, PointerType, StructType, VoidType};
 use super::state::ModuleExportState;
 
 impl<'a> ModuleExportState<'a> {
-    pub(super) fn export_type(&self, ty: Ptr<TypeObj>, output: &mut String) -> Result<(), String> {
+    pub(super) fn export_type(&self, ty: TypeHandle, output: &mut String) -> Result<(), String> {
         let ty_ref = ty.deref(self.ctx);
         if let Some(int_ty) = ty_ref.downcast_ref::<IntegerType>() {
             write!(output, "i{}", int_ty.width()).unwrap();
@@ -65,7 +64,7 @@ impl<'a> ModuleExportState<'a> {
     /// Used as the fallback when no explicit alignment is stamped on a
     /// load/store/alloca op. Required for atomic loads/stores (LLVM IR
     /// mandates explicit alignment) and for vectorization hints.
-    pub(super) fn natural_alignment(&self, ty: Ptr<TypeObj>) -> u32 {
+    pub(super) fn natural_alignment(&self, ty: TypeHandle) -> u32 {
         let ty_ref = ty.deref(self.ctx);
         if let Some(int_ty) = ty_ref.downcast_ref::<IntegerType>() {
             // ceil(width / 8), minimum 1.

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -46,7 +46,7 @@ pub mod types {
         pub const TMEM: u32 = 6;
     }
 
-    use pliron::{context::Context, r#type::TypePtr};
+    use pliron::{context::Context, r#type::TypedHandle};
     pub use pliron_llvm::types::PointerType;
 
     /// Address-space convenience constructors/predicates re-homed from the
@@ -54,13 +54,13 @@ pub mod types {
     /// `PointerType::get(ctx, address_space)` + `address_space()`.
     pub trait PointerTypeExt {
         /// Pointer into the generic address space.
-        fn get_generic(ctx: &mut Context) -> TypePtr<PointerType>;
+        fn get_generic(ctx: &mut Context) -> TypedHandle<PointerType>;
         /// Pointer into the shared address space.
-        fn get_shared(ctx: &mut Context) -> TypePtr<PointerType>;
+        fn get_shared(ctx: &mut Context) -> TypedHandle<PointerType>;
         /// Pointer into the global address space.
-        fn get_global(ctx: &mut Context) -> TypePtr<PointerType>;
+        fn get_global(ctx: &mut Context) -> TypedHandle<PointerType>;
         /// Pointer into tensor memory.
-        fn get_tmem(ctx: &mut Context) -> TypePtr<PointerType>;
+        fn get_tmem(ctx: &mut Context) -> TypedHandle<PointerType>;
         /// True if this pointer is in the shared address space.
         fn is_shared(&self) -> bool;
         /// True if this pointer is in tensor memory.
@@ -68,16 +68,16 @@ pub mod types {
     }
 
     impl PointerTypeExt for PointerType {
-        fn get_generic(ctx: &mut Context) -> TypePtr<PointerType> {
+        fn get_generic(ctx: &mut Context) -> TypedHandle<PointerType> {
             PointerType::get(ctx, address_space::GENERIC)
         }
-        fn get_shared(ctx: &mut Context) -> TypePtr<PointerType> {
+        fn get_shared(ctx: &mut Context) -> TypedHandle<PointerType> {
             PointerType::get(ctx, address_space::SHARED)
         }
-        fn get_global(ctx: &mut Context) -> TypePtr<PointerType> {
+        fn get_global(ctx: &mut Context) -> TypedHandle<PointerType> {
             PointerType::get(ctx, address_space::GLOBAL)
         }
-        fn get_tmem(ctx: &mut Context) -> TypePtr<PointerType> {
+        fn get_tmem(ctx: &mut Context) -> TypedHandle<PointerType> {
             PointerType::get(ctx, address_space::TMEM)
         }
         fn is_shared(&self) -> bool {
@@ -152,7 +152,7 @@ pub mod ops {
         op::Op,
         operation::Operation,
         result::Error,
-        r#type::TypeObj,
+        r#type::TypeHandle,
         value::Value,
     };
     use pliron_derive::{pliron_attr, pliron_op};
@@ -205,7 +205,7 @@ pub mod ops {
         /// Build an `InlineAsmOp` tagged with the given [`AsmKind`].
         fn build(
             ctx: &mut Context,
-            result_ty: Ptr<TypeObj>,
+            result_ty: TypeHandle,
             inputs: Vec<Value>,
             asm_template: &str,
             constraints: &str,
@@ -216,7 +216,7 @@ pub mod ops {
     impl InlineAsmOpExt for InlineAsmOp {
         fn build(
             ctx: &mut Context,
-            result_ty: Ptr<TypeObj>,
+            result_ty: TypeHandle,
             inputs: Vec<Value>,
             asm_template: &str,
             constraints: &str,
@@ -968,7 +968,7 @@ pub mod ops {
         fn new_with_alignment(
             ctx: &mut Context,
             name: Identifier,
-            ty: Ptr<TypeObj>,
+            ty: TypeHandle,
             alignment: u64,
         ) -> Self;
         /// Read the explicit alignment (bytes), if one was set.
@@ -979,7 +979,7 @@ pub mod ops {
         fn new_with_alignment(
             ctx: &mut Context,
             name: Identifier,
-            ty: Ptr<TypeObj>,
+            ty: TypeHandle,
             alignment: u64,
         ) -> Self {
             let op = GlobalOp::new(ctx, name, ty);

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -100,12 +100,17 @@ fn export_volatile_load_prints_keyword() {
     let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
     let ptr_ty = PointerType::get(&mut ctx, 0);
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![ptr_ty.to_ptr()], false);
+    let func_ty = FuncType::get(
+        &mut ctx,
+        void_ty.to_handle(),
+        vec![ptr_ty.to_handle()],
+        false,
+    );
     let func = FuncOp::new(&mut ctx, "volatile_load_test".try_into().unwrap(), func_ty);
     let entry = func.get_or_create_entry_block(&mut ctx);
     let ptr = entry.deref(&ctx).get_argument(0);
 
-    let load = LoadOp::new(&mut ctx, ptr, i32_ty.to_ptr());
+    let load = LoadOp::new(&mut ctx, ptr, i32_ty.to_handle());
     llvm_export::ops::set_op_volatile(&mut ctx, load.get_operation(), true);
     load.get_operation().insert_at_back(entry, &ctx);
     ReturnOp::new(&mut ctx, None)
@@ -137,8 +142,8 @@ fn export_volatile_store_prints_keyword() {
     let void_ty = VoidType::get(&ctx);
     let func_ty = FuncType::get(
         &mut ctx,
-        void_ty.to_ptr(),
-        vec![ptr_ty.to_ptr(), i32_ty.to_ptr()],
+        void_ty.to_handle(),
+        vec![ptr_ty.to_handle(), i32_ty.to_handle()],
         false,
     );
     let func = FuncOp::new(&mut ctx, "volatile_store_test".try_into().unwrap(), func_ty);
@@ -190,13 +195,13 @@ fn export_addressof_uses_symbol_when_definition_block_prints_later() {
     let global = GlobalOp::new(
         &mut ctx,
         "__shared_mem_20".try_into().unwrap(),
-        i32_ty.to_ptr(),
+        i32_ty.to_handle(),
     );
     global.set_address_space(&mut ctx, 3);
     global.get_operation().insert_at_back(module_block, &ctx);
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "uses_late_addressof".try_into().unwrap(), func_ty);
     let entry = func.get_or_create_entry_block(&mut ctx);
     let func_region = func.get_operation().deref(&ctx).get_region(0);
@@ -220,7 +225,7 @@ fn export_addressof_uses_symbol_when_definition_block_prints_later() {
         &mut ctx,
         address_value,
         vec![GepIndex::Constant(0)],
-        i32_ty.to_ptr(),
+        i32_ty.to_handle(),
     );
     gep.get_operation().insert_at_back(use_block, &ctx);
     ReturnOp::new(&mut ctx, None)
@@ -263,7 +268,7 @@ fn export_inline_asm_respects_sideeffect_marker() {
     let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "has_inline_asm".try_into().unwrap(), func_ty);
     let entry = func.get_or_create_entry_block(&mut ctx);
 
@@ -306,7 +311,7 @@ fn export_inline_asm_escapes_llvm_string_literals() {
     let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(
         &mut ctx,
         "has_escaped_inline_asm".try_into().unwrap(),
@@ -351,7 +356,7 @@ fn nvvm_metadata_version_uses_next_allocated_metadata_id() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "bounded_kernel".try_into().unwrap(), func_ty);
     let entry = func.get_or_create_entry_block(&mut ctx);
     ReturnOp::new(&mut ctx, None)
@@ -400,7 +405,7 @@ fn line_table_debug_metadata_emits_function_scope_and_instruction_locations() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 7, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -471,7 +476,7 @@ fn export_alwaysinline_function_attribute_uses_llvm_define_syntax() {
     let module_block = module_top_block(&mut ctx, &module);
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "inline_helper".try_into().unwrap(), func_ty);
     let entry = func.get_or_create_entry_block(&mut ctx);
     ReturnOp::new(&mut ctx, None)
@@ -510,7 +515,7 @@ fn export_alwaysinline_coexists_with_debug_scope() {
     let module_block = module_top_block(&mut ctx, &module);
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "inline_helper".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 7, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -559,7 +564,7 @@ fn line_table_debug_metadata_uses_file_scope_for_cross_file_locations() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 38, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -620,7 +625,7 @@ fn line_table_debug_metadata_emits_inlined_at_for_callsite_locations() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 38, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -673,7 +678,7 @@ fn debug_metadata_shares_allocator_with_nvvm_metadata() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 10, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -739,7 +744,7 @@ fn debug_locations_use_rustc_source_scope_positions() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 10, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -826,7 +831,7 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 30, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -936,7 +941,7 @@ fn full_debug_metadata_uses_file_scope_for_cross_file_local_variables() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 30, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -1016,7 +1021,7 @@ fn full_debug_metadata_emits_dbg_value_for_promoted_locals() {
 
     let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![i32_ty.into()], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![i32_ty.into()], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 30, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -1101,7 +1106,7 @@ fn full_debug_metadata_uses_inlined_callee_scope_for_inlined_arguments() {
 
     let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![i32_ty.into()], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![i32_ty.into()], false);
     let func = FuncOp::new(&mut ctx, "caller_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 30, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -1235,7 +1240,7 @@ fn line_table_debug_metadata_ignores_tagged_alloca_variables() {
     };
 
     let void_ty = VoidType::get(&ctx);
-    let func_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let func_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 40, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
@@ -1304,11 +1309,11 @@ fn line_table_debug_metadata_adds_fallback_locations_to_calls() {
 
     let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
     let void_ty = VoidType::get(&ctx);
-    let helper_ty = FuncType::get(&mut ctx, i32_ty.to_ptr(), vec![], false);
+    let helper_ty = FuncType::get(&mut ctx, i32_ty.to_handle(), vec![], false);
     let helper = FuncOp::new(&mut ctx, "helper".try_into().unwrap(), helper_ty);
     helper.get_operation().insert_at_back(module_block, &ctx);
 
-    let caller_ty = FuncType::get(&mut ctx, void_ty.to_ptr(), vec![], false);
+    let caller_ty = FuncType::get(&mut ctx, void_ty.to_handle(), vec![], false);
     let caller = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), caller_ty);
     let caller_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 20, 3);
     caller.get_operation().deref_mut(&ctx).set_loc(caller_loc);
@@ -1418,7 +1423,7 @@ fn export_emits_fast_math_flags_only_on_flagged_float_ops() {
     let void_ty = VoidType::get(&ctx);
     let func_ty = FuncType::get(
         &mut ctx,
-        void_ty.to_ptr(),
+        void_ty.to_handle(),
         vec![f32_ty.into(), f32_ty.into()],
         false,
     );

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -677,7 +677,7 @@ fn add_device_extern_declarations(
 }
 
 /// Convert LLVM type string to pliron type.
-fn llvm_type_string_to_pliron(ctx: &mut Context, type_str: &str) -> Ptr<pliron::r#type::TypeObj> {
+fn llvm_type_string_to_pliron(ctx: &mut Context, type_str: &str) -> pliron::r#type::TypeHandle {
     use llvm_export::types::PointerType;
     use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -49,7 +49,7 @@ use pliron::location::{Located, Location};
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::printable::Printable;
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::utils::apint::APInt;
 use pliron::value::Value;
 use pliron::{input_err, input_err_noloc, input_error, input_error_noloc};
@@ -74,7 +74,7 @@ use std::num::NonZeroUsize;
 fn cast_to_generic_addrspace_if_needed(
     ctx: &mut Context,
     value: Value,
-    expected_type: Ptr<TypeObj>,
+    expected_type: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -82,14 +82,14 @@ fn cast_to_generic_addrspace_if_needed(
     let value_type = value.get_type(ctx);
 
     // Check if both are pointer types
-    let value_ptr_info: Option<(Ptr<TypeObj>, bool, u32)> = {
+    let value_ptr_info: Option<(TypeHandle, bool, u32)> = {
         let ty_ref = value_type.deref(ctx);
         ty_ref
             .downcast_ref::<dialect_mir::types::MirPtrType>()
             .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space))
     };
 
-    let expected_ptr_info: Option<(Ptr<TypeObj>, bool, u32)> = {
+    let expected_ptr_info: Option<(TypeHandle, bool, u32)> = {
         let ty_ref = expected_type.deref(ctx);
         ty_ref
             .downcast_ref::<dialect_mir::types::MirPtrType>()
@@ -142,13 +142,13 @@ fn cast_to_generic_addrspace_if_needed(
 fn cast_struct_fields_to_expected_types(
     ctx: &mut Context,
     field_values: Vec<Value>,
-    struct_type: Ptr<TypeObj>,
+    struct_type: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> (Vec<Value>, Option<Ptr<Operation>>) {
     // Get field types from the struct type
-    let field_types: Vec<Ptr<TypeObj>> = {
+    let field_types: Vec<TypeHandle> = {
         let ty_ref = struct_type.deref(ctx);
         if let Some(st) = ty_ref.downcast_ref::<dialect_mir::types::MirStructType>() {
             st.field_types.clone()
@@ -188,14 +188,14 @@ fn cast_struct_fields_to_expected_types(
 fn cast_enum_fields_to_expected_types(
     ctx: &mut Context,
     field_values: Vec<Value>,
-    enum_type: Ptr<TypeObj>,
+    enum_type: TypeHandle,
     variant_idx: usize,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> (Vec<Value>, Option<Ptr<Operation>>) {
     // Get the field types for this variant from the enum type
-    let variant_field_types: Vec<Ptr<TypeObj>> = {
+    let variant_field_types: Vec<TypeHandle> = {
         let ty_ref = enum_type.deref(ctx);
         if let Some(et) = ty_ref.downcast_ref::<dialect_mir::types::MirEnumType>() {
             // Calculate the field offset for this variant
@@ -361,27 +361,27 @@ pub fn translate_rvalue(
                 // Comparison operations - return bool (i1)
                 mir::BinOp::Lt => (
                     MirLtOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 mir::BinOp::Le => (
                     MirLeOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 mir::BinOp::Gt => (
                     MirGtOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 mir::BinOp::Ge => (
                     MirGeOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 mir::BinOp::Eq => (
                     MirEqOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 mir::BinOp::Ne => (
                     MirNeOp::get_concrete_op_info(),
-                    types::get_bool_type(ctx).to_ptr(),
+                    types::get_bool_type(ctx).to_handle(),
                 ),
                 // Three-way comparison (`Ord::cmp`) - returns
                 // `core::cmp::Ordering`. rustc's `BinOp::ty` knows the
@@ -472,7 +472,7 @@ pub fn translate_rvalue(
                     let op = Operation::new(
                         ctx,
                         MirExtractFieldOp::get_concrete_op_info(),
-                        vec![result_type.to_ptr()],
+                        vec![result_type.to_handle()],
                         vec![operand_val],
                         vec![],
                         0,
@@ -667,7 +667,7 @@ pub fn translate_rvalue(
                     let operand_type = left_val.get_type(ctx);
                     let bool_type = types::get_bool_type(ctx).into();
                     let tuple_type = types::MirTupleType::get(ctx, vec![operand_type, bool_type]);
-                    let result_type_ptr = tuple_type.to_ptr();
+                    let result_type_ptr = tuple_type.to_handle();
 
                     // Create a checked operation based on the binary operator
                     let op_id = match bin_op {
@@ -1307,7 +1307,7 @@ pub fn translate_rvalue(
                             // pointer. Values coming from shared memory carry
                             // addrspace(3); normalize them like the struct/array
                             // arms do.
-                            let expected_ptr_ty: Ptr<TypeObj> =
+                            let expected_ptr_ty: TypeHandle =
                                 dialect_mir::types::MirPtrType::get_generic(
                                     ctx,
                                     element_type,
@@ -2557,7 +2557,7 @@ pub fn translate_operand(
             use pliron::builtin::types::{IntegerType, Signedness};
             use pliron::utils::apint::APInt;
 
-            let bool_ty: Ptr<TypeObj> = IntegerType::get(ctx, 1, Signedness::Signless).into();
+            let bool_ty: TypeHandle = IntegerType::get(ctx, 1, Signedness::Signless).into();
             let false_val = APInt::from_u64(0, std::num::NonZeroUsize::new(1).unwrap());
             let const_attr =
                 IntegerAttr::new(IntegerType::get(ctx, 1, Signedness::Signless), false_val);
@@ -2969,7 +2969,7 @@ fn translate_place_value_fallback(
                     let base_ty = base_value.get_type(ctx);
 
                     // Extract pointee info while holding the borrow, then release before fallback
-                    let pointee_info: Option<(Ptr<pliron::r#type::TypeObj>, bool)> = {
+                    let pointee_info: Option<(pliron::r#type::TypeHandle, bool)> = {
                         let base_ty_ref = base_ty.deref(ctx);
                         base_ty_ref
                             .downcast_ref::<dialect_mir::types::MirPtrType>()
@@ -2990,7 +2990,7 @@ fn translate_place_value_fallback(
 
                     let (res_ty, is_zst) = pointee_info.unwrap_or_else(|| {
                         // Fallback: assume i32 if we can't determine the type
-                        (types::get_i32_type(ctx).to_ptr(), false)
+                        (types::get_i32_type(ctx).to_handle(), false)
                     });
 
                     // For ZST pointees (like SharedArray), don't create a load op.
@@ -3411,11 +3411,11 @@ fn apply_deref_projection(
 
     enum DerefKind {
         Ptr {
-            pointee: Ptr<pliron::r#type::TypeObj>,
+            pointee: pliron::r#type::TypeHandle,
             is_zst: bool,
         },
         Slice {
-            element_ty: Ptr<pliron::r#type::TypeObj>,
+            element_ty: pliron::r#type::TypeHandle,
         },
     }
 
@@ -3533,7 +3533,7 @@ fn apply_field_addr_and_load(
     use dialect_mir::ops::MirFieldAddrOp;
 
     let field_type = types::translate_type(ctx, field_ty)?;
-    let field_ptr_ty: Ptr<TypeObj> =
+    let field_ptr_ty: TypeHandle =
         dialect_mir::types::MirPtrType::get_generic(ctx, field_type, false).into();
 
     let addr_op = Operation::new(
@@ -3857,7 +3857,7 @@ fn translate_place_addr_from_slot(
                         // Its pointee is the slice's element type: the
                         // struct itself for a fat struct reference, or the
                         // element for an ordinary `&[T]` / `DisjointSlice`.
-                        let data_ptr_ty: Ptr<TypeObj> =
+                        let data_ptr_ty: TypeHandle =
                             dialect_mir::types::MirPtrType::get_generic(ctx, elem_ty, is_mutable)
                                 .into();
                         let extract_ptr = Operation::new(
@@ -3900,7 +3900,7 @@ fn translate_place_addr_from_slot(
                             // type (see `translate_type`'s ADT arm), so the
                             // field-addr result is a pointer to the element
                             // and the dialect verifier agrees.
-                            let tail_ptr_ty: Ptr<TypeObj> =
+                            let tail_ptr_ty: TypeHandle =
                                 dialect_mir::types::MirPtrType::get_generic(
                                     ctx,
                                     tail_elem_ty,
@@ -3928,7 +3928,7 @@ fn translate_place_addr_from_slot(
                             let extract_len = Operation::new(
                                 ctx,
                                 MirExtractFieldOp::get_concrete_op_info(),
-                                vec![usize_ty.to_ptr()],
+                                vec![usize_ty.to_handle()],
                                 vec![fat_val],
                                 vec![],
                                 0,
@@ -4162,7 +4162,7 @@ fn translate_place_addr_from_slot(
 enum PointeeKind {
     /// Pointee is `[T; N]` (carries `T`). Element addressing GEPs through
     /// the array type via `mir.array_element_addr`.
-    Array(Ptr<TypeObj>),
+    Array(TypeHandle),
     /// Pointee is any other type. When an `Index` / `ConstantIndex`
     /// projection meets such a pointer, MIR typing guarantees the indexed
     /// place is a slice whose data pointer (produced by the fat-pointer
@@ -4173,11 +4173,11 @@ enum PointeeKind {
 
 fn indexed_element_ptr_type(
     ctx: &mut Context,
-    current_ptr_ty: Ptr<TypeObj>,
+    current_ptr_ty: TypeHandle,
     pointee_kind: PointeeKind,
     addr_space: u32,
     is_mutable: bool,
-) -> Ptr<TypeObj> {
+) -> TypeHandle {
     match pointee_kind {
         PointeeKind::Array(element_ty) => {
             dialect_mir::types::MirPtrType::get(ctx, element_ty, is_mutable, addr_space).into()
@@ -4251,7 +4251,7 @@ fn pointer_pointee_kind(ctx: &Context, ptr_value: Value) -> Option<(PointeeKind,
 
 /// Inspect a pointer type and return its pointee kind + address space, or
 /// `None` if the type isn't a `MirPtrType`.
-fn pointer_type_pointee_kind(ctx: &Context, ptr_ty: Ptr<TypeObj>) -> Option<(PointeeKind, u32)> {
+fn pointer_type_pointee_kind(ctx: &Context, ptr_ty: TypeHandle) -> Option<(PointeeKind, u32)> {
     let ty_ref = ptr_ty.deref(ctx);
     let mir_ptr_ty = ty_ref.downcast_ref::<dialect_mir::types::MirPtrType>()?;
     let pointee = mir_ptr_ty.pointee;
@@ -4266,20 +4266,20 @@ fn pointer_type_pointee_kind(ctx: &Context, ptr_ty: Ptr<TypeObj>) -> Option<(Poi
     Some((kind, addr_space))
 }
 
-fn mir_ptr_pointee(ctx: &Context, ptr_ty: Ptr<TypeObj>) -> Option<Ptr<TypeObj>> {
+fn mir_ptr_pointee(ctx: &Context, ptr_ty: TypeHandle) -> Option<TypeHandle> {
     ptr_ty
         .deref(ctx)
         .downcast_ref::<dialect_mir::types::MirPtrType>()
         .map(|ptr_ty| ptr_ty.pointee)
 }
 
-fn is_empty_tuple_type(ctx: &Context, ty: Ptr<TypeObj>) -> bool {
+fn is_empty_tuple_type(ctx: &Context, ty: TypeHandle) -> bool {
     ty.deref(ctx)
         .downcast_ref::<dialect_mir::types::MirTupleType>()
         .is_some_and(|tt| tt.get_types().is_empty())
 }
 
-fn slice_like_element_type(ctx: &Context, ty: Ptr<TypeObj>) -> Option<Ptr<TypeObj>> {
+fn slice_like_element_type(ctx: &Context, ty: TypeHandle) -> Option<TypeHandle> {
     let ty_ref = ty.deref(ctx);
     ty_ref
         .downcast_ref::<dialect_mir::types::MirSliceType>()
@@ -4460,11 +4460,11 @@ pub fn translate_place_iterative(
                 // before creating operations (which need &mut ctx).
                 enum IndexableKind {
                     Array {
-                        element_ty: Ptr<TypeObj>,
+                        element_ty: TypeHandle,
                     },
                     Ptr {
-                        element_ty: Ptr<TypeObj>,
-                        ptr_ty: Ptr<TypeObj>,
+                        element_ty: TypeHandle,
+                        ptr_ty: TypeHandle,
                     },
                 }
 
@@ -4588,11 +4588,11 @@ pub fn translate_place_iterative(
                 // before creating operations (which need &mut ctx).
                 enum ConstIndexKind {
                     Array {
-                        element_ty: Ptr<TypeObj>,
+                        element_ty: TypeHandle,
                     },
                     Ptr {
-                        element_ty: Ptr<TypeObj>,
-                        ptr_ty: Ptr<TypeObj>,
+                        element_ty: TypeHandle,
+                        ptr_ty: TypeHandle,
                     },
                 }
 
@@ -4772,7 +4772,7 @@ pub fn translate_place_iterative(
 fn translate_ptr_to_array_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -4850,7 +4850,7 @@ fn translate_ptr_to_array_constant(
 fn translate_array_value_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -4876,7 +4876,7 @@ fn translate_array_value_constant(
 /// constant rule instead of falling through to a generic byte-lowering error.
 fn array_constant_type_byte_size(
     ctx: &Context,
-    ty: Ptr<TypeObj>,
+    ty: TypeHandle,
     loc: Location,
 ) -> TranslationResult<usize> {
     use pliron::builtin::types::{FP32Type, FP64Type, IntegerType};
@@ -4920,7 +4920,7 @@ fn array_constant_type_byte_size(
 /// etc.) are handled by repeated decomposition.
 fn build_array_op_from_bytes(
     ctx: &mut Context,
-    array_ty: Ptr<TypeObj>,
+    array_ty: TypeHandle,
     bytes: &[u8],
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -5174,7 +5174,7 @@ fn build_array_op_from_bytes(
 fn translate_array_value_constant_inner(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
-    array_ty: Ptr<TypeObj>,
+    array_ty: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -5200,7 +5200,7 @@ fn translate_struct_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
     _rust_ty: &rustc_public::ty::Ty, // Reserved for future layout computation
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -5209,7 +5209,7 @@ fn translate_struct_constant(
 
     // Get the struct type to access field information
     // Clone field types to avoid borrow conflicts when we need to mutate ctx later
-    let field_types: Vec<Ptr<TypeObj>> = {
+    let field_types: Vec<TypeHandle> = {
         let ty_obj = const_ty_ptr.deref(ctx);
         let struct_ty = ty_obj
             .downcast_ref::<dialect_mir::types::MirStructType>()
@@ -5683,7 +5683,7 @@ fn translate_tuple_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
     rust_ty: &rustc_public::ty::Ty,
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -5800,7 +5800,7 @@ fn translate_tuple_constant(
     Ok((op.deref(ctx).get_result(0), Some(op)))
 }
 
-fn constant_storage_size(ctx: &Context, ty_ptr: Ptr<TypeObj>) -> Option<usize> {
+fn constant_storage_size(ctx: &Context, ty_ptr: TypeHandle) -> Option<usize> {
     let ty_ref = ty_ptr.deref(ctx);
     if types::is_zst_type(ctx, ty_ptr) {
         Some(0)
@@ -5836,7 +5836,7 @@ fn constant_storage_size(ctx: &Context, ty_ptr: Ptr<TypeObj>) -> Option<usize> {
 /// structs), which the flat per-field path could not translate.
 fn build_const_from_bytes(
     ctx: &mut Context,
-    ty_ptr: Ptr<TypeObj>,
+    ty_ptr: TypeHandle,
     bytes: &[u8],
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -6006,7 +6006,7 @@ fn translate_enum_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
     rust_ty: &rustc_public::ty::Ty,
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -6027,7 +6027,7 @@ fn translate_enum_constant(
 fn translate_enum_constant_from_bytes(
     ctx: &mut Context,
     rust_ty: &rustc_public::ty::Ty,
-    const_ty_ptr: Ptr<TypeObj>,
+    const_ty_ptr: TypeHandle,
     enum_bytes: &[u8],
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -6183,7 +6183,7 @@ fn translate_enum_constant_from_bytes(
 fn translate_constant_value_from_bytes(
     ctx: &mut Context,
     rust_ty: &rustc_public::ty::Ty,
-    ty_ptr: Ptr<TypeObj>,
+    ty_ptr: TypeHandle,
     bytes: &[u8],
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -6472,7 +6472,7 @@ fn translate_constant_value_from_bytes(
 /// Build a zero-sized struct or tuple value.
 fn translate_zero_sized_constant_value(
     ctx: &mut Context,
-    ty_ptr: Ptr<TypeObj>,
+    ty_ptr: TypeHandle,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -6509,7 +6509,7 @@ fn translate_zero_sized_constant_value(
     // synthesize a ZST value for each field type (e.g. `TryFromIntError(())`,
     // which surfaces when building `core` for nvptx via `-Zbuild-std`).
     if matches!(zero_sized_kind, ZeroSizedKind::Struct) {
-        let field_types: Vec<Ptr<TypeObj>> = {
+        let field_types: Vec<TypeHandle> = {
             let ty_ref = ty_ptr.deref(ctx);
             ty_ref
                 .downcast_ref::<dialect_mir::types::MirStructType>()
@@ -7253,7 +7253,7 @@ fn get_static_pointer_info(ty: &rustc_public::ty::Ty) -> Option<(rustc_public::t
 fn extract_shared_array_info(
     ctx: &mut Context,
     ty: &rustc_public::ty::Ty,
-) -> TranslationResult<(Ptr<pliron::r#type::TypeObj>, usize, usize)> {
+) -> TranslationResult<(pliron::r#type::TypeHandle, usize, usize)> {
     use rustc_public::ty::{GenericArgKind, RigidTy, TyKind};
 
     /// Parse a const generic value from debug string
@@ -7355,7 +7355,7 @@ fn extract_shared_array_info(
 /// The caller is responsible for inserting the returned op into a block.
 fn create_zst_aggregate(
     ctx: &mut Context,
-    ty_ptr: Ptr<pliron::r#type::TypeObj>,
+    ty_ptr: pliron::r#type::TypeHandle,
     loc: Location,
 ) -> Ptr<Operation> {
     use dialect_mir::ops::{MirConstructStructOp, MirConstructTupleOp};
@@ -7398,7 +7398,7 @@ fn create_zst_aggregate(
 /// link it via `insert_after` / `insert_at_front`.
 fn create_ghost_enum_default(
     ctx: &mut Context,
-    ty_ptr: Ptr<pliron::r#type::TypeObj>,
+    ty_ptr: pliron::r#type::TypeHandle,
     loc: Location,
 ) -> Ptr<Operation> {
     use dialect_mir::ops::MirConstructEnumOp;

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -947,7 +947,7 @@ fn slot_array_element_ty(
     ctx: &pliron::context::Context,
     arr_ptr: Value,
     loc: &Location,
-) -> TranslationResult<(pliron::context::Ptr<pliron::r#type::TypeObj>, u32)> {
+) -> TranslationResult<(pliron::r#type::TypeHandle, u32)> {
     let arr_ptr_ty = arr_ptr.get_type(ctx);
     let arr_ptr_ty_ref = arr_ptr_ty.deref(ctx);
     let mir_ptr_ty = arr_ptr_ty_ref
@@ -983,7 +983,7 @@ fn emit_array_element_store(
     array_ptr: Value,
     index: Value,
     value: Value,
-    element_ty: pliron::context::Ptr<pliron::r#type::TypeObj>,
+    element_ty: pliron::r#type::TypeHandle,
     address_space: u32,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,

--- a/crates/mir-importer/src/translator/terminator/helpers.rs
+++ b/crates/mir-importer/src/translator/terminator/helpers.rs
@@ -129,7 +129,7 @@ pub fn emit_function_call(
     callee_name: &str,
     args: &[mir::Operand],
     destination: &mir::Place,
-    return_type: Ptr<pliron::r#type::TypeObj>,
+    return_type: pliron::r#type::TypeHandle,
     target: &Option<usize>,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -220,7 +220,7 @@ pub fn emit_nvvm_intrinsic(
 ) -> TranslationResult<Ptr<Operation>> {
     let u32_type = IntegerType::get(ctx, 32, Signedness::Unsigned);
 
-    let nvvm_op = Operation::new(ctx, opid, vec![u32_type.to_ptr()], vec![], vec![], 0);
+    let nvvm_op = Operation::new(ctx, opid, vec![u32_type.to_handle()], vec![], vec![], 0);
     nvvm_op.deref_mut(ctx).set_loc(loc.clone());
 
     let last_op = if let Some(prev) = prev_op {

--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -100,7 +100,7 @@ pub struct AtomicTypeInfo {
 
 impl AtomicTypeInfo {
     /// Get the pliron result type for this atomic's element.
-    fn element_type(&self, ctx: &mut Context) -> Ptr<pliron::r#type::TypeObj> {
+    fn element_type(&self, ctx: &mut Context) -> pliron::r#type::TypeHandle {
         if self.is_float {
             match self.bit_width {
                 // Rust `f16` is represented by dialect-mir's own `mir.fp16` (apfloat::Half);
@@ -116,7 +116,7 @@ impl AtomicTypeInfo {
             } else {
                 Signedness::Unsigned
             };
-            IntegerType::get(ctx, self.bit_width, signedness).to_ptr()
+            IntegerType::get(ctx, self.bit_width, signedness).to_handle()
         }
     }
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/clc.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/clc.rs
@@ -258,7 +258,7 @@ fn emit_clc_query(
     let query_op = Operation::new(
         ctx,
         concrete_op_info,
-        vec![i32_type.to_ptr()],
+        vec![i32_type.to_handle()],
         vec![resp_lo, resp_hi],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/cluster.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/cluster.rs
@@ -54,7 +54,7 @@ pub fn emit_cluster_ctaid_x(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterCtaidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -100,7 +100,7 @@ pub fn emit_cluster_ctaid_y(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterCtaidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -146,7 +146,7 @@ pub fn emit_cluster_ctaid_z(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterCtaidZOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -196,7 +196,7 @@ pub fn emit_cluster_nctaid_x(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterNctaidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -242,7 +242,7 @@ pub fn emit_cluster_nctaid_y(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterNctaidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -288,7 +288,7 @@ pub fn emit_cluster_nctaid_z(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterNctaidZOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -338,7 +338,7 @@ pub fn emit_cluster_idx(
     let op = Operation::new(
         ctx,
         ReadPtxSregClusterIdxOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -384,7 +384,7 @@ pub fn emit_num_clusters(
     let op = Operation::new(
         ctx,
         ReadPtxSregNclusterIdOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -605,7 +605,7 @@ pub fn emit_dsmem_read_u32(
     let op = Operation::new(
         ctx,
         DsmemReadU32Op::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![src_ptr, rank],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/convert.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/convert.rs
@@ -77,7 +77,7 @@ pub fn emit_cvt_f16x2_f32(
     let cvt_op = Operation::new(
         ctx,
         CvtF16x2F32Op::get_concrete_op_info(),
-        vec![i32_type.to_ptr()],
+        vec![i32_type.to_handle()],
         vec![lo_val, hi_val],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
@@ -55,8 +55,8 @@ pub fn emit_clock(
     let clock_op = Operation::new(
         ctx,
         ReadPtxSregClockOp::get_concrete_op_info(),
-        vec![i32_type.to_ptr()], // Result: i32
-        vec![],                  // No operands
+        vec![i32_type.to_handle()], // Result: i32
+        vec![],                     // No operands
         vec![],
         0,
     );
@@ -110,8 +110,8 @@ pub fn emit_clock64(
     let clock_op = Operation::new(
         ctx,
         ReadPtxSregClock64Op::get_concrete_op_info(),
-        vec![i64_type.to_ptr()], // Result: i64
-        vec![],                  // No operands
+        vec![i64_type.to_handle()], // Result: i64
+        vec![],                     // No operands
         vec![],
         0,
     );
@@ -163,7 +163,7 @@ pub fn emit_globaltimer(
     let timer_op = Operation::new(
         ctx,
         ReadPtxSregGlobaltimerOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()],
+        vec![i64_type.to_handle()],
         vec![],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/indexing.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/indexing.rs
@@ -72,7 +72,7 @@ pub fn emit_index_1d_expansion(
     let tid_op = Operation::new(
         ctx,
         ReadPtxSregTidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -94,7 +94,7 @@ pub fn emit_index_1d_expansion(
     let bid_op = Operation::new(
         ctx,
         ReadPtxSregCtaidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -107,7 +107,7 @@ pub fn emit_index_1d_expansion(
     let bdim_op = Operation::new(
         ctx,
         ReadPtxSregNtidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -120,7 +120,7 @@ pub fn emit_index_1d_expansion(
     let mul_op = Operation::new(
         ctx,
         MirMulOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![bid_val, bdim_val],
         vec![],
         0,
@@ -133,7 +133,7 @@ pub fn emit_index_1d_expansion(
     let add_op = Operation::new(
         ctx,
         MirAddOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![mul_val, tid_val],
         vec![],
         0,
@@ -146,7 +146,7 @@ pub fn emit_index_1d_expansion(
     let cast_op = Operation::new(
         ctx,
         MirCastOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![add_val],
         vec![],
         0,
@@ -189,7 +189,7 @@ pub fn emit_index_2d_row(
     let tid_op = Operation::new(
         ctx,
         ReadPtxSregTidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -211,7 +211,7 @@ pub fn emit_index_2d_row(
     let bid_op = Operation::new(
         ctx,
         ReadPtxSregCtaidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -224,7 +224,7 @@ pub fn emit_index_2d_row(
     let bdim_op = Operation::new(
         ctx,
         ReadPtxSregNtidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -237,7 +237,7 @@ pub fn emit_index_2d_row(
     let mul_op = Operation::new(
         ctx,
         MirMulOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![bid_val, bdim_val],
         vec![],
         0,
@@ -250,7 +250,7 @@ pub fn emit_index_2d_row(
     let add_op = Operation::new(
         ctx,
         MirAddOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![mul_val, tid_val],
         vec![],
         0,
@@ -263,7 +263,7 @@ pub fn emit_index_2d_row(
     let cast_op = Operation::new(
         ctx,
         MirCastOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![add_val],
         vec![],
         0,
@@ -353,7 +353,7 @@ pub fn emit_index_2d(
     let tid_y_op = Operation::new(
         ctx,
         ReadPtxSregTidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -369,7 +369,7 @@ pub fn emit_index_2d(
     let bid_y_op = Operation::new(
         ctx,
         ReadPtxSregCtaidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -382,7 +382,7 @@ pub fn emit_index_2d(
     let bdim_y_op = Operation::new(
         ctx,
         ReadPtxSregNtidYOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -395,7 +395,7 @@ pub fn emit_index_2d(
     let mul_y_op = Operation::new(
         ctx,
         MirMulOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![bid_y_val, bdim_y_val],
         vec![],
         0,
@@ -408,7 +408,7 @@ pub fn emit_index_2d(
     let row_u32_op = Operation::new(
         ctx,
         MirAddOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![mul_y_val, tid_y_val],
         vec![],
         0,
@@ -422,7 +422,7 @@ pub fn emit_index_2d(
     let row_op = Operation::new(
         ctx,
         MirCastOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![row_u32_val],
         vec![],
         0,
@@ -437,7 +437,7 @@ pub fn emit_index_2d(
     let tid_x_op = Operation::new(
         ctx,
         ReadPtxSregTidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -450,7 +450,7 @@ pub fn emit_index_2d(
     let bid_x_op = Operation::new(
         ctx,
         ReadPtxSregCtaidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -463,7 +463,7 @@ pub fn emit_index_2d(
     let bdim_x_op = Operation::new(
         ctx,
         ReadPtxSregNtidXOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -476,7 +476,7 @@ pub fn emit_index_2d(
     let mul_x_op = Operation::new(
         ctx,
         MirMulOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![bid_x_val, bdim_x_val],
         vec![],
         0,
@@ -489,7 +489,7 @@ pub fn emit_index_2d(
     let col_u32_op = Operation::new(
         ctx,
         MirAddOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![mul_x_val, tid_x_val],
         vec![],
         0,
@@ -503,7 +503,7 @@ pub fn emit_index_2d(
     let col_op = Operation::new(
         ctx,
         MirCastOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![col_u32_val],
         vec![],
         0,
@@ -518,7 +518,7 @@ pub fn emit_index_2d(
     let row_stride_op = Operation::new(
         ctx,
         MirMulOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![row_val, stride_val],
         vec![],
         0,
@@ -532,7 +532,7 @@ pub fn emit_index_2d(
     let result_op = Operation::new(
         ctx,
         MirAddOp::get_concrete_op_info(),
-        vec![usize_type.to_ptr()],
+        vec![usize_type.to_handle()],
         vec![row_stride_val, col_val],
         vec![],
         0,
@@ -646,11 +646,11 @@ pub fn emit_get_thread_local(
     // Determine if we have a DisjointSlice value or a pointer to one
     enum SliceKind {
         Direct {
-            element_ty: Ptr<pliron::r#type::TypeObj>,
+            element_ty: pliron::r#type::TypeHandle,
         },
         Pointer {
-            pointee: Ptr<pliron::r#type::TypeObj>,
-            element_ty: Ptr<pliron::r#type::TypeObj>,
+            pointee: pliron::r#type::TypeHandle,
+            element_ty: pliron::r#type::TypeHandle,
         },
     }
 

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -570,7 +570,7 @@ impl PtrOffsetFromResult {
     fn result_type(
         self,
         ctx: &mut Context,
-    ) -> pliron::r#type::TypePtr<pliron::builtin::types::IntegerType> {
+    ) -> pliron::r#type::TypedHandle<pliron::builtin::types::IntegerType> {
         match self {
             Self::Signed => types::get_isize_type(ctx),
             Self::Unsigned => types::get_usize_type(ctx),
@@ -682,7 +682,7 @@ fn emit_ptr_offset_from_with_result(
 
     let elem_size = pointee_size_bytes(body, &args[0], result_kind.intrinsic_name(), loc.clone())?;
     let result_ty = result_kind.result_type(ctx);
-    let result_type = result_ty.to_ptr();
+    let result_type = result_ty.to_handle();
 
     let (this_ptr, op_after_this) = rvalue::translate_operand(
         ctx,
@@ -824,7 +824,7 @@ fn pointee_size_bytes(
 fn emit_pointer_expose_address(
     ctx: &mut Context,
     ptr: Value,
-    result_type: Ptr<pliron::r#type::TypeObj>,
+    result_type: pliron::r#type::TypeHandle,
     insert_after: Option<Ptr<Operation>>,
     block_ptr: Ptr<BasicBlock>,
     loc: Location,
@@ -849,7 +849,7 @@ fn emit_pointer_expose_address(
 
 fn emit_integer_constant(
     ctx: &mut Context,
-    ty: pliron::r#type::TypePtr<IntegerType>,
+    ty: pliron::r#type::TypedHandle<IntegerType>,
     value: u64,
     insert_after: Ptr<Operation>,
     loc: Location,
@@ -868,7 +868,7 @@ fn emit_integer_constant(
     let const_op = Operation::new(
         ctx,
         MirConstantOp::get_concrete_op_info(),
-        vec![ty.to_ptr()],
+        vec![ty.to_handle()],
         vec![],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/sync.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/sync.rs
@@ -342,8 +342,8 @@ pub fn emit_mbarrier_arrive(
     let arrive_op = Operation::new(
         ctx,
         MbarrierArriveSharedOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()], // Result: i64 token
-        vec![bar_ptr],           // Operand: ptr
+        vec![i64_type.to_handle()], // Result: i64 token
+        vec![bar_ptr],              // Operand: ptr
         vec![],
         0,
     );
@@ -435,8 +435,8 @@ pub fn emit_mbarrier_arrive_expect_tx(
     let arrive_op = Operation::new(
         ctx,
         MbarrierArriveExpectTxSharedOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()], // Result: i64 token
-        vec![bar_ptr, bytes],    // Operands: ptr, bytes
+        vec![i64_type.to_handle()], // Result: i64 token
+        vec![bar_ptr, bytes],       // Operands: ptr, bytes
         vec![],
         0,
     );
@@ -658,8 +658,8 @@ pub fn emit_mbarrier_test_wait(
     let test_wait_op = Operation::new(
         ctx,
         MbarrierTestWaitSharedOp::get_concrete_op_info(),
-        vec![i1_type.to_ptr()], // Result: i1 (bool)
-        vec![bar_ptr, token],   // Operands: ptr, token
+        vec![i1_type.to_handle()], // Result: i1 (bool)
+        vec![bar_ptr, token],      // Operands: ptr, token
         vec![],
         0,
     );
@@ -749,8 +749,8 @@ pub fn emit_mbarrier_try_wait(
     let try_wait_op = Operation::new(
         ctx,
         MbarrierTryWaitSharedOp::get_concrete_op_info(),
-        vec![i1_type.to_ptr()], // Result: i1 (bool)
-        vec![bar_ptr, token],   // Operands: ptr, token
+        vec![i1_type.to_handle()], // Result: i1 (bool)
+        vec![bar_ptr, token],      // Operands: ptr, token
         vec![],
         0,
     );

--- a/crates/mir-importer/src/translator/terminator/intrinsics/tcgen05.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/tcgen05.rs
@@ -34,7 +34,7 @@ use pliron::input_err;
 use pliron::location::{Located, Location};
 use pliron::op::Op;
 use pliron::operation::Operation;
-use pliron::r#type::TypeObj;
+use pliron::r#type::TypeHandle;
 use pliron::value::Value;
 use rustc_public::mir;
 
@@ -51,7 +51,7 @@ fn destination_struct_type(
     body: &mir::Body,
     destination: &mir::Place,
     loc: Location,
-) -> TranslationResult<Ptr<TypeObj>> {
+) -> TranslationResult<TypeHandle> {
     let dest_rust_ty = match destination.ty(body.locals()) {
         Ok(t) => t,
         Err(e) => {

--- a/crates/mir-importer/src/translator/terminator/intrinsics/tma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/tma.rs
@@ -148,7 +148,7 @@ pub fn emit_tma_g2s(
     let cta_mask_raw_op = Operation::new(
         ctx,
         MirConstantOp::get_concrete_op_info(),
-        vec![i16_type.to_ptr()],
+        vec![i16_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -174,7 +174,7 @@ pub fn emit_tma_g2s(
     let cache_hint_raw_op = Operation::new(
         ctx,
         MirConstantOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()],
+        vec![i64_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -485,7 +485,7 @@ pub fn emit_tma_g2s_multicast(
     let cache_hint_raw_op = Operation::new(
         ctx,
         MirConstantOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()],
+        vec![i64_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -656,7 +656,7 @@ pub fn emit_tma_g2s_multicast_cg2(
     let cache_hint_raw_op = Operation::new(
         ctx,
         MirConstantOp::get_concrete_op_info(),
-        vec![i64_type.to_ptr()],
+        vec![i64_type.to_handle()],
         vec![],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/warp.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/warp.rs
@@ -48,7 +48,7 @@ pub fn emit_lane_id(
     let lane_id_op = Operation::new(
         ctx,
         ReadPtxSregLaneIdOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -99,7 +99,7 @@ pub fn emit_active_mask(
     let active_mask_op = Operation::new(
         ctx,
         ActiveMaskOp::get_concrete_op_info(),
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![],
         vec![],
         0,
@@ -259,7 +259,7 @@ pub fn emit_warp_shuffle_i32(
     let shuffle_op = Operation::new(
         ctx,
         shuffle_opid,
-        vec![u32_type.to_ptr()],
+        vec![u32_type.to_handle()],
         vec![mask, val, lane_or_delta],
         vec![],
         0,
@@ -424,7 +424,7 @@ pub fn emit_warp_match(
 
     let _ = value_is_i64;
 
-    let result_ty = IntegerType::get(ctx, 32, Signedness::Unsigned).to_ptr();
+    let result_ty = IntegerType::get(ctx, 32, Signedness::Unsigned).to_handle();
 
     let (mask, mut last_op) = rvalue::translate_operand(
         ctx,
@@ -525,7 +525,7 @@ pub fn emit_warp_redux(
     } else {
         Signedness::Unsigned
     };
-    let result_ty = IntegerType::get(ctx, 32, signedness).to_ptr();
+    let result_ty = IntegerType::get(ctx, 32, signedness).to_handle();
 
     let (mask, mut last_op) = rvalue::translate_operand(
         ctx,
@@ -742,9 +742,9 @@ pub fn emit_warp_vote(
     last_op = last_op_after;
 
     let result_type = if result_is_i32 {
-        IntegerType::get(ctx, 32, Signedness::Unsigned).to_ptr()
+        IntegerType::get(ctx, 32, Signedness::Unsigned).to_handle()
     } else {
-        types::get_bool_type(ctx).to_ptr()
+        types::get_bool_type(ctx).to_handle()
     };
 
     let vote_op = Operation::new(

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -355,7 +355,7 @@ fn translate_assert(
         let not_op = Operation::new(
             ctx,
             MirNotOp::get_concrete_op_info(),
-            vec![bool_type.to_ptr()],
+            vec![bool_type.to_handle()],
             vec![cond_value],
             vec![],
             0,
@@ -467,7 +467,7 @@ fn translate_switch(
         let discr_ty = discr_value.get_type(ctx);
         let bool_ty = types::get_bool_type(ctx);
 
-        let (condition, last_inserted_op) = if discr_ty == bool_ty.to_ptr() {
+        let (condition, last_inserted_op) = if discr_ty == bool_ty.to_handle() {
             // discr is already i1
             // For boolean switch: val=0 means "if false", val=1 means "if true"
             // switchInt(bool) -> [0: bb_false, otherwise: bb_true]
@@ -477,7 +477,7 @@ fn translate_switch(
                 let not_op = Operation::new(
                     ctx,
                     MirNotOp::get_concrete_op_info(),
-                    vec![bool_ty.to_ptr()],
+                    vec![bool_ty.to_handle()],
                     vec![discr_value],
                     vec![],
                     0,
@@ -551,7 +551,7 @@ fn translate_switch(
             let eq_op = Operation::new(
                 ctx,
                 MirEqOp::get_concrete_op_info(),
-                vec![bool_ty.to_ptr()],
+                vec![bool_ty.to_handle()],
                 vec![discr_value, const_val],
                 vec![],
                 0,
@@ -692,7 +692,7 @@ fn translate_switch(
         let cmp_op = Operation::new(
             ctx,
             MirEqOp::get_concrete_op_info(),
-            vec![bool_ty.to_ptr()],
+            vec![bool_ty.to_handle()],
             vec![discr_value, const_val],
             vec![],
             0,

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -34,8 +34,8 @@
 //! | `TmaDescriptor`   | `[u64; 16]` (128-byte opaque blob)    |
 
 use crate::error::{TranslationErr, TranslationResult};
-use pliron::context::{Context, Ptr};
-use pliron::r#type::TypeObj;
+use pliron::context::Context;
+use pliron::r#type::TypeHandle;
 use pliron::{input_err_noloc, input_error_noloc};
 use rustc_public::CrateDef;
 use rustc_public_bridge::IndexedVal;
@@ -49,21 +49,21 @@ use rustc_public::mir::Mutability;
 /// Returns the signed 32-bit integer type.
 pub fn get_i32_type(
     ctx: &mut Context,
-) -> pliron::r#type::TypePtr<pliron::builtin::types::IntegerType> {
+) -> pliron::r#type::TypedHandle<pliron::builtin::types::IntegerType> {
     pliron::builtin::types::IntegerType::get(ctx, 32, pliron::builtin::types::Signedness::Signed)
 }
 
 /// Returns the boolean type (i1, signless).
 pub fn get_bool_type(
     ctx: &mut Context,
-) -> pliron::r#type::TypePtr<pliron::builtin::types::IntegerType> {
+) -> pliron::r#type::TypedHandle<pliron::builtin::types::IntegerType> {
     pliron::builtin::types::IntegerType::get(ctx, 1, pliron::builtin::types::Signedness::Signless)
 }
 
 /// Returns the `usize` type (u64 on 64-bit targets).
 pub fn get_usize_type(
     ctx: &mut Context,
-) -> pliron::r#type::TypePtr<pliron::builtin::types::IntegerType> {
+) -> pliron::r#type::TypedHandle<pliron::builtin::types::IntegerType> {
     pliron::builtin::types::IntegerType::get(ctx, 64, pliron::builtin::types::Signedness::Unsigned)
 }
 
@@ -87,14 +87,14 @@ fn closure_upvar_tys(substs: &rustc_public::ty::GenericArgs) -> Option<Vec<rustc
 /// Returns the `isize` type (i64 on 64-bit targets).
 pub fn get_isize_type(
     ctx: &mut Context,
-) -> pliron::r#type::TypePtr<pliron::builtin::types::IntegerType> {
+) -> pliron::r#type::TypedHandle<pliron::builtin::types::IntegerType> {
     pliron::builtin::types::IntegerType::get(ctx, 64, pliron::builtin::types::Signedness::Signed)
 }
 
 /// Returns the 32-bit floating point type.
 pub fn get_f32_type(
     ctx: &mut Context,
-) -> pliron::r#type::TypePtr<pliron::builtin::types::FP32Type> {
+) -> pliron::r#type::TypedHandle<pliron::builtin::types::FP32Type> {
     pliron::builtin::types::FP32Type::get(ctx)
 }
 
@@ -110,7 +110,7 @@ pub fn get_f32_type(
 /// - Lifetime/variance tracking (`PhantomData<&'a T>`)
 /// - Typestate patterns (`struct Allocated;`, `struct Deallocated;`)
 /// - Type-level markers for layout/configuration
-pub fn is_zst_type(ctx: &pliron::context::Context, ty: Ptr<TypeObj>) -> bool {
+pub fn is_zst_type(ctx: &pliron::context::Context, ty: TypeHandle) -> bool {
     let ty_ref = ty.deref(ctx);
 
     // Empty tuple - e.g., () or MirTupleType with no fields
@@ -215,7 +215,7 @@ fn translate_pointer_like(
     ctx: &mut Context,
     pointee: &rustc_public::ty::Ty,
     is_mutable: bool,
-) -> TranslationResult<Ptr<TypeObj>> {
+) -> TranslationResult<TypeHandle> {
     match pointee.kind() {
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(elem_ty)) => {
             // `*const [T]` / `*mut [T]` have the same runtime layout as `&[T]`
@@ -298,7 +298,7 @@ fn shared_array_element_type(
     ctx: &mut Context,
     substs: &rustc_public::ty::GenericArgs,
     label: &'static str,
-) -> TranslationResult<Ptr<TypeObj>> {
+) -> TranslationResult<TypeHandle> {
     for arg in substs.0.iter() {
         if let rustc_public::ty::GenericArgKind::Type(t) = arg {
             return translate_type(ctx, t);
@@ -326,7 +326,7 @@ pub fn translate_destination_type(
     body: &rustc_public::mir::Body,
     destination: &rustc_public::mir::Place,
     loc: &pliron::location::Location,
-) -> TranslationResult<Ptr<TypeObj>> {
+) -> TranslationResult<TypeHandle> {
     let dest_rust_ty = match destination.ty(body.locals()) {
         Ok(t) => t,
         Err(e) => {
@@ -347,7 +347,7 @@ pub fn translate_destination_type(
 pub fn translate_type(
     ctx: &mut Context,
     rust_ty: &rustc_public::ty::Ty,
-) -> TranslationResult<Ptr<TypeObj>> {
+) -> TranslationResult<TypeHandle> {
     let ty_kind = rust_ty.kind();
 
     match ty_kind {
@@ -695,7 +695,7 @@ pub fn translate_type(
                     // except for Direct-tag enums, where mir-lower uses
                     // them to build the memory-faithful representation.
                     let (discriminant_ty, tag_offset, total_size, abi_align): (
-                        Ptr<TypeObj>,
+                        TypeHandle,
                         u64,
                         u64,
                         u64,

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -42,7 +42,7 @@ use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
 use pliron::op::Op;
 use pliron::operation::Operation;
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::value::Value;
 use rustc_public::CrateDef;
 use rustc_public::mir;
@@ -95,7 +95,7 @@ impl ValueMap {
     /// Returns the inserted op and its result pointer value.
     pub fn emit_alloca(
         ctx: &mut Context,
-        elem_ty: Ptr<TypeObj>,
+        elem_ty: TypeHandle,
         block: Ptr<BasicBlock>,
         prev_op: Option<Ptr<Operation>>,
     ) -> (Ptr<Operation>, Value) {
@@ -178,7 +178,7 @@ impl ValueMap {
 fn maybe_ptr_coerce(
     ctx: &mut Context,
     value: Value,
-    target_ty: Ptr<TypeObj>,
+    target_ty: TypeHandle,
     block: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
 ) -> (Value, Option<Ptr<Operation>>) {
@@ -213,7 +213,7 @@ fn maybe_ptr_coerce(
 /// Recover the pointee (element) type of a slot value. Panics if the value is
 /// not a `MirPtrType`; this invariant is established when a slot is recorded
 /// via [`ValueMap::set_slot`] after an [`ValueMap::emit_alloca`] call.
-fn slot_pointee(ctx: &Context, slot: Value) -> Ptr<TypeObj> {
+fn slot_pointee(ctx: &Context, slot: Value) -> TypeHandle {
     let ptr_ty = slot.get_type(ctx);
     ptr_ty
         .deref(ctx)
@@ -598,11 +598,7 @@ fn propagate_from_local(local: mir::Local, classes: &[SlotAddrSpace]) -> WriteCl
 ///
 /// Used by `body::emit_entry_allocas` to override a Rust-declared pointer
 /// addrspace with the one inferred by [`SlotAddrSpaceMap`].
-pub fn align_pointer_addr_space(
-    ctx: &mut Context,
-    elem_ty: Ptr<TypeObj>,
-    target: u32,
-) -> Ptr<TypeObj> {
+pub fn align_pointer_addr_space(ctx: &mut Context, elem_ty: TypeHandle, target: u32) -> TypeHandle {
     let ptr_info = elem_ty
         .deref(ctx)
         .downcast_ref::<MirPtrType>()
@@ -619,7 +615,7 @@ pub fn align_pointer_addr_space(
 /// Extract a pointer type's address space, or `None` if `elem_ty` is not a
 /// [`MirPtrType`]. Useful as the `rust_declared` fallback for
 /// [`SlotAddrSpaceMap::effective`].
-pub fn pointer_addr_space(ctx: &Context, elem_ty: Ptr<TypeObj>) -> Option<u32> {
+pub fn pointer_addr_space(ctx: &Context, elem_ty: TypeHandle) -> Option<u32> {
     elem_ty
         .deref(ctx)
         .downcast_ref::<MirPtrType>()

--- a/crates/mir-lower/src/convert/intrinsics/common.rs
+++ b/crates/mir-lower/src/convert/intrinsics/common.rs
@@ -130,7 +130,7 @@ pub fn call_intrinsic(
     rewriter: &mut DialectConversionRewriter,
     current_op: Ptr<Operation>,
     intrinsic_name: &str,
-    func_ty: pliron::r#type::TypePtr<llvm_types::FuncType>,
+    func_ty: pliron::r#type::TypedHandle<llvm_types::FuncType>,
     args: Vec<Value>,
 ) -> Result<Ptr<Operation>> {
     let parent_block = current_op.deref(ctx).get_parent_block().unwrap();
@@ -149,7 +149,7 @@ pub fn call_intrinsic(
 pub fn inline_asm_convergent(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
-    result_ty: Ptr<pliron::r#type::TypeObj>,
+    result_ty: pliron::r#type::TypeHandle,
     inputs: Vec<Value>,
     asm_template: &str,
     constraints: &str,

--- a/crates/mir-lower/src/convert/intrinsics/tcgen05.rs
+++ b/crates/mir-lower/src/convert/intrinsics/tcgen05.rs
@@ -39,7 +39,7 @@ use pliron::irbuild::rewriter::Rewriter;
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
-use pliron::r#type::TypeObj;
+use pliron::r#type::TypeHandle;
 
 // ============================================================================
 // Allocation operations
@@ -425,7 +425,7 @@ pub(crate) fn convert_ld_16x256b_x8_pure(
     let tmem_addr = op.deref(ctx).get_operand(0);
 
     let f32_ty = FP32Type::get(ctx);
-    let field_types: Vec<Ptr<TypeObj>> = (0..32).map(|_| f32_ty.into()).collect();
+    let field_types: Vec<TypeHandle> = (0..32).map(|_| f32_ty.into()).collect();
     let struct_ty = llvm_types::StructType::get_unnamed(ctx, field_types);
 
     let inline_asm = llvm::InlineAsmOp::build(
@@ -475,7 +475,7 @@ pub(crate) fn convert_ld_16x256b_pure(
     let tmem_addr = op.deref(ctx).get_operand(0);
 
     let f32_ty = FP32Type::get(ctx);
-    let field_types: Vec<Ptr<TypeObj>> = (0..4).map(|_| f32_ty.into()).collect();
+    let field_types: Vec<TypeHandle> = (0..4).map(|_| f32_ty.into()).collect();
     let struct_ty = llvm_types::StructType::get_unnamed(ctx, field_types);
 
     let inline_asm = llvm::InlineAsmOp::build(

--- a/crates/mir-lower/src/convert/intrinsics/tma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/tma.rs
@@ -116,7 +116,7 @@ fn convert_g2s_impl(
     let dst_casted = cast_to_cluster_shared_addrspace(ctx, rewriter, operands[0]);
     let barrier_casted = cast_to_shared_addrspace(ctx, rewriter, operands[1]);
 
-    let mut arg_types: Vec<Ptr<pliron::r#type::TypeObj>> = vec![
+    let mut arg_types: Vec<pliron::r#type::TypeHandle> = vec![
         shared_cluster_ptr_ty.into(),
         smem_ptr_ty.into(),
         generic_ptr_ty.into(),
@@ -193,7 +193,7 @@ pub(crate) fn convert_s2g(
 
     let src_casted = cast_to_shared_addrspace(ctx, rewriter, operands[0]);
 
-    let mut arg_types: Vec<Ptr<pliron::r#type::TypeObj>> =
+    let mut arg_types: Vec<pliron::r#type::TypeHandle> =
         vec![smem_ptr_ty.into(), generic_ptr_ty.into()];
     for _ in 0..dims {
         arg_types.push(i32_ty.into());

--- a/crates/mir-lower/src/convert/intrinsics/warp.rs
+++ b/crates/mir-lower/src/convert/intrinsics/warp.rs
@@ -151,7 +151,7 @@ pub(crate) fn convert_vote(
     }
     let (mask, predicate) = (operands[0], operands[1]);
 
-    let result_ty: Ptr<pliron::r#type::TypeObj> = if intrinsic_name.contains("ballot") {
+    let result_ty: pliron::r#type::TypeHandle = if intrinsic_name.contains("ballot") {
         i32_ty.into()
     } else {
         i1_ty.into()
@@ -181,7 +181,7 @@ pub(crate) fn convert_match_any(
     op: Ptr<Operation>,
     _operands_info: &OperandsInfo,
     intrinsic_name: &str,
-    value_ty: Ptr<pliron::r#type::TypeObj>,
+    value_ty: pliron::r#type::TypeHandle,
 ) -> Result<()> {
     let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
 
@@ -308,7 +308,7 @@ pub(crate) fn convert_match_all(
     op: Ptr<Operation>,
     _operands_info: &OperandsInfo,
     intrinsic_name: &str,
-    value_ty: Ptr<pliron::r#type::TypeObj>,
+    value_ty: pliron::r#type::TypeHandle,
 ) -> Result<()> {
     use llvm_export::ops::ExtractValueOp;
 

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -53,9 +53,8 @@ use pliron::irbuild::inserter::Inserter;
 use pliron::irbuild::rewriter::Rewriter;
 use pliron::op::Op;
 use pliron::operation::Operation;
-use pliron::printable::Printable;
 use pliron::result::Result;
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::utils::apint::APInt;
 use pliron::value::Value;
 use std::num::NonZeroUsize;
@@ -563,7 +562,7 @@ fn spill_enum_value(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     enum_val: Value,
-    llvm_struct_ty: Ptr<TypeObj>,
+    llvm_struct_ty: TypeHandle,
     abi_align: u64,
 ) -> Value {
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
@@ -597,7 +596,7 @@ fn enum_byte_gep(
     offset: u64,
 ) -> Value {
     use llvm_export::ops::GepIndex;
-    let i8_ty: Ptr<TypeObj> = IntegerType::get(ctx, 8, Signedness::Signless).into();
+    let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
     let gep_op =
         llvm::GetElementPtrOp::new(ctx, base, vec![GepIndex::Constant(offset as u32)], i8_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
@@ -638,7 +637,7 @@ pub(crate) fn convert_construct_enum(
     let (variant_discriminants, variant_field_counts, mir_discr_ty, abi_align): (
         Vec<u64>,
         Vec<u32>,
-        Ptr<TypeObj>,
+        TypeHandle,
         u64,
     ) = {
         let ty_ref = result_ty.deref(ctx);
@@ -797,7 +796,7 @@ fn enum_slot_map_of_operand(
         }
     };
     let abi_align = enum_ty.abi_align();
-    let mir_ty: Ptr<TypeObj> = pliron::r#type::Type::register_instance(enum_ty, ctx).into();
+    let mir_ty: TypeHandle = pliron::r#type::Type::register_instance(enum_ty, ctx).into();
     let map = build_enum_slot_map(ctx, mir_ty).map_err(anyhow_to_pliron)?;
     Ok((map, abi_align))
 }

--- a/crates/mir-lower/src/convert/ops/arithmetic.rs
+++ b/crates/mir-lower/src/convert/ops/arithmetic.rs
@@ -474,7 +474,7 @@ fn mask_shift_amount(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     rhs: Value,
-    lhs_ty: Ptr<pliron::r#type::TypeObj>,
+    lhs_ty: pliron::r#type::TypeHandle,
     lhs_width: u32,
 ) -> Value {
     use pliron::utils::apint::APInt;
@@ -780,7 +780,7 @@ fn emit_cmp_value(
 fn emit_discriminant_const(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
-    discr_ty: Ptr<pliron::r#type::TypeObj>,
+    discr_ty: pliron::r#type::TypeHandle,
     value: u64,
 ) -> Result<Value> {
     use pliron::utils::apint::APInt;
@@ -813,7 +813,7 @@ mod tests {
     use llvm_export::attributes::FastmathFlags;
     use llvm_export::op_interfaces::FastMathFlags as FastMathFlagsTrait;
     use llvm_export::ops as llvm;
-    use pliron::r#type::TypeObj;
+    use pliron::r#type::TypeHandle;
 
     /// A float `mir.mul` lowers to `llvm.fmul` carrying exactly the `contract`
     /// fast-math flag: enough for the NVPTX backend to fuse a feeding multiply
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn convert_mul_float_sets_only_contract_flag() {
         let mut ctx = make_ctx();
-        let f32_ty: Ptr<TypeObj> = pliron::builtin::types::FP32Type::get(&ctx).into();
+        let f32_ty: TypeHandle = pliron::builtin::types::FP32Type::get(&ctx).into();
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![f32_ty, f32_ty], vec![]);
         let lhs = block.deref(&ctx).get_argument(0);
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn convert_add_float_sets_only_contract_flag() {
         let mut ctx = make_ctx();
-        let f32_ty: Ptr<TypeObj> = pliron::builtin::types::FP32Type::get(&ctx).into();
+        let f32_ty: TypeHandle = pliron::builtin::types::FP32Type::get(&ctx).into();
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![f32_ty, f32_ty], vec![]);
         let lhs = block.deref(&ctx).get_argument(0);

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -89,7 +89,7 @@ use pliron::location::Located;
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::utils::apint::APInt;
 use pliron::value::Value;
 use std::num::NonZeroUsize;
@@ -327,7 +327,7 @@ impl RustFloatMathIntrinsic {
     fn libdevice_name(
         self,
         ctx: &Context,
-        result_ty: Ptr<TypeObj>,
+        result_ty: TypeHandle,
         loc: pliron::location::Location,
     ) -> Result<&'static str> {
         match self {
@@ -898,7 +898,7 @@ fn convert_rust_carrying_mul_add(
         );
     };
 
-    let wide_ty: Ptr<TypeObj> = IntegerType::get(ctx, width * 2, Signedness::Signless).into();
+    let wide_ty: TypeHandle = IntegerType::get(ctx, width * 2, Signedness::Signless).into();
 
     // Widen every operand to 2*N bits with the signedness-appropriate extension.
     let mut wide_args = Vec::with_capacity(4);
@@ -1079,7 +1079,7 @@ fn lower_fast_binop(
 /// Read the width from an integer type, or report a useful lowering error.
 fn integer_bit_width(
     ctx: &Context,
-    ty: Ptr<TypeObj>,
+    ty: TypeHandle,
     loc: pliron::location::Location,
 ) -> Result<u32> {
     let ty_ref = ty.deref(ctx);
@@ -1092,7 +1092,7 @@ fn integer_bit_width(
 /// Return the libdevice `fabs` entry point for the concrete float type.
 fn fabs_libdevice_name(
     ctx: &Context,
-    ty: Ptr<TypeObj>,
+    ty: TypeHandle,
     loc: pliron::location::Location,
 ) -> Result<&'static str> {
     let ty_ref = ty.deref(ctx);
@@ -1131,7 +1131,7 @@ fn cast_integer_value_to_type(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     value: Value,
-    target_ty: Ptr<TypeObj>,
+    target_ty: TypeHandle,
     loc: pliron::location::Location,
 ) -> Result<(Value, Option<Ptr<Operation>>)> {
     let source_width = integer_bit_width(ctx, value.get_type(ctx), loc.clone())?;
@@ -1177,13 +1177,13 @@ fn flatten_arguments(
     rewriter: &mut DialectConversionRewriter,
     args: &[Value],
     operands_info: &OperandsInfo,
-    expected_param_tys: Option<&[Ptr<TypeObj>]>,
-) -> Result<(Vec<Value>, Vec<Ptr<TypeObj>>)> {
+    expected_param_tys: Option<&[TypeHandle]>,
+) -> Result<(Vec<Value>, Vec<TypeHandle>)> {
     let mut flattened_args = Vec::new();
     let mut flattened_arg_types = Vec::new();
 
     // Helper: pull the next expected param type, if any.
-    let take_expected = |flattened_arg_types: &Vec<Ptr<TypeObj>>| -> Option<Ptr<TypeObj>> {
+    let take_expected = |flattened_arg_types: &Vec<TypeHandle>| -> Option<TypeHandle> {
         let idx = flattened_arg_types.len();
         expected_param_tys.and_then(|tys| tys.get(idx).copied())
     };
@@ -1310,9 +1310,9 @@ fn coerce_arg_to_param_ty(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     arg: Value,
-    arg_ty: Ptr<TypeObj>,
-    expected_ty: Option<Ptr<TypeObj>>,
-) -> Result<(Value, Ptr<TypeObj>)> {
+    arg_ty: TypeHandle,
+    expected_ty: Option<TypeHandle>,
+) -> Result<(Value, TypeHandle)> {
     if let Some(expected_ty) = expected_ty {
         if arg_ty == expected_ty {
             return Ok((arg, arg_ty));
@@ -1348,7 +1348,7 @@ fn coerce_arg_to_param_ty(
 }
 
 /// Return the address space of `ty` if it is an LLVM pointer type.
-fn pointer_addrspace(ctx: &Context, ty: Ptr<TypeObj>) -> Option<u32> {
+fn pointer_addrspace(ctx: &Context, ty: TypeHandle) -> Option<u32> {
     ty.deref(ctx)
         .downcast_ref::<llvm_types::PointerType>()
         .map(|ptr_ty| ptr_ty.address_space())
@@ -1378,7 +1378,7 @@ fn find_callee_arg_types(
     ctx: &mut Context,
     op: Ptr<Operation>,
     callee_ident: &pliron::identifier::Identifier,
-) -> Option<Vec<Ptr<TypeObj>>> {
+) -> Option<Vec<TypeHandle>> {
     let block = op.deref(ctx).get_parent_block()?;
     let func_op = block.deref(ctx).get_parent_op(ctx)?;
     let module_op = func_op.deref(ctx).get_parent_op(ctx)?;

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -175,10 +175,10 @@ fn convert_int_to_int(
     ctx: &mut Context,
     _rewriter: &mut DialectConversionRewriter,
     val: pliron::value::Value,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
+    llvm_ty: pliron::r#type::TypeHandle,
     src_w: u32,
     dst_w: u32,
-    mir_opd_ty: Ptr<pliron::r#type::TypeObj>,
+    mir_opd_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     if dst_w > src_w {
         let is_signed = {
@@ -215,8 +215,8 @@ fn convert_int_to_float(
     ctx: &mut Context,
     _rewriter: &mut DialectConversionRewriter,
     val: pliron::value::Value,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
-    mir_opd_ty: Ptr<pliron::r#type::TypeObj>,
+    llvm_ty: pliron::r#type::TypeHandle,
+    mir_opd_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let is_signed = {
         let ty_obj = mir_opd_ty.deref(ctx);
@@ -253,8 +253,8 @@ fn convert_float_to_int(
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
     val: pliron::value::Value,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
-    mir_result_ty: Ptr<pliron::r#type::TypeObj>,
+    llvm_ty: pliron::r#type::TypeHandle,
+    mir_result_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let val_ty = val.get_type(ctx);
     let is_signed = {
@@ -336,9 +336,9 @@ fn emit_unsize_cast(
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
     val: pliron::value::Value,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
-    mir_opd_ty: Ptr<pliron::r#type::TypeObj>,
+    val_ty: pliron::r#type::TypeHandle,
+    llvm_ty: pliron::r#type::TypeHandle,
+    mir_opd_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let array_len = {
         let mir_ref = mir_opd_ty.deref(ctx);
@@ -416,8 +416,8 @@ fn emit_pointer_cast(
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
     val: pliron::value::Value,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
+    val_ty: pliron::r#type::TypeHandle,
+    llvm_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let src_is_struct = val_ty.deref(ctx).is::<llvm_export::types::StructType>();
     let dst_is_struct = llvm_ty.deref(ctx).is::<llvm_export::types::StructType>();
@@ -538,7 +538,7 @@ fn const_i64(
 fn const_int_of(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
-    ty: Ptr<pliron::r#type::TypeObj>,
+    ty: pliron::r#type::TypeHandle,
     value: i64,
 ) -> Result<pliron::value::Value> {
     let int_ty = ty
@@ -571,8 +571,8 @@ const MAX_NEWTYPE_DEPTH: usize = 8;
 /// slot exists within `MAX_NEWTYPE_DEPTH` layers.
 fn deep_scalar_index_path(
     ctx: &Context,
-    aggregate_ty: Ptr<pliron::r#type::TypeObj>,
-    scalar_ty: Ptr<pliron::r#type::TypeObj>,
+    aggregate_ty: pliron::r#type::TypeHandle,
+    scalar_ty: pliron::r#type::TypeHandle,
 ) -> Option<Vec<u32>> {
     let mut path = Vec::new();
     let mut current = aggregate_ty;
@@ -627,8 +627,8 @@ fn emit_scalar_to_niched_enum(
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
     val: pliron::value::Value,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
+    val_ty: pliron::r#type::TypeHandle,
+    llvm_ty: pliron::r#type::TypeHandle,
     niche: dialect_mir::attributes::NicheEncodingAttr,
 ) -> Result<Ptr<Operation>> {
     let (disc_ty, payload_ty) = {
@@ -688,7 +688,7 @@ fn emit_scalar_to_niched_enum(
     // when niche_start is 0, the case rustc actually emits).
     let src_is_ptr = val_ty.deref(ctx).is::<llvm_export::types::PointerType>();
     let cmp_const = if src_is_ptr {
-        let i64_ty: Ptr<pliron::r#type::TypeObj> =
+        let i64_ty: pliron::r#type::TypeHandle =
             IntegerType::get(ctx, 64, Signedness::Signless).into();
         let i64_const = const_int_of(ctx, rewriter, i64_ty, niche.niche_start as i64)?;
         let i2p = llvm::IntToPtrOp::new(ctx, i64_const, val_ty);
@@ -744,8 +744,8 @@ fn emit_struct_to_scalar(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     val: pliron::value::Value,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
+    val_ty: pliron::r#type::TypeHandle,
+    llvm_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let dst_width = llvm_ty
         .deref(ctx)
@@ -785,7 +785,7 @@ fn emit_struct_to_scalar(
 /// Walks single-field struct wrappers (`{ { i64 } }`, `{ ptr }`, etc.)
 /// and returns the bit width of the innermost scalar, or `None` if the
 /// aggregate has any layer that is not a single-field wrapper.
-fn single_scalar_struct_width(ctx: &Context, ty: Ptr<pliron::r#type::TypeObj>) -> Option<u32> {
+fn single_scalar_struct_width(ctx: &Context, ty: pliron::r#type::TypeHandle) -> Option<u32> {
     let mut current = ty;
     for _ in 0..MAX_NEWTYPE_DEPTH {
         let r = current.deref(ctx);
@@ -831,8 +831,8 @@ fn emit_transmute_via_memory(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     val: pliron::value::Value,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
+    val_ty: pliron::r#type::TypeHandle,
+    llvm_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let Some(src_bytes) = type_byte_size(ctx, val_ty) else {
         return pliron::input_err_noloc!(
@@ -889,12 +889,12 @@ fn emit_transmute_via_memory(
 /// computed confidently (a struct that needs padding, an opaque struct,
 /// or an unknown type), so callers refuse the transmute loudly instead
 /// of guessing.
-fn type_byte_size(ctx: &Context, ty: Ptr<pliron::r#type::TypeObj>) -> Option<u64> {
+fn type_byte_size(ctx: &Context, ty: pliron::r#type::TypeHandle) -> Option<u64> {
     let r = ty.deref(ctx);
     if let Some(i) = r.downcast_ref::<IntegerType>() {
         return Some((i.width() as u64).div_ceil(8));
     }
-    if let Some(f) = type_cast::<dyn FloatTypeInterface>(&**r) {
+    if let Some(f) = type_cast::<dyn FloatTypeInterface>(&*r) {
         return Some((f.get_semantics().bits as u64).div_ceil(8));
     }
     if r.is::<llvm_export::types::PointerType>() {
@@ -936,12 +936,12 @@ fn type_byte_size(ctx: &Context, ty: Ptr<pliron::r#type::TypeObj>) -> Option<u64
 /// the natural-alignment fallback in the textual `.ll` exporter so the
 /// alignment stamped on a transmute stack slot agrees with what the
 /// exporter assumes for direct loads/stores of the same type.
-fn abi_alignment_bytes(ctx: &Context, ty: Ptr<pliron::r#type::TypeObj>) -> u32 {
+fn abi_alignment_bytes(ctx: &Context, ty: pliron::r#type::TypeHandle) -> u32 {
     let r = ty.deref(ctx);
     if let Some(i) = r.downcast_ref::<IntegerType>() {
         return std::cmp::max(1, i.width() / 8);
     }
-    if let Some(f) = type_cast::<dyn FloatTypeInterface>(&**r) {
+    if let Some(f) = type_cast::<dyn FloatTypeInterface>(&*r) {
         return std::cmp::max(1, (f.get_semantics().bits / 8) as u32);
     }
     if r.is::<llvm_export::types::PointerType>() {
@@ -971,8 +971,8 @@ fn convert_float_to_float(
     ctx: &mut Context,
     _rewriter: &mut DialectConversionRewriter,
     val: pliron::value::Value,
-    llvm_ty: Ptr<pliron::r#type::TypeObj>,
-    val_ty: Ptr<pliron::r#type::TypeObj>,
+    llvm_ty: pliron::r#type::TypeHandle,
+    val_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
     let src_width = float_bit_width(ctx, val_ty)?;
     let dst_width = float_bit_width(ctx, llvm_ty)?;
@@ -999,9 +999,9 @@ fn convert_float_to_float(
     }
 }
 
-fn float_bit_width(ctx: &Context, ty: Ptr<pliron::r#type::TypeObj>) -> Result<usize> {
+fn float_bit_width(ctx: &Context, ty: pliron::r#type::TypeHandle) -> Result<usize> {
     let ty_ref = ty.deref(ctx);
-    let Some(float_ty) = type_cast::<dyn FloatTypeInterface>(&**ty_ref) else {
+    let Some(float_ty) = type_cast::<dyn FloatTypeInterface>(&*ty_ref) else {
         return pliron::input_err_noloc!("expected floating-point type");
     };
     Ok(float_ty.get_semantics().bits)

--- a/crates/mir-lower/src/convert/ops/control_flow.rs
+++ b/crates/mir-lower/src/convert/ops/control_flow.rs
@@ -265,11 +265,10 @@ mod tests {
     use llvm_export::ops as llvm;
     use pliron::builtin::op_interfaces::{BranchOpInterface, OperandSegmentInterface};
     use pliron::builtin::types::{IntegerType, Signedness};
-    use pliron::context::Ptr;
     use pliron::linked_list::ContainsLinkedList;
     use pliron::op::Op;
     use pliron::operation::Operation;
-    use pliron::r#type::TypeObj;
+    use pliron::r#type::TypeHandle;
 
     #[test]
     fn convert_return_void_lowers_to_llvm_return_without_value() {
@@ -292,7 +291,7 @@ mod tests {
     #[test]
     fn convert_return_with_scalar_value_lowers_to_llvm_return_with_value() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i32_ty], vec![i32_ty]);
         let arg = entry.deref(&ctx).get_argument(0);
         append_mir_return(&mut ctx, entry, vec![arg]);
@@ -318,7 +317,7 @@ mod tests {
         // to an empty `llvm.struct`; `convert_return` checks for the latter,
         // not the former.
         let mut ctx = make_ctx();
-        let unit_ty: Ptr<TypeObj> = MirTupleType::get(&mut ctx, vec![]).into();
+        let unit_ty: TypeHandle = MirTupleType::get(&mut ctx, vec![]).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![], vec![unit_ty]);
 
         let undef = mir::MirUndefOp::new(&mut ctx, unit_ty);
@@ -365,8 +364,8 @@ mod tests {
         // (expects i32), false_block takes none — so the lowered cond_br must
         // expose one true-side operand and zero false-side.
         let mut ctx = make_ctx();
-        let i1_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i1_ty: TypeHandle = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i1_ty, i32_ty], vec![]);
         let cond = entry.deref(&ctx).get_argument(0);
         let val = entry.deref(&ctx).get_argument(1);
@@ -403,7 +402,7 @@ mod tests {
         // mir.assert lowers to a llvm.cond_br whose false side is a fresh
         // block ending in llvm.unreachable.
         let mut ctx = make_ctx();
-        let i1_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
+        let i1_ty: TypeHandle = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i1_ty], vec![]);
         let cond = entry.deref(&ctx).get_argument(0);
         let success = append_block(&mut ctx, entry, vec![]);
@@ -454,7 +453,7 @@ mod tests {
     fn convert_goto_lowers_to_llvm_br() {
         // mir.goto next(%arg) -> llvm.br targeting `next`, forwarding %arg.
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i32_ty], vec![]);
         let arg = entry.deref(&ctx).get_argument(0);
 
@@ -495,8 +494,8 @@ mod tests {
         // omitted ZST arg must be filled with a synthesised `llvm.undef` so
         // the lowered br still carries both operands.
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
-        let unit_ty: Ptr<TypeObj> = MirTupleType::get(&mut ctx, vec![]).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let unit_ty: TypeHandle = MirTupleType::get(&mut ctx, vec![]).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i32_ty], vec![]);
         let arg = entry.deref(&ctx).get_argument(0);
 
@@ -541,8 +540,8 @@ mod tests {
     #[test]
     fn convert_goto_errors_when_missing_arg_is_not_zst() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
-        let i64_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i64_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i32_ty], vec![]);
         let arg = entry.deref(&ctx).get_argument(0);
 
@@ -571,7 +570,7 @@ mod tests {
     #[test]
     fn convert_return_multiple_operands_errors() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) =
             build_kernel(&mut ctx, vec![i32_ty, i32_ty], vec![i32_ty, i32_ty]);
         let arg0 = entry.deref(&ctx).get_argument(0);
@@ -592,8 +591,8 @@ mod tests {
     #[test]
     fn convert_cond_branch_operand_count_mismatch_errors() {
         let mut ctx = make_ctx();
-        let i1_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i1_ty: TypeHandle = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i1_ty, i32_ty], vec![]);
         let cond = entry.deref(&ctx).get_argument(0);
 
@@ -627,7 +626,7 @@ mod tests {
     #[test]
     fn convert_assert_missing_successor_errors() {
         let mut ctx = make_ctx();
-        let i1_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
+        let i1_ty: TypeHandle = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i1_ty], vec![]);
         let cond = entry.deref(&ctx).get_argument(0);
 
@@ -656,7 +655,7 @@ mod tests {
     #[test]
     fn convert_goto_too_many_operands_errors() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i32_ty], vec![]);
         let arg = entry.deref(&ctx).get_argument(0);
 
@@ -688,9 +687,9 @@ mod tests {
         // land on the true side and the i64 on the false side, checked by
         // value identity not just counts.
         let mut ctx = make_ctx();
-        let i1_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
-        let i64_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
+        let i1_ty: TypeHandle = IntegerType::get(&mut ctx, 1, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i64_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
         let (module_ptr, entry) = build_kernel(&mut ctx, vec![i1_ty, i32_ty, i64_ty], vec![]);
         let cond = entry.deref(&ctx).get_argument(0);
         let v_true = entry.deref(&ctx).get_argument(1);

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -71,7 +71,7 @@ use pliron::location::Located;
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
-use pliron::r#type::{TypeObj, Typed};
+use pliron::r#type::{TypeHandle, Typed};
 use pliron::utils::apint::APInt;
 
 fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
@@ -545,7 +545,7 @@ fn create_shared_global(
     ctx: &mut Context,
     op: Ptr<Operation>,
     shared_globals: &mut SharedGlobalsMap,
-    mir_elem_type: Ptr<TypeObj>,
+    mir_elem_type: TypeHandle,
     size: u64,
     alignment: u64,
     alloc_key: Option<String>,
@@ -675,7 +675,7 @@ fn create_device_global(
     op: Ptr<Operation>,
     device_globals: &mut DeviceGlobalsMap,
     global_key: &str,
-    mir_global_type: Ptr<TypeObj>,
+    mir_global_type: TypeHandle,
     alignment: u64,
     addr_space: u32,
 ) -> Result<pliron::identifier::Identifier> {
@@ -914,7 +914,7 @@ mod tests {
     use pliron::operation::Operation;
     use std::path::PathBuf;
 
-    fn ptr_addrspace(ctx: &Context, ty: Ptr<TypeObj>) -> u32 {
+    fn ptr_addrspace(ctx: &Context, ty: TypeHandle) -> u32 {
         ty.deref(ctx)
             .downcast_ref::<PointerType>()
             .expect("expected llvm.PointerType")
@@ -931,7 +931,7 @@ mod tests {
     #[test]
     fn convert_alloca_lowers_to_llvm_alloca() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
@@ -964,7 +964,7 @@ mod tests {
     #[test]
     fn convert_alloca_preserves_debug_local_metadata() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
@@ -1015,7 +1015,7 @@ mod tests {
     #[test]
     fn convert_store_lowers_to_llvm_store() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         // Kernel takes (ptr, val) so we can store one into the other.
@@ -1048,14 +1048,14 @@ mod tests {
         // convert_store swaps operand order: mir.store is [ptr, value] but
         // llvm.store takes (value, ptr). Verify that mapping survived.
         let store = find_first::<llvm::StoreOp>(&ctx, &body).unwrap();
-        let addr_ty = store.address_opd(&ctx).get_type(&ctx);
+        let addr_ty = store.get_operand_address(&ctx).get_type(&ctx);
         assert!(addr_ty.deref(&ctx).is::<PointerType>(), "operand 1 is ptr");
     }
 
     #[test]
     fn convert_store_preserves_volatile() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into(), i32_ty], vec![]);
@@ -1087,7 +1087,7 @@ mod tests {
     #[test]
     fn convert_load_lowers_to_llvm_load() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, false);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into()], vec![]);
@@ -1114,7 +1114,7 @@ mod tests {
     #[test]
     fn convert_dbg_value_lowers_to_llvm_dbg_value() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![i32_ty], vec![]);
         let value = block.deref(&ctx).get_argument(0);
@@ -1191,7 +1191,7 @@ mod tests {
     #[test]
     fn mem2reg_salvages_tagged_alloca_into_mir_dbg_value() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![i32_ty], vec![i32_ty]);
@@ -1279,7 +1279,7 @@ mod tests {
     #[test]
     fn convert_load_preserves_volatile() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, false);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into()], vec![]);
@@ -1310,7 +1310,7 @@ mod tests {
     #[test]
     fn convert_ref_lowers_to_alloca_then_store() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, false);
 
         // Take a u32 by value, build `&x`.
@@ -1348,8 +1348,8 @@ mod tests {
     #[test]
     fn convert_ptr_offset_lowers_to_gep_with_pointee_elem_type() {
         let mut ctx = make_ctx();
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
-        let i64_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i64_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into(), i64_ty], vec![]);
@@ -1396,8 +1396,8 @@ mod tests {
         variants: Vec<EnumVariant>,
         total_size: u64,
         abi_align: u64,
-    ) -> Ptr<TypeObj> {
-        let tag_ty: Ptr<TypeObj> = IntegerType::get(ctx, tag_bits, Signedness::Unsigned).into();
+    ) -> TypeHandle {
+        let tag_ty: TypeHandle = IntegerType::get(ctx, tag_bits, Signedness::Unsigned).into();
         // Sequential 0..n discriminants: these layout tests only exercise
         // size/width, not value mapping.
         let discriminants: Vec<u64> = (0..variants.len() as u64).collect();
@@ -1457,7 +1457,7 @@ mod tests {
         // u8 tag + i64 payload, rustc size 16: the slot map places the
         // payload at its rustc byte offset 8 behind an explicit
         // [7 x i8] filler, making the layout datalayout-independent.
-        let i64_payload: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let i64_payload: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
         let payload = make_enum_ty(
             &mut ctx,
             "OnePayload",
@@ -1514,11 +1514,11 @@ mod tests {
         use crate::convert::types::{build_enum_slot_map, llvm_type_size_align};
 
         let mut ctx = make_ctx();
-        let u64_a: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
-        let u64_b: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
-        let tag_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 8, Signedness::Unsigned).into();
+        let u64_a: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let u64_b: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let tag_ty: TypeHandle = IntegerType::get(&mut ctx, 8, Signedness::Unsigned).into();
         // enum F { A(u64), B(u64) }: payloads share byte 0, tag at byte 8.
-        let ty: Ptr<TypeObj> = MirEnumType::get_with_layout(
+        let ty: TypeHandle = MirEnumType::get_with_layout(
             &mut ctx,
             "TagAtEight".to_string(),
             tag_ty,
@@ -1546,9 +1546,9 @@ mod tests {
     /// Multi-payload enum whose variants overlap in Rust (8 bytes) but
     /// concatenate in our model (12 bytes structural): mimics
     /// `#[repr(u32)] enum E { A(u32), B(u32) }`.
-    fn make_multi_payload_enum_ty(ctx: &mut Context) -> Ptr<TypeObj> {
-        let i32_a: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
-        let i32_b: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+    fn make_multi_payload_enum_ty(ctx: &mut Context) -> TypeHandle {
+        let i32_a: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let i32_b: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
         make_enum_ty(
             ctx,
             "MultiPayload",
@@ -1572,7 +1572,7 @@ mod tests {
     fn device_local_multi_payload_enum_gep_and_load_lower() {
         let mut ctx = make_ctx();
         let enum_ty = make_multi_payload_enum_ty(&mut ctx);
-        let i64_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
+        let i64_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Signless).into();
         let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, enum_ty, true);
 
         let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into(), i64_ty], vec![]);
@@ -1655,10 +1655,10 @@ mod tests {
         // The device's model of Option<&T>: an explicit u8 tag plus the
         // pointer payload, with total_size 0 ("layout not recorded"),
         // exactly what the importer builds for niche-encoded enums.
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
         let pointee = MirPtrType::get_generic(&mut ctx, i32_ty, false);
-        let tag_ty: Ptr<TypeObj> = IntegerType::get(&mut ctx, 8, Signedness::Unsigned).into();
-        let niched: Ptr<TypeObj> = MirEnumType::get(
+        let tag_ty: TypeHandle = IntegerType::get(&mut ctx, 8, Signedness::Unsigned).into();
+        let niched: TypeHandle = MirEnumType::get(
             &mut ctx,
             "Option".to_string(),
             tag_ty,
@@ -1707,7 +1707,7 @@ mod tests {
         use pliron::builtin::attributes::IntegerAttr;
         use pliron::utils::apint::APInt;
 
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Signless).into();
         let result_ty = MirPtrType::get_shared(ctx, i32_ty, true);
         let op = Operation::new(
             ctx,
@@ -1811,7 +1811,7 @@ mod tests {
         global_key: &str,
         constant: bool,
     ) {
-        let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signless).into();
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Signless).into();
         let result_ty = if constant {
             MirPtrType::get_constant(ctx, i32_ty, false)
         } else {

--- a/crates/mir-lower/src/convert/ops/test_util.rs
+++ b/crates/mir-lower/src/convert/ops/test_util.rs
@@ -26,7 +26,7 @@ use pliron::context::{Context, Ptr};
 use pliron::linked_list::ContainsLinkedList;
 use pliron::op::Op;
 use pliron::operation::Operation;
-use pliron::r#type::TypeObj;
+use pliron::r#type::TypeHandle;
 use pliron::value::Value;
 
 /// Fresh context with every dialect this crate's lowering needs registered.
@@ -45,8 +45,8 @@ pub(crate) fn make_ctx() -> Context {
 /// block; the caller appends ops (including the terminator) before lowering.
 pub(crate) fn build_kernel(
     ctx: &mut Context,
-    arg_tys: Vec<Ptr<TypeObj>>,
-    ret_tys: Vec<Ptr<TypeObj>>,
+    arg_tys: Vec<TypeHandle>,
+    ret_tys: Vec<TypeHandle>,
 ) -> (Ptr<Operation>, Ptr<BasicBlock>) {
     let module = ModuleOp::new(ctx, "test_module".try_into().unwrap());
     let module_ptr = module.get_operation();
@@ -78,7 +78,7 @@ pub(crate) fn build_kernel(
 pub(crate) fn append_block(
     ctx: &mut Context,
     entry: Ptr<BasicBlock>,
-    arg_tys: Vec<Ptr<TypeObj>>,
+    arg_tys: Vec<TypeHandle>,
 ) -> Ptr<BasicBlock> {
     let region = entry.deref(ctx).get_parent_region().unwrap();
     let block = BasicBlock::new(ctx, None, arg_tys);

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -106,7 +106,7 @@ use pliron::builtin::type_interfaces::FunctionTypeInterface;
 use pliron::builtin::types::{FP32Type, FP64Type, FunctionType, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
 use pliron::operation::Operation;
-use pliron::r#type::{TypeObj, type_cast};
+use pliron::r#type::{TypeHandle, type_cast};
 
 use crate::type_conversion_interface::MirTypeConversion;
 
@@ -165,7 +165,7 @@ pub fn is_kernel_func(ctx: &Context, op: Ptr<Operation>) -> bool {
 ///
 /// By stripping ZSTs at the LLVM type level, we avoid this issue regardless of
 /// inlining decisions.
-pub fn is_zero_sized_type(ctx: &Context, ty: Ptr<TypeObj>) -> bool {
+pub fn is_zero_sized_type(ctx: &Context, ty: TypeHandle) -> bool {
     // Check if LLVM StructType with zero fields
     if let Some(struct_ty) = ty.deref(ctx).downcast_ref::<llvm_types::StructType>() {
         let num_fields = struct_ty.num_fields();
@@ -191,11 +191,11 @@ pub fn is_zero_sized_type(ctx: &Context, ty: Ptr<TypeObj>) -> bool {
 /// The function-pointer indirection avoids a borrow-checker conflict:
 /// `type_cast` borrows `ctx` immutably, but conversion needs `&mut ctx`.
 /// We extract the `Copy` function pointer, drop the borrow, then call it.
-pub fn convert_type(ctx: &mut Context, ty: Ptr<TypeObj>) -> Result<Ptr<TypeObj>, anyhow::Error> {
+pub fn convert_type(ctx: &mut Context, ty: TypeHandle) -> Result<TypeHandle, anyhow::Error> {
     // Phase 1: extract a Copy function pointer while ctx is immutably borrowed.
     let converter_fn = {
         let ty_ref = ty.deref(ctx);
-        type_cast::<dyn MirTypeConversion>(&**ty_ref).map(|conv| conv.converter())
+        type_cast::<dyn MirTypeConversion>(&*ty_ref).map(|conv| conv.converter())
     };
     // Phase 2: borrow dropped — ctx is free for &mut.
     if let Some(conv_fn) = converter_fn {
@@ -281,9 +281,9 @@ pub fn convert_type(ctx: &mut Context, ty: Ptr<TypeObj>) -> Result<Ptr<TypeObj>,
 /// reconstruction paths.
 pub fn convert_function_type(
     ctx: &mut Context,
-    func_type: pliron::r#type::TypePtr<FunctionType>,
+    func_type: pliron::r#type::TypedHandle<FunctionType>,
     is_kernel_entry: bool,
-) -> Result<pliron::r#type::TypePtr<llvm_types::FuncType>, anyhow::Error> {
+) -> Result<pliron::r#type::TypedHandle<llvm_types::FuncType>, anyhow::Error> {
     // Extract input/output types before mutating context
     let (inputs_ptr, results_ptr) = {
         let func_ty_ref = func_type.deref(ctx);
@@ -304,7 +304,7 @@ pub fn convert_function_type(
         enum FlattenKind {
             Slice,
             Struct {
-                field_types: Vec<Ptr<TypeObj>>,
+                field_types: Vec<TypeHandle>,
                 mem_to_decl: Vec<usize>,
             },
             None,
@@ -391,7 +391,7 @@ pub fn convert_function_type(
 /// `&mut Context` for type interning.
 pub(crate) struct StructLayoutInfo {
     /// Field types in declaration order.
-    pub field_types: Vec<Ptr<TypeObj>>,
+    pub field_types: Vec<TypeHandle>,
     /// Memory order: `mem_to_decl[mem_idx] = decl_idx`. Always full length
     /// (identity when rustc did not reorder).
     pub mem_to_decl: Vec<usize>,
@@ -436,12 +436,12 @@ impl StructLayoutInfo {
 /// `[N x i8]` padding slots) happened.
 pub(crate) struct StructSlotMap {
     /// The final LLVM struct type, including any `[N x i8]` padding slots.
-    pub llvm_struct_ty: Ptr<TypeObj>,
+    pub llvm_struct_ty: TypeHandle,
     /// `decl_to_llvm[decl_idx]` = LLVM slot of that declaration-order field;
     /// `None` when the field is zero-sized and was stripped.
     pub decl_to_llvm: Vec<Option<u32>>,
     /// Converted LLVM type of each declaration-order field (ZSTs included).
-    pub field_llvm_types: Vec<Ptr<TypeObj>>,
+    pub field_llvm_types: Vec<TypeHandle>,
 }
 
 /// Lower a struct/tuple layout to its LLVM struct type and slot map.
@@ -505,7 +505,7 @@ pub(crate) fn build_struct_slot_map(
         field_llvm_types.push(convert_type(ctx, field_ty)?);
     }
 
-    let mut llvm_fields: Vec<Ptr<TypeObj>> = Vec::new();
+    let mut llvm_fields: Vec<TypeHandle> = Vec::new();
     let mut decl_to_llvm: Vec<Option<u32>> = vec![None; num_fields];
     let mut current_offset: u64 = 0;
 
@@ -557,7 +557,7 @@ pub(crate) fn build_struct_slot_map(
 }
 
 /// Create a padding type: `[N x i8]` for N bytes of padding.
-fn make_padding_type(ctx: &mut Context, size: u64) -> Ptr<TypeObj> {
+fn make_padding_type(ctx: &mut Context, size: u64) -> TypeHandle {
     let i8_ty = IntegerType::get(ctx, 8, Signedness::Signless);
     llvm_types::ArrayType::get(ctx, i8_ty.into(), size).into()
 }
@@ -569,7 +569,7 @@ fn make_padding_type(ctx: &mut Context, size: u64) -> Ptr<TypeObj> {
 /// of such aggregates multiply it out. Returns `None` when no stored size
 /// is available (e.g. niched/single-variant enums store 0) and the caller
 /// must fall back to the LLVM-level approximation.
-fn mir_stored_size(ctx: &Context, mir_ty: Ptr<TypeObj>) -> Option<u64> {
+fn mir_stored_size(ctx: &Context, mir_ty: TypeHandle) -> Option<u64> {
     let ty_ref = mir_ty.deref(ctx);
     if let Some(s) = ty_ref.downcast_ref::<MirStructType>() {
         if s.total_size() > 0 {
@@ -598,7 +598,7 @@ fn mir_stored_size(ctx: &Context, mir_ty: Ptr<TypeObj>) -> Option<u64> {
 /// Unlike [`get_type_size`], which sums struct fields without alignment,
 /// this computes the real allocation size, which is what GEP striding and
 /// the enum size check below need.
-pub(crate) fn llvm_type_size_align(ctx: &Context, ty: Ptr<TypeObj>) -> (u64, u64) {
+pub(crate) fn llvm_type_size_align(ctx: &Context, ty: TypeHandle) -> (u64, u64) {
     let ty_ref = ty.deref(ctx);
 
     if let Some(int_ty) = ty_ref.downcast_ref::<IntegerType>() {
@@ -639,7 +639,7 @@ pub(crate) fn llvm_type_size_align(ctx: &Context, ty: Ptr<TypeObj>) -> (u64, u64
 /// the last field, `size` is `end` rounded up to the struct alignment (the
 /// allocation size LLVM uses for GEP striding), and `align` is the widest
 /// field alignment.
-pub(crate) fn natural_struct_layout(ctx: &Context, fields: &[Ptr<TypeObj>]) -> (u64, u64, u64) {
+pub(crate) fn natural_struct_layout(ctx: &Context, fields: &[TypeHandle]) -> (u64, u64, u64) {
     let mut end = 0u64;
     let mut align = 1u64;
     for field in fields {
@@ -661,7 +661,7 @@ pub(crate) fn natural_struct_layout(ctx: &Context, fields: &[Ptr<TypeObj>]) -> (
 /// separately is how the issue #128 class of bug happened for structs.)
 pub(crate) struct EnumSlotMap {
     /// The final LLVM struct type, including any `[N x i8]` filler slots.
-    pub llvm_struct_ty: Ptr<TypeObj>,
+    pub llvm_struct_ty: TypeHandle,
     /// Which struct slot holds the tag.
     pub tag_slot: u32,
     /// Which struct slot holds each payload field, in the flattened
@@ -674,7 +674,7 @@ pub(crate) struct EnumSlotMap {
     /// the type; empty when the layout was not recorded).
     pub field_offsets: Vec<u64>,
     /// Converted LLVM type of each payload field.
-    pub field_llvm_types: Vec<Ptr<TypeObj>>,
+    pub field_llvm_types: Vec<TypeHandle>,
 }
 
 /// Build the LLVM struct for an enum, placing everything at the byte
@@ -722,7 +722,7 @@ pub(crate) struct EnumSlotMap {
 /// hard error rather than a debug assertion.
 pub(crate) fn build_enum_slot_map(
     ctx: &mut Context,
-    ty: Ptr<TypeObj>,
+    ty: TypeHandle,
 ) -> Result<EnumSlotMap, anyhow::Error> {
     let (
         name,
@@ -784,7 +784,7 @@ pub(crate) fn build_enum_slot_map(
     // Phase 1: decide who gets a struct slot. The tag goes first so a
     // payload field can never take its bytes.
     // claims: (byte position, byte size, converted type), no two overlap.
-    let mut claims: Vec<(u64, u64, Ptr<TypeObj>)> = Vec::new();
+    let mut claims: Vec<(u64, u64, TypeHandle)> = Vec::new();
     let (tag_size, tag_align) = llvm_type_size_align(ctx, llvm_discr_ty);
     if tag_offset % tag_align.max(1) != 0 || tag_offset + tag_size > total_size {
         return Err(anyhow::anyhow!(
@@ -847,7 +847,7 @@ pub(crate) fn build_enum_slot_map(
     // the tail) with [N x i8] so the struct's size is exactly rustc's.
     let mut emit_order: Vec<usize> = (0..claims.len()).collect();
     emit_order.sort_by_key(|&ci| claims[ci].0);
-    let mut llvm_fields: Vec<Ptr<TypeObj>> = Vec::new();
+    let mut llvm_fields: Vec<TypeHandle> = Vec::new();
     let mut slot_of_claim: Vec<u32> = vec![0; claims.len()];
     let mut current_offset: u64 = 0;
     for &ci in &emit_order {
@@ -902,8 +902,8 @@ pub(crate) fn build_enum_slot_map(
 /// the slot map, never compute it by hand.
 pub(crate) fn convert_enum_to_llvm(
     ctx: &mut Context,
-    ty: Ptr<TypeObj>,
-) -> Result<Ptr<TypeObj>, anyhow::Error> {
+    ty: TypeHandle,
+) -> Result<TypeHandle, anyhow::Error> {
     Ok(build_enum_slot_map(ctx, ty)?.llvm_struct_ty)
 }
 
@@ -938,7 +938,7 @@ pub(crate) fn convert_enum_to_llvm(
 /// for the two sides to disagree about.
 ///
 /// Returns the enum's name when its bytes are unmodeled, else `None`.
-pub(crate) fn enum_unmodeled_in_memory(ctx: &Context, ty: Ptr<TypeObj>) -> Option<String> {
+pub(crate) fn enum_unmodeled_in_memory(ctx: &Context, ty: TypeHandle) -> Option<String> {
     let ty_ref = ty.deref(ctx);
     let enum_ty = ty_ref.downcast_ref::<MirEnumType>()?;
     (enum_ty.total_size() == 0 && enum_ty.variant_count() > 1).then(|| enum_ty.name().to_string())
@@ -958,12 +958,12 @@ pub(crate) fn enum_unmodeled_in_memory(ctx: &Context, ty: Ptr<TypeObj>) -> Optio
 /// fine and is deliberately not rejected: there, both reader and writer
 /// are the device, using one consistent layout.
 ///
-/// `visited` breaks cycles through recursive types (`Ptr<TypeObj>` is
+/// `visited` breaks cycles through recursive types (`TypeHandle` is
 /// interned, so equality is identity).
 pub(crate) fn find_unmodeled_enum_in_abi(
     ctx: &mut Context,
-    ty: Ptr<TypeObj>,
-    visited: &mut Vec<Ptr<TypeObj>>,
+    ty: TypeHandle,
+    visited: &mut Vec<TypeHandle>,
 ) -> Result<Option<String>, anyhow::Error> {
     if visited.contains(&ty) {
         return Ok(None);
@@ -974,7 +974,7 @@ pub(crate) fn find_unmodeled_enum_in_abi(
         return Ok(Some(name));
     }
 
-    let children: Vec<Ptr<TypeObj>> = {
+    let children: Vec<TypeHandle> = {
         let ty_ref = ty.deref(ctx);
         if let Some(p) = ty_ref.downcast_ref::<dialect_mir::types::MirPtrType>() {
             vec![p.pointee]
@@ -1010,7 +1010,7 @@ pub(crate) fn find_unmodeled_enum_in_abi(
 /// built with explicit padding (the pads are real fields) but an
 /// approximation otherwise; prefer [`mir_stored_size`] whenever the MIR
 /// type is at hand.
-pub(crate) fn get_type_size(ctx: &Context, ty: Ptr<TypeObj>) -> u64 {
+pub(crate) fn get_type_size(ctx: &Context, ty: TypeHandle) -> u64 {
     let ty_ref = ty.deref(ctx);
 
     // Integer types
@@ -1078,7 +1078,7 @@ pub(crate) fn get_type_size(ctx: &Context, ty: Ptr<TypeObj>) -> u64 {
 /// - `&[T]` slice arguments
 /// - `DisjointSlice<T>` (unique-ownership slice) arguments
 /// - Any other fat pointer representation
-pub(crate) fn make_slice_struct(ctx: &mut Context) -> Ptr<TypeObj> {
+pub(crate) fn make_slice_struct(ctx: &mut Context) -> TypeHandle {
     let ptr_ty = llvm_types::PointerType::get_generic(ctx);
     let len_ty = IntegerType::get(ctx, 64, Signedness::Signless);
     llvm_types::StructType::get_unnamed(ctx, vec![ptr_ty.into(), len_ty.into()]).into()
@@ -1101,26 +1101,26 @@ mod tests {
     }
 
     /// A MIR-level unsigned integer type (what the importer produces).
-    fn mir_uint(ctx: &mut Context, width: u32) -> Ptr<TypeObj> {
+    fn mir_uint(ctx: &mut Context, width: u32) -> TypeHandle {
         IntegerType::get(ctx, width, Signedness::Unsigned).into()
     }
 
     /// A converted (signless) LLVM integer type.
-    fn llvm_int(ctx: &mut Context, width: u32) -> Ptr<TypeObj> {
+    fn llvm_int(ctx: &mut Context, width: u32) -> TypeHandle {
         IntegerType::get(ctx, width, Signedness::Signless).into()
     }
 
     /// `[n x i8]` padding type, as `make_padding_type` builds it.
-    fn pad(ctx: &mut Context, n: u64) -> Ptr<TypeObj> {
+    fn pad(ctx: &mut Context, n: u64) -> TypeHandle {
         make_padding_type(ctx, n)
     }
 
     /// A zero-sized MIR struct (PhantomData shape).
-    fn mir_zst(ctx: &mut Context) -> Ptr<TypeObj> {
+    fn mir_zst(ctx: &mut Context) -> TypeHandle {
         MirStructType::get(ctx, "Phantom".into(), vec![], vec![]).into()
     }
 
-    fn struct_fields(ctx: &Context, ty: Ptr<TypeObj>) -> Vec<Ptr<TypeObj>> {
+    fn struct_fields(ctx: &Context, ty: TypeHandle) -> Vec<TypeHandle> {
         ty.deref(ctx)
             .downcast_ref::<llvm_types::StructType>()
             .expect("expected an LLVM struct type")
@@ -1236,7 +1236,7 @@ mod tests {
         //     layout=0     pad=1     big=2 cap=3 stride=4
         let discr = mir_uint(&mut ctx, 8);
         let payload = mir_uint(&mut ctx, 32);
-        let layout_enum: Ptr<TypeObj> = MirEnumType::get(
+        let layout_enum: TypeHandle = MirEnumType::get(
             &mut ctx,
             "Layout".into(),
             discr,
@@ -1269,7 +1269,7 @@ mod tests {
         let i8s = llvm_int(&mut ctx, 8);
         let i32s = llvm_int(&mut ctx, 32);
         let i64s = llvm_int(&mut ctx, 64);
-        let enum_llvm: Ptr<TypeObj> =
+        let enum_llvm: TypeHandle =
             llvm_types::StructType::get_unnamed(&mut ctx, vec![i8s, i32s]).into();
         let pad3 = pad(&mut ctx, 3);
         assert_eq!(
@@ -1287,7 +1287,7 @@ mod tests {
         // field's offset exactly: NO interior pad before it.
         let x = mir_uint(&mut ctx, 8);
         let y = mir_uint(&mut ctx, 64);
-        let inner: Ptr<TypeObj> = MirStructType::get_with_full_layout(
+        let inner: TypeHandle = MirStructType::get_with_full_layout(
             &mut ctx,
             "Inner".into(),
             vec!["x".into(), "y".into()],

--- a/crates/mir-lower/src/helpers.rs
+++ b/crates/mir-lower/src/helpers.rs
@@ -297,7 +297,7 @@ pub fn ensure_intrinsic_declared(
     ctx: &mut Context,
     llvm_block: Ptr<BasicBlock>,
     intrinsic_name: &str,
-    func_ty: pliron::r#type::TypePtr<llvm_export::types::FuncType>,
+    func_ty: pliron::r#type::TypedHandle<llvm_export::types::FuncType>,
 ) -> Result<(), anyhow::Error> {
     // Navigate from block to parent function
     let func_op = llvm_block

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -141,7 +141,7 @@ use pliron::{
     op::{Op, op_cast},
     operation::Operation,
     result::Result,
-    r#type::{TypeObj, type_impls},
+    r#type::{TypeHandle, type_impls},
 };
 
 use context::{DeviceGlobalsMap, DynamicSmemAlignmentMap, SharedGlobalsMap};
@@ -181,7 +181,7 @@ impl DialectConversion for MirToLlvmConversionDriver {
         is_mir_or_nvvm_op(ctx, op)
     }
 
-    fn can_convert_type(&self, ctx: &Context, ty: Ptr<TypeObj>) -> bool {
+    fn can_convert_type(&self, ctx: &Context, ty: TypeHandle) -> bool {
         let ty_ref = ty.deref(ctx);
 
         // Signed/unsigned integers need signless normalisation (LLVM convention).
@@ -189,10 +189,10 @@ impl DialectConversion for MirToLlvmConversionDriver {
             return int_ty.signedness() != Signedness::Signless;
         }
 
-        type_impls::<dyn MirConvertibleType>(&**ty_ref)
+        type_impls::<dyn MirConvertibleType>(&*ty_ref)
     }
 
-    fn convert_type(&mut self, ctx: &mut Context, ty: Ptr<TypeObj>) -> Result<Ptr<TypeObj>> {
+    fn convert_type(&mut self, ctx: &mut Context, ty: TypeHandle) -> Result<TypeHandle> {
         convert_type(ctx, ty).map_err(|e| pliron::input_error_noloc!("{e}"))
     }
 

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -49,7 +49,7 @@ use pliron::{
     op::Op,
     operation::Operation,
     result::Result,
-    r#type::{TypeObj, Typed},
+    r#type::{TypeHandle, Typed},
     value::Value,
 };
 
@@ -273,7 +273,7 @@ fn propagate_alwaysinline_attr(
 /// per-argument and emits the matching reconstruction sequence.
 fn build_entry_prologue(
     ctx: &mut Context,
-    mir_arg_types: &[Ptr<TypeObj>],
+    mir_arg_types: &[TypeHandle],
     llvm_entry: Ptr<BasicBlock>,
     is_kernel_entry: bool,
 ) -> std::result::Result<Vec<Value>, anyhow::Error> {
@@ -356,7 +356,7 @@ enum ReconstructKind {
 /// both ABIs.
 fn classify_argument_type(
     ctx: &mut Context,
-    arg_ty: Ptr<TypeObj>,
+    arg_ty: TypeHandle,
     is_kernel_entry: bool,
 ) -> ReconstructKind {
     let (is_slice, struct_fields) = {
@@ -414,7 +414,7 @@ fn reconstruct_slice(
     ctx: &mut Context,
     llvm_block: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
-    mir_ty: Ptr<TypeObj>,
+    mir_ty: TypeHandle,
     ptr_val: Value,
     len_val: Value,
 ) -> std::result::Result<(Value, Ptr<Operation>), anyhow::Error> {
@@ -453,7 +453,7 @@ fn reconstruct_struct(
     ctx: &mut Context,
     llvm_block: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
-    mir_ty: Ptr<TypeObj>,
+    mir_ty: TypeHandle,
     field_vals: &[Value],
 ) -> std::result::Result<(Value, Ptr<Operation>), anyhow::Error> {
     let layout = {
@@ -572,7 +572,7 @@ fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
 /// lowers to `{ i8, [7 x i8] }` looks like "align 1" to LLVM even when
 /// Rust requires align 8. Memory ops touching such values get stamped
 /// with the recorded alignment instead.
-fn aggregate_over_align(ctx: &Context, ty: Ptr<TypeObj>) -> Option<u64> {
+fn aggregate_over_align(ctx: &Context, ty: TypeHandle) -> Option<u64> {
     let ty_ref = ty.deref(ctx);
     if let Some(s) = ty_ref.downcast_ref::<MirStructType>() {
         return Some(s.abi_align).filter(|a| *a > 0);

--- a/crates/mir-lower/src/type_conversion_interface.rs
+++ b/crates/mir-lower/src/type_conversion_interface.rs
@@ -17,16 +17,16 @@
 //!   actual conversion (function-pointer indirection is required because
 //!   `type_cast` borrows `ctx` immutably, but conversion needs `&mut ctx`).
 
-use pliron::context::{Context, Ptr};
+use pliron::context::Context;
 use pliron::derive::type_interface;
 use pliron::result::Result;
-use pliron::r#type::{Type, TypeObj};
+use pliron::r#type::{Type, TypeHandle};
 
 /// Function pointer type for MIR → LLVM type conversion.
 ///
 /// The indirection lets us extract a `Copy` value from the immutable borrow,
 /// drop the borrow, then call with `&mut Context`.
-pub type ConvertMirTypeFn = fn(Ptr<TypeObj>, &mut Context) -> anyhow::Result<Ptr<TypeObj>>;
+pub type ConvertMirTypeFn = fn(TypeHandle, &mut Context) -> anyhow::Result<TypeHandle>;
 
 /// Marker interface: "this type has an LLVM equivalent".
 ///

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -804,7 +804,7 @@ fn test_cmp_predicate_lowering() -> Result<(), anyhow::Error> {
 
     // Args: (f32, f32, i32, u32). The integer args carry pre-conversion
     // signedness, which is what selects signed vs unsigned icmp predicates.
-    let arg_tys: Vec<pliron::context::Ptr<pliron::r#type::TypeObj>> = vec![
+    let arg_tys: Vec<pliron::r#type::TypeHandle> = vec![
         f32_ty.into(),
         f32_ty.into(),
         i32_signed.into(),
@@ -1016,7 +1016,7 @@ fn make_test_ctx() -> Context {
 /// returning the module ptr and entry block.
 fn build_test_kernel(
     ctx: &mut Context,
-    arg_tys: Vec<pliron::context::Ptr<pliron::r#type::TypeObj>>,
+    arg_tys: Vec<pliron::r#type::TypeHandle>,
 ) -> (
     pliron::context::Ptr<Operation>,
     pliron::context::Ptr<pliron::basic_block::BasicBlock>,
@@ -1072,13 +1072,13 @@ fn test_fast_float_intrinsics_lower_to_explicit_fast_binops() -> Result<(), anyh
     use pliron::builtin::attributes::StringAttr;
     use pliron::builtin::op_interfaces::CallOpInterface;
     use pliron::builtin::types::{FP32Type, FP64Type};
-    use pliron::r#type::{TypeObj, Typed};
+    use pliron::r#type::{TypeHandle, Typed};
 
     let mut ctx = make_test_ctx();
     let f32_ty = FP32Type::get(&ctx);
     let f64_ty = FP64Type::get(&ctx);
-    let f32_ty_obj: pliron::context::Ptr<TypeObj> = f32_ty.into();
-    let f64_ty_obj: pliron::context::Ptr<TypeObj> = f64_ty.into();
+    let f32_ty_obj: TypeHandle = f32_ty.into();
+    let f64_ty_obj: TypeHandle = f64_ty.into();
     let (module_ptr, entry) = build_test_kernel(
         &mut ctx,
         vec![f32_ty_obj, f32_ty_obj, f64_ty_obj, f64_ty_obj],
@@ -1454,7 +1454,7 @@ fn test_bool_phi_cmp_lowers_to_unsigned_i1_icmp() -> Result<(), anyhow::Error> {
     let module_ptr = module.get_operation();
 
     let bool_ty = IntegerType::get(&mut ctx, 1, Signedness::Signless);
-    let arg_tys: Vec<pliron::context::Ptr<pliron::r#type::TypeObj>> =
+    let arg_tys: Vec<pliron::r#type::TypeHandle> =
         vec![bool_ty.into(), bool_ty.into(), bool_ty.into()];
     let func_name = "bool_phi_cmp";
     let func_ty = FunctionType::get(&mut ctx, arg_tys.clone(), vec![]);
@@ -1565,7 +1565,7 @@ fn test_bool_phi_cmp_lowers_to_unsigned_i1_icmp() -> Result<(), anyhow::Error> {
         }
     }
 
-    let i1: pliron::context::Ptr<pliron::r#type::TypeObj> = bool_ty.into();
+    let i1: pliron::r#type::TypeHandle = bool_ty.into();
     assert_eq!(
         icmps,
         vec![(ICmpPredicateAttr::EQ, i1), (ICmpPredicateAttr::ULT, i1),],

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "awint"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +367,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_vec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6298074a1742b584aaca148a6c61ecb27f0b55fdf237c235939c84924377a1"
+
+[[package]]
 name = "oxide-artifacts"
 version = "0.2.1"
 dependencies = [
@@ -381,8 +381,8 @@ dependencies = [
 
 [[package]]
 name = "pliron"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "awint",
  "combine",
@@ -393,6 +393,7 @@ dependencies = [
  "inventory",
  "linkme",
  "log",
+ "once_vec",
  "pliron-derive",
  "regex",
  "rustc-hash",
@@ -400,13 +401,12 @@ dependencies = [
  "slotmap",
  "spin",
  "thiserror",
- "utf8-chars",
 ]
 
 [[package]]
 name = "pliron-derive"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "combine",
  "convert_case",
@@ -418,8 +418,8 @@ dependencies = [
 
 [[package]]
 name = "pliron-llvm"
-version = "0.15.0"
-source = "git+https://github.com/pliron-org/pliron?rev=af1b7d07dda91dad140c1df1df665754cd1646e5#af1b7d07dda91dad140c1df1df665754cd1646e5"
+version = "0.16.0"
+source = "git+https://github.com/pliron-org/pliron?rev=847561916b34649ba944d4eb7db50d02cf9ddf30#847561916b34649ba944d4eb7db50d02cf9ddf30"
 dependencies = [
  "bitflags",
  "log",
@@ -616,15 +616,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "utf8-chars"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe49e006d6df172d7f14794568a90fe41e05a1fa9e03dc276fa6da4bb747ec3"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "version_check"

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -29,8 +29,8 @@ oxide-artifacts = { path = "../oxide-artifacts", features = ["object-write"] }
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml
 # [workspace.dependencies] section. Source MUST match the root (same git + rev),
 # or pliron resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "af1b7d07dda91dad140c1df1df665754cd1646e5" }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "847561916b34649ba944d4eb7db50d02cf9ddf30" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "847561916b34649ba944d4eb7db50d02cf9ddf30" }
 linkme = "0.3"            # must match workspace
 combine = "4.6"           # must match workspace
 once_cell = "1.18"        # must match workspace


### PR DESCRIPTION
## Summary

- Bumps the pinned pliron rev from `af1b7d0` to `8475619` (current `pliron-org/pliron` master) in **both** the root workspace and the `rustc-codegen-cuda` build root, kept in sync so pliron resolves to a single crate and types keep unifying.
- Migrates the dialect and lowering crates to pliron master's new type-handle API: `Ptr<TypeObj>` becomes `TypeHandle`, `TypePtr<T>` becomes `TypedHandle<T>`, and the now-unused `Ptr` / `TypeObj` imports are dropped.
- Touches `mir-importer`, `mir-lower`, `dialect-mir`, `dialect-nvvm`, and `llvm-export`. This is a dependency bump plus a mechanical API rename; no codegen/behavior changes.

```text
Before: ty: Ptr<pliron::r#type::TypeObj>
After:  ty: pliron::r#type::TypeHandle
```

## Test plan

- [x] `cargo fmt --all -- --check` (root + `rustc-codegen-cuda`)
- [x] `cargo clippy --workspace -- -D warnings` (+ `rustc-codegen-cuda --all-targets`)
- [x] Unit-test matrix: `cargo test -p <pkg> --all-targets` across all CI crates + `cuda-core --lib` (all pass, 0 failures)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` + `cargo test --doc --workspace --exclude cuda-bindings`
- [x] `just smoketest`: 116/116 examples pass (RTX 5090, sm_120)