### PR TITLE
Add build and test passthrough configuration to cargo-oxide

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -27,6 +27,7 @@ cargo oxide run vecadd              # build + run an example
 cargo oxide build vecadd            # compile only (no run)
 cargo oxide emit-ltoir vecadd --arch sm_100  # device code -> .ltoir (Tile/SIMT interop)
 cargo oxide build -- -p my_app      # arbitrary cargo build through cuda-oxide
+cargo oxide test                    # cargo test with cuda-oxide defaults
 cargo oxide test -- -p my_app       # arbitrary cargo test through cuda-oxide
 cargo oxide pipeline vecadd         # verbose pipeline dump
                                     # (MIR -> dialect-mir -> LLVM dialect -> LLVM IR -> PTX)
@@ -43,10 +44,10 @@ cargo oxide setup                   # explicitly build the codegen backend
 |------------------------------|----------------------------------|-------------------------------------------------|
 | `--emit-nvvm-ir`             | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
 | `--arch <sm_XX>`             | run, build, test, pipeline, emit-ltoir | Target architecture override          |
-| `--features <F>`             | run, build examples, emit-ltoir  | Comma-separated cargo features to enable        |
+| `--features <F>`             | run, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
 | `-o, --output <P>`           | emit-ltoir                       | Output path for the `.ltoir` artifact           |
 | `--cargo-target-dir <PATH>`  | build/test passthrough           | Cargo target directory                          |
-| `--device-codegen-crate <LIST>` | build/test passthrough        | Device owner filter                             |
+| `--device-codegen-crate <LIST>` | build/test passthrough        | Comma-separated device owner crate filter       |
 | `--device-cfg <NAME>`        | build/test passthrough           | Append `--cfg NAME` to rustflags                |
 | `-v, --verbose`              | run, build, test, emit-ltoir     | Show detailed compilation output                |
 | `--no-fmad`                  | run, build, pipeline             | Disable FMA contraction (keep separate mul+add) |
@@ -107,9 +108,27 @@ arguments after `--`; cargo-oxide supplies the backend, target architecture,
 configured environment, and optional device owner filters.
 
 ```bash
+cargo oxide build --                           # plain `cargo build`
 cargo oxide build --arch sm_86 -- -p my_app --bin app --release
 cargo oxide build --cargo-target-dir target/cuda -- -p my_app --release
+cargo oxide build --device-codegen-crate gpu-kernels,math_gpu -- -p my_app
 ```
+
+The owner filter is matched against rustc crate names, so Cargo package hyphens
+are normalized to underscores (`gpu-kernels` matches `gpu_kernels`). The CUDA
+backend still compiles host code for every crate through LLVM; it emits device
+artifacts only for the listed owner crates.
+
+The filter controls compilation, not runtime module names. Code in an excluded
+crate or target must not call that target's generated `load()` function. In a
+package with several targets, embedded bundles still use the package name, so
+an excluded target's loader could otherwise find a selected sibling target's
+bundle.
+
+Passthrough builds include the effective codegen settings and backend build in
+Cargo's rustc fingerprint. Changing the target, output mode, FMA policy, owner
+list, configured codegen environment, or backend `.so` therefore regenerates
+device artifacts instead of reusing a stale Cargo result.
 
 ### `cargo oxide emit-ltoir <crate>`
 
@@ -135,11 +154,12 @@ alongside the artifact so the runtime uses the same format.
 
 ### `cargo oxide test`
 
-Runs arbitrary `cargo test` invocations through the cuda-oxide backend. Put all
-Cargo test arguments after `--`, including the test binary separator when
-needed.
+Runs `cargo test` through the cuda-oxide backend. With no extra arguments it
+runs the workspace's normal test selection. Put Cargo test arguments after
+`--`, including the test-binary separator when needed.
 
 ```bash
+cargo oxide test
 cargo oxide test -- -p my_app --release --test gpu_smoke -- --nocapture
 cargo oxide test --device-codegen-crate gpu_smoke -- -p my_app --test gpu_smoke
 ```
@@ -200,8 +220,8 @@ When `cargo oxide` needs the `librustc_codegen_cuda.so` backend, it searches in 
 4. **Cached `.so`** — checks `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`
 5. **Auto-fetch** — clones the cuda-oxide repo, builds, and caches (one-time)
 
-Project config can also provide the default architecture, extra rustflags, and
-child-process environment:
+Project config can also provide the default architecture, extra rustc flags,
+and child-process environment:
 
 ```toml
 backend = "/path/to/librustc_codegen_cuda.so"
@@ -211,6 +231,23 @@ extra-rustflags = ["--cfg", "my_device_cfg"]
 [env]
 MY_BUILD_FLAG = "1"
 ```
+
+Relative backend paths are resolved from the `.cargo` directory containing the
+config file. Each `extra-rustflags` array element remains one rustc argument,
+including values that contain spaces.
+
+Configuration values are defaults. Precedence is:
+
+1. explicit `cargo oxide` flags and internal artifact paths;
+2. environment variables inherited by `cargo oxide`;
+3. `.cargo/cuda-oxide.toml` defaults.
+
+Do not put `RUSTFLAGS` or `CARGO_ENCODED_RUSTFLAGS` in the `[env]` table; use
+`extra-rustflags` for project defaults. cargo-oxide combines configured flags,
+inherited user flags, explicit `--device-cfg` values, and its required compiler
+flags in boundary-preserving `CARGO_ENCODED_RUSTFLAGS`. Required compiler flags
+are applied last so inherited settings cannot replace the cuda-oxide backend or
+disable its correctness-critical codegen options.
 
 ## Architecture
 

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -26,6 +26,8 @@ cargo oxide new my_project --async  # scaffold with async template (tokio + cuda
 cargo oxide run vecadd              # build + run an example
 cargo oxide build vecadd            # compile only (no run)
 cargo oxide emit-ltoir vecadd --arch sm_100  # device code -> .ltoir (Tile/SIMT interop)
+cargo oxide build -- -p my_app      # arbitrary cargo build through cuda-oxide
+cargo oxide test -- -p my_app       # arbitrary cargo test through cuda-oxide
 cargo oxide pipeline vecadd         # verbose pipeline dump
                                     # (MIR -> dialect-mir -> LLVM dialect -> LLVM IR -> PTX)
 cargo oxide debug vecadd --tui      # build + launch cuda-gdb
@@ -37,18 +39,21 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 ### Flags
 
-| Flag               | Applies to                       | Description                                     |
-|--------------------|----------------------------------|-------------------------------------------------|
-| `--emit-nvvm-ir`   | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
-| `--arch <sm_XX>`   | run, build, pipeline, emit-ltoir | Target arch override                            |
-| `--features <F>`   | run, build, emit-ltoir           | Comma-separated cargo features to enable        |
-| `-o, --output <P>` | emit-ltoir                       | Output path for the `.ltoir` artifact           |
-| `-v, --verbose`    | run, build, emit-ltoir           | Show detailed compilation output                |
-| `--no-fmad`        | run, build, pipeline             | Disable FMA contraction (keep separate mul+add) |
-| `--async`          | new                              | Use the async template                          |
-| `--cgdb`           | debug                            | Use cgdb instead of cuda-gdb                    |
-| `--tui`            | debug                            | Use GDB's TUI interface                         |
-| `--check`          | fmt                              | Check formatting only                           |
+| Flag                         | Applies to                       | Description                                     |
+|------------------------------|----------------------------------|-------------------------------------------------|
+| `--emit-nvvm-ir`             | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
+| `--arch <sm_XX>`             | run, build, test, pipeline, emit-ltoir | Target architecture override          |
+| `--features <F>`             | run, build examples, emit-ltoir  | Comma-separated cargo features to enable        |
+| `-o, --output <P>`           | emit-ltoir                       | Output path for the `.ltoir` artifact           |
+| `--cargo-target-dir <PATH>`  | build/test passthrough           | Cargo target directory                          |
+| `--device-codegen-crate <LIST>` | build/test passthrough        | Device owner filter                             |
+| `--device-cfg <NAME>`        | build/test passthrough           | Append `--cfg NAME` to rustflags                |
+| `-v, --verbose`              | run, build, test, emit-ltoir     | Show detailed compilation output                |
+| `--no-fmad`                  | run, build, pipeline             | Disable FMA contraction (keep separate mul+add) |
+| `--async`                    | new                              | Use the async template                          |
+| `--cgdb`                     | debug                            | Use cgdb instead of cuda-gdb                    |
+| `--tui`                      | debug                            | Use GDB's TUI interface                         |
+| `--check`                    | fmt                              | Check formatting only                           |
 
 `--arch` is required for `emit-ltoir` and explicit NVVM IR output because those
 artifacts are architecture-specific. Without an override, `run` detects the
@@ -97,6 +102,15 @@ cargo oxide build htens          # compiles PTX, doesn't try to run on GPU
 cargo oxide build tcgen05        # sm_100a only, but PTX generation works anywhere
 ```
 
+`build` also has a passthrough mode for normal Cargo workspaces. Put the Cargo
+arguments after `--`; cargo-oxide supplies the backend, target architecture,
+configured environment, and optional device owner filters.
+
+```bash
+cargo oxide build --arch sm_86 -- -p my_app --bin app --release
+cargo oxide build --cargo-target-dir target/cuda -- -p my_app --release
+```
+
 ### `cargo oxide emit-ltoir <crate>`
 
 Compiles a crate's device code to a binary LTOIR artifact in one step, for the
@@ -118,6 +132,17 @@ cuda-oxide chooses the NVVM IR format from the selected architecture.
 Pre-Blackwell targets use LLVM 7 typed pointers; `compute_100` and newer targets
 use modern opaque pointers. The target is checked before export and recorded
 alongside the artifact so the runtime uses the same format.
+
+### `cargo oxide test`
+
+Runs arbitrary `cargo test` invocations through the cuda-oxide backend. Put all
+Cargo test arguments after `--`, including the test binary separator when
+needed.
+
+```bash
+cargo oxide test -- -p my_app --release --test gpu_smoke -- --nocapture
+cargo oxide test --device-codegen-crate gpu_smoke -- -p my_app --test gpu_smoke
+```
 
 ### `cargo oxide pipeline <example>`
 
@@ -170,9 +195,22 @@ Explicitly builds (or rebuilds) the codegen backend. Normally this happens autom
 When `cargo oxide` needs the `librustc_codegen_cuda.so` backend, it searches in this order:
 
 1. **`CUDA_OXIDE_BACKEND` env var** — explicit path override
-2. **Local repo** — detects `crates/rustc-codegen-cuda` relative to workspace root, builds from source
-3. **Cached `.so`** — checks `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`
-4. **Auto-fetch** — clones the cuda-oxide repo, builds, and caches (one-time)
+2. **Project config** — `.cargo/cuda-oxide.toml`
+3. **Local repo** — detects `crates/rustc-codegen-cuda` relative to workspace root, builds from source
+4. **Cached `.so`** — checks `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`
+5. **Auto-fetch** — clones the cuda-oxide repo, builds, and caches (one-time)
+
+Project config can also provide the default architecture, extra rustflags, and
+child-process environment:
+
+```toml
+backend = "/path/to/librustc_codegen_cuda.so"
+default-arch = "sm_86"
+extra-rustflags = ["--cfg", "my_device_cfg"]
+
+[env]
+MY_BUILD_FLAG = "1"
+```
 
 ## Architecture
 
@@ -190,7 +228,6 @@ crates/cargo-oxide/
 | Command                         | Description                                             |
 |---------------------------------|---------------------------------------------------------|
 | `cargo oxide bench <example>`   | GPU profiling (nsys/ncu integration), report TFLOPS     |
-| `cargo oxide test`              | Run all examples as a test suite, report pass/fail      |
 | `cargo oxide clean`             | Remove generated PTX/LL/LTOIR artifacts and build caches|
 | `cargo oxide update`            | Update the cached codegen backend to latest version     |
 | `cargo oxide list`              | List examples with descriptions and hardware reqs       |

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -8,10 +8,11 @@
 //! Finds or builds `librustc_codegen_cuda.so` using this priority:
 //!
 //! 1. `CUDA_OXIDE_BACKEND` env var (explicit override)
-//! 2. Local repo (detected by presence of `crates/rustc-codegen-cuda`)
-//! 3. Cached `.so` at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`,
+//! 2. Project config (`.cargo/cuda-oxide.toml`)
+//! 3. Local repo (detected by presence of `crates/rustc-codegen-cuda`)
+//! 4. Cached `.so` at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`,
 //!    but only when it isn't older than the running `cargo-oxide` binary
-//! 4. Auto-fetch from git and build (one-time, or after a stale-cache miss)
+//! 5. Auto-fetch from git and build (one-time, or after a stale-cache miss)
 //!
 //! ## Cache staleness (issue #49)
 //!
@@ -81,10 +82,11 @@ pub fn find_workspace_root() -> Option<PathBuf> {
 ///
 /// Discovery order:
 /// 1. `CUDA_OXIDE_BACKEND` env var
-/// 2. Local repo build (crates/rustc-codegen-cuda)
-/// 3. Cached build at ~/.cargo/cuda-oxide/
-/// 4. Auto-fetch + build from git
-pub fn find_or_build_backend(workspace_root: &Path) -> PathBuf {
+/// 2. Project config (`.cargo/cuda-oxide.toml`)
+/// 3. Local repo build (crates/rustc-codegen-cuda)
+/// 4. Cached build at ~/.cargo/cuda-oxide/
+/// 5. Auto-fetch + build from git
+pub fn find_or_build_backend(workspace_root: &Path, configured_backend: Option<&Path>) -> PathBuf {
     // 1. Explicit override
     if let Ok(path) = std::env::var("CUDA_OXIDE_BACKEND") {
         let p = PathBuf::from(&path);
@@ -97,7 +99,20 @@ pub fn find_or_build_backend(workspace_root: &Path) -> PathBuf {
         );
     }
 
-    // 2. Local repo
+    // 2. Project config
+    if let Some(path) = configured_backend {
+        if path.exists() {
+            return path.to_path_buf();
+        }
+        eprintln!(
+            "Error: configured cuda-oxide backend does not exist: {}",
+            path.display()
+        );
+        eprintln!("Build it or update `.cargo/cuda-oxide.toml`.");
+        std::process::exit(1);
+    }
+
+    // 3. Local repo
     let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
     if codegen_crate.is_dir() {
         let so_path = codegen_crate.join("target/debug/librustc_codegen_cuda.so");
@@ -105,7 +120,7 @@ pub fn find_or_build_backend(workspace_root: &Path) -> PathBuf {
         return so_path;
     }
 
-    // 3. Cached .so. Only honored when it isn't older than the running
+    // 4. Cached .so. Only honored when it isn't older than the running
     //    cargo-oxide binary; see the module-level comment about issue #49.
     if let Some(cache_dir) = cache_directory() {
         let cached_so = cache_dir.join("librustc_codegen_cuda.so");
@@ -137,7 +152,7 @@ pub fn find_or_build_backend(workspace_root: &Path) -> PathBuf {
         }
     }
 
-    // 4. Auto-fetch from git
+    // 5. Auto-fetch from git
     auto_fetch_and_build()
 }
 
@@ -149,14 +164,20 @@ pub fn find_or_build_backend(workspace_root: &Path) -> PathBuf {
 ///
 /// 1. `CUDA_OXIDE_BACKEND` env var, returned even when the file is missing
 ///    so the caller can report the configured-but-absent path.
-/// 2. Local repo build path (`crates/rustc-codegen-cuda/target/debug/...`).
-/// 3. Cache path at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`.
+/// 2. Project config (`.cargo/cuda-oxide.toml`), returned even when missing
+///    so the caller can report the configured-but-absent path.
+/// 3. Local repo build path (`crates/rustc-codegen-cuda/target/debug/...`).
+/// 4. Cache path at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`.
 ///
 /// `cargo oxide doctor` uses this so that a diagnostic run never triggers a
 /// multi-minute backend build or a git clone before it can print anything.
-pub fn backend_so_candidate(workspace_root: &Path) -> PathBuf {
+pub fn backend_so_candidate(workspace_root: &Path, configured_backend: Option<&Path>) -> PathBuf {
     if let Ok(path) = std::env::var("CUDA_OXIDE_BACKEND") {
         return PathBuf::from(path);
+    }
+
+    if let Some(path) = configured_backend {
+        return path.to_path_buf();
     }
 
     let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -18,10 +18,10 @@
 //!
 //! `cargo install` always rewrites `~/.cargo/bin/cargo-oxide` on every
 //! upgrade, bumping its mtime. The cached `.so` is only ever written by
-//! step 4 below, so a binary newer than the cache is the canonical signal
+//! step 5 below, so a binary newer than the cache is the canonical signal
 //! that the user has just upgraded `cargo-oxide` and the cached backend
-//! no longer matches the binary loading it. When step 3 detects that, we
-//! drop both the cached `.so` *and* the cached source tree so that step 4
+//! no longer matches the binary loading it. When step 4 detects that, we
+//! drop both the cached `.so` *and* the cached source tree so that step 5
 //! re-clones fresh and rebuilds, rather than rebuilding from a clone that
 //! was taken whenever the user first installed.
 //!

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -9,6 +9,7 @@
 //! - Backend path resolved via discovery chain instead of hardcoded relative path
 //! - Workspace root resolved by walking up from CWD instead of assuming CWD
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -19,7 +20,7 @@ use crate::backend;
 pub struct OxideConfig {
     /// Explicit backend shared object path.
     pub backend: Option<PathBuf>,
-    /// Default CUDA architecture for build/test/pipeline commands.
+    /// Default CUDA architecture for codegen commands.
     pub default_arch: Option<String>,
     /// Additional rustflags appended after cuda-oxide's required flags.
     pub extra_rustflags: Vec<String>,
@@ -152,7 +153,7 @@ pub fn resolve_doctor_context() -> Context {
 
 /// Build and run an example with the custom codegen backend.
 ///
-/// Cleans stale artifacts, sets `RUSTFLAGS` to point at the backend `.so`,
+/// Cleans stale artifacts, sets encoded rustc flags to point at the backend `.so`,
 /// and invokes `cargo run --release` from the example directory. Environment
 /// variables control output format (PTX / NVVM IR) and verbosity.
 #[allow(clippy::too_many_arguments)]
@@ -217,7 +218,8 @@ pub fn codegen_run(
         println!("Output format: {}", output_format);
         println!(
             "Target arch: {}",
-            target_arch.expect("--emit-nvvm-ir requires --arch")
+            configured_arch_label(ctx, arch)
+                .expect("--emit-nvvm-ir requires a configured architecture")
         );
         println!();
     } else if let Some(dev) = detected_device_arch.as_deref() {
@@ -229,17 +231,13 @@ pub fn codegen_run(
         println!();
     }
     println!("This is the proper cargo workflow:");
-    println!("  RUSTFLAGS=\"-Z codegen-backend=...\" cargo run");
+    println!("  CARGO_ENCODED_RUSTFLAGS=<cuda-oxide flags> cargo run");
     println!();
-
-    let rustflags = build_rustflags(ctx, false);
 
     touch_main_rs(&example_dir);
 
     let mut cmd = Command::new("cargo");
-    cmd.args(["run", "--release"])
-        .current_dir(&example_dir)
-        .env("RUSTFLAGS", &rustflags);
+    cmd.args(["run", "--release"]).current_dir(&example_dir);
 
     if let Some(bin) = bin {
         cmd.args(["--bin", bin]);
@@ -249,6 +247,7 @@ pub fn codegen_run(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
 
@@ -317,7 +316,7 @@ fn codegen_run_interop(
         arch,
         detected_device_arch,
     );
-    run_host_cargo(example, example_dir, "run", features, bin, verbose);
+    run_host_cargo(ctx, example, example_dir, "run", features, bin, verbose);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -344,7 +343,7 @@ fn codegen_build_interop(
     // `build` may cross-compile for another machine, so no device-arch hint:
     // only an explicit `--arch` pins the target here.
     build_interop_device_crates(ctx, example_dir, interop, verbose, arch, None);
-    run_host_cargo(example, example_dir, "build", features, None, verbose);
+    run_host_cargo(ctx, example, example_dir, "build", features, None, verbose);
 }
 
 fn reject_interop_nvvm_ir(emit_nvvm_ir: bool) {
@@ -413,16 +412,16 @@ fn build_interop_device_crate(
 
     println!("Building device crate {}...", manifest_path.display());
 
-    let rustflags = build_rustflags(ctx, false);
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release", "--manifest-path"])
         .arg(&manifest_path)
-        .current_dir(device_dir)
-        .env("RUSTFLAGS", &rustflags)
-        .env_remove("CARGO_ENCODED_RUSTFLAGS")
-        .env("CUDA_OXIDE_PTX_DIR", &ptx_dir);
+        .current_dir(device_dir);
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, false);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
+    // This is an internal artifact contract, so it must override a project
+    // `[env]` default for the same variable.
+    cmd.env("CUDA_OXIDE_PTX_DIR", &ptx_dir);
     apply_output_mode(&mut cmd, false, arch);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
 
@@ -447,6 +446,7 @@ fn build_interop_device_crate(
 }
 
 fn run_host_cargo(
+    ctx: &Context,
     example: &str,
     example_dir: &Path,
     cargo_subcommand: &str,
@@ -468,7 +468,8 @@ fn run_host_cargo(
         cmd.args(["--features", features]);
     }
 
-    apply_ld_library_path(&mut cmd);
+    apply_config_env(&mut cmd, ctx);
+    apply_ld_library_path(&mut cmd, ctx);
 
     if cargo_subcommand == "run" {
         if let Some(bin) = bin {
@@ -543,20 +544,17 @@ pub fn codegen_build(
     println!("=========================================");
     println!();
 
-    let rustflags = build_rustflags(ctx, false);
-
     touch_main_rs(&example_dir);
 
     let mut cmd = Command::new("cargo");
-    cmd.args(["build", "--release"])
-        .current_dir(&example_dir)
-        .env("RUSTFLAGS", &rustflags);
+    cmd.args(["build", "--release"]).current_dir(&example_dir);
 
     if let Some(features) = features {
         cmd.args(["--features", features]);
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
 
     println!("Building {}...", example);
@@ -765,14 +763,228 @@ fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, arch: &libnvvm_sys::CudaArch) ->
 }
 
 /// Options for `cargo oxide build -- ...` / `cargo oxide test -- ...`.
+#[derive(Clone, Copy)]
 pub struct CargoPassthroughOptions<'a> {
     pub verbose: bool,
     pub emit_nvvm_ir: bool,
     pub arch: Option<&'a str>,
+    pub features: Option<&'a str>,
     pub cargo_target_dir: Option<&'a Path>,
     pub device_codegen_crate: Option<&'a str>,
     pub device_cfgs: &'a [String],
     pub no_fmad: bool,
+}
+
+fn normalize_device_codegen_crates(raw: &str) -> Result<String, String> {
+    let mut normalized = Vec::new();
+    for item in raw.split(',') {
+        let name = item.trim().replace('-', "_");
+        if name.is_empty() {
+            return Err(
+                "--device-codegen-crate requires a comma-separated list without empty entries"
+                    .to_string(),
+            );
+        }
+        if !name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+        {
+            return Err(format!(
+                "invalid device-codegen crate name `{item}`; use Cargo crate names separated by commas"
+            ));
+        }
+        if !normalized.contains(&name) {
+            normalized.push(name);
+        }
+    }
+    Ok(normalized.join(","))
+}
+
+fn project_config_env<'a>(ctx: &'a Context, key: &str) -> Option<&'a str> {
+    ctx.config
+        .env
+        .iter()
+        .find(|(configured_key, _)| configured_key == key)
+        .map(|(_, value)| value.as_str())
+}
+
+fn configured_device_codegen_crates(
+    ctx: &Context,
+    explicit: Option<&str>,
+) -> Result<Option<String>, String> {
+    let inherited = std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE").ok();
+    resolve_device_codegen_crates(
+        explicit,
+        inherited.as_deref(),
+        project_config_env(ctx, "CUDA_OXIDE_DEVICE_CODEGEN_CRATE"),
+    )
+}
+
+fn resolve_device_codegen_crates(
+    explicit: Option<&str>,
+    inherited: Option<&str>,
+    configured: Option<&str>,
+) -> Result<Option<String>, String> {
+    if let Some(explicit) = explicit {
+        return normalize_device_codegen_crates(explicit).map(Some);
+    }
+
+    inherited
+        .or(configured)
+        .filter(|value| !value.trim().is_empty())
+        .map(normalize_device_codegen_crates)
+        .transpose()
+}
+
+fn passthrough_codegen_fingerprint(
+    ctx: &Context,
+    opts: &CargoPassthroughOptions<'_>,
+    owner_filter: Option<&str>,
+    target_arch: Option<&str>,
+) -> String {
+    let inherited_env: BTreeMap<String, Option<String>> = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            key.into_string()
+                .ok()
+                .map(|key| (key, value.into_string().ok()))
+        })
+        .collect();
+    passthrough_codegen_fingerprint_with_env(ctx, opts, owner_filter, target_arch, &inherited_env)
+}
+
+fn passthrough_codegen_fingerprint_with_env(
+    ctx: &Context,
+    opts: &CargoPassthroughOptions<'_>,
+    owner_filter: Option<&str>,
+    target_arch: Option<&str>,
+    inherited_env: &BTreeMap<String, Option<String>>,
+) -> String {
+    let mut effective_env = BTreeMap::new();
+    effective_env.insert(
+        "__CUDA_OXIDE_BACKEND_ARTIFACT".to_string(),
+        backend_artifact_identity(&ctx.backend_so),
+    );
+
+    // Project-configured CUDA_OXIDE_* variables are defaults. Mirror the same
+    // parent override rule as `apply_config_env` so changes that can affect
+    // codegen also change Cargo's rustflags fingerprint.
+    for (key, configured_value) in &ctx.config.env {
+        if !key.starts_with("CUDA_OXIDE_") {
+            continue;
+        }
+        match inherited_env.get(key) {
+            Some(Some(value)) => {
+                effective_env.insert(key.clone(), value.clone());
+            }
+            // `apply_config_env` sees the non-Unicode parent value through
+            // var_os and does not replace it; backend readers using `var`
+            // ignore it, so there is no effective Unicode value to hash.
+            Some(None) => {}
+            None => {
+                effective_env.insert(key.clone(), configured_value.clone());
+            }
+        }
+    }
+    // Capture backend settings inherited outside project config, including
+    // current and future CUDA_OXIDE_* switches.
+    for (key, value) in inherited_env
+        .iter()
+        .filter(|(key, value)| key.starts_with("CUDA_OXIDE_") && value.is_some())
+    {
+        effective_env.insert(
+            key.clone(),
+            value
+                .as_ref()
+                .expect("filtered to Unicode environment values")
+                .clone(),
+        );
+    }
+
+    if opts.verbose {
+        effective_env.insert("CUDA_OXIDE_VERBOSE".to_string(), "1".to_string());
+    }
+    if opts.no_fmad {
+        effective_env.insert("CUDA_OXIDE_NO_FMA".to_string(), "1".to_string());
+    }
+    if opts.emit_nvvm_ir {
+        effective_env.insert("CUDA_OXIDE_EMIT_NVVM_IR".to_string(), "1".to_string());
+    }
+    if let Some(target_arch) = target_arch {
+        effective_env.insert("CUDA_OXIDE_TARGET".to_string(), target_arch.to_string());
+    }
+    if let Some(owner_filter) = owner_filter {
+        effective_env.insert(
+            "CUDA_OXIDE_DEVICE_CODEGEN_CRATE".to_string(),
+            owner_filter.to_string(),
+        );
+    }
+
+    // Stable FNV-1a over length-delimited key/value pairs. The cfg carries
+    // only the digest, so backend settings are not included verbatim in rustc
+    // command lines or diagnostics.
+    let mut hash = 0xcbf29ce484222325_u64;
+    for (key, value) in effective_env {
+        for bytes in [key.as_bytes(), value.as_bytes()] {
+            for byte in (bytes.len() as u64).to_le_bytes().iter().chain(bytes) {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+        }
+    }
+    format!("{hash:016x}")
+}
+
+fn backend_artifact_identity(path: &Path) -> String {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let path = canonical.to_string_lossy();
+    let Ok(metadata) = std::fs::metadata(&canonical) else {
+        return format!("{path}|missing");
+    };
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("{path}|{}|{modified}", metadata.len())
+}
+
+fn cargo_passthrough_command(
+    ctx: &Context,
+    cargo_subcommand: &str,
+    opts: &CargoPassthroughOptions<'_>,
+    cargo_args: &[String],
+) -> Result<Command, String> {
+    let target_arch = configured_arch(ctx, opts.arch);
+    let owner_filter = configured_device_codegen_crates(ctx, opts.device_codegen_crate)?;
+    let mut fingerprinted_device_cfgs = opts.device_cfgs.to_vec();
+    // Cargo does not fingerprint arbitrary child environment variables. An
+    // otherwise-unused cfg makes every effective codegen setting part of the
+    // rustc command line, so changing target/output/FMA/filter settings reruns
+    // the backend instead of silently reusing stale PTX or NVVM IR.
+    let fingerprint =
+        passthrough_codegen_fingerprint(ctx, opts, owner_filter.as_deref(), target_arch);
+    fingerprinted_device_cfgs.push(format!("cuda_oxide_internal_codegen_env=\"{fingerprint}\""));
+    let mut cmd = Command::new("cargo");
+    cmd.arg(cargo_subcommand);
+    if let Some(features) = opts.features {
+        cmd.args(["--features", features]);
+    }
+    cmd.args(cargo_args).current_dir(&ctx.workspace_root);
+
+    // Project configuration provides defaults. Explicit wrapper flags and
+    // internal compiler requirements are applied afterward and therefore win.
+    apply_common_codegen_env(&mut cmd, ctx, opts.verbose, opts.no_fmad);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &fingerprinted_device_cfgs);
+
+    if let Some(cargo_target_dir) = opts.cargo_target_dir {
+        cmd.env("CARGO_TARGET_DIR", cargo_target_dir);
+    }
+    if let Some(owner_filter) = owner_filter {
+        cmd.env("CUDA_OXIDE_DEVICE_CODEGEN_CRATE", owner_filter);
+    }
+    apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch);
+    Ok(cmd)
 }
 
 /// Run an arbitrary Cargo build-like subcommand through the cuda-oxide backend.
@@ -786,48 +998,31 @@ pub fn codegen_cargo_passthrough(
     opts: CargoPassthroughOptions<'_>,
     cargo_args: &[String],
 ) {
-    if cargo_args.is_empty() {
-        eprintln!(
-            "Error: `cargo oxide {}` passthrough requires Cargo args after `--`",
-            cargo_subcommand
-        );
-        eprintln!(
-            "Example: cargo oxide {} -- --release -p my_package",
-            cargo_subcommand
-        );
-        std::process::exit(2);
-    }
-
     println!("=========================================");
     println!("RUSTC-CODEGEN-CUDA CARGO {}", cargo_subcommand);
     println!("=========================================");
     println!();
 
-    let target_arch = configured_arch(ctx, opts.arch);
-    let rustflags = build_rustflags_with_device_cfgs(ctx, false, opts.device_cfgs);
+    let mut cmd = cargo_passthrough_command(ctx, cargo_subcommand, &opts, cargo_args)
+        .unwrap_or_else(|error| {
+            eprintln!("Error: {error}");
+            std::process::exit(2);
+        });
 
-    let mut cmd = Command::new("cargo");
-    cmd.arg(cargo_subcommand)
-        .args(cargo_args)
-        .current_dir(&ctx.workspace_root)
-        .env("RUSTFLAGS", &rustflags)
-        .env_remove("CARGO_ENCODED_RUSTFLAGS");
-
-    if let Some(cargo_target_dir) = opts.cargo_target_dir {
-        cmd.env("CARGO_TARGET_DIR", cargo_target_dir);
+    let displayed_args: Vec<_> = cmd
+        .get_args()
+        .skip(1)
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    if displayed_args.is_empty() {
+        println!("Running cargo {}...", cargo_subcommand);
+    } else {
+        println!(
+            "Running cargo {} {}...",
+            cargo_subcommand,
+            displayed_args.join(" ")
+        );
     }
-    if let Some(owner_filter) = opts.device_codegen_crate {
-        cmd.env("CUDA_OXIDE_DEVICE_CODEGEN_CRATE", owner_filter);
-    }
-
-    apply_common_codegen_env(&mut cmd, ctx, opts.verbose, opts.no_fmad);
-    apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch);
-
-    println!(
-        "Running cargo {} {}...",
-        cargo_subcommand,
-        cargo_args.join(" ")
-    );
     println!();
 
     let status = cmd.status().expect("Failed to run cargo");
@@ -875,16 +1070,17 @@ pub fn codegen_show_pipeline(
     println!("RUSTC-CODEGEN-CUDA PIPELINE: {}", example);
     println!("=========================================");
     println!();
-    match (emit_nvvm_ir, target_arch) {
+    let target_arch_label = configured_arch_label(ctx, arch);
+    match (emit_nvvm_ir, target_arch_label.as_deref()) {
         (true, Some(target_arch)) => println!("Output format: NVVM IR (arch: {})", target_arch),
         (false, Some(target_arch)) => {
             println!("Output format: PTX (arch override: {})", target_arch)
         }
         (false, None) => println!("Output format: PTX (auto-detected arch)"),
-        (true, None) => unreachable!("--emit-nvvm-ir requires --arch"),
+        (true, None) => unreachable!("--emit-nvvm-ir requires a configured architecture"),
     }
     println!();
-    println!("Required flags (applied via RUSTFLAGS):");
+    println!("Required flags (applied via CARGO_ENCODED_RUSTFLAGS):");
     println!("  -C opt-level=3              MIR optimization");
     println!("  -C debug-assertions=off     Remove debug checks");
     println!("  -Z mir-enable-passes=-JumpThreading");
@@ -894,28 +1090,23 @@ pub fn codegen_show_pipeline(
     println!("      unwind paths as unreachable (CUDA toolchain limitation, not HW).");
     println!();
 
-    let rustflags = build_rustflags(ctx, false);
-
     touch_main_rs(&example_dir);
 
     let mut cmd = Command::new("cargo");
-    cmd.args(["build", "--release"])
-        .current_dir(&example_dir)
-        .env("RUSTFLAGS", &rustflags);
+    cmd.args(["build", "--release"]).current_dir(&example_dir);
 
+    apply_config_env(&mut cmd, ctx);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
     cmd.env("CUDA_OXIDE_VERBOSE", "1");
     cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_LLVM", "1");
     if no_fmad {
         cmd.env("CUDA_OXIDE_NO_FMA", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_NO_FMA");
     }
 
-    apply_config_env(&mut cmd, ctx);
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
-    apply_ld_library_path(&mut cmd);
+    apply_ld_library_path(&mut cmd, ctx);
 
     println!("Building {}...", example);
     println!();
@@ -979,7 +1170,8 @@ pub fn codegen_debug(
         ctx.workspace_root.clone()
     };
 
-    let detected_device_arch = detect_run_target_arch(arch, false);
+    let target_arch = configured_arch(ctx, arch);
+    let detected_device_arch = detect_run_target_arch(target_arch, false);
 
     println!("Building {} with debug info...", example);
     if let Some(dev) = detected_device_arch.as_deref() {
@@ -988,24 +1180,17 @@ pub fn codegen_debug(
 
     clean_generated_files(&example_dir, example);
 
-    let rustflags = build_rustflags(ctx, true);
-
     touch_main_rs(&example_dir);
 
     let mut cmd = Command::new("cargo");
-    cmd.args(["build", "--release"])
-        .current_dir(&example_dir)
-        .env("RUSTFLAGS", &rustflags)
-        .env("CARGO_PROFILE_RELEASE_DEBUG", "2");
-
-    forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
+    cmd.args(["build", "--release"]).current_dir(&example_dir);
 
     apply_config_env(&mut cmd, ctx);
-    apply_output_mode(&mut cmd, false, arch);
-    apply_device_arch_hint(&mut cmd, arch, detected_device_arch.as_deref());
-    apply_ld_library_path(&mut cmd);
+    apply_codegen_rustflags(&mut cmd, ctx, true, &[]);
+    cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "2");
+    apply_output_mode(&mut cmd, false, target_arch);
+    apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
+    apply_ld_library_path(&mut cmd, ctx);
 
     let status = cmd.status().expect("Failed to run cargo build");
     if !status.success() {
@@ -1840,55 +2025,76 @@ fn resolve_example_dir(ctx: &Context, example: &str) -> PathBuf {
     example_dir
 }
 
-/// Construct the `RUSTFLAGS` string that configures rustc to use our backend.
-///
-/// Always includes `-Z codegen-backend`, `-C opt-level=3`, disabled debug
-/// assertions, suppressed JumpThreading (prevents barrier duplication), and
-/// v0 symbol mangling. Appends `-C debuginfo=2` when `debug` is true, then
-/// appends any existing user-provided `RUSTFLAGS`.
-fn build_rustflags(ctx: &Context, debug: bool) -> String {
-    build_rustflags_with_device_cfgs(ctx, debug, &[])
-}
+const ENCODED_RUSTFLAGS_SEPARATOR: char = '\u{1f}';
 
-fn build_rustflags_with_device_cfgs(ctx: &Context, debug: bool, device_cfgs: &[String]) -> String {
+/// Construct boundary-preserving rustc flags for Cargo.
+///
+/// `RUSTFLAGS` is whitespace-split by Cargo, which corrupts a single flag
+/// containing spaces. `CARGO_ENCODED_RUSTFLAGS` uses unit separators and keeps
+/// every configured array element and `--device-cfg` value intact.
+fn build_encoded_rustflags(ctx: &Context, debug: bool, device_cfgs: &[String]) -> String {
+    let existing_encoded = std::env::var("CARGO_ENCODED_RUSTFLAGS").ok();
     let existing = std::env::var("RUSTFLAGS").ok();
-    let mut extra_rustflags = ctx.config.extra_rustflags.clone();
+    let mut explicit_rustflags = Vec::new();
     for cfg in device_cfgs {
-        extra_rustflags.push("--cfg".to_string());
-        extra_rustflags.push(cfg.clone());
+        explicit_rustflags.push("--cfg".to_string());
+        explicit_rustflags.push(cfg.clone());
     }
-    build_rustflags_with_existing(
+    build_encoded_rustflags_with_existing(
         &ctx.backend_so,
         debug,
-        &extra_rustflags,
+        &ctx.config.extra_rustflags,
+        &explicit_rustflags,
+        existing_encoded.as_deref(),
         existing.as_deref(),
     )
 }
 
-fn build_rustflags_with_existing(
+fn build_encoded_rustflags_with_existing(
     backend_so: &Path,
     debug: bool,
-    extra_rustflags: &[String],
+    configured_rustflags: &[String],
+    explicit_rustflags: &[String],
+    existing_encoded_rustflags: Option<&str>,
     existing_rustflags: Option<&str>,
 ) -> String {
-    let mut flags = format!(
-        "-Z codegen-backend={} -C opt-level=3 -C debug-assertions=off -Z mir-enable-passes=-JumpThreading -Csymbol-mangling-version=v0",
-        backend_so.display()
-    );
+    // Project flags are defaults, inherited flags are user overrides, and
+    // explicit wrapper flags are stronger. cuda-oxide's compiler invariants
+    // come last because rustc resolves repeated -C/-Z options last-one-wins.
+    let mut flags = configured_rustflags.to_vec();
+
+    if let Some(existing) = existing_encoded_rustflags {
+        flags.extend(
+            existing
+                .split(ENCODED_RUSTFLAGS_SEPARATOR)
+                .filter(|flag| !flag.is_empty())
+                .map(str::to_string),
+        );
+    } else if let Some(existing) = existing_rustflags {
+        // Match Cargo's legacy RUSTFLAGS behavior when converting it to the
+        // encoded representation.
+        flags.extend(existing.split_whitespace().map(str::to_string));
+    }
+    flags.extend(explicit_rustflags.iter().cloned());
+    flags.extend([
+        format!("-Zcodegen-backend={}", backend_so.display()),
+        "-Copt-level=3".to_string(),
+        "-Cdebug-assertions=off".to_string(),
+        "-Zmir-enable-passes=-JumpThreading".to_string(),
+        "-Csymbol-mangling-version=v0".to_string(),
+    ]);
     if debug {
-        flags.push_str(" -C debuginfo=2");
+        flags.push("-Cdebuginfo=2".to_string());
     }
-    for flag in extra_rustflags {
-        flags.push(' ');
-        flags.push_str(flag);
-    }
-    if let Some(existing) = existing_rustflags
-        && !existing.is_empty()
-    {
-        flags.push(' ');
-        flags.push_str(existing);
-    }
-    flags
+    flags.join(&ENCODED_RUSTFLAGS_SEPARATOR.to_string())
+}
+
+fn apply_codegen_rustflags(cmd: &mut Command, ctx: &Context, debug: bool, device_cfgs: &[String]) {
+    cmd.env(
+        "CARGO_ENCODED_RUSTFLAGS",
+        build_encoded_rustflags(ctx, debug, device_cfgs),
+    )
+    .env_remove("RUSTFLAGS");
 }
 
 /// Set environment variables for the codegen backend.
@@ -1906,17 +2112,29 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
 }
 
 fn configured_arch<'a>(ctx: &'a Context, cli_arch: Option<&'a str>) -> Option<&'a str> {
-    if cli_arch.is_some() || std::env::var_os("CUDA_OXIDE_TARGET").is_some() {
+    if cli_arch.is_some() || std::env::var("CUDA_OXIDE_TARGET").is_ok() {
         cli_arch
     } else {
-        ctx.config.default_arch.as_deref()
+        ctx.config
+            .default_arch
+            .as_deref()
+            .or_else(|| project_config_env(ctx, "CUDA_OXIDE_TARGET"))
     }
+}
+
+fn configured_arch_label(ctx: &Context, cli_arch: Option<&str>) -> Option<String> {
+    cli_arch
+        .map(str::to_string)
+        .or_else(|| std::env::var("CUDA_OXIDE_TARGET").ok())
+        .or_else(|| ctx.config.default_arch.clone())
+        .or_else(|| project_config_env(ctx, "CUDA_OXIDE_TARGET").map(str::to_string))
 }
 
 pub fn has_configured_arch(ctx: &Context, cli_arch: Option<&str>) -> bool {
     cli_arch.is_some()
-        || std::env::var_os("CUDA_OXIDE_TARGET").is_some()
+        || std::env::var("CUDA_OXIDE_TARGET").is_ok()
         || ctx.config.default_arch.is_some()
+        || project_config_env(ctx, "CUDA_OXIDE_TARGET").is_some()
 }
 
 fn apply_config_env(cmd: &mut Command, ctx: &Context) {
@@ -1924,26 +2142,24 @@ fn apply_config_env(cmd: &mut Command, ctx: &Context) {
         if matches!(key.as_str(), "RUSTFLAGS" | "CARGO_ENCODED_RUSTFLAGS") {
             continue;
         }
-        cmd.env(key, value);
+        // Project values are defaults. An explicitly inherited environment is
+        // stronger, and command-specific CLI/internal settings are applied
+        // after this helper and are stronger still.
+        if std::env::var_os(key).is_none() {
+            cmd.env(key, value);
+        }
     }
 }
 
 fn apply_common_codegen_env(cmd: &mut Command, ctx: &Context, verbose: bool, no_fmad: bool) {
     apply_config_env(cmd, ctx);
-    if verbose || std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
+    if verbose {
         cmd.env("CUDA_OXIDE_VERBOSE", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_VERBOSE");
     }
-    forward_env_var(cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
-    forward_env_var(cmd, "CUDA_OXIDE_DUMP_MIR");
-    forward_env_var(cmd, "CUDA_OXIDE_DUMP_LLVM");
     if no_fmad {
         cmd.env("CUDA_OXIDE_NO_FMA", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_NO_FMA");
     }
-    apply_ld_library_path(cmd);
+    apply_ld_library_path(cmd, ctx);
 }
 
 /// Forward the auto-detected GPU arch as a *hint* via `CUDA_OXIDE_DEVICE_ARCH`.
@@ -2124,13 +2340,14 @@ fn format_sm_arch((major, minor): (u32, u32)) -> String {
     }
 }
 
-/// Forward an env var to the child process if it's set in the parent, otherwise remove it.
-fn forward_env_var(cmd: &mut Command, var: &str) {
-    if let Ok(val) = std::env::var(var) {
-        cmd.env(var, val);
-    } else {
-        cmd.env_remove(var);
-    }
+fn inherited_or_configured_env(ctx: &Context, key: &str) -> Option<String> {
+    std::env::var(key).ok().or_else(|| {
+        ctx.config
+            .env
+            .iter()
+            .find(|(configured_key, _)| configured_key == key)
+            .map(|(_, value)| value.clone())
+    })
 }
 
 /// Build `LD_LIBRARY_PATH` for the child cargo process.
@@ -2138,15 +2355,15 @@ fn forward_env_var(cmd: &mut Command, var: &str) {
 /// Includes the rustc sysroot lib (for `librustc_driver.so` etc.), the
 /// libmathdx lib (when `LIBMATHDX_PATH` is set), and any existing
 /// `LD_LIBRARY_PATH` from the parent environment.
-fn apply_ld_library_path(cmd: &mut Command) {
+fn apply_ld_library_path(cmd: &mut Command, ctx: &Context) {
     let mut ld_paths: Vec<String> = Vec::new();
     if let Some(sysroot) = backend::get_rustc_sysroot() {
         ld_paths.push(format!("{}/lib", sysroot));
     }
-    if let Ok(libmathdx_path) = std::env::var("LIBMATHDX_PATH") {
+    if let Some(libmathdx_path) = inherited_or_configured_env(ctx, "LIBMATHDX_PATH") {
         ld_paths.push(format!("{}/lib", libmathdx_path));
     }
-    if let Ok(existing) = std::env::var("LD_LIBRARY_PATH") {
+    if let Some(existing) = inherited_or_configured_env(ctx, "LD_LIBRARY_PATH") {
         ld_paths.push(existing);
     }
     if !ld_paths.is_empty() {
@@ -2484,6 +2701,29 @@ mod tests {
             .and_then(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
     }
 
+    fn decoded_rustflags(encoded: &str) -> Vec<&str> {
+        encoded.split(ENCODED_RUSTFLAGS_SEPARATOR).collect()
+    }
+
+    fn has_codegen_env_fingerprint(flags: &[&str]) -> bool {
+        flags.windows(2).any(|pair| {
+            pair[0] == "--cfg"
+                && pair[1].starts_with("cuda_oxide_internal_codegen_env=\"")
+                && pair[1].ends_with('"')
+        })
+    }
+
+    fn test_context(config: OxideConfig) -> Context {
+        Context {
+            workspace_root: PathBuf::from("/tmp/cargo-oxide-test-workspace"),
+            codegen_crate: PathBuf::from("/tmp/cargo-oxide-test-codegen"),
+            examples_dir: PathBuf::from("/tmp/cargo-oxide-test-examples"),
+            backend_so: PathBuf::from("/tmp/backend path/librustc_codegen_cuda.so"),
+            is_workspace: false,
+            config,
+        }
+    }
+
     #[test]
     fn artifact_stem_normalizes_hyphens_like_cargo() {
         assert_eq!(artifact_stem("rustlantis-smoke"), "rustlantis_smoke");
@@ -2523,45 +2763,402 @@ mod tests {
     }
 
     #[test]
-    fn build_rustflags_appends_existing_rustflags_after_required_flags() {
-        let rustflags = build_rustflags_with_existing(
+    fn encoded_rustflags_preserve_inherited_flags_but_required_flags_win() {
+        let rustflags = build_encoded_rustflags_with_existing(
             Path::new("/tmp/librustc_codegen_cuda.so"),
             false,
             &[],
+            &[],
+            Some(
+                "-Lnative=/nix/store/cuda-cudart/lib\u{1f}-Copt-level=0\u{1f}-Zcodegen-backend=llvm",
+            ),
             Some("-L native=/nix/store/cuda-cudart/lib"),
         );
+        let flags = decoded_rustflags(&rustflags);
+
+        assert_eq!(flags[0], "-Lnative=/nix/store/cuda-cudart/lib");
+        assert!(flags.contains(&"-Copt-level=0"));
+        assert!(flags.contains(&"-Zcodegen-backend=llvm"));
+        assert_eq!(
+            &flags[flags.len() - 5..],
+            [
+                "-Zcodegen-backend=/tmp/librustc_codegen_cuda.so",
+                "-Copt-level=3",
+                "-Cdebug-assertions=off",
+                "-Zmir-enable-passes=-JumpThreading",
+                "-Csymbol-mangling-version=v0",
+            ]
+        );
+        assert!(!flags.contains(&"native=/nix/store/cuda-cudart/lib"));
+    }
+
+    #[test]
+    fn encoded_rustflags_preserve_configured_flag_boundaries_and_spaces() {
+        let rustflags = build_encoded_rustflags_with_existing(
+            Path::new("/tmp/backend path/librustc_codegen_cuda.so"),
+            false,
+            &["--cfg".to_string(), "model=\"alpha beta\"".to_string()],
+            &[],
+            None,
+            Some("-L native=/nix/store/cuda-cudart/lib"),
+        );
+        let flags = decoded_rustflags(&rustflags);
 
         assert!(
-            rustflags
-                .starts_with("-Z codegen-backend=/tmp/librustc_codegen_cuda.so -C opt-level=3")
+            flags
+                .windows(2)
+                .any(|pair| pair == ["--cfg", "model=\"alpha beta\""])
         );
-        assert!(rustflags.ends_with(" -L native=/nix/store/cuda-cudart/lib"));
+        assert_eq!(&flags[2..4], ["-L", "native=/nix/store/cuda-cudart/lib"]);
+        assert_eq!(
+            flags[flags.len() - 5],
+            "-Zcodegen-backend=/tmp/backend path/librustc_codegen_cuda.so"
+        );
     }
 
     #[test]
-    fn build_rustflags_appends_configured_extra_flags_before_existing_flags() {
-        let rustflags = build_rustflags_with_existing(
-            Path::new("/tmp/librustc_codegen_cuda.so"),
-            false,
-            &["--cfg".to_string(), "impulse_model_a".to_string()],
-            Some("-L native=/nix/store/cuda-cudart/lib"),
-        );
-
-        assert!(rustflags.contains(" --cfg impulse_model_a "));
-        assert!(rustflags.ends_with(" -L native=/nix/store/cuda-cudart/lib"));
-    }
-
-    #[test]
-    fn build_rustflags_ignores_empty_existing_rustflags() {
-        let rustflags = build_rustflags_with_existing(
+    fn encoded_rustflags_ignore_empty_existing_flags() {
+        let rustflags = build_encoded_rustflags_with_existing(
             Path::new("/tmp/librustc_codegen_cuda.so"),
             true,
             &[],
+            &[],
+            None,
             Some(""),
         );
+        let flags = decoded_rustflags(&rustflags);
 
-        assert!(rustflags.contains(" -C debuginfo=2"));
-        assert!(!rustflags.ends_with(' '));
+        assert!(flags.contains(&"-Cdebuginfo=2"));
+        assert!(!flags.contains(&""));
+    }
+
+    #[test]
+    fn project_config_parser_loads_backend_arch_flags_and_env() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_config_test_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let cargo_dir = root.join(".cargo");
+        std::fs::create_dir_all(&cargo_dir).unwrap();
+        std::fs::write(
+            cargo_dir.join("cuda-oxide.toml"),
+            r#"
+backend = "../backend/librustc_codegen_cuda.so"
+default-arch = "sm_90"
+extra-rustflags = ["--cfg", "model=\"alpha beta\""]
+
+[env]
+MY_BUILD_FLAG = "configured"
+"#,
+        )
+        .unwrap();
+
+        let config = load_oxide_config(&root);
+        assert_eq!(
+            config.backend,
+            Some(cargo_dir.join("../backend/librustc_codegen_cuda.so"))
+        );
+        assert_eq!(config.default_arch.as_deref(), Some("sm_90"));
+        assert_eq!(config.extra_rustflags, ["--cfg", "model=\"alpha beta\""]);
+        assert_eq!(
+            config.env,
+            vec![("MY_BUILD_FLAG".to_string(), "configured".to_string())]
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn passthrough_command_preserves_argv_and_cli_overrides_config_defaults() {
+        let config = OxideConfig {
+            extra_rustflags: vec!["--cfg".to_string(), "from_config".to_string()],
+            env: vec![
+                ("CARGO_TARGET_DIR".to_string(), "config-target".to_string()),
+                (
+                    "CUDA_OXIDE_DEVICE_CODEGEN_CRATE".to_string(),
+                    "config_owner".to_string(),
+                ),
+                ("CUDA_OXIDE_VERBOSE".to_string(), "configured".to_string()),
+            ],
+            ..OxideConfig::default()
+        };
+        let ctx = test_context(config);
+        let device_cfgs = vec!["model=\"alpha beta\"".to_string()];
+        let opts = CargoPassthroughOptions {
+            verbose: true,
+            emit_nvvm_ir: false,
+            arch: Some("sm_90"),
+            features: Some("wrapper_feature"),
+            cargo_target_dir: Some(Path::new("cli-target")),
+            device_codegen_crate: Some("gpu-kernels, math_gpu"),
+            device_cfgs: &device_cfgs,
+            no_fmad: false,
+        };
+        let cargo_args = vec![
+            "-p".to_string(),
+            "gpu-app".to_string(),
+            "--".to_string(),
+            "--nocapture".to_string(),
+        ];
+
+        let cmd = cargo_passthrough_command(&ctx, "test", &opts, &cargo_args).unwrap();
+        assert_eq!(
+            cmd.get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "test",
+                "--features",
+                "wrapper_feature",
+                "-p",
+                "gpu-app",
+                "--",
+                "--nocapture",
+            ]
+        );
+        assert_eq!(
+            command_env(&cmd, "CARGO_TARGET_DIR").as_deref(),
+            Some("cli-target")
+        );
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_DEVICE_CODEGEN_CRATE").as_deref(),
+            Some("gpu_kernels,math_gpu")
+        );
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_TARGET").as_deref(),
+            Some("sm_90")
+        );
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_VERBOSE").as_deref(),
+            Some("1")
+        );
+
+        let encoded = command_env(&cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
+        let flags = decoded_rustflags(&encoded);
+        assert!(
+            flags
+                .windows(2)
+                .any(|pair| pair == ["--cfg", "from_config"])
+        );
+        assert!(
+            flags
+                .windows(2)
+                .any(|pair| pair == ["--cfg", "model=\"alpha beta\""])
+        );
+        assert!(has_codegen_env_fingerprint(&flags));
+        assert!(
+            cmd.get_envs()
+                .any(|(key, value)| key == OsStr::new("RUSTFLAGS") && value.is_none())
+        );
+    }
+
+    #[test]
+    fn passthrough_command_accepts_empty_cargo_args() {
+        let ctx = test_context(OxideConfig::default());
+        let opts = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: None,
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+        };
+
+        let cmd = cargo_passthrough_command(&ctx, "test", &opts, &[]).unwrap();
+        assert_eq!(
+            cmd.get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            ["test"]
+        );
+    }
+
+    #[test]
+    fn owner_filter_resolution_is_normalized_and_has_explicit_precedence() {
+        assert_eq!(
+            resolve_device_codegen_crates(None, None, Some("gpu-kernels, math_gpu"))
+                .unwrap()
+                .as_deref(),
+            Some("gpu_kernels,math_gpu"),
+        );
+        assert_eq!(
+            resolve_device_codegen_crates(None, Some("parent-owner"), Some("config-owner"))
+                .unwrap()
+                .as_deref(),
+            Some("parent_owner"),
+        );
+        assert!(
+            resolve_device_codegen_crates(Some(""), Some("parent-owner"), Some("config-owner"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn passthrough_fingerprint_tracks_output_affecting_settings() {
+        let ctx = test_context(OxideConfig::default());
+        let base = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: Some("sm_80"),
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+        };
+        let inherited_env = BTreeMap::new();
+        let base_hash = passthrough_codegen_fingerprint_with_env(
+            &ctx,
+            &base,
+            None,
+            Some("sm_80"),
+            &inherited_env,
+        );
+
+        let arch = CargoPassthroughOptions {
+            arch: Some("sm_90"),
+            ..base
+        };
+        let emit = CargoPassthroughOptions {
+            emit_nvvm_ir: true,
+            ..base
+        };
+        let no_fmad = CargoPassthroughOptions {
+            no_fmad: true,
+            ..base
+        };
+        let configured_ptx = test_context(OxideConfig {
+            env: vec![(
+                "CUDA_OXIDE_PTX_DIR".to_string(),
+                "configured-ptx".to_string(),
+            )],
+            ..OxideConfig::default()
+        });
+
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &arch,
+                None,
+                Some("sm_90"),
+                &inherited_env,
+            )
+        );
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &emit,
+                None,
+                Some("sm_80"),
+                &inherited_env,
+            )
+        );
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &no_fmad,
+                None,
+                Some("sm_80"),
+                &inherited_env,
+            )
+        );
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &base,
+                Some("gpu_kernel"),
+                Some("sm_80"),
+                &inherited_env,
+            )
+        );
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &configured_ptx,
+                &base,
+                None,
+                Some("sm_80"),
+                &inherited_env,
+            )
+        );
+    }
+
+    #[test]
+    fn passthrough_fingerprint_tracks_backend_rebuild_at_same_path() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_backend_fingerprint_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let backend = root.join("librustc_codegen_cuda.so");
+        std::fs::write(&backend, b"first").unwrap();
+
+        let mut ctx = test_context(OxideConfig::default());
+        ctx.backend_so = backend.clone();
+        let opts = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: None,
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+        };
+        let inherited_env = BTreeMap::new();
+        let before =
+            passthrough_codegen_fingerprint_with_env(&ctx, &opts, None, None, &inherited_env);
+        std::fs::write(&backend, b"second-build-is-larger").unwrap();
+        let after =
+            passthrough_codegen_fingerprint_with_env(&ctx, &opts, None, None, &inherited_env);
+
+        assert_ne!(before, after);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn owner_filter_rejects_empty_or_invalid_entries() {
+        assert_eq!(
+            normalize_device_codegen_crates("gpu-kernels, math_gpu").unwrap(),
+            "gpu_kernels,math_gpu"
+        );
+        assert!(normalize_device_codegen_crates("").is_err());
+        assert!(normalize_device_codegen_crates("   ").is_err());
+        assert!(normalize_device_codegen_crates("gpu,").is_err());
+        assert!(normalize_device_codegen_crates("gpu,not a crate").is_err());
+    }
+
+    #[test]
+    fn internal_ptx_directory_overrides_project_env_default() {
+        let ctx = test_context(OxideConfig {
+            env: vec![(
+                "CUDA_OXIDE_PTX_DIR".to_string(),
+                "configured-ptx".to_string(),
+            )],
+            ..OxideConfig::default()
+        });
+        let mut cmd = Command::new("cargo");
+        apply_common_codegen_env(&mut cmd, &ctx, false, false);
+        cmd.env("CUDA_OXIDE_PTX_DIR", "internal-ptx");
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_PTX_DIR").as_deref(),
+            Some("internal-ptx")
+        );
     }
 
     #[test]

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -14,6 +14,19 @@ use std::process::Command;
 
 use crate::backend;
 
+/// Project-local cuda-oxide defaults loaded from `.cargo/cuda-oxide.toml`.
+#[derive(Debug, Clone, Default)]
+pub struct OxideConfig {
+    /// Explicit backend shared object path.
+    pub backend: Option<PathBuf>,
+    /// Default CUDA architecture for build/test/pipeline commands.
+    pub default_arch: Option<String>,
+    /// Additional rustflags appended after cuda-oxide's required flags.
+    pub extra_rustflags: Vec<String>,
+    /// Environment variables applied to child Cargo invocations.
+    pub env: Vec<(String, String)>,
+}
+
 /// Pre-resolved context shared across all commands.
 ///
 /// Built once at startup by [`resolve_context`] and passed by reference to
@@ -30,6 +43,8 @@ pub struct Context {
     /// True when running from inside the cuda-oxide workspace; false for
     /// standalone projects scaffolded by `cargo oxide new`.
     pub is_workspace: bool,
+    /// Project-local cuda-oxide defaults.
+    pub config: OxideConfig,
 }
 
 /// Resolve the workspace root and backend, or exit with a helpful error.
@@ -45,13 +60,15 @@ pub fn resolve_context() -> Context {
     if let Some(workspace_root) = backend::find_workspace_root() {
         let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
         let examples_dir = codegen_crate.join("examples");
-        let backend_so = backend::find_or_build_backend(&workspace_root);
+        let config = load_oxide_config(&workspace_root);
+        let backend_so = backend::find_or_build_backend(&workspace_root, config.backend.as_deref());
         return Context {
             workspace_root,
             codegen_crate,
             examples_dir,
             backend_so,
             is_workspace: true,
+            config,
         };
     }
 
@@ -61,13 +78,15 @@ pub fn resolve_context() -> Context {
     });
 
     if cwd.join("Cargo.toml").is_file() {
-        let backend_so = backend::find_or_build_backend(&cwd);
+        let config = load_oxide_config(&cwd);
+        let backend_so = backend::find_or_build_backend(&cwd, config.backend.as_deref());
         return Context {
             workspace_root: cwd.clone(),
             codegen_crate: cwd.clone(),
             examples_dir: cwd.clone(),
             backend_so,
             is_workspace: false,
+            config,
         };
     }
 
@@ -90,13 +109,15 @@ pub fn resolve_doctor_context() -> Context {
     if let Some(workspace_root) = backend::find_workspace_root() {
         let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
         let examples_dir = codegen_crate.join("examples");
-        let backend_so = backend::backend_so_candidate(&workspace_root);
+        let config = load_oxide_config(&workspace_root);
+        let backend_so = backend::backend_so_candidate(&workspace_root, config.backend.as_deref());
         return Context {
             workspace_root,
             codegen_crate,
             examples_dir,
             backend_so,
             is_workspace: true,
+            config,
         };
     }
 
@@ -106,13 +127,15 @@ pub fn resolve_doctor_context() -> Context {
     });
 
     if cwd.join("Cargo.toml").is_file() {
-        let backend_so = backend::backend_so_candidate(&cwd);
+        let config = load_oxide_config(&cwd);
+        let backend_so = backend::backend_so_candidate(&cwd, config.backend.as_deref());
         return Context {
             workspace_root: cwd.clone(),
             codegen_crate: cwd.clone(),
             examples_dir: cwd.clone(),
             backend_so,
             is_workspace: false,
+            config,
         };
     }
 
@@ -152,6 +175,7 @@ pub fn codegen_run(
     let interop = load_interop_config(&example_dir);
 
     let output_format = format_label(emit_nvvm_ir);
+    let target_arch = configured_arch(ctx, arch);
     // Target precedence for `cargo oxide run` (highest first):
     //   1. --arch <sm_XX>            explicit user override   -> CUDA_OXIDE_TARGET
     //   2. CUDA_OXIDE_TARGET=<sm_XX> explicit env override (from the parent)
@@ -165,7 +189,7 @@ pub fn codegen_run(
     // We only detect for `run`, not `build`/`pipeline`: `run` loads the cubin
     // on the local GPU, whereas those may legitimately cross-compile for
     // another machine.
-    let detected_device_arch = detect_run_target_arch(arch, emit_nvvm_ir);
+    let detected_device_arch = detect_run_target_arch(target_arch, emit_nvvm_ir);
 
     if let Some(interop) = interop.filter(|config| !config.device_crates.is_empty()) {
         codegen_run_interop(
@@ -175,7 +199,7 @@ pub fn codegen_run(
             &interop,
             verbose,
             emit_nvvm_ir,
-            arch,
+            target_arch,
             detected_device_arch.as_deref(),
             features,
             bin,
@@ -193,7 +217,7 @@ pub fn codegen_run(
         println!("Output format: {}", output_format);
         println!(
             "Target arch: {}",
-            arch.expect("--emit-nvvm-ir requires --arch")
+            target_arch.expect("--emit-nvvm-ir requires --arch")
         );
         println!();
     } else if let Some(dev) = detected_device_arch.as_deref() {
@@ -208,7 +232,7 @@ pub fn codegen_run(
     println!("  RUSTFLAGS=\"-Z codegen-backend=...\" cargo run");
     println!();
 
-    let rustflags = build_rustflags(&ctx.backend_so, false);
+    let rustflags = build_rustflags(ctx, false);
 
     touch_main_rs(&example_dir);
 
@@ -224,23 +248,9 @@ pub fn codegen_run(
         cmd.args(["--features", features]);
     }
 
-    if verbose || std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
-        cmd.env("CUDA_OXIDE_VERBOSE", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_VERBOSE");
-    }
-    forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
-    if no_fmad {
-        cmd.env("CUDA_OXIDE_NO_FMA", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_NO_FMA");
-    }
-
-    apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
-    apply_device_arch_hint(&mut cmd, arch, detected_device_arch.as_deref());
-    apply_ld_library_path(&mut cmd);
+    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
+    apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
 
     if let Some(bin) = bin {
         println!("Building and running {} (bin: {})...", example, bin);
@@ -403,7 +413,7 @@ fn build_interop_device_crate(
 
     println!("Building device crate {}...", manifest_path.display());
 
-    let rustflags = build_rustflags(&ctx.backend_so, false);
+    let rustflags = build_rustflags(ctx, false);
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release", "--manifest-path"])
         .arg(&manifest_path)
@@ -412,17 +422,9 @@ fn build_interop_device_crate(
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env("CUDA_OXIDE_PTX_DIR", &ptx_dir);
 
-    if verbose || std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
-        cmd.env("CUDA_OXIDE_VERBOSE", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_VERBOSE");
-    }
-    forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
+    apply_common_codegen_env(&mut cmd, ctx, verbose, false);
     apply_output_mode(&mut cmd, false, arch);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
-    apply_ld_library_path(&mut cmd);
 
     let status = cmd.status().expect("Failed to build interop device crate");
     if !status.success() {
@@ -511,6 +513,7 @@ pub fn codegen_build(
     features: Option<&str>,
     no_fmad: bool,
 ) {
+    let target_arch = configured_arch(ctx, arch);
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
     } else {
@@ -527,7 +530,7 @@ pub fn codegen_build(
             &interop,
             verbose,
             emit_nvvm_ir,
-            arch,
+            target_arch,
             features,
         );
         return;
@@ -540,7 +543,7 @@ pub fn codegen_build(
     println!("=========================================");
     println!();
 
-    let rustflags = build_rustflags(&ctx.backend_so, false);
+    let rustflags = build_rustflags(ctx, false);
 
     touch_main_rs(&example_dir);
 
@@ -553,22 +556,8 @@ pub fn codegen_build(
         cmd.args(["--features", features]);
     }
 
-    if verbose || std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
-        cmd.env("CUDA_OXIDE_VERBOSE", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_VERBOSE");
-    }
-    forward_env_var(&mut cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
-    forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
-    if no_fmad {
-        cmd.env("CUDA_OXIDE_NO_FMA", "1");
-    } else {
-        cmd.env_remove("CUDA_OXIDE_NO_FMA");
-    }
-
-    apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
-    apply_ld_library_path(&mut cmd);
+    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
 
     println!("Building {}...", example);
     println!();
@@ -775,6 +764,86 @@ fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, arch: &libnvvm_sys::CudaArch) ->
         })
 }
 
+/// Options for `cargo oxide build -- ...` / `cargo oxide test -- ...`.
+pub struct CargoPassthroughOptions<'a> {
+    pub verbose: bool,
+    pub emit_nvvm_ir: bool,
+    pub arch: Option<&'a str>,
+    pub cargo_target_dir: Option<&'a Path>,
+    pub device_codegen_crate: Option<&'a str>,
+    pub device_cfgs: &'a [String],
+    pub no_fmad: bool,
+}
+
+/// Run an arbitrary Cargo build-like subcommand through the cuda-oxide backend.
+///
+/// Unlike example mode, this does not touch source files or clean generated
+/// artifacts. It is intended for final-target workspace builds where Cargo's
+/// incremental behavior should remain intact.
+pub fn codegen_cargo_passthrough(
+    ctx: &Context,
+    cargo_subcommand: &str,
+    opts: CargoPassthroughOptions<'_>,
+    cargo_args: &[String],
+) {
+    if cargo_args.is_empty() {
+        eprintln!(
+            "Error: `cargo oxide {}` passthrough requires Cargo args after `--`",
+            cargo_subcommand
+        );
+        eprintln!(
+            "Example: cargo oxide {} -- --release -p my_package",
+            cargo_subcommand
+        );
+        std::process::exit(2);
+    }
+
+    println!("=========================================");
+    println!("RUSTC-CODEGEN-CUDA CARGO {}", cargo_subcommand);
+    println!("=========================================");
+    println!();
+
+    let target_arch = configured_arch(ctx, opts.arch);
+    let rustflags = build_rustflags_with_device_cfgs(ctx, false, opts.device_cfgs);
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg(cargo_subcommand)
+        .args(cargo_args)
+        .current_dir(&ctx.workspace_root)
+        .env("RUSTFLAGS", &rustflags)
+        .env_remove("CARGO_ENCODED_RUSTFLAGS");
+
+    if let Some(cargo_target_dir) = opts.cargo_target_dir {
+        cmd.env("CARGO_TARGET_DIR", cargo_target_dir);
+    }
+    if let Some(owner_filter) = opts.device_codegen_crate {
+        cmd.env("CUDA_OXIDE_DEVICE_CODEGEN_CRATE", owner_filter);
+    }
+
+    apply_common_codegen_env(&mut cmd, ctx, opts.verbose, opts.no_fmad);
+    apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch);
+
+    println!(
+        "Running cargo {} {}...",
+        cargo_subcommand,
+        cargo_args.join(" ")
+    );
+    println!();
+
+    let status = cmd.status().expect("Failed to run cargo");
+    if !status.success() {
+        eprintln!(
+            "\nCargo {} failed with exit code: {:?}",
+            cargo_subcommand,
+            status.code()
+        );
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    println!();
+    println!("✓ Cargo {} succeeded", cargo_subcommand);
+}
+
 // =============================================================================
 // Pipeline command
 // =============================================================================
@@ -793,6 +862,7 @@ pub fn codegen_show_pipeline(
     arch: Option<&str>,
     no_fmad: bool,
 ) {
+    let target_arch = configured_arch(ctx, arch);
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
     } else {
@@ -805,7 +875,7 @@ pub fn codegen_show_pipeline(
     println!("RUSTC-CODEGEN-CUDA PIPELINE: {}", example);
     println!("=========================================");
     println!();
-    match (emit_nvvm_ir, arch) {
+    match (emit_nvvm_ir, target_arch) {
         (true, Some(target_arch)) => println!("Output format: NVVM IR (arch: {})", target_arch),
         (false, Some(target_arch)) => {
             println!("Output format: PTX (arch override: {})", target_arch)
@@ -824,7 +894,7 @@ pub fn codegen_show_pipeline(
     println!("      unwind paths as unreachable (CUDA toolchain limitation, not HW).");
     println!();
 
-    let rustflags = build_rustflags(&ctx.backend_so, false);
+    let rustflags = build_rustflags(ctx, false);
 
     touch_main_rs(&example_dir);
 
@@ -843,7 +913,8 @@ pub fn codegen_show_pipeline(
         cmd.env_remove("CUDA_OXIDE_NO_FMA");
     }
 
-    apply_output_mode(&mut cmd, emit_nvvm_ir, arch);
+    apply_config_env(&mut cmd, ctx);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
     apply_ld_library_path(&mut cmd);
 
     println!("Building {}...", example);
@@ -917,7 +988,7 @@ pub fn codegen_debug(
 
     clean_generated_files(&example_dir, example);
 
-    let rustflags = build_rustflags(&ctx.backend_so, true);
+    let rustflags = build_rustflags(ctx, true);
 
     touch_main_rs(&example_dir);
 
@@ -931,7 +1002,9 @@ pub fn codegen_debug(
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_MIR");
     forward_env_var(&mut cmd, "CUDA_OXIDE_DUMP_LLVM");
 
-    apply_debug_output_mode(&mut cmd, arch, detected_device_arch.as_deref());
+    apply_config_env(&mut cmd, ctx);
+    apply_output_mode(&mut cmd, false, arch);
+    apply_device_arch_hint(&mut cmd, arch, detected_device_arch.as_deref());
     apply_ld_library_path(&mut cmd);
 
     let status = cmd.status().expect("Failed to run cargo build");
@@ -1485,6 +1558,133 @@ pub fn setup(ctx: &Context) {
 // Helpers
 // =============================================================================
 
+fn load_oxide_config(workspace_root: &Path) -> OxideConfig {
+    let config_path = workspace_root.join(".cargo/cuda-oxide.toml");
+    if !config_path.exists() {
+        return OxideConfig::default();
+    }
+
+    let source = std::fs::read_to_string(&config_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read cuda-oxide config {}: {}",
+            config_path.display(),
+            e
+        );
+        std::process::exit(1);
+    });
+    let document: toml::Value = toml::from_str(&source).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not parse cuda-oxide config {}: {}",
+            config_path.display(),
+            e
+        );
+        std::process::exit(1);
+    });
+    let table = document.as_table().unwrap_or_else(|| {
+        eprintln!(
+            "Error: cuda-oxide config {} must be a TOML table",
+            config_path.display()
+        );
+        std::process::exit(1);
+    });
+
+    let backend = optional_config_string(table, "backend", &config_path)
+        .map(PathBuf::from)
+        .map(|path| absolutize_config_path(path, &config_path));
+    let default_arch = optional_config_string(table, "default-arch", &config_path);
+    let extra_rustflags = optional_config_string_array(table, "extra-rustflags", &config_path);
+    let env = table
+        .get("env")
+        .map(|value| parse_config_env(value, &config_path))
+        .unwrap_or_default();
+
+    OxideConfig {
+        backend,
+        default_arch,
+        extra_rustflags,
+        env,
+    }
+}
+
+fn absolutize_config_path(path: PathBuf, config_path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(path)
+}
+
+fn optional_config_string(table: &toml::Table, key: &str, config_path: &Path) -> Option<String> {
+    table.get(key).map(|value| {
+        value.as_str().map(str::to_string).unwrap_or_else(|| {
+            eprintln!(
+                "Error: cuda-oxide config {} field `{}` must be a string",
+                config_path.display(),
+                key
+            );
+            std::process::exit(1);
+        })
+    })
+}
+
+fn optional_config_string_array(table: &toml::Table, key: &str, config_path: &Path) -> Vec<String> {
+    table
+        .get(key)
+        .map(|value| {
+            value
+                .as_array()
+                .unwrap_or_else(|| {
+                    eprintln!(
+                        "Error: cuda-oxide config {} field `{}` must be an array of strings",
+                        config_path.display(),
+                        key
+                    );
+                    std::process::exit(1);
+                })
+                .iter()
+                .map(|item| {
+                    item.as_str().map(str::to_string).unwrap_or_else(|| {
+                        eprintln!(
+                            "Error: cuda-oxide config {} field `{}` must be an array of strings",
+                            config_path.display(),
+                            key
+                        );
+                        std::process::exit(1);
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_config_env(value: &toml::Value, config_path: &Path) -> Vec<(String, String)> {
+    let table = value.as_table().unwrap_or_else(|| {
+        eprintln!(
+            "Error: cuda-oxide config {} field `env` must be a table of strings",
+            config_path.display()
+        );
+        std::process::exit(1);
+    });
+    let mut env: Vec<_> = table
+        .iter()
+        .map(|(key, value)| {
+            let value = value.as_str().unwrap_or_else(|| {
+                eprintln!(
+                    "Error: cuda-oxide config {} env value `{}` must be a string",
+                    config_path.display(),
+                    key
+                );
+                std::process::exit(1);
+            });
+            (key.clone(), value.to_string())
+        })
+        .collect();
+    env.sort_by(|left, right| left.0.cmp(&right.0));
+    env
+}
+
 fn load_interop_config(example_dir: &Path) -> Option<InteropConfig> {
     let manifest_path = example_dir.join("Cargo.toml");
     let source = std::fs::read_to_string(&manifest_path).unwrap_or_else(|e| {
@@ -1646,14 +1846,29 @@ fn resolve_example_dir(ctx: &Context, example: &str) -> PathBuf {
 /// assertions, suppressed JumpThreading (prevents barrier duplication), and
 /// v0 symbol mangling. Appends `-C debuginfo=2` when `debug` is true, then
 /// appends any existing user-provided `RUSTFLAGS`.
-fn build_rustflags(backend_so: &Path, debug: bool) -> String {
+fn build_rustflags(ctx: &Context, debug: bool) -> String {
+    build_rustflags_with_device_cfgs(ctx, debug, &[])
+}
+
+fn build_rustflags_with_device_cfgs(ctx: &Context, debug: bool, device_cfgs: &[String]) -> String {
     let existing = std::env::var("RUSTFLAGS").ok();
-    build_rustflags_with_existing(backend_so, debug, existing.as_deref())
+    let mut extra_rustflags = ctx.config.extra_rustflags.clone();
+    for cfg in device_cfgs {
+        extra_rustflags.push("--cfg".to_string());
+        extra_rustflags.push(cfg.clone());
+    }
+    build_rustflags_with_existing(
+        &ctx.backend_so,
+        debug,
+        &extra_rustflags,
+        existing.as_deref(),
+    )
 }
 
 fn build_rustflags_with_existing(
     backend_so: &Path,
     debug: bool,
+    extra_rustflags: &[String],
     existing_rustflags: Option<&str>,
 ) -> String {
     let mut flags = format!(
@@ -1662,6 +1877,10 @@ fn build_rustflags_with_existing(
     );
     if debug {
         flags.push_str(" -C debuginfo=2");
+    }
+    for flag in extra_rustflags {
+        flags.push(' ');
+        flags.push_str(flag);
     }
     if let Some(existing) = existing_rustflags
         && !existing.is_empty()
@@ -1686,18 +1905,45 @@ fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) 
     }
 }
 
-/// Configure the device-code target for `cargo oxide debug`.
-///
-/// Debug launches the built binary immediately, so it follows `run` rather than
-/// `build`: an explicit `--arch`/`CUDA_OXIDE_TARGET` remains a hard override,
-/// while the local GPU arch is forwarded as a compatibility hint.
-fn apply_debug_output_mode(
-    cmd: &mut Command,
-    explicit_arch: Option<&str>,
-    detected_device_arch: Option<&str>,
-) {
-    apply_output_mode(cmd, false, explicit_arch);
-    apply_device_arch_hint(cmd, explicit_arch, detected_device_arch);
+fn configured_arch<'a>(ctx: &'a Context, cli_arch: Option<&'a str>) -> Option<&'a str> {
+    if cli_arch.is_some() || std::env::var_os("CUDA_OXIDE_TARGET").is_some() {
+        cli_arch
+    } else {
+        ctx.config.default_arch.as_deref()
+    }
+}
+
+pub fn has_configured_arch(ctx: &Context, cli_arch: Option<&str>) -> bool {
+    cli_arch.is_some()
+        || std::env::var_os("CUDA_OXIDE_TARGET").is_some()
+        || ctx.config.default_arch.is_some()
+}
+
+fn apply_config_env(cmd: &mut Command, ctx: &Context) {
+    for (key, value) in &ctx.config.env {
+        if matches!(key.as_str(), "RUSTFLAGS" | "CARGO_ENCODED_RUSTFLAGS") {
+            continue;
+        }
+        cmd.env(key, value);
+    }
+}
+
+fn apply_common_codegen_env(cmd: &mut Command, ctx: &Context, verbose: bool, no_fmad: bool) {
+    apply_config_env(cmd, ctx);
+    if verbose || std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
+        cmd.env("CUDA_OXIDE_VERBOSE", "1");
+    } else {
+        cmd.env_remove("CUDA_OXIDE_VERBOSE");
+    }
+    forward_env_var(cmd, "CUDA_OXIDE_SHOW_RUSTC_MIR");
+    forward_env_var(cmd, "CUDA_OXIDE_DUMP_MIR");
+    forward_env_var(cmd, "CUDA_OXIDE_DUMP_LLVM");
+    if no_fmad {
+        cmd.env("CUDA_OXIDE_NO_FMA", "1");
+    } else {
+        cmd.env_remove("CUDA_OXIDE_NO_FMA");
+    }
+    apply_ld_library_path(cmd);
 }
 
 /// Forward the auto-detected GPU arch as a *hint* via `CUDA_OXIDE_DEVICE_ARCH`.
@@ -2281,6 +2527,7 @@ mod tests {
         let rustflags = build_rustflags_with_existing(
             Path::new("/tmp/librustc_codegen_cuda.so"),
             false,
+            &[],
             Some("-L native=/nix/store/cuda-cudart/lib"),
         );
 
@@ -2292,10 +2539,24 @@ mod tests {
     }
 
     #[test]
+    fn build_rustflags_appends_configured_extra_flags_before_existing_flags() {
+        let rustflags = build_rustflags_with_existing(
+            Path::new("/tmp/librustc_codegen_cuda.so"),
+            false,
+            &["--cfg".to_string(), "impulse_model_a".to_string()],
+            Some("-L native=/nix/store/cuda-cudart/lib"),
+        );
+
+        assert!(rustflags.contains(" --cfg impulse_model_a "));
+        assert!(rustflags.ends_with(" -L native=/nix/store/cuda-cudart/lib"));
+    }
+
+    #[test]
     fn build_rustflags_ignores_empty_existing_rustflags() {
         let rustflags = build_rustflags_with_existing(
             Path::new("/tmp/librustc_codegen_cuda.so"),
             true,
+            &[],
             Some(""),
         );
 
@@ -2392,10 +2653,11 @@ mod tests {
     }
 
     #[test]
-    fn apply_debug_output_mode_forwards_detected_gpu_hint() {
+    fn debug_output_mode_forwards_detected_gpu_hint() {
         let mut cmd = Command::new("cargo");
 
-        apply_debug_output_mode(&mut cmd, None, Some("sm_120a"));
+        apply_output_mode(&mut cmd, false, None);
+        apply_device_arch_hint(&mut cmd, None, Some("sm_120a"));
 
         assert_eq!(
             command_env(&cmd, "CUDA_OXIDE_DEVICE_ARCH").as_deref(),
@@ -2406,10 +2668,11 @@ mod tests {
     }
 
     #[test]
-    fn apply_debug_output_mode_honors_explicit_arch_override() {
+    fn debug_output_mode_honors_explicit_arch_override() {
         let mut cmd = Command::new("cargo");
 
-        apply_debug_output_mode(&mut cmd, Some("sm_90"), Some("sm_120a"));
+        apply_output_mode(&mut cmd, false, Some("sm_90"));
+        apply_device_arch_hint(&mut cmd, Some("sm_90"), Some("sm_120a"));
 
         assert_eq!(
             command_env(&cmd, "CUDA_OXIDE_TARGET").as_deref(),

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -97,6 +97,39 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Cargo target directory for passthrough mode
+        #[arg(long)]
+        cargo_target_dir: Option<PathBuf>,
+        /// Optional cuda-oxide owner filter for passthrough device codegen
+        #[arg(long)]
+        device_codegen_crate: Option<String>,
+        /// Repeatable cfg appended as `--cfg NAME` for passthrough device codegen
+        #[arg(long = "device-cfg")]
+        device_cfgs: Vec<String>,
+        /// Cargo build arguments for passthrough mode. Use after `--`.
+        #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
+        cargo_args: Vec<String>,
+    },
+    /// Run Cargo tests through the cuda-oxide backend
+    Test {
+        /// Target architecture (e.g., sm_90, sm_100, sm_120)
+        #[arg(long)]
+        arch: Option<String>,
+        /// Cargo target directory
+        #[arg(long)]
+        cargo_target_dir: Option<PathBuf>,
+        /// Optional cuda-oxide owner filter for device codegen
+        #[arg(long)]
+        device_codegen_crate: Option<String>,
+        /// Repeatable cfg appended as `--cfg NAME` for device codegen
+        #[arg(long = "device-cfg")]
+        device_cfgs: Vec<String>,
+        /// Show verbose compilation output
+        #[arg(short, long)]
+        verbose: bool,
+        /// Cargo test arguments. Use after `--`.
+        #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
+        cargo_args: Vec<String>,
     },
     /// Compile a crate's device code to a binary LTOIR artifact in one step.
     ///
@@ -199,7 +232,7 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "run");
-            validate_nvvm_ir_arch(&example, emit_nvvm_ir, &arch);
+            validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
             commands::codegen_run(
                 &ctx,
                 &example,
@@ -218,18 +251,70 @@ fn main() {
             features,
             verbose,
             no_fmad,
+            cargo_target_dir,
+            device_codegen_crate,
+            device_cfgs,
+            cargo_args,
         } => {
             let ctx = commands::resolve_context();
-            let example = resolve_example_name(example, &ctx, "build");
-            validate_nvvm_ir_arch(&example, emit_nvvm_ir, &arch);
-            commands::codegen_build(
+            if cargo_args.is_empty() {
+                let example = resolve_example_name(example, &ctx, "build");
+                validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
+                commands::codegen_build(
+                    &ctx,
+                    &example,
+                    verbose,
+                    emit_nvvm_ir,
+                    arch.as_deref(),
+                    features.as_deref(),
+                    no_fmad,
+                );
+            } else {
+                if example.is_some() {
+                    eprintln!(
+                        "Error: `cargo oxide build` accepts either an example name or passthrough args after `--`, not both"
+                    );
+                    std::process::exit(2);
+                }
+                validate_nvvm_ir_arch(&ctx, "cargo build", emit_nvvm_ir, arch.as_deref());
+                commands::codegen_cargo_passthrough(
+                    &ctx,
+                    "build",
+                    commands::CargoPassthroughOptions {
+                        verbose,
+                        emit_nvvm_ir,
+                        arch: arch.as_deref(),
+                        cargo_target_dir: cargo_target_dir.as_deref(),
+                        device_codegen_crate: device_codegen_crate.as_deref(),
+                        device_cfgs: &device_cfgs,
+                        no_fmad,
+                    },
+                    &cargo_args,
+                );
+            }
+        }
+        Commands::Test {
+            arch,
+            cargo_target_dir,
+            device_codegen_crate,
+            device_cfgs,
+            verbose,
+            cargo_args,
+        } => {
+            let ctx = commands::resolve_context();
+            commands::codegen_cargo_passthrough(
                 &ctx,
-                &example,
-                verbose,
-                emit_nvvm_ir,
-                arch.as_deref(),
-                features.as_deref(),
-                no_fmad,
+                "test",
+                commands::CargoPassthroughOptions {
+                    verbose,
+                    emit_nvvm_ir: false,
+                    arch: arch.as_deref(),
+                    cargo_target_dir: cargo_target_dir.as_deref(),
+                    device_codegen_crate: device_codegen_crate.as_deref(),
+                    device_cfgs: &device_cfgs,
+                    no_fmad: false,
+                },
+                &cargo_args,
             );
             println!();
             println!("✓ Build succeeded");
@@ -260,7 +345,7 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "pipeline");
-            validate_nvvm_ir_arch(&example, emit_nvvm_ir, &arch);
+            validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
             commands::codegen_show_pipeline(&ctx, &example, emit_nvvm_ir, arch.as_deref(), no_fmad);
         }
         Commands::Debug {
@@ -323,8 +408,13 @@ fn resolve_example_name(name: Option<String>, ctx: &commands::Context, subcomman
 ///
 /// NVVM IR output is architecture-specific, so omitting `--arch` would produce
 /// an unusable artifact. Exits with a descriptive error and usage example.
-fn validate_nvvm_ir_arch(example: &str, emit_nvvm_ir: bool, arch: &Option<String>) {
-    if emit_nvvm_ir && arch.is_none() {
+fn validate_nvvm_ir_arch(
+    ctx: &commands::Context,
+    example: &str,
+    emit_nvvm_ir: bool,
+    arch: Option<&str>,
+) {
+    if emit_nvvm_ir && !commands::has_configured_arch(ctx, arch) {
         eprintln!("Error: --emit-nvvm-ir requires --arch=sm_XXX");
         eprintln!();
         eprintln!("NVVM IR output is architecture-specific. Please specify the target:");

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -100,7 +100,7 @@ enum Commands {
         /// Cargo target directory for passthrough mode
         #[arg(long)]
         cargo_target_dir: Option<PathBuf>,
-        /// Optional cuda-oxide owner filter for passthrough device codegen
+        /// Comma-separated cuda-oxide owner crate filter for device codegen
         #[arg(long)]
         device_codegen_crate: Option<String>,
         /// Repeatable cfg appended as `--cfg NAME` for passthrough device codegen
@@ -118,7 +118,7 @@ enum Commands {
         /// Cargo target directory
         #[arg(long)]
         cargo_target_dir: Option<PathBuf>,
-        /// Optional cuda-oxide owner filter for device codegen
+        /// Comma-separated cuda-oxide owner crate filter for device codegen
         #[arg(long)]
         device_codegen_crate: Option<String>,
         /// Repeatable cfg appended as `--cfg NAME` for device codegen
@@ -127,7 +127,7 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
-        /// Cargo test arguments. Use after `--`.
+        /// Cargo test arguments. Use after `--`; empty runs plain `cargo test`.
         #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
         cargo_args: Vec<String>,
     },
@@ -205,6 +205,24 @@ enum Commands {
     Setup,
 }
 
+fn has_passthrough_separator(args: &[String]) -> bool {
+    args.iter().skip(2).any(|arg| arg == "--")
+}
+
+fn use_build_passthrough(
+    explicit_separator: bool,
+    cargo_target_dir_is_set: bool,
+    owner_filter_is_set: bool,
+    has_device_cfgs: bool,
+    has_cargo_args: bool,
+) -> bool {
+    explicit_separator
+        || cargo_target_dir_is_set
+        || owner_filter_is_set
+        || has_device_cfgs
+        || has_cargo_args
+}
+
 fn main() {
     // Handle both invocation methods:
     // 1. Cargo subcommand: `cargo oxide run vecadd` → argv = ["cargo-oxide", "oxide", "run", "vecadd"]
@@ -218,6 +236,7 @@ fn main() {
         args
     };
 
+    let explicit_passthrough = has_passthrough_separator(&effective_args);
     let cli = Cli::parse_from(effective_args);
 
     match cli.command {
@@ -257,7 +276,14 @@ fn main() {
             cargo_args,
         } => {
             let ctx = commands::resolve_context();
-            if cargo_args.is_empty() {
+            let passthrough = use_build_passthrough(
+                explicit_passthrough,
+                cargo_target_dir.is_some(),
+                device_codegen_crate.is_some(),
+                !device_cfgs.is_empty(),
+                !cargo_args.is_empty(),
+            );
+            if !passthrough {
                 let example = resolve_example_name(example, &ctx, "build");
                 validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
                 commands::codegen_build(
@@ -284,6 +310,7 @@ fn main() {
                         verbose,
                         emit_nvvm_ir,
                         arch: arch.as_deref(),
+                        features: features.as_deref(),
                         cargo_target_dir: cargo_target_dir.as_deref(),
                         device_codegen_crate: device_codegen_crate.as_deref(),
                         device_cfgs: &device_cfgs,
@@ -309,6 +336,7 @@ fn main() {
                     verbose,
                     emit_nvvm_ir: false,
                     arch: arch.as_deref(),
+                    features: None,
                     cargo_target_dir: cargo_target_dir.as_deref(),
                     device_codegen_crate: device_codegen_crate.as_deref(),
                     device_cfgs: &device_cfgs,
@@ -316,8 +344,6 @@ fn main() {
                 },
                 &cargo_args,
             );
-            println!();
-            println!("✓ Build succeeded");
         }
         Commands::EmitLtoir {
             example,
@@ -404,10 +430,10 @@ fn resolve_example_name(name: Option<String>, ctx: &commands::Context, subcomman
     std::process::exit(1);
 }
 
-/// Ensures `--arch` is provided when `--emit-nvvm-ir` is used.
+/// Ensures an architecture is configured when `--emit-nvvm-ir` is used.
 ///
-/// NVVM IR output is architecture-specific, so omitting `--arch` would produce
-/// an unusable artifact. Exits with a descriptive error and usage example.
+/// NVVM IR output is architecture-specific, so omitting every target source
+/// would produce an unusable artifact. Exits with a descriptive error.
 fn validate_nvvm_ir_arch(
     ctx: &commands::Context,
     example: &str,
@@ -415,14 +441,85 @@ fn validate_nvvm_ir_arch(
     arch: Option<&str>,
 ) {
     if emit_nvvm_ir && !commands::has_configured_arch(ctx, arch) {
-        eprintln!("Error: --emit-nvvm-ir requires --arch=sm_XXX");
+        eprintln!("Error: --emit-nvvm-ir requires a target architecture");
         eprintln!();
-        eprintln!("NVVM IR output is architecture-specific. Please specify the target:");
+        eprintln!("NVVM IR output is architecture-specific. Pass --arch, set");
+        eprintln!("CUDA_OXIDE_TARGET, or configure default-arch. For example:");
         eprintln!("  --arch sm_120    Blackwell (RTX 50 series)");
         eprintln!("  --arch sm_100    Blackwell");
         eprintln!();
         eprintln!("Example:");
         eprintln!("  cargo oxide run {} --emit-nvvm-ir --arch sm_120", example);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    #[test]
+    fn build_parser_preserves_nested_cargo_and_test_separators() {
+        let args = strings(&[
+            "cargo-oxide",
+            "build",
+            "--cargo-target-dir",
+            "target/cuda",
+            "--",
+            "-p",
+            "gpu-app",
+            "--test",
+            "smoke",
+            "--",
+            "--nocapture",
+        ]);
+        assert!(has_passthrough_separator(&args));
+
+        let cli = Cli::try_parse_from(args).expect("passthrough CLI should parse");
+        let Commands::Build {
+            cargo_target_dir,
+            cargo_args,
+            ..
+        } = cli.command
+        else {
+            panic!("expected build command");
+        };
+        assert_eq!(cargo_target_dir, Some(PathBuf::from("target/cuda")));
+        assert_eq!(
+            cargo_args,
+            strings(&["-p", "gpu-app", "--test", "smoke", "--", "--nocapture"])
+        );
+    }
+
+    #[test]
+    fn empty_test_and_explicit_empty_build_passthrough_are_distinct() {
+        let test_cli = Cli::try_parse_from(["cargo-oxide", "test"])
+            .expect("cargo oxide test should accept no Cargo arguments");
+        let Commands::Test { cargo_args, .. } = test_cli.command else {
+            panic!("expected test command");
+        };
+        assert!(cargo_args.is_empty());
+
+        let build_args = strings(&["cargo-oxide", "build", "--"]);
+        assert!(has_passthrough_separator(&build_args));
+        let build_cli = Cli::try_parse_from(build_args).expect("empty passthrough should parse");
+        let Commands::Build { cargo_args, .. } = build_cli.command else {
+            panic!("expected build command");
+        };
+        assert!(cargo_args.is_empty());
+    }
+
+    #[test]
+    fn build_mode_uses_only_unambiguous_passthrough_signals() {
+        assert!(!use_build_passthrough(false, false, false, false, false));
+        assert!(use_build_passthrough(true, false, false, false, false));
+        assert!(use_build_passthrough(false, true, false, false, false));
+        assert!(use_build_passthrough(false, false, true, false, false));
+        assert!(use_build_passthrough(false, false, false, true, false));
+        assert!(use_build_passthrough(false, false, false, false, true));
     }
 }

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -103,7 +103,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use reserved_oxide_symbols::{
     DEVICE_EXTERN_PREFIX, DEVICE_PREFIX, INSTANTIATE_PREFIX, KERNEL_PREFIX, KERNEL_SCOPE_LOCAL,
-    RESERVED_ROOT, artifact_anchor_symbol, constant_symbol, kernel_symbol,
+    RESERVED_ROOT, artifact_anchor_symbol, artifact_anchor_symbol_v2, constant_symbol,
+    kernel_symbol,
 };
 use syn::{
     Expr, ExprCall, ExprMethodCall, ExprPath, FnArg, ForeignItem, GenericArgument, GenericParam,
@@ -461,10 +462,13 @@ fn collect_cuda_module_kernels(items: &[Item]) -> syn::Result<Vec<CudaModuleKern
 /// Without this handshake the bundle was silently dropped and `load()`
 /// failed at runtime with `ModuleNotFound` (issue #72).
 ///
-/// Both sides derive the symbol name from `CARGO_PKG_NAME` and
-/// `CARGO_PKG_VERSION`: this proc macro reads them while rustc compiles
-/// the crate, and the codegen backend reads them inside the same rustc
-/// process, so the names always agree under cargo.
+/// Without an owner filter, both sides keep using the legacy package+version
+/// anchor for compatibility with older wrappers and backends. A non-empty
+/// owner filter activates the v2 package+version+crate+binary identity. That
+/// target-specific identity prevents an unselected binary from satisfying a
+/// selected library's reference (or vice versa); an unselected new macro emits
+/// no reference at all. The backend also keeps a weak legacy alias for older
+/// macro expansions in mixed-version builds.
 ///
 /// The reference is only emitted when the module is guaranteed to produce
 /// an artifact for this crate. Generic kernels are monomorphized (and
@@ -477,9 +481,10 @@ fn collect_cuda_module_kernels(items: &[Item]) -> syn::Result<Vec<CudaModuleKern
 fn cuda_module_artifact_anchor_statements(
     kernels: &[CudaModuleKernel],
 ) -> syn::Result<TokenStream2> {
-    let (Ok(package_name), Ok(package_version)) = (
+    let (Ok(package_name), Ok(package_version), Ok(crate_name)) = (
         std::env::var("CARGO_PKG_NAME"),
         std::env::var("CARGO_PKG_VERSION"),
+        std::env::var("CARGO_CRATE_NAME"),
     ) else {
         // Not built by cargo (e.g. a raw rustc invocation): the backend
         // falls back to crate-name-based bundle naming and we cannot
@@ -487,6 +492,15 @@ fn cuda_module_artifact_anchor_statements(
         // undefined symbol.
         return Ok(TokenStream2::new());
     };
+
+    let owner_filter = std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE").ok();
+    let owner_selection = device_codegen_owner_selection(owner_filter.as_deref(), &crate_name);
+    if owner_selection == Some(false) {
+        // The backend deliberately omits this crate's artifact. Omitting the
+        // reference as well keeps the host link valid without pretending that
+        // a loadable bundle exists.
+        return Ok(TokenStream2::new());
+    }
 
     let non_generic: Vec<&CudaModuleKernel> =
         kernels.iter().filter(|kernel| !kernel.is_generic).collect();
@@ -517,7 +531,17 @@ fn cuda_module_artifact_anchor_statements(
         Some(quote! { #[cfg(any( #(#alternatives),* ))] })
     };
 
-    let anchor = artifact_anchor_symbol(&package_name, &package_version);
+    let binary_name = std::env::var("CARGO_BIN_NAME").ok();
+    let anchor = if owner_selection.is_some() {
+        artifact_anchor_symbol_v2(
+            &package_name,
+            &package_version,
+            &crate_name,
+            binary_name.as_deref(),
+        )
+    } else {
+        artifact_anchor_symbol(&package_name, &package_version)
+    };
     let anchor_name = LitStr::new(&anchor, proc_macro2::Span::call_site());
     Ok(quote! {
         // Keep-alive handshake with the codegen backend: see the macro
@@ -532,6 +556,18 @@ fn cuda_module_artifact_anchor_statements(
                 ::core::ptr::addr_of!(CUDA_OXIDE_BUNDLE_ANCHOR)
             })
         };
+    })
+}
+
+fn device_codegen_owner_selection(raw: Option<&str>, crate_name: &str) -> Option<bool> {
+    let crate_name = crate_name.trim().replace('-', "_");
+    raw.and_then(|raw| {
+        let owners: Vec<_> = raw
+            .split(',')
+            .map(|name| name.trim().replace('-', "_"))
+            .filter(|name| !name.is_empty())
+            .collect();
+        (!owners.is_empty()).then(|| owners.iter().any(|owner| owner == &crate_name))
     })
 }
 
@@ -4041,6 +4077,20 @@ mod tests {
             .expect("cuda_module expansion failed")
             .to_string()
             .replace(' ', "")
+    }
+
+    #[test]
+    fn device_codegen_owner_selection_matches_backend_name_rules() {
+        assert_eq!(device_codegen_owner_selection(None, "gpu_lib"), None);
+        assert_eq!(device_codegen_owner_selection(Some(" , "), "gpu_lib"), None);
+        assert_eq!(
+            device_codegen_owner_selection(Some("gpu-lib, math_gpu"), "gpu_lib"),
+            Some(true)
+        );
+        assert_eq!(
+            device_codegen_owner_selection(Some("gpu-lib, math_gpu"), "host_app"),
+            Some(false)
+        );
     }
 
     #[test]

--- a/crates/oxide-artifacts/src/lib.rs
+++ b/crates/oxide-artifacts/src/lib.rs
@@ -12,6 +12,8 @@
 use core::fmt;
 
 pub const ARTIFACT_SECTION_NAME: &str = ".oxart";
+#[cfg(feature = "object-write")]
+const ARTIFACT_ANCHOR_SECTION_NAME: &str = ".oxlink";
 pub const ARTIFACT_MAGIC: [u8; 8] = *b"OXIDEART";
 pub const ARTIFACT_VERSION: u16 = 1;
 
@@ -530,18 +532,86 @@ pub fn build_host_object_for_target(
     target: &str,
     anchor_symbol: Option<&str>,
 ) -> Result<Vec<u8>, ArtifactError> {
-    use object::write::{Object, Symbol, SymbolSection};
-    use object::{SectionFlags, SectionKind, SymbolFlags, SymbolKind, SymbolScope};
-
     if section_data.is_empty() {
         return Err(ArtifactError::EmptyPayload);
     }
+
+    match anchor_symbol {
+        Some(anchor_symbol) => build_host_object_with_section(
+            ARTIFACT_SECTION_NAME,
+            section_data,
+            target,
+            &[(anchor_symbol, false)],
+        ),
+        None => build_host_object_with_section(ARTIFACT_SECTION_NAME, section_data, target, &[]),
+    }
+}
+
+/// Wrap an artifact blob with a target-specific anchor and a weak legacy alias.
+///
+/// New owner-filter-aware macros reference the target-specific symbol. The
+/// weak package-level alias keeps older macro expansions link-compatible while
+/// avoiding duplicate-symbol failures when one package has several targets.
+#[cfg(feature = "object-write")]
+pub fn build_host_object_for_target_with_legacy_anchor(
+    section_data: &[u8],
+    target: &str,
+    anchor_symbol: &str,
+    legacy_anchor_symbol: &str,
+) -> Result<Vec<u8>, ArtifactError> {
+    if section_data.is_empty() {
+        return Err(ArtifactError::EmptyPayload);
+    }
+    build_host_object_with_section(
+        ARTIFACT_SECTION_NAME,
+        section_data,
+        target,
+        &[(anchor_symbol, false), (legacy_anchor_symbol, true)],
+    )
+}
+
+/// Build a host object that only defines an artifact link-anchor symbol.
+///
+/// The CUDA backend uses this when an owner filter deliberately suppresses a
+/// crate's device artifact. Older `#[cuda_module]` expansions can still
+/// contain the legacy anchor reference, so the linker needs a matching weak
+/// definition even though no `.oxart` section should be embedded. Keeping the
+/// placeholder in a separate section means artifact discovery correctly sees
+/// no device bundle.
+#[cfg(feature = "object-write")]
+pub fn build_host_anchor_object_for_target(
+    target: &str,
+    anchor_symbol: &str,
+) -> Result<Vec<u8>, ArtifactError> {
+    if anchor_symbol.is_empty() {
+        return Err(ArtifactError::Malformed(
+            "embedded artifact anchor symbol is empty".to_string(),
+        ));
+    }
+
+    build_host_object_with_section(
+        ARTIFACT_ANCHOR_SECTION_NAME,
+        &[0],
+        target,
+        &[(anchor_symbol, true)],
+    )
+}
+
+#[cfg(feature = "object-write")]
+fn build_host_object_with_section(
+    section_name: &str,
+    section_data: &[u8],
+    target: &str,
+    anchor_symbols: &[(&str, bool)],
+) -> Result<Vec<u8>, ArtifactError> {
+    use object::write::{Object, Symbol, SymbolSection};
+    use object::{SectionFlags, SectionKind, SymbolFlags, SymbolKind, SymbolScope};
 
     let target = HostObjectTarget::parse(target)?;
     let mut object = Object::new(target.format, target.architecture, target.endianness);
     let section_id = object.add_section(
         Vec::new(),
-        ARTIFACT_SECTION_NAME.as_bytes().to_vec(),
+        section_name.as_bytes().to_vec(),
         SectionKind::Data,
     );
     let section = object.section_mut(section_id);
@@ -550,7 +620,7 @@ pub fn build_host_object_for_target(
         sh_flags: elf::SHF_ALLOC | elf::SHF_GNU_RETAIN,
     };
 
-    if let Some(anchor_symbol) = anchor_symbol {
+    for (anchor_symbol, weak) in anchor_symbols {
         // Global binding so the symbol can satisfy undefined references
         // from other objects (that is what triggers archive extraction);
         // `Linkage` scope so it stays hidden and never leaks into the
@@ -561,7 +631,7 @@ pub fn build_host_object_for_target(
             size: 0,
             kind: SymbolKind::Data,
             scope: SymbolScope::Linkage,
-            weak: false,
+            weak: *weak,
             section: SymbolSection::Section(section_id),
             flags: SymbolFlags::None,
         });
@@ -936,6 +1006,147 @@ mod tests {
 
         let file = object::File::parse(bytes.as_slice()).unwrap();
         assert_eq!(file.symbols().count(), 0);
+    }
+
+    /// A filtered crate still needs to satisfy the host macro's anchor
+    /// reference, but it must not look like it contains a device artifact.
+    #[cfg(all(feature = "object-read", feature = "object-write"))]
+    #[test]
+    fn anchor_only_object_defines_symbol_without_artifact_section() {
+        use object::{Object, ObjectSymbol};
+
+        let bytes = build_host_anchor_object_for_target(
+            "x86_64-unknown-linux-gnu",
+            "filtered_crate_anchor",
+        )
+        .unwrap();
+        let file = object::File::parse(bytes.as_slice()).unwrap();
+        let anchor = file
+            .symbols()
+            .find(|symbol| symbol.name() == Ok("filtered_crate_anchor"))
+            .expect("anchor symbol missing from placeholder object");
+
+        assert!(anchor.is_definition());
+        assert!(anchor.is_global());
+        assert!(anchor.is_weak());
+        assert!(
+            read_artifact_bundles_from_object_bytes(&bytes)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[cfg(feature = "object-write")]
+    #[test]
+    fn anchor_only_object_rejects_empty_symbol() {
+        assert!(matches!(
+            build_host_anchor_object_for_target("x86_64-unknown-linux-gnu", ""),
+            Err(ArtifactError::Malformed(_))
+        ));
+    }
+
+    #[cfg(all(feature = "object-read", feature = "object-write"))]
+    #[test]
+    fn target_anchor_object_also_defines_weak_legacy_alias() {
+        use object::{Object, ObjectSymbol};
+
+        let blob = sample_blob();
+        let bytes = build_host_object_for_target_with_legacy_anchor(
+            &blob,
+            "x86_64-unknown-linux-gnu",
+            "target_anchor",
+            "legacy_anchor",
+        )
+        .unwrap();
+        let file = object::File::parse(bytes.as_slice()).unwrap();
+        let target = file
+            .symbols()
+            .find(|symbol| symbol.name() == Ok("target_anchor"))
+            .expect("target-specific anchor missing");
+        let legacy = file
+            .symbols()
+            .find(|symbol| symbol.name() == Ok("legacy_anchor"))
+            .expect("legacy anchor alias missing");
+
+        assert!(target.is_definition());
+        assert!(!target.is_weak());
+        assert!(legacy.is_definition());
+        assert!(legacy.is_weak());
+        assert_eq!(
+            read_artifact_bundles_from_object_bytes(&bytes)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    /// A strong undefined reference must pull an archive member whose matching
+    /// compatibility alias is weak; otherwise old macros could link but lose
+    /// the actual `.oxart` payload.
+    #[cfg(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        feature = "object-read",
+        feature = "object-write"
+    ))]
+    #[test]
+    fn weak_legacy_alias_extracts_artifact_from_static_archive() {
+        use std::process::Command;
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "oxide_artifact_weak_archive_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+
+        let object = build_host_object_for_target_with_legacy_anchor(
+            &sample_blob(),
+            "x86_64-unknown-linux-gnu",
+            "target_anchor",
+            "legacy_anchor",
+        )
+        .unwrap();
+        let object_path = root.join("artifact.o");
+        let archive_path = root.join("libartifact.a");
+        let source_path = root.join("main.c");
+        let binary_path = root.join("app");
+        std::fs::write(&object_path, object).unwrap();
+        std::fs::write(
+            &source_path,
+            b"extern const unsigned char legacy_anchor;\nint main(void) { return legacy_anchor; }\n",
+        )
+        .unwrap();
+
+        let ar = Command::new("ar")
+            .args(["crs"])
+            .arg(&archive_path)
+            .arg(&object_path)
+            .status()
+            .expect("`ar` is required for the static-archive anchor test");
+        assert!(ar.success(), "failed to create static archive");
+        let cc = Command::new("cc")
+            .arg(&source_path)
+            .arg(&archive_path)
+            .arg("-Wl,-z,noexecstack")
+            .arg("-o")
+            .arg(&binary_path)
+            .status()
+            .expect("a C linker driver is required for the anchor test");
+        assert!(
+            cc.success(),
+            "weak anchor did not resolve the host reference"
+        );
+
+        let executable = std::fs::read(&binary_path).unwrap();
+        let bundles = read_artifact_bundles_from_object_bytes(&executable).unwrap();
+        assert_eq!(bundles.len(), 1, "archive payload was not extracted");
+        assert_eq!(bundles[0].name, "demo");
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[cfg(feature = "object-write")]

--- a/crates/reserved-oxide-symbols/src/lib.rs
+++ b/crates/reserved-oxide-symbols/src/lib.rs
@@ -193,18 +193,16 @@ pub fn constant_symbol(base: &str) -> String {
     format!("{CONSTANT_PREFIX}{base}")
 }
 
-/// Build the artifact link-anchor symbol for a package name and version.
+/// Build the legacy artifact link-anchor symbol for a package and version.
 ///
 /// Both the codegen backend (which defines the symbol inside the embedded
 /// artifact object) and the `#[cuda_module]` macro (which references it
-/// from the generated `load_named()`) derive the name from the
-/// `CARGO_PKG_NAME` / `CARGO_PKG_VERSION` environment of the same rustc
-/// invocation, so the two sides always agree.
+/// from the generated `load_named()`) derive the name from `CARGO_PKG_NAME`
+/// and `CARGO_PKG_VERSION` in the same rustc invocation.
 ///
 /// The version is part of the name so that two different versions of one
 /// package in the same dependency graph each keep their own bundle. Any
-/// character that is not valid in a symbol name (for example the `-` in
-/// package names or the `.` in versions) is mapped to `_`.
+/// character that is not valid in a symbol name is mapped to `_`.
 ///
 /// ```
 /// use reserved_oxide_symbols::artifact_anchor_symbol;
@@ -218,6 +216,35 @@ pub fn artifact_anchor_symbol(package_name: &str, package_version: &str) -> Stri
     push_symbol_sanitized(&mut symbol, package_name);
     symbol.push('_');
     push_symbol_sanitized(&mut symbol, package_version);
+    symbol
+}
+
+/// Build the target-specific v2 artifact anchor.
+///
+/// V2 extends the legacy identity with rustc's crate target and Cargo's
+/// optional binary target name. This prevents a package's library, binaries,
+/// examples, and tests from satisfying one another's anchor references. The
+/// legacy builder remains available for mixed-version compatibility.
+pub fn artifact_anchor_symbol_v2(
+    package_name: &str,
+    package_version: &str,
+    crate_name: &str,
+    binary_name: Option<&str>,
+) -> String {
+    let mut symbol = String::from(ARTIFACT_ANCHOR_PREFIX);
+    symbol.push_str("v2_");
+    push_symbol_sanitized(&mut symbol, package_name);
+    symbol.push('_');
+    push_symbol_sanitized(&mut symbol, package_version);
+    symbol.push('_');
+    push_symbol_sanitized(&mut symbol, crate_name);
+    match binary_name {
+        Some(binary_name) => {
+            symbol.push_str("_bin_");
+            push_symbol_sanitized(&mut symbol, binary_name);
+        }
+        None => symbol.push_str("_nonbin"),
+    }
     symbol
 }
 
@@ -570,10 +597,10 @@ mod tests {
     /// name/version cargo can produce, and must live in the reserved root.
     #[test]
     fn artifact_anchor_symbol_is_sanitized_and_reserved() {
-        let anchor = artifact_anchor_symbol("my-kernels", "1.2.0-rc.3");
+        let anchor = artifact_anchor_symbol_v2("my-kernels", "1.2.0-rc.3", "kernel_lib", None);
         assert_eq!(
             anchor,
-            "cuda_oxide_artifact_anchor_246e25db_my_kernels_1_2_0_rc_3",
+            "cuda_oxide_artifact_anchor_246e25db_v2_my_kernels_1_2_0_rc_3_kernel_lib_nonbin",
         );
         assert!(anchor.starts_with(RESERVED_ROOT));
         assert!(
@@ -584,8 +611,28 @@ mod tests {
         // Distinct versions of one package must get distinct anchors, so
         // both archive members can be extracted into the same binary.
         assert_ne!(
-            artifact_anchor_symbol("my-kernels", "0.1.0"),
-            artifact_anchor_symbol("my-kernels", "0.2.0"),
+            artifact_anchor_symbol_v2("my-kernels", "0.1.0", "kernel_lib", None),
+            artifact_anchor_symbol_v2("my-kernels", "0.2.0", "kernel_lib", None),
+        );
+        // Distinct rustc targets from one package must not satisfy each
+        // other's anchor references.
+        assert_ne!(
+            artifact_anchor_symbol_v2("my-kernels", "0.1.0", "kernel_lib", None),
+            artifact_anchor_symbol_v2("my-kernels", "0.1.0", "host_bin", Some("host-bin")),
+        );
+        // Cargo permits a package's library and default binary to share the
+        // same crate name; CARGO_BIN_NAME still keeps their anchors distinct.
+        assert_ne!(
+            artifact_anchor_symbol_v2("my-kernels", "0.1.0", "same_name", None),
+            artifact_anchor_symbol_v2("my-kernels", "0.1.0", "same_name", Some("same_name")),
+        );
+        assert_eq!(
+            artifact_anchor_symbol("my-kernels", "1.2.0-rc.3"),
+            "cuda_oxide_artifact_anchor_246e25db_my_kernels_1_2_0_rc_3"
+        );
+        assert_ne!(
+            artifact_anchor_symbol("my-kernels", "1.2.0+kernel-lib.nonbin"),
+            artifact_anchor_symbol_v2("my-kernels", "1.2.0", "kernel-lib", None),
         );
     }
 

--- a/crates/rustc-codegen-cuda/README.md
+++ b/crates/rustc-codegen-cuda/README.md
@@ -76,19 +76,24 @@ These are set automatically by `cargo oxide`. For manual invocations, all three 
 
 ### Environment Variables
 
-| Variable                    | Effect                         |
-|-----------------------------|--------------------------------|
-| `CUDA_OXIDE_VERBOSE`        | Verbose compilation output     |
-| `CUDA_OXIDE_PTX_DIR`        | Output directory for PTX files |
-| `CUDA_OXIDE_TARGET`         | GPU architecture override      |
-| `CUDA_OXIDE_LLC`            | Path to a specific `llc`       |
-| `CUDA_OXIDE_DUMP_MIR`       | Dump the `dialect-mir` module  |
-| `CUDA_OXIDE_DUMP_LLVM`      | Dump the LLVM dialect module   |
-| `CUDA_OXIDE_SHOW_RUSTC_MIR` | Dump raw rustc MIR             |
-| `CUDA_OXIDE_EMIT_NVVM_IR`   | Emit NVVM IR for libNVVM       |
+| Variable                             | Effect                                      |
+|--------------------------------------|---------------------------------------------|
+| `CUDA_OXIDE_VERBOSE`                 | Verbose compilation output                  |
+| `CUDA_OXIDE_PTX_DIR`                 | Output directory for PTX files              |
+| `CUDA_OXIDE_TARGET`                  | GPU architecture override                   |
+| `CUDA_OXIDE_LLC`                     | Path to a specific `llc`                    |
+| `CUDA_OXIDE_DUMP_MIR`                | Dump the `dialect-mir` module               |
+| `CUDA_OXIDE_DUMP_LLVM`               | Dump the LLVM dialect module                |
+| `CUDA_OXIDE_SHOW_RUSTC_MIR`          | Dump raw rustc MIR                          |
+| `CUDA_OXIDE_EMIT_NVVM_IR`            | Emit NVVM IR for libNVVM                    |
+| `CUDA_OXIDE_DEVICE_CODEGEN_CRATE`    | Comma-separated device owner crate filter   |
 
 `cargo oxide --arch <sm_XX>` sets `CUDA_OXIDE_TARGET`. When it is unset,
 PTX output auto-detects the required target from generated LLVM IR.
+Owner-filter names are normalized like Cargo crate names, so hyphens match
+underscores. Host LLVM codegen still runs for every crate. An excluded target
+must not call its generated module loader; the filter suppresses its device
+artifact but does not give sibling targets separate runtime bundle names.
 
 ## Source Layout
 

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -276,13 +276,14 @@
 //!
 //! ## Environment Variables
 //!
-//! | Variable               | Effect                               |
-//! |------------------------|--------------------------------------|
-//! | `CUDA_OXIDE_VERBOSE`   | Print detailed compilation progress  |
-//! | `CUDA_OXIDE_DUMP_MIR`  | Dump the `dialect-mir` module        |
-//! | `CUDA_OXIDE_DUMP_LLVM` | Dump the LLVM dialect module         |
-//! | `CUDA_OXIDE_PTX_DIR`   | Override PTX output directory        |
-//! | `CUDA_OXIDE_TARGET`    | Override GPU target (e.g., `sm_90a`) |
+//! | Variable                          | Effect                               |
+//! |-----------------------------------|--------------------------------------|
+//! | `CUDA_OXIDE_VERBOSE`              | Print detailed compilation progress  |
+//! | `CUDA_OXIDE_DUMP_MIR`             | Dump the `dialect-mir` module        |
+//! | `CUDA_OXIDE_DUMP_LLVM`            | Dump the LLVM dialect module         |
+//! | `CUDA_OXIDE_PTX_DIR`              | Override PTX output directory        |
+//! | `CUDA_OXIDE_TARGET`               | Override GPU target (e.g., `sm_90a`) |
+//! | `CUDA_OXIDE_DEVICE_CODEGEN_CRATE` | Filter device owner crate names      |
 //!
 //! ## Module Structure
 //!
@@ -329,6 +330,7 @@ use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_session::Session;
 use rustc_session::config::OutputFilenames;
 use std::any::Any;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -376,18 +378,22 @@ pub struct CudaCodegenConfig {
     pub dump_llvm_dialect: bool,
     /// Override PTX output directory (defaults to current directory).
     pub ptx_output_dir: Option<std::path::PathBuf>,
+    /// When set, emit device code only for these normalized local crate names.
+    /// Host code still goes through the wrapped LLVM backend for every crate.
+    pub device_codegen_crates: Option<BTreeSet<String>>,
 }
 
 impl CudaCodegenConfig {
     /// Load configuration from environment variables.
     ///
-    /// | Variable                    | Config Field        |
-    /// |-----------------------------|---------------------|
-    /// | `CUDA_OXIDE_VERBOSE`        | `verbose`           |
-    /// | `CUDA_OXIDE_SHOW_RUSTC_MIR` | `dump_rustc_mir`    |
-    /// | `CUDA_OXIDE_DUMP_MIR`       | `dump_mir_dialect`  |
-    /// | `CUDA_OXIDE_DUMP_LLVM`      | `dump_llvm_dialect` |
-    /// | `CUDA_OXIDE_PTX_DIR`        | `ptx_output_dir`    |
+    /// | Variable                             | Config Field             |
+    /// |--------------------------------------|--------------------------|
+    /// | `CUDA_OXIDE_VERBOSE`                 | `verbose`                |
+    /// | `CUDA_OXIDE_SHOW_RUSTC_MIR`          | `dump_rustc_mir`         |
+    /// | `CUDA_OXIDE_DUMP_MIR`                | `dump_mir_dialect`       |
+    /// | `CUDA_OXIDE_DUMP_LLVM`               | `dump_llvm_dialect`      |
+    /// | `CUDA_OXIDE_PTX_DIR`                 | `ptx_output_dir`         |
+    /// | `CUDA_OXIDE_DEVICE_CODEGEN_CRATE`  | `device_codegen_crates`  |
     pub fn from_env() -> Self {
         Self {
             verbose: std::env::var("CUDA_OXIDE_VERBOSE").is_ok(),
@@ -397,8 +403,42 @@ impl CudaCodegenConfig {
             ptx_output_dir: std::env::var("CUDA_OXIDE_PTX_DIR")
                 .ok()
                 .map(std::path::PathBuf::from),
+            device_codegen_crates: parse_device_codegen_crates(
+                std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE")
+                    .ok()
+                    .as_deref(),
+            ),
         }
     }
+
+    fn allows_device_codegen_for(&self, crate_name: &str) -> bool {
+        self.device_codegen_crates
+            .as_ref()
+            .is_none_or(|owners| owners.contains(&normalize_device_crate_name(crate_name)))
+    }
+}
+
+fn normalize_device_crate_name(name: &str) -> String {
+    name.trim().replace('-', "_")
+}
+
+fn parse_device_codegen_crates(raw: Option<&str>) -> Option<BTreeSet<String>> {
+    raw.and_then(|raw| {
+        let owners: BTreeSet<_> = raw
+            .split(',')
+            .map(normalize_device_crate_name)
+            .filter(|name| !name.is_empty())
+            .collect();
+        (!owners.is_empty()).then_some(owners)
+    })
+}
+
+fn should_codegen_device_crate(
+    config: &CudaCodegenConfig,
+    crate_name: &str,
+    contains_device_code: bool,
+) -> bool {
+    contains_device_code && config.allows_device_codegen_for(crate_name)
 }
 
 impl CodegenBackend for CudaCodegenBackend {
@@ -472,12 +512,49 @@ impl CodegenBackend for CudaCodegenBackend {
             let kernel_count = collector::count_kernels_in_cgus(tcx, mono_partitions.codegen_units);
             let device_fn_count =
                 collector::count_device_fns_in_cgus(tcx, mono_partitions.codegen_units);
-            let has_device_code = kernel_count > 0 || device_fn_count > 0;
+            let crate_name = tcx.crate_name(rustc_hir::def_id::LOCAL_CRATE);
+            let owner_selected = self.config.allows_device_codegen_for(crate_name.as_str());
+            let contains_device_code = kernel_count > 0 || device_fn_count > 0;
+            let has_device_code = should_codegen_device_crate(
+                &self.config,
+                crate_name.as_str(),
+                contains_device_code,
+            );
             let mut artifact_objects = Vec::new();
+
+            if self.config.verbose && contains_device_code && !owner_selected {
+                eprintln!(
+                    "[rustc_codegen_cuda] Skipping device code for crate '{}' because it is not in CUDA_OXIDE_DEVICE_CODEGEN_CRATE",
+                    crate_name
+                );
+            }
+
+            // Older `#[cuda_module]` expansions always reference the legacy
+            // package-level anchor. An owner filter deliberately suppresses
+            // this crate's device artifact, but mixed-version host code must
+            // still link. Supply a weak legacy anchor-only object without an
+            // `.oxart` bundle. New owner-aware macros omit the reference for
+            // unselected crates and do not need the fallback.
+            if kernel_count > 0 && !owner_selected {
+                let output_dir = self
+                    .config
+                    .ptx_output_dir
+                    .clone()
+                    .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+                match write_filtered_artifact_anchor_object(
+                    &output_dir,
+                    crate_name.as_str(),
+                    tcx.sess.target.llvm_target.as_ref(),
+                ) {
+                    Ok(path) => artifact_objects.push(path),
+                    Err(error) => tcx.dcx().fatal(format!(
+                        "[rustc_codegen_cuda] Failed to write filtered artifact anchor: {error}"
+                    )),
+                }
+            }
 
             // Only log for crates that have device code (reduces noise from dependency crates)
             if self.config.verbose && has_device_code {
-                let crate_name = tcx.crate_name(rustc_hir::def_id::LOCAL_CRATE);
                 eprintln!(
                     "[rustc_codegen_cuda] Compiling crate '{}': {} CGUs, {} kernel(s), {} device fn(s)",
                     crate_name,
@@ -611,6 +688,7 @@ impl CodegenBackend for CudaCodegenBackend {
                                 &result,
                                 artifact,
                                 device_functions,
+                                self.config.device_codegen_crates.is_some(),
                             ) {
                                 Ok(path) => {
                                     if self.config.verbose {
@@ -709,6 +787,7 @@ fn write_device_artifact_object(
     result: &device_codegen::DeviceCodegenResult,
     artifact: &device_codegen::DeviceCodegenArtifact,
     functions: &[collector::CollectedFunction<'_>],
+    use_target_specific_anchor: bool,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let bundle_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| output_name.to_string());
     let payload_kind = match artifact.kind {
@@ -746,16 +825,56 @@ fn write_device_artifact_object(
     // this crate is a library, the artifact object becomes an rlib archive
     // member, and the linker only extracts it if some other object holds an
     // undefined reference to a symbol defined here. The `#[cuda_module]`
-    // macro emits that reference from the generated `load_named()`, derived
-    // from the same CARGO_PKG_NAME / CARGO_PKG_VERSION environment that this
-    // rustc invocation sees, so the two names always match. Without the
-    // anchor, library-crate bundles were dead-stripped and `load()` failed
-    // at runtime with ModuleNotFound (issue #72).
+    // macro emits that reference from the generated `load_named()`. Normal
+    // builds preserve the legacy package-level symbol. Owner-filtered builds
+    // use a target-specific v2 symbol plus a weak legacy alias, so an older
+    // macro still links without letting a filtered target hide a selected
+    // target's artifact. Without an anchor, library-crate bundles were
+    // dead-stripped and `load()` failed at runtime with ModuleNotFound
+    // (issue #72).
+    let package_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let legacy_anchor =
+        reserved_oxide_symbols::artifact_anchor_symbol(&bundle_name, &package_version);
+    let object = if use_target_specific_anchor {
+        let binary_name = std::env::var("CARGO_BIN_NAME").ok();
+        let target_anchor = reserved_oxide_symbols::artifact_anchor_symbol_v2(
+            &bundle_name,
+            &package_version,
+            output_name,
+            binary_name.as_deref(),
+        );
+        oxide_artifacts::build_host_object_for_target_with_legacy_anchor(
+            &blob,
+            host_target,
+            &target_anchor,
+            &legacy_anchor,
+        )?
+    } else {
+        oxide_artifacts::build_host_object_for_target(&blob, host_target, Some(&legacy_anchor))?
+    };
+    write_artifact_object(output_dir, output_name, host_target, &object, "embed")
+}
+
+fn write_filtered_artifact_anchor_object(
+    output_dir: &Path,
+    output_name: &str,
+    host_target: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let bundle_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| output_name.to_string());
     let package_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
     let anchor_symbol =
         reserved_oxide_symbols::artifact_anchor_symbol(&bundle_name, &package_version);
-    let object =
-        oxide_artifacts::build_host_object_for_target(&blob, host_target, Some(&anchor_symbol))?;
+    let object = oxide_artifacts::build_host_anchor_object_for_target(host_target, &anchor_symbol)?;
+    write_artifact_object(output_dir, output_name, host_target, &object, "anchor")
+}
+
+fn write_artifact_object(
+    output_dir: &Path,
+    output_name: &str,
+    host_target: &str,
+    object: &[u8],
+    kind: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let safe_output_name = sanitize_path_component(output_name);
     let artifact_id = ARTIFACT_OBJECT_COUNTER.fetch_add(1, Ordering::Relaxed);
     let object_dir = output_dir
@@ -764,7 +883,7 @@ fn write_device_artifact_object(
         .join(sanitize_path_component(host_target));
     std::fs::create_dir_all(&object_dir)?;
     let object_path = object_dir.join(format!(
-        "{safe_output_name}.{}.{artifact_id}.embed.o",
+        "{safe_output_name}.{}.{artifact_id}.{kind}.o",
         std::process::id(),
     ));
     std::fs::write(&object_path, object)?;
@@ -820,4 +939,47 @@ pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
         config,
         llvm_backend,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_codegen_owner_filter_normalizes_and_matches_crate_names() {
+        let owners = parse_device_codegen_crates(Some(" gpu-kernels,math_gpu , gpu-kernels "))
+            .expect("an explicitly configured filter");
+        assert_eq!(
+            owners,
+            BTreeSet::from(["gpu_kernels".to_string(), "math_gpu".to_string()])
+        );
+
+        let config = CudaCodegenConfig {
+            device_codegen_crates: Some(owners),
+            ..CudaCodegenConfig::default()
+        };
+        assert!(config.allows_device_codegen_for("gpu_kernels"));
+        assert!(config.allows_device_codegen_for("gpu-kernels"));
+        assert!(config.allows_device_codegen_for("math_gpu"));
+        assert!(!config.allows_device_codegen_for("host_app"));
+        assert!(should_codegen_device_crate(&config, "gpu_kernels", true));
+        assert!(!should_codegen_device_crate(&config, "host_app", true));
+        assert!(!should_codegen_device_crate(&config, "gpu_kernels", false));
+    }
+
+    #[test]
+    fn absent_owner_filter_allows_device_codegen_for_every_crate() {
+        let config = CudaCodegenConfig::default();
+        assert!(config.allows_device_codegen_for("gpu_kernels"));
+        assert!(config.allows_device_codegen_for("host_app"));
+    }
+
+    #[test]
+    fn empty_owner_filter_is_treated_as_unset() {
+        let config = CudaCodegenConfig {
+            device_codegen_crates: parse_device_codegen_crates(Some(" , ")),
+            ..CudaCodegenConfig::default()
+        };
+        assert!(config.allows_device_codegen_for("gpu_kernels"));
+    }
 }


### PR DESCRIPTION
Closes #287.

## Summary

Adds a reliable passthrough mode for `cargo oxide build` and `cargo oxide test`.
Applications can select Cargo targets normally while cuda-oxide supplies the
backend, architecture, project configuration, device-owner filter, and required
compiler flags.

```text
Before: passthrough settings were missing or could be silently overridden,
        and Cargo could reuse stale device artifacts.
After:  settings have defined precedence and every codegen-relevant input is
        part of Cargo's fingerprint.
```

## What changed

### CLI and configuration

- Adds build/test passthrough arguments for target directory, architecture,
  features, device-owner crates, and extra device `cfg` values.
- Loads `.cargo/cuda-oxide.toml` relative to the selected project and applies
  explicit CLI > inherited environment > project-config precedence.
- Combines user and required rustc options through
  `CARGO_ENCODED_RUSTFLAGS`, preserving argument boundaries and applying
  correctness-critical backend flags last.
- Preserves nested Cargo separators, test-binary arguments, empty build/test
  invocations, and forwarded feature selection.

### Device ownership and artifacts

- Matches owner filters against normalized rustc crate names and carries the
  same decision through macro expansion, backend collection, artifact
  registration, and embedding.
- Handles packages with multiple targets without confusing package and target
  identities; legacy artifact aliases remain available as weak compatibility
  fallbacks.
- Fingerprints architecture, output mode, FMA policy, owner selection,
  configured environment, rustflags, and backend identity so changing any of
  them rebuilds device artifacts instead of reusing stale output.

### Documentation

- Documents passthrough syntax, option precedence, owner filtering, bundle-name
  behavior, and configuration-file rules in the cargo-oxide README.

## Testing

- `cargo fmt --all --check`
- Strict clippy for every changed crate
- `cargo check --workspace --all-targets`
- 46 cargo-oxide tests
- 17 oxide-artifacts tests
- Full cuda-macros unit, compile-fail, and doctest coverage
- rustc-codegen-cuda backend tests, including all targets
- Real passthrough builds for selected and unselected owner crates, library and
  binary targets in one package, feature forwarding, custom target dirs,
  architecture changes, and backend replacement
- Fresh and incremental builds verified to regenerate only when effective
  codegen inputs change

## Checklist

- [x] Contributor commit preserved and rebased onto current `main`
- [x] Existing build/run behavior retained
- [x] CLI, configuration, fingerprint, and artifact edge cases covered
- [x] Documentation updated

