### PR TITLE
Derive DeviceCopy for zero-valid enums

### DIFF
--- a/crates/cuda-core/tests/derive_device_copy/fail_enum.stderr
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum.stderr
@@ -1,5 +1,7 @@
-error: `#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires every bit pattern (including the all-zero pattern written by `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant leaves most byte patterns invalid, so a zeroed or device-written buffer could materialize an out-of-range discriminant (undefined behavior). If you can guarantee every device-produced byte pattern is a valid variant, write `unsafe impl DeviceCopy for ... {}` by hand.
-  --> tests/derive_device_copy/fail_enum.rs:12:6
-   |
-12 | enum Tag {
-   |      ^^^
+error[E0080]: evaluation panicked: aborted execution: attempted to zero-initialize type `Tag`, which is invalid
+ --> tests/derive_device_copy/fail_enum.rs:8:23
+  |
+8 | #[derive(Copy, Clone, DeviceCopy)]
+  |                       ^^^^^^^^^^ evaluation of `_` failed here
+  |
+  = note: this error originates in the derive macro `DeviceCopy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum_generic.rs
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum_generic.rs
@@ -3,15 +3,12 @@
 
 use cuda_core::DeviceCopy;
 
-// This enum has no zero discriminant, so `DeviceBuffer::zeroed::<Tag>` would
-// create an invalid value.
 #[derive(Copy, Clone, DeviceCopy)]
-#[repr(u8)]
-enum Tag {
-    A = 1,
-    B = 2,
+enum Maybe<T> {
+    Empty,
+    Value(T),
 }
 
 fn main() {
-    let _ = Tag::A;
+    let _ = core::mem::size_of::<Maybe<u32>>();
 }

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum_generic.stderr
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[derive(DeviceCopy)]` supports enums only when the enum is not generic, because rustc must be able to const-evaluate `mem::zeroed::<Enum>()` for the concrete enum type and reject enums whose all-zero bit pattern is invalid.
+ --> tests/derive_device_copy/fail_enum_generic.rs:7:6
+  |
+7 | enum Maybe<T> {
+  |      ^^^^^

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum_payload.rs
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum_payload.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::num::NonZeroU32;
+
+use cuda_core::DeviceCopy;
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct ZeroInvalid(NonZeroU32);
+
+// SAFETY: This local impl is deliberately used to isolate enum zero-validity:
+// the derive must reject `BadPayload` because zero is invalid for the payload,
+// not because the field fails the ordinary `DeviceCopy` bound.
+unsafe impl DeviceCopy for ZeroInvalid {}
+
+#[derive(Copy, Clone, DeviceCopy)]
+enum BadPayload {
+    Scalar(ZeroInvalid),
+}
+
+fn main() {
+    let _ = core::mem::size_of::<BadPayload>();
+}

--- a/crates/cuda-core/tests/derive_device_copy/fail_enum_payload.stderr
+++ b/crates/cuda-core/tests/derive_device_copy/fail_enum_payload.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation panicked: aborted execution: attempted to zero-initialize type `BadPayload`, which is invalid
+  --> tests/derive_device_copy/fail_enum_payload.rs:17:23
+   |
+17 | #[derive(Copy, Clone, DeviceCopy)]
+   |                       ^^^^^^^^^^ evaluation of `_` failed here
+   |
+   = note: this error originates in the derive macro `DeviceCopy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-core/tests/derive_device_copy/pass_enum.rs
+++ b/crates/cuda-core/tests/derive_device_copy/pass_enum.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+#[repr(u8)]
+enum Tag {
+    Zero = 0,
+    One = 1,
+}
+
+#[derive(Copy, Clone, DeviceCopy)]
+enum Packet {
+    Empty,
+    Scalar(u32),
+    Pair { x: f32, y: [u16; 2] },
+}
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+fn main() {
+    assert_device_copy::<Tag>();
+    assert_device_copy::<Packet>();
+}

--- a/crates/cuda-core/tests/device_copy_derive.rs
+++ b/crates/cuda-core/tests/device_copy_derive.rs
@@ -5,7 +5,10 @@
 fn device_copy_derive_compile_pass() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_device_copy/pass_structs.rs");
+    t.pass("tests/derive_device_copy/pass_enum.rs");
     t.pass("tests/derive_device_copy/pass_union.rs");
     t.compile_fail("tests/derive_device_copy/fail_non_device_copy_field.rs");
     t.compile_fail("tests/derive_device_copy/fail_enum.rs");
+    t.compile_fail("tests/derive_device_copy/fail_enum_payload.rs");
+    t.compile_fail("tests/derive_device_copy/fail_enum_generic.rs");
 }

--- a/crates/cuda-macros/src/device_copy.rs
+++ b/crates/cuda-macros/src/device_copy.rs
@@ -9,42 +9,34 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
-    Data, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound, parse_str,
+    Data, DataEnum, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound,
+    parse_str,
 };
 
 pub fn impl_device_copy(input: &DeriveInput, import: TokenStream) -> TokenStream {
     let input_type = &input.ident;
 
-    // Generate the code to type-check all fields of the derived struct/union. We can't perform
+    // Generate the code to type-check all fields of the derived type. We can't perform
     // type checking at expansion-time, so instead we generate a dummy nested function with a
-    // type-bound on DeviceCopy and call it with every type that's in the struct/union.
+    // type-bound on DeviceCopy and call it with every field type.
     // This will fail to compile if any of the nested types doesn't implement DeviceCopy.
-    //
-    // Enums are deliberately rejected: `DeviceCopy`'s safety contract requires
-    // every bit pattern, including the all-zero pattern written by
-    // `DeviceBuffer::zeroed`, to be a valid value of the type. That holds for
-    // product types (structs/unions) when every field is `DeviceCopy`, but NOT
-    // for enums, whose discriminant leaves most byte patterns invalid. A zeroed
-    // or device-written buffer could then materialize an out-of-range
-    // discriminant (undefined behavior). This is the same reason `bool`, `char`,
-    // and `NonZeroU32` are not `DeviceCopy`. Per-field checking is necessary but
-    // not sufficient for enums, so we refuse rather than emit an unsound impl.
-    let check_types_code = match input.data {
-        Data::Struct(ref data_struct) => type_check_struct(data_struct),
-        Data::Union(ref data_union) => type_check_union(data_union),
-        Data::Enum(_) => {
-            return syn::Error::new_spanned(
-                input_type,
-                "`#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires \
-                 every bit pattern (including the all-zero pattern written by \
-                 `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant \
-                 leaves most byte patterns invalid, so a zeroed or device-written buffer \
-                 could materialize an out-of-range discriminant (undefined behavior). If you \
-                 can guarantee every device-produced byte pattern is a valid variant, write \
-                 `unsafe impl DeviceCopy for ... {}` by hand.",
-            )
-            .to_compile_error();
-        }
+    let (check_types_code, zero_validity_code) = match input.data {
+        Data::Struct(ref data_struct) => (type_check_struct(data_struct), quote! {}),
+        Data::Union(ref data_union) => (type_check_union(data_union), quote! {}),
+        Data::Enum(ref data_enum) => match type_check_enum(input, data_enum) {
+            Ok(check_types_code) => {
+                let enum_ty = &input.ident;
+                (
+                    check_types_code,
+                    quote! {
+                        const _: () = {
+                            let _ = unsafe { ::core::mem::zeroed::<#enum_ty>() };
+                        };
+                    },
+                )
+            }
+            Err(err) => return err.to_compile_error(),
+        },
     };
 
     // We need a function for the type-checking code to live in, so generate a complicated and
@@ -61,6 +53,8 @@ pub fn impl_device_copy(input: &DeriveInput, import: TokenStream) -> TokenStream
 
     // Finally, generate the unsafe impl and the type-checking function.
     let generated_code = quote! {
+        #zero_validity_code
+
         unsafe impl #impl_generics #import for #input_type #type_generics #where_clause {}
 
         #[doc(hidden)]
@@ -100,6 +94,35 @@ fn type_check_struct(s: &DataStruct) -> TokenStream {
     quote!(
         #(#checks)*
     )
+}
+
+fn type_check_enum(input: &DeriveInput, s: &DataEnum) -> syn::Result<TokenStream> {
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[derive(DeviceCopy)]` supports enums only when the enum is not generic, because \
+             rustc must be able to const-evaluate `mem::zeroed::<Enum>()` for the concrete enum \
+             type and reject enums whose all-zero bit pattern is invalid.",
+        ));
+    }
+
+    let mut checks = vec![];
+    for variant in &s.variants {
+        match variant.fields {
+            Fields::Named(ref named_fields) => {
+                let fields: Vec<&Field> = named_fields.named.iter().collect();
+                checks.extend(check_fields(&fields));
+            }
+            Fields::Unnamed(ref unnamed_fields) => {
+                let fields: Vec<&Field> = unnamed_fields.unnamed.iter().collect();
+                checks.extend(check_fields(&fields));
+            }
+            Fields::Unit => {}
+        }
+    }
+    Ok(quote!(
+        #(#checks)*
+    ))
 }
 
 fn type_check_union(s: &DataUnion) -> TokenStream {

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -90,6 +90,10 @@ pub fn ptx_asm(input: TokenStream) -> TokenStream {
 /// Derive `cuda_core::DeviceCopy` for a type whose fields are all themselves
 /// `DeviceCopy`.
 ///
+/// Concrete enums are accepted only when rustc can const-evaluate
+/// `mem::zeroed::<Enum>()`, rejecting layouts whose all-zero bit pattern is not
+/// a valid enum value.
+///
 /// Re-exported from `cuda_core` next to the `DeviceCopy` trait so that
 /// `use cuda_core::DeviceCopy;` brings both the trait and this derive into scope
 /// (the serde `Serialize` trait+derive pattern).


### PR DESCRIPTION
Closes #285.

# Derive DeviceCopy for zero-valid enums

## Problem

`DeviceCopy` derive handled structs and unions, but it could not safely support
enums. The missing rule is that enum fields must be `DeviceCopy` and the enum's
all-zero bit pattern must be valid for the concrete type.

## Fix

The derive implementation now handles non-generic enums by reusing the existing
field-type checks for all variant fields and emitting a const-time
`mem::zeroed::<Enum>()` validity check. Rustc rejects expansions where the
zeroed enum value would be invalid, so the macro does not need to approximate
enum layout itself.

Generic enums are rejected for now because the macro cannot const-evaluate the
validity check for every possible instantiation.

## Diligence

The check is deliberately based on rustc's validity rules rather than variant
count or discriminant heuristics. The payload failure test uses a local
`DeviceCopy` wrapper whose zero bit pattern is invalid, so it isolates the
enum-validity rule instead of failing on a field trait bound first.

## Tests

- `cargo test -p cuda-core --test device_copy_derive -- --nocapture`
- `cargo test -p cuda-core --test device_copy_impls -- --nocapture`

Upstream red:

- The enum derive trybuild regression fails on `upstream/main`: zero-valid enum cases are rejected and the zero-invalid enum checks are absent.
