### PR TITLE
feat: add typed kernel launch contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ name = "cuda-macros"
 version = "0.2.1"
 dependencies = [
  "cuda-core",
+ "cuda-device",
  "cuda-host",
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -57,15 +57,19 @@ fn main() {
 
     // Launch with a closure — factor is captured and passed to the GPU automatically
     let factor = 2.5f32;
-    module
-        .map::<f32, _>(
+    // SAFETY: this raw configuration is fully 1-D, matches index_1d(), and
+    // launches one thread per output element. A launch contract can move this
+    // proof into the generated safe API.
+    unsafe {
+        module.map::<f32, _>(
             &stream,
             LaunchConfig::for_num_elems(1024),
             move |x: f32| x * factor,
             &input,
             &mut output,
         )
-        .unwrap();
+    }
+    .unwrap();
 
     let result = output.to_host_vec(&stream).unwrap();
     assert!((result[1] - 2.5).abs() < 1e-5);
@@ -76,7 +80,10 @@ The above example defines a generic `#[kernel]` function `map` that accepts any
 `Fn(T) -> T` closure. `#[cuda_module]` embeds the generated device artifact into
 the host binary and generates a typed `module.map::<f32, _>(...)` launch method.
 The closure `move |x| x * factor` is captured, scalarized, and passed as kernel
-parameters automatically.
+parameters automatically. `LaunchConfig` is intentionally raw data, so using
+it to launch a kernel is unsafe: the caller must prove that its dimensions and
+resources match the kernel. Kernels with `#[launch_contract(...)]` instead use
+a checked `PreparedLaunch` through the safe generated method.
 
 For composable async GPU work, `stream:` disappears, `{kernel}_async` returns a
 lazy `DeviceOperation`, and execution happens when you call `.sync()` or
@@ -87,14 +94,16 @@ use cuda_async::device_operation::DeviceOperation;
 
 // Assuming `module`, `input`, and `output` come from the cuda-async setup:
 let factor = 2.5f32;
-module
-    .map_async::<f32, _>(
+let launch = unsafe {
+    // SAFETY: the raw launch is 1-D and matches this kernel's index space.
+    module.map_async::<f32, _>(
         LaunchConfig::for_num_elems(1024),
         move |x: f32| x * factor,
         &input,
         &mut output,
     )?
-    .sync()?;
+};
+launch.sync()?;
 // or: .await?;
 ```
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -3157,14 +3157,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     })?;
 
-    module
-        .vecadd_async(
+    // SAFETY: this is a 1D launch and `vecadd` guards its index against the
+    // output length before writing.
+    unsafe {
+        module.vecadd_async(
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
-        )?
-        .sync()?;
+        )
+    }?
+    .sync()?;
 
     let mut c_host = vec![0.0f32; N];
     cuda_async::device_context::with_cuda_context(0, |ctx| {
@@ -3227,15 +3230,18 @@ fn main() {
     let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .vecadd(
+    // SAFETY: this is a 1D launch and `vecadd` guards its index against the
+    // output length before writing.
+    unsafe {
+        module.vecadd(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let c_host = c_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/cuda-async/README.md
+++ b/crates/cuda-async/README.md
@@ -10,7 +10,7 @@ The crate is organized around a single idea: GPU work is described lazily, sched
   module.kernel_async(...)
          |
          v
-  AsyncKernelLaunch          <-- lazy description, no GPU work yet
+  AsyncKernelLaunch          <-- immutable lazy operation, no GPU work yet
          |
     .and_then(|()| ...)      <-- compose with other DeviceOperations
          |
@@ -62,19 +62,17 @@ Borrow buffers when the launch completes in the current scope:
 use cuda_async::device_context::init_device_contexts;
 use cuda_async::device_operation::DeviceOperation;
 use cuda_host::cuda_module;
-use cuda_core::LaunchConfig;
+use cuda_core::LaunchConfig1D;
 
 // 1. Enable cuda-host's "async" feature, then initialize once per thread.
 init_device_contexts(0, 1)?;
-let module = kernels::load_async(0)?;
+// SAFETY: this program loads the embedded artifact generated from this exact
+// contracted module, so its entry points and contract metadata match.
+let module = unsafe { kernels::load_async(0)? };
 
-// 2. Build a lazy operation
-let op = module.vecadd_async(
-    LaunchConfig::for_num_elems(1024),
-    &a_dev,
-    &b_dev,
-    &mut c_dev,
-)?;
+// 2. Prove the launch matches vecadd's declared 1-D contract, then build it.
+let prepared = module.prepare_vecadd(LaunchConfig1D::new(4, 256, 0))?;
+let op = module.vecadd_async(&prepared, &a_dev, &b_dev, &mut c_dev);
 
 // 3. Execute
 op.sync()?;       // blocking
@@ -87,18 +85,39 @@ Move buffers into the launch when it needs to be spawned or stored as a
 ```rust
 use std::future::IntoFuture;
 
-let op = module.vecadd_async_owned(
-    LaunchConfig::for_num_elems(1024),
-    a_dev,
-    b_dev,
-    c_dev,
-)?;
+let prepared = module.prepare_vecadd(LaunchConfig1D::new(4, 256, 0))?;
+let op = module.vecadd_async_owned(&prepared, a_dev, b_dev, c_dev);
 
 let (a_dev, b_dev, c_dev) = tokio::spawn(op.into_future()).await??;
 ```
 
 The owned form keeps device buffers alive until the CUDA stream reaches the
 kernel completion callback, then returns those buffers as the operation output.
+
+## Raw launch safety boundary
+
+The low-level builder is safe because it only stores inert data. A raw
+`LaunchConfig` becomes runnable only through an explicit unsafe transition:
+
+```text
+AsyncKernelLaunchBuilder
+       |  unsafe finalize_unchecked(raw_config)
+       v
+AsyncKernelLaunch          <-- DeviceOperation + IntoFuture
+```
+
+```rust,ignore
+let mut builder = AsyncKernelLaunchBuilder::new(function);
+builder.push_args((input_ptr, output_ptr, len));
+
+// SAFETY: this kernel uses 1-D indexing, accepts 256 threads per block, and
+// every pointer and argument matches its device-side signature.
+let operation = unsafe { builder.finalize_unchecked(config) };
+operation.sync()?;
+```
+
+Prefer generated prepared-launch methods. They validate the kernel's declared
+contract and keep this unsafe proof inside generated code.
 
 ## Cancellation and deferred reclamation
 

--- a/crates/cuda-async/src/device_box.rs
+++ b/crates/cuda-async/src/device_box.rs
@@ -17,7 +17,7 @@
 
 use crate::device_context::with_deallocator_stream;
 use crate::error::DeviceError;
-use crate::launch::{AsyncKernelLaunch, KernelArgument};
+use crate::launch::{AsyncKernelLaunchBuilder, KernelArgument};
 use cuda_bindings::CUdeviceptr;
 use cuda_core::memory::free_async;
 use std::io::{self, Write};
@@ -49,7 +49,7 @@ impl<T> DevicePointer<T> {
 
 /// Pushes the underlying device address as a kernel argument.
 impl<T: Send + Sized> KernelArgument for DevicePointer<T> {
-    fn push_arg(self, launcher: &mut AsyncKernelLaunch<'_>) {
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
         launcher.push_arg(self.cu_deviceptr());
     }
 }

--- a/crates/cuda-async/src/launch.rs
+++ b/crates/cuda-async/src/launch.rs
@@ -5,9 +5,11 @@
 
 //! CUDA kernel launch builder with argument marshalling.
 //!
-//! [`AsyncKernelLaunch`] accumulates a kernel function reference, launch
-//! configuration, and type-erased argument pointers, then submits the launch
-//! through the CUDA driver when executed as a [`DeviceOperation`].
+//! [`AsyncKernelLaunchBuilder`] safely accumulates a kernel function reference,
+//! launch attributes, and type-erased argument pointers. An explicit unsafe
+//! call to [`AsyncKernelLaunchBuilder::finalize_unchecked`] supplies the raw
+//! launch geometry and returns an immutable [`AsyncKernelLaunch`] that can be
+//! scheduled as a [`DeviceOperation`].
 //!
 //! Arguments are heap-allocated via [`KernelArgument::push_arg`] and freed when
 //! the launcher is dropped after submission. This keeps the pointed-to values
@@ -27,19 +29,39 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-/// Builder that accumulates kernel arguments and submits a CUDA kernel launch.
+/// Safe, inert builder for an unchecked CUDA kernel launch.
 ///
-/// Implements [`DeviceOperation`] so it can be composed with other operations
-/// and scheduled onto any stream. Also implements [`IntoFuture`] for `.await`
-/// syntax.
+/// Building a launch does not enqueue GPU work. The builder deliberately does
+/// not implement [`DeviceOperation`] or [`IntoFuture`]: raw launch geometry
+/// must first cross the explicit unsafe boundary at
+/// [`finalize_unchecked`](Self::finalize_unchecked).
+///
+/// ```compile_fail,E0277
+/// use cuda_async::device_operation::DeviceOperation;
+/// use cuda_async::launch::AsyncKernelLaunchBuilder;
+///
+/// fn schedule<O: DeviceOperation>(_operation: O) {}
+///
+/// fn cannot_schedule(builder: AsyncKernelLaunchBuilder<'static>) {
+///     schedule(builder);
+/// }
+/// ```
+///
+/// Builders stay on the thread that assembles their type-erased argument
+/// storage. Only the immutable finalized operation is `Send`:
+///
+/// ```compile_fail,E0277
+/// use cuda_async::launch::AsyncKernelLaunchBuilder;
+///
+/// fn assert_send<T: Send>() {}
+/// assert_send::<AsyncKernelLaunchBuilder<'static>>();
+/// ```
 #[derive(Debug)]
-pub struct AsyncKernelLaunch<'a> {
+pub struct AsyncKernelLaunchBuilder<'a> {
     /// Handle to the compiled device function.
-    pub func: Arc<CudaFunction>,
+    func: Arc<CudaFunction>,
     /// Heap-allocated, type-erased argument storage passed to the CUDA driver.
     args: KernelArgStorage,
-    /// Grid/block dimensions and shared memory size. Must be set before launch.
-    cfg: Option<LaunchConfig>,
     /// Optional thread-block cluster dimensions for `cuLaunchKernelEx`.
     cluster_dim: Option<(u32, u32, u32)>,
     /// When `true`, launch via `cuLaunchKernelEx` with
@@ -50,10 +72,44 @@ pub struct AsyncKernelLaunch<'a> {
     _borrows: PhantomData<&'a mut ()>,
 }
 
+/// Immutable, runnable CUDA kernel launch.
+///
+/// This type can only be created by consuming an
+/// [`AsyncKernelLaunchBuilder`]. It exposes no safe geometry or argument
+/// setters, so its safety assumptions cannot be invalidated after the raw
+/// launch configuration has been accepted.
+///
+/// ```compile_fail,E0599
+/// use cuda_async::launch::AsyncKernelLaunch;
+/// use cuda_core::LaunchConfig;
+///
+/// fn cannot_reconfigure(launch: &mut AsyncKernelLaunch<'_>, config: LaunchConfig) {
+///     launch.set_launch_config(config);
+/// }
+/// ```
+#[derive(Debug)]
+pub struct AsyncKernelLaunch<'a> {
+    /// Handle to the compiled device function.
+    func: Arc<CudaFunction>,
+    /// Heap-allocated, type-erased argument storage passed to the CUDA driver.
+    args: KernelArgStorage,
+    /// Complete grid/block dimensions and dynamic shared-memory size.
+    cfg: LaunchConfig,
+    /// Optional thread-block cluster dimensions for `cuLaunchKernelEx`.
+    cluster_dim: Option<(u32, u32, u32)>,
+    /// Whether this launch requests cooperative grid residency.
+    cooperative: bool,
+    /// Ties borrowed device buffers to the lazy launch operation.
+    _borrows: PhantomData<&'a mut ()>,
+}
+
 /// # Safety
 ///
-/// The `*mut c_void` pointers in `args` are heap-allocated boxes that do not
-/// alias mutable state. The `Arc<CudaFunction>` is `Send + Sync`.
+/// The argument pointers refer to heap allocations owned by the launch.
+/// Non-`Copy` values enter that storage only through `KernelArgument: Send`;
+/// copied scalar values have no destructor. The runnable type exposes none of
+/// those erased values to safe Rust. The `Arc<CudaFunction>` is `Send + Sync`,
+/// and `_borrows` preserves source lifetimes captured while building.
 unsafe impl<'a> Send for AsyncKernelLaunch<'a> {}
 
 #[derive(Debug, Default)]
@@ -71,7 +127,7 @@ impl Drop for KernelArgStorage {
 }
 
 impl KernelArgStorage {
-    fn push_boxed_arg<T>(&mut self, arg: Box<T>) {
+    fn push_send_arg<T: Send>(&mut self, arg: Box<T>) {
         unsafe fn drop_box<T>(arg: *mut c_void) {
             let _ = unsafe { Box::from_raw(arg as *mut T) };
         }
@@ -81,7 +137,12 @@ impl KernelArgStorage {
     }
 
     fn push_scalar_arg<T: Copy>(&mut self, arg: T) {
-        self.push_boxed_arg(Box::new(arg));
+        unsafe fn drop_copy_box<T: Copy>(arg: *mut c_void) {
+            let _ = unsafe { Box::from_raw(arg as *mut T) };
+        }
+
+        self.ptrs.push(Box::into_raw(Box::new(arg)) as *mut c_void);
+        self.drops.push(drop_copy_box::<T>);
     }
 
     fn as_mut_slice(&mut self) -> &mut [*mut c_void] {
@@ -89,13 +150,13 @@ impl KernelArgStorage {
     }
 }
 
-impl<'a> AsyncKernelLaunch<'a> {
-    /// Creates a launcher for `func` with no arguments and no launch config.
+impl<'a> AsyncKernelLaunchBuilder<'a> {
+    /// Creates an inert builder for `func` with no arguments or launch
+    /// attributes.
     pub fn new(func: Arc<CudaFunction>) -> Self {
         Self {
             func,
             args: KernelArgStorage::default(),
-            cfg: None,
             cluster_dim: None,
             cooperative: false,
             _borrows: PhantomData,
@@ -120,6 +181,18 @@ impl<'a> AsyncKernelLaunch<'a> {
     ///
     /// The allocated storage remains alive until launch submission finishes or
     /// the builder is dropped without launching.
+    ///
+    /// Values with thread-affine ownership cannot be hidden in the erased
+    /// storage that will later become a `Send` operation:
+    ///
+    /// ```compile_fail,E0277
+    /// use cuda_async::launch::AsyncKernelLaunchBuilder;
+    /// use std::rc::Rc;
+    ///
+    /// fn reject_rc(mut builder: AsyncKernelLaunchBuilder<'static>) {
+    ///     builder.push_arg(Box::new(Rc::new(1_u32)));
+    /// }
+    /// ```
     #[inline(always)]
     pub fn push_arg<T: KernelArgument>(&mut self, arg: T) -> &mut Self {
         arg.push_arg(self);
@@ -142,12 +215,6 @@ impl<'a> AsyncKernelLaunch<'a> {
         self
     }
 
-    /// Sets the grid/block dimensions and shared memory size for the launch.
-    pub fn set_launch_config(&mut self, cfg: LaunchConfig) -> &mut Self {
-        self.cfg = Some(cfg);
-        self
-    }
-
     /// Sets thread-block cluster dimensions for a cluster launch.
     pub fn set_cluster_dim(&mut self, cluster_dim: (u32, u32, u32)) -> &mut Self {
         self.cluster_dim = Some(cluster_dim);
@@ -166,6 +233,55 @@ impl<'a> AsyncKernelLaunch<'a> {
         self
     }
 
+    /// Accepts an unverified raw launch configuration and seals this builder
+    /// into an immutable, schedulable operation.
+    ///
+    /// Prefer the generated typed module APIs for application code. They check
+    /// a kernel's declared launch contract before constructing the runnable
+    /// operation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must prove all facts that a typed prepared launch normally
+    /// checks:
+    ///
+    /// - `cfg` must match the kernel's indexing dimensionality, launch bounds,
+    ///   block shape, and dynamic shared-memory requirements;
+    /// - the cluster and cooperative attributes must be legal for the kernel;
+    /// - the function signature must exactly match the arguments, in order,
+    ///   type, size, and alignment;
+    /// - referenced device allocations must remain valid for the complete GPU
+    ///   operation and satisfy Rust's aliasing requirements; and
+    /// - the scheduling policy must select a stream from the CUDA context that
+    ///   owns `func`.
+    ///
+    /// Violating these requirements can cause memory corruption, data races,
+    /// or CUDA driver errors.
+    ///
+    /// ```compile_fail,E0133
+    /// use cuda_async::launch::AsyncKernelLaunchBuilder;
+    /// use cuda_core::LaunchConfig;
+    ///
+    /// fn raw_finalize_requires_unsafe(
+    ///     builder: AsyncKernelLaunchBuilder<'static>,
+    ///     config: LaunchConfig,
+    /// ) {
+    ///     let _ = builder.finalize_unchecked(config);
+    /// }
+    /// ```
+    pub unsafe fn finalize_unchecked(self, cfg: LaunchConfig) -> AsyncKernelLaunch<'a> {
+        AsyncKernelLaunch {
+            func: self.func,
+            args: self.args,
+            cfg,
+            cluster_dim: self.cluster_dim,
+            cooperative: self.cooperative,
+            _borrows: self._borrows,
+        }
+    }
+}
+
+impl<'a> AsyncKernelLaunch<'a> {
     /// Submits the kernel to `stream` via `cuLaunchKernel`, or via
     /// `cuLaunchKernelEx` when cluster dimensions or a cooperative launch
     /// were requested.
@@ -182,12 +298,10 @@ impl<'a> AsyncKernelLaunch<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`DeviceError::Launch`] if no launch config was set, or
-    /// [`DeviceError::Driver`] if context binding or launch submission fails.
+    /// Returns [`DeviceError::Driver`] if context binding or launch submission
+    /// fails.
     unsafe fn launch(mut self, stream: &Arc<CudaStream>) -> Result<(), DeviceError> {
-        let cfg = self
-            .cfg
-            .ok_or_else(|| DeviceError::Launch("Launch config not set.".to_string()))?;
+        let cfg = self.cfg;
         let result = match (self.cluster_dim, self.cooperative) {
             (Some(cluster_dim), true) => unsafe {
                 cuda_core::launch_kernel_ex_cooperative_on_stream(
@@ -263,18 +377,18 @@ impl<R: Send> OwnedAsyncKernelLaunch<R> {
 /// Implemented for all common scalar primitives (`u8`–`u64`, `i8`–`i64`,
 /// `f32`, `f64`, `usize`, `isize`, `bool`) so callers can write
 /// `.push_arg(42u32)` without manual `Box::new`.
-pub trait KernelArgument {
+pub trait KernelArgument: Send {
     /// Heap-allocates `self` and appends the pointer to `launcher.args`.
-    fn push_arg(self, launcher: &mut AsyncKernelLaunch<'_>);
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>);
 }
 
 /// Passes the box's raw pointer directly as a kernel argument.
 ///
 /// This is the low-level escape hatch. Prefer passing scalars directly -- they
 /// are auto-boxed via the blanket scalar impls.
-impl<T: 'static> KernelArgument for Box<T> {
-    fn push_arg(self, launcher: &mut AsyncKernelLaunch<'_>) {
-        launcher.args.push_boxed_arg(self);
+impl<T: Send + 'static> KernelArgument for Box<T> {
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
+        launcher.args.push_send_arg(self);
     }
 }
 
@@ -283,7 +397,7 @@ macro_rules! impl_scalar_kernel_arg {
         $(
             impl KernelArgument for $t {
                 #[inline(always)]
-                fn push_arg(self, launcher: &mut AsyncKernelLaunch<'_>) {
+                fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
                     launcher.push_scalar_arg(self);
                 }
             }
@@ -310,7 +424,7 @@ impl_scalar_kernel_arg!(
 )]
 pub trait KernelArguments {
     /// Pushes every element into `launcher` in order.
-    fn push_args(self, launcher: &mut AsyncKernelLaunch<'_>);
+    fn push_args(self, launcher: &mut AsyncKernelLaunchBuilder<'_>);
 }
 
 macro_rules! impl_kernel_args_tuple {
@@ -318,14 +432,14 @@ macro_rules! impl_kernel_args_tuple {
     () => {
         impl KernelArguments for () {
             #[inline(always)]
-            fn push_args(self, _launcher: &mut AsyncKernelLaunch<'_>) {}
+            fn push_args(self, _launcher: &mut AsyncKernelLaunchBuilder<'_>) {}
         }
     };
     // Recursive case: (A, B, C, ...) where each element is a KernelArgument
     ($($idx:tt : $T:ident),+) => {
         impl<$($T: KernelArgument),+> KernelArguments for ($($T,)+) {
             #[inline(always)]
-            fn push_args(self, launcher: &mut AsyncKernelLaunch<'_>) {
+            fn push_args(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
                 $(launcher.push_arg(self.$idx);)+
             }
         }
@@ -412,8 +526,7 @@ impl<R: Send + 'static> IntoFuture for OwnedAsyncKernelLaunch<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
-    use std::rc::Rc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, PartialEq)]
@@ -438,21 +551,21 @@ mod tests {
 
     #[test]
     fn arg_storage_drops_values_with_their_original_type() {
-        struct DropCounter(Rc<Cell<usize>>);
+        struct DropCounter(Arc<AtomicUsize>);
 
         impl Drop for DropCounter {
             fn drop(&mut self) {
-                self.0.set(self.0.get() + 1);
+                self.0.fetch_add(1, Ordering::Relaxed);
             }
         }
 
-        let drops = Rc::new(Cell::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
         let mut storage = KernelArgStorage::default();
 
-        storage.push_boxed_arg(Box::new(DropCounter(Rc::clone(&drops))));
-        assert_eq!(drops.get(), 0);
+        storage.push_send_arg(Box::new(DropCounter(Arc::clone(&drops))));
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
 
         drop(storage);
-        assert_eq!(drops.get(), 1);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/cuda-core/README.md
+++ b/crates/cuda-core/README.md
@@ -24,7 +24,7 @@ This crate turns raw CUDA handles into Rust types with automatic cleanup on drop
 - **Memory**: Async (`malloc_async`, `free_async`, `memcpy_htod_async`, ...) and sync (`malloc_sync`, `free_sync`) device memory operations.
 - **Device buffers**: `DeviceBuffer<T>` owns device memory and provides host-device transfer helpers for `T: DeviceCopy`. Safe borrowed host-to-device copies synchronize before returning; unchecked async HtoD helpers are `unsafe`.
 - **Pinned host memory**: `PinnedHostBuffer<T>` allocates page-locked host memory for faster transfers. The async transfer helpers (`DeviceBuffer::from_pinned_host`, `copy_from_pinned_host_async`, `copy_to_pinned_host_async`) are `unsafe` because they only enqueue the copy and the caller must keep the pinned buffer alive until `stream.synchronize()`. Use `copy_to_pinned_host` for a blocking DtoH helper that syncs internally.
-- **Launch**: `launch_kernel(func, grid, block, smem, stream, params)` enqueues a kernel on a stream. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
+- **Launch**: the `unsafe` `launch_kernel(func, grid, block, smem, stream, params)` family enqueues raw launches. The caller must prove both the argument ABI and the kernel's geometry/resource assumptions. `launch_kernel_ex(...)` adds cluster dimensions (Hopper+); `launch_kernel_cooperative(...)` enables `Grid::sync()` for grid-wide barriers.
 - **Events**: `ctx.new_event(flags)` for synchronization points and GPU-side timing via `event.elapsed_ms(end)`.
 
 ## Usage

--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -17,6 +17,7 @@
 //! callers do not need to manage the context stack manually.
 
 use crate::error::{DriverError, IntoResult};
+use crate::launch::DeviceLaunchLimits;
 use crate::stream::CudaStream;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
@@ -88,6 +89,20 @@ impl PartialEq for CudaContext {
 impl Eq for CudaContext {}
 
 impl CudaContext {
+    fn device_attribute(
+        &self,
+        attribute: cuda_bindings::CUdevice_attribute,
+    ) -> Result<u32, DriverError> {
+        self.bind_to_thread()?;
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuDeviceGetAttribute(value.as_mut_ptr(), attribute, self.cu_device)
+                .result()?;
+            u32::try_from(value.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
     /// Creates a new context for the device at `ordinal`.
     ///
     /// Calls [`cuInit`](crate::init), obtains the device handle, retains the
@@ -255,6 +270,78 @@ impl CudaContext {
             .result()?;
             Ok((major.assume_init(), minor.assume_init()))
         }
+    }
+
+    /// Queries dimension, thread-count, and portable shared-memory launch
+    /// limits for this device.
+    ///
+    /// Cooperative and cluster capabilities are deliberately not queried
+    /// here. Typed launch preparation asks for those newer attributes only
+    /// when the kernel contract requires the corresponding launch mode.
+    pub fn launch_limits(&self) -> Result<DeviceLaunchLimits, DriverError> {
+        Ok(DeviceLaunchLimits {
+            max_threads_per_block: self.device_attribute(
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+            )?,
+            max_block_dim: (
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z,
+                )?,
+            ),
+            max_grid_dim: (
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z,
+                )?,
+            ),
+            max_shared_memory_per_block: self.device_attribute(
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+            )?,
+        })
+    }
+
+    /// Queries the non-portable opt-in shared-memory limit per block.
+    ///
+    /// Typed launch preparation calls this only when static plus dynamic
+    /// shared memory exceeds the portable limit.
+    pub fn max_opt_in_shared_memory_per_block(&self) -> Result<u32, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        )
+    }
+
+    /// Returns whether this device supports cooperative kernel launches.
+    pub fn supports_cooperative_launch(&self) -> Result<bool, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH,
+        )
+        .map(|value| value != 0)
+    }
+
+    /// Returns whether this device supports thread-block cluster launches.
+    pub fn supports_cluster_launch(&self) -> Result<bool, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLUSTER_LAUNCH,
+        )
+        .map(|value| value != 0)
+    }
+
+    /// Returns the number of streaming multiprocessors on this device.
+    pub fn multiprocessor_count(&self) -> Result<u32, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+        )
     }
 
     /// Atomically reads and clears the sticky error state.

--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -5,16 +5,23 @@
 
 //! Kernel launch configuration.
 //!
-//! [`LaunchConfig`] bundles the grid dimensions, block dimensions, and dynamic
-//! shared memory size required by [`launch_kernel`](crate::launch_kernel). Use
-//! [`LaunchConfig::for_num_elems`] as a quick 1-D launch helper.
+//! [`LaunchConfig`] bundles raw grid dimensions, block dimensions, and dynamic
+//! shared memory size. Constructing one is harmless, but submitting it without
+//! proving that it matches a kernel is unsafe. Use a rank-preserving config and
+//! [`PreparedLaunch`] for the checked path.
+
+use crate::{CudaFunction, CudaStream, DriverError};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::marker::PhantomData;
 
 /// Grid and block dimensions plus dynamic shared memory size for a kernel
 /// launch.
 ///
-/// Each dimension tuple is `(x, y, z)`. Pass this to
-/// [`launch_kernel`](crate::launch_kernel) or destructure it manually for
-/// custom launch wrappers.
+/// Each dimension tuple is `(x, y, z)`. This is inert configuration data: it
+/// does not know which kernel will consume it and therefore cannot prove the
+/// kernel's indexing, resource, or synchronization assumptions. Passing it to
+/// a raw launch is an unsafe operation.
 #[derive(Clone, Copy, Debug)]
 pub struct LaunchConfig {
     /// Grid dimensions `(x, y, z)` in blocks.
@@ -32,7 +39,8 @@ impl LaunchConfig {
     /// ceiling division. No dynamic shared memory is requested.
     ///
     /// Suitable for simple element-wise kernels where thread index maps
-    /// directly to element index.
+    /// directly to element index. The helper does not inspect a kernel, so it
+    /// does not by itself make a raw launch safe.
     pub fn for_num_elems(n: u32) -> Self {
         const DEFAULT_BLOCK_SIZE: u32 = 256;
         let grid_x = n.div_ceil(DEFAULT_BLOCK_SIZE);
@@ -41,5 +49,1661 @@ impl LaunchConfig {
             block_dim: (DEFAULT_BLOCK_SIZE, 1, 1),
             shared_mem_bytes: 0,
         }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A rank-preserving launch configuration accepted by a typed kernel contract.
+///
+/// This trait is sealed. Use [`LaunchConfig1D`], [`LaunchConfig2D`], or
+/// [`LaunchConfig3D`]; downstream crates cannot provide a configuration that
+/// bypasses their fixed trailing dimensions.
+pub trait KernelLaunchConfig: sealed::Sealed + Copy {
+    #[doc(hidden)]
+    fn __raw(self) -> LaunchConfig;
+}
+
+/// A one-dimensional launch configuration.
+///
+/// The hidden `y` and `z` grid and block dimensions are always `1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig1D {
+    grid_x: u32,
+    block_x: u32,
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig1D {
+    /// Creates a one-dimensional launch configuration.
+    ///
+    /// Zero dimensions are reported when the configuration is prepared for a
+    /// concrete kernel, where the error can include that kernel's name.
+    pub const fn new(grid_x: u32, block_x: u32, shared_mem_bytes: u32) -> Self {
+        Self {
+            grid_x,
+            block_x,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig1D {}
+
+impl KernelLaunchConfig for LaunchConfig1D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: (self.grid_x, 1, 1),
+            block_dim: (self.block_x, 1, 1),
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// A two-dimensional launch configuration.
+///
+/// The hidden `z` grid and block dimensions are always `1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig2D {
+    grid: (u32, u32),
+    block: (u32, u32),
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig2D {
+    /// Creates a two-dimensional launch configuration.
+    pub const fn new(grid: (u32, u32), block: (u32, u32), shared_mem_bytes: u32) -> Self {
+        Self {
+            grid,
+            block,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig2D {}
+
+impl KernelLaunchConfig for LaunchConfig2D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: (self.grid.0, self.grid.1, 1),
+            block_dim: (self.block.0, self.block.1, 1),
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// A three-dimensional launch configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig3D {
+    grid: (u32, u32, u32),
+    block: (u32, u32, u32),
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig3D {
+    /// Creates a three-dimensional launch configuration.
+    pub const fn new(grid: (u32, u32, u32), block: (u32, u32, u32), shared_mem_bytes: u32) -> Self {
+        Self {
+            grid,
+            block,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig3D {}
+
+impl KernelLaunchConfig for LaunchConfig3D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: self.grid,
+            block_dim: self.block,
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// The block shapes accepted by a kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockRequirement {
+    /// The launch must use exactly these `(x, y, z)` block dimensions.
+    Exact((u32, u32, u32)),
+    /// The block may contain at most this many threads in total.
+    ///
+    /// This matches CUDA `__launch_bounds__` / PTX `.maxntid` semantics: the
+    /// product `block.x * block.y * block.z` is bounded, not each axis.
+    /// `MaxThreads(256)` therefore accepts both `(256, 1, 1)` and
+    /// `(16, 16, 1)`.
+    MaxThreads(u32),
+}
+
+/// The dynamic shared-memory sizes accepted by a kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DynamicSharedMemoryRequirement {
+    /// The launch must allocate exactly `bytes` bytes.
+    Exact {
+        /// Required bytes per block.
+        bytes: u32,
+        /// Minimum alignment assumed by the generated device code.
+        min_alignment: u32,
+    },
+    /// The launch may allocate any size in the inclusive range.
+    ///
+    /// Preparation requires the live function/device to support `max_bytes`,
+    /// even when one prepared configuration chooses fewer bytes. This proves
+    /// the function's dynamic-memory capacity for the full interval and lets
+    /// concurrent preparations install one monotonic, race-safe maximum.
+    /// Geometry-dependent cluster or cooperative occupancy is still checked
+    /// for each concrete prepared configuration.
+    Range {
+        /// Smallest valid allocation in bytes.
+        min_bytes: u32,
+        /// Largest valid allocation in bytes.
+        max_bytes: u32,
+        /// Minimum alignment assumed by the generated device code.
+        min_alignment: u32,
+    },
+}
+
+/// An immutable description of a kernel's launch-time assumptions.
+///
+/// Macro-generated contract marker types expose one of these through
+/// [`KernelLaunchContract::SPEC`]. The name is retained in every validation
+/// error so failures point at the kernel whose assumptions were violated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchContractSpec {
+    kernel_name: &'static str,
+    block: BlockRequirement,
+    dynamic_shared_memory: DynamicSharedMemoryRequirement,
+    cluster: Option<(u32, u32, u32)>,
+    cooperative: bool,
+    min_compute_capability: Option<(u32, u32)>,
+}
+
+impl LaunchContractSpec {
+    /// Creates a contract without cluster, cooperative, or architecture
+    /// requirements.
+    pub const fn new(
+        kernel_name: &'static str,
+        block: BlockRequirement,
+        dynamic_shared_memory: DynamicSharedMemoryRequirement,
+    ) -> Self {
+        Self {
+            kernel_name,
+            block,
+            dynamic_shared_memory,
+            cluster: None,
+            cooperative: false,
+            min_compute_capability: None,
+        }
+    }
+
+    /// Requires fixed thread-block cluster dimensions.
+    #[must_use]
+    pub const fn with_cluster(mut self, cluster: (u32, u32, u32)) -> Self {
+        self.cluster = Some(cluster);
+        self
+    }
+
+    /// Requires a cooperative launch.
+    #[must_use]
+    pub const fn with_cooperative(mut self) -> Self {
+        self.cooperative = true;
+        self
+    }
+
+    /// Requires at least the supplied CUDA compute capability.
+    #[must_use]
+    pub const fn with_min_compute_capability(mut self, major: u32, minor: u32) -> Self {
+        self.min_compute_capability = Some((major, minor));
+        self
+    }
+
+    /// Returns the diagnostic kernel name.
+    pub const fn kernel_name(&self) -> &'static str {
+        self.kernel_name
+    }
+
+    /// Returns the block-shape requirement.
+    pub const fn block(&self) -> BlockRequirement {
+        self.block
+    }
+
+    /// Returns the dynamic shared-memory requirement.
+    pub const fn dynamic_shared_memory(&self) -> DynamicSharedMemoryRequirement {
+        self.dynamic_shared_memory
+    }
+
+    /// Returns the required cluster dimensions, if any.
+    pub const fn cluster(&self) -> Option<(u32, u32, u32)> {
+        self.cluster
+    }
+
+    /// Returns whether the kernel requires a cooperative launch.
+    pub const fn cooperative(&self) -> bool {
+        self.cooperative
+    }
+
+    /// Returns the minimum compute capability, if one was declared.
+    pub const fn min_compute_capability(&self) -> Option<(u32, u32)> {
+        self.min_compute_capability
+    }
+}
+
+/// A macro-generated kernel marker implements this trait to bind a launch
+/// rank to one immutable contract.
+pub trait KernelLaunchContract {
+    /// Rank-preserving host launch configuration for this kernel.
+    type Config: KernelLaunchConfig;
+
+    /// Compile-time launch assumptions emitted by the kernel macro.
+    const SPEC: LaunchContractSpec;
+}
+
+/// Device launch limits that apply independently of a particular kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeviceLaunchLimits {
+    pub(crate) max_threads_per_block: u32,
+    pub(crate) max_block_dim: (u32, u32, u32),
+    pub(crate) max_grid_dim: (u32, u32, u32),
+    pub(crate) max_shared_memory_per_block: u32,
+}
+
+impl DeviceLaunchLimits {
+    /// Maximum threads in one block.
+    pub const fn max_threads_per_block(&self) -> u32 {
+        self.max_threads_per_block
+    }
+
+    /// Maximum block dimensions `(x, y, z)`.
+    pub const fn max_block_dim(&self) -> (u32, u32, u32) {
+        self.max_block_dim
+    }
+
+    /// Maximum grid dimensions `(x, y, z)`.
+    pub const fn max_grid_dim(&self) -> (u32, u32, u32) {
+        self.max_grid_dim
+    }
+
+    /// Portable shared-memory limit per block, including static and dynamic
+    /// shared memory.
+    pub const fn max_shared_memory_per_block(&self) -> u32 {
+        self.max_shared_memory_per_block
+    }
+}
+
+/// Which launch dimension is named by a validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchDimension {
+    /// Grid dimensions, measured in blocks.
+    Grid,
+    /// Block dimensions, measured in threads.
+    Block,
+    /// Thread-block cluster dimensions, measured in blocks.
+    Cluster,
+}
+
+/// Axis named by a dimension validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchAxis {
+    /// X axis.
+    X,
+    /// Y axis.
+    Y,
+    /// Z axis.
+    Z,
+}
+
+/// Why preparation of a typed kernel launch failed.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LaunchContractError {
+    /// The contract omitted a useful kernel name.
+    EmptyKernelName,
+    /// A grid, block, or cluster dimension was zero.
+    ZeroDimension {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Dimension group containing the zero.
+        dimension: LaunchDimension,
+        /// Axis containing the zero.
+        axis: LaunchAxis,
+    },
+    /// Multiplying a three-dimensional shape exceeded the representable range.
+    DimensionProductOverflow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Shape whose product overflowed.
+        dimension: LaunchDimension,
+    },
+    /// A shared-memory alignment was not a nonzero power of two.
+    InvalidSharedMemoryAlignment {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Invalid alignment.
+        alignment: u32,
+    },
+    /// A shared-memory range had its endpoints reversed.
+    InvalidSharedMemoryRange {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Inclusive lower bound.
+        min_bytes: u32,
+        /// Inclusive upper bound.
+        max_bytes: u32,
+    },
+    /// The launch block did not equal the contract's exact block.
+    BlockShapeMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Required block dimensions.
+        required: (u32, u32, u32),
+        /// Requested block dimensions.
+        actual: (u32, u32, u32),
+    },
+    /// The block contained more threads than the contract permits.
+    BlockThreadsExceedContract {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Contract maximum threads per block.
+        max: u32,
+    },
+    /// Dynamic shared memory did not equal the contract's exact size.
+    DynamicSharedMemoryExactMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Required byte count.
+        required: u32,
+        /// Requested byte count.
+        actual: u32,
+    },
+    /// Dynamic shared memory fell outside the contract's inclusive range.
+    DynamicSharedMemoryOutsideRange {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Inclusive lower bound.
+        min: u32,
+        /// Inclusive upper bound.
+        max: u32,
+        /// Requested byte count.
+        actual: u32,
+    },
+    /// A cluster axis did not evenly divide the corresponding grid axis.
+    ClusterDoesNotDivideGrid {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Axis that is not divisible.
+        axis: LaunchAxis,
+        /// Requested grid axis size.
+        grid: u32,
+        /// Required cluster axis size.
+        cluster: u32,
+    },
+    /// A launch dimension exceeded a live device limit.
+    DeviceDimensionExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Grid or block dimensions.
+        dimension: LaunchDimension,
+        /// Axis that exceeded its limit.
+        axis: LaunchAxis,
+        /// Requested size.
+        actual: u32,
+        /// Device maximum.
+        max: u32,
+    },
+    /// The block contained more threads than the device permits.
+    DeviceThreadsPerBlockExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Device maximum.
+        max: u32,
+    },
+    /// The block contained more threads than this function permits.
+    FunctionThreadsPerBlockExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Function maximum.
+        max: u32,
+    },
+    /// Static plus dynamic shared-memory arithmetic overflowed.
+    SharedMemoryTotalOverflow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Function's static allocation.
+        static_bytes: u32,
+        /// Requested dynamic allocation.
+        dynamic_bytes: u32,
+    },
+    /// Static plus dynamic shared memory exceeded the device limit.
+    DeviceSharedMemoryExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested static plus dynamic bytes.
+        total: u64,
+        /// Device maximum.
+        max: u32,
+        /// Whether `max` is the device's opt-in limit.
+        opt_in: bool,
+    },
+    /// The device compute capability is below the contract minimum.
+    ComputeCapabilityTooLow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Contract minimum.
+        required: (u32, u32),
+        /// Live device capability.
+        actual: (u32, u32),
+    },
+    /// The live device does not support cooperative launch.
+    CooperativeLaunchUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+    },
+    /// The live device does not support thread-block clusters.
+    ClusterLaunchUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+    },
+    /// The requested cluster contains more blocks than this function and
+    /// launch shape support on the live device.
+    ClusterSizeExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested blocks per cluster.
+        blocks: u64,
+        /// Maximum blocks per cluster reported by occupancy.
+        max: u32,
+    },
+    /// The contract disagrees with cluster dimensions compiled into the
+    /// function.
+    FunctionClusterShapeMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Cluster dimensions declared by the host contract.
+        declared: (u32, u32, u32),
+        /// Cluster dimensions required by the compiled function.
+        required: (u32, u32, u32),
+    },
+    /// The host contract declares a fixed cluster but the compiled function
+    /// does not contain matching required-cluster metadata.
+    RequiredClusterDimensionsMissing {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Cluster dimensions declared by the host contract.
+        declared: (u32, u32, u32),
+    },
+    /// CUDA rejected the concrete cluster shape for this function and launch
+    /// configuration.
+    ClusterShapeUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested cluster dimensions.
+        cluster: (u32, u32, u32),
+    },
+    /// CUDA reported that no cluster of the requested shape can be resident.
+    ClusterHasNoResidency {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested cluster dimensions.
+        cluster: (u32, u32, u32),
+    },
+    /// Safe cooperative-residency validation for clustered launches is not
+    /// available through the non-cluster occupancy query.
+    ClusteredCooperativeValidationUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+    },
+    /// A cooperative grid cannot be fully resident on the device.
+    CooperativeGridTooLarge {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested number of blocks.
+        blocks: u64,
+        /// Maximum resident blocks for this function and launch shape.
+        resident_capacity: u64,
+    },
+    /// A stream belongs to a different CUDA context from the prepared function.
+    ContextMismatch {
+        /// Kernel being launched.
+        kernel: &'static str,
+        /// Function device ordinal.
+        function_device: usize,
+        /// Stream device ordinal.
+        stream_device: usize,
+    },
+    /// A CUDA driver query or one-time function configuration failed.
+    Driver(DriverError),
+}
+
+impl Display for LaunchContractError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyKernelName => write!(f, "kernel launch contract has an empty name"),
+            Self::ZeroDimension {
+                kernel,
+                dimension,
+                axis,
+            } => write!(f, "{kernel}: {dimension:?}.{axis:?} must be nonzero"),
+            Self::DimensionProductOverflow { kernel, dimension } => {
+                write!(f, "{kernel}: {dimension:?} dimension product overflowed")
+            }
+            Self::InvalidSharedMemoryAlignment { kernel, alignment } => write!(
+                f,
+                "{kernel}: dynamic shared-memory alignment {alignment} is not a nonzero power of two"
+            ),
+            Self::InvalidSharedMemoryRange {
+                kernel,
+                min_bytes,
+                max_bytes,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared-memory range {min_bytes}..={max_bytes} is invalid"
+            ),
+            Self::BlockShapeMismatch {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: block {actual:?} does not match required block {required:?}"
+            ),
+            Self::BlockThreadsExceedContract {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; contract maximum is {max}"
+            ),
+            Self::DynamicSharedMemoryExactMismatch {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared memory is {actual} bytes; contract requires {required}"
+            ),
+            Self::DynamicSharedMemoryOutsideRange {
+                kernel,
+                min,
+                max,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared memory is {actual} bytes; contract permits {min}..={max}"
+            ),
+            Self::ClusterDoesNotDivideGrid {
+                kernel,
+                axis,
+                grid,
+                cluster,
+            } => write!(
+                f,
+                "{kernel}: cluster {axis:?} size {cluster} does not divide grid size {grid}"
+            ),
+            Self::DeviceDimensionExceeded {
+                kernel,
+                dimension,
+                axis,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: {dimension:?}.{axis:?} size {actual} exceeds device maximum {max}"
+            ),
+            Self::DeviceThreadsPerBlockExceeded {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; device maximum is {max}"
+            ),
+            Self::FunctionThreadsPerBlockExceeded {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; function maximum is {max}"
+            ),
+            Self::SharedMemoryTotalOverflow {
+                kernel,
+                static_bytes,
+                dynamic_bytes,
+            } => write!(
+                f,
+                "{kernel}: {static_bytes} static + {dynamic_bytes} dynamic shared-memory bytes overflowed"
+            ),
+            Self::DeviceSharedMemoryExceeded {
+                kernel,
+                total,
+                max,
+                opt_in,
+            } => write!(
+                f,
+                "{kernel}: {total} shared-memory bytes exceed the device {} limit {max}",
+                if *opt_in { "opt-in" } else { "portable" }
+            ),
+            Self::ComputeCapabilityTooLow {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: compute capability {}.{} is below required {}.{}",
+                actual.0, actual.1, required.0, required.1
+            ),
+            Self::CooperativeLaunchUnsupported { kernel } => {
+                write!(f, "{kernel}: device does not support cooperative launch")
+            }
+            Self::ClusterLaunchUnsupported { kernel } => {
+                write!(f, "{kernel}: device does not support cluster launch")
+            }
+            Self::ClusterSizeExceeded {
+                kernel,
+                blocks,
+                max,
+            } => write!(
+                f,
+                "{kernel}: cluster has {blocks} blocks; live maximum is {max}"
+            ),
+            Self::FunctionClusterShapeMismatch {
+                kernel,
+                declared,
+                required,
+            } => write!(
+                f,
+                "{kernel}: declared cluster {declared:?} does not match function-required cluster {required:?}"
+            ),
+            Self::RequiredClusterDimensionsMissing { kernel, declared } => write!(
+                f,
+                "{kernel}: declared cluster {declared:?} is missing from the compiled function metadata"
+            ),
+            Self::ClusterShapeUnsupported { kernel, cluster } => write!(
+                f,
+                "{kernel}: cluster shape {cluster:?} is unsupported for this launch"
+            ),
+            Self::ClusterHasNoResidency { kernel, cluster } => write!(
+                f,
+                "{kernel}: no cluster with shape {cluster:?} can be resident"
+            ),
+            Self::ClusteredCooperativeValidationUnsupported { kernel } => write!(
+                f,
+                "{kernel}: clustered cooperative residency cannot be validated by this API"
+            ),
+            Self::CooperativeGridTooLarge {
+                kernel,
+                blocks,
+                resident_capacity,
+            } => write!(
+                f,
+                "{kernel}: cooperative grid has {blocks} blocks but only {resident_capacity} can be resident"
+            ),
+            Self::ContextMismatch {
+                kernel,
+                function_device,
+                stream_device,
+            } => write!(
+                f,
+                "{kernel}: function is on device {function_device}, stream is on device {stream_device}"
+            ),
+            Self::Driver(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl Error for LaunchContractError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Driver(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<DriverError> for LaunchContractError {
+    fn from(value: DriverError) -> Self {
+        Self::Driver(value)
+    }
+}
+
+/// A kernel function and launch configuration whose contract has been checked.
+///
+/// Preparation performs all device/function resource queries. Reusing this
+/// value performs no contract query; it only compares the stream's context
+/// handle before the normal launch path binds that context.
+pub struct PreparedLaunch<C: KernelLaunchContract> {
+    function: CudaFunction,
+    config: LaunchConfig,
+    _contract: PhantomData<fn(C) -> C>,
+}
+
+impl<C: KernelLaunchContract> Clone for PreparedLaunch<C> {
+    fn clone(&self) -> Self {
+        Self {
+            function: self.function.clone(),
+            config: self.config,
+            _contract: PhantomData,
+        }
+    }
+}
+
+impl<C: KernelLaunchContract> PreparedLaunch<C> {
+    /// Validates and prepares one generated kernel launch.
+    ///
+    /// This entry point is public only so `#[cuda_module]` expansions in
+    /// downstream crates can call it. Applications should use the generated
+    /// module constructor.
+    ///
+    /// # Safety
+    ///
+    /// `C::SPEC` must truthfully describe the compiled device function,
+    /// including its rank, fixed block assumptions, shared-memory layout, and
+    /// launch mode. cuda-oxide's macros generate that marker and uphold this
+    /// relationship.
+    #[doc(hidden)]
+    pub unsafe fn __prepare(
+        function: CudaFunction,
+        config: C::Config,
+    ) -> Result<Self, LaunchContractError> {
+        let raw = config.__raw();
+        validate_static(C::SPEC, raw)?;
+
+        let context = function.context();
+        let limits = context.launch_limits()?;
+        let function_max_threads = function.max_threads_per_block()?;
+        let static_shared = function.static_shared_memory_bytes()?;
+        let function_max_dynamic = function.max_dynamic_shared_memory_bytes()?;
+
+        validate_live_shape(C::SPEC, raw, limits, function_max_threads)?;
+
+        // Configure the immutable contract maximum, not this particular
+        // launch's chosen size. Concurrent preparations of two range values
+        // therefore write the same function attribute and cannot lower the
+        // maximum underneath an already prepared launch.
+        let contract_dynamic_max = dynamic_shared_memory_max(C::SPEC.dynamic_shared_memory);
+        let total_shared =
+            shared_memory_total(C::SPEC.kernel_name, static_shared, contract_dynamic_max)?;
+        if validate_shared_memory_limit(
+            C::SPEC.kernel_name,
+            total_shared,
+            limits.max_shared_memory_per_block,
+            false,
+        )
+        .is_err()
+        {
+            let opt_in_max = context.max_opt_in_shared_memory_per_block()?;
+            validate_shared_memory_limit(C::SPEC.kernel_name, total_shared, opt_in_max, true)?;
+        }
+
+        if let Some(required) = C::SPEC.min_compute_capability {
+            let (major, minor) = context.compute_capability()?;
+            let actual = (
+                u32::try_from(major).map_err(|_| {
+                    DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE)
+                })?,
+                u32::try_from(minor).map_err(|_| {
+                    DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE)
+                })?,
+            );
+            validate_compute_capability(C::SPEC.kernel_name, required, actual)?;
+        }
+
+        if let Some(cluster) = C::SPEC.cluster {
+            validate_cluster_support(C::SPEC.kernel_name, context.supports_cluster_launch()?)?;
+            validate_required_cluster(
+                C::SPEC.kernel_name,
+                cluster,
+                function.required_cluster_dimensions()?,
+            )?;
+        }
+
+        if C::SPEC.cooperative {
+            validate_cooperative_support(
+                C::SPEC.kernel_name,
+                context.supports_cooperative_launch()?,
+            )?;
+            if C::SPEC.cluster.is_some() {
+                return Err(
+                    LaunchContractError::ClusteredCooperativeValidationUnsupported {
+                        kernel: C::SPEC.kernel_name,
+                    },
+                );
+            }
+        }
+
+        // Perform the only persistent function mutation after all checks that
+        // do not themselves depend on the opted-in maximum. Cluster occupancy
+        // is checked next and may leave this monotonic increase in place when
+        // the concrete cluster shape is rejected.
+        if contract_dynamic_max > function_max_dynamic {
+            function.set_max_dynamic_shared_memory_bytes(contract_dynamic_max)?;
+        }
+
+        if let Some(cluster) = C::SPEC.cluster {
+            let max_cluster_size = function.max_potential_cluster_size(
+                raw.grid_dim,
+                raw.block_dim,
+                raw.shared_mem_bytes,
+            )?;
+            let cluster_blocks =
+                shape_product(C::SPEC.kernel_name, LaunchDimension::Cluster, cluster)?;
+            validate_cluster_size(C::SPEC.kernel_name, cluster_blocks, max_cluster_size)?;
+
+            let active_clusters = match function.max_active_clusters(
+                raw.grid_dim,
+                raw.block_dim,
+                raw.shared_mem_bytes,
+                cluster,
+            ) {
+                Ok(active_clusters) => active_clusters,
+                Err(error)
+                    if error.0 == cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CLUSTER_SIZE =>
+                {
+                    return Err(LaunchContractError::ClusterShapeUnsupported {
+                        kernel: C::SPEC.kernel_name,
+                        cluster,
+                    });
+                }
+                Err(error) => return Err(error.into()),
+            };
+            validate_cluster_residency(C::SPEC.kernel_name, cluster, active_clusters)?;
+        }
+
+        if C::SPEC.cooperative {
+            let block_threads =
+                shape_product(C::SPEC.kernel_name, LaunchDimension::Block, raw.block_dim)?;
+            let active_per_sm = function
+                .max_active_blocks_per_multiprocessor(block_threads as u32, raw.shared_mem_bytes)?;
+            let multiprocessors = context.multiprocessor_count()?;
+            let resident_capacity = u64::from(active_per_sm) * u64::from(multiprocessors);
+            let blocks = shape_product(C::SPEC.kernel_name, LaunchDimension::Grid, raw.grid_dim)?;
+            validate_cooperative_residency(C::SPEC.kernel_name, blocks, resident_capacity)?;
+        }
+
+        Ok(Self {
+            function,
+            config: raw,
+            _contract: PhantomData,
+        })
+    }
+
+    /// Returns the prepared CUDA function.
+    pub fn function(&self) -> &CudaFunction {
+        &self.function
+    }
+
+    /// Returns a copy of the validated raw launch configuration.
+    ///
+    /// This is hidden because generated launch methods are its intended
+    /// consumer. Mutating the copy cannot change the prepared launch.
+    #[doc(hidden)]
+    pub fn __raw_config(&self) -> LaunchConfig {
+        self.config
+    }
+
+    /// Rejects a stream from a different context without making a driver call.
+    pub fn validate_stream(&self, stream: &CudaStream) -> Result<(), LaunchContractError> {
+        let function_context = self.function.context();
+        let stream_context = stream.context();
+        if function_context.cu_ctx() == stream_context.cu_ctx() {
+            Ok(())
+        } else {
+            Err(LaunchContractError::ContextMismatch {
+                kernel: C::SPEC.kernel_name,
+                function_device: function_context.ordinal(),
+                stream_device: stream_context.ordinal(),
+            })
+        }
+    }
+}
+
+fn validate_static(
+    spec: LaunchContractSpec,
+    config: LaunchConfig,
+) -> Result<(), LaunchContractError> {
+    if spec.kernel_name.trim().is_empty() {
+        return Err(LaunchContractError::EmptyKernelName);
+    }
+
+    validate_shape(spec.kernel_name, LaunchDimension::Grid, config.grid_dim)?;
+    validate_shape(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+
+    match spec.block {
+        BlockRequirement::Exact(required) => {
+            validate_shape(spec.kernel_name, LaunchDimension::Block, required)?;
+            if config.block_dim != required {
+                return Err(LaunchContractError::BlockShapeMismatch {
+                    kernel: spec.kernel_name,
+                    required,
+                    actual: config.block_dim,
+                });
+            }
+        }
+        BlockRequirement::MaxThreads(max) => {
+            let actual = shape_product(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+            if actual > u64::from(max) {
+                return Err(LaunchContractError::BlockThreadsExceedContract {
+                    kernel: spec.kernel_name,
+                    actual,
+                    max,
+                });
+            }
+        }
+    }
+
+    match spec.dynamic_shared_memory {
+        DynamicSharedMemoryRequirement::Exact {
+            bytes,
+            min_alignment,
+        } => {
+            validate_alignment(spec.kernel_name, min_alignment)?;
+            if config.shared_mem_bytes != bytes {
+                return Err(LaunchContractError::DynamicSharedMemoryExactMismatch {
+                    kernel: spec.kernel_name,
+                    required: bytes,
+                    actual: config.shared_mem_bytes,
+                });
+            }
+        }
+        DynamicSharedMemoryRequirement::Range {
+            min_bytes,
+            max_bytes,
+            min_alignment,
+        } => {
+            validate_alignment(spec.kernel_name, min_alignment)?;
+            if min_bytes > max_bytes {
+                return Err(LaunchContractError::InvalidSharedMemoryRange {
+                    kernel: spec.kernel_name,
+                    min_bytes,
+                    max_bytes,
+                });
+            }
+            if !(min_bytes..=max_bytes).contains(&config.shared_mem_bytes) {
+                return Err(LaunchContractError::DynamicSharedMemoryOutsideRange {
+                    kernel: spec.kernel_name,
+                    min: min_bytes,
+                    max: max_bytes,
+                    actual: config.shared_mem_bytes,
+                });
+            }
+        }
+    }
+
+    if let Some(cluster) = spec.cluster {
+        validate_shape(spec.kernel_name, LaunchDimension::Cluster, cluster)?;
+        for (axis, grid, cluster) in axes(config.grid_dim, cluster) {
+            if grid % cluster != 0 {
+                return Err(LaunchContractError::ClusterDoesNotDivideGrid {
+                    kernel: spec.kernel_name,
+                    axis,
+                    grid,
+                    cluster,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_live_shape(
+    spec: LaunchContractSpec,
+    config: LaunchConfig,
+    limits: DeviceLaunchLimits,
+    function_max_threads: u32,
+) -> Result<(), LaunchContractError> {
+    validate_axes(config.grid_dim, limits.max_grid_dim, |axis, actual, max| {
+        LaunchContractError::DeviceDimensionExceeded {
+            kernel: spec.kernel_name,
+            dimension: LaunchDimension::Grid,
+            axis,
+            actual,
+            max,
+        }
+    })?;
+    validate_axes(
+        config.block_dim,
+        limits.max_block_dim,
+        |axis, actual, max| LaunchContractError::DeviceDimensionExceeded {
+            kernel: spec.kernel_name,
+            dimension: LaunchDimension::Block,
+            axis,
+            actual,
+            max,
+        },
+    )?;
+
+    let threads = shape_product(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+    if threads > u64::from(limits.max_threads_per_block) {
+        return Err(LaunchContractError::DeviceThreadsPerBlockExceeded {
+            kernel: spec.kernel_name,
+            actual: threads,
+            max: limits.max_threads_per_block,
+        });
+    }
+    if threads > u64::from(function_max_threads) {
+        return Err(LaunchContractError::FunctionThreadsPerBlockExceeded {
+            kernel: spec.kernel_name,
+            actual: threads,
+            max: function_max_threads,
+        });
+    }
+
+    Ok(())
+}
+
+fn shared_memory_total(
+    kernel: &'static str,
+    static_bytes: u32,
+    dynamic_bytes: u32,
+) -> Result<u64, LaunchContractError> {
+    static_bytes
+        .checked_add(dynamic_bytes)
+        .map(u64::from)
+        .ok_or(LaunchContractError::SharedMemoryTotalOverflow {
+            kernel,
+            static_bytes,
+            dynamic_bytes,
+        })
+}
+
+const fn dynamic_shared_memory_max(requirement: DynamicSharedMemoryRequirement) -> u32 {
+    match requirement {
+        DynamicSharedMemoryRequirement::Exact { bytes, .. } => bytes,
+        DynamicSharedMemoryRequirement::Range { max_bytes, .. } => max_bytes,
+    }
+}
+
+fn validate_shared_memory_limit(
+    kernel: &'static str,
+    total: u64,
+    max: u32,
+    opt_in: bool,
+) -> Result<(), LaunchContractError> {
+    if total <= u64::from(max) {
+        Ok(())
+    } else {
+        Err(LaunchContractError::DeviceSharedMemoryExceeded {
+            kernel,
+            total,
+            max,
+            opt_in,
+        })
+    }
+}
+
+fn validate_compute_capability(
+    kernel: &'static str,
+    required: (u32, u32),
+    actual: (u32, u32),
+) -> Result<(), LaunchContractError> {
+    if actual >= required {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ComputeCapabilityTooLow {
+            kernel,
+            required,
+            actual,
+        })
+    }
+}
+
+fn validate_cluster_support(
+    kernel: &'static str,
+    supported: bool,
+) -> Result<(), LaunchContractError> {
+    if supported {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterLaunchUnsupported { kernel })
+    }
+}
+
+fn validate_cluster_size(
+    kernel: &'static str,
+    blocks: u64,
+    max: u32,
+) -> Result<(), LaunchContractError> {
+    if blocks <= u64::from(max) {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterSizeExceeded {
+            kernel,
+            blocks,
+            max,
+        })
+    }
+}
+
+fn validate_required_cluster(
+    kernel: &'static str,
+    declared: (u32, u32, u32),
+    required: Option<(u32, u32, u32)>,
+) -> Result<(), LaunchContractError> {
+    match required {
+        Some(required) if declared == required => Ok(()),
+        Some(required) => Err(LaunchContractError::FunctionClusterShapeMismatch {
+            kernel,
+            declared,
+            required,
+        }),
+        None => Err(LaunchContractError::RequiredClusterDimensionsMissing { kernel, declared }),
+    }
+}
+
+fn validate_cluster_residency(
+    kernel: &'static str,
+    cluster: (u32, u32, u32),
+    active_clusters: u32,
+) -> Result<(), LaunchContractError> {
+    if active_clusters != 0 {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterHasNoResidency { kernel, cluster })
+    }
+}
+
+fn validate_cooperative_support(
+    kernel: &'static str,
+    supported: bool,
+) -> Result<(), LaunchContractError> {
+    if supported {
+        Ok(())
+    } else {
+        Err(LaunchContractError::CooperativeLaunchUnsupported { kernel })
+    }
+}
+
+fn validate_cooperative_residency(
+    kernel: &'static str,
+    blocks: u64,
+    resident_capacity: u64,
+) -> Result<(), LaunchContractError> {
+    if blocks <= resident_capacity {
+        Ok(())
+    } else {
+        Err(LaunchContractError::CooperativeGridTooLarge {
+            kernel,
+            blocks,
+            resident_capacity,
+        })
+    }
+}
+
+fn validate_alignment(kernel: &'static str, alignment: u32) -> Result<(), LaunchContractError> {
+    if alignment.is_power_of_two() {
+        Ok(())
+    } else {
+        Err(LaunchContractError::InvalidSharedMemoryAlignment { kernel, alignment })
+    }
+}
+
+fn validate_shape(
+    kernel: &'static str,
+    dimension: LaunchDimension,
+    shape: (u32, u32, u32),
+) -> Result<(), LaunchContractError> {
+    for (axis, value, _) in axes(shape, shape) {
+        if value == 0 {
+            return Err(LaunchContractError::ZeroDimension {
+                kernel,
+                dimension,
+                axis,
+            });
+        }
+    }
+    shape_product(kernel, dimension, shape)?;
+    Ok(())
+}
+
+fn shape_product(
+    kernel: &'static str,
+    dimension: LaunchDimension,
+    shape: (u32, u32, u32),
+) -> Result<u64, LaunchContractError> {
+    u64::from(shape.0)
+        .checked_mul(u64::from(shape.1))
+        .and_then(|xy| xy.checked_mul(u64::from(shape.2)))
+        .ok_or(LaunchContractError::DimensionProductOverflow { kernel, dimension })
+}
+
+fn axes(actual: (u32, u32, u32), limit: (u32, u32, u32)) -> [(LaunchAxis, u32, u32); 3] {
+    [
+        (LaunchAxis::X, actual.0, limit.0),
+        (LaunchAxis::Y, actual.1, limit.1),
+        (LaunchAxis::Z, actual.2, limit.2),
+    ]
+}
+
+fn validate_axes(
+    actual: (u32, u32, u32),
+    limit: (u32, u32, u32),
+    error: impl Fn(LaunchAxis, u32, u32) -> LaunchContractError,
+) -> Result<(), LaunchContractError> {
+    for (axis, actual, max) in axes(actual, limit) {
+        if actual > max {
+            return Err(error(axis, actual, max));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KERNEL: &str = "test_kernel";
+
+    struct NonCloneContract;
+
+    impl KernelLaunchContract for NonCloneContract {
+        type Config = LaunchConfig1D;
+
+        const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+            "non_clone",
+            BlockRequirement::Exact((1, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+    }
+
+    fn exact_spec(block: (u32, u32, u32)) -> LaunchContractSpec {
+        LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact(block),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        )
+    }
+
+    fn raw(
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        shared_mem_bytes: u32,
+    ) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+        }
+    }
+
+    fn generous_limits() -> DeviceLaunchLimits {
+        DeviceLaunchLimits {
+            max_threads_per_block: 1024,
+            max_block_dim: (1024, 1024, 64),
+            max_grid_dim: (u32::MAX, 65_535, 65_535),
+            max_shared_memory_per_block: 48 * 1024,
+        }
+    }
+
+    #[test]
+    fn typed_configs_fix_trailing_dimensions() {
+        let one = LaunchConfig1D::new(7, 64, 16).__raw();
+        assert_eq!(one.grid_dim, (7, 1, 1));
+        assert_eq!(one.block_dim, (64, 1, 1));
+        assert_eq!(one.shared_mem_bytes, 16);
+
+        let two = LaunchConfig2D::new((7, 5), (16, 8), 32).__raw();
+        assert_eq!(two.grid_dim, (7, 5, 1));
+        assert_eq!(two.block_dim, (16, 8, 1));
+
+        let three = LaunchConfig3D::new((7, 5, 3), (16, 8, 2), 64).__raw();
+        assert_eq!(three.grid_dim, (7, 5, 3));
+        assert_eq!(three.block_dim, (16, 8, 2));
+    }
+
+    #[test]
+    fn prepared_launch_clone_does_not_require_clone_brand() {
+        fn assert_clone<T: Clone>() {}
+        assert_clone::<PreparedLaunch<NonCloneContract>>();
+    }
+
+    #[test]
+    fn rejects_zero_and_overflowing_shapes() {
+        let zero = validate_static(exact_spec((32, 1, 1)), raw((0, 1, 1), (32, 1, 1), 0));
+        assert!(matches!(
+            zero,
+            Err(LaunchContractError::ZeroDimension {
+                dimension: LaunchDimension::Grid,
+                axis: LaunchAxis::X,
+                ..
+            })
+        ));
+
+        let overflow = validate_static(
+            exact_spec((1, 1, 1)),
+            raw((u32::MAX, u32::MAX, 2), (1, 1, 1), 0),
+        );
+        assert!(matches!(
+            overflow,
+            Err(LaunchContractError::DimensionProductOverflow {
+                dimension: LaunchDimension::Grid,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn exact_block_requires_the_whole_shape() {
+        let result = validate_static(exact_spec((32, 4, 1)), raw((1, 1, 1), (64, 2, 1), 0));
+        assert!(matches!(
+            result,
+            Err(LaunchContractError::BlockShapeMismatch {
+                required: (32, 4, 1),
+                actual: (64, 2, 1),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn max_threads_applies_to_the_block_product_and_checks_overflow() {
+        let spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(256),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        assert!(validate_static(spec, raw((1, 1, 1), (128, 1, 1), 0)).is_ok());
+        assert!(validate_static(spec, raw((1, 1, 1), (16, 16, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((1, 1, 1), (17, 16, 1), 0)),
+            Err(LaunchContractError::BlockThreadsExceedContract {
+                actual: 272,
+                max: 256,
+                ..
+            })
+        ));
+
+        let overflowing_spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(u32::MAX),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        assert!(matches!(
+            validate_static(overflowing_spec, raw((1, 1, 1), (u32::MAX, u32::MAX, 2), 0),),
+            Err(LaunchContractError::DimensionProductOverflow {
+                dimension: LaunchDimension::Block,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_dynamic_shared_memory_exact_range_and_alignment() {
+        let exact = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 1024,
+                min_alignment: 16,
+            },
+        );
+        assert!(validate_static(exact, raw((1, 1, 1), (32, 1, 1), 1024)).is_ok());
+        assert!(matches!(
+            validate_static(exact, raw((1, 1, 1), (32, 1, 1), 512)),
+            Err(LaunchContractError::DynamicSharedMemoryExactMismatch { .. })
+        ));
+
+        let range = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Range {
+                min_bytes: 512,
+                max_bytes: 2048,
+                min_alignment: 32,
+            },
+        );
+        assert!(validate_static(range, raw((1, 1, 1), (32, 1, 1), 512)).is_ok());
+        assert!(validate_static(range, raw((1, 1, 1), (32, 1, 1), 2048)).is_ok());
+        assert!(matches!(
+            validate_static(range, raw((1, 1, 1), (32, 1, 1), 256)),
+            Err(LaunchContractError::DynamicSharedMemoryOutsideRange { .. })
+        ));
+
+        let reversed = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Range {
+                min_bytes: 2,
+                max_bytes: 1,
+                min_alignment: 1,
+            },
+        );
+        assert!(matches!(
+            validate_static(reversed, raw((1, 1, 1), (32, 1, 1), 1)),
+            Err(LaunchContractError::InvalidSharedMemoryRange { .. })
+        ));
+
+        let bad_alignment = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 3,
+            },
+        );
+        assert!(matches!(
+            validate_static(bad_alignment, raw((1, 1, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::InvalidSharedMemoryAlignment { alignment: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn cluster_dimensions_must_be_nonzero_and_divide_grid() {
+        let spec = exact_spec((32, 1, 1)).with_cluster((2, 2, 1));
+        assert!(validate_static(spec, raw((8, 4, 1), (32, 1, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((7, 4, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::ClusterDoesNotDivideGrid {
+                axis: LaunchAxis::X,
+                grid: 7,
+                cluster: 2,
+                ..
+            })
+        ));
+
+        let zero = exact_spec((32, 1, 1)).with_cluster((2, 0, 1));
+        assert!(matches!(
+            validate_static(zero, raw((8, 4, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::ZeroDimension {
+                dimension: LaunchDimension::Cluster,
+                axis: LaunchAxis::Y,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_device_and_function_block_limits() {
+        let spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(2048),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        let limits = generous_limits();
+
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (1025, 1, 1), 0), limits, 1024),
+            Err(LaunchContractError::DeviceDimensionExceeded {
+                dimension: LaunchDimension::Block,
+                axis: LaunchAxis::X,
+                ..
+            })
+        ));
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (33, 33, 1), 0), limits, 2048),
+            Err(LaunchContractError::DeviceThreadsPerBlockExceeded { actual: 1089, .. })
+        ));
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (32, 16, 1), 0), limits, 256),
+            Err(LaunchContractError::FunctionThreadsPerBlockExceeded {
+                actual: 512,
+                max: 256,
+                ..
+            })
+        ));
+        assert!(matches!(
+            validate_live_shape(
+                spec,
+                raw((u32::MAX, 65_536, 1), (32, 1, 1), 0),
+                limits,
+                1024,
+            ),
+            Err(LaunchContractError::DeviceDimensionExceeded {
+                dimension: LaunchDimension::Grid,
+                axis: LaunchAxis::Y,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_static_plus_dynamic_shared_resources() {
+        let total = shared_memory_total(KERNEL, 16 * 1024, 40 * 1024).unwrap();
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, total, 48 * 1024, false),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded {
+                total: 57_344,
+                max: 49_152,
+                opt_in: false,
+                ..
+            })
+        ));
+        assert!(validate_shared_memory_limit(KERNEL, total, 96 * 1024, true).is_ok());
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, 100 * 1024, 96 * 1024, true),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded { opt_in: true, .. })
+        ));
+        assert!(matches!(
+            shared_memory_total(KERNEL, u32::MAX, 1),
+            Err(LaunchContractError::SharedMemoryTotalOverflow { .. })
+        ));
+        assert_eq!(
+            dynamic_shared_memory_max(DynamicSharedMemoryRequirement::Range {
+                min_bytes: 1024,
+                max_bytes: 8192,
+                min_alignment: 16,
+            }),
+            8192
+        );
+    }
+
+    #[test]
+    fn shared_memory_range_requires_support_for_its_advertised_maximum() {
+        let requirement = DynamicSharedMemoryRequirement::Range {
+            min_bytes: 1024,
+            max_bytes: 96 * 1024,
+            min_alignment: 16,
+        };
+        let spec =
+            LaunchContractSpec::new(KERNEL, BlockRequirement::Exact((32, 1, 1)), requirement);
+
+        // The concrete 32 KiB choice belongs to the range.
+        assert!(validate_static(spec, raw((1, 1, 1), (32, 1, 1), 32 * 1024)).is_ok());
+
+        // Preparation nevertheless validates the immutable contract maximum,
+        // so every value advertised by the range is safe on this device.
+        let total = shared_memory_total(KERNEL, 0, dynamic_shared_memory_max(requirement)).unwrap();
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, total, 64 * 1024, true),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded {
+                total: 98_304,
+                max: 65_536,
+                opt_in: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_architecture_and_optional_capabilities() {
+        assert!(validate_compute_capability(KERNEL, (9, 0), (10, 0)).is_ok());
+        assert!(matches!(
+            validate_compute_capability(KERNEL, (9, 0), (8, 9)),
+            Err(LaunchContractError::ComputeCapabilityTooLow { .. })
+        ));
+        assert!(matches!(
+            validate_cluster_support(KERNEL, false),
+            Err(LaunchContractError::ClusterLaunchUnsupported { .. })
+        ));
+        assert!(validate_cluster_size(KERNEL, 8, 8).is_ok());
+        assert!(matches!(
+            validate_cluster_size(KERNEL, 16, 8),
+            Err(LaunchContractError::ClusterSizeExceeded {
+                blocks: 16,
+                max: 8,
+                ..
+            })
+        ));
+        assert!(validate_required_cluster(KERNEL, (2, 1, 1), Some((2, 1, 1))).is_ok());
+        assert!(matches!(
+            validate_required_cluster(KERNEL, (2, 1, 1), Some((4, 1, 1))),
+            Err(LaunchContractError::FunctionClusterShapeMismatch { .. })
+        ));
+        assert!(matches!(
+            validate_required_cluster(KERNEL, (2, 1, 1), None),
+            Err(LaunchContractError::RequiredClusterDimensionsMissing { .. })
+        ));
+        assert!(validate_cluster_residency(KERNEL, (2, 1, 1), 1).is_ok());
+        assert!(matches!(
+            validate_cluster_residency(KERNEL, (2, 1, 1), 0),
+            Err(LaunchContractError::ClusterHasNoResidency { .. })
+        ));
+        assert!(matches!(
+            validate_cooperative_support(KERNEL, false),
+            Err(LaunchContractError::CooperativeLaunchUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_cooperative_residency_capacity() {
+        assert!(validate_cooperative_residency(KERNEL, 80, 80).is_ok());
+        assert!(matches!(
+            validate_cooperative_residency(KERNEL, 81, 80),
+            Err(LaunchContractError::CooperativeGridTooLarge {
+                blocks: 81,
+                resident_capacity: 80,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn spec_builders_preserve_diagnostic_metadata() {
+        let spec = exact_spec((32, 1, 1))
+            .with_cluster((2, 1, 1))
+            .with_cooperative()
+            .with_min_compute_capability(9, 0);
+        assert_eq!(spec.kernel_name(), KERNEL);
+        assert_eq!(spec.block(), BlockRequirement::Exact((32, 1, 1)));
+        assert_eq!(spec.cluster(), Some((2, 1, 1)));
+        assert!(spec.cooperative());
+        assert_eq!(spec.min_compute_capability(), Some((9, 0)));
     }
 }

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -73,7 +73,11 @@ pub use device_buffer::{DeviceBuffer, DeviceCopy};
 pub use embedded::{EmbeddedModule, EmbeddedModuleError};
 pub use error::{DriverError, IntoResult};
 pub use event::CudaEvent;
-pub use launch::LaunchConfig;
+pub use launch::{
+    BlockRequirement, DeviceLaunchLimits, DynamicSharedMemoryRequirement, KernelLaunchConfig,
+    KernelLaunchContract, LaunchAxis, LaunchConfig, LaunchConfig1D, LaunchConfig2D, LaunchConfig3D,
+    LaunchContractError, LaunchContractSpec, LaunchDimension, PreparedLaunch,
+};
 pub use module::{ConstantHandle, CudaFunction, CudaModule};
 pub use pinned_host_buffer::PinnedHostBuffer;
 pub use stream::CudaStream;
@@ -126,6 +130,10 @@ pub unsafe fn init(flags: c_uint) -> Result<(), DriverError> {
 /// - The pointed-to argument values must remain valid until this function
 ///   returns, because the driver reads them during launch submission.
 /// - The grid and block dimensions must not exceed device limits.
+/// - The grid, block, dynamic-shared-memory size, and launch mode must satisfy
+///   every semantic invariant assumed by the kernel body. In particular,
+///   device acceptance does not prove that an index is unique or that a
+///   synchronization primitive is being launched correctly.
 /// - The calling thread must already have the context that owns both `func` and
 ///   `stream` bound as its current context.
 ///
@@ -180,6 +188,9 @@ pub unsafe fn launch_kernel(
 /// - The pointed-to argument values must remain valid until this function
 ///   returns.
 /// - The grid and block dimensions must not exceed device limits.
+/// - The grid, block, dynamic-shared-memory size, and launch mode must satisfy
+///   every semantic invariant assumed by the kernel body, including index-space
+///   uniqueness and synchronization requirements.
 ///
 /// # Errors
 ///
@@ -296,6 +307,8 @@ pub unsafe fn launch_kernel_ex(
 ///   returns.
 /// - The grid, block, and cluster dimensions must satisfy the device limits and
 ///   CUDA cluster-launch requirements.
+/// - The launch geometry, dynamic-shared-memory size, and cluster mode must
+///   satisfy every semantic invariant assumed by the kernel body.
 ///
 /// # Errors
 ///

--- a/crates/cuda-core/src/module.rs
+++ b/crates/cuda-core/src/module.rs
@@ -443,6 +443,212 @@ impl CudaModule {
 }
 
 impl CudaFunction {
+    fn attribute(
+        &self,
+        attribute: cuda_bindings::CUfunction_attribute,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuFuncGetAttribute(value.as_mut_ptr(), attribute, self.cu_function)
+                .result()?;
+            u32::try_from(value.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Returns the context that owns this function.
+    pub fn context(&self) -> &Arc<CudaContext> {
+        self.module.context()
+    }
+
+    /// Queries the largest thread block accepted by this function.
+    pub fn max_threads_per_block(&self) -> Result<u32, DriverError> {
+        self.attribute(
+            cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        )
+    }
+
+    /// Queries this function's statically allocated shared memory per block.
+    pub fn static_shared_memory_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES)
+    }
+
+    /// Queries the currently configured dynamic shared-memory maximum.
+    pub fn max_dynamic_shared_memory_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(
+            cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+        )
+    }
+
+    /// Queries a cluster shape compiled into this function, if present.
+    ///
+    /// CUDA requires the three required-cluster attributes to be either all
+    /// zero or all positive. A partial tuple is treated as an invalid driver
+    /// response rather than silently normalizing it.
+    pub fn required_cluster_dimensions(&self) -> Result<Option<(u32, u32, u32)>, DriverError> {
+        let required = (
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH,
+            )?,
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT,
+            )?,
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH,
+            )?,
+        );
+        match required {
+            (0, 0, 0) => Ok(None),
+            (x, y, z) if x != 0 && y != 0 && z != 0 => Ok(Some(required)),
+            _ => Err(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            )),
+        }
+    }
+
+    /// Opts this function into a larger dynamic shared-memory allocation.
+    ///
+    /// Typed launch preparation calls this at most once, and only after
+    /// checking static plus dynamic memory against the device opt-in limit.
+    pub(crate) fn set_max_dynamic_shared_memory_bytes(
+        &self,
+        bytes: u32,
+    ) -> Result<(), DriverError> {
+        self.context().bind_to_thread()?;
+        let bytes = i32::try_from(bytes)
+            .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))?;
+        unsafe {
+            cuda_bindings::cuFuncSetAttribute(
+                self.cu_function,
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                bytes,
+            )
+        }
+        .result()
+    }
+
+    /// Computes the maximum active blocks per streaming multiprocessor for a
+    /// concrete non-cluster launch shape.
+    pub fn max_active_blocks_per_multiprocessor(
+        &self,
+        block_threads: u32,
+        dynamic_shared_memory_bytes: u32,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let block_threads = i32::try_from(block_threads)
+            .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))?;
+        let mut blocks = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxActiveBlocksPerMultiprocessor(
+                blocks.as_mut_ptr(),
+                self.cu_function,
+                block_threads,
+                dynamic_shared_memory_bytes as usize,
+            )
+            .result()?;
+            u32::try_from(blocks.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Queries the maximum cluster size for this function and launch shape on
+    /// the current device.
+    ///
+    /// CUDA documents that `cuOccupancyMaxPotentialClusterSize` ignores any
+    /// cluster-dimension attribute in the supplied launch configuration, so
+    /// this query intentionally supplies only grid, block, and dynamic shared
+    /// memory. It respects compile-time cluster launch bounds and any function
+    /// opt-in to non-portable cluster sizes.
+    pub fn max_potential_cluster_size(
+        &self,
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        dynamic_shared_memory_bytes: u32,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let config = cuda_bindings::CUlaunchConfig_st {
+            gridDimX: grid_dim.0,
+            gridDimY: grid_dim.1,
+            gridDimZ: grid_dim.2,
+            blockDimX: block_dim.0,
+            blockDimY: block_dim.1,
+            blockDimZ: block_dim.2,
+            sharedMemBytes: dynamic_shared_memory_bytes,
+            hStream: std::ptr::null_mut(),
+            attrs: std::ptr::null_mut(),
+            numAttrs: 0,
+        };
+        let mut cluster_size = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxPotentialClusterSize(
+                cluster_size.as_mut_ptr(),
+                self.cu_function,
+                &config,
+            )
+            .result()?;
+            u32::try_from(cluster_size.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Queries how many clusters with the exact requested shape can be active
+    /// on the target device.
+    ///
+    /// Unlike [`max_potential_cluster_size`](Self::max_potential_cluster_size),
+    /// this passes `cluster_dim` as a launch attribute. CUDA therefore checks
+    /// the concrete shape and any compiled required-cluster dimensions.
+    pub fn max_active_clusters(
+        &self,
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        dynamic_shared_memory_bytes: u32,
+        cluster_dim: (u32, u32, u32),
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+
+        // CUlaunchAttribute_st is opaque in the generated CUDA 13.2+
+        // bindings. Its C layout stores the id at offset 0 and the value union
+        // at offset 8; clusterDim.x/y/z occupy the first three u32 values in
+        // that union. This matches the launch helpers in cuda-core's root.
+        let mut cluster_attribute: cuda_bindings::CUlaunchAttribute_st =
+            unsafe { std::mem::zeroed() };
+        unsafe {
+            let base = &mut cluster_attribute as *mut _ as *mut u8;
+            (base as *mut u32).write(
+                cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION,
+            );
+            let dimensions = base.add(8) as *mut u32;
+            dimensions.write(cluster_dim.0);
+            dimensions.add(1).write(cluster_dim.1);
+            dimensions.add(2).write(cluster_dim.2);
+        }
+
+        let config = cuda_bindings::CUlaunchConfig_st {
+            gridDimX: grid_dim.0,
+            gridDimY: grid_dim.1,
+            gridDimZ: grid_dim.2,
+            blockDimX: block_dim.0,
+            blockDimY: block_dim.1,
+            blockDimZ: block_dim.2,
+            sharedMemBytes: dynamic_shared_memory_bytes,
+            hStream: std::ptr::null_mut(),
+            attrs: &mut cluster_attribute,
+            numAttrs: 1,
+        };
+        let mut active_clusters = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxActiveClusters(
+                active_clusters.as_mut_ptr(),
+                self.cu_function,
+                &config,
+            )
+            .result()?;
+            u32::try_from(active_clusters.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
     /// Returns the raw `CUfunction` handle.
     ///
     /// # Safety

--- a/crates/cuda-core/tests/launch_contract/fail_private_construction.rs
+++ b/crates/cuda-core/tests/launch_contract/fail_private_construction.rs
@@ -1,0 +1,9 @@
+use cuda_core::LaunchConfig1D;
+
+fn main() {
+    let _forged = LaunchConfig1D {
+        grid_x: 1,
+        block_x: 32,
+        shared_mem_bytes: 0,
+    };
+}

--- a/crates/cuda-core/tests/launch_contract/fail_private_construction.stderr
+++ b/crates/cuda-core/tests/launch_contract/fail_private_construction.stderr
@@ -1,0 +1,11 @@
+error[E0451]: fields `grid_x`, `block_x` and `shared_mem_bytes` of struct `LaunchConfig1D` are private
+ --> tests/launch_contract/fail_private_construction.rs:5:9
+  |
+4 |     let _forged = LaunchConfig1D {
+  |                   -------------- in this type
+5 |         grid_x: 1,
+  |         ^^^^^^ private field
+6 |         block_x: 32,
+  |         ^^^^^^^ private field
+7 |         shared_mem_bytes: 0,
+  |         ^^^^^^^^^^^^^^^^ private field

--- a/crates/cuda-core/tests/launch_contract/fail_private_mutation.rs
+++ b/crates/cuda-core/tests/launch_contract/fail_private_mutation.rs
@@ -1,0 +1,6 @@
+use cuda_core::LaunchConfig1D;
+
+fn main() {
+    let mut valid = LaunchConfig1D::new(1, 32, 0);
+    valid.block_x = 64;
+}

--- a/crates/cuda-core/tests/launch_contract/fail_private_mutation.stderr
+++ b/crates/cuda-core/tests/launch_contract/fail_private_mutation.stderr
@@ -1,0 +1,5 @@
+error[E0616]: field `block_x` of struct `LaunchConfig1D` is private
+ --> tests/launch_contract/fail_private_mutation.rs:5:11
+  |
+5 |     valid.block_x = 64;
+  |           ^^^^^^^ private field

--- a/crates/cuda-core/tests/launch_contract/fail_wrong_brand.rs
+++ b/crates/cuda-core/tests/launch_contract/fail_wrong_brand.rs
@@ -1,0 +1,35 @@
+use cuda_core::{
+    BlockRequirement, DynamicSharedMemoryRequirement, KernelLaunchContract, LaunchConfig1D,
+    LaunchContractSpec, PreparedLaunch,
+};
+
+struct KernelA;
+struct KernelB;
+
+macro_rules! contract {
+    ($kernel:ty, $name:literal) => {
+        impl KernelLaunchContract for $kernel {
+            type Config = LaunchConfig1D;
+
+            const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+                $name,
+                BlockRequirement::Exact((32, 1, 1)),
+                DynamicSharedMemoryRequirement::Exact {
+                    bytes: 0,
+                    min_alignment: 1,
+                },
+            );
+        }
+    };
+}
+
+contract!(KernelA, "kernel_a");
+contract!(KernelB, "kernel_b");
+
+fn launch_b(_: &PreparedLaunch<KernelB>) {}
+
+fn launch_a_as_b(prepared: &PreparedLaunch<KernelA>) {
+    launch_b(prepared);
+}
+
+fn main() {}

--- a/crates/cuda-core/tests/launch_contract/fail_wrong_brand.stderr
+++ b/crates/cuda-core/tests/launch_contract/fail_wrong_brand.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> tests/launch_contract/fail_wrong_brand.rs:32:14
+   |
+32 |     launch_b(prepared);
+   |     -------- ^^^^^^^^ expected `&PreparedLaunch<KernelB>`, found `&PreparedLaunch<KernelA>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected reference `&PreparedLaunch<KernelB>`
+              found reference `&PreparedLaunch<KernelA>`
+note: function defined here
+  --> tests/launch_contract/fail_wrong_brand.rs:29:4
+   |
+29 | fn launch_b(_: &PreparedLaunch<KernelB>) {}
+   |    ^^^^^^^^ ---------------------------

--- a/crates/cuda-core/tests/launch_contract/fail_wrong_rank.rs
+++ b/crates/cuda-core/tests/launch_contract/fail_wrong_rank.rs
@@ -1,0 +1,25 @@
+use cuda_core::{
+    BlockRequirement, DynamicSharedMemoryRequirement, KernelLaunchContract, LaunchConfig1D,
+    LaunchConfig2D, LaunchContractSpec,
+};
+
+struct OneDimensionalKernel;
+
+impl KernelLaunchContract for OneDimensionalKernel {
+    type Config = LaunchConfig1D;
+
+    const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+        "one_dimensional",
+        BlockRequirement::Exact((32, 1, 1)),
+        DynamicSharedMemoryRequirement::Exact {
+            bytes: 0,
+            min_alignment: 1,
+        },
+    );
+}
+
+fn prepare(_: <OneDimensionalKernel as KernelLaunchContract>::Config) {}
+
+fn main() {
+    prepare(LaunchConfig2D::new((1, 1), (32, 1), 0));
+}

--- a/crates/cuda-core/tests/launch_contract/fail_wrong_rank.stderr
+++ b/crates/cuda-core/tests/launch_contract/fail_wrong_rank.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> tests/launch_contract/fail_wrong_rank.rs:24:13
+   |
+24 |     prepare(LaunchConfig2D::new((1, 1), (32, 1), 0));
+   |     ------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `LaunchConfig1D`, found `LaunchConfig2D`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/launch_contract/fail_wrong_rank.rs:21:4
+   |
+21 | fn prepare(_: <OneDimensionalKernel as KernelLaunchContract>::Config) {}
+   |    ^^^^^^^ ---------------------------------------------------------

--- a/crates/cuda-core/tests/launch_contract_types.rs
+++ b/crates/cuda-core/tests/launch_contract_types.rs
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#[test]
+fn launch_contract_types_fail_closed() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/launch_contract/fail_wrong_rank.rs");
+    tests.compile_fail("tests/launch_contract/fail_wrong_brand.rs");
+    tests.compile_fail("tests/launch_contract/fail_private_construction.rs");
+    tests.compile_fail("tests/launch_contract/fail_private_mutation.rs");
+}

--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -51,7 +51,8 @@
 
 `ThreadIndex` is an opaque witness with no public constructor. The trusted index functions are:
 
-- `thread::index_1d()` -- unconditionally unique per thread (1D grids).
+- `thread::index_1d()` -- unique only for a fully 1-D launch: grid and block
+  Y/Z dimensions must all be `1`.
 - `thread::index_2d::<S>()` -- const-stride 2D index. The witness type carries `S`, so a `DisjointSlice<T, Index2D<S>>` rejects mismatched strides at compile time.
 - `unsafe thread::index_2d_runtime(s)` -- escape hatch for runtime strides; the `unsafe` is the contract that every thread used the same `s`.
 
@@ -67,7 +68,12 @@ pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
 }
 ```
 
-The explicit two-step form `let idx = thread::index_1d(); c.get_mut(idx)` is also available when you need the index for arithmetic against multiple slices. For non-trivial patterns (reductions, histograms), `get_unchecked_mut(usize)` is the `unsafe` escape hatch.
+The explicit two-step form `let idx = thread::index_1d(); c.get_mut(idx)` is
+also available when you need the index for arithmetic against multiple slices.
+A `#[launch_contract(domain = 1, ...)]` moves the 1-D geometry proof into the
+safe prepared host launch; raw launch geometry is unsafe. For non-trivial
+patterns (reductions, histograms), `get_unchecked_mut(usize)` is the unsafe
+element-access escape hatch.
 
 ### `SharedArray<T, N, ALIGN>` and `DynamicSharedArray<T, ALIGN>`
 

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -31,8 +31,10 @@
 //! 4. **`get_unchecked_mut()`**: Unsafe escape hatch for performance-critical
 //!    paths where bounds have been validated by other means.
 //!
-//! The unsafe boundary is pushed to the construction of `DisjointSlice` from raw
-//! memory, not to the per-access level.
+//! The unsafe boundary is pushed away from each access. A prepared launch proves
+//! that the kernel's declared index domain matches its geometry; an unprepared
+//! raw launch is unsafe and leaves that proof to the caller. Constructing a
+//! `DisjointSlice` from raw memory is also unsafe.
 
 use crate::thread::{Index1D, IndexFormula, KernelScope, ThreadIndex};
 use core::marker::PhantomData;
@@ -47,7 +49,9 @@ use core::marker::PhantomData;
 ///    (`index_1d`, `index_2d::<S>`, `unsafe index_2d_runtime`), which
 ///    derive the index from hardware built-in variables -- read-only
 ///    special registers assigned by the runtime at launch.
-/// 3. Each thread's `ThreadIndex` is unique within its index space.
+/// 3. Each thread's `ThreadIndex` is unique within its index space when the
+///    prepared launch contract matches that space. Raw launch callers must
+///    uphold the same condition explicitly.
 ///
 /// Each thread accesses a unique element, making parallel writes safe without
 /// synchronization.
@@ -64,8 +68,8 @@ use core::marker::PhantomData;
 /// the caller to check bounds externally; in release builds this was UB for
 /// out-of-bounds indices — a soundness hole. The current design follows
 /// `slice::get_mut()` / `slice::get_unchecked_mut()` from std: the safe
-/// path is always sound, and the unsafe escape hatch (`get_unchecked_mut`)
-/// is explicitly opted into.
+/// path is sound when reached through a prepared launch. Raw launch geometry
+/// and the unchecked element accessor are explicit unsafe escape hatches.
 ///
 /// The type is `Send` but NOT `Sync`: each GPU thread gets its own copy of
 /// the struct (with the same backing pointer), then uses its unique
@@ -92,6 +96,49 @@ pub struct DisjointSlice<'a, T, IndexSpace = Index1D> {
     len: usize,
     _marker: PhantomData<&'a mut [T]>,
     _space: PhantomData<fn() -> IndexSpace>,
+}
+
+mod launch_contract_sealed {
+    pub trait Sealed {}
+}
+
+impl<'a, T, IndexSpace> launch_contract_sealed::Sealed for DisjointSlice<'a, T, IndexSpace> {}
+
+/// Compiler-facing proof that a `DisjointSlice` has the expected element type
+/// and supports a launch domain.
+///
+/// This trait is sealed: only the genuine [`DisjointSlice`] type can implement
+/// it. `#[cuda_module]` adds this bound to contracted kernels so Rust resolves
+/// type aliases before checking the declared launch domain.
+///
+/// A 2D index space also supports a 1D launch (all Y dimensions are one), but
+/// a 1D index space cannot support a 2D launch.
+#[doc(hidden)]
+pub trait __LaunchContractDisjointSlice<Element, const DOMAIN: u8>:
+    launch_contract_sealed::Sealed
+{
+}
+
+impl<'a, T> __LaunchContractDisjointSlice<T, 1> for DisjointSlice<'a, T, Index1D> {}
+
+impl<'a, T, const ROW_STRIDE: usize> __LaunchContractDisjointSlice<T, 1>
+    for DisjointSlice<'a, T, crate::thread::Index2D<ROW_STRIDE>>
+{
+}
+
+impl<'a, T, const ROW_STRIDE: usize> __LaunchContractDisjointSlice<T, 2>
+    for DisjointSlice<'a, T, crate::thread::Index2D<ROW_STRIDE>>
+{
+}
+
+impl<'a, T> __LaunchContractDisjointSlice<T, 1>
+    for DisjointSlice<'a, T, crate::thread::Runtime2DIndex>
+{
+}
+
+impl<'a, T> __LaunchContractDisjointSlice<T, 2>
+    for DisjointSlice<'a, T, crate::thread::Runtime2DIndex>
+{
 }
 
 impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
@@ -163,8 +210,9 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     ///    can only be indexed by a matching witness.
     ///
     /// 3. **No data races**: Given the constraint above, each thread's
-    ///    `ThreadIndex` is unique, and threads cannot share `ThreadIndex`
-    ///    values, so each thread accesses a different memory location.
+    ///    `ThreadIndex` is unique under the prepared launch's matching index
+    ///    domain. An unsafe raw launch takes responsibility for the same
+    ///    geometry invariant, so each thread accesses a different location.
     ///
     /// # Example
     ///
@@ -181,8 +229,9 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
         if i < self.len {
             // SAFETY:
             // - Bounds check passed above.
-            // - `idx` is a ThreadIndex derived from hardware built-in variables,
-            //   guaranteeing a unique index per thread (no data races).
+            // - `idx` is a ThreadIndex derived from hardware built-in variables.
+            //   The prepared launch contract, or an unsafe raw launch caller,
+            //   guarantees that its index space is unique for this geometry.
             // - The DisjointSlice was constructed with valid memory (from_raw_parts safety).
             Some(unsafe { &mut *self.ptr.add(i) })
         } else {
@@ -292,9 +341,9 @@ impl<'a, T, IS: IndexFormula> DisjointSlice<'a, T, IS> {
         if i < self.len {
             // SAFETY:
             // - bounds check passed above
-            // - idx is a thread-unique witness in IS, freshly minted from
-            //   hardware special registers (no laundering — !Copy, !Send,
-            //   `'kernel`-bound)
+            // - idx is freshly minted from hardware special registers (no
+            //   laundering — !Copy, !Send, `'kernel`-bound); the prepared
+            //   launch, or unsafe raw caller, proves IS is unique here
             // - DisjointSlice was constructed with valid memory
             //   (from_raw_parts safety)
             Some((unsafe { &mut *self.ptr.add(i) }, idx))
@@ -305,7 +354,8 @@ impl<'a, T, IS: IndexFormula> DisjointSlice<'a, T, IS> {
 }
 
 // SAFETY: DisjointSlice can be sent between threads because:
-// - Each thread will access unique elements (guaranteed by ThreadIndex)
+// - A prepared launch, or unsafe raw caller, guarantees that each thread's
+//   ThreadIndex selects a unique element for the active geometry
 // - The pointer and length are just data, no thread affinity
 // - T: Send means the elements themselves can be sent between threads
 unsafe impl<'a, T: Send, IndexSpace> Send for DisjointSlice<'a, T, IndexSpace> {}
@@ -313,7 +363,7 @@ unsafe impl<'a, T: Send, IndexSpace> Send for DisjointSlice<'a, T, IndexSpace> {
 // DisjointSlice auto-trait summary:
 //   Send: yes (explicit impl above, when T: Send)
 //   Sync: NO (not implemented) — each GPU thread gets its own copy of the
-//         struct, then uses its unique ThreadIndex to access a different
-//         element. Sharing &DisjointSlice across threads would allow
+//         struct, then uses its conditionally unique ThreadIndex to access a
+//         different element. Sharing &DisjointSlice across threads would allow
 //         multiple threads to call get_mut() on the same struct, which
 //         would produce aliasing &mut T references — unsound.

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub use cuda_macros::{
     cluster_launch, constant, convergent, cooperative_launch, cuda_module, device, gpu_printf,
-    kernel, launch_bounds, ptx_asm, pure, readonly,
+    kernel, launch_bounds, launch_contract, ptx_asm, pure, readonly,
 };
 
 // Re-export for convenience
@@ -58,6 +58,8 @@ pub use barrier::{
 };
 pub use constant::{ConstantMemory, ConstantMemoryValue};
 pub use cusimd::{CuSimd, Float2, Float4, TmemRegs4, TmemRegs32};
+#[doc(hidden)]
+pub use disjoint::__LaunchContractDisjointSlice;
 pub use disjoint::DisjointSlice;
 pub use fence::*;
 pub use shared::{DynamicSharedArray, SharedArray};

--- a/crates/cuda-device/src/shared.rs
+++ b/crates/cuda-device/src/shared.rs
@@ -254,6 +254,17 @@ impl<T, const N: usize, const ALIGN: usize> IndexMut<usize> for SharedArray<T, N
 // DynamicSharedArray - Runtime-sized shared memory
 // ============================================================================
 
+/// Compile-time minimum alignment marker for a kernel's dynamic shared memory.
+///
+/// This is injected by `#[launch_contract]`. cuda-oxide removes the call before
+/// code generation, so it adds no kernel hot-path instructions. Kernel authors
+/// should use the attribute rather than calling this function directly.
+#[doc(hidden)]
+#[inline(never)]
+pub fn __dynamic_shared_alignment<const ALIGN: usize>() {
+    // The MIR importer removes this marker after recording ALIGN.
+}
+
 /// Dynamic (runtime-sized) shared memory with configurable alignment.
 ///
 /// Unlike [`SharedArray`] which has a compile-time known size, `DynamicSharedArray`

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -29,7 +29,8 @@
 //!    `outer * stride + inner` combines these into a scalar index per thread.
 //! 3. `index_1d`: unique per thread only for a 1D launch
 //!    (`blockDim.y == blockDim.z == 1` and `gridDim.y == gridDim.z == 1`). It
-//!    reads only the X registers, so a 2D/3D launch collides; see issue #115.
+//!    reads only the X registers, so a 2D/3D launch collides. A prepared
+//!    `domain = 1` launch enforces this; raw launches are unsafe.
 //! 4. `index_2d::<S>()`: unique per thread for const-stride 2D grids.
 //!    The stride lives in the witness type, and `DisjointSlice` only
 //!    accepts indices from the matching index space -- mismatched
@@ -119,11 +120,12 @@ impl<'kernel> KernelScope<'kernel> {
     }
 }
 
-/// A thread-unique index derived from hardware built-in variables (special registers).
+/// A conditionally thread-unique index derived from hardware built-in variables.
 ///
 /// `ThreadIndex` cannot be constructed directly. The contained `usize` is
-/// unique per thread, which is what makes parallel writes to `DisjointSlice`
-/// race-free without synchronisation.
+/// unique when the launch geometry matches its index space. A prepared launch
+/// proves that condition; an unsafe raw launch must uphold it explicitly. That
+/// conditional uniqueness makes parallel writes to `DisjointSlice` race-free.
 ///
 /// The index-space parameter ties each witness to the indexing scheme that
 /// created it. A `DisjointSlice<T, Index2D<128>>` won't accept a
@@ -284,7 +286,8 @@ pub mod __internal {
     ///
     /// Unique per thread **only for a 1D launch** (`blockDim.y == blockDim.z ==
     /// 1` and `gridDim.y == gridDim.z == 1`); a 2D/3D launch collides because
-    /// this reads only the X registers. Tracked in issue #115.
+    /// this reads only the X registers. A prepared `domain = 1` launch enforces
+    /// those trailing dimensions; a raw launch must prove them explicitly.
     #[inline(always)]
     pub fn index_1d<'kernel>(
         scope: &'kernel KernelScope<'kernel>,
@@ -353,9 +356,10 @@ pub mod __internal {
 /// `gridDim.y == gridDim.z == 1`.
 ///
 /// Under a 2D or 3D launch, threads that share the same X but differ in Y or Z
-/// get the *same* index, which would alias the same `DisjointSlice` slot. Every
-/// shipped example launches 1D, so nothing hits this today. Tracked in issue
-/// #115 (a fix that makes this sound under any launch is being weighed).
+/// get the *same* index, which would alias the same `DisjointSlice` slot. A
+/// kernel with `#[launch_contract(domain = 1, ...)]` can only use matching
+/// prepared geometry through its safe host method. Launching with unverified
+/// raw geometry is unsafe and leaves this uniqueness proof to the caller.
 ///
 /// # Example
 ///

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -35,13 +35,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
 
     let module = kernels::load(&ctx)?;
-    module.vecadd(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &a_dev,
-        &b_dev,
-        &mut c_dev,
-    )?;
+    // SAFETY: this raw configuration is one-dimensional and matches vecadd's
+    // index calculation. Prefer a launch contract when geometry is known.
+    unsafe {
+        module.vecadd(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &a_dev,
+            &b_dev,
+            &mut c_dev,
+        )?;
+    }
 
     Ok(())
 }
@@ -54,13 +58,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Item | Purpose |
 |------|---------|
 | `LoadedModule` | Typed handle around the embedded CUDA module and cached kernel functions |
-| `load(&Arc<CudaContext>)` | Load the current crate's embedded artifact bundle |
-| `load_named(&Arc<CudaContext>, name)` | Load a specific embedded bundle by name |
-| `from_module(Arc<CudaModule>)` | Wrap an already-loaded CUDA module |
-| `LoadedModule::{kernel}` | One launch method per `#[kernel]` function |
-| `load_async(device_id)` | With feature `async`, load from a `cuda-async` device context |
-| `LoadedModule::{kernel}_async` | With feature `async`, build a lazy `AsyncKernelLaunch` |
-| `LoadedModule::{kernel}_async_owned` | With feature `async`, build an owned async launch that returns its buffers |
+| `load(&Arc<CudaContext>)` | Load the current package's embedded bundle; unsafe when the module has a launch contract |
+| `load_named(&Arc<CudaContext>, name)` | Load a specific embedded bundle by name; unsafe when the module has a launch contract |
+| `from_module(Arc<CudaModule>)` | Wrap an already-loaded CUDA module; unsafe when the module has a launch contract |
+| `LoadedModule::{kernel}` | Safe prepared launch for a contracted kernel; unsafe raw launch otherwise |
+| `load_async(device_id)` | With feature `async`, load from a `cuda-async` device context; unsafe when contracted |
+| `LoadedModule::{kernel}_async` | With feature `async`, build a lazy prepared launch; unsafe when given raw configuration |
+| `LoadedModule::{kernel}_async_owned` | Build an owned async launch that returns its buffers; unsafe when given raw configuration |
 
 Kernel parameters are mapped into host launch parameters:
 
@@ -76,6 +80,95 @@ kernel names, show argument names, and type-check arguments before the program
 runs. By-value arguments are copied into the CUDA launch packet through the
 `KernelScalar` boundary; device slices are encoded as pointer-plus-length pairs.
 
+`LaunchConfig` is safe to create because it is only data. Launching with one is
+unsafe because its dimensions and resource values are not tied to the kernel:
+
+```text
+raw LaunchConfig   -> unsafe launch
+PreparedLaunch<K>  -> safe launch of exactly K
+```
+
+For example, a 1-D index calculation silently repeats indices when launched
+with a 2-D grid. An unsafe raw launch makes the caller acknowledge that proof;
+the prepared path below checks it for safe code.
+
+## Prepared Launch Contracts
+
+`#[launch_contract]` is an opt-in path for kernels whose geometry and resource
+assumptions are part of correctness, not merely a tuning choice:
+
+```rust
+#[kernel]
+#[launch_bounds(256)]
+#[launch_contract(
+    domain = 1,
+    block = (256, 1, 1),
+    dynamic_shared = 1024,
+    dynamic_shared_alignment = 128,
+    min_compute_capability = (9, 0),
+)]
+fn reduce(input: &[f32], mut output: DisjointSlice<f32>) { /* ... */ }
+```
+
+Preparation resolves the exact generic kernel entry and checks the live CUDA
+device and function once:
+
+```text
+LaunchConfig1D
+      │ check block/grid limits, shared memory, CC, cluster/cooperative rules
+      ▼
+PreparedLaunch<reduce<T>>
+      │ immutable function + configuration + context
+      └──────────────> repeated launches make no capability/resource queries
+```
+
+```rust
+let prepared = module.prepare_reduce(LaunchConfig1D::new(blocks, 256, 1024))?;
+module.reduce(&stream, &prepared, &input, &mut output)?;
+```
+
+`LaunchConfig1D`, `LaunchConfig2D`, and `LaunchConfig3D` have private fields;
+a 2-D configuration cannot be passed to a 1-D contract. The prepared value is
+also branded with the exact kernel specialization, so `reduce::<f32>` and
+`reduce::<f64>` are not interchangeable. Generic closures can use the generated
+`prepare_{kernel}_for(&closure, config)` helper to infer their anonymous type.
+
+For contracted kernels, raw `LaunchConfig` is available only through generated
+unsafe methods such as `reduce_unchecked`. Uncontracted generated methods are
+also unsafe because there is no prepared proof for their raw configuration.
+Borrowed and owned prepared async methods return immutable wrappers, so safe
+code cannot change geometry after validation; they recheck the
+scheduler-selected stream's context at submission time.
+
+Binding code is a one-time unsafe boundary for contracted modules. Embedded
+bundles are currently named per package, not per library/binary target, so even
+`load()` cannot prove that a same-package sibling contains the matching ABI and
+contract. `load`, `load_async`, `from_module`, `load_named`, and
+`load_async_named` therefore require the caller to assert artifact provenance.
+For generic modules, the caller must also ensure the merged PTX bundles contain
+the matching specializations and no conflicting entry definitions. Preparation
+and repeated launches are safe after that binding.
+
+The declared dynamic shared-memory byte range is an author contract because
+arbitrary pointer offsets cannot be inferred. Alignment is compiler-enforced:
+the marker emitted by `#[launch_contract]` is merged with alignment requests in
+the body and reachable local helpers, and the stronger value reaches PTX.
+Prelinked external helpers keep the alignment recorded when they were compiled.
+
+Cluster and cooperative contracts are validated separately. A contract that
+combines both currently fails preparation because the available occupancy query
+cannot prove the combined residency rule; the unsafe launch method remains the
+explicit expert escape hatch.
+
+This closes the unsafe gap from issue #115. A 1-D contract rejects a 2-D launch
+in safe code, while an uncontracted or deliberately mismatched launch requires
+an explicit unsafe block:
+
+```text
+LaunchConfig1D -> prepare -> safe launch
+raw dimensions ----------> unsafe launch
+```
+
 Enable the `async` feature to generate async launch methods. They use the same
 scalar mapping, but take no stream argument:
 
@@ -83,24 +176,40 @@ scalar mapping, but take no stream argument:
 use cuda_async::device_operation::DeviceOperation;
 
 let module = kernels::load_async(0)?;
-module
-    .vecadd_async(LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?
-    .sync()?;
+let launch = unsafe {
+    // SAFETY: this raw configuration matches vecadd's 1-D indexing.
+    module.vecadd_async(
+        LaunchConfig::for_num_elems(N as u32),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )?
+};
+launch.sync()?;
 ```
 
 For async launches, device-slice parameters accept either `DeviceBuffer<T>` or
-`cuda_async::device_box::DeviceBox<[T]>`. Borrowed methods return
-`AsyncKernelLaunch<'_>`, so Rust keeps referenced buffers and non-`'static`
-scalar arguments borrowed until the lazy operation is dropped, `.sync()` has
-returned, or `.await` has completed.
+`cuda_async::device_box::DeviceBox<[T]>`. The mutable
+`AsyncKernelLaunchBuilder` collects arguments and options. Finalizing it with a
+raw configuration is unsafe and produces an immutable `AsyncKernelLaunch<'_>`;
+geometry cannot be changed after that point. Rust keeps referenced buffers and
+non-`'static` scalar arguments borrowed until the lazy operation is dropped,
+`.sync()` has returned, or `.await` has completed.
 
 Use `{kernel}_async_owned` when the operation needs to leave the current stack
 frame, for example in a spawned Tokio task or a long-lived pipeline:
 
 ```rust
-let (a_dev, b_dev, c_dev) = module
-    .vecadd_async_owned(LaunchConfig::for_num_elems(N as u32), a_dev, b_dev, c_dev)?
-    .await?;
+let launch = unsafe {
+    // SAFETY: this raw configuration matches vecadd's 1-D indexing.
+    module.vecadd_async_owned(
+        LaunchConfig::for_num_elems(N as u32),
+        a_dev,
+        b_dev,
+        c_dev,
+    )?
+};
+let (a_dev, b_dev, c_dev) = launch.await?;
 ```
 
 Owned async launch methods take device-slice arguments by value, keep them alive

--- a/crates/cuda-host/src/launch.rs
+++ b/crates/cuda-host/src/launch.rs
@@ -11,13 +11,16 @@
 //! - **Macro** (`cuda_launch!`): Captures kernel identifier → PTX name string,
 //!   marshals arguments into a `Vec<*mut c_void>`, and calls
 //!   `cuda_core::launch_kernel` directly. The macro is caller-unsafe: it
-//!   cannot check argument count or types against the kernel, so every use
-//!   must sit inside an `unsafe { }` block. Prefer `#[cuda_module]` for
+//!   cannot check argument count, types, or whether the raw launch geometry
+//!   matches the kernel's indexing assumptions, so every use must sit inside
+//!   an `unsafe { }` block. Prefer `#[cuda_module]` with a launch contract for
 //!   kernels embedded in your own crate.
 //! - **Traits** (`CudaKernel`, `GenericCudaKernel`): Provide PTX entry-point
 //!   names for rust-analyzer and compile-time validation.
 
 use std::ffi::c_void;
+#[cfg(feature = "async")]
+use std::future::IntoFuture;
 #[cfg(feature = "async")]
 use std::sync::Arc;
 
@@ -186,8 +189,34 @@ pub fn push_kernel_device_slice(
 
 /// A typed device allocation that can be passed to an async kernel launch as a
 /// read-only device slice.
+///
+/// # Safety
+///
+/// For a nonzero byte extent, every value returned by
+/// [`cu_deviceptr`](Self::cu_deviceptr) must identify a live, correctly aligned
+/// device allocation covering at least `len()` consecutive `Elem` values. The
+/// allocation must remain valid for the full borrow or owned operation in
+/// which this value is used. When used as a read-only `KernelSliceArg`, the
+/// reported range must obey Rust's shared-reference rules: it cannot be
+/// mutated except through `UnsafeCell`-based or atomic element types under
+/// their synchronization contract.
+///
+/// Implementing this trait is unsafe because generated launch methods trust
+/// the pointer and length without inspecting the allocation:
+///
+/// ```compile_fail,E0200
+/// use cuda_host::KernelSliceArg;
+///
+/// struct Fake;
+///
+/// impl KernelSliceArg for Fake {
+///     type Elem = u32;
+///     fn cu_deviceptr(&self) -> cuda_core::sys::CUdeviceptr { 1 }
+///     fn len(&self) -> usize { 1_000_000 }
+/// }
+/// ```
 #[cfg(feature = "async")]
-pub trait KernelSliceArg {
+pub unsafe trait KernelSliceArg {
     /// Element type stored in the allocation.
     type Elem;
 
@@ -205,11 +234,21 @@ pub trait KernelSliceArg {
 
 /// A typed device allocation that can be passed to an async kernel launch as a
 /// writable device slice.
+///
+/// # Safety
+///
+/// The pointer, extent, alignment, and lifetime requirements from
+/// [`KernelSliceArg`] still apply. Its shared-read restriction is replaced by
+/// this rule: the implementor must own exclusive device-write authority for
+/// the entire reported element range for the lifetime of the mutable borrow or
+/// owned operation.
 #[cfg(feature = "async")]
-pub trait KernelSliceArgMut: KernelSliceArg {}
+pub unsafe trait KernelSliceArgMut: KernelSliceArg {}
 
 #[cfg(feature = "async")]
-impl<T> KernelSliceArg for cuda_core::DeviceBuffer<T> {
+// SAFETY: DeviceBuffer owns the reported allocation and keeps its CUDA context
+// alive; its pointer and length accessors describe that allocation exactly.
+unsafe impl<T> KernelSliceArg for cuda_core::DeviceBuffer<T> {
     type Elem = T;
 
     fn cu_deviceptr(&self) -> cuda_core::sys::CUdeviceptr {
@@ -222,10 +261,14 @@ impl<T> KernelSliceArg for cuda_core::DeviceBuffer<T> {
 }
 
 #[cfg(feature = "async")]
-impl<T> KernelSliceArgMut for cuda_core::DeviceBuffer<T> {}
+// SAFETY: &mut DeviceBuffer provides exclusive host authority to launch device
+// writes through this adapter for the duration of the operation.
+unsafe impl<T> KernelSliceArgMut for cuda_core::DeviceBuffer<T> {}
 
 #[cfg(feature = "async")]
-impl<T: Send> KernelSliceArg for cuda_async::device_box::DeviceBox<[T]> {
+// SAFETY: DeviceBox owns the reported allocation and its raw constructor
+// requires the pointer, element count, and device ordinal to be truthful.
+unsafe impl<T: Send> KernelSliceArg for cuda_async::device_box::DeviceBox<[T]> {
     type Elem = T;
 
     fn cu_deviceptr(&self) -> cuda_core::sys::CUdeviceptr {
@@ -238,10 +281,14 @@ impl<T: Send> KernelSliceArg for cuda_async::device_box::DeviceBox<[T]> {
 }
 
 #[cfg(feature = "async")]
-impl<T: Send> KernelSliceArgMut for cuda_async::device_box::DeviceBox<[T]> {}
+// SAFETY: &mut DeviceBox provides exclusive host authority to launch device
+// writes through this adapter for the duration of the operation.
+unsafe impl<T: Send> KernelSliceArgMut for cuda_async::device_box::DeviceBox<[T]> {}
 
 #[cfg(feature = "async")]
-impl<B> KernelSliceArg for Arc<B>
+// SAFETY: Arc only extends the lifetime of B and delegates both truthful
+// accessors unchanged to B's unsafe implementation.
+unsafe impl<B> KernelSliceArg for Arc<B>
 where
     B: KernelSliceArg + ?Sized,
 {
@@ -258,13 +305,10 @@ where
 
 #[doc(hidden)]
 #[cfg(feature = "async")]
-pub fn new_async_kernel_launch<'a>(
+pub fn new_async_kernel_launch_builder<'a>(
     func: cuda_core::CudaFunction,
-    config: cuda_core::LaunchConfig,
-) -> cuda_async::launch::AsyncKernelLaunch<'a> {
-    let mut launch = cuda_async::launch::AsyncKernelLaunch::new(Arc::new(func));
-    launch.set_launch_config(config);
-    launch
+) -> cuda_async::launch::AsyncKernelLaunchBuilder<'a> {
+    cuda_async::launch::AsyncKernelLaunchBuilder::new(Arc::new(func))
 }
 
 #[doc(hidden)]
@@ -276,10 +320,174 @@ pub fn new_owned_async_kernel_launch<R: Send>(
     cuda_async::launch::OwnedAsyncKernelLaunch::new(launch, resources)
 }
 
+/// Async operation carrying a validated, kernel-branded launch.
+///
+/// The underlying [`cuda_async::launch::AsyncKernelLaunch`] is immutable after
+/// its builder is finalized. This wrapper additionally carries the prepared
+/// contract and checks the stream selected by the async scheduler against the
+/// prepared function's CUDA context immediately before submission.
+#[cfg(feature = "async")]
+pub struct PreparedAsyncKernelLaunch<'a, Contract>
+where
+    Contract: cuda_core::KernelLaunchContract,
+{
+    launch: cuda_async::launch::AsyncKernelLaunch<'a>,
+    prepared: cuda_core::PreparedLaunch<Contract>,
+}
+
+#[cfg(feature = "async")]
+impl<Contract> std::fmt::Debug for PreparedAsyncKernelLaunch<'_, Contract>
+where
+    Contract: cuda_core::KernelLaunchContract,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedAsyncKernelLaunch")
+            .field("contract", &Contract::SPEC.kernel_name())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Owns async kernel resources while preserving an immutable prepared launch.
+#[cfg(feature = "async")]
+pub struct PreparedOwnedAsyncKernelLaunch<R, Contract>
+where
+    R: Send,
+    Contract: cuda_core::KernelLaunchContract,
+{
+    launch: cuda_async::launch::OwnedAsyncKernelLaunch<R>,
+    prepared: cuda_core::PreparedLaunch<Contract>,
+}
+
+#[cfg(feature = "async")]
+impl<R, Contract> std::fmt::Debug for PreparedOwnedAsyncKernelLaunch<R, Contract>
+where
+    R: Send,
+    Contract: cuda_core::KernelLaunchContract,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedOwnedAsyncKernelLaunch")
+            .field("contract", &Contract::SPEC.kernel_name())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Seals a fully marshalled async launch behind its prepared contract.
+///
+/// # Safety
+///
+/// `launch` must contain the same function and raw launch configuration as
+/// `prepared`, with the cluster/cooperative mode declared by its contract.
+#[doc(hidden)]
+#[cfg(feature = "async")]
+pub unsafe fn new_prepared_async_kernel_launch<'a, Contract>(
+    launch: cuda_async::launch::AsyncKernelLaunch<'a>,
+    prepared: cuda_core::PreparedLaunch<Contract>,
+) -> PreparedAsyncKernelLaunch<'a, Contract>
+where
+    Contract: cuda_core::KernelLaunchContract,
+{
+    PreparedAsyncKernelLaunch { launch, prepared }
+}
+
+/// Seals a fully marshalled owned async launch behind its prepared contract.
+///
+/// # Safety
+///
+/// `launch` must contain the same function and raw launch configuration as
+/// `prepared`, with the cluster/cooperative mode declared by its contract.
+#[doc(hidden)]
+#[cfg(feature = "async")]
+pub unsafe fn new_prepared_owned_async_kernel_launch<R, Contract>(
+    launch: cuda_async::launch::OwnedAsyncKernelLaunch<R>,
+    prepared: cuda_core::PreparedLaunch<Contract>,
+) -> PreparedOwnedAsyncKernelLaunch<R, Contract>
+where
+    R: Send,
+    Contract: cuda_core::KernelLaunchContract,
+{
+    PreparedOwnedAsyncKernelLaunch { launch, prepared }
+}
+
+#[cfg(feature = "async")]
+impl<'a, Contract> cuda_async::device_operation::DeviceOperation
+    for PreparedAsyncKernelLaunch<'a, Contract>
+where
+    Contract: cuda_core::KernelLaunchContract,
+{
+    type Output = ();
+
+    unsafe fn execute(
+        self,
+        context: &cuda_async::device_operation::ExecutionContext,
+    ) -> Result<(), cuda_async::error::DeviceError> {
+        self.prepared
+            .validate_stream(context.get_cuda_stream())
+            .map_err(|error| cuda_async::error::DeviceError::Launch(error.to_string()))?;
+        unsafe { cuda_async::device_operation::DeviceOperation::execute(self.launch, context) }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a, Contract> IntoFuture for PreparedAsyncKernelLaunch<'a, Contract>
+where
+    Contract: cuda_core::KernelLaunchContract,
+{
+    type Output = Result<(), cuda_async::error::DeviceError>;
+    type IntoFuture = cuda_async::device_future::DeviceFuture<(), Self>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        match cuda_async::device_context::with_default_device_policy(|policy| {
+            cuda_async::scheduling_policies::SchedulingPolicy::schedule(policy, self)
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(error)) | Err(error) => cuda_async::device_future::DeviceFuture::failed(error),
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<R, Contract> cuda_async::device_operation::DeviceOperation
+    for PreparedOwnedAsyncKernelLaunch<R, Contract>
+where
+    R: Send + 'static,
+    Contract: cuda_core::KernelLaunchContract,
+{
+    type Output = R;
+
+    unsafe fn execute(
+        self,
+        context: &cuda_async::device_operation::ExecutionContext,
+    ) -> Result<R, cuda_async::error::DeviceError> {
+        self.prepared
+            .validate_stream(context.get_cuda_stream())
+            .map_err(|error| cuda_async::error::DeviceError::Launch(error.to_string()))?;
+        unsafe { cuda_async::device_operation::DeviceOperation::execute(self.launch, context) }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<R, Contract> IntoFuture for PreparedOwnedAsyncKernelLaunch<R, Contract>
+where
+    R: Send + 'static,
+    Contract: cuda_core::KernelLaunchContract,
+{
+    type Output = Result<R, cuda_async::error::DeviceError>;
+    type IntoFuture = cuda_async::device_future::DeviceFuture<R, Self>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        match cuda_async::device_context::with_default_device_policy(|policy| {
+            cuda_async::scheduling_policies::SchedulingPolicy::schedule(policy, self)
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(error)) | Err(error) => cuda_async::device_future::DeviceFuture::failed(error),
+        }
+    }
+}
+
 #[doc(hidden)]
 #[cfg(feature = "async")]
 pub fn set_async_kernel_cluster_dim(
-    launch: &mut cuda_async::launch::AsyncKernelLaunch<'_>,
+    launch: &mut cuda_async::launch::AsyncKernelLaunchBuilder<'_>,
     cluster_dim: (u32, u32, u32),
 ) {
     launch.set_cluster_dim(cluster_dim);
@@ -288,7 +496,7 @@ pub fn set_async_kernel_cluster_dim(
 #[doc(hidden)]
 #[cfg(feature = "async")]
 pub fn set_async_kernel_cooperative(
-    launch: &mut cuda_async::launch::AsyncKernelLaunch<'_>,
+    launch: &mut cuda_async::launch::AsyncKernelLaunchBuilder<'_>,
     cooperative: bool,
 ) {
     launch.set_cooperative(cooperative);
@@ -297,7 +505,7 @@ pub fn set_async_kernel_cooperative(
 #[doc(hidden)]
 #[cfg(feature = "async")]
 pub fn push_async_kernel_scalar<'a, T: KernelScalar + 'a>(
-    launch: &mut cuda_async::launch::AsyncKernelLaunch<'a>,
+    launch: &mut cuda_async::launch::AsyncKernelLaunchBuilder<'a>,
     value: T,
 ) {
     if std::mem::size_of::<T>() != 0 {
@@ -308,7 +516,7 @@ pub fn push_async_kernel_scalar<'a, T: KernelScalar + 'a>(
 #[doc(hidden)]
 #[cfg(feature = "async")]
 pub fn push_async_read_only_device_slice<B>(
-    launch: &mut cuda_async::launch::AsyncKernelLaunch<'_>,
+    launch: &mut cuda_async::launch::AsyncKernelLaunchBuilder<'_>,
     buffer: &B,
 ) where
     B: KernelSliceArg + ?Sized,
@@ -320,7 +528,7 @@ pub fn push_async_read_only_device_slice<B>(
 #[doc(hidden)]
 #[cfg(feature = "async")]
 pub fn push_async_writable_device_slice<B>(
-    launch: &mut cuda_async::launch::AsyncKernelLaunch<'_>,
+    launch: &mut cuda_async::launch::AsyncKernelLaunchBuilder<'_>,
     buffer: &mut B,
 ) where
     B: KernelSliceArgMut + ?Sized,

--- a/crates/cuda-host/src/lib.rs
+++ b/crates/cuda-host/src/lib.rs
@@ -69,13 +69,18 @@
 //! let b_dev = DeviceBuffer::from_host(&stream, &b_host)?;
 //! let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
 //!
-//! module.vecadd(
-//!     &stream,
-//!     LaunchConfig::for_num_elems(N as u32),
-//!     &a_dev,
-//!     &b_dev,
-//!     &mut c_dev,
-//! )?;
+//! // SAFETY: this raw configuration is one-dimensional and matches vecadd's
+//! // index calculation. Prefer a #[launch_contract] and PreparedLaunch when
+//! // the kernel's geometry is known.
+//! unsafe {
+//!     module.vecadd(
+//!         &stream,
+//!         LaunchConfig::for_num_elems(N as u32),
+//!         &a_dev,
+//!         &b_dev,
+//!         &mut c_dev,
+//!     )?;
+//! }
 //!
 //! let c_host = c_dev.to_host_vec(&stream)?;
 //! ```
@@ -104,16 +109,18 @@ pub use type_id::{type_id_u128, type_id_u128_of_val};
 
 #[cfg(feature = "async")]
 pub use launch::{
-    KernelSliceArg, KernelSliceArgMut, load_cuda_module_from_async_context,
-    load_kernel_module_async, new_async_kernel_launch, new_owned_async_kernel_launch,
-    push_async_kernel_scalar, push_async_read_only_device_slice, push_async_writable_device_slice,
+    KernelSliceArg, KernelSliceArgMut, PreparedAsyncKernelLaunch, PreparedOwnedAsyncKernelLaunch,
+    load_cuda_module_from_async_context, load_kernel_module_async, new_async_kernel_launch_builder,
+    new_owned_async_kernel_launch, new_prepared_async_kernel_launch,
+    new_prepared_owned_async_kernel_launch, push_async_kernel_scalar,
+    push_async_read_only_device_slice, push_async_writable_device_slice,
     set_async_kernel_cluster_dim, set_async_kernel_cooperative,
 };
 
 #[cfg(feature = "async")]
 pub use cuda_async;
 #[cfg(feature = "async")]
-pub use cuda_async::launch::{AsyncKernelLaunch, OwnedAsyncKernelLaunch};
+pub use cuda_async::launch::{AsyncKernelLaunch, AsyncKernelLaunchBuilder, OwnedAsyncKernelLaunch};
 
 pub use embedded::{
     EmbeddedModuleError, load_all_ptx_bundles_merged, load_embedded_module,
@@ -133,9 +140,10 @@ pub use cuda_macros::{cuda_launch, cuda_module};
 
 /// Re-export of [`cuda_macros::cuda_launch_async`].
 ///
-/// Returns a lazy `cuda_async::launch::AsyncKernelLaunch`. Stream assignment is
-/// deferred to the scheduling policy -- call `.sync()` to block or `.await` to
-/// suspend.
+/// Builds a lazy `cuda_async::launch::AsyncKernelLaunch`. Raw launch
+/// configuration is not tied to the kernel's indexing assumptions, so the
+/// macro must be called inside `unsafe`. Stream assignment is deferred to the
+/// scheduling policy -- call `.sync()` to block or `.await` to suspend.
 #[cfg(feature = "async")]
 pub use cuda_macros::cuda_launch_async;
 pub use tiling::{

--- a/crates/cuda-host/tests/cuda_module_api.rs
+++ b/crates/cuda-host/tests/cuda_module_api.rs
@@ -5,13 +5,13 @@
 
 #![allow(dead_code, non_upper_case_globals, clippy::needless_lifetimes)]
 
-use cuda_core::{CudaStream, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaStream, DeviceBuffer, LaunchConfig, LaunchConfig1D};
 #[cfg(feature = "async")]
 use cuda_host::cuda_async::device_box::DeviceBox;
 #[cfg(feature = "async")]
 use cuda_host::cuda_async::device_operation::DeviceOperation;
 use cuda_host::cuda_module;
-use cuda_macros::{cooperative_launch, kernel};
+use cuda_macros::{cooperative_launch, kernel, launch_contract};
 
 #[cfg(feature = "async")]
 type TwoF32Buffers = (DeviceBox<[f32]>, DeviceBox<[f32]>);
@@ -82,6 +82,42 @@ mod kernels {
         let _ = (__cuda_oxide_args, output);
     }
 
+    // This kernel keeps the prepared-launch generators honest after the
+    // const-generic hygiene work. Its user names intentionally match every
+    // private name used by the sync, borrowed-async, and owned-async paths.
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1), dynamic_shared = 0)]
+    pub fn contracted_hygiene_probe<
+        '__cuda_oxide_async,
+        F: Copy + '__cuda_oxide_async,
+        const __cuda_oxide_stream: usize,
+        const __cuda_oxide_config: usize,
+        const __cuda_oxide_prepared: usize,
+        const __cuda_oxide_function: usize,
+        const __cuda_oxide_args: usize,
+        const __cuda_oxide_launch: usize,
+        const __cuda_oxide_owned: usize,
+        const __cuda_oxide_type_witness_0: usize,
+    >(
+        stream: &'__cuda_oxide_async [u32],
+        config: &[u32],
+        prepared: F,
+    ) {
+        let _ = (
+            stream,
+            config,
+            prepared,
+            __cuda_oxide_stream,
+            __cuda_oxide_config,
+            __cuda_oxide_prepared,
+            __cuda_oxide_function,
+            __cuda_oxide_args,
+            __cuda_oxide_launch,
+            __cuda_oxide_owned,
+            __cuda_oxide_type_witness_0,
+        );
+    }
+
     #[kernel]
     pub unsafe fn unsafe_raw_pointer(raw: *mut f32) {
         let _ = raw;
@@ -94,6 +130,29 @@ mod kernels {
     #[cooperative_launch]
     pub fn cooperative_grid_sync(output: &mut [u32]) {
         let _ = output;
+    }
+
+    #[kernel]
+    #[launch_contract(
+        domain = 1,
+        block = (64, 1, 1),
+        dynamic_shared = 0,
+        min_compute_capability = (8, 0),
+    )]
+    pub fn contracted_read(input: &[u32]) {
+        let _ = input;
+    }
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1), dynamic_shared = 0)]
+    pub fn contracted_closure<F: Fn(u32) -> u32 + Copy>(op: F, input: &[u32]) {
+        let _ = (op, input);
+    }
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1), dynamic_shared = 0)]
+    pub fn contracted_const<const N: usize>(input: &[u32]) {
+        let _ = (N, input);
     }
 }
 
@@ -117,7 +176,7 @@ fn assert_owned_unit<O: DeviceOperation<Output = ()>>(op: O) {
     let _ = op;
 }
 
-fn generated_methods_accept_kernel_scalar_types(
+unsafe fn generated_methods_accept_kernel_scalar_types(
     module: &kernels::LoadedModule,
     stream: &CudaStream,
     config: LaunchConfig,
@@ -132,27 +191,58 @@ fn generated_methods_accept_kernel_scalar_types(
     };
     let raw = core::ptr::null::<f32>();
 
-    module.scalar_args(stream, config, 2.0, params, raw, input, output)?;
-
+    let raw_mut = core::ptr::null_mut::<f32>();
     let offset = 5u32;
     let op = move |x: u32| x + offset;
-    module.copy_closure(stream, config, op, output_u32)?;
-    module.const_only::<4>(stream, config, output_u32)?;
-    module.mixed::<u32, 8>(stream, config, 7, output_u32)?;
-    module.lifetime_mixed::<u32, 4>(stream, config, input_u32, output_u32)?;
 
-    let raw_mut = core::ptr::null_mut::<f32>();
+    // Raw configurations are deliberately an unsafe launch path: this
+    // typechecking probe asserts that each configuration matches the kernel's
+    // indexing and resource assumptions.
     unsafe {
+        module.scalar_args(stream, config, 2.0, params, raw, input, output)?;
+        module.copy_closure(stream, config, op, output_u32)?;
+        module.const_only::<4>(stream, config, output_u32)?;
+        module.mixed::<u32, 8>(stream, config, 7, output_u32)?;
+        module.lifetime_mixed::<u32, 4>(stream, config, input_u32, output_u32)?;
         module.unsafe_raw_pointer(stream, config, raw_mut)?;
+        module.cooperative_grid_sync(stream, config, output_u32)?;
     }
-
-    module.cooperative_grid_sync(stream, config, output_u32)?;
 
     Ok(())
 }
 
+fn generated_prepared_methods_bind_the_exact_kernel_and_specialization(
+    module: &kernels::LoadedModule,
+    stream: &CudaStream,
+    input: &DeviceBuffer<u32>,
+) -> Result<(), cuda_core::LaunchContractError> {
+    let prepared = module.prepare_contracted_read(LaunchConfig1D::new(1, 64, 0))?;
+    module.contracted_read(stream, &prepared, input)?;
+
+    let offset = 7u32;
+    let op = move |value: u32| value + offset;
+    let generic = module.prepare_contracted_closure_for(&op, LaunchConfig1D::new(1, 64, 0))?;
+    module.contracted_closure(stream, &generic, op, input)?;
+
+    let const_generic = module.prepare_contracted_const::<4>(LaunchConfig1D::new(1, 64, 0))?;
+    module.contracted_const::<4>(stream, &const_generic, input)?;
+
+    unsafe {
+        module.contracted_read_unchecked(
+            stream,
+            LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            input,
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(feature = "async")]
-fn generated_async_methods_accept_borrowed_buffers(
+unsafe fn generated_async_methods_accept_borrowed_buffers(
     module: &kernels::LoadedModule,
     config: LaunchConfig,
     input: &DeviceBuffer<f32>,
@@ -168,37 +258,61 @@ fn generated_async_methods_accept_borrowed_buffers(
     let raw = core::ptr::null::<f32>();
     let raw_mut = core::ptr::null_mut::<f32>();
 
-    let launch = module.scalar_args_async(config, 2.0, params, raw, input, output)?;
-    assert_unit_operation(launch);
-
-    let launch = module.scalar_args_async(config, 2.0, params, raw, async_input, async_output)?;
-    assert_unit_operation(launch);
-
     let offset = 5u32;
     let offset_ref = &offset;
     let op = |x: u32| x + *offset_ref;
-    let launch = module.copy_closure_async(config, op, async_output_u32)?;
-    assert_unit_operation(launch);
 
-    let launch = module.const_only_async::<4>(config, async_output_u32)?;
-    assert_unit_operation(launch);
-
-    let launch = module.mixed_async::<u32, 8>(config, 7, async_output_u32)?;
-    assert_unit_operation(launch);
-
+    // Finalizing a lazy operation with an unproved raw configuration is the
+    // async unsafe boundary, just as submitting it is for synchronous launch.
     unsafe {
+        let launch = module.scalar_args_async(config, 2.0, params, raw, input, output)?;
+        assert_unit_operation(launch);
+
+        let launch =
+            module.scalar_args_async(config, 2.0, params, raw, async_input, async_output)?;
+        assert_unit_operation(launch);
+
+        let launch = module.copy_closure_async(config, op, async_output_u32)?;
+        assert_unit_operation(launch);
+
+        let launch = module.const_only_async::<4>(config, async_output_u32)?;
+        assert_unit_operation(launch);
+
+        let launch = module.mixed_async::<u32, 8>(config, 7, async_output_u32)?;
+        assert_unit_operation(launch);
+
         let launch = module.unsafe_raw_pointer_async(config, raw_mut)?;
         assert_unit_operation(launch);
-    }
 
-    let launch = module.cooperative_grid_sync_async(config, async_output_u32)?;
-    assert_unit_operation(launch);
+        let launch = module.cooperative_grid_sync_async(config, async_output_u32)?;
+        assert_unit_operation(launch);
+    }
 
     Ok(())
 }
 
 #[cfg(feature = "async")]
-fn generated_owned_async_methods_accept_owned_buffers(
+fn generated_prepared_async_methods_are_immutable_operations(
+    module: &kernels::LoadedModule,
+    input: &DeviceBuffer<u32>,
+    async_input: &DeviceBox<[u32]>,
+) -> Result<(), cuda_core::LaunchContractError> {
+    let prepared = module.prepare_contracted_read(LaunchConfig1D::new(1, 64, 0))?;
+    assert_unit_operation(module.contracted_read_async(&prepared, input));
+    assert_unit_operation(module.contracted_read_async(&prepared, async_input));
+
+    let offset = 7u32;
+    let op = move |value: u32| value + offset;
+    let generic = module.prepare_contracted_closure_for(&op, LaunchConfig1D::new(1, 64, 0))?;
+    assert_unit_operation(module.contracted_closure_async(&generic, op, async_input));
+
+    let const_generic = module.prepare_contracted_const::<4>(LaunchConfig1D::new(1, 64, 0))?;
+    assert_unit_operation(module.contracted_const_async::<4>(&const_generic, async_input));
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+unsafe fn generated_owned_async_methods_accept_owned_buffers(
     module: &kernels::LoadedModule,
     config: LaunchConfig,
     async_input: DeviceBox<[f32]>,
@@ -213,56 +327,80 @@ fn generated_owned_async_methods_accept_owned_buffers(
     let raw = core::ptr::null::<f32>();
     let raw_mut = core::ptr::null_mut::<f32>();
 
-    let launch: cuda_host::OwnedAsyncKernelLaunch<TwoF32Buffers> =
-        module.scalar_args_async_owned(config, 2.0, params, raw, async_input, async_output)?;
-    assert_owned_two_f32_buffers(launch);
-
     let offset = 5u32;
     let op = move |x: u32| x + offset;
-    let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
-        module.copy_closure_async_owned(config, op, async_output_u32)?;
-    assert_owned_u32_buffer(launch);
 
     unsafe {
+        let launch: cuda_host::OwnedAsyncKernelLaunch<TwoF32Buffers> =
+            module.scalar_args_async_owned(config, 2.0, params, raw, async_input, async_output)?;
+        assert_owned_two_f32_buffers(launch);
+
+        let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
+            module.copy_closure_async_owned(config, op, async_output_u32)?;
+        assert_owned_u32_buffer(launch);
+
         let launch: cuda_host::OwnedAsyncKernelLaunch<()> =
             module.unsafe_raw_pointer_async_owned(config, raw_mut)?;
         assert_owned_unit(launch);
-    }
 
-    let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
-        module.cooperative_grid_sync_async_owned(config, async_coop_output_u32)?;
-    assert_owned_u32_buffer(launch);
+        let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
+            module.cooperative_grid_sync_async_owned(config, async_coop_output_u32)?;
+        assert_owned_u32_buffer(launch);
+    }
 
     Ok(())
 }
 
 #[cfg(feature = "async")]
-fn generated_owned_async_methods_forward_const_generics(
+unsafe fn generated_owned_async_methods_forward_const_generics(
     module: &kernels::LoadedModule,
     config: LaunchConfig,
     const_output: DeviceBox<[u32]>,
     mixed_output: DeviceBox<[u32]>,
 ) -> Result<(), cuda_core::DriverError> {
-    let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
-        module.const_only_async_owned::<4, _>(config, const_output)?;
+    unsafe {
+        let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
+            module.const_only_async_owned::<4, _>(config, const_output)?;
+        assert_owned_u32_buffer(launch);
+
+        let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
+            module.mixed_async_owned::<u32, 8, _>(config, 7, mixed_output)?;
+        assert_owned_u32_buffer(launch);
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+fn generated_prepared_owned_async_methods_are_immutable_operations(
+    module: &kernels::LoadedModule,
+    async_input: DeviceBox<[u32]>,
+    const_input: DeviceBox<[u32]>,
+) -> Result<(), cuda_core::LaunchContractError> {
+    let prepared = module.prepare_contracted_read(LaunchConfig1D::new(1, 64, 0))?;
+    let launch = module.contracted_read_async_owned(&prepared, async_input);
     assert_owned_u32_buffer(launch);
 
-    let launch: cuda_host::OwnedAsyncKernelLaunch<DeviceBox<[u32]>> =
-        module.mixed_async_owned::<u32, 8, _>(config, 7, mixed_output)?;
+    let const_generic = module.prepare_contracted_const::<4>(LaunchConfig1D::new(1, 64, 0))?;
+    let launch = module.contracted_const_async_owned::<4, _>(&const_generic, const_input);
     assert_owned_u32_buffer(launch);
-
     Ok(())
 }
 
 #[test]
 fn generated_cuda_module_api_typechecks() {
     let _ = generated_methods_accept_kernel_scalar_types;
+    let _ = generated_prepared_methods_bind_the_exact_kernel_and_specialization;
     #[cfg(feature = "async")]
     let _ = generated_async_methods_accept_borrowed_buffers;
+    #[cfg(feature = "async")]
+    let _ = generated_prepared_async_methods_are_immutable_operations;
     #[cfg(feature = "async")]
     let _ = generated_owned_async_methods_accept_owned_buffers;
     #[cfg(feature = "async")]
     let _ = generated_owned_async_methods_forward_const_generics;
+    #[cfg(feature = "async")]
+    let _ = generated_prepared_owned_async_methods_are_immutable_operations;
 }
 
 // =============================================================================

--- a/crates/cuda-macros/Cargo.toml
+++ b/crates/cuda-macros/Cargo.toml
@@ -29,3 +29,4 @@ trybuild = "1"
 # package is tested with `--features async`.
 cuda-host = { workspace = true, features = ["async"] }
 cuda-core = { workspace = true }
+cuda-device = { workspace = true }

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -3,9 +3,10 @@
 Procedural macros for writing CUDA kernels in Rust. Provides `#[cuda_module]`
 for typed embedded-module loading, `#[kernel]` for GPU entry points,
 `#[device]`, `#[launch_bounds]`, `#[cluster_launch]`, `#[cooperative_launch]`,
-`gpu_printf!`, `ptx_asm!`, and the lower-level `cuda_launch!` / `cuda_launch_async!`
-escape hatches. `cuda_launch!` is caller-unsafe: prefer `#[cuda_module]`
-unless you are launching a module loaded at runtime by name.
+`#[launch_contract]`, `gpu_printf!`, `ptx_asm!`, and the lower-level `cuda_launch!` / `cuda_launch_async!`
+escape hatches. Both lower-level launch macros are caller-unsafe: prefer
+`#[cuda_module]` with a launch contract unless you are launching a module
+loaded at runtime by name.
 
 ## Attributes
 
@@ -45,7 +46,7 @@ pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
 // Mode 1: call-site specialization (PTX name from the function-item TypeId)
 #[kernel]
 pub fn scale<T: Copy + Mul<Output = T>>(factor: T, input: &[T], mut out: DisjointSlice<T>) { ... }
-// Launch: module.scale::<f32>(&stream, config, factor, &input, &mut out)?
+// Raw launch: unsafe { module.scale::<f32>(&stream, config, factor, &input, &mut out)? }
 // Inspect its generated entry name: scale_ptx_name::<f32>()
 
 // Mode 2: explicit instantiation list
@@ -83,7 +84,9 @@ extern "C" {
 
 ### `#[launch_bounds(max_threads, min_blocks)]`
 
-Occupancy hints for register allocation. Must come **after** `#[kernel]`.
+Occupancy hints for register allocation. It may appear before or after
+`#[kernel]`; generic kernels forward its compiler marker to every generated
+entry.
 
 ```rust
 #[kernel]
@@ -92,9 +95,84 @@ pub fn optimized(out: DisjointSlice<f32>) { ... }
 // PTX: .entry optimized .maxntid 256 .minnctapersm 2 { ... }
 ```
 
+### `#[launch_contract(...)]`
+
+Declares a kernel's launch-time correctness assumptions. Inside
+`#[cuda_module]`, this changes that kernel's generated API from a raw
+`LaunchConfig` to a prepared, specialization-branded launch:
+
+```rust
+#[kernel]
+#[launch_bounds(256)]
+#[launch_contract(
+    domain = 1,
+    block = (256, 1, 1),
+    dynamic_shared_range = (1024, 49152),
+    dynamic_shared_alignment = 128,
+    min_compute_capability = (9, 0),
+)]
+pub fn reduce(input: &[f32], mut out: DisjointSlice<f32>) { /* ... */ }
+
+let prepared = module.prepare_reduce(LaunchConfig1D::new(blocks, 256, 8192))?;
+module.reduce(&stream, &prepared, &input, &mut out)?;
+```
+
+Kernel configuration attributes may appear before or after `#[kernel]`. If an
+attribute expands first, generic kernel generation forwards its exact internal
+marker to the exported entry.
+
+```text
+prepare_reduce: dimensions + live CUDA limits -> PreparedLaunch<reduce>
+reduce:         PreparedLaunch<reduce>         -> enqueue
+reduce_unchecked: raw LaunchConfig             -> unsafe expert path
+```
+
+`block` is exact. If it is omitted, `#[launch_bounds]` supplies the compiled
+maximum total threads per block. For example, a limit of 256 accepts both
+`(256, 1, 1)` and `(16, 16, 1)`. Dynamic shared memory is either exact
+(`dynamic_shared = BYTES`) or an inclusive range. The byte extent is an author
+promise; the alignment is a compiler-visible minimum and is merged with any
+higher `DynamicSharedArray<T, ALIGN>` request in the body or a reachable local
+helper. Prelinked external helpers retain their separately compiled alignment.
+Contract values are integer literals in this initial API; specialization const
+expressions are not accepted yet.
+
+`domain` is deliberately explicit because calls through device helpers defeat
+AST inference. `#[cuda_module]` adds a sealed trait bound to the complete
+`DisjointSlice` parameter type, so Rust resolves aliases before checking the
+rank:
+
+```text
+type Tile = Index2D<64>;  DisjointSlice<_, Tile>    + domain 2 -> accepted
+type Tile = Index1D;      DisjointSlice<_, Tile>    + domain 2 -> type error
+local struct named DisjointSlice                     -> type error
+```
+
+Mutable slice parameters, incompatible cluster axes, and blocks above the
+emitted launch bounds are also rejected.
+
+Opted-in kernels gain generated sync, borrowed-async, and owned-async safe
+methods that consume the same prepared proof. Their raw paths use an
+`_unchecked` suffix. Uncontracted methods keep their existing names, but are
+also unsafe because no proof ties their raw configuration to the kernel.
+
+All loaders for a module containing a contracted kernel are unsafe. Bundles are
+currently identified at package granularity, so `load()` cannot distinguish a
+library artifact from a same-package binary artifact by name alone. The caller
+must prove that `load`, `load_async`, `load_named`, `load_async_named`, or
+`from_module` binds code with the ABI and resource semantics declared by the
+module. Generic loading also merges all PTX bundles, so those specializations
+must match and have no conflicting entry definitions. Preparation and launch
+are safe after this one-time binding.
+
+Cluster and cooperative requirements are each checked against the live device.
+Combining them currently fails preparation because cuda-oxide cannot yet prove
+the combined residency limit with the available occupancy query.
+
 ### `#[cluster_launch(x, y, z)]`
 
-Compile-time thread block cluster dimensions (Hopper+). Must come **after** `#[kernel]`.
+Compile-time thread block cluster dimensions (Hopper+). It may appear before or
+after `#[kernel]`.
 
 ```rust
 #[kernel]
@@ -106,10 +184,11 @@ pub fn cluster_kernel(out: DisjointSlice<u32>) { ... }
 ### `#[cooperative_launch]`
 
 Marks a kernel for cooperative launch, the precondition for grid-wide
-barriers (`cuda_device::grid::sync()`). Must come **after** `#[kernel]`.
-Unlike `#[cluster_launch]` this changes nothing in the PTX: `#[cuda_module]`
-reads the marker and routes every generated launch method through
-`cuLaunchKernelEx` with `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` set. May be
+barriers (`cuda_device::grid::sync()`). It may appear before or after
+`#[kernel]`. Unlike `#[cluster_launch]` this changes nothing in the PTX:
+`#[cuda_module]` records the setting before nested attributes expand and
+routes every generated launch method through `cuLaunchKernelEx` with
+`CU_LAUNCH_ATTRIBUTE_COOPERATIVE` set. May be
 combined with `#[cluster_launch]`; both attributes then go into the same
 `cuLaunchKernelEx` call.
 
@@ -142,7 +221,10 @@ mod kernels {
 }
 
 let module = kernels::load(&ctx)?;
-module.vecadd(&stream, LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?;
+// SAFETY: the raw geometry is 1-D and matches vecadd's indexing and resources.
+unsafe {
+    module.vecadd(&stream, LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?;
+}
 ```
 
 When `cuda-host` is built with its `async` feature, async code can load the
@@ -150,7 +232,11 @@ same embedded module from a `cuda-async` device context:
 
 ```rust
 let module = kernels::load_async(0)?;
-module.vecadd_async(LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?.sync()?;
+let launch = unsafe {
+    // SAFETY: the raw geometry is 1-D and matches vecadd's assumptions.
+    module.vecadd_async(LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?
+};
+launch.sync()?;
 ```
 
 Borrowed async methods return `AsyncKernelLaunch<'_>` and tie the lazy operation
@@ -158,9 +244,11 @@ to referenced buffers and borrowed scalar arguments. Owned async methods take
 device buffers by value and return them after completion:
 
 ```rust
-let (a_dev, b_dev, c_dev) = module
-    .vecadd_async_owned(LaunchConfig::for_num_elems(N as u32), a_dev, b_dev, c_dev)?
-    .await?;
+let launch = unsafe {
+    // SAFETY: the raw geometry is 1-D and matches vecadd's assumptions.
+    module.vecadd_async_owned(LaunchConfig::for_num_elems(N as u32), a_dev, b_dev, c_dev)?
+};
+let (a_dev, b_dev, c_dev) = launch.await?;
 ```
 
 ## `cuda_launch!` -- Unsafe Lower-Level Synchronous Kernel Launch
@@ -170,11 +258,12 @@ the kernel signatures at compile time and generates typed launch methods.
 `cuda_launch!` is the unsafe escape hatch for the remaining case, modules
 loaded at runtime by name, where no compile-time signature exists to check.
 
-The macro verifies nothing about the argument list. The caller promises that
-argument count, order, and types match the kernel's actual signature and that
-pointer arguments are device-accessible; a mismatch is undefined behavior
-(the driver reads past the end of the args array, or the device dereferences
-junk). Every use must therefore sit inside an `unsafe { }` block:
+The macro verifies neither the argument list nor the kernel's launch contract.
+The caller promises that argument count, order, and types match the actual
+signature, pointer arguments are device-accessible, and the geometry/resources
+satisfy the kernel's indexing and synchronization assumptions. A mismatch can
+cause undefined behavior. Every use must therefore sit inside an `unsafe { }`
+block:
 
 ```rust
 // SAFETY: argument count, order, and types match vecadd's signature;
@@ -227,14 +316,20 @@ call.
 
 ## `cuda_launch_async!` -- Lower-Level Async Kernel Launch
 
-Returns an `AsyncKernelLaunch` implementing `DeviceOperation` for `cuda-async` scheduling. Same argument forms as `cuda_launch!` but no `stream:` or `cluster_dim:` fields.
+Returns an immutable `AsyncKernelLaunch` implementing `DeviceOperation` for
+`cuda-async` scheduling. The macro first builds inert launch data, then crosses
+the same caller-unsafe raw finalization boundary as `cuda_launch!`. It accepts
+the same argument forms, but has no `stream:` or `cluster_dim:` fields.
 
 ```rust
-let op = cuda_launch_async! {
-    kernel: vecadd,
-    module: module,
-    config: LaunchConfig::for_num_elems(N as u32),
-    args: [slice(a_dev), slice(b_dev), slice_mut(c_dev)]
+// SAFETY: ABI, lifetimes, geometry, and resources match vecadd.
+let op = unsafe {
+    cuda_launch_async! {
+        kernel: vecadd,
+        module: module,
+        config: LaunchConfig::for_num_elems(N as u32),
+        args: [slice(a_dev), slice(b_dev), slice_mut(c_dev)]
+    }
 };
 ```
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -314,15 +314,32 @@ impl Parse for KernelArgs {
 /// }
 ///
 /// let module = kernels::load(&ctx)?;
-/// module.vecadd(&stream, LaunchConfig::for_num_elems(n), &a, &b, &mut c)?;
+/// // SAFETY: the raw launch is fully 1-D and matches vecadd's resources.
+/// unsafe {
+///     module.vecadd(&stream, LaunchConfig::for_num_elems(n), &a, &b, &mut c)?;
+/// }
 ///
 /// let module = kernels::load_async(0)?;
-/// module.vecadd_async(LaunchConfig::for_num_elems(n), &a, &b, &mut c)?.sync()?;
+/// // SAFETY: the raw launch is fully 1-D and matches vecadd's resources.
+/// unsafe {
+///     module.vecadd_async(LaunchConfig::for_num_elems(n), &a, &b, &mut c)
+/// }?.sync()?;
 ///
-/// let (a, b, c) = module
-///     .vecadd_async_owned(LaunchConfig::for_num_elems(n), a, b, c)?
+/// // SAFETY: the raw launch is fully 1-D and matches vecadd's resources.
+/// let (a, b, c) = unsafe {
+///     module.vecadd_async_owned(LaunchConfig::for_num_elems(n), a, b, c)
+/// }?
 ///     .await?;
 /// ```
+///
+/// # Raw launch safety
+///
+/// A raw [`LaunchConfig`](https://docs.rs/cuda-core/latest/cuda_core/struct.LaunchConfig.html)
+/// is not tied to the kernel's indexing model. The generated raw synchronous,
+/// borrowed-async, and owned-async methods are therefore `unsafe`: callers must
+/// prove that the chosen dimensions and resources satisfy the kernel. Add
+/// `#[launch_contract(...)]` to generate a prepared-launch path that is safe
+/// when the source kernel itself is safe.
 #[proc_macro_attribute]
 pub fn cuda_module(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
@@ -359,7 +376,212 @@ struct CudaModuleKernel {
     params: Vec<CudaModuleParam>,
     cluster_dim: Option<(u32, u32, u32)>,
     cooperative: bool,
+    launch_contract: Option<CudaModuleLaunchContract>,
     is_generic: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DynamicSharedContract {
+    Exact(u32),
+    Range { min_bytes: u32, max_bytes: u32 },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CudaModuleLaunchContract {
+    domain: u8,
+    exact_block: Option<(u32, u32, u32)>,
+    max_block_threads: Option<u32>,
+    dynamic_shared: DynamicSharedContract,
+    dynamic_shared_alignment: u32,
+    min_compute_capability: (u32, u32),
+}
+
+/// Arguments accepted by `#[launch_contract(...)]`.
+///
+/// The attribute is intentionally declarative. The kernel author states the
+/// launch domain and resource envelope; `#[cuda_module]` turns that statement
+/// into a branded host configuration and validates it against the live
+/// function/device once during preparation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LaunchContractArgs {
+    domain: u8,
+    exact_block: Option<(u32, u32, u32)>,
+    dynamic_shared: DynamicSharedContract,
+    dynamic_shared_alignment: u32,
+    min_compute_capability: (u32, u32),
+}
+
+impl Parse for LaunchContractArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut domain = None;
+        let mut exact_block = None;
+        let mut dynamic_shared = None;
+        let mut dynamic_shared_range = None;
+        let mut dynamic_shared_alignment = None;
+        let mut min_compute_capability = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            match key.to_string().as_str() {
+                "domain" => {
+                    reject_duplicate(&key, domain.is_some())?;
+                    let value: syn::LitInt = input.parse()?;
+                    domain = Some(value.base10_parse::<u8>()?);
+                }
+                "block" => {
+                    reject_duplicate(&key, exact_block.is_some())?;
+                    exact_block = Some(parse_u32_triplet(input, "block")?);
+                }
+                "dynamic_shared" => {
+                    reject_duplicate(&key, dynamic_shared.is_some())?;
+                    let value: syn::LitInt = input.parse()?;
+                    dynamic_shared = Some(value.base10_parse::<u32>()?);
+                }
+                "dynamic_shared_range" => {
+                    reject_duplicate(&key, dynamic_shared_range.is_some())?;
+                    dynamic_shared_range = Some(parse_u32_pair(input, "dynamic_shared_range")?);
+                }
+                "dynamic_shared_alignment" => {
+                    reject_duplicate(&key, dynamic_shared_alignment.is_some())?;
+                    let value: syn::LitInt = input.parse()?;
+                    dynamic_shared_alignment = Some(value.base10_parse::<u32>()?);
+                }
+                "min_compute_capability" => {
+                    reject_duplicate(&key, min_compute_capability.is_some())?;
+                    let (major, minor) = parse_u32_pair(input, "min_compute_capability")?;
+                    min_compute_capability = Some((major, minor));
+                }
+                _ => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        "unknown launch_contract field; expected domain, block, dynamic_shared, dynamic_shared_range, dynamic_shared_alignment, or min_compute_capability",
+                    ));
+                }
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        let domain = domain.ok_or_else(|| {
+            syn::Error::new(
+                input.span(),
+                "launch_contract requires `domain = 1`, `2`, or `3`",
+            )
+        })?;
+        if !(1..=3).contains(&domain) {
+            return Err(syn::Error::new(
+                input.span(),
+                "launch_contract domain must be 1, 2, or 3",
+            ));
+        }
+        if dynamic_shared.is_some() && dynamic_shared_range.is_some() {
+            return Err(syn::Error::new(
+                input.span(),
+                "launch_contract accepts either `dynamic_shared` or `dynamic_shared_range`, not both",
+            ));
+        }
+        let dynamic_shared = match (dynamic_shared, dynamic_shared_range) {
+            (Some(bytes), None) => DynamicSharedContract::Exact(bytes),
+            (None, Some((min_bytes, max_bytes))) if min_bytes <= max_bytes => {
+                DynamicSharedContract::Range {
+                    min_bytes,
+                    max_bytes,
+                }
+            }
+            (None, Some(_)) => {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "dynamic_shared_range minimum cannot exceed its maximum",
+                ));
+            }
+            (None, None) => DynamicSharedContract::Exact(0),
+            (Some(_), Some(_)) => unreachable!(),
+        };
+        let dynamic_shared_alignment = dynamic_shared_alignment.unwrap_or_else(|| {
+            if dynamic_shared_max(dynamic_shared) == 0 {
+                1
+            } else {
+                16
+            }
+        });
+        if dynamic_shared_alignment == 0 || !dynamic_shared_alignment.is_power_of_two() {
+            return Err(syn::Error::new(
+                input.span(),
+                "dynamic_shared_alignment must be a non-zero power of two",
+            ));
+        }
+        if exact_block.is_none() {
+            // A missing exact shape is valid only when #[launch_bounds]
+            // supplies the compiled maximum. This is checked after all kernel
+            // attributes have been collected so the two attributes remain one
+            // source of truth rather than duplicate integers.
+        }
+        let min_compute_capability = min_compute_capability.unwrap_or((0, 0));
+        Ok(Self {
+            domain,
+            exact_block,
+            dynamic_shared,
+            dynamic_shared_alignment,
+            min_compute_capability,
+        })
+    }
+}
+
+fn dynamic_shared_max(contract: DynamicSharedContract) -> u32 {
+    match contract {
+        DynamicSharedContract::Exact(bytes) => bytes,
+        DynamicSharedContract::Range { max_bytes, .. } => max_bytes,
+    }
+}
+
+fn reject_duplicate(key: &Ident, duplicate: bool) -> syn::Result<()> {
+    if duplicate {
+        Err(syn::Error::new(
+            key.span(),
+            format!("duplicate launch_contract field `{key}`"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_u32_triplet(input: ParseStream, field: &str) -> syn::Result<(u32, u32, u32)> {
+    let content;
+    parenthesized!(content in input);
+    let values: Punctuated<syn::LitInt, Token![,]> = Punctuated::parse_terminated(&content)?;
+    if values.len() != 3 {
+        return Err(syn::Error::new(
+            content.span(),
+            format!("{field} must be a three-dimensional tuple `(x, y, z)`"),
+        ));
+    }
+    let mut values = values.iter();
+    Ok((
+        values.next().unwrap().base10_parse()?,
+        values.next().unwrap().base10_parse()?,
+        values.next().unwrap().base10_parse()?,
+    ))
+}
+
+fn parse_u32_pair(input: ParseStream, field: &str) -> syn::Result<(u32, u32)> {
+    let content;
+    parenthesized!(content in input);
+    let values: Punctuated<syn::LitInt, Token![,]> = Punctuated::parse_terminated(&content)?;
+    if values.len() != 2 {
+        return Err(syn::Error::new(
+            content.span(),
+            format!("{field} must be a two-value tuple"),
+        ));
+    }
+    let mut values = values.iter();
+    Ok((
+        values.next().unwrap().base10_parse()?,
+        values.next().unwrap().base10_parse()?,
+    ))
 }
 
 struct CudaModuleParam {
@@ -367,6 +589,9 @@ struct CudaModuleParam {
     sync_host_ty: TokenStream2,
     async_host_ty: TokenStream2,
     marshal: CudaModuleParamMarshal,
+    mutable_slice: bool,
+    disjoint_slice_ty: Option<Type>,
+    disjoint_slice_elem: Option<TokenStream2>,
 }
 
 enum CudaModuleParamMarshal {
@@ -423,6 +648,10 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
 
     let artifact_anchor_statements = cuda_module_artifact_anchor_statements(&transformed.kernels)?;
     let has_generic = transformed.kernels.iter().any(|k| k.is_generic);
+    let has_launch_contract = transformed
+        .kernels
+        .iter()
+        .any(|kernel| kernel.launch_contract.is_some());
     let module_loader = if has_generic {
         // At least one kernel is generic: its PTX is emitted into the
         // consuming binary's bundle, not this crate's bundle. Merge all
@@ -441,6 +670,12 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
     let constant_initializers = constants
         .iter()
         .map(generate_cuda_module_constant_initializer);
+    let launch_contract_impls = direct_kernels
+        .iter()
+        .filter_map(generate_cuda_module_launch_contract_impl);
+    let prepare_launch_methods = direct_kernels
+        .iter()
+        .filter_map(generate_cuda_module_prepare_launch_methods);
     let launch_methods = direct_kernels
         .iter()
         .map(generate_cuda_module_launch_method);
@@ -450,7 +685,42 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
     let set_constant_methods = constants
         .iter()
         .map(generate_cuda_module_set_constant_method);
-    let async_module_items = if cfg!(feature = "async") {
+    let async_module_items = if cfg!(feature = "async") && has_launch_contract {
+        quote! {
+            /// Loads this package's embedded artifact for a contracted module.
+            ///
+            /// # Safety
+            ///
+            /// For a non-generic module, the selected package bundle must be
+            /// the artifact compiled from this `cuda_module`; package names are
+            /// not yet unique across all library and binary targets. For a
+            /// generic module, the merged PTX set must contain each matching
+            /// specialization and no conflicting entry definition.
+            pub unsafe fn load_async(
+                device_id: usize,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::cuda_async::error::DeviceError> {
+                // SAFETY: upheld by this function's caller.
+                unsafe { load_async_named(device_id, env!("CARGO_PKG_NAME")) }
+            }
+
+            /// Loads a caller-selected artifact for this contracted module.
+            ///
+            /// # Safety
+            ///
+            /// Every selected kernel must have the exact ABI and resource
+            /// semantics declared by this `cuda_module`. A matching symbol
+            /// name alone is not sufficient.
+            pub unsafe fn load_async_named(
+                device_id: usize,
+                name: &str,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::cuda_async::error::DeviceError> {
+                ::cuda_host::load_cuda_module_from_async_context(device_id, |ctx| {
+                    // SAFETY: upheld by this function's caller.
+                    unsafe { load_named(ctx, name) }
+                })
+            }
+        }
+    } else if cfg!(feature = "async") {
         quote! {
             pub fn load_async(
                 device_id: usize,
@@ -467,6 +737,102 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
         }
     } else {
         TokenStream2::new()
+    };
+    let load_definition = if has_launch_contract {
+        quote! {
+            /// Loads this package's embedded artifact for a contracted module.
+            ///
+            /// # Safety
+            ///
+            /// For a non-generic module, the selected package bundle must be
+            /// the artifact compiled from this `cuda_module`; package names are
+            /// not yet unique across all library and binary targets. For a
+            /// generic module, the merged PTX set must contain each matching
+            /// specialization and no conflicting entry definition.
+            pub unsafe fn load(
+                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
+                // SAFETY: upheld by this function's caller.
+                unsafe { load_named(ctx, env!("CARGO_PKG_NAME")) }
+            }
+        }
+    } else {
+        quote! {
+            pub fn load(
+                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
+                load_named(ctx, env!("CARGO_PKG_NAME"))
+            }
+        }
+    };
+    let load_named_definition = if has_launch_contract {
+        quote! {
+            /// Loads a caller-selected artifact for this contracted module.
+            ///
+            /// # Safety
+            ///
+            /// Every selected kernel must have the exact ABI and resource
+            /// semantics declared by this `cuda_module`. A matching symbol
+            /// name alone is not sufficient.
+            pub unsafe fn load_named(
+                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
+                name: &str,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
+                #artifact_anchor_statements
+                #module_loader
+                // SAFETY: upheld by this function's caller.
+                unsafe { from_module(module) }.map_err(::cuda_host::EmbeddedModuleError::Driver)
+            }
+        }
+    } else {
+        quote! {
+            pub fn load_named(
+                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
+                name: &str,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
+                #artifact_anchor_statements
+                #module_loader
+                from_module(module).map_err(::cuda_host::EmbeddedModuleError::Driver)
+            }
+        }
+    };
+    let from_module_definition = if has_launch_contract {
+        quote! {
+            /// Binds caller-provided CUDA code to this module's launch API.
+            ///
+            /// # Safety
+            ///
+            /// Every loaded kernel must have the exact ABI and resource
+            /// semantics declared by this `cuda_module`. A matching symbol
+            /// name alone is not sufficient.
+            pub unsafe fn from_module(
+                module: ::std::sync::Arc<::cuda_core::CudaModule>,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_core::DriverError> {
+                Ok(LoadedModule {
+                    __module: module.clone(),
+                    __generic_functions: ::std::sync::Arc::new(
+                        ::std::sync::Mutex::new(::std::collections::HashMap::new())
+                    ),
+                    #(#function_initializers)*
+                    #(#constant_initializers)*
+                })
+            }
+        }
+    } else {
+        quote! {
+            pub fn from_module(
+                module: ::std::sync::Arc<::cuda_core::CudaModule>,
+            ) -> ::core::result::Result<LoadedModule, ::cuda_core::DriverError> {
+                Ok(LoadedModule {
+                    __module: module.clone(),
+                    __generic_functions: ::std::sync::Arc::new(
+                        ::std::sync::Mutex::new(::std::collections::HashMap::new())
+                    ),
+                    #(#function_initializers)*
+                    #(#constant_initializers)*
+                })
+            }
+        }
     };
     let async_launch_methods = if cfg!(feature = "async") {
         let async_launch_methods = direct_kernels
@@ -487,6 +853,7 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
         #(#module_attrs)*
         #vis mod #ident {
             #(#module_items)*
+            #(#launch_contract_impls)*
 
             #[derive(Clone, Debug)]
             #[allow(non_snake_case)]
@@ -501,33 +868,11 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
                 #(#constant_fields)*
             }
 
-            pub fn load(
-                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
-            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
-                load_named(ctx, env!("CARGO_PKG_NAME"))
-            }
+            #load_definition
 
-            pub fn load_named(
-                ctx: &::std::sync::Arc<::cuda_core::CudaContext>,
-                name: &str,
-            ) -> ::core::result::Result<LoadedModule, ::cuda_host::EmbeddedModuleError> {
-                #artifact_anchor_statements
-                #module_loader
-                from_module(module).map_err(::cuda_host::EmbeddedModuleError::Driver)
-            }
+            #load_named_definition
 
-            pub fn from_module(
-                module: ::std::sync::Arc<::cuda_core::CudaModule>,
-            ) -> ::core::result::Result<LoadedModule, ::cuda_core::DriverError> {
-                Ok(LoadedModule {
-                    __module: module.clone(),
-                    __generic_functions: ::std::sync::Arc::new(
-                        ::std::sync::Mutex::new(::std::collections::HashMap::new())
-                    ),
-                    #(#function_initializers)*
-                    #(#constant_initializers)*
-                })
-            }
+            #from_module_definition
 
             #async_module_items
 
@@ -537,6 +882,7 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
                 }
 
                 #(#launch_methods)*
+                #(#prepare_launch_methods)*
                 #(#constant_resolver_methods)*
                 #(#set_constant_methods)*
                 #async_launch_methods
@@ -726,6 +1072,12 @@ fn cuda_module_kernel(
     let cluster_dim = cuda_module_cluster_dim(&item_fn.attrs)?;
     let cooperative = cuda_module_cooperative(&item_fn.attrs)?;
     let params = cuda_module_params(item_fn)?;
+    let launch_contract =
+        cuda_module_launch_contract(&item_fn.attrs, &item_fn.sig.ident, &params, cluster_dim)?;
+    let mut generics = item_fn.sig.generics.clone();
+    if let Some(contract) = launch_contract {
+        add_cuda_module_disjoint_contract_bounds(&mut generics, &params, contract.domain);
+    }
     let is_generic = has_codegen_generics(&item_fn.sig.generics);
     let cfg_attrs = cuda_module_cfg_attrs(&item_fn.attrs)?;
     let mut effective_cfg_attrs = ancestor_cfg_attrs.to_vec();
@@ -738,15 +1090,22 @@ fn cuda_module_kernel(
         method_attrs: cuda_module_method_attrs(&item_fn.attrs),
         unsafety: item_fn.sig.unsafety,
         fn_name: item_fn.sig.ident.clone(),
-        generics: item_fn.sig.generics.clone(),
+        generics,
         params,
         cluster_dim,
         cooperative,
+        launch_contract,
         is_generic,
     }))
 }
 
 fn generate_nested_cuda_module_support(kernels: &[CudaModuleKernel]) -> TokenStream2 {
+    let launch_contract_impls = kernels
+        .iter()
+        .filter_map(generate_cuda_module_launch_contract_impl);
+    let prepare_launch_methods = kernels
+        .iter()
+        .filter_map(generate_cuda_module_prepare_launch_methods);
     let non_generic_kernels = kernels.iter().filter(|kernel| !kernel.is_generic);
     let function_fields = non_generic_kernels.clone().map(|kernel| {
         let cfg_attrs = &kernel.cfg_attrs;
@@ -780,6 +1139,8 @@ fn generate_nested_cuda_module_support(kernels: &[CudaModuleKernel]) -> TokenStr
     };
 
     quote! {
+        #(#launch_contract_impls)*
+
         #[derive(Clone, Debug)]
         #[allow(non_snake_case)]
         pub struct LoadedModule {
@@ -811,6 +1172,7 @@ fn generate_nested_cuda_module_support(kernels: &[CudaModuleKernel]) -> TokenStr
             }
 
             #(#launch_methods)*
+            #(#prepare_launch_methods)*
             #async_launch_methods
         }
     }
@@ -1362,6 +1724,132 @@ fn cuda_module_cooperative(attrs: &[syn::Attribute]) -> syn::Result<bool> {
     Ok(false)
 }
 
+fn cuda_module_launch_contract(
+    attrs: &[syn::Attribute],
+    _fn_name: &Ident,
+    params: &[CudaModuleParam],
+    cluster_dim: Option<(u32, u32, u32)>,
+) -> syn::Result<Option<CudaModuleLaunchContract>> {
+    let contract_attrs: Vec<_> = attrs
+        .iter()
+        .filter(|attr| attr_path_ends_with(attr, "launch_contract"))
+        .collect();
+    if contract_attrs.len() > 1 {
+        return Err(syn::Error::new_spanned(
+            contract_attrs[1],
+            "a kernel may have only one launch_contract",
+        ));
+    }
+    let Some(attr) = contract_attrs.first() else {
+        return Ok(None);
+    };
+    let args = attr.parse_args::<LaunchContractArgs>()?;
+
+    if let Some(param) = params.iter().find(|param| param.mutable_slice) {
+        return Err(syn::Error::new(
+            param.name.span(),
+            "contracted kernels cannot take `&mut [T]`; use `DisjointSlice<T, IndexSpace>` so the launch domain and per-thread write ownership are explicit",
+        ));
+    }
+    if let Some(block) = args.exact_block {
+        validate_dimensions_for_domain(block, args.domain, "block", attr.span())?;
+    }
+    if let Some(cluster) = cluster_dim {
+        validate_dimensions_for_domain(cluster, args.domain, "cluster", attr.span())?;
+    }
+
+    let launch_bounds = cuda_module_launch_bounds(attrs)?;
+    if launch_bounds.is_some_and(|bounds| bounds.max_threads == 0) {
+        return Err(syn::Error::new_spanned(
+            attr,
+            "contracted #[launch_bounds] must allow at least one X-dimension thread",
+        ));
+    }
+    if args.exact_block.is_none() && launch_bounds.is_none() {
+        return Err(syn::Error::new_spanned(
+            attr,
+            "launch_contract requires either an exact `block = (x, y, z)` or #[launch_bounds(max_threads)]",
+        ));
+    }
+    let max_block_threads = launch_bounds.map(|bounds| bounds.max_threads);
+    if let (Some(exact), Some(maximum)) = (args.exact_block, max_block_threads) {
+        let exact_threads = u64::from(exact.0)
+            .checked_mul(u64::from(exact.1))
+            .and_then(|xy| xy.checked_mul(u64::from(exact.2)))
+            .ok_or_else(|| {
+                syn::Error::new_spanned(attr, "launch_contract block thread count overflows u64")
+            })?;
+        if exact_threads > u64::from(maximum) {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!(
+                    "launch_contract block {exact:?} has {exact_threads} threads, exceeding #[launch_bounds({maximum})]"
+                ),
+            ));
+        }
+    }
+
+    let min_compute_capability = match cluster_dim {
+        Some(_) if args.min_compute_capability < (9, 0) => (9, 0),
+        _ => args.min_compute_capability,
+    };
+
+    Ok(Some(CudaModuleLaunchContract {
+        domain: args.domain,
+        exact_block: args.exact_block,
+        max_block_threads,
+        dynamic_shared: args.dynamic_shared,
+        dynamic_shared_alignment: args.dynamic_shared_alignment,
+        min_compute_capability,
+    }))
+}
+
+fn cuda_module_launch_bounds(attrs: &[syn::Attribute]) -> syn::Result<Option<LaunchBoundsArgs>> {
+    let matching: Vec<_> = attrs
+        .iter()
+        .filter(|attr| attr_path_ends_with(attr, "launch_bounds"))
+        .collect();
+    if matching.len() > 1 {
+        return Err(syn::Error::new_spanned(
+            matching[1],
+            "a kernel may have only one launch_bounds attribute",
+        ));
+    }
+    matching
+        .first()
+        .map(|attr| attr.parse_args::<LaunchBoundsArgs>())
+        .transpose()
+}
+
+fn validate_dimensions_for_domain(
+    dimensions: (u32, u32, u32),
+    domain: u8,
+    kind: &str,
+    span: proc_macro2::Span,
+) -> syn::Result<()> {
+    if dimensions.0 == 0 || dimensions.1 == 0 || dimensions.2 == 0 {
+        return Err(syn::Error::new(
+            span,
+            format!("launch_contract {kind} dimensions must be non-zero"),
+        ));
+    }
+    let outside_domain = match domain {
+        1 => dimensions.1 != 1 || dimensions.2 != 1,
+        2 => dimensions.2 != 1,
+        3 => false,
+        _ => unreachable!(),
+    };
+    if outside_domain {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "launch_contract {kind} dimensions {dimensions:?} exceed the declared {domain}D domain"
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn cuda_module_params(item_fn: &ItemFn) -> syn::Result<Vec<CudaModuleParam>> {
     item_fn
         .sig
@@ -1386,11 +1874,19 @@ fn cuda_module_param_from_typed(pat_type: &syn::PatType) -> syn::Result<CudaModu
     };
     let name = pat_ident.ident.clone();
     let (sync_host_ty, async_host_ty, marshal) = cuda_module_host_type(&pat_type.ty)?;
+    let mutable_slice = cuda_module_slice_elem(&pat_type.ty).is_some_and(|(_, mutable)| mutable);
+    let disjoint_slice_elem = cuda_module_disjoint_slice_elem(&pat_type.ty);
+    let disjoint_slice_ty = disjoint_slice_elem
+        .as_ref()
+        .map(|_| pat_type.ty.as_ref().clone());
     Ok(CudaModuleParam {
         name,
         sync_host_ty,
         async_host_ty,
         marshal,
+        mutable_slice,
+        disjoint_slice_ty,
+        disjoint_slice_elem,
     })
 }
 
@@ -1468,20 +1964,247 @@ fn cuda_module_disjoint_slice_elem(ty: &Type) -> Option<TokenStream2> {
     let PathArguments::AngleBracketed(args) = &segment.arguments else {
         return None;
     };
-    args.args.iter().find_map(|arg| {
-        if let GenericArgument::Type(ty) = arg {
-            Some(quote! { #ty })
-        } else {
-            None
+    let type_args: Vec<_> = args
+        .args
+        .iter()
+        .filter_map(|arg| match arg {
+            GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect();
+    let elem = *type_args.first()?;
+    Some(quote! { #elem })
+}
+
+/// Adds a semantic launch-domain proof for every writable device slice.
+///
+/// The macro only uses the outer `DisjointSlice` spelling to select the host
+/// ABI. The Rust compiler decides whether the *resolved, complete type* is a
+/// genuine cuda-device slice with a compatible index space. This makes type
+/// aliases work without letting a local look-alike bypass the contract.
+fn add_cuda_module_disjoint_contract_bounds(
+    generics: &mut syn::Generics,
+    params: &[CudaModuleParam],
+    domain: u8,
+) {
+    for param in params {
+        let (Some(device_ty), Some(element_ty)) =
+            (&param.disjoint_slice_ty, &param.disjoint_slice_elem)
+        else {
+            continue;
+        };
+        let (device_ty, bound_lifetime) = cuda_module_disjoint_bound_type(device_ty);
+        generics.make_where_clause().predicates.push(parse_quote! {
+            for<#bound_lifetime> #device_ty:
+                ::cuda_device::__LaunchContractDisjointSlice<#element_ty, #domain>
+        });
+    }
+}
+
+/// Makes the elided `DisjointSlice` lifetime explicit so the complete device
+/// type can appear in an impl-level where-clause.
+fn cuda_module_disjoint_bound_type(ty: &Type) -> (Type, syn::Lifetime) {
+    let mut ty = ty.clone();
+    let Type::Path(type_path) = &mut ty else {
+        unreachable!("only recognized DisjointSlice paths reach this helper");
+    };
+    let segment = type_path
+        .path
+        .segments
+        .last_mut()
+        .expect("recognized DisjointSlice path has a final segment");
+    let PathArguments::AngleBracketed(args) = &mut segment.arguments else {
+        unreachable!("recognized DisjointSlice path has generic arguments");
+    };
+    let bound_ident = internal_ident("__cuda_oxide_disjoint");
+    let bound_lifetime = syn::Lifetime::new(&format!("'{}", bound_ident), bound_ident.span());
+    if let Some(GenericArgument::Lifetime(lifetime)) = args.args.first_mut() {
+        *lifetime = bound_lifetime.clone();
+    } else {
+        let previous = core::mem::take(&mut args.args);
+        args.args
+            .push(GenericArgument::Lifetime(bound_lifetime.clone()));
+        args.args.extend(previous);
+    }
+    (ty, bound_lifetime)
+}
+
+fn cuda_module_kernel_marker_type(kernel: &CudaModuleKernel) -> TokenStream2 {
+    let marker = cuda_kernel_marker_name(&kernel.fn_name);
+    if !kernel.is_generic {
+        return quote! { #marker };
+    }
+    let marker_args = generic_arguments(&kernel.generics);
+    if marker_args.is_empty() {
+        quote! { #marker }
+    } else {
+        quote! { #marker<#(#marker_args),*> }
+    }
+}
+
+fn generate_cuda_module_launch_contract_impl(kernel: &CudaModuleKernel) -> Option<TokenStream2> {
+    let contract = kernel.launch_contract.as_ref()?;
+    let cfg_attrs = &kernel.cfg_attrs;
+    let marker_ty = cuda_module_kernel_marker_type(kernel);
+    // `#[kernel]` erases lifetime-only generic lists because lifetimes do not
+    // create codegen instances. Mirror the marker that `#[kernel]` actually
+    // emits instead of applying erased lifetimes to a non-generic marker.
+    let generics = if kernel.is_generic {
+        kernel.generics.clone()
+    } else {
+        syn::Generics::default()
+    };
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let config_ty = match contract.domain {
+        1 => quote! { ::cuda_core::LaunchConfig1D },
+        2 => quote! { ::cuda_core::LaunchConfig2D },
+        3 => quote! { ::cuda_core::LaunchConfig3D },
+        _ => unreachable!(),
+    };
+    let block = if let Some((x, y, z)) = contract.exact_block {
+        quote! { ::cuda_core::BlockRequirement::Exact((#x, #y, #z)) }
+    } else {
+        let max_threads = contract
+            .max_block_threads
+            .expect("validated contract without exact block has launch bounds");
+        quote! { ::cuda_core::BlockRequirement::MaxThreads(#max_threads) }
+    };
+    let alignment = contract.dynamic_shared_alignment;
+    let dynamic_shared = match contract.dynamic_shared {
+        DynamicSharedContract::Exact(bytes) => quote! {
+            ::cuda_core::DynamicSharedMemoryRequirement::Exact {
+                bytes: #bytes,
+                min_alignment: #alignment,
+            }
+        },
+        DynamicSharedContract::Range {
+            min_bytes,
+            max_bytes,
+        } => quote! {
+            ::cuda_core::DynamicSharedMemoryRequirement::Range {
+                min_bytes: #min_bytes,
+                max_bytes: #max_bytes,
+                min_alignment: #alignment,
+            }
+        },
+    };
+    let kernel_name = kernel.fn_name.to_string();
+    let cluster = contract.cluster_tokens(kernel.cluster_dim);
+    let cooperative = kernel.cooperative.then(|| quote! { .with_cooperative() });
+    let (major, minor) = contract.min_compute_capability;
+    let compute_capability = ((major, minor) != (0, 0)).then(|| {
+        quote! { .with_min_compute_capability(#major, #minor) }
+    });
+
+    Some(quote! {
+        #(#cfg_attrs)*
+        impl #impl_generics ::cuda_core::KernelLaunchContract for #marker_ty
+        #where_clause
+        {
+            type Config = #config_ty;
+            const SPEC: ::cuda_core::LaunchContractSpec =
+                ::cuda_core::LaunchContractSpec::new(#kernel_name, #block, #dynamic_shared)
+                    #cluster
+                    #cooperative
+                    #compute_capability;
         }
     })
 }
 
+impl CudaModuleLaunchContract {
+    fn cluster_tokens(&self, cluster_dim: Option<(u32, u32, u32)>) -> Option<TokenStream2> {
+        cluster_dim.map(|(x, y, z)| quote! { .with_cluster((#x, #y, #z)) })
+    }
+}
+
+fn generate_cuda_module_prepare_launch_methods(kernel: &CudaModuleKernel) -> Option<TokenStream2> {
+    kernel.launch_contract.as_ref()?;
+    let vis = &kernel.vis;
+    let cfg_attrs = &kernel.cfg_attrs;
+    let fn_name = &kernel.fn_name;
+    let prepare_name = format_ident!("prepare_{}", fn_name);
+    let prepare_for_name = format_ident!("prepare_{}_for", fn_name);
+    let marker_ty = cuda_module_kernel_marker_type(kernel);
+    let generics = kernel.generics.clone();
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let function_binding = cuda_module_function_binding(kernel);
+    let function = internal_ident("__cuda_oxide_function");
+    let config = internal_ident("__cuda_oxide_config");
+    let codegen_args = codegen_generic_arguments(&kernel.generics);
+    let turbofish = if codegen_args.is_empty() {
+        quote! {}
+    } else {
+        quote! { ::<#(#codegen_args),*> }
+    };
+    let type_params: Vec<_> = kernel
+        .generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            GenericParam::Type(type_param) => Some(&type_param.ident),
+            GenericParam::Lifetime(_) | GenericParam::Const(_) => None,
+        })
+        .collect();
+    let witness_params = type_params.iter().enumerate().map(|(index, ty)| {
+        let name = internal_ident(&format!("__cuda_oxide_type_witness_{index}"));
+        quote! { #name: &#ty }
+    });
+    let prepare_for = (!type_params.is_empty()).then(|| {
+        quote! {
+            #(#cfg_attrs)*
+            #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+            #vis fn #prepare_for_name #impl_generics (
+                &self,
+                #(#witness_params,)*
+                #config: <#marker_ty as ::cuda_core::KernelLaunchContract>::Config,
+            ) -> ::core::result::Result<
+                ::cuda_core::PreparedLaunch<#marker_ty>,
+                ::cuda_core::LaunchContractError,
+            >
+            #where_clause
+            {
+                self.#prepare_name #turbofish (#config)
+            }
+        }
+    });
+
+    Some(quote! {
+        #(#cfg_attrs)*
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis fn #prepare_name #impl_generics (
+            &self,
+            #config: <#marker_ty as ::cuda_core::KernelLaunchContract>::Config,
+        ) -> ::core::result::Result<
+            ::cuda_core::PreparedLaunch<#marker_ty>,
+            ::cuda_core::LaunchContractError,
+        >
+        #where_clause
+        {
+            #function_binding
+            unsafe {
+                ::cuda_core::PreparedLaunch::<#marker_ty>::__prepare(
+                    #function.clone(),
+                    #config,
+                )
+            }
+        }
+
+        #prepare_for
+    })
+}
+
 fn generate_cuda_module_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+    if kernel.launch_contract.is_some() {
+        generate_cuda_module_prepared_launch_method(kernel)
+    } else {
+        generate_cuda_module_legacy_launch_method(kernel)
+    }
+}
+
+fn generate_cuda_module_legacy_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
     let vis = &kernel.vis;
     let cfg_attrs = &kernel.cfg_attrs;
     let method_attrs = &kernel.method_attrs;
-    let unsafety = &kernel.unsafety;
     let fn_name = &kernel.fn_name;
     let generics = cuda_module_launch_generics(kernel);
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -1504,8 +2227,12 @@ fn generate_cuda_module_launch_method(kernel: &CudaModuleKernel) -> TokenStream2
     quote! {
         #(#cfg_attrs)*
         #(#method_attrs)*
+        #[doc = "Launches this kernel with an unverified raw launch configuration."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "The launch dimensions and resources must satisfy every indexing, memory-access, launch-bounds, and dynamic-shared-memory assumption made by the kernel. Dimensions not represented by the kernel's index model must not introduce overlapping or out-of-bounds accesses. The caller must also uphold any safety requirements documented on the kernel itself."]
         #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
-        #vis #unsafety fn #fn_name #impl_generics (
+        #vis unsafe fn #fn_name #impl_generics (
             &self,
             #stream: &::cuda_core::CudaStream,
             #config: ::cuda_core::LaunchConfig,
@@ -1521,11 +2248,98 @@ fn generate_cuda_module_launch_method(kernel: &CudaModuleKernel) -> TokenStream2
     }
 }
 
-fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+fn generate_cuda_module_prepared_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
     let vis = &kernel.vis;
     let cfg_attrs = &kernel.cfg_attrs;
     let method_attrs = &kernel.method_attrs;
     let unsafety = &kernel.unsafety;
+    let fn_name = &kernel.fn_name;
+    let unchecked_name = format_ident!("{}_unchecked", fn_name);
+    let marker_ty = cuda_module_kernel_marker_type(kernel);
+    let generics = cuda_module_launch_generics(kernel);
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let params: Vec<_> = kernel
+        .params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let host_ty = &param.sync_host_ty;
+            quote! { #name: #host_ty }
+        })
+        .collect();
+    let prepared_arg_marshalling = kernel
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, param)| cuda_module_arg_marshalling(index, param));
+    let unchecked_arg_marshalling = kernel
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, param)| cuda_module_arg_marshalling(index, param));
+    let unchecked_function_binding = cuda_module_function_binding(kernel);
+    let launch_call = cuda_module_launch_call(kernel);
+    let unchecked_launch_call = cuda_module_launch_call(kernel);
+    let stream = internal_ident("__cuda_oxide_stream");
+    let prepared = internal_ident("__cuda_oxide_prepared");
+    let function = internal_ident("__cuda_oxide_function");
+    let config = internal_ident("__cuda_oxide_config");
+    let args = internal_ident("__cuda_oxide_args");
+
+    quote! {
+        #(#cfg_attrs)*
+        #(#method_attrs)*
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis #unsafety fn #fn_name #impl_generics (
+            &self,
+            #stream: &::cuda_core::CudaStream,
+            #prepared: &::cuda_core::PreparedLaunch<#marker_ty>,
+            #(#params),*
+        ) -> ::core::result::Result<(), ::cuda_core::LaunchContractError>
+        #where_clause
+        {
+            #prepared.validate_stream(#stream)?;
+            let #function = #prepared.function();
+            let #config = #prepared.__raw_config();
+            let mut #args: ::std::vec::Vec<*mut ::std::ffi::c_void> = ::std::vec::Vec::new();
+            #(#prepared_arg_marshalling)*
+            (#launch_call).map_err(::cuda_core::LaunchContractError::from)
+        }
+
+        #(#cfg_attrs)*
+        #[doc = "Unchecked launch escape hatch for this contracted kernel."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "The caller must uphold the kernel's declared geometry, resource, capability, and context contract."]
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis unsafe fn #unchecked_name #impl_generics (
+            &self,
+            #stream: &::cuda_core::CudaStream,
+            #config: ::cuda_core::LaunchConfig,
+            #(#params),*
+        ) -> ::core::result::Result<(), ::cuda_core::DriverError>
+        #where_clause
+        {
+            #unchecked_function_binding
+            let mut #args: ::std::vec::Vec<*mut ::std::ffi::c_void> = ::std::vec::Vec::new();
+            #(#unchecked_arg_marshalling)*
+            #unchecked_launch_call
+        }
+    }
+}
+
+fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+    if kernel.launch_contract.is_some() {
+        generate_cuda_module_prepared_async_launch_method(kernel)
+    } else {
+        generate_cuda_module_legacy_async_launch_method(kernel)
+    }
+}
+
+fn generate_cuda_module_legacy_async_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+    let vis = &kernel.vis;
+    let cfg_attrs = &kernel.cfg_attrs;
+    let method_attrs = &kernel.method_attrs;
     let fn_name = format_ident!("{}_async", kernel.fn_name);
     let generics = cuda_module_async_launch_generics(kernel);
     let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
@@ -1555,8 +2369,12 @@ fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenS
     quote! {
         #(#cfg_attrs)*
         #(#method_attrs)*
+        #[doc = "Builds a lazy async launch from an unverified raw launch configuration."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "Before scheduling the returned operation, the launch dimensions and resources must satisfy every indexing, memory-access, launch-bounds, and dynamic-shared-memory assumption made by the kernel. Dimensions not represented by the kernel's index model must not introduce overlapping or out-of-bounds accesses. The caller must also uphold any safety requirements documented on the kernel itself."]
         #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
-        #vis #unsafety fn #fn_name #impl_generics (
+        #vis unsafe fn #fn_name #impl_generics (
             &self,
             #config: ::cuda_core::LaunchConfig,
             #(#params),*
@@ -1564,20 +2382,130 @@ fn generate_cuda_module_async_launch_method(kernel: &CudaModuleKernel) -> TokenS
         #where_clause
         {
             #function_binding
-            let mut #launch = ::cuda_host::new_async_kernel_launch(#function.clone(), #config);
+            let mut #launch = ::cuda_host::new_async_kernel_launch_builder(#function.clone());
             #set_cluster_dim
             #set_cooperative
             #(#arg_marshalling)*
-            Ok(#launch)
+            // SAFETY: this method is unsafe and its caller must uphold the raw
+            // launch configuration contract documented above.
+            Ok(unsafe { #launch.finalize_unchecked(#config) })
+        }
+    }
+}
+
+fn generate_cuda_module_prepared_async_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+    let vis = &kernel.vis;
+    let cfg_attrs = &kernel.cfg_attrs;
+    let method_attrs = &kernel.method_attrs;
+    let unsafety = &kernel.unsafety;
+    let fn_name = format_ident!("{}_async", kernel.fn_name);
+    let unchecked_name = format_ident!("{}_async_unchecked", kernel.fn_name);
+    let marker_ty = cuda_module_kernel_marker_type(kernel);
+    let generics = cuda_module_async_launch_generics(kernel);
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let params: Vec<_> = kernel
+        .params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let host_ty = &param.async_host_ty;
+            quote! { #name: #host_ty }
+        })
+        .collect();
+    let prepared_marshalling = kernel.params.iter().map(cuda_module_async_arg_marshalling);
+    let unchecked_marshalling = kernel.params.iter().map(cuda_module_async_arg_marshalling);
+    let unchecked_function_binding = cuda_module_function_binding(kernel);
+    let prepared = internal_ident("__cuda_oxide_prepared");
+    let config = internal_ident("__cuda_oxide_config");
+    let function = internal_ident("__cuda_oxide_function");
+    let launch = internal_ident("__cuda_oxide_launch");
+    let async_lifetime = cuda_module_async_lifetime();
+    let cluster_dim = kernel.cluster_dim.map(|(x, y, z)| quote! { (#x, #y, #z) });
+    let prepared_cluster = cluster_dim.as_ref().map(|cluster_dim| {
+        quote! { ::cuda_host::set_async_kernel_cluster_dim(&mut #launch, #cluster_dim); }
+    });
+    let unchecked_cluster = cluster_dim.as_ref().map(|cluster_dim| {
+        quote! { ::cuda_host::set_async_kernel_cluster_dim(&mut #launch, #cluster_dim); }
+    });
+    let prepared_cooperative = kernel.cooperative.then(|| {
+        quote! { ::cuda_host::set_async_kernel_cooperative(&mut #launch, true); }
+    });
+    let unchecked_cooperative = kernel.cooperative.then(|| {
+        quote! { ::cuda_host::set_async_kernel_cooperative(&mut #launch, true); }
+    });
+
+    quote! {
+        #(#cfg_attrs)*
+        #(#method_attrs)*
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis #unsafety fn #fn_name #impl_generics (
+            &self,
+            #prepared: &::cuda_core::PreparedLaunch<#marker_ty>,
+            #(#params),*
+        ) -> ::cuda_host::PreparedAsyncKernelLaunch<#async_lifetime, #marker_ty>
+        #where_clause
+        {
+            let mut #launch =
+                ::cuda_host::new_async_kernel_launch_builder(#prepared.function().clone());
+            #prepared_cluster
+            #prepared_cooperative
+            #(#prepared_marshalling)*
+            // SAFETY: PreparedLaunch validated this kernel-branded config and
+            // the builder has not exposed a way to mutate it after finalization.
+            let #launch = unsafe {
+                #launch.finalize_unchecked(#prepared.__raw_config())
+            };
+            unsafe {
+                ::cuda_host::new_prepared_async_kernel_launch(
+                    #launch,
+                    (*#prepared).clone(),
+                )
+            }
+        }
+
+        #(#cfg_attrs)*
+        #[doc = "Unchecked async launch escape hatch for this contracted kernel."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "The caller must uphold the kernel's declared geometry, resource, capability, and context contract when the returned operation is scheduled."]
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis unsafe fn #unchecked_name #impl_generics (
+            &self,
+            #config: ::cuda_core::LaunchConfig,
+            #(#params),*
+        ) -> ::core::result::Result<
+            ::cuda_host::AsyncKernelLaunch<#async_lifetime>,
+            ::cuda_core::DriverError,
+        >
+        #where_clause
+        {
+            #unchecked_function_binding
+            let mut #launch =
+                ::cuda_host::new_async_kernel_launch_builder(#function.clone());
+            #unchecked_cluster
+            #unchecked_cooperative
+            #(#unchecked_marshalling)*
+            // SAFETY: this method is unsafe and its caller must uphold the
+            // contracted kernel's raw launch requirements documented above.
+            Ok(unsafe { #launch.finalize_unchecked(#config) })
         }
     }
 }
 
 fn generate_cuda_module_owned_async_launch_method(kernel: &CudaModuleKernel) -> TokenStream2 {
+    if kernel.launch_contract.is_some() {
+        generate_cuda_module_prepared_owned_async_launch_method(kernel)
+    } else {
+        generate_cuda_module_legacy_owned_async_launch_method(kernel)
+    }
+}
+
+fn generate_cuda_module_legacy_owned_async_launch_method(
+    kernel: &CudaModuleKernel,
+) -> TokenStream2 {
     let vis = &kernel.vis;
     let cfg_attrs = &kernel.cfg_attrs;
     let method_attrs = &kernel.method_attrs;
-    let unsafety = &kernel.unsafety;
     let fn_name = format_ident!("{}_async_owned", kernel.fn_name);
     let resources = cuda_module_owned_resource_params(kernel);
     let generics = cuda_module_owned_async_launch_generics(kernel, &resources);
@@ -1629,8 +2557,12 @@ fn generate_cuda_module_owned_async_launch_method(kernel: &CudaModuleKernel) -> 
     quote! {
         #(#cfg_attrs)*
         #(#method_attrs)*
+        #[doc = "Builds a lazy owned async launch from an unverified raw launch configuration."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "Before scheduling the returned operation, the launch dimensions and resources must satisfy every indexing, memory-access, launch-bounds, and dynamic-shared-memory assumption made by the kernel. Dimensions not represented by the kernel's index model must not introduce overlapping or out-of-bounds accesses. The caller must also uphold any safety requirements documented on the kernel itself."]
         #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
-        #vis #unsafety fn #fn_name #impl_generics (
+        #vis unsafe fn #fn_name #impl_generics (
             &self,
             #config: ::cuda_core::LaunchConfig,
             #(#params),*
@@ -1638,12 +2570,157 @@ fn generate_cuda_module_owned_async_launch_method(kernel: &CudaModuleKernel) -> 
         #where_clause
         {
             #function_binding
-            let mut #launch: ::cuda_host::AsyncKernelLaunch<'static> =
-                ::cuda_host::new_async_kernel_launch(#function.clone(), #config);
+            let mut #launch =
+                ::cuda_host::new_async_kernel_launch_builder(#function.clone());
             #set_cluster_dim
             #set_cooperative
             #(#arg_marshalling)*
+            // SAFETY: this method is unsafe and its caller must uphold the raw
+            // launch configuration contract documented above.
+            let #launch: ::cuda_host::AsyncKernelLaunch<'static> =
+                unsafe { #launch.finalize_unchecked(#config) };
             Ok(::cuda_host::new_owned_async_kernel_launch(#launch, #resources_expr))
+        }
+    }
+}
+
+fn generate_cuda_module_prepared_owned_async_launch_method(
+    kernel: &CudaModuleKernel,
+) -> TokenStream2 {
+    let vis = &kernel.vis;
+    let cfg_attrs = &kernel.cfg_attrs;
+    let method_attrs = &kernel.method_attrs;
+    let unsafety = &kernel.unsafety;
+    let fn_name = format_ident!("{}_async_owned", kernel.fn_name);
+    let unchecked_name = format_ident!("{}_async_owned_unchecked", kernel.fn_name);
+    let marker_ty = cuda_module_kernel_marker_type(kernel);
+    let resources = cuda_module_owned_resource_params(kernel);
+    let generics = cuda_module_owned_async_launch_generics(kernel, &resources);
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+    let params: Vec<_> = kernel
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, param)| {
+            let name = &param.name;
+            match &param.marshal {
+                CudaModuleParamMarshal::Scalar => {
+                    let host_ty = &param.async_host_ty;
+                    quote! { #name: #host_ty }
+                }
+                CudaModuleParamMarshal::ReadOnlyDeviceBuffer { .. } => {
+                    let resource_ty = cuda_module_owned_resource_type(index);
+                    quote! { #name: #resource_ty }
+                }
+                CudaModuleParamMarshal::WritableDeviceBuffer { .. } => {
+                    let resource_ty = cuda_module_owned_resource_type(index);
+                    quote! { mut #name: #resource_ty }
+                }
+            }
+        })
+        .collect();
+    let prepared_marshalling = kernel
+        .params
+        .iter()
+        .map(cuda_module_owned_async_arg_marshalling);
+    let unchecked_marshalling = kernel
+        .params
+        .iter()
+        .map(cuda_module_owned_async_arg_marshalling);
+    let unchecked_function_binding = cuda_module_function_binding(kernel);
+    let prepared = internal_ident("__cuda_oxide_prepared");
+    let config = internal_ident("__cuda_oxide_config");
+    let function = internal_ident("__cuda_oxide_function");
+    let launch = internal_ident("__cuda_oxide_launch");
+    let owned = internal_ident("__cuda_oxide_owned");
+    let cluster_dim = kernel.cluster_dim.map(|(x, y, z)| quote! { (#x, #y, #z) });
+    let prepared_cluster = cluster_dim.as_ref().map(|cluster_dim| {
+        quote! { ::cuda_host::set_async_kernel_cluster_dim(&mut #launch, #cluster_dim); }
+    });
+    let unchecked_cluster = cluster_dim.as_ref().map(|cluster_dim| {
+        quote! { ::cuda_host::set_async_kernel_cluster_dim(&mut #launch, #cluster_dim); }
+    });
+    let prepared_cooperative = kernel.cooperative.then(|| {
+        quote! { ::cuda_host::set_async_kernel_cooperative(&mut #launch, true); }
+    });
+    let unchecked_cooperative = kernel.cooperative.then(|| {
+        quote! { ::cuda_host::set_async_kernel_cooperative(&mut #launch, true); }
+    });
+    let resources_ty = cuda_module_owned_resources_ty(&resources);
+    let prepared_resource_names = resources.iter().map(|(_, name, _, _)| name);
+    let unchecked_resource_names = resources.iter().map(|(_, name, _, _)| name);
+    let prepared_resources_expr = if resources.is_empty() {
+        quote! { () }
+    } else {
+        quote! { (#(#prepared_resource_names),*) }
+    };
+    let unchecked_resources_expr = if resources.is_empty() {
+        quote! { () }
+    } else {
+        quote! { (#(#unchecked_resource_names),*) }
+    };
+
+    quote! {
+        #(#cfg_attrs)*
+        #(#method_attrs)*
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis #unsafety fn #fn_name #impl_generics (
+            &self,
+            #prepared: &::cuda_core::PreparedLaunch<#marker_ty>,
+            #(#params),*
+        ) -> ::cuda_host::PreparedOwnedAsyncKernelLaunch<#resources_ty, #marker_ty>
+        #where_clause
+        {
+            let mut #launch =
+                ::cuda_host::new_async_kernel_launch_builder(#prepared.function().clone());
+            #prepared_cluster
+            #prepared_cooperative
+            #(#prepared_marshalling)*
+            // SAFETY: PreparedLaunch validated this kernel-branded config and
+            // the builder has not exposed a way to mutate it after finalization.
+            let #launch: ::cuda_host::AsyncKernelLaunch<'static> = unsafe {
+                #launch.finalize_unchecked(#prepared.__raw_config())
+            };
+            let #owned =
+                ::cuda_host::new_owned_async_kernel_launch(#launch, #prepared_resources_expr);
+            unsafe {
+                ::cuda_host::new_prepared_owned_async_kernel_launch(
+                    #owned,
+                    (*#prepared).clone(),
+                )
+            }
+        }
+
+        #(#cfg_attrs)*
+        #[doc = "Unchecked owned-async launch escape hatch for this contracted kernel."]
+        #[doc = ""]
+        #[doc = "# Safety"]
+        #[doc = "The caller must uphold the kernel's declared geometry, resource, capability, and context contract when the returned operation is scheduled."]
+        #[allow(clippy::multiple_bound_locations, clippy::too_many_arguments)]
+        #vis unsafe fn #unchecked_name #impl_generics (
+            &self,
+            #config: ::cuda_core::LaunchConfig,
+            #(#params),*
+        ) -> ::core::result::Result<
+            ::cuda_host::OwnedAsyncKernelLaunch<#resources_ty>,
+            ::cuda_core::DriverError,
+        >
+        #where_clause
+        {
+            #unchecked_function_binding
+            let mut #launch =
+                ::cuda_host::new_async_kernel_launch_builder(#function.clone());
+            #unchecked_cluster
+            #unchecked_cooperative
+            #(#unchecked_marshalling)*
+            // SAFETY: this method is unsafe and its caller must uphold the
+            // contracted kernel's raw launch requirements documented above.
+            let #launch: ::cuda_host::AsyncKernelLaunch<'static> =
+                unsafe { #launch.finalize_unchecked(#config) };
+            Ok(::cuda_host::new_owned_async_kernel_launch(
+                #launch,
+                #unchecked_resources_expr,
+            ))
         }
     }
 }
@@ -2592,6 +3669,53 @@ fn inject_thread_index_scope(input: &mut ItemFn) {
     }
 }
 
+/// Return compiler configuration markers already materialized in a generic
+/// kernel body by attributes that expanded before `#[kernel]`.
+///
+/// Only exact, zero-argument calls to cuda-oxide's three internal marker paths
+/// are forwarded. Nested calls and unrelated top-level calls remain solely in
+/// the helper body.
+fn top_level_kernel_configuration_markers(input: &ItemFn) -> Vec<Stmt> {
+    input
+        .block
+        .stmts
+        .iter()
+        .filter(|statement| is_kernel_configuration_marker(statement))
+        .cloned()
+        .collect()
+}
+
+fn is_kernel_configuration_marker(statement: &Stmt) -> bool {
+    let Stmt::Expr(Expr::Call(call), Some(_semicolon)) = statement else {
+        return false;
+    };
+    if !call.args.is_empty() {
+        return false;
+    }
+    let Expr::Path(ExprPath {
+        qself: None, path, ..
+    }) = &*call.func
+    else {
+        return false;
+    };
+    let segments: Vec<_> = path.segments.iter().collect();
+    if path.leading_colon.is_none()
+        || segments.len() != 3
+        || segments[0].ident != "cuda_device"
+        || !matches!(segments[0].arguments, PathArguments::None)
+        || !matches!(segments[1].arguments, PathArguments::None)
+        || !matches!(segments[2].arguments, PathArguments::AngleBracketed(_))
+    {
+        return false;
+    }
+
+    let module = &segments[1].ident;
+    let marker = &segments[2].ident;
+    (module == "thread" && marker == "__launch_bounds_config")
+        || (module == "cluster" && marker == "__cluster_config")
+        || (module == "shared" && marker == "__dynamic_shared_alignment")
+}
+
 /// Generate a generic kernel that will be instantiated from call sites (nvcc-style)
 fn generate_generic_kernel_no_instantiation(mut input: ItemFn) -> TokenStream {
     inject_thread_index_scope(&mut input);
@@ -2601,7 +3725,7 @@ fn generate_generic_kernel_no_instantiation(mut input: ItemFn) -> TokenStream {
     // function, keep ordinary Rust attributes on the user-facing
     // implementation, and copy cfg gates to every generated item.
     let (implementation_attrs, entry_attrs, cfg_attrs) = route_generic_kernel_attrs(&input.attrs);
-
+    let entry_config_markers = top_level_kernel_configuration_markers(&input);
     let fn_name = &input.sig.ident;
     let vis = &input.vis;
     let generics = &input.sig.generics;
@@ -2705,6 +3829,7 @@ fn generate_generic_kernel_no_instantiation(mut input: ItemFn) -> TokenStream {
         #(#entry_attrs)*
         #[inline(never)]
         #vis #constness #unsafety #abi fn #kernel_name #generics (#(#wrapper_inputs),*) #output #where_clause {
+            #(#entry_config_markers)*
             #implementation_call
         }
 
@@ -2735,6 +3860,7 @@ fn route_generic_kernel_attrs(
     };
     let is_entry_directive = |attr: &syn::Attribute| {
         attr_path_ends_with(attr, "launch_bounds")
+            || attr_path_ends_with(attr, "launch_contract")
             || attr_path_ends_with(attr, "cluster_launch")
             || attr_path_ends_with(attr, "cooperative_launch")
     };
@@ -2938,6 +4064,9 @@ fn generate_cuda_kernel_impl(fn_name: &Ident, ptx_name: &str, _func: &ItemFn) ->
 fn generate_generic_kernel(mut input: ItemFn, instantiate_types: Vec<Type>) -> TokenStream {
     inject_thread_index_scope(&mut input);
 
+    let (implementation_attrs, entry_attrs, _cfg_attrs) = route_generic_kernel_attrs(&input.attrs);
+    let entry_config_markers = top_level_kernel_configuration_markers(&input);
+    input.attrs.clear();
     let fn_name = &input.sig.ident;
     let vis = &input.vis;
     let generics = &input.sig.generics;
@@ -2975,6 +4104,8 @@ fn generate_generic_kernel(mut input: ItemFn, instantiate_types: Vec<Type>) -> T
     let wrappers: Vec<TokenStream2> = instantiate_types
         .iter()
         .map(|inst_type| {
+            let entry_attrs = &entry_attrs;
+            let entry_config_markers = &entry_config_markers;
             // Get a clean name for the type (for the kernel name suffix)
             let type_name = get_type_name(inst_type);
             let wrapper_name = format_ident!("{}{}_{}", KERNEL_PREFIX, fn_name, type_name);
@@ -2999,9 +4130,11 @@ fn generate_generic_kernel(mut input: ItemFn, instantiate_types: Vec<Type>) -> T
                 .collect();
 
             quote! {
+                #(#entry_attrs)*
                 #[unsafe(no_mangle)]
                 #[unsafe(export_name = #export_name_str)]
                 #vis fn #wrapper_name(#(#wrapper_args),*) {
+                    #(#entry_config_markers)*
                     #fn_name::<#inst_type>(#(#arg_names),*);
                 }
             }
@@ -3011,6 +4144,7 @@ fn generate_generic_kernel(mut input: ItemFn, instantiate_types: Vec<Type>) -> T
     // Keep the original generic function (without #[no_mangle] - it's not an entry point)
     // and add all the wrapper kernels
     let expanded = quote! {
+        #(#implementation_attrs)*
         #[inline(always)]
         #input
 
@@ -3084,7 +4218,8 @@ fn substitute_type(ty: &Type, param: &syn::Ident, replacement: &Type) -> TokenSt
 /// # Requirements
 ///
 /// - Must be used WITH `#[kernel]` (not standalone)
-/// - The `#[launch_bounds]` attribute must come AFTER `#[kernel]`
+/// - May appear before or after `#[kernel]`; generic entry generation forwards
+///   an already-expanded compiler marker to each entry wrapper
 ///
 /// # Performance Impact
 ///
@@ -3108,7 +4243,7 @@ pub fn launch_bounds(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Inject the launch bounds config marker at the start of the function body
     let marker_call: syn::Stmt = syn::parse_quote! {
-        cuda_device::thread::__launch_bounds_config::<#max_threads, #min_blocks>();
+        ::cuda_device::thread::__launch_bounds_config::<#max_threads, #min_blocks>();
     };
 
     // Prepend the marker to the function body
@@ -3120,7 +4255,64 @@ pub fn launch_bounds(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Declares the host launch geometry and resource contract for a kernel.
+///
+/// `#[cuda_module]` uses this opt-in declaration to generate a prepared,
+/// kernel-branded launch path. A prepared launch can be reused without
+/// repeating CUDA capability and function-resource queries, while raw
+/// [`LaunchConfig`](https://docs.rs/cuda-core/latest/cuda_core/struct.LaunchConfig.html)
+/// remains available through an explicitly unsafe generated method.
+///
+/// ```ignore
+/// use cuda_device::{kernel, launch_bounds, launch_contract, DisjointSlice};
+///
+/// #[kernel]
+/// #[launch_bounds(256)]
+/// #[launch_contract(
+///     domain = 1,
+///     block = (256, 1, 1),
+///     dynamic_shared = 0,
+///     min_compute_capability = (8, 0),
+/// )]
+/// pub fn map(mut output: DisjointSlice<f32>) {
+///     // ...
+/// }
+/// ```
+///
+/// `domain` is an author declaration, not body inference: helper calls can
+/// hide which hardware indices a kernel reads. For obvious mismatches,
+/// `#[cuda_module]` cross-checks the declaration against `DisjointSlice` index
+/// spaces and the fixed cluster shape.
+///
+/// Dynamic shared memory may be fixed with `dynamic_shared = BYTES` or bounded
+/// with `dynamic_shared_range = (MIN, MAX)`. The byte extent remains an author
+/// contract because arbitrary pointer arithmetic cannot be inferred. When the
+/// maximum is non-zero, the macro injects a compiler marker whose call is
+/// removed before code generation. The declared `dynamic_shared_alignment`
+/// therefore becomes a minimum alignment in generated PTX without adding
+/// kernel hot-path instructions.
+#[proc_macro_attribute]
+pub fn launch_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as LaunchContractArgs);
+    let mut input = parse_macro_input!(item as ItemFn);
+
+    inject_launch_contract_alignment_marker(&args, &mut input);
+
+    quote! { #input }.into()
+}
+
+fn inject_launch_contract_alignment_marker(args: &LaunchContractArgs, input: &mut ItemFn) {
+    if dynamic_shared_max(args.dynamic_shared) != 0 {
+        let alignment = args.dynamic_shared_alignment as usize;
+        let alignment_marker: syn::Stmt = parse_quote! {
+            ::cuda_device::shared::__dynamic_shared_alignment::<#alignment>();
+        };
+        input.block.stmts.insert(0, alignment_marker);
+    }
+}
+
 /// Arguments for `#[launch_bounds(...)]` attribute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct LaunchBoundsArgs {
     max_threads: u32,
     min_blocks: u32,
@@ -3143,8 +4335,8 @@ impl Parse for LaunchBoundsArgs {
                 max_threads: values[0],
                 min_blocks: values[1],
             }),
-            _ => Err(syn::Error::new_spanned(
-                args.first().unwrap(),
+            _ => Err(syn::Error::new(
+                input.span(),
                 "launch_bounds expects 1 or 2 parameters: #[launch_bounds(max_threads)] or #[launch_bounds(max_threads, min_blocks)]",
             )),
         }
@@ -3335,7 +4527,8 @@ fn rewrite_loop_unroll_attrs(input: &mut ItemFn) -> syn::Result<()> {
 ///
 /// - Must be used WITH `#[kernel]` (not standalone)
 /// - Requires sm_90+ (Hopper) or newer GPU
-/// - The `#[cluster_launch]` attribute must come AFTER `#[kernel]`
+/// - May appear before or after `#[kernel]`; generic entry generation forwards
+///   an already-expanded compiler marker to each entry wrapper
 ///
 /// # How It Works
 ///
@@ -3369,7 +4562,7 @@ pub fn cluster_launch(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Inject the cluster config marker at the start of the function body
     let marker_call: syn::Stmt = syn::parse_quote! {
-        cuda_device::cluster::__cluster_config::<#x, #y, #z>();
+        ::cuda_device::cluster::__cluster_config::<#x, #y, #z>();
     };
 
     // Prepend the marker to the function body
@@ -3452,7 +4645,8 @@ impl Parse for ClusterArgs {
 ///
 /// - Must be used WITH `#[kernel]` (not standalone), on a kernel inside a
 ///   `#[cuda_module]` module
-/// - The `#[cooperative_launch]` attribute must come AFTER `#[kernel]`
+/// - May appear before or after `#[kernel]`; `#[cuda_module]` records this
+///   launch-time setting before nested function attributes expand
 /// - The device must support cooperative launch
 ///   (`CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH`)
 /// - The grid must fit on the device in one wave, otherwise the driver
@@ -4113,23 +5307,26 @@ impl Parse for CudaLaunchInput {
 ///   kernel parameter;
 /// - every pointer argument is **device-accessible** (a valid device
 ///   allocation, or host memory reachable via HMM/unified memory) and stays
-///   alive until the kernel finishes.
+///   alive until the kernel finishes;
+/// - the grid, block, dynamic-shared-memory size, cluster dimensions, and
+///   cooperative mode satisfy every indexing, resource, and synchronization
+///   assumption made by the kernel.
 ///
 /// A mismatch is undefined behavior, not a runtime error: too few or
 /// mistyped arguments make the driver read past the end of the args array,
 /// and a bad pointer makes the device dereference junk.
 ///
-/// For kernels embedded in your own crate, prefer `#[cuda_module]`: it
-/// reads the kernel signatures at compile time and generates typed launch
-/// methods, so none of the above can go wrong. This macro's remaining niche
-/// is modules loaded at **runtime by name** (e.g. external PTX files),
-/// where no compile-time signature exists to check.
+/// For kernels embedded in your own crate, prefer `#[cuda_module]` with a
+/// launch contract: it checks the signature and prepares a kernel-branded
+/// geometry/resource proof. This macro's remaining niche is modules loaded at
+/// **runtime by name** (e.g. external PTX files), where no compile-time
+/// contract exists to check.
 ///
 /// # Usage
 ///
 /// ```ignore
-/// // SAFETY: argument count, order, and types match `vecadd`'s signature;
-/// // a_dev, b_dev, c_dev are live device buffers.
+/// // SAFETY: argument count, order, and types match `vecadd`; the buffers stay
+/// // live, and the raw configuration matches vecadd's 1-D index space.
 /// unsafe {
 ///     cuda_launch! {
 ///         kernel: vecadd,
@@ -4543,17 +5740,33 @@ impl Parse for CudaLaunchAsyncInput {
 /// An `AsyncKernelLaunch` implementing `DeviceOperation`. No GPU work is enqueued
 /// until the caller schedules it.
 ///
+/// # Safety
+///
+/// This is a raw launch API. The caller must ensure that:
+///
+/// - argument count, order, type, size, and alignment match the kernel ABI;
+/// - referenced allocations remain valid and correctly aliased until the lazy
+///   operation completes;
+/// - the scheduled stream belongs to the function's CUDA context; and
+/// - dimensions, block shape, shared memory, and launch mode satisfy every
+///   indexing, resource, and synchronization assumption made by the kernel.
+///
+/// The macro invocation must therefore be inside an `unsafe` block.
+///
 /// # Usage
 ///
 /// ```ignore
 /// use cuda_host::cuda_launch_async;
 /// use cuda_core::LaunchConfig;
 ///
-/// let op = cuda_launch_async! {
-///     kernel: vecadd,
-///     module: module,
-///     config: LaunchConfig::for_num_elems(N as u32),
-///     args: [slice(a_dev), slice(b_dev), slice_mut(c_dev)]
+/// // SAFETY: ABI, lifetimes, geometry, and resources match vecadd.
+/// let op = unsafe {
+///     cuda_launch_async! {
+///         kernel: vecadd,
+///         module: module,
+///         config: LaunchConfig::for_num_elems(N as u32),
+///         args: [slice(a_dev), slice(b_dev), slice_mut(c_dev)]
+///     }
 /// };
 ///
 /// // Synchronous (blocks calling thread):
@@ -4569,7 +5782,10 @@ impl Parse for CudaLaunchAsyncInput {
 #[proc_macro]
 pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as CudaLaunchAsyncInput);
+    expand_cuda_launch_async(input).into()
+}
 
+fn expand_cuda_launch_async(input: CudaLaunchAsyncInput) -> TokenStream2 {
     let module = &input.module;
     let config = &input.config;
     let (kernel_base, _generics) = input.kernel_parts();
@@ -4607,7 +5823,7 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
             match arg {
                 CudaLaunchArg::Direct(expr) => {
                     quote! {
-                        #launch_ident.push_arg(Box::new(#expr));
+                        #launch_ident.push_scalar_arg(#expr);
                     }
                 }
                 CudaLaunchArg::SliceWithLen(expr) => {
@@ -4643,7 +5859,7 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let expanded = if has_closure {
+    if has_closure {
         let closure_expr = closure_expr.expect("has_closure but no closure expression");
         quote! {
             {
@@ -4657,12 +5873,11 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
                         #error_ident,
                     )
                 });
-                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunch::new(
+                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunchBuilder::new(
                     std::sync::Arc::new(#function_ident),
                 );
                 #(#arg_code)*
-                #launch_ident.set_launch_config(#config);
-                #launch_ident
+                #launch_ident.finalize_unchecked(#config)
             }
         }
     } else if input.is_generic() {
@@ -4677,12 +5892,11 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
                         #error_ident,
                     )
                 });
-                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunch::new(
+                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunchBuilder::new(
                     std::sync::Arc::new(#function_ident),
                 );
                 #(#arg_code)*
-                #launch_ident.set_launch_config(#config);
-                #launch_ident
+                #launch_ident.finalize_unchecked(#config)
             }
         }
     } else {
@@ -4698,17 +5912,14 @@ pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
                         #error_ident,
                     )
                 });
-                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunch::new(
+                let mut #launch_ident = cuda_async::launch::AsyncKernelLaunchBuilder::new(
                     std::sync::Arc::new(#function_ident),
                 );
                 #(#arg_code)*
-                #launch_ident.set_launch_config(#config);
-                #launch_ident
+                #launch_ident.finalize_unchecked(#config)
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    }
 }
 
 #[cfg(test)]
@@ -5000,6 +6211,42 @@ mod tests {
     }
 
     #[test]
+    fn nested_launch_contract_stays_in_its_namespace_and_taints_root_loading() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                pub mod stage {
+                    #[kernel]
+                    #[launch_contract(domain = 1, block = (64, 1, 1))]
+                    pub fn map(mut out: DisjointSlice<u32>) {}
+                }
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert_eq!(
+            expanded
+                .matches("impl::cuda_core::KernelLaunchContract")
+                .count(),
+            1,
+            "the contract impl must be emitted once in the child namespace:\n{expanded}"
+        );
+        assert_eq!(
+            expanded.matches("fnprepare_map(").count(),
+            1,
+            "the prepared launcher must be emitted once in the child namespace:\n{expanded}"
+        );
+        assert!(
+            expanded.contains("pubunsafefnload("),
+            "a descendant contract must make root artifact binding unsafe:\n{expanded}"
+        );
+        assert!(
+            expanded.contains("pubmodstage{")
+                && expanded.contains("from_parent(parent:&super::LoadedModule"),
+            "main's nested module view must remain intact:\n{expanded}"
+        );
+    }
+
+    #[test]
     fn nested_generic_kernel_uses_local_ptx_name_helper() {
         let module: ItemMod = parse_quote! {
             mod kernels {
@@ -5083,6 +6330,227 @@ mod tests {
     }
 
     #[test]
+    fn launch_contract_generates_prepared_and_unsafe_raw_paths() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_bounds(256)]
+                #[launch_contract(
+                    domain = 1,
+                    block = (256, 1, 1),
+                    dynamic_shared = 1024,
+                    dynamic_shared_alignment = 128,
+                    min_compute_capability = (8, 0),
+                )]
+                pub fn map(input: &[u32], mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("impl::cuda_core::KernelLaunchContractfor__map_CudaKernel"));
+        assert!(expanded.contains("typeConfig=::cuda_core::LaunchConfig1D"));
+        assert!(expanded.contains("fnprepare_map("));
+        assert!(expanded.contains("PreparedLaunch<__map_CudaKernel>"));
+        assert!(expanded.contains("fnmap("));
+        assert!(
+            !expanded.contains("unsafefnmap("),
+            "a safe source kernel must keep its prepared launch method safe: {expanded}"
+        );
+        assert!(
+            expanded
+                .contains("__cuda_oxide_prepared:&::cuda_core::PreparedLaunch<__map_CudaKernel>")
+        );
+        assert!(expanded.contains("unsafefnmap_unchecked("));
+        assert!(expanded.contains("__cuda_oxide_config:::cuda_core::LaunchConfig"));
+        assert!(expanded.contains("min_alignment:128u32"));
+        assert!(expanded.contains("with_min_compute_capability(8u32,0u32)"));
+    }
+
+    #[test]
+    fn uncontracted_sync_launch_is_always_unsafe() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn map(input: &[u32], mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("pubunsafefnmap("));
+        assert!(expanded.contains("#Safety"));
+        assert!(expanded.contains("unverifiedrawlaunchconfiguration"));
+    }
+
+    #[test]
+    fn unsafe_source_kernel_keeps_prepared_launch_unsafe() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_contract(domain = 1, block = (64, 1, 1))]
+                pub unsafe fn map(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("pubunsafefnmap("));
+        assert!(expanded.contains("pubunsafefnmap_unchecked("));
+        #[cfg(feature = "async")]
+        {
+            assert!(expanded.contains("pubunsafefnmap_async"));
+            assert!(expanded.contains("pubunsafefnmap_async_owned"));
+        }
+    }
+
+    #[test]
+    fn contracted_module_requires_provenance_for_every_loader() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_contract(domain = 1, block = (64, 1, 1))]
+                pub fn map(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("pubunsafefnload("));
+        assert!(expanded.contains("pubunsafefnload_named("));
+        assert!(expanded.contains("pubunsafefnfrom_module("));
+        assert!(expanded.contains("#Safety"));
+        #[cfg(feature = "async")]
+        {
+            assert!(expanded.contains("pubunsafefnload_async("));
+            assert!(expanded.contains("pubunsafefnload_async_named("));
+        }
+    }
+
+    #[test]
+    fn uncontracted_module_preserves_safe_custom_loaders() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn map(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("pubfnload_named("));
+        assert!(expanded.contains("pubfnfrom_module("));
+        assert!(!expanded.contains("pubunsafefnload_named("));
+        assert!(!expanded.contains("pubunsafefnfrom_module("));
+        #[cfg(feature = "async")]
+        assert!(expanded.contains("pubfnload_async_named("));
+    }
+
+    #[test]
+    fn generic_contract_brand_and_prepare_witness_keep_specialization_type() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_bounds(128)]
+                #[launch_contract(domain = 1, dynamic_shared = 0)]
+                pub fn apply<F: Fn(u32) -> u32 + Copy>(op: F, out: *mut u32) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("KernelLaunchContractfor__apply_CudaKernel<F>"));
+        assert!(expanded.contains("PreparedLaunch<__apply_CudaKernel<F>>"));
+        assert!(expanded.contains("fnprepare_apply_for<F"));
+        assert!(expanded.contains("__cuda_oxide_type_witness_0:&F"));
+        assert!(expanded.contains("BlockRequirement::MaxThreads(128u32)"));
+    }
+
+    #[test]
+    fn generic_kernel_routes_launch_contract_to_entry_only() {
+        let kernel: ItemFn = parse_quote! {
+            #[doc = "kept on the helper"]
+            #[cuda_device::launch_bounds(128)]
+            #[cuda_device::launch_contract(
+                domain = 1,
+                dynamic_shared = 256,
+                dynamic_shared_alignment = 64,
+            )]
+            #[cuda_device::cluster_launch(2, 1, 1)]
+            #[cuda_device::cooperative_launch]
+            pub fn map<T: Copy>(value: T) {}
+        };
+
+        let (implementation, entry, _cfg) = route_generic_kernel_attrs(&kernel.attrs);
+        let entry_names: Vec<_> = entry
+            .iter()
+            .map(|attr| attr.path().segments.last().unwrap().ident.to_string())
+            .collect();
+        let implementation_names: Vec<_> = implementation
+            .iter()
+            .map(|attr| attr.path().segments.last().unwrap().ident.to_string())
+            .collect();
+
+        assert_eq!(
+            entry_names,
+            [
+                "launch_bounds",
+                "launch_contract",
+                "cluster_launch",
+                "cooperative_launch",
+            ]
+        );
+        assert_eq!(implementation_names, ["doc"]);
+    }
+
+    #[test]
+    fn generic_kernel_forwards_only_exact_top_level_configuration_markers() {
+        let kernel: ItemFn = parse_quote! {
+            fn map<T>() {
+                ::cuda_device::thread::__launch_bounds_config::<64, 2>();
+                ::cuda_device::cluster::__cluster_config::<2, 1, 1>();
+                ::cuda_device::shared::__dynamic_shared_alignment::<128>();
+                cuda_device::thread::__launch_bounds_config::<4, 1>();
+                unrelated();
+                other::cuda_device::thread::__launch_bounds_config::<32, 1>();
+                cuda_device::thread::__launch_bounds_config::<16, 1>(7);
+                {
+                    cuda_device::thread::__launch_bounds_config::<8, 1>();
+                }
+            }
+        };
+
+        let markers = top_level_kernel_configuration_markers(&kernel);
+        let forwarded = quote!(#(#markers)*).to_string().replace(' ', "");
+
+        assert_eq!(markers.len(), 3);
+        assert!(forwarded.contains("__launch_bounds_config::<64,2>()"));
+        assert!(forwarded.contains("__cluster_config::<2,1,1>()"));
+        assert!(forwarded.contains("__dynamic_shared_alignment::<128>()"));
+        assert!(!forwarded.contains("unrelated"));
+        assert!(!forwarded.contains("::<4,1>()"));
+        assert!(!forwarded.contains("other::cuda_device"));
+        assert!(!forwarded.contains("::<16,1>(7)"));
+        assert!(!forwarded.contains("::<8,1>()"));
+    }
+
+    #[test]
+    fn launch_contract_injects_one_alignment_marker_only_when_shared_is_used() {
+        let args: LaunchContractArgs =
+            syn::parse_str("domain = 1, dynamic_shared = 256, dynamic_shared_alignment = 64")
+                .unwrap();
+        let mut helper: ItemFn = parse_quote! { fn helper<T>() {} };
+        inject_launch_contract_alignment_marker(&args, &mut helper);
+        let expanded = quote!(#helper).to_string();
+        assert_eq!(expanded.matches("__dynamic_shared_alignment").count(), 1);
+        assert!(expanded.contains("64usize"));
+
+        let zero_args: LaunchContractArgs =
+            syn::parse_str("domain = 1, dynamic_shared = 0").unwrap();
+        let mut zero_helper: ItemFn = parse_quote! { fn zero_helper<T>() {} };
+        inject_launch_contract_alignment_marker(&zero_args, &mut zero_helper);
+        assert!(
+            !quote!(#zero_helper)
+                .to_string()
+                .contains("__dynamic_shared_alignment")
+        );
+    }
+
+    #[test]
     fn cfg_gated_duplicate_kernel_names_are_rejected_until_ptx_names_are_qualified() {
         let module: ItemMod = parse_quote! {
             mod kernels {
@@ -5101,6 +6569,23 @@ mod tests {
                 .to_string()
                 .contains("PTX entry names are currently bare"),
             "unexpected error message: {error}"
+        );
+    }
+
+    #[test]
+    fn contract_without_block_or_launch_bounds_is_rejected() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_contract(domain = 1, dynamic_shared = 0)]
+                pub fn missing_block(input: &[u32]) {}
+            }
+        };
+        let error = expand_cuda_module(module).expect_err("contract should fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("requires either an exact `block = (x, y, z)` or #[launch_bounds")
         );
     }
 
@@ -5241,6 +6726,196 @@ mod tests {
             error.to_string().contains("method name `from_parent`"),
             "unexpected error message: {error}"
         );
+    }
+
+    #[test]
+    fn contracted_mut_slice_is_rejected_in_favor_of_disjoint_slice() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_contract(domain = 1, block = (64, 1, 1))]
+                pub fn aliased(out: &mut [u32]) {}
+            }
+        };
+        let error = expand_cuda_module(module).expect_err("mutable slice must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("contracted kernels cannot take `&mut [T]`")
+        );
+    }
+
+    #[test]
+    fn aliased_disjoint_index_space_is_checked_by_rust_type_resolution() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                type Alias = Index2D<128>;
+
+                #[kernel]
+                #[launch_contract(domain = 2, block = (16, 16, 1))]
+                pub fn aliased(mut out: DisjointSlice<u32, Alias>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded.contains(
+                "for<'__cuda_oxide_disjoint>DisjointSlice<'__cuda_oxide_disjoint,u32,Alias>:"
+            ),
+            "the bound must preserve the original index-space alias: {expanded}"
+        );
+        assert!(expanded.contains("__LaunchContractDisjointSlice<u32,2u8>"));
+    }
+
+    #[test]
+    fn one_dimensional_index_space_is_not_accepted_by_identifier_spelling() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                type Index2D = Index1D;
+
+                #[kernel]
+                #[launch_contract(domain = 2, block = (16, 16, 1))]
+                pub fn wrong_rank(mut out: DisjointSlice<u32, Index2D>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded.contains(
+                "for<'__cuda_oxide_disjoint>DisjointSlice<'__cuda_oxide_disjoint,u32,Index2D>:"
+            ),
+            "the bound must preserve the misleading alias for Rust to resolve: {expanded}"
+        );
+        assert!(expanded.contains("__LaunchContractDisjointSlice<u32,2u8>"));
+    }
+
+    #[test]
+    fn local_disjoint_slice_lookalike_gets_the_genuine_type_bound() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                struct DisjointSlice<'a, T, IndexSpace = Index1D> {
+                    value: &'a mut T,
+                    index: PhantomData<IndexSpace>,
+                }
+
+                #[kernel]
+                #[launch_contract(domain = 1, block = (64, 1, 1))]
+                pub fn fake(mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded
+                .contains("for<'__cuda_oxide_disjoint>DisjointSlice<'__cuda_oxide_disjoint,u32>:"),
+            "the look-alike must receive the genuine cuda-device trait bound: {expanded}"
+        );
+        assert!(expanded.contains("__LaunchContractDisjointSlice<u32,1u8>"));
+    }
+
+    #[test]
+    fn launch_bounds_accepts_a_two_dimensional_block_with_the_same_product() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_bounds(256)]
+                #[launch_contract(domain = 2, block = (16, 16, 1))]
+                pub fn tiled(input: &[u32]) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+        assert!(expanded.contains("BlockRequirement::Exact((16u32,16u32,1u32))"));
+    }
+
+    #[test]
+    fn exact_block_cannot_exceed_compiled_launch_bounds_thread_count() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_bounds(256)]
+                #[launch_contract(domain = 2, block = (17, 16, 1))]
+                pub fn impossible(input: &[u32]) {}
+            }
+        };
+        let error = expand_cuda_module(module).expect_err("bounds mismatch must fail closed");
+        assert!(error.to_string().contains("272 threads"));
+        assert!(error.to_string().contains("launch_bounds(256)"));
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn contracted_async_methods_return_immutable_wrappers() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                #[launch_contract(domain = 1, block = (64, 1, 1))]
+                pub fn map(input: &[u32], mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded.contains("PreparedAsyncKernelLaunch<'__cuda_oxide_async,__map_CudaKernel>")
+        );
+        assert!(expanded.contains("PreparedOwnedAsyncKernelLaunch<"));
+        assert!(expanded.contains("fnmap_async_unchecked"));
+        assert!(expanded.contains("fnmap_async_owned_unchecked"));
+        assert!(expanded.matches("unsafe").count() >= 4);
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn uncontracted_async_launch_methods_are_always_unsafe() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn map(input: &[u32], mut out: DisjointSlice<u32>) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(expanded.contains("pubunsafefnmap_async"));
+        assert!(expanded.contains("pubunsafefnmap_async_owned"));
+        assert_eq!(
+            expanded.matches("new_async_kernel_launch_builder").count(),
+            2
+        );
+        assert_eq!(expanded.matches("finalize_unchecked").count(), 2);
+    }
+
+    #[test]
+    fn raw_async_launch_macro_leaves_finalization_caller_unsafe() {
+        let inputs: [CudaLaunchAsyncInput; 3] = [
+            parse_quote! {
+                kernel: kernels::map,
+                module: module,
+                config: config,
+                args: []
+            },
+            parse_quote! {
+                kernel: kernels::map::<u32>,
+                module: module,
+                config: config,
+                args: []
+            },
+            parse_quote! {
+                kernel: kernels::map,
+                module: module,
+                config: config,
+                args: [|value: u32| value]
+            },
+        ];
+
+        for input in inputs {
+            let expanded = expand_cuda_launch_async(input).to_string().replace(' ', "");
+            assert!(expanded.contains("AsyncKernelLaunchBuilder::new"));
+            assert!(expanded.contains(".finalize_unchecked(config)"));
+            assert!(!expanded.contains("set_launch_config"));
+            assert!(
+                !expanded.contains("unsafe{"),
+                "the macro must not hide its raw-launch safety obligation: {expanded}"
+            );
+        }
     }
 
     /// Runs the per-loop `#[unroll]` visitor over `func`'s body and returns the

--- a/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.rs
+++ b/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::cuda_launch_async;
+
+#[allow(non_camel_case_types)]
+struct __raw_CudaKernel;
+
+impl cuda_host::CudaKernel for __raw_CudaKernel {
+    const PTX_NAME: &'static str = "raw";
+}
+
+struct FakeModule;
+
+impl FakeModule {
+    fn load_function(&self, _name: &str) -> Result<cuda_core::CudaFunction, ()> {
+        unimplemented!()
+    }
+}
+
+mod cuda_async {
+    pub mod launch {
+        use cuda_core::{CudaFunction, LaunchConfig};
+        use std::sync::Arc;
+
+        pub struct AsyncKernelLaunchBuilder;
+
+        impl AsyncKernelLaunchBuilder {
+            pub fn new(_function: Arc<CudaFunction>) -> Self {
+                Self
+            }
+
+            pub unsafe fn finalize_unchecked(self, _config: LaunchConfig) {}
+        }
+    }
+}
+
+fn launch_without_unsafe(module: &FakeModule) {
+    let _ = cuda_launch_async! {
+        kernel: raw,
+        module: module,
+        config: cuda_core::LaunchConfig {
+            grid_dim: (1, 2, 1),
+            block_dim: (64, 1, 1),
+            shared_mem_bytes: 0,
+        },
+        args: [],
+    };
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.stderr
+++ b/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.stderr
@@ -1,0 +1,15 @@
+error[E0133]: call to unsafe function `cuda_async::launch::AsyncKernelLaunchBuilder::finalize_unchecked` is unsafe and requires unsafe block
+  --> tests/compile_fail/async_launch_macro_requires_unsafe.rs:39:13
+   |
+39 |       let _ = cuda_launch_async! {
+   |  _____________^
+40 | |         kernel: raw,
+41 | |         module: module,
+42 | |         config: cuda_core::LaunchConfig {
+...  |
+47 | |         args: [],
+48 | |     };
+   | |_____^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+   = note: this error originates in the macro `cuda_launch_async` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-macros/tests/compile_fail/contract_unchecked_requires_unsafe.rs
+++ b/crates/cuda-macros/tests/compile_fail/contract_unchecked_requires_unsafe.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::{cuda_module, kernel, launch_contract};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1), dynamic_shared = 0)]
+    pub fn contracted(input: &[u32]) {
+        let _ = input;
+    }
+}
+
+fn unchecked_without_unsafe(
+    module: &kernels::LoadedModule,
+    stream: &cuda_core::CudaStream,
+    input: &cuda_core::DeviceBuffer<u32>,
+) {
+    module
+        .contracted_unchecked(
+            stream,
+            cuda_core::LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            input,
+        )
+        .unwrap();
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/contract_unchecked_requires_unsafe.stderr
+++ b/crates/cuda-macros/tests/compile_fail/contract_unchecked_requires_unsafe.stderr
@@ -1,0 +1,13 @@
+error[E0133]: call to unsafe function `LoadedModule::contracted_unchecked` is unsafe and requires unsafe block
+  --> tests/compile_fail/contract_unchecked_requires_unsafe.rs:22:5
+   |
+22 | /     module
+23 | |         .contracted_unchecked(
+24 | |             stream,
+25 | |             cuda_core::LaunchConfig {
+...  |
+30 | |             input,
+31 | |         )
+   | |_________^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_fake_disjoint_slice.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_fake_disjoint_slice.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::marker::PhantomData;
+use cuda_device::thread::Index1D;
+use cuda_device::{cuda_module, kernel, launch_contract};
+
+#[repr(C)]
+pub struct DisjointSlice<'a, T, IndexSpace = Index1D> {
+    ptr: *mut T,
+    len: usize,
+    marker: PhantomData<(&'a mut T, IndexSpace)>,
+}
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn lookalike(mut out: DisjointSlice<u32>) {
+        let _ = &mut out;
+    }
+}
+
+fn prepare(module: &kernels::LoadedModule) {
+    let _ = module.prepare_lookalike(cuda_core::LaunchConfig1D::new(1, 64, 0));
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_fake_disjoint_slice.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_fake_disjoint_slice.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `for<'__cuda_oxide_disjoint> DisjointSlice<'__cuda_oxide_disjoint, u32>: cuda_device::__LaunchContractDisjointSlice<u32, 1>` is not satisfied
+  --> tests/compile_fail/launch_contract_fake_disjoint_slice.rs:27:20
+   |
+27 |     let _ = module.prepare_lookalike(cuda_core::LaunchConfig1D::new(1, 64, 0));
+   |                    ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `for<'__cuda_oxide_disjoint> cuda_device::__LaunchContractDisjointSlice<u32, 1>` is not implemented for `DisjointSlice<'__cuda_oxide_disjoint, u32>`
+  --> tests/compile_fail/launch_contract_fake_disjoint_slice.rs:9:1
+   |
+ 9 | pub struct DisjointSlice<'a, T, IndexSpace = Index1D> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `cuda_device::__LaunchContractDisjointSlice<Element, DOMAIN>`:
+             `cuda_device::DisjointSlice<'a, T, Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'a, T, Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'a, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'a, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'a, T>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+note: required by a bound in `LoadedModule::prepare_lookalike`
+  --> tests/compile_fail/launch_contract_fake_disjoint_slice.rs:15:1
+   |
+15 | #[cuda_module]
+   | ^^^^^^^^^^^^^^ required by this bound in `LoadedModule::prepare_lookalike`
+...
+21 |     pub fn lookalike(mut out: DisjointSlice<u32>) {
+   |            --------- required by a bound in this associated function
+   = note: this error originates in the attribute macro `cuda_module` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_misleading_index_alias.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_misleading_index_alias.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_device::thread::Index1D as Index2D;
+use cuda_device::{DisjointSlice, cuda_module, kernel, launch_contract};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 2, block = (8, 8, 1))]
+    pub fn misleading_name(mut out: DisjointSlice<u32, Index2D>) {
+        let _ = &mut out;
+    }
+}
+
+fn prepare(module: &kernels::LoadedModule) {
+    let _ = module.prepare_misleading_name(cuda_core::LaunchConfig2D::new(
+        (1, 1),
+        (8, 8),
+        0,
+    ));
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_misleading_index_alias.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_misleading_index_alias.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `for<'__cuda_oxide_disjoint> cuda_device::DisjointSlice<'__cuda_oxide_disjoint, u32>: cuda_device::__LaunchContractDisjointSlice<u32, 2>` is not satisfied
+  --> tests/compile_fail/launch_contract_misleading_index_alias.rs:19:20
+   |
+19 |     let _ = module.prepare_misleading_name(cuda_core::LaunchConfig2D::new(
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `for<'__cuda_oxide_disjoint> cuda_device::__LaunchContractDisjointSlice<u32, 2>` is not implemented for `cuda_device::DisjointSlice<'__cuda_oxide_disjoint, u32>`
+   = help: the following other types implement trait `cuda_device::__LaunchContractDisjointSlice<Element, DOMAIN>`:
+             `cuda_device::DisjointSlice<'_, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'_, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'_, T, cuda_device::Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'_, T, cuda_device::Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'_, T>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+note: required by a bound in `LoadedModule::prepare_misleading_name`
+  --> tests/compile_fail/launch_contract_misleading_index_alias.rs:7:1
+   |
+ 7 | #[cuda_module]
+   | ^^^^^^^^^^^^^^ required by this bound in `LoadedModule::prepare_misleading_name`
+...
+13 |     pub fn misleading_name(mut out: DisjointSlice<u32, Index2D>) {
+   |            --------------- required by a bound in this associated function
+   = note: this error originates in the attribute macro `cuda_module` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_reordered_disjoint_alias.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_reordered_disjoint_alias.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_device::thread::Index1D;
+use cuda_device::{cuda_module, kernel, launch_contract};
+
+// The element is deliberately the second type argument. Host marshalling must
+// not mistake `IS` for the element type and expose a safe mismatched launch.
+type DisjointSlice<'a, IS, T> = cuda_device::DisjointSlice<'a, T, IS>;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn reordered(mut out: DisjointSlice<Index1D, u64>) {
+        let _ = &mut out;
+    }
+}
+
+fn prepare(module: &kernels::LoadedModule) {
+    let _ = module.prepare_reordered(cuda_core::LaunchConfig1D::new(1, 64, 0));
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_reordered_disjoint_alias.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_reordered_disjoint_alias.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `for<'__cuda_oxide_disjoint> cuda_device::DisjointSlice<'__cuda_oxide_disjoint, u64>: cuda_device::__LaunchContractDisjointSlice<cuda_device::Index1D, 1>` is not satisfied
+  --> tests/compile_fail/launch_contract_reordered_disjoint_alias.rs:23:20
+   |
+23 |     let _ = module.prepare_reordered(cuda_core::LaunchConfig1D::new(1, 64, 0));
+   |                    ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `for<'__cuda_oxide_disjoint> cuda_device::__LaunchContractDisjointSlice<cuda_device::Index1D, 1>` is not implemented for `cuda_device::DisjointSlice<'__cuda_oxide_disjoint, u64>`
+   = help: the following other types implement trait `cuda_device::__LaunchContractDisjointSlice<Element, DOMAIN>`:
+             `cuda_device::DisjointSlice<'_, T, Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'_, T, Index2D<ROW_STRIDE>>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'_, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+             `cuda_device::DisjointSlice<'_, T, Runtime2DIndex>` implements `cuda_device::__LaunchContractDisjointSlice<T, 2>`
+             `cuda_device::DisjointSlice<'_, T>` implements `cuda_device::__LaunchContractDisjointSlice<T, 1>`
+note: required by a bound in `LoadedModule::prepare_reordered`
+  --> tests/compile_fail/launch_contract_reordered_disjoint_alias.rs:11:1
+   |
+11 | #[cuda_module]
+   | ^^^^^^^^^^^^^^ required by this bound in `LoadedModule::prepare_reordered`
+...
+17 |     pub fn reordered(mut out: DisjointSlice<Index1D, u64>) {
+   |            --------- required by a bound in this associated function
+   = note: this error originates in the attribute macro `cuda_module` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_untrusted_loaders.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_untrusted_loaders.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use cuda_core::{CudaContext, CudaModule};
+use cuda_device::{cuda_module, kernel, launch_contract};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn contracted(input: &[u32]) {
+        let _ = input;
+    }
+}
+
+fn bind_untrusted(module: Arc<CudaModule>, context: &Arc<CudaContext>) {
+    let _ = kernels::load(context);
+    let _ = kernels::from_module(module);
+    let _ = kernels::load_named(context, "some-other-artifact");
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_untrusted_loaders.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_untrusted_loaders.stderr
@@ -1,0 +1,23 @@
+error[E0133]: call to unsafe function `load` is unsafe and requires unsafe block
+  --> tests/compile_fail/launch_contract_untrusted_loaders.rs:21:13
+   |
+21 |     let _ = kernels::load(context);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function `from_module` is unsafe and requires unsafe block
+  --> tests/compile_fail/launch_contract_untrusted_loaders.rs:22:13
+   |
+22 |     let _ = kernels::from_module(module);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function `load_named` is unsafe and requires unsafe block
+  --> tests/compile_fail/launch_contract_untrusted_loaders.rs:23:13
+   |
+23 |     let _ = kernels::load_named(context, "some-other-artifact");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_wrong_const_brand.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_wrong_const_brand.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_device::{cuda_module, kernel, launch_contract};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn const_kernel<const N: usize>(input: &[u32]) {
+        let _ = (N, input);
+    }
+}
+
+fn launch_eight_with_four(
+    module: &kernels::LoadedModule,
+    stream: &cuda_core::CudaStream,
+    prepared: &cuda_core::PreparedLaunch<kernels::__const_kernel_CudaKernel<4>>,
+    input: &cuda_core::DeviceBuffer<u32>,
+) {
+    let _ = module.const_kernel::<8>(stream, prepared, input);
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_wrong_const_brand.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_wrong_const_brand.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> tests/compile_fail/launch_contract_wrong_const_brand.rs:23:46
+   |
+23 |     let _ = module.const_kernel::<8>(stream, prepared, input);
+   |                    -----------------         ^^^^^^^^ expected `8`, found `4`
+   |                    |
+   |                    arguments to this method are incorrect
+   |
+   = note: expected reference `&PreparedLaunch<__const_kernel_CudaKernel<8>>`
+              found reference `&PreparedLaunch<__const_kernel_CudaKernel<4>>`
+note: method defined here
+  --> tests/compile_fail/launch_contract_wrong_const_brand.rs:12:12
+   |
+ 6 | #[cuda_module]
+   | --------------
+...
+12 |     pub fn const_kernel<const N: usize>(input: &[u32]) {
+   |            ^^^^^^^^^^^^

--- a/crates/cuda-macros/tests/compile_fail/uncontracted_launch_requires_unsafe.rs
+++ b/crates/cuda-macros/tests/compile_fail/uncontracted_launch_requires_unsafe.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::{cuda_module, kernel};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    pub fn uncontracted(value: u32) {
+        let _ = value;
+    }
+}
+
+fn launch_without_unsafe(
+    module: &kernels::LoadedModule,
+    stream: &cuda_core::CudaStream,
+) {
+    module
+        .uncontracted(
+            stream,
+            cuda_core::LaunchConfig {
+                grid_dim: (1, 2, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            7,
+        )
+        .unwrap();
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/uncontracted_launch_requires_unsafe.stderr
+++ b/crates/cuda-macros/tests/compile_fail/uncontracted_launch_requires_unsafe.stderr
@@ -1,0 +1,13 @@
+error[E0133]: call to unsafe function `LoadedModule::uncontracted` is unsafe and requires unsafe block
+  --> tests/compile_fail/uncontracted_launch_requires_unsafe.rs:20:5
+   |
+20 | /     module
+21 | |         .uncontracted(
+22 | |             stream,
+23 | |             cuda_core::LaunchConfig {
+...  |
+28 | |             7,
+29 | |         )
+   | |_________^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/crates/cuda-macros/tests/launch_contract_semantics.rs
+++ b/crates/cuda-macros/tests/launch_contract_semantics.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// trybuild's generated crate does not mirror feature flags onto the separate
+// cuda-host dev dependency. Async expansion is covered by the macro unit tests
+// and cuda-host integration tests instead.
+#[cfg(not(feature = "async"))]
+#[test]
+fn launch_contract_types_are_resolved_semantically() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/pass/launch_contract_disjoint_aliases.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_misleading_index_alias.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_fake_disjoint_slice.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_untrusted_loaders.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_wrong_const_brand.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_reordered_disjoint_alias.rs");
+}

--- a/crates/cuda-macros/tests/macro_guard.rs
+++ b/crates/cuda-macros/tests/macro_guard.rs
@@ -30,11 +30,24 @@ fn macro_guards() {
     t.compile_fail("tests/compile_fail/cuda_module_include_kernel_boundary.rs");
 }
 
-/// `cuda_launch!` is a caller-unsafe API: its expansion calls the unsafe
-/// `cuda_core` launch functions without an internal `unsafe { }`, so a bare
-/// invocation must fail to compile with an unsafe-required error (E0133).
+/// Raw launch APIs leave their safety obligation at the call site. A bare
+/// `cuda_launch!`, `cuda_launch_async!`, or generated raw module launch must
+/// therefore fail to compile with an unsafe-required error (E0133).
 #[test]
 fn cuda_launch_requires_unsafe() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fail/launch_requires_unsafe.rs");
+    t.compile_fail("tests/compile_fail/async_launch_macro_requires_unsafe.rs");
+    t.pass("tests/pass/async_launch_macro_in_unsafe.rs");
+
+    // This case expands `#[cuda_module]`. The trybuild fixture depends on the
+    // non-async `cuda-host` API, so only compile it with the matching macro
+    // feature set. Async contract expansion is covered by the macro unit tests
+    // and the `cuda-host --all-features` integration tests.
+    #[cfg(not(feature = "async"))]
+    {
+        t.compile_fail("tests/compile_fail/contract_unchecked_requires_unsafe.rs");
+        t.compile_fail("tests/compile_fail/uncontracted_launch_requires_unsafe.rs");
+        t.pass("tests/pass/uncontracted_launch_in_unsafe.rs");
+    }
 }

--- a/crates/cuda-macros/tests/pass/async_launch_macro_in_unsafe.rs
+++ b/crates/cuda-macros/tests/pass/async_launch_macro_in_unsafe.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::cuda_launch_async;
+
+#[allow(non_camel_case_types)]
+struct __raw_CudaKernel;
+
+impl cuda_host::CudaKernel for __raw_CudaKernel {
+    const PTX_NAME: &'static str = "raw";
+}
+
+struct FakeModule;
+
+impl FakeModule {
+    fn load_function(&self, _name: &str) -> Result<cuda_core::CudaFunction, ()> {
+        unimplemented!()
+    }
+}
+
+mod cuda_async {
+    pub mod launch {
+        use cuda_core::{CudaFunction, LaunchConfig};
+        use std::sync::Arc;
+
+        pub struct AsyncKernelLaunchBuilder;
+
+        impl AsyncKernelLaunchBuilder {
+            pub fn new(_function: Arc<CudaFunction>) -> Self {
+                Self
+            }
+
+            pub unsafe fn finalize_unchecked(self, _config: LaunchConfig) {}
+        }
+    }
+}
+
+fn launch_with_unsafe(module: &FakeModule) {
+    let _ = unsafe {
+        cuda_launch_async! {
+            kernel: raw,
+            module: module,
+            config: cuda_core::LaunchConfig {
+                grid_dim: (1, 2, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            args: [],
+        }
+    };
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/pass/cuda_module_inline_namespaces.rs
+++ b/crates/cuda-macros/tests/pass/cuda_module_inline_namespaces.rs
@@ -78,7 +78,8 @@ mod kernels {
             stream: &CudaStream,
             config: LaunchConfig,
         ) {
-            let _ = module.private_map(stream, config, 7u32);
+            // SAFETY: this compile-pass fixture supplies the raw launch proof.
+            let _ = unsafe { module.private_map(stream, config, 7u32) };
         }
     }
 
@@ -123,7 +124,8 @@ mod kernels {
         stream: &CudaStream,
         config: LaunchConfig,
     ) {
-        let _ = module.scoped(stream, config, 11u32);
+        // SAFETY: this compile-pass fixture supplies the raw launch proof.
+        let _ = unsafe { module.scoped(stream, config, 11u32) };
     }
 }
 
@@ -133,12 +135,15 @@ fn typecheck_namespaces(
     stream: &CudaStream,
     config: LaunchConfig,
 ) {
-    let _ = root.root_typed(stream, config, Params { value: 1 });
-    let _ = child.child_typed(
-        stream,
-        config,
-        kernels::child::Params { values: [2; 4] },
-    );
+    // SAFETY: this compile-pass fixture supplies the raw launch proofs.
+    unsafe {
+        let _ = root.root_typed(stream, config, Params { value: 1 });
+        let _ = child.child_typed(
+            stream,
+            config,
+            kernels::child::Params { values: [2; 4] },
+        );
+    }
 
     let _ = kernels::child::LoadedModule::from_parent(root);
     let bridge = kernels::bridge::LoadedModule::from_parent(root).unwrap();

--- a/crates/cuda-macros/tests/pass/launch_contract_disjoint_aliases.rs
+++ b/crates/cuda-macros/tests/pass/launch_contract_disjoint_aliases.rs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_device::thread::{Index2D, Runtime2DIndex};
+use cuda_device::{DisjointSlice, cuda_module, kernel, launch_bounds, launch_contract};
+
+type Tiled = Index2D<64>;
+use cuda_device::thread::Index2D as ImportedIndex2D;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_bounds(64)]
+    #[launch_contract(domain = 2, block = (8, 8, 1))]
+    pub fn type_alias(mut out: DisjointSlice<u32, Tiled>) {
+        let _ = &mut out;
+    }
+
+    #[kernel]
+    #[launch_contract(domain = 2, block = (8, 8, 1))]
+    pub fn import_alias(mut out: DisjointSlice<u32, ImportedIndex2D<64>>) {
+        let _ = &mut out;
+    }
+
+    #[kernel]
+    #[launch_contract(domain = 2, block = (8, 8, 1))]
+    pub fn runtime_2d(mut out: DisjointSlice<u32, Runtime2DIndex>) {
+        let _ = &mut out;
+    }
+
+    // A 2D index formula is also sound for a 1D launch because every Y
+    // dimension is constrained to one.
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn two_dimensional_index_on_1d_launch(mut out: DisjointSlice<u32, Tiled>) {
+        let _ = &mut out;
+    }
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn lifetime_only<'a>(input: &'a [u32]) {
+        let _ = input;
+    }
+}
+
+fn prepared_methods_exist(module: &kernels::LoadedModule) {
+    let _ = module.prepare_type_alias(cuda_core::LaunchConfig2D::new((1, 1), (8, 8), 0));
+    let _ = module.prepare_import_alias(cuda_core::LaunchConfig2D::new((1, 1), (8, 8), 0));
+    let _ = module.prepare_runtime_2d(cuda_core::LaunchConfig2D::new((1, 1), (8, 8), 0));
+    let _ = module.prepare_two_dimensional_index_on_1d_launch(
+        cuda_core::LaunchConfig1D::new(1, 64, 0),
+    );
+    let _ = module.prepare_lifetime_only(cuda_core::LaunchConfig1D::new(1, 64, 0));
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/pass/uncontracted_launch_in_unsafe.rs
+++ b/crates/cuda-macros/tests/pass/uncontracted_launch_in_unsafe.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::{cuda_module, kernel};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    pub fn uncontracted(value: u32) {
+        let _ = value;
+    }
+}
+
+fn launch_with_unsafe(
+    module: &kernels::LoadedModule,
+    stream: &cuda_core::CudaStream,
+) {
+    unsafe {
+        module
+            .uncontracted(
+                stream,
+                cuda_core::LaunchConfig {
+                    grid_dim: (1, 2, 1),
+                    block_dim: (64, 1, 1),
+                    shared_mem_bytes: 0,
+                },
+                7,
+            )
+            .unwrap();
+    }
+}
+
+fn main() {}

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -69,6 +69,12 @@ pub struct LaunchBounds {
     pub min_blocks: u32,
 }
 
+/// Minimum extern-shared alignment declared by `#[launch_contract]`.
+#[derive(Debug, Clone, Copy)]
+pub struct DynamicSharedAlignment {
+    pub bytes: u64,
+}
+
 /// Scans MIR for `__cluster_config::<X, Y, Z>()` marker and extracts cluster dimensions.
 ///
 /// The `#[cluster(x,y,z)]` macro injects this call at the start of the kernel.
@@ -165,6 +171,43 @@ fn detect_launch_bounds_config(body: &mir::Body) -> Option<LaunchBounds> {
             max_threads: values[0],
             min_blocks: values[1],
         });
+    }
+    None
+}
+
+/// Scans MIR for the dynamic-shared alignment marker injected by
+/// `#[launch_contract]` and extracts its const generic argument. The importer
+/// records the value before removing the call from the executable path.
+fn detect_dynamic_shared_alignment(body: &mir::Body) -> Option<DynamicSharedAlignment> {
+    use rustc_public::ty::TyConstKind;
+
+    for block in &body.blocks {
+        let mir::TerminatorKind::Call { func, .. } = &block.terminator.kind else {
+            continue;
+        };
+        let mir::Operand::Constant(constant) = func else {
+            continue;
+        };
+        let ConstantKind::ZeroSized = constant.const_.kind() else {
+            continue;
+        };
+        let TyKind::RigidTy(RigidTy::FnDef(def_id, args)) = constant.const_.ty().kind() else {
+            continue;
+        };
+        let fn_name = def_id.name();
+        if fn_name != "__dynamic_shared_alignment"
+            && !fn_name.ends_with("::__dynamic_shared_alignment")
+        {
+            continue;
+        }
+        let rustc_public::ty::GenericArgKind::Const(alignment) = args.0.first()? else {
+            continue;
+        };
+        let bytes = match alignment.kind() {
+            TyConstKind::Value(_, alloc) => alloc.read_uint().ok().map(|value| value as u64),
+            _ => alignment.eval_target_usize().ok(),
+        }?;
+        return Some(DynamicSharedAlignment { bytes });
     }
     None
 }
@@ -856,6 +899,33 @@ pub fn translate_body(
                     );
                 }
             }
+        }
+    }
+
+    // Attribute macros may run before `#[kernel]`. Generic expansion forwards
+    // that marker to the entry but also keeps the original in its helper, so
+    // record markers on any function. mir-lower treats every marked local
+    // function as a propagation root and carries the minimum to its callees.
+    if let Some(alignment) = detect_dynamic_shared_alignment(body) {
+        use pliron::builtin::attributes::IntegerAttr;
+        use pliron::builtin::types::Signedness;
+        use pliron::utils::apint::APInt;
+        use std::num::NonZero;
+
+        let u64_ty = pliron::builtin::types::IntegerType::get(ctx, 64, Signedness::Unsigned);
+        let value = APInt::from_u64(alignment.bytes, NonZero::new(64).unwrap());
+        let key: Identifier = "dynamic_shared_alignment".try_into().unwrap();
+        mir_func_op
+            .get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(key, IntegerAttr::new(u64_ty, value));
+
+        if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
+            eprintln!(
+                "  Dynamic shared-memory contract alignment detected: {}",
+                alignment.bytes
+            );
         }
     }
 

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3156,6 +3156,41 @@ fn try_dispatch_intrinsic(
                 loc,
             )))
         }
+        "cuda_device::shared::__dynamic_shared_alignment" => {
+            // Zero-cost marker injected by #[launch_contract]. body.rs records
+            // the const alignment on the kernel; no runtime call survives.
+            let actual_prev_op = match prev_op {
+                Some(op) => op,
+                None => {
+                    let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+                    let dummy = Operation::new(
+                        ctx,
+                        MirConstantOp::get_concrete_op_info(),
+                        vec![bool_ty.into()],
+                        vec![],
+                        vec![],
+                        0,
+                    );
+                    dummy.deref_mut(ctx).set_loc(loc.clone());
+                    let const_op = MirConstantOp::new(dummy);
+                    use pliron::builtin::attributes::IntegerAttr;
+                    use pliron::utils::apint::APInt;
+                    use std::num::NonZeroUsize;
+                    let false_val = APInt::from_u64(0, NonZeroUsize::new(1).unwrap());
+                    const_op.set_attr_value(ctx, IntegerAttr::new(bool_ty, false_val));
+                    let dummy = const_op.get_operation();
+                    dummy.insert_at_front(block_ptr, ctx);
+                    dummy
+                }
+            };
+            Ok(Some(helpers::emit_goto(
+                ctx,
+                target.expect("__dynamic_shared_alignment must have target"),
+                actual_prev_op,
+                block_map,
+                loc,
+            )))
+        }
         // =================================================================
         // Warp Primitives (from intrinsics::warp)
         // =================================================================

--- a/crates/mir-lower/src/context.rs
+++ b/crates/mir-lower/src/context.rs
@@ -61,14 +61,12 @@ pub type SharedGlobalsMap = FxHashMap<String, pliron::identifier::Identifier>;
 /// CUDA global memory (address space 1), not shared memory.
 pub type DeviceGlobalsMap = FxHashMap<String, pliron::identifier::Identifier>;
 
-/// Tracking for dynamic shared memory alignment per kernel.
+/// Tracking for dynamic shared memory alignment per lowered function.
 ///
-/// Maps kernel name to `(symbol_name, max_alignment)`.
+/// Maps function name to `(symbol_name, max_alignment)`.
 ///
-/// Each kernel gets its own symbol (e.g., `__dynamic_smem_my_kernel`)
-/// for explicit separation in the generated PTX. Before converting any
-/// operations, the pass pre-scans all `MirExternSharedOp` operations in
-/// a function to determine the maximum alignment required by any
-/// `DynamicSharedArray<T, ALIGN>` call, ensuring the global is created
-/// with the correct alignment from the start.
+/// Each function that owns a dynamic shared-memory access gets a symbol. Before
+/// conversion, the pass combines the alignment requested by the function body
+/// with every propagated launch-contract marker that can reach it. This
+/// ensures a helper shared by several kernels uses their strongest requirement.
 pub type DynamicSmemAlignmentMap = FxHashMap<String, (pliron::identifier::Identifier, u64)>;

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -28,14 +28,15 @@
 //!
 //! ## Dynamic Shared Memory (`DynamicSharedArray<T, ALIGN>`)
 //!
-//! Dynamic shared memory uses a per-kernel symbol (`__dynamic_smem_{kernel_name}`).
+//! Dynamic shared memory uses a symbol for each function that owns an access
+//! (`__dynamic_smem_{function_name}`).
 //! Key characteristics:
 //!
-//! - **Per-kernel symbols**: Each kernel gets its own extern shared symbol
-//! - **Pre-computed alignment**: A pre-pass scans all `DynamicSharedArray` calls in a kernel
-//!   to determine the maximum alignment before creating the global
-//! - **Single pool per kernel**: All `DynamicSharedArray` calls within a kernel share the
-//!   same runtime pool (sized by `shared_mem_bytes` at launch)
+//! - **Per-owner symbols**: Each function containing an access gets an extern symbol
+//! - **Pre-computed alignment**: A pre-pass combines the owner's body alignment with
+//!   the strongest launch-contract marker that can reach it
+//! - **Single runtime pool per launch**: The symbols refer to dynamic shared memory
+//!   sized by `shared_mem_bytes` at launch
 //!
 //! ### PTX Output Example
 //!
@@ -786,16 +787,16 @@ fn initializer_hex_byte_count(hex: &str) -> std::result::Result<u64, anyhow::Err
 /// with address space 3 and zero-length array type `[0 x i8]`. The actual size
 /// is determined at kernel launch via `LaunchConfig::shared_mem_bytes`.
 ///
-/// # Per-Kernel Symbols
+/// # Per-Owner Symbols
 ///
-/// Each kernel gets its own dynamic shared memory symbol (`__dynamic_smem_{kernel_name}`).
-/// This ensures explicit separation in the generated PTX.
+/// Each function that owns an access gets a dynamic shared-memory symbol
+/// (`__dynamic_smem_{function_name}`).
 ///
 /// # Alignment
 ///
-/// The alignment is pre-computed during the lowering pre-pass. All
-/// `DynamicSharedArray<T, ALIGN>` calls in a kernel share the same global, which
-/// uses the maximum alignment requested by any call.
+/// The alignment is pre-computed during the lowering pre-pass. It is the
+/// maximum of the owner's body requirements and every launch-contract marker
+/// that can reach it.
 ///
 /// # Byte Offset
 ///
@@ -873,17 +874,16 @@ pub fn convert_extern_shared_dc(
     Ok(())
 }
 
-/// Get or create the extern shared memory global for a kernel.
+/// Get or create the extern shared memory global for an owning function.
 ///
 /// Creates an LLVM global variable with:
 /// - Zero-length array type: `[0 x i8]`
 /// - External linkage (no initializer)
 /// - Address space 3 (shared memory)
-/// - Pre-computed maximum alignment from all DynamicSharedArray calls in the kernel
+/// - Pre-computed body and calling-kernel contract alignment
 ///
-/// Each kernel gets its own dynamic shared memory symbol
-/// (`__dynamic_smem_kernel_name`). Uses `shared_globals` for deduplication
-/// (only one global per kernel).
+/// Each owning function gets its own dynamic shared memory symbol. Uses
+/// `shared_globals` for deduplication (only one global per function).
 fn get_or_create_extern_shared_global(
     ctx: &mut Context,
     op: Ptr<Operation>,
@@ -895,7 +895,7 @@ fn get_or_create_extern_shared_global(
     let (symbol_name, max_alignment) = dynamic_smem_alignments.get(func_name).cloned().ok_or_else(
         || {
             anyhow_to_pliron(anyhow::anyhow!(
-                "Internal error: dynamic shared memory alignment not pre-computed for kernel '{}'. \
+                "Internal error: dynamic shared memory alignment not pre-computed for function '{}'. \
                  This should have been done in compute_max_dynamic_smem_alignment.",
                 func_name
             ))

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -185,7 +185,7 @@ pub struct MirToLlvmConversionDriver {
     pub shared_globals: SharedGlobalsMap,
     /// Device global deduplication across all functions.
     pub device_globals: DeviceGlobalsMap,
-    /// Per-kernel dynamic shared memory alignment tracking.
+    /// Per-owning-function dynamic shared memory alignment tracking.
     pub dynamic_smem_alignments: DynamicSmemAlignmentMap,
 }
 
@@ -333,6 +333,10 @@ pub fn lower_mir_to_llvm_with_options(
     options: LoweringOptions,
 ) -> Result<()> {
     context::set_lowering_options(ctx, options);
+    // Dynamic shared-memory operations may live in device helpers. Compute
+    // every kernel-to-helper requirement while the complete MIR call graph is
+    // still available; function conversion removes that graph incrementally.
+    lowering::propagate_kernel_dynamic_shared_alignments(ctx, module_op);
     let mut conversion = MirToLlvmConversionDriver {
         shared_globals: FxHashMap::default(),
         device_globals: FxHashMap::default(),

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -54,6 +54,145 @@ use pliron::{
     r#type::{TypeHandle, Typed},
     value::Value,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
+
+const DYNAMIC_SHARED_ALIGNMENT_ATTR: &str = "dynamic_shared_alignment";
+
+// ============================================================================
+// Dynamic shared-memory contract propagation
+// ============================================================================
+
+/// Propagate dynamic shared-memory alignment markers through the local MIR
+/// call graph before any function is lowered.
+///
+/// The marker normally belongs to a kernel entry. Attribute expansion may put
+/// it in a generic helper when `#[launch_contract]` appears above `#[kernel]`,
+/// so every marked local function is a propagation root. A dynamic
+/// shared-memory access can also live in a deeper ordinary helper. Shared
+/// helpers receive the maximum requirement from every marked root that can
+/// reach them.
+pub(crate) fn propagate_kernel_dynamic_shared_alignments(
+    ctx: &mut Context,
+    module_op: Ptr<Operation>,
+) {
+    let mut functions = FxHashMap::default();
+    for region in module_op.deref(ctx).regions() {
+        for block in region.deref(ctx).iter(ctx) {
+            for op in block.deref(ctx).iter(ctx) {
+                if let Some(function) = MirFuncOp::wrap(ctx, op) {
+                    functions.insert(function.get_symbol_name(ctx).to_string(), op);
+                }
+            }
+        }
+    }
+
+    let call_graph: FxHashMap<String, Vec<String>> = functions
+        .iter()
+        .map(|(name, op)| (name.clone(), collect_mir_callees(ctx, *op)))
+        .collect();
+    let alignment_roots: Vec<(String, u64)> = functions
+        .iter()
+        .filter_map(|(name, op)| {
+            dynamic_shared_alignment_attr(ctx, *op).map(|value| (name.clone(), value))
+        })
+        .collect();
+
+    for (name, propagated_alignment) in
+        propagate_alignments_through_call_graph(&call_graph, &alignment_roots)
+    {
+        let Some(function) = functions.get(&name).copied() else {
+            continue;
+        };
+        let alignment = dynamic_shared_alignment_attr(ctx, function)
+            .map_or(propagated_alignment, |local| {
+                local.max(propagated_alignment)
+            });
+        set_dynamic_shared_alignment_attr(ctx, function, alignment);
+    }
+}
+
+fn collect_mir_callees(ctx: &Context, root: Ptr<Operation>) -> Vec<String> {
+    fn visit(ctx: &Context, op: Ptr<Operation>, callees: &mut Vec<String>) {
+        if let Some(call) = Operation::get_op::<dialect_mir::ops::MirCallOp>(op, ctx)
+            && let Some(callee) = call.get_attr_callee(ctx)
+        {
+            callees.push(String::from((*callee).clone()));
+        }
+
+        let children: Vec<_> = op
+            .deref(ctx)
+            .regions()
+            .flat_map(|region| region.deref(ctx).iter(ctx))
+            .flat_map(|block| block.deref(ctx).iter(ctx))
+            .collect();
+        for child in children {
+            visit(ctx, child, callees);
+        }
+    }
+
+    let mut callees = Vec::new();
+    visit(ctx, root, &mut callees);
+    callees.sort_unstable();
+    callees.dedup();
+    callees
+}
+
+fn propagate_alignments_through_call_graph(
+    call_graph: &FxHashMap<String, Vec<String>>,
+    alignment_roots: &[(String, u64)],
+) -> FxHashMap<String, u64> {
+    let mut propagated = FxHashMap::default();
+
+    for (root, alignment) in alignment_roots {
+        let mut worklist = vec![root.clone()];
+        let mut visited = FxHashSet::default();
+
+        while let Some(function) = worklist.pop() {
+            if !visited.insert(function.clone()) {
+                continue;
+            }
+            if !call_graph.contains_key(&function) {
+                continue;
+            }
+
+            propagated
+                .entry(function.clone())
+                .and_modify(|current: &mut u64| *current = (*current).max(*alignment))
+                .or_insert(*alignment);
+            if let Some(callees) = call_graph.get(&function) {
+                worklist.extend(callees.iter().cloned());
+            }
+        }
+    }
+
+    propagated
+}
+
+fn dynamic_shared_alignment_attr(ctx: &Context, op: Ptr<Operation>) -> Option<u64> {
+    let key: pliron::identifier::Identifier = DYNAMIC_SHARED_ALIGNMENT_ATTR
+        .try_into()
+        .expect("static identifier");
+    op.deref(ctx)
+        .attributes
+        .get::<pliron::builtin::attributes::IntegerAttr>(&key)
+        .map(|attribute| attribute.value().to_u64())
+}
+
+fn set_dynamic_shared_alignment_attr(ctx: &mut Context, op: Ptr<Operation>, alignment: u64) {
+    use pliron::builtin::attributes::IntegerAttr;
+    use pliron::builtin::types::Signedness;
+    use pliron::utils::apint::APInt;
+    use std::num::NonZero;
+
+    let key: pliron::identifier::Identifier = DYNAMIC_SHARED_ALIGNMENT_ATTR
+        .try_into()
+        .expect("static identifier");
+    let u64_ty = pliron::builtin::types::IntegerType::get(ctx, 64, Signedness::Unsigned);
+    let value = APInt::from_u64(alignment, NonZero::new(64).unwrap());
+    op.deref_mut(ctx)
+        .attributes
+        .set(key, IntegerAttr::new(u64_ty, value));
+}
 
 // ============================================================================
 // Function Conversion
@@ -144,7 +283,12 @@ pub fn convert_func(
         // Pre-scan MIR blocks for max dynamic shared memory alignment.
         // Must happen BEFORE inline_region empties the MIR region.
         let mir_blocks: Vec<_> = mir_region.deref(ctx).iter(ctx).collect();
-        let max_align = compute_max_dynamic_smem_alignment(ctx, &mir_blocks);
+        let body_max_align = compute_max_dynamic_smem_alignment(ctx, &mir_blocks);
+        let contract_min_align = dynamic_shared_alignment_attr(ctx, op);
+        let max_align = match (body_max_align, contract_min_align) {
+            (Some(body), Some(contract)) => Some(body.max(contract)),
+            (body, contract) => body.or(contract),
+        };
 
         // Stamp ABI alignment onto load/store/alloca/ref ops while types are
         // still MIR — repr(align(N)) is visible on MirStructType but lost after
@@ -656,3 +800,54 @@ fn stamp_memory_op_alignment(ctx: &mut Context, mir_blocks: &[Ptr<BasicBlock>]) 
 
 /// Register the MIR → LLVM lowering pass (placeholder for pass infrastructure).
 pub fn register(_ctx: &mut Context) {}
+
+#[cfg(test)]
+mod dynamic_shared_contract_tests {
+    use super::*;
+
+    fn graph(entries: &[(&str, &[&str])]) -> FxHashMap<String, Vec<String>> {
+        entries
+            .iter()
+            .map(|(caller, callees)| {
+                (
+                    (*caller).to_string(),
+                    callees.iter().map(|callee| (*callee).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn propagation_is_transitive_cycle_safe_and_takes_shared_helper_maximum() {
+        let call_graph = graph(&[
+            ("kernel_32", &["forward", "external"]),
+            ("kernel_256", &["shared"]),
+            ("kernel_64", &["cycle_a"]),
+            ("forward", &["shared"]),
+            ("shared", &[]),
+            ("cycle_a", &["cycle_b"]),
+            ("cycle_b", &["cycle_a"]),
+            ("marked_helper", &["marked_owner"]),
+            ("marked_owner", &[]),
+            ("uncontracted", &["unreached_helper"]),
+            ("unreached_helper", &[]),
+        ]);
+        let contracts = [
+            ("kernel_32".to_string(), 32),
+            ("kernel_256".to_string(), 256),
+            ("kernel_64".to_string(), 64),
+            ("marked_helper".to_string(), 128),
+        ];
+
+        let propagated = propagate_alignments_through_call_graph(&call_graph, &contracts);
+
+        assert_eq!(propagated.get("forward"), Some(&32));
+        assert_eq!(propagated.get("shared"), Some(&256));
+        assert_eq!(propagated.get("cycle_a"), Some(&64));
+        assert_eq!(propagated.get("cycle_b"), Some(&64));
+        assert_eq!(propagated.get("marked_owner"), Some(&128));
+        assert!(!propagated.contains_key("external"));
+        assert!(!propagated.contains_key("uncontracted"));
+        assert!(!propagated.contains_key("unreached_helper"));
+    }
+}

--- a/crates/rustc-codegen-cuda/examples/abi_hmm/README.md
+++ b/crates/rustc-codegen-cuda/examples/abi_hmm/README.md
@@ -99,8 +99,9 @@ Field access mapping:
 let mut data = Extreme { a: b'X', b: 42 };
 let ptr = &mut data as *mut Extreme;  // HOST stack pointer!
 
-// GPU directly modifies host memory
-module.modify_extreme_hmm(stream.as_ref(), cfg, ptr, 2i128, &mut device_ran)?;
+// SAFETY: cfg launches one thread, and both HMM stack values remain alive
+// until the stream is synchronized.
+unsafe { module.modify_extreme_hmm(stream.as_ref(), cfg, ptr, 2i128, &mut device_ran) }?;
 
 assert_eq!(data.b, 84);   // GPU wrote to host memory ✓
 assert_eq!(device_ran, 1); // Kernel executed on GPU ✓
@@ -113,7 +114,8 @@ let scale: i128 = 3;
 // move closure: captures `scale` BY VALUE
 let closure = move |p: *mut Extreme| unsafe { (*p).b *= scale };
 
-module.with_closure_hmm(stream.as_ref(), cfg, ptr, &mut device_ran, closure)?;
+// SAFETY: cfg launches one thread, and the HMM values outlive synchronization.
+unsafe { module.with_closure_hmm(stream.as_ref(), cfg, ptr, &mut device_ran, closure) }?;
 
 assert_eq!(data.b, 300);  // 100 * 3 = 300 ✓
 ```
@@ -126,15 +128,19 @@ let scale: i128 = 4;
 // The closure struct contains { scale: &i128 } - a pointer to host memory!
 // GPU accesses this host address via HMM
 
-module.with_closure_hmm(
-    stream.as_ref(),
-    cfg,
-    ptr,
-    &mut device_ran,
-    |p: *mut Extreme| unsafe {
-        (*p).b *= scale  // GPU reads &scale via HMM
-    },
-)?;
+// SAFETY: cfg launches one thread, and the HMM values and captured reference
+// remain alive until the stream is synchronized.
+unsafe {
+    module.with_closure_hmm(
+        stream.as_ref(),
+        cfg,
+        ptr,
+        &mut device_ran,
+        |p: *mut Extreme| unsafe {
+            (*p).b *= scale  // GPU reads &scale via HMM
+        },
+    )
+}?;
 
 assert_eq!(data.b, 200);  // 50 * 4 = 200 ✓
 ```
@@ -148,15 +154,19 @@ let scale: i128 = 5;
 let offset: i128 = 7;
 // Closure captures BOTH by reference: { scale: &i128, offset: &i128 }
 
-module.with_closure_hmm(
-    stream.as_ref(),
-    cfg,
-    ptr,
-    &mut device_ran,
-    |p: *mut Extreme| unsafe {
-        (*p).b = (*p).b * scale + offset  // GPU reads both via HMM
-    },
-)?;
+// SAFETY: cfg launches one thread, and the HMM values and captured references
+// remain alive until the stream is synchronized.
+unsafe {
+    module.with_closure_hmm(
+        stream.as_ref(),
+        cfg,
+        ptr,
+        &mut device_ran,
+        |p: *mut Extreme| unsafe {
+            (*p).b = (*p).b * scale + offset  // GPU reads both via HMM
+        },
+    )
+}?;
 
 assert_eq!(data.b, 57);  // 10 * 5 + 7 = 57 ✓
 ```

--- a/crates/rustc-codegen-cuda/examples/abi_hmm/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/abi_hmm/src/main.rs
@@ -147,13 +147,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let device_ran_ptr: *mut i32 = &mut device_ran;
         let scale: i128 = 2;
 
-        module.modify_extreme_hmm(
-            &stream,
-            LaunchConfig::for_num_elems(1),
-            data_ptr,
-            scale,
-            device_ran_ptr,
-        )?;
+        // SAFETY: exactly one thread uses the valid HMM pointers while their
+        // stack allocations remain alive until the stream is synchronized.
+        unsafe {
+            module.modify_extreme_hmm(
+                &stream,
+                LaunchConfig::for_num_elems(1),
+                data_ptr,
+                scale,
+                device_ran_ptr,
+            )
+        }?;
 
         stream.synchronize()?;
 
@@ -197,14 +201,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let device_ran_ptr: *mut i32 = &mut device_ran;
 
         let scale: i128 = 3;
+        let scale_b = move |p: *mut Extreme| unsafe { (*p).b *= scale };
 
-        module.with_closure_hmm::<_>(
-            &stream,
-            LaunchConfig::for_num_elems(1),
-            data_ptr,
-            device_ran_ptr,
-            move |p: *mut Extreme| unsafe { (*p).b *= scale },
-        )?;
+        // SAFETY: exactly one thread uses the valid HMM pointers while their
+        // stack allocations remain alive until the stream is synchronized.
+        unsafe {
+            module.with_closure_hmm::<_>(
+                &stream,
+                LaunchConfig::for_num_elems(1),
+                data_ptr,
+                device_ran_ptr,
+                scale_b,
+            )
+        }?;
 
         stream.synchronize()?;
 
@@ -243,14 +252,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "    &scale = {:p} (HOST address - closure captures this!)",
             &scale
         );
+        let scale_b = |p: *mut Extreme| unsafe { (*p).b *= scale };
 
-        module.with_closure_hmm::<_>(
-            &stream,
-            LaunchConfig::for_num_elems(1),
-            data_ptr,
-            device_ran_ptr,
-            |p: *mut Extreme| unsafe { (*p).b *= scale },
-        )?;
+        // SAFETY: exactly one thread uses valid HMM pointers and captured
+        // references while the stack values remain alive through synchronization.
+        unsafe {
+            module.with_closure_hmm::<_>(
+                &stream,
+                LaunchConfig::for_num_elems(1),
+                data_ptr,
+                device_ran_ptr,
+                scale_b,
+            )
+        }?;
 
         stream.synchronize()?;
 
@@ -299,14 +313,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "    &scale = {:p}, &offset = {:p} (both HOST addresses)",
             &scale, &offset
         );
+        let affine_b = |p: *mut Extreme| unsafe { (*p).b = (*p).b * scale + offset };
 
-        module.with_closure_hmm::<_>(
-            &stream,
-            LaunchConfig::for_num_elems(1),
-            data_ptr,
-            device_ran_ptr,
-            |p: *mut Extreme| unsafe { (*p).b = (*p).b * scale + offset },
-        )?;
+        // SAFETY: exactly one thread uses valid HMM pointers and captured
+        // references while the stack values remain alive through synchronization.
+        unsafe {
+            module.with_closure_hmm::<_>(
+                &stream,
+                LaunchConfig::for_num_elems(1),
+                data_ptr,
+                device_ran_ptr,
+                affine_b,
+            )
+        }?;
 
         stream.synchronize()?;
 

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -69,7 +69,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out = DeviceBuffer::<f32>::zeroed(&stream, 1)?;
     let seed: f32 = 7.0;
 
-    module.sharedarray_late_use(stream.as_ref(), cfg, seed, &mut out)?;
+    // SAFETY: one thread is launched, matching the kernel's single-element
+    // output access and fixed shared-memory use.
+    unsafe { module.sharedarray_late_use(stream.as_ref(), cfg, seed, &mut out) }?;
 
     let result = out.to_host_vec(&stream)?[0];
     let expected: f32 = 21.0; // seed * repro_weight() == 7.0 * 3.0

--- a/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
@@ -83,12 +83,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_f32 = DeviceBuffer::<f32>::zeroed(&stream, N)?;
     let mut out_u32 = DeviceBuffer::<u32>::zeroed(&stream, N)?;
 
-    module.check_array_constants(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &mut out_f32,
-        &mut out_u32,
-    )?;
+    // SAFETY: this is a 1D launch and the kernel bounds-checks each output
+    // access against the corresponding slice length.
+    unsafe {
+        module.check_array_constants(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &mut out_f32,
+            &mut out_u32,
+        )
+    }?;
 
     let got_f32 = out_f32.to_host_vec(&stream)?;
     let got_u32 = out_u32.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -97,14 +97,16 @@ fn main() {
     };
 
     let mut d_u32 = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .sum_u32_array(stream.as_ref(), cfg, &mut d_u32)
+    // SAFETY: the 32-thread 1D block matches both kernels' indexing model and
+    // the 32-element output allocations.
+    unsafe { module.sum_u32_array(stream.as_ref(), cfg, &mut d_u32) }
         .expect("launch sum_u32_array");
     let got_u32 = d_u32.to_host_vec(&stream).unwrap();
 
     let mut d_pts = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .sum_point_array(stream.as_ref(), cfg, &mut d_pts)
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.sum_point_array(stream.as_ref(), cfg, &mut d_pts) }
         .expect("launch sum_point_array");
     let got_pts = d_pts.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
@@ -363,8 +363,8 @@ fn run_test_const_index_read(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_const_index_read((stream).as_ref(), config, &mut d_out)
+    // SAFETY: this test launches exactly one thread for one output element.
+    unsafe { module.test_const_index_read((stream).as_ref(), config, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
@@ -391,8 +391,8 @@ fn run_test_const_index_read_expr(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_const_index_read_expr((stream).as_ref(), config, &mut d_out)
+    // SAFETY: this test launches exactly one thread for one output element.
+    unsafe { module.test_const_index_read_expr((stream).as_ref(), config, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
@@ -420,8 +420,9 @@ fn run_test_runtime_index_read(
     };
 
     let index = 2u32; // Read arr[2] = 300
-    module
-        .test_runtime_index_read((stream).as_ref(), config, index, &mut d_out)
+    // SAFETY: this test launches exactly one thread, and `index` selects a
+    // valid element of the kernel's four-element local array.
+    unsafe { module.test_runtime_index_read((stream).as_ref(), config, index, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
@@ -448,8 +449,8 @@ fn run_test_runtime_index_read_loop(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_runtime_index_read_loop((stream).as_ref(), config, &mut d_out)
+    // SAFETY: this test launches exactly one thread for one output element.
+    unsafe { module.test_runtime_index_read_loop((stream).as_ref(), config, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
@@ -477,8 +478,9 @@ fn run_test_mixed_read(
     };
 
     let index = 2u32; // arr[2] = 30
-    module
-        .test_mixed_read((stream).as_ref(), config, index, &mut d_out)
+    // SAFETY: this test launches exactly one thread, and `index` selects a
+    // valid element of the kernel's four-element local array.
+    unsafe { module.test_mixed_read((stream).as_ref(), config, index, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
@@ -506,7 +508,8 @@ fn run_test_const_index_write(
     };
 
     let val = 5u32;
-    match module.test_const_index_write((stream).as_ref(), config, val, &mut d_out) {
+    // SAFETY: this test launches exactly one thread for one output element.
+    match unsafe { module.test_const_index_write((stream).as_ref(), config, val, &mut d_out) } {
         Ok(_) => {
             let result = d_out.to_host_vec(stream).unwrap()[0];
             let expected = 26u32; // 5 + 6 + 7 + 8
@@ -537,7 +540,8 @@ fn run_test_runtime_index_write_loop(
         shared_mem_bytes: 0,
     };
 
-    match module.test_runtime_index_write_loop((stream).as_ref(), config, &mut d_out) {
+    // SAFETY: this test launches exactly one thread for one output element.
+    match unsafe { module.test_runtime_index_write_loop((stream).as_ref(), config, &mut d_out) } {
         Ok(_) => {
             let result = d_out.to_host_vec(stream).unwrap()[0];
             let expected = 280u32; // 0+10+20+30+40+50+60+70
@@ -573,7 +577,11 @@ fn run_test_copy_to_local_array(
         shared_mem_bytes: 0,
     };
 
-    match module.test_copy_to_local_array((stream).as_ref(), config, &d_input, &mut d_out) {
+    // SAFETY: one thread reads the four-element input and writes the single
+    // output element allocated above.
+    match unsafe {
+        module.test_copy_to_local_array((stream).as_ref(), config, &d_input, &mut d_out)
+    } {
         Ok(_) => {
             let result = d_out.to_host_vec(stream).unwrap()[0];
             let expected = 1000u32; // 100+200+300+400
@@ -607,7 +615,8 @@ fn run_test_read_modify_write(
         shared_mem_bytes: 0,
     };
 
-    match module.test_read_modify_write((stream).as_ref(), config, &mut d_out) {
+    // SAFETY: this test launches exactly one thread for one output element.
+    match unsafe { module.test_read_modify_write((stream).as_ref(), config, &mut d_out) } {
         Ok(_) => {
             let result = d_out.to_host_vec(stream).unwrap()[0];
             let expected = 20u32; // 2+4+6+8

--- a/crates/rustc-codegen-cuda/examples/array_init/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_init/src/main.rs
@@ -103,9 +103,9 @@ fn main() {
     // --- array_sum ---
     // arr = [1, 2, 3, 4]; arr[2] += i; sum = 1 + 2 + (3 + i) + 4 = 10 + i
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .array_sum(&stream, cfg, &mut out_dev)
-        .expect("array_sum launch");
+    // SAFETY: this is a 1D launch and the output allocation has one element
+    // for every launched thread.
+    unsafe { module.array_sum(&stream, cfg, &mut out_dev) }.expect("array_sum launch");
     let out = out_dev.to_host_vec(&stream).unwrap();
 
     let mut errors = 0usize;
@@ -122,8 +122,9 @@ fn main() {
     // --- zeroed_array_sum ---
     // arr[k] = i + k; sum = sum_{k=0}^{7}(i + k) = 8i + 28
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .zeroed_array_sum(&stream, cfg, &mut out_dev)
+    // SAFETY: this is a 1D launch and the output allocation has one element
+    // for every launched thread.
+    unsafe { module.zeroed_array_sum(&stream, cfg, &mut out_dev) }
         .expect("zeroed_array_sum launch");
     let out2 = out_dev.to_host_vec(&stream).unwrap();
 
@@ -143,8 +144,8 @@ fn main() {
     // --- scratch_2d ---
     // scratch[2] = [0.0, 42.0]; out[0] = scratch[2][1]  => 42.0
     let mut out_dev = DeviceBuffer::<f64>::zeroed(&stream, 1).unwrap();
-    module
-        .scratch_2d(&stream, LaunchConfig::for_num_elems(1), &mut out_dev)
+    // SAFETY: `scratch_2d` is launched with one thread and writes one output.
+    unsafe { module.scratch_2d(&stream, LaunchConfig::for_num_elems(1), &mut out_dev) }
         .expect("scratch_2d launch");
     let out3 = out_dev.to_host_vec(&stream).unwrap();
     if (out3[0] - 42.0_f64).abs() > 1e-12 {

--- a/crates/rustc-codegen-cuda/examples/asin_acos_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/asin_acos_smoke/src/main.rs
@@ -147,10 +147,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_asin_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
     let mut out_acos_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
 
-    module.asin_f32(&stream, cfg, &xs32, &mut out_asin_f32)?;
-    module.acos_f32(&stream, cfg, &xs32, &mut out_acos_f32)?;
-    module.asin_f64(&stream, cfg, &xs64, &mut out_asin_f64)?;
-    module.acos_f64(&stream, cfg, &xs64, &mut out_acos_f64)?;
+    // SAFETY: these are 1D launches and every input and output slice has `n`
+    // elements, matching the guarded per-thread accesses in each kernel.
+    unsafe {
+        module.asin_f32(&stream, cfg, &xs32, &mut out_asin_f32)?;
+        module.acos_f32(&stream, cfg, &xs32, &mut out_acos_f32)?;
+        module.asin_f64(&stream, cfg, &xs64, &mut out_asin_f64)?;
+        module.acos_f64(&stream, cfg, &xs64, &mut out_acos_f64)?;
+    }
 
     let got_asin_f32 = out_asin_f32.to_host_vec(&stream)?;
     let got_acos_f32 = out_acos_f32.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/async_mlp/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/async_mlp/src/main.rs
@@ -264,12 +264,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     DeviceBox<[f32]>,
                     DeviceBox<[f32]>,
                 )| {
-                    let launch = module
-                        .sgemm_naive_async_owned(
+                    // SAFETY: the 2D grid and block match `sgemm_naive`'s
+                    // indexing, and all matrices are DIM x DIM allocations.
+                    let launch = unsafe {
+                        module.sgemm_naive_async_owned(
                             gemm_cfg, DIM as u32, DIM as u32, DIM as u32, 1.0f32, input, w0,
                             0.0f32, hidden,
                         )
-                        .expect("Failed to build sgemm_naive launch");
+                    }
+                    .expect("Failed to build sgemm_naive launch");
                     launch
                         .and_then(move |(_input, _w0, hidden)| value((hidden, output, w1, module)))
                 },
@@ -282,19 +285,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Arc<DeviceBox<[f32]>>,
                     kernels::LoadedModule,
                 )| {
-                    let launch = module
-                        .matvec_naive_async_owned(
+                    // SAFETY: this is a 1D launch of DIM guarded threads over
+                    // DIM-sized vectors and a DIM x DIM matrix.
+                    let launch = unsafe {
+                        module.matvec_naive_async_owned(
                             matvec_cfg, DIM as u32, DIM as u32, hidden, w1, output,
                         )
-                        .expect("Failed to build matvec_naive launch");
+                    }
+                    .expect("Failed to build matvec_naive launch");
                     launch.and_then(move |(_hidden, _w1, output)| value((output, module)))
                 },
             )
             // ── Stage 3: ReLU  result = max(0, output) ──────────────────
             .and_then(
                 move |(output, module): (DeviceBox<[f32]>, kernels::LoadedModule)| {
-                    module
-                        .relu_async_owned(relu_cfg, output)
+                    // SAFETY: this is a 1D launch and the ReLU kernel guards
+                    // accesses using the owned output's DIM-element length.
+                    unsafe { module.relu_async_owned(relu_cfg, output) }
                         .expect("Failed to build relu launch")
                 },
             )

--- a/crates/rustc-codegen-cuda/examples/async_vecadd/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/async_vecadd/src/main.rs
@@ -92,14 +92,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 4. Launch the kernel asynchronously.
     //    `vecadd_async` returns an AsyncKernelLaunch (a DeviceOperation).
     //    No GPU work happens until we `.sync()` or `.await`.
-    module
-        .vecadd_async(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.vecadd_async(
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
-        )?
-        .sync()?;
+        )
+    }?
+    .sync()?;
 
     // 5. Copy results back.
     let mut c_host = vec![0.0f32; N];

--- a/crates/rustc-codegen-cuda/examples/atomic_f16/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/atomic_f16/src/bin/bench.rs
@@ -106,12 +106,14 @@ fn bench_no_return(
 
     let f32_ms = time_gpu_iters(stream, ITERS, || {
         reset(&hist_f32, stream)?;
-        module.f32_add(stream, cfg, &hist_f32, N, bins)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.f32_add(stream, cfg, &hist_f32, N, bins) }?;
         Ok(())
     })?;
     let f16_ms = time_gpu_iters(stream, ITERS, || {
         reset(&hist_f16, stream)?;
-        module.f16_add(stream, cfg, &hist_f16, N, bins)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.f16_add(stream, cfg, &hist_f16, N, bins) }?;
         Ok(())
     })?;
 
@@ -133,12 +135,14 @@ fn bench_return(
 
     let f32_ms = time_gpu_iters(stream, ITERS, || {
         reset(&hist_f32, stream)?;
-        module.f32_add_return(stream, cfg, &hist_f32, &mut old_f32, N, bins)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.f32_add_return(stream, cfg, &hist_f32, &mut old_f32, N, bins) }?;
         Ok(())
     })?;
     let f16_ms = time_gpu_iters(stream, ITERS, || {
         reset(&hist_f16, stream)?;
-        module.f16_add_return(stream, cfg, &hist_f16, &mut old_f16, N, bins)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.f16_add_return(stream, cfg, &hist_f16, &mut old_f16, N, bins) }?;
         Ok(())
     })?;
 

--- a/crates/rustc-codegen-cuda/examples/atomic_f16/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/atomic_f16/src/main.rs
@@ -123,8 +123,9 @@ fn run_device_hist(
 
     let hist = DeviceBuffer::<f16>::zeroed(stream, nbins as usize).unwrap();
     let mut old = DeviceBuffer::<f16>::zeroed(stream, n as usize).unwrap();
-    module
-        .device_hist_f16(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.device_hist_f16(
             stream,
             LaunchConfig::for_num_elems(n),
             &hist,
@@ -132,7 +133,8 @@ fn run_device_hist(
             n,
             nbins,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
 
@@ -158,8 +160,8 @@ fn run_device_sub(module: &kernels::LoadedModule, stream: &cuda_core::CudaStream
     let counter = DeviceBuffer::from_host(stream, &initial).unwrap();
     let mut old = DeviceBuffer::<f16>::zeroed(stream, n as usize).unwrap();
 
-    module
-        .device_sub_f16(stream, LaunchConfig::for_num_elems(n), &counter, &mut old)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.device_sub_f16(stream, LaunchConfig::for_num_elems(n), &counter, &mut old) }
         .expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
@@ -180,8 +182,8 @@ fn run_system_add(module: &kernels::LoadedModule, stream: &cuda_core::CudaStream
     let counter = DeviceBuffer::<f16>::zeroed(stream, 1).unwrap();
     let mut old = DeviceBuffer::<f16>::zeroed(stream, n as usize).unwrap();
 
-    module
-        .system_add_f16(stream, LaunchConfig::for_num_elems(n), &counter, &mut old)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.system_add_f16(stream, LaunchConfig::for_num_elems(n), &counter, &mut old) }
         .expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
@@ -207,8 +209,9 @@ fn run_device_swap(module: &kernels::LoadedModule, stream: &cuda_core::CudaStrea
     let vals = DeviceBuffer::from_host(stream, &host_vals).unwrap();
     let mut old = DeviceBuffer::<f16>::zeroed(stream, n as usize).unwrap();
 
-    module
-        .device_swap_f16(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.device_swap_f16(
             stream,
             LaunchConfig::for_num_elems(n),
             &cell,
@@ -216,7 +219,8 @@ fn run_device_swap(module: &kernels::LoadedModule, stream: &cuda_core::CudaStrea
             &mut old,
             n,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
 
@@ -247,9 +251,11 @@ fn run_device_store_load(module: &kernels::LoadedModule, stream: &cuda_core::Cud
     let cells = DeviceBuffer::from_host(stream, &host_init).unwrap();
     let mut out = DeviceBuffer::<f16>::zeroed(stream, n as usize).unwrap();
 
-    module
-        .device_store_load_f16(stream, LaunchConfig::for_num_elems(n), &cells, &mut out, n)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.device_store_load_f16(stream, LaunchConfig::for_num_elems(n), &cells, &mut out, n)
+    }
+    .expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
 
@@ -291,9 +297,8 @@ fn run_block_hist(
         shared_mem_bytes: 0,
     };
 
-    module
-        .block_hist_f16(stream, cfg, &hist, &mut old)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.block_hist_f16(stream, cfg, &hist, &mut old) }.expect("Kernel launch failed");
 
     stream.synchronize().unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
@@ -565,8 +565,8 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -605,8 +605,8 @@ fn main() {
         let flag_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_load_store_test((stream).as_ref(), cfg, &flag_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_load_store_test((stream).as_ref(), cfg, &flag_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -635,8 +635,8 @@ fn main() {
         let winner_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_cas_test((stream).as_ref(), cfg, &winner_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_cas_test((stream).as_ref(), cfg, &winner_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -667,9 +667,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_fetch_add_acqrel_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_fetch_add_acqrel_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -706,9 +708,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_fetch_add_seqcst_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_fetch_add_seqcst_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -746,15 +750,17 @@ fn main() {
         let cas_target_dev = DeviceBuffer::<i32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_i32_test(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_i32_test(
                 (stream).as_ref(),
                 cfg,
                 &counter_dev,
                 &cas_target_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -794,14 +800,16 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, total_threads).unwrap();
 
-        module
-            .atomic_multiblock_test(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_multiblock_test(
                 (stream).as_ref(),
                 multiblock_cfg,
                 &counter_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -841,9 +849,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<u64>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_u64_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_u64_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -878,15 +888,17 @@ fn main() {
         let cas_target_dev = DeviceBuffer::<i64>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<i64>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_i64_test(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_i64_test(
                 (stream).as_ref(),
                 cfg,
                 &counter_dev,
                 &cas_target_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -920,8 +932,8 @@ fn main() {
         let counter_dev = DeviceBuffer::from_host(&stream, &counter_host).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_fetch_sub_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_fetch_sub_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -963,8 +975,9 @@ fn main() {
 
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_bitwise_test(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_bitwise_test(
                 (stream).as_ref(),
                 cfg,
                 &or_dev,
@@ -972,7 +985,8 @@ fn main() {
                 &xor_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let or_val = or_dev.to_host_vec(&stream).unwrap()[0];
@@ -1007,8 +1021,8 @@ fn main() {
         let target_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_swap_test((stream).as_ref(), cfg, &target_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_swap_test((stream).as_ref(), cfg, &target_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -1046,9 +1060,11 @@ fn main() {
         let max_dev = DeviceBuffer::from_host(&stream, &max_host).unwrap();
         let mut out_dev = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_minmax_test((stream).as_ref(), cfg, &min_dev, &max_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_minmax_test((stream).as_ref(), cfg, &min_dev, &max_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let min_val = min_dev.to_host_vec(&stream).unwrap()[0];
@@ -1075,9 +1091,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<f32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_f32_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_f32_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -1108,9 +1126,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<f64>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_f64_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_f64_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -1140,8 +1160,8 @@ fn main() {
         let target_dev = DeviceBuffer::<f32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_f32_swap_test((stream).as_ref(), cfg, &target_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.atomic_f32_swap_test((stream).as_ref(), cfg, &target_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -1176,9 +1196,17 @@ fn main() {
         let max_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_unsigned_minmax_test((stream).as_ref(), cfg, &min_dev, &max_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_unsigned_minmax_test(
+                (stream).as_ref(),
+                cfg,
+                &min_dev,
+                &max_dev,
+                &mut out_dev,
+            )
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let min_val = min_dev.to_host_vec(&stream).unwrap();
@@ -1213,9 +1241,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_block_scope_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_block_scope_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -1256,9 +1286,16 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .atomic_block_scope_acqrel_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.atomic_block_scope_acqrel_test(
+                (stream).as_ref(),
+                cfg,
+                &counter_dev,
+                &mut out_dev,
+            )
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();
@@ -1298,9 +1335,11 @@ fn main() {
         let counter_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .core_atomic_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.core_atomic_fetch_add_test((stream).as_ref(), cfg, &counter_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
         let counter_val = counter_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/barrier/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/barrier/src/main.rs
@@ -143,8 +143,8 @@ fn main() {
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .barrier_sync_test((stream).as_ref(), cfg, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.barrier_sync_test((stream).as_ref(), cfg, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();
@@ -173,8 +173,8 @@ fn main() {
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .barrier_shared_data_test((stream).as_ref(), cfg, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.barrier_shared_data_test((stream).as_ref(), cfg, &mut out_dev) }
             .expect("Kernel launch failed");
 
         stream.synchronize().unwrap();

--- a/crates/rustc-codegen-cuda/examples/bf16x2_arith/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/bf16x2_arith/src/main.rs
@@ -93,8 +93,8 @@ fn main() {
     let module = kernels::load(&ctx).expect("load embedded PTX");
     let mut out = DeviceBuffer::<[u32; NUM_OPS]>::zeroed(&stream, 1).unwrap();
 
-    module
-        .test_bf16x2_arith(&stream, LaunchConfig::for_num_elems(1), &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_bf16x2_arith(&stream, LaunchConfig::for_num_elems(1), &mut out) }
         .expect("launch test_bf16x2_arith");
 
     let rows = out.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/bf16x2_fma/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/bf16x2_fma/src/main.rs
@@ -57,8 +57,8 @@ fn main() {
     let module = kernels::load(&ctx).expect("load embedded PTX");
     let mut out = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
 
-    module
-        .run_fma(&stream, LaunchConfig::for_num_elems(1), &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.run_fma(&stream, LaunchConfig::for_num_elems(1), &mut out) }
         .expect("launch run_fma");
 
     let got = out.to_host_vec(&stream).unwrap()[0];

--- a/crates/rustc-codegen-cuda/examples/bool_phi_cmp/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/bool_phi_cmp/src/main.rs
@@ -68,15 +68,17 @@ fn main() {
     let dev_b = DeviceBuffer::from_host(&stream, &b).unwrap();
     let mut dev_out = DeviceBuffer::<u32>::zeroed(&stream, a.len()).unwrap();
 
-    module
-        .bool_phi_cmp(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.bool_phi_cmp(
             &stream,
             LaunchConfig::for_num_elems(a.len() as u32),
             &dev_a,
             &dev_b,
             &mut dev_out,
         )
-        .expect("launch");
+    }
+    .expect("launch");
 
     let out = dev_out.to_host_vec(&stream).unwrap();
     println!("got    : {out:?}");

--- a/crates/rustc-codegen-cuda/examples/carrying_mul_add/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/carrying_mul_add/src/main.rs
@@ -123,8 +123,9 @@ fn main() {
     let mut out = DeviceBuffer::<u64>::zeroed(&stream, SLOTS).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .bigint_helpers(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.bigint_helpers(
             &stream,
             LaunchConfig::for_num_elems(1),
             a,
@@ -139,7 +140,8 @@ fn main() {
             t,
             &mut out,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let got = out.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/cast_tests/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cast_tests/src/main.rs
@@ -436,7 +436,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 → u64
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_cast_u32_to_u64((stream).as_ref(), cfg, 42u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_u32_to_u64((stream).as_ref(), cfg, 42u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42u64 {
             println!("  [PASS] u32 → u64: {} → {}", 42u32, r[0]);
@@ -453,7 +454,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let val: u64 = 0x1_0000_002A; // upper bits should be dropped, leaving 42
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_cast_u64_to_u32((stream).as_ref(), cfg, val, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_u64_to_u32((stream).as_ref(), cfg, val, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42u32 {
             println!("  [PASS] u64 → u32 (trunc): 0x{:X} → {}", val, r[0]);
@@ -469,7 +471,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // i32 → i64 (sign extension)
     {
         let mut out = DeviceBuffer::<i64>::zeroed(&stream, N)?;
-        module.test_cast_i32_to_i64((stream).as_ref(), cfg, -7i32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_i32_to_i64((stream).as_ref(), cfg, -7i32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -7i64 {
             println!("  [PASS] i32 → i64 (sext): -7 → {}", r[0]);
@@ -485,7 +488,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 → f32
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.test_cast_u32_to_f32((stream).as_ref(), cfg, 42u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_u32_to_f32((stream).as_ref(), cfg, 42u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if (r[0] - 42.0f32).abs() < 0.001 {
             println!("  [PASS] u32 → f32: 42 → {}", r[0]);
@@ -501,7 +505,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // i32 → f32 (signed)
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.test_cast_i32_to_f32((stream).as_ref(), cfg, -7i32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_i32_to_f32((stream).as_ref(), cfg, -7i32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if (r[0] - (-7.0f32)).abs() < 0.001 {
             println!("  [PASS] i32 → f32: -7 → {}", r[0]);
@@ -517,7 +522,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32 → u32
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_cast_f32_to_u32((stream).as_ref(), cfg, 42.9f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f32_to_u32((stream).as_ref(), cfg, 42.9f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42u32 {
             println!("  [PASS] f32 → u32: 42.9 → {}", r[0]);
@@ -533,7 +539,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32 → i32
     {
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_cast_f32_to_i32((stream).as_ref(), cfg, -7.8f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f32_to_i32((stream).as_ref(), cfg, -7.8f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -7i32 {
             println!("  [PASS] f32 → i32: -7.8 → {}", r[0]);
@@ -549,7 +556,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 → u32
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_cast_f64_to_u32((stream).as_ref(), cfg, 42.9f64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f64_to_u32((stream).as_ref(), cfg, 42.9f64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42u32 {
             println!("  [PASS] f64 → u32: 42.9 → {}", r[0]);
@@ -565,7 +573,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 → i32
     {
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_cast_f64_to_i32((stream).as_ref(), cfg, -7.8f64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f64_to_i32((stream).as_ref(), cfg, -7.8f64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -7i32 {
             println!("  [PASS] f64 → i32: -7.8 → {}", r[0]);
@@ -581,7 +590,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 → u64
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_cast_f64_to_u64((stream).as_ref(), cfg, 100.5f64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f64_to_u64((stream).as_ref(), cfg, 100.5f64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 100u64 {
             println!("  [PASS] f64 → u64: 100.5 → {}", r[0]);
@@ -597,7 +607,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 → i64
     {
         let mut out = DeviceBuffer::<i64>::zeroed(&stream, N)?;
-        module.test_cast_f64_to_i64((stream).as_ref(), cfg, -100.5f64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f64_to_i64((stream).as_ref(), cfg, -100.5f64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -100i64 {
             println!("  [PASS] f64 → i64: -100.5 → {}", r[0]);
@@ -613,7 +624,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32 → u64 (mixed precision)
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_cast_f32_to_u64((stream).as_ref(), cfg, 42.9f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f32_to_u64((stream).as_ref(), cfg, 42.9f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42u64 {
             println!("  [PASS] f32 → u64 (mixed): 42.9 → {}", r[0]);
@@ -629,7 +641,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32 → i64 (mixed precision)
     {
         let mut out = DeviceBuffer::<i64>::zeroed(&stream, N)?;
-        module.test_cast_f32_to_i64((stream).as_ref(), cfg, -7.8f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f32_to_i64((stream).as_ref(), cfg, -7.8f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -7i64 {
             println!("  [PASS] f32 → i64 (mixed): -7.8 → {}", r[0]);
@@ -645,7 +658,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32 → f64
     {
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, N)?;
-        module.test_cast_f32_to_f64((stream).as_ref(), cfg, 3.14f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f32_to_f64((stream).as_ref(), cfg, 3.14f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if (r[0] - 3.14f64).abs() < 0.001 {
             println!("  [PASS] f32 → f64: 3.14 → {}", r[0]);
@@ -661,7 +675,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 → f32
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.test_cast_f64_to_f32((stream).as_ref(), cfg, 3.14f64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_f64_to_f32((stream).as_ref(), cfg, 3.14f64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if (r[0] - 3.14f32).abs() < 0.01 {
             println!("  [PASS] f64 → f32: 3.14 → {}", r[0]);
@@ -677,7 +692,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // bool → u32
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_cast_bool_to_u32((stream).as_ref(), cfg, true, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_bool_to_u32((stream).as_ref(), cfg, true, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 1u32 {
             println!("  [PASS] bool → u32: true → {}", r[0]);
@@ -699,7 +715,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let bits: i32 = 0x3F800000_u32 as i32; // bit pattern for 1.0f32
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.test_transmute_i32_to_f32((stream).as_ref(), cfg, bits, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_transmute_i32_to_f32((stream).as_ref(), cfg, bits, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 1.0f32;
         if (r[0] - expected).abs() < f32::EPSILON {
@@ -719,7 +736,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // transmute f32 → u32: 1.0f32 should become 0x3F800000
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_transmute_f32_to_u32((stream).as_ref(), cfg, 1.0f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_transmute_f32_to_u32((stream).as_ref(), cfg, 1.0f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 0x3F800000u32;
         if r[0] == expected {
@@ -740,7 +758,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let bits: u64 = 0x4000000000000000; // bit pattern for 2.0f64
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, N)?;
-        module.test_transmute_u64_to_f64((stream).as_ref(), cfg, bits, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_transmute_u64_to_f64((stream).as_ref(), cfg, bits, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 2.0f64;
         if (r[0] - expected).abs() < f64::EPSILON {
@@ -761,7 +780,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let val: u32 = 0xFFFFFFFF; // should become -1 as i32
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_transmute_u32_to_i32((stream).as_ref(), cfg, val, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_transmute_u32_to_i32((stream).as_ref(), cfg, val, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -1i32 {
             println!("  [PASS] transmute u32(0xFFFFFFFF) → i32: {}", r[0]);
@@ -785,7 +805,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let bits: i32 = 0x3F800000_u32 as i32;
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.test_from_bits_i32_to_f32((stream).as_ref(), cfg, bits, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_from_bits_i32_to_f32((stream).as_ref(), cfg, bits, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 1.0f32;
         if (r[0] - expected).abs() < f32::EPSILON {
@@ -805,7 +826,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f32::to_bits — same as transmute f32→u32
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_to_bits_f32((stream).as_ref(), cfg, 1.0f32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_to_bits_f32((stream).as_ref(), cfg, 1.0f32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 0x3F800000u32;
         if r[0] == expected {
@@ -826,7 +848,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let bits: u64 = 0x4000000000000000;
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, N)?;
-        module.test_from_bits_u64_to_f64((stream).as_ref(), cfg, bits, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_from_bits_u64_to_f64((stream).as_ref(), cfg, bits, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         let expected = 2.0f64;
         if (r[0] - expected).abs() < f64::EPSILON {
@@ -844,7 +867,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let val: u32 = 0xFFFFFFFF;
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_cast_signed_u32_to_i32((stream).as_ref(), cfg, val, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_signed_u32_to_i32((stream).as_ref(), cfg, val, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -1i32 {
             println!("  [PASS] u32::cast_signed(0xFFFFFFFF): {}", r[0]);
@@ -861,7 +885,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let val: i32 = -1;
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_cast_unsigned_i32_to_u32((stream).as_ref(), cfg, val, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_unsigned_i32_to_u32((stream).as_ref(), cfg, val, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 0xFFFFFFFF {
             println!("  [PASS] i32::cast_unsigned(-1): 0x{:08X}", r[0]);
@@ -888,7 +913,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let val: u32 = 42;
         let host_ptr: *const u32 = &val;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_cast_ptr_reinterpret((stream).as_ref(), cfg, host_ptr, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_ptr_reinterpret((stream).as_ref(), cfg, host_ptr, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] != 0 {
             println!(
@@ -909,7 +935,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let val: u32 = 42;
         let host_ptr: *const u32 = &val;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_cast_ptr_to_usize((stream).as_ref(), cfg, host_ptr, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cast_ptr_to_usize((stream).as_ref(), cfg, host_ptr, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] != 0 {
             println!(
@@ -934,7 +961,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input_data: Vec<u32> = vec![42, 99, 7, 255];
         let input_gpu = DeviceBuffer::from_host(&stream, &input_data)?;
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_slice_constant_index((stream).as_ref(), cfg, &input_gpu, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_slice_constant_index((stream).as_ref(), cfg, &input_gpu, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 42 {
             println!("  [PASS] slice constant index: data[0] = {}", r[0]);
@@ -956,11 +984,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let n = 4usize;
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, n)?;
-        let result = module.test_unsize_array_to_slice(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &mut out,
-        );
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe {
+            module.test_unsize_array_to_slice(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &mut out,
+            )
+        };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;
@@ -988,11 +1019,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let n = 4usize;
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, n)?;
-        let result = module.test_unsize_array_as_slice(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &mut out,
-        );
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe {
+            module.test_unsize_array_as_slice(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &mut out,
+            )
+        };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;
@@ -1019,7 +1053,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // array iter sum via .as_slice()
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        let result = module.test_unsize_array_iter_sum((stream).as_ref(), cfg, &mut out);
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe { module.test_unsize_array_iter_sum((stream).as_ref(), cfg, &mut out) };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;
@@ -1050,11 +1085,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let n = 3usize;
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, n)?;
-        let result = module.test_unsize_f64_as_slice(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &mut out,
-        );
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe {
+            module.test_unsize_f64_as_slice(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &mut out,
+            )
+        };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;
@@ -1082,11 +1120,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let n = 3usize;
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, n)?;
-        let result = module.test_unsize_f64_explicit(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &mut out,
-        );
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe {
+            module.test_unsize_f64_explicit(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &mut out,
+            )
+        };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;
@@ -1113,7 +1154,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f64 iter sum
     {
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, N)?;
-        let result = module.test_unsize_f64_iter_sum((stream).as_ref(), cfg, &mut out);
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let result = unsafe { module.test_unsize_f64_iter_sum((stream).as_ref(), cfg, &mut out) };
         match result {
             Ok(_) => {
                 let r = out.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/cbrt_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cbrt_smoke/src/main.rs
@@ -124,8 +124,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_cbrt_f32 = DeviceBuffer::<f32>::zeroed(&stream, n)?;
     let mut out_cbrt_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
 
-    module.cbrt_f32(&stream, cfg, &xs32, &mut out_cbrt_f32)?;
-    module.cbrt_f64(&stream, cfg, &xs64, &mut out_cbrt_f64)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cbrt_f32(&stream, cfg, &xs32, &mut out_cbrt_f32) }?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cbrt_f64(&stream, cfg, &xs64, &mut out_cbrt_f64) }?;
 
     let got_cbrt_f32 = out_cbrt_f32.to_host_vec(&stream)?;
     let got_cbrt_f64 = out_cbrt_f64.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
@@ -88,8 +88,8 @@ fn main() {
     let a_dev = DeviceBuffer::from_host(&stream, &a_add).unwrap();
     let b_dev = DeviceBuffer::from_host(&stream, &b_add).unwrap();
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
-    module
-        .checked_add(&stream, cfg, &a_dev, &b_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.checked_add(&stream, cfg, &a_dev, &b_dev, &mut out_dev) }
         .expect("checked_add launch");
     let out_add = out_dev.to_host_vec(&stream).unwrap();
 
@@ -103,8 +103,8 @@ fn main() {
     let a_dev = DeviceBuffer::from_host(&stream, &a_sub).unwrap();
     let b_dev = DeviceBuffer::from_host(&stream, &b_sub).unwrap();
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
-    module
-        .checked_sub(&stream, cfg, &a_dev, &b_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.checked_sub(&stream, cfg, &a_dev, &b_dev, &mut out_dev) }
         .expect("checked_sub launch");
     let out_sub = out_dev.to_host_vec(&stream).unwrap();
 
@@ -118,8 +118,8 @@ fn main() {
     let a_dev = DeviceBuffer::from_host(&stream, &a_mul).unwrap();
     let b_dev = DeviceBuffer::from_host(&stream, &b_mul).unwrap();
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
-    module
-        .checked_mul(&stream, cfg, &a_dev, &b_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.checked_mul(&stream, cfg, &a_dev, &b_dev, &mut out_dev) }
         .expect("checked_mul launch");
     let out_mul = out_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/clc/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/clc/src/main.rs
@@ -222,16 +222,19 @@ fn main() {
     );
     println!("Total tiles: {}\n", total_tiles);
 
-    let launch_result = module.test_clc_try_cancel(
-        (stream).as_ref(),
-        LaunchConfig {
-            grid_dim: (TILES_X, TILES_Y, 1),
-            block_dim: (32, 1, 1),
-            shared_mem_bytes: 0,
-        },
-        &mut output_dev,
-        total_tiles,
-    );
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    let launch_result = unsafe {
+        module.test_clc_try_cancel(
+            (stream).as_ref(),
+            LaunchConfig {
+                grid_dim: (TILES_X, TILES_Y, 1),
+                block_dim: (32, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            &mut output_dev,
+            total_tiles,
+        )
+    };
 
     match launch_result {
         Ok(_) => match stream.synchronize() {
@@ -285,15 +288,18 @@ fn main() {
 
     let mut all_output = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
 
-    let launch_result = module.test_clc_all_intrinsics(
-        (stream).as_ref(),
-        LaunchConfig {
-            grid_dim: (4, 1, 1),
-            block_dim: (32, 1, 1),
-            shared_mem_bytes: 0,
-        },
-        &mut all_output,
-    );
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    let launch_result = unsafe {
+        module.test_clc_all_intrinsics(
+            (stream).as_ref(),
+            LaunchConfig {
+                grid_dim: (4, 1, 1),
+                block_dim: (32, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            &mut all_output,
+        )
+    };
 
     match launch_result {
         Ok(_) => match stream.synchronize() {

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -239,8 +239,9 @@ fn main() {
     println!("Launching test_cluster_compile_time via cuLaunchKernelEx");
     println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1\n");
 
-    module
-        .test_cluster_compile_time(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_cluster_compile_time(
             (stream).as_ref(),
             LaunchConfig {
                 grid_dim: (cluster_size, 1, 1),
@@ -249,7 +250,8 @@ fn main() {
             },
             &mut ct_output,
         )
-        .expect("Launch compile-time cluster kernel");
+    }
+    .expect("Launch compile-time cluster kernel");
     stream.synchronize().expect("Synchronize");
 
     let ct_results: Vec<u32> = ct_output.to_host_vec(&stream).unwrap();
@@ -296,8 +298,9 @@ fn main() {
     println!("Launching test_cluster_intrinsics...");
     println!("  Grid: 4x1x1 blocks, Block: 32 threads\n");
 
-    module
-        .test_cluster_intrinsics(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_cluster_intrinsics(
             (stream).as_ref(),
             LaunchConfig {
                 grid_dim: (n_blocks, 1, 1),
@@ -306,7 +309,8 @@ fn main() {
             },
             &mut output_dev,
         )
-        .expect("Launch kernel");
+    }
+    .expect("Launch kernel");
     stream.synchronize().expect("Synchronize");
 
     let output: Vec<u32> = output_dev.to_host_vec(&stream).unwrap();
@@ -340,8 +344,9 @@ fn main() {
     println!("Launching test_cluster_sync via cuLaunchKernelEx");
     println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1\n");
 
-    module
-        .test_cluster_sync(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_cluster_sync(
             (stream).as_ref(),
             LaunchConfig {
                 grid_dim: (cluster_size, 1, 1),
@@ -350,7 +355,8 @@ fn main() {
             },
             &mut sync_output,
         )
-        .expect("Launch sync kernel");
+    }
+    .expect("Launch sync kernel");
     stream.synchronize().expect("Synchronize");
 
     let sync_results: Vec<u32> = sync_output.to_host_vec(&stream).unwrap();
@@ -378,15 +384,18 @@ fn main() {
     println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1");
     println!("  Expected: Block 0 reads 1001, Block 1 reads 1002, ...\n");
 
-    let ring_result = module.test_dsmem_ring_exchange(
-        (stream).as_ref(),
-        LaunchConfig {
-            grid_dim: (cluster_size, 1, 1),
-            block_dim: (32, 1, 1),
-            shared_mem_bytes: 0,
-        },
-        &mut ring_output,
-    );
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    let ring_result = unsafe {
+        module.test_dsmem_ring_exchange(
+            (stream).as_ref(),
+            LaunchConfig {
+                grid_dim: (cluster_size, 1, 1),
+                block_dim: (32, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            &mut ring_output,
+        )
+    };
 
     let (ring_pass, dsmem_context_error) = match ring_result {
         Ok(_) => match stream.synchronize() {
@@ -442,15 +451,18 @@ fn main() {
         println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1");
         println!("  Expected: Block 0 sums all blocks' values: 10+20+30+40 = 100\n");
 
-        let reduce_result = module.test_dsmem_reduction(
-            (stream).as_ref(),
-            LaunchConfig {
-                grid_dim: (cluster_size, 1, 1),
-                block_dim: (32, 1, 1),
-                shared_mem_bytes: 0,
-            },
-            &mut reduce_output,
-        );
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let reduce_result = unsafe {
+            module.test_dsmem_reduction(
+                (stream).as_ref(),
+                LaunchConfig {
+                    grid_dim: (cluster_size, 1, 1),
+                    block_dim: (32, 1, 1),
+                    shared_mem_bytes: 0,
+                },
+                &mut reduce_output,
+            )
+        };
 
         match reduce_result {
             Ok(_) => match stream.synchronize() {

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -436,7 +436,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: baseline_while_loop");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.baseline_while_loop((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.baseline_while_loop((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 28, "baseline_while_loop failed");
         println!("  ✓ Result: {} (expected 28)", result[0]);
@@ -446,13 +447,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: baseline_binary_match");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.baseline_binary_match((stream).as_ref(), cfg, true, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.baseline_binary_match((stream).as_ref(), cfg, true, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 100, "baseline_binary_match(true) failed");
         println!("  ✓ flag=true: {} (expected 100)", result[0]);
 
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.baseline_binary_match((stream).as_ref(), cfg, false, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.baseline_binary_match((stream).as_ref(), cfg, false, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 0, "baseline_binary_match(false) failed");
         println!("  ✓ flag=false: {} (expected 0)", result[0]);
@@ -469,13 +472,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b_dev = DeviceBuffer::from_host(&stream, &b)?;
         let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, n)?;
 
-        module.baseline_vecadd(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &a_dev,
-            &b_dev,
-            &mut c_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.baseline_vecadd(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &a_dev,
+                &b_dev,
+                &mut c_dev,
+            )
+        }?;
         let result = c_dev.to_host_vec(&stream)?;
         let expected = vec![11.0f32, 22.0, 33.0, 44.0];
         assert_eq!(result, expected, "baseline_vecadd failed");
@@ -488,7 +494,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let test_cases = [(0u32, 10u32), (1, 20), (2, 30), (3, 99), (100, 99)];
         for (val, expected) in test_cases {
             let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-            module.test_multiway_match_u32((stream).as_ref(), cfg, val, &mut out_dev)?;
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_multiway_match_u32((stream).as_ref(), cfg, val, &mut out_dev) }?;
             let result = out_dev.to_host_vec(&stream)?;
             assert_eq!(
                 result[0], expected,
@@ -505,7 +512,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let test_cases = [(0u32, 0u32), (1u32, 1u32), (42u32, 42u32)];
         for (val, expected) in test_cases {
             let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-            module.test_option((stream).as_ref(), cfg, val, &mut out_dev)?;
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_option((stream).as_ref(), cfg, val, &mut out_dev) }?;
             let result = out_dev.to_host_vec(&stream)?;
             assert_eq!(result[0], expected, "test_option({}) failed", val);
             println!("  ✓ val={}: {} (expected {})", val, result[0], expected);
@@ -516,7 +524,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_for_loop_sum");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_for_loop_sum((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_for_loop_sum((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 28, "test_for_loop_sum failed");
         println!("  ✓ Result: {} (expected 28)", result[0]);
@@ -528,7 +537,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![1u32, 2, 3, 4, 5];
         let data_dev = DeviceBuffer::from_host(&stream, &data)?;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_iter_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_iter_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 15, "test_iter_sum failed");
         println!("  ✓ Result: {} (expected 15)", result[0]);
@@ -540,7 +550,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![10u32, 20, 30, 40]; // 0*10 + 1*20 + 2*30 + 3*40 = 0+20+60+120=200
         let data_dev = DeviceBuffer::from_host(&stream, &data)?;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_enumerate((stream).as_ref(), cfg, &data_dev, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_enumerate((stream).as_ref(), cfg, &data_dev, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 200, "test_enumerate failed");
         println!("  ✓ Result: {} (expected 200)", result[0]);
@@ -550,7 +561,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_for_loop_break");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_for_loop_break((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_for_loop_break((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 10, "test_for_loop_break failed");
         println!("  ✓ Result: {} (expected 10)", result[0]);
@@ -560,7 +572,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_for_loop_continue");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_for_loop_continue((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_for_loop_continue((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 16, "test_for_loop_continue failed");
         println!("  ✓ Result: {} (expected 16)", result[0]);
@@ -570,7 +583,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_nested_for_loops");
     {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_nested_for_loops((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_nested_for_loops((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 36, "test_nested_for_loops failed");
         println!("  ✓ Result: {} (expected 36)", result[0]);
@@ -580,7 +594,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_u64_shift_by_32");
     {
         let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_u64_shift_by_32((stream).as_ref(), cfg, 8u64, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u64_shift_by_32((stream).as_ref(), cfg, 8u64, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         let expected = 8u64 << 32;
         assert_eq!(result[0], expected, "test_u64_shift_by_32 failed");
@@ -594,7 +609,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Testing: test_u64_shift_by_46");
     {
         let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_u64_shift_by_46((stream).as_ref(), cfg, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u64_shift_by_46((stream).as_ref(), cfg, &mut out_dev) }?;
         let result = out_dev.to_host_vec(&stream)?;
         let expected = 1u64 << 46;
         assert_eq!(result[0], expected, "test_u64_shift_by_46 failed");
@@ -610,12 +626,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input = vec![2.0f32; 4]; // p(2) = 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 = 255
         let input_dev = DeviceBuffer::from_host(&stream, &input)?;
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
-        module.parallel_polynomial_eval(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(4),
-            &input_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_polynomial_eval(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(4),
+                &input_dev,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         let expected = 255.0f32;
         assert!(
@@ -632,13 +651,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let data_dev = DeviceBuffer::from_host(&stream, &data)?;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
         // 4 threads, chunk_size=4: thread 0 sums 1+2+3+4=10, thread 1 sums 5+6+7+8=26, etc.
-        module.parallel_chunked_sum(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(4),
-            &data_dev,
-            4u32,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_chunked_sum(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(4),
+                &data_dev,
+                4u32,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 10, "parallel_chunked_sum[0] failed");
         assert_eq!(result[1], 26, "parallel_chunked_sum[1] failed");
@@ -652,13 +674,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let matrix: Vec<u32> = (1..=16).collect();
         let matrix_dev = DeviceBuffer::from_host(&stream, &matrix)?;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
-        module.parallel_row_sum(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(4),
-            &matrix_dev,
-            4u32,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_row_sum(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(4),
+                &matrix_dev,
+                4u32,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         // Row 0: 1+2+3+4=10, Row 1: 5+6+7+8=26, Row 2: 9+10+11+12=42, Row 3: 13+14+15+16=58
         assert_eq!(result, vec![10, 26, 42, 58], "parallel_row_sum failed");
@@ -673,12 +698,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Thread 1: product of 4,5,6 = 120
         // Thread 2: product of 7,8,9 = 504
         // Thread 3: product of 10,11,12 = 1320
-        module.parallel_partial_product(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(4),
-            3u32,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_partial_product(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(4),
+                3u32,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         assert_eq!(result[0], 6, "parallel_partial_product[0] failed");
         assert_eq!(result[1], 120, "parallel_partial_product[1] failed");
@@ -693,13 +721,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let data: Vec<f32> = (0..N).map(|i| i as f32).collect();
         let data_dev = DeviceBuffer::from_host(&stream, &data)?;
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-        module.parallel_local_average(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(N as u32),
-            &data_dev,
-            RADIUS,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_local_average(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(N as u32),
+                &data_dev,
+                RADIUS,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         // At position 256 (middle), average of 253..259 = 256.0
         let mid = N / 2;
@@ -730,14 +761,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let a_dev = DeviceBuffer::from_host(&stream, &a)?;
         let b_dev = DeviceBuffer::from_host(&stream, &b)?;
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, NUM_THREADS)?;
-        module.parallel_dot_product_chunked(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(NUM_THREADS as u32),
-            &a_dev,
-            &b_dev,
-            CHUNK_SIZE,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_dot_product_chunked(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(NUM_THREADS as u32),
+                &a_dev,
+                &b_dev,
+                CHUNK_SIZE,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         // Each thread: chunk_size * 2.0 = 64.0, total = 128 * 64 = 8192.0
         let total: f32 = result.iter().sum();
@@ -766,15 +800,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, NUM_THREADS)?;
         let low: u32 = 50;
         let high: u32 = 150;
-        module.parallel_range_count(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(NUM_THREADS as u32),
-            &data_dev,
-            CHUNK_SIZE,
-            low,
-            high,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.parallel_range_count(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(NUM_THREADS as u32),
+                &data_dev,
+                CHUNK_SIZE,
+                low,
+                high,
+                &mut out_dev,
+            )
+        }?;
         let result = out_dev.to_host_vec(&stream)?;
         // Count values in [50, 150) = 100 values
         let total: u32 = result.iter().sum();

--- a/crates/rustc-codegen-cuda/examples/complex_mul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/complex_mul/src/main.rs
@@ -102,8 +102,8 @@ fn run_complex_square_add(module: &kernels::LoadedModule, stream: &Arc<CudaStrea
     };
 
     // c = (0.5, 0.0): z0 = (0,0) -> z1 = (0.5,0) -> z2 = (0.75,0); re+im = 0.75.
-    module
-        .complex_square_add(stream.as_ref(), config, 0.5_f32, 0.0_f32, &mut d_out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.complex_square_add(stream.as_ref(), config, 0.5_f32, 0.0_f32, &mut d_out) }
         .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
@@ -144,8 +144,8 @@ fn main() {
         block_dim: (N as u32, 1, 1),
         shared_mem_bytes: 0,
     };
-    module
-        .const_aggregate(stream.as_ref(), config, &mut d_out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.const_aggregate(stream.as_ref(), config, &mut d_out) }
         .expect("Kernel launch failed");
 
     let out = d_out.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/constant_memory/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/constant_memory/src/main.rs
@@ -73,11 +73,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // set + launch on the same stream → naturally ordered. The second
         // launch demonstrates that re-setting between launches is observed.
         module.set_coeffs(&stream, &coeffs)?;
-        module.apply(
-            &stream,
-            LaunchConfig::for_num_elems(N as u32),
-            &mut output_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.apply(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                &mut output_dev,
+            )
+        }?;
         verify(label, &output_dev.to_host_vec(&stream)?, &coeffs);
     }
 

--- a/crates/rustc-codegen-cuda/examples/constant_memory_coeffs/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/constant_memory_coeffs/src/main.rs
@@ -51,7 +51,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     module.set_coeffs(&stream, &h_coeffs)?;
 
     let mut out = DeviceBuffer::<f32>::zeroed(&stream, 10)?;
-    module.compute(&stream, LaunchConfig::for_num_elems(10), &mut out)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.compute(&stream, LaunchConfig::for_num_elems(10), &mut out) }?;
 
     let result = out.to_host_vec(&stream)?;
     println!("{:?}", result);

--- a/crates/rustc-codegen-cuda/examples/constant_memory_simple/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/constant_memory_simple/src/main.rs
@@ -40,7 +40,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     module.set_scale(&stream, &3.0)?;
 
     let mut out = DeviceBuffer::<f32>::zeroed(&stream, 8)?;
-    module.multiply(&stream, LaunchConfig::for_num_elems(8), &mut out)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.multiply(&stream, LaunchConfig::for_num_elems(8), &mut out) }?;
 
     let result = out.to_host_vec(&stream)?;
     println!("{:?}", result);

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
@@ -696,8 +696,8 @@ fn main() {
     };
     let mut markers = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
     let mut sums = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
-    grid_sync_module
-        .test_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { grid_sync_module.test_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums) }
         .expect("test_grid_sync cooperative launch failed");
     let host = sums.to_host_vec(&stream).unwrap();
     let expected: u32 = (1..=BLOCKS).sum();
@@ -804,9 +804,11 @@ fn main() {
     println!("\n--- this_grid().sync() (cooperative launch) ---");
     let mut markers = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
     let mut sums = DeviceBuffer::<u32>::zeroed(&stream, BLOCKS as usize).unwrap();
-    grid_sync_module
-        .test_typed_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums)
-        .expect("test_typed_grid_sync cooperative launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        grid_sync_module.test_typed_grid_sync(stream.as_ref(), coop_cfg, &mut markers, &mut sums)
+    }
+    .expect("test_typed_grid_sync cooperative launch failed");
     let host = sums.to_host_vec(&stream).unwrap();
     let expected: u32 = (1..=BLOCKS).sum();
     let ok = host.iter().all(|&s| s == expected);

--- a/crates/rustc-codegen-cuda/examples/copy_nonoverlapping/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/copy_nonoverlapping/src/main.rs
@@ -101,9 +101,8 @@ fn main() {
 
     // count == 1 per thread.
     let mut out_each = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .copy_each(&stream, cfg, &in_u32, &mut out_each)
-        .expect("copy_each launch");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.copy_each(&stream, cfg, &in_u32, &mut out_each) }.expect("copy_each launch");
     assert_eq!(
         out_each.to_host_vec(&stream).unwrap(),
         input_u32,
@@ -112,8 +111,8 @@ fn main() {
 
     // count == N in one call (byte scaling).
     let mut out_block = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .copy_block_u32(&stream, cfg, &in_u32, &mut out_block, N)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.copy_block_u32(&stream, cfg, &in_u32, &mut out_block, N) }
         .expect("copy_block_u32 launch");
     assert_eq!(
         out_block.to_host_vec(&stream).unwrap(),
@@ -123,8 +122,8 @@ fn main() {
 
     // u8 (no scaling).
     let mut out_u8 = DeviceBuffer::<u8>::zeroed(&stream, N).unwrap();
-    module
-        .copy_block_u8(&stream, cfg, &in_u8, &mut out_u8, N)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.copy_block_u8(&stream, cfg, &in_u8, &mut out_u8, N) }
         .expect("copy_block_u8 launch");
     assert_eq!(
         out_u8.to_host_vec(&stream).unwrap(),
@@ -134,8 +133,8 @@ fn main() {
 
     // shared destination.
     let mut out_shared = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .copy_into_shared(&stream, cfg, &in_u32, &mut out_shared)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.copy_into_shared(&stream, cfg, &in_u32, &mut out_shared) }
         .expect("copy_into_shared launch");
     assert_eq!(
         out_shared.to_host_vec(&stream).unwrap(),

--- a/crates/rustc-codegen-cuda/examples/cp_async_small/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cp_async_small/src/main.rs
@@ -129,8 +129,8 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 32).unwrap();
 
-        module
-            .test_cp_async_4(&stream, cfg32, &input_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cp_async_4(&stream, cfg32, &input_dev, &mut out_dev) }
             .expect("test_cp_async_4 launch failed");
 
         let out = out_dev.to_host_vec(&stream).unwrap();
@@ -153,8 +153,8 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 64).unwrap();
 
-        module
-            .test_cp_async_8(&stream, cfg32, &input_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cp_async_8(&stream, cfg32, &input_dev, &mut out_dev) }
             .expect("test_cp_async_8 launch failed");
 
         let out = out_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/cp_async_zfill/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cp_async_zfill/src/main.rs
@@ -100,8 +100,8 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 32).unwrap();
 
-        module
-            .test_zfill_4(&stream, cfg, &input_dev, 4u32, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_zfill_4(&stream, cfg, &input_dev, 4u32, &mut out_dev) }
             .expect("launch failed");
 
         let mut test_pass = true;
@@ -131,8 +131,8 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 32).unwrap();
 
-        module
-            .test_zfill_4(&stream, cfg, &input_dev, 2u32, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_zfill_4(&stream, cfg, &input_dev, 2u32, &mut out_dev) }
             .expect("launch failed");
 
         let mut test_pass = true;
@@ -160,8 +160,8 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 32).unwrap();
 
-        module
-            .test_zfill_4(&stream, cfg, &input_dev, 0u32, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_zfill_4(&stream, cfg, &input_dev, 0u32, &mut out_dev) }
             .expect("launch failed");
 
         let mut test_pass = true;

--- a/crates/rustc-codegen-cuda/examples/cross_crate_embedded/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_embedded/src/main.rs
@@ -42,8 +42,8 @@ fn main() {
         let input: Vec<f32> = (0..N).map(|i| i as f32).collect();
         let in_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
-        module
-            .scale::<f32>(&stream, cfg, factor, &in_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.scale::<f32>(&stream, cfg, factor, &in_dev, &mut out_dev) }
             .expect("scale::<f32> launch");
         let out = out_dev.to_host_vec(&stream).unwrap();
         for (i, (&got, &x)) in out.iter().zip(input.iter()).enumerate() {
@@ -67,8 +67,8 @@ fn main() {
         let input: Vec<i32> = (0..N as i32).collect();
         let in_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
-        module
-            .scale::<i32>(&stream, cfg, factor, &in_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.scale::<i32>(&stream, cfg, factor, &in_dev, &mut out_dev) }
             .expect("scale::<i32> launch");
         let out = out_dev.to_host_vec(&stream).unwrap();
         for (i, (&got, &x)) in out.iter().zip(input.iter()).enumerate() {

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/README.md
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/README.md
@@ -101,15 +101,17 @@ use kernel_lib::kernels;
 fn main() {
     // scale::<f32> is monomorphized HERE, not in kernel-lib
     let module = kernels::from_module(raw_module).expect("typed module");
-    module
-        .scale::<f32>(
+    // SAFETY: this is a 1D launch and both buffers contain N elements.
+    unsafe {
+        module.scale::<f32>(
             stream.as_ref(),
             LaunchConfig::for_num_elems(N as u32),
             factor,
             &input_dev,
             &mut output_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 }
 ```
 

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/src/main.rs
@@ -106,15 +106,17 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        module
-            .scale::<f32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale::<f32>(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let output: Vec<f32> = output_dev.to_host_vec(&stream).unwrap();
 
@@ -141,15 +143,17 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut output_dev = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
 
-        module
-            .scale::<i32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale::<i32>(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let output: Vec<i32> = output_dev.to_host_vec(&stream).unwrap();
 
@@ -175,15 +179,17 @@ fn main() {
         let b_dev = DeviceBuffer::from_host(&stream, &b).unwrap();
         let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        module
-            .add::<f32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.add::<f32>(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 &a_dev,
                 &b_dev,
                 &mut c_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let c: Vec<f32> = c_dev.to_host_vec(&stream).unwrap();
 
@@ -210,15 +216,17 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        module
-            .scale_with_helper::<f32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale_with_helper::<f32>(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let output: Vec<f32> = output_dev.to_host_vec(&stream).unwrap();
 
@@ -245,11 +253,11 @@ fn main() {
         let mut output_8 = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
         let config = LaunchConfig::for_num_elems(N as u32);
 
-        module
-            .add_const::<4>((stream).as_ref(), config, &input_dev, &mut output_4)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.add_const::<4>((stream).as_ref(), config, &input_dev, &mut output_4) }
             .expect("add_const::<4> launch failed");
-        module
-            .add_const::<8>((stream).as_ref(), config, &input_dev, &mut output_8)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.add_const::<8>((stream).as_ref(), config, &input_dev, &mut output_8) }
             .expect("add_const::<8> launch failed");
 
         let result_4 = output_4.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/README.md
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/README.md
@@ -13,6 +13,77 @@ marshal correctly:
 Regular Rust struct layout is tested separately by `abi_hmm`; cuda-oxide does
 not require `#[repr(C)]` for Rust-only shared structs.
 
+The example also pins the prepared 1-D launch contract:
+
+```text
+LaunchConfig1D
+      │ validate once: exact 256-thread block + live CUDA limits
+      ▼
+PreparedLaunch<mixed_abi>
+      │ reusable; cannot accept Y/Z geometry or another kernel's config
+      ▼
+typed mixed_abi launch
+```
+
+The kernel's `DisjointSlice` uses the 1-D index space, so
+`#[launch_contract(domain = 1, ...)]` makes the host geometry match that
+assumption. Raw `LaunchConfig` remains available only through the generated
+unsafe `mixed_abi_unchecked` escape hatch.
+
+The example also crosses the module-provenance boundary once with
+`unsafe { kernels::load(&ctx) }`: this crate has one device-code owner, so the
+package-named embedded bundle is the code generated from this module. Prepared
+launches are safe after that assertion.
+
+The second kernel proves the dynamic shared-memory alignment path. Its body
+requests 16-byte alignment while the launch contract requires 128 bytes; the
+compiler takes the stronger requirement and emits:
+
+```ptx
+.extern .shared .align 128 .b8 __dynamic_smem_aligned_dynamic_shared[];
+```
+
+Contracts also follow ordinary device calls, including more than one level of
+helpers. Two 32-thread entries reach the same shared-memory owner; one requires
+32-byte alignment and the other requires 256:
+
+```text
+helper_contract_32  ─┐
+                     ├─> forward helper -> shared owner -> `.align 256`
+helper_contract_256 ─┘
+```
+
+The maximum is required because the helper has one compiled extern-shared
+declaration that may run under either entry.
+
+The generic closure kernel checks the other ownership path. Its exported entry
+calls an inline generic helper, and that helper owns the shared-memory access:
+
+```text
+generic_aligned entry (contract: 64-byte alignment)
+        -> generic helper (body asks for 16 bytes)
+        -> PTX extern shared symbol uses 64 bytes
+```
+
+This matters because the helper still exists when MIR is lowered; waiting for
+LLVM to inline it would be too late to choose the extern-shared declaration.
+The GPU-free verifier checks both that `.align 64` declaration and the generic
+entry's `.maxntid 64, 1, 1` directive.
+
+That kernel deliberately writes `#[launch_contract]` and `#[launch_bounds]`
+above `#[kernel]`. In this order the attributes have already become body
+markers when the generic entry is generated, so the macro must copy those exact
+compiler markers to the entry rather than depending on attribute order.
+
+A small `#[kernel(u32)]` compile-only kernel checks the explicit-instantiation
+form too: its helper asks for 8-byte alignment, its contract raises that to 32,
+and the generated `explicit_aligned_u32` entry keeps `.maxntid 32, 1, 1`. It
+uses the opposite pre-`#[kernel]` ordering of bounds and contract attributes.
+
 ```bash
 cargo oxide run cuda_module_contract
+
+# GPU-free: build, then verify launch bounds and shared-memory alignment.
+cargo oxide build cuda_module_contract
+crates/rustc-codegen-cuda/examples/cuda_module_contract/target/release/cuda_module_contract --verify-ptx
 ```

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
@@ -9,14 +9,57 @@
 //! module macro must lower correctly: scalars, slice, raw device pointer, and
 //! `DisjointSlice` output.
 
-use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
+use cuda_device::{
+    DisjointSlice, DynamicSharedArray, cuda_module, kernel, launch_bounds, launch_contract, thread,
+};
 
 #[cuda_module]
 mod kernels {
     use super::*;
 
+    #[inline(never)]
+    fn ordinary_shared_owner(value: u32) {
+        let shared = DynamicSharedArray::<u32, 16>::get();
+        unsafe {
+            core::ptr::write_volatile(shared, value);
+        }
+    }
+
+    #[inline(never)]
+    fn ordinary_shared_forward(value: u32) {
+        ordinary_shared_owner(value);
+    }
+
+    /// Two entries share the same transitive helper. The helper's single PTX
+    /// declaration must use the stronger contract from either caller.
     #[kernel]
+    #[launch_bounds(32)]
+    #[launch_contract(
+        domain = 1,
+        block = (32, 1, 1),
+        dynamic_shared = 128,
+        dynamic_shared_alignment = 32,
+    )]
+    pub fn helper_contract_32(value: u32) {
+        ordinary_shared_forward(value);
+    }
+
+    #[kernel]
+    #[launch_bounds(32)]
+    #[launch_contract(
+        domain = 1,
+        block = (32, 1, 1),
+        dynamic_shared = 128,
+        dynamic_shared_alignment = 256,
+    )]
+    pub fn helper_contract_256(value: u32) {
+        ordinary_shared_forward(value);
+    }
+
+    #[kernel]
+    #[launch_bounds(256)]
+    #[launch_contract(domain = 1, block = (256, 1, 1), dynamic_shared = 0)]
     pub fn mixed_abi(
         scale: f32,
         bias: f32,
@@ -32,14 +75,92 @@ mod kernels {
             *out_elem = input[idx_raw] * scale + bias + extra + offset;
         }
     }
+
+    /// Compile-time proof that a contract alignment is merged with alignment
+    /// requested by the body. The body asks for 16 bytes; the contract raises
+    /// the emitted extern-shared declaration to 128 bytes.
+    #[kernel]
+    #[launch_bounds(256)]
+    #[launch_contract(
+        domain = 1,
+        block = (256, 1, 1),
+        dynamic_shared = 1024,
+        dynamic_shared_alignment = 128,
+    )]
+    pub fn aligned_dynamic_shared(mut output: DisjointSlice<u8>) {
+        let index = thread::index_1d();
+        let linear = index.get();
+        let shared = DynamicSharedArray::<u8, 16>::get_raw();
+        unsafe {
+            *shared.add(thread::threadIdx_x() as usize) = linear as u8;
+        }
+        if let Some(output) = output.get_mut(index) {
+            *output = unsafe { *shared.add(thread::threadIdx_x() as usize) };
+        }
+    }
+
+    /// Generic/closure pin: the prepared brand and compiler-side alignment
+    /// marker must both survive monomorphization onto the exported wrapper.
+    // Deliberately put both configuration attributes above #[kernel]. They
+    // expand into body markers before the generic entry wrapper is generated.
+    #[launch_contract(
+        domain = 1,
+        block = (64, 1, 1),
+        dynamic_shared = 256,
+        dynamic_shared_alignment = 64,
+    )]
+    #[launch_bounds(64)]
+    #[kernel]
+    pub fn generic_aligned<F: Fn(u32) -> u32 + Copy>(op: F, mut output: DisjointSlice<u32>) {
+        let index = thread::index_1d();
+        let linear = index.get();
+        let shared = DynamicSharedArray::<u32, 16>::get();
+        unsafe {
+            *shared.add(thread::threadIdx_x() as usize) = op(linear as u32);
+        }
+        if let Some(output) = output.get_mut(index) {
+            *output = unsafe { *shared.add(thread::threadIdx_x() as usize) };
+        }
+    }
+}
+
+/// Compile-only coverage for `#[kernel(Type)]`, the explicit-instantiation
+/// form. Its concrete entry still calls a generic helper, so the entry's
+/// alignment contract must propagate to the helper that owns shared memory.
+mod explicit_instantiation {
+    use super::*;
+
+    // The explicit-instantiation expansion must forward pre-expanded markers
+    // just like the call-site monomorphization path above.
+    #[launch_bounds(32)]
+    #[launch_contract(
+        domain = 1,
+        block = (32, 1, 1),
+        dynamic_shared = 128,
+        dynamic_shared_alignment = 32,
+    )]
+    #[kernel(u32)]
+    pub fn explicit_aligned<T: Copy>(value: T) {
+        let shared = DynamicSharedArray::<T, 8>::get();
+        unsafe {
+            core::ptr::write_volatile(shared, value);
+        }
+    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::args().any(|arg| arg == "--verify-ptx") {
+        return verify_launch_contract_ptx();
+    }
+
     println!("=== cuda_module ABI Contract Test ===\n");
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = kernels::load(&ctx)?;
+    // SAFETY: this example has one device-code owner, and `cargo oxide` builds
+    // the merged PTX set from the `kernels` module above with no conflicting
+    // entry definitions.
+    let module = unsafe { kernels::load(&ctx)? };
 
     const N: usize = 1024;
     let scale = 1.5f32;
@@ -52,9 +173,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let offset_dev = DeviceBuffer::from_host(&stream, &offset_host)?;
     let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
 
+    let launch = module.prepare_mixed_abi(LaunchConfig1D::new((N as u32).div_ceil(256), 256, 0))?;
+
     module.mixed_abi(
         &stream,
-        LaunchConfig::for_num_elems(N as u32),
+        &launch,
         scale,
         bias,
         extra,
@@ -72,6 +195,103 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .count();
 
     assert_eq!(errors, 0, "mixed ABI kernel produced {errors} errors");
+
+    let mut generic_output = DeviceBuffer::<u32>::zeroed(&stream, N)?;
+    let add_three = |value: u32| value + 3;
+    let generic_launch = module.prepare_generic_aligned_for(
+        &add_three,
+        LaunchConfig1D::new((N as u32).div_ceil(64), 64, 256),
+    )?;
+    module.generic_aligned(&stream, &generic_launch, add_three, &mut generic_output)?;
+    let generic_output = generic_output.to_host_vec(&stream)?;
+    assert!(
+        generic_output
+            .iter()
+            .enumerate()
+            .all(|(index, &value)| value == index as u32 + 3),
+        "generic prepared launch produced an unexpected value",
+    );
+
     println!("SUCCESS: mixed ABI typed launch passed");
+    Ok(())
+}
+
+fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
+    let ptx_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("cuda_module_contract.ptx");
+    let ptx = std::fs::read_to_string(&ptx_path)?;
+    let aligned_symbol = ".extern .shared .align 128 .b8 __dynamic_smem_aligned_dynamic_shared[];";
+    if !ptx.contains(aligned_symbol) {
+        return Err(format!(
+            "{} does not contain the contract-enforced dynamic shared-memory alignment",
+            ptx_path.display()
+        )
+        .into());
+    }
+    if !ptx.lines().any(|line| {
+        line.contains(".extern .shared .align 64 .b8 __dynamic_smem_")
+            && line.contains("generic_aligned")
+    }) {
+        return Err(
+            "generic launch contract alignment did not reach its PTX specialization".into(),
+        );
+    }
+    if !ptx.lines().any(|line| {
+        line.contains(".extern .shared .align 32 .b8 __dynamic_smem_")
+            && line.contains("explicit_aligned")
+    }) {
+        return Err("explicit generic instantiation alignment did not reach its PTX helper".into());
+    }
+    if !ptx.lines().any(|line| {
+        line.contains(".extern .shared .align 256 .b8 __dynamic_smem_")
+            && line.contains("ordinary_shared_owner")
+    }) {
+        return Err(
+            "shared ordinary helper did not receive the strongest calling-kernel alignment".into(),
+        );
+    }
+
+    for entry in ["aligned_dynamic_shared", "mixed_abi"] {
+        let start = ptx
+            .find(&format!(".visible .entry {entry}("))
+            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
+        let rest = &ptx[start..];
+        let end = rest[1..]
+            .find(".visible .entry ")
+            .map_or(rest.len(), |offset| offset + 1);
+        if !rest[..end].contains(".maxntid 256, 1, 1") {
+            return Err(format!("PTX entry {entry} lost its launch bounds").into());
+        }
+    }
+
+    for entry in [
+        "helper_contract_32",
+        "helper_contract_256",
+        "explicit_aligned_u32",
+    ] {
+        let start = ptx
+            .find(&format!(".visible .entry {entry}("))
+            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
+        let rest = &ptx[start..];
+        let end = rest[1..]
+            .find(".visible .entry ")
+            .map_or(rest.len(), |offset| offset + 1);
+        if !rest[..end].contains(".maxntid 32, 1, 1") {
+            return Err(format!("PTX entry {entry} lost its launch bounds").into());
+        }
+    }
+
+    let generic_start = ptx
+        .find(".visible .entry generic_aligned_TID_")
+        .ok_or("missing generic_aligned PTX specialization")?;
+    let generic_rest = &ptx[generic_start..];
+    let generic_end = generic_rest[1..]
+        .find(".visible .entry ")
+        .map_or(generic_rest.len(), |offset| offset + 1);
+    if !generic_rest[..generic_end].contains(".maxntid 64, 1, 1") {
+        return Err("generic_aligned PTX specialization lost its launch bounds".into());
+    }
+
+    println!("SUCCESS: prepared-launch PTX contract verified");
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/cuda_module_in_lib/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_in_lib/src/main.rs
@@ -124,24 +124,30 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        ops.scale_f32(
-            &stream,
-            LaunchConfig::for_num_elems(N as u32),
-            factor,
-            &input_dev,
-            &mut output_dev,
-        )
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            ops.scale_f32(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                factor,
+                &input_dev,
+                &mut output_dev,
+            )
+        }
         .expect("scale_f32 launch failed");
         let scaled: Vec<f32> = output_dev.to_host_vec(&stream).unwrap();
 
         let mut sum_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
-        ops.add_f32(
-            &stream,
-            LaunchConfig::for_num_elems(N as u32),
-            &input_dev,
-            &output_dev,
-            &mut sum_dev,
-        )
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            ops.add_f32(
+                &stream,
+                LaunchConfig::for_num_elems(N as u32),
+                &input_dev,
+                &output_dev,
+                &mut sum_dev,
+            )
+        }
         .expect("add_f32 launch failed");
         let sums: Vec<f32> = sum_dev.to_host_vec(&stream).unwrap();
 
@@ -166,8 +172,8 @@ fn main() {
     {
         let module = bin_kernels::load(&ctx).expect("Failed to load binary cuda_module");
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
-        module
-            .iota_f32(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.iota_f32(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev) }
             .expect("iota_f32 launch failed");
         let out: Vec<f32> = out_dev.to_host_vec(&stream).unwrap();
         let errors = (0..N).filter(|&i| out[i] != i as f32).count();

--- a/crates/rustc-codegen-cuda/examples/cuda_module_nested/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_nested/src/main.rs
@@ -109,18 +109,22 @@ fn main() {
         .expect("Failed to bind double launchers");
     let config = LaunchConfig::for_num_elems(N as u32);
 
-    // The init kernel feeds the three processing kernels.
-    init.fill_index(&stream, config, &mut idx_dev)
-        .expect("fill_index launch failed");
-    scale
-        .scale_by(&stream, config, &idx_dev, &mut scaled_dev)
-        .expect("scale_by launch failed");
-    offset
-        .offset_by(&stream, config, &idx_dev, &mut offset_dev)
-        .expect("offset_by launch failed");
-    double
-        .double_all(&stream, config, &idx_dev, &mut doubled_dev)
-        .expect("double_all launch failed");
+    // SAFETY: every launch is one-dimensional over N elements, and each
+    // input/output buffer covers the full range accessed by its kernel.
+    unsafe {
+        // The init kernel feeds the three processing kernels.
+        init.fill_index(&stream, config, &mut idx_dev)
+            .expect("fill_index launch failed");
+        scale
+            .scale_by(&stream, config, &idx_dev, &mut scaled_dev)
+            .expect("scale_by launch failed");
+        offset
+            .offset_by(&stream, config, &idx_dev, &mut offset_dev)
+            .expect("offset_by launch failed");
+        double
+            .double_all(&stream, config, &idx_dev, &mut doubled_dev)
+            .expect("double_all launch failed");
+    }
 
     let scaled = scaled_dev.to_host_vec(&stream).unwrap();
     let offset = offset_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/cvt_f16x2/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cvt_f16x2/src/main.rs
@@ -76,7 +76,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
 
     let cfg = LaunchConfig::for_num_elems(N as u32);
-    module.pack_f16x2(&stream, cfg, &lo_dev, &hi_dev, &mut out_dev)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.pack_f16x2(&stream, cfg, &lo_dev, &hi_dev, &mut out_dev) }?;
 
     let out_host = out_dev.to_host_vec(&stream)?;
     let mut failures = 0;
@@ -95,7 +96,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Device-side scalar kernel must agree bit-for-bit with the intrinsic.
     let mut out_scalar_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-    module.pack_f16x2_scalar(&stream, cfg, &lo_dev, &hi_dev, &mut out_scalar_dev)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.pack_f16x2_scalar(&stream, cfg, &lo_dev, &hi_dev, &mut out_scalar_dev) }?;
     let out_scalar = out_scalar_dev.to_host_vec(&stream)?;
     for i in 0..N {
         if out_scalar[i] != out_host[i] {
@@ -113,7 +115,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // f16(1.5) = 0x3E00 (low half), f16(-2.25) = 0xC080 (high half).
     let mut out_const_dev = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
     let cfg1 = LaunchConfig::for_num_elems(1);
-    module.pack_f16x2_consts(&stream, cfg1, &mut out_const_dev)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.pack_f16x2_consts(&stream, cfg1, &mut out_const_dev) }?;
     let got_const = out_const_dev.to_host_vec(&stream)?[0];
     if got_const != 0xC080_3E00 {
         eprintln!("CONST MISMATCH: got={got_const:#010x} want=0xc0803e00");

--- a/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
@@ -91,8 +91,8 @@ fn main() {
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, NUM_VARIANTS).unwrap();
     let cfg = LaunchConfig::for_num_elems(1);
 
-    module
-        .cvt_packed_variants(&stream, cfg, lo, hi, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cvt_packed_variants(&stream, cfg, lo, hi, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let results = out_dev.to_host_vec(&stream).unwrap();
@@ -130,8 +130,8 @@ fn main() {
 
     // PTX specifies that `.relu` converts NaN results to canonical NaN rather
     // than clamping them to zero. Check both packed lanes for each format.
-    module
-        .cvt_packed_variants(&stream, cfg, f32::NAN, f32::NAN, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cvt_packed_variants(&stream, cfg, f32::NAN, f32::NAN, &mut out_dev) }
         .expect("NaN kernel launch failed");
     let nan_results = out_dev.to_host_vec(&stream).unwrap();
     for (label, packed, expected_nan) in [

--- a/crates/rustc-codegen-cuda/examples/debug/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/debug/src/main.rs
@@ -194,7 +194,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.clock_test((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.clock_test((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<u64> = output_dev.to_host_vec(&stream)?;
@@ -214,12 +215,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input_dev = DeviceBuffer::from_host(&stream, &input)?;
         let mut output_dev = DeviceBuffer::<i32>::zeroed(&stream, n)?;
 
-        module.trap_test(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &input_dev,
-            &mut output_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.trap_test(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &input_dev,
+                &mut output_dev,
+            )
+        }?;
         stream.synchronize()?;
 
         let output: Vec<i32> = output_dev.to_host_vec(&stream)?;
@@ -245,12 +249,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input_dev = DeviceBuffer::from_host(&stream, &input)?;
         let mut output_dev = DeviceBuffer::<i32>::zeroed(&stream, n)?;
 
-        module.assert_test(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &input_dev,
-            &mut output_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.assert_test(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &input_dev,
+                &mut output_dev,
+            )
+        }?;
         stream.synchronize()?;
 
         let output: Vec<i32> = output_dev.to_host_vec(&stream)?;
@@ -288,12 +295,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let input_dev = DeviceBuffer::from_host(&stream, &input)?;
         let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, n)?;
 
-        module.profiler_test(
-            (stream).as_ref(),
-            LaunchConfig::for_num_elems(n as u32),
-            &input_dev,
-            &mut output_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.profiler_test(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &input_dev,
+                &mut output_dev,
+            )
+        }?;
         stream.synchronize()?;
 
         let output: Vec<f32> = output_dev.to_host_vec(&stream)?;
@@ -327,7 +337,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.launch_bounds_test((stream).as_ref(), cfg, &input_dev, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.launch_bounds_test((stream).as_ref(), cfg, &input_dev, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<i32> = output_dev.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/device_closures/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_closures/src/main.rs
@@ -296,13 +296,15 @@ fn main() {
         const N: usize = 8;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_inline_closure(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_inline_closure(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i * 2) as u32).collect();
@@ -327,15 +329,17 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .scale_kernel(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale_kernel(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = input.iter().map(|&x| x * factor).collect();
@@ -362,8 +366,9 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
 
-        module
-            .transform_kernel(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.transform_kernel(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 offset,
@@ -371,7 +376,8 @@ fn main() {
                 &input_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<i32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<i32> = input.iter().map(|&x| (x + offset) * scale).collect();
@@ -397,15 +403,17 @@ fn main() {
         let input_dev = DeviceBuffer::from_host(&stream, &input).unwrap();
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .inline_with_param(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.inline_with_param(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = input.iter().map(|&x| x * factor).collect();
@@ -425,13 +433,15 @@ fn main() {
         const N: usize = 8;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_closure_constant(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_constant(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = vec![42; N];
@@ -450,13 +460,15 @@ fn main() {
         const N: usize = 8;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_closure_multi_arg(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_multi_arg(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| i as u32 + 10).collect();
@@ -475,13 +487,15 @@ fn main() {
         const N: usize = 8;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_closure_fnonce(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_fnonce(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i * 3) as u32).collect();
@@ -506,14 +520,16 @@ fn main() {
 
         println!("  factor = {}", factor);
 
-        module
-            .test_closure_capture_fnonce(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_capture_fnonce(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i * factor as usize) as u32).collect();
@@ -535,14 +551,16 @@ fn main() {
 
         println!("  factor = {}", factor);
 
-        module
-            .test_wrapper_method_named_call(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_wrapper_method_named_call(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i as u32) * factor + 1).collect();
@@ -562,14 +580,16 @@ fn main() {
         let factor: u32 = 5;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_closure_field_projection(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_field_projection(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i as u32) * factor).collect();
@@ -589,14 +609,16 @@ fn main() {
         let factor: u32 = 7;
         let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-        module
-            .test_closure_double_ref(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_closure_double_ref(
                 (stream).as_ref(),
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &mut out_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
 
         let out: Vec<u32> = out_dev.to_host_vec(&stream).unwrap();
         let expected: Vec<u32> = (0..N).map(|i| (i as u32) * factor).collect();

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -580,13 +580,15 @@ fn test_simple_device_funcs_runner(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_simple_device_funcs(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_simple_device_funcs(
             (stream).as_ref(),
             config,
             d_output.cu_deviceptr() as *mut f32,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
 
@@ -642,14 +644,16 @@ fn test_cub_warp_reduce_runner(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_cub_warp_reduce(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_cub_warp_reduce(
             (stream).as_ref(),
             config,
             d_input.cu_deviceptr() as *const f32,
             d_output.cu_deviceptr() as *mut f32,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
 
@@ -703,8 +707,9 @@ fn test_mixed_attrs_runner(
         shared_mem_bytes: 0,
     };
 
-    module
-        .test_mixed_attrs(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_mixed_attrs(
             (stream).as_ref(),
             config,
             d_a.cu_deviceptr() as *const f32,
@@ -712,7 +717,8 @@ fn test_mixed_attrs_runner(
             d_output.cu_deviceptr() as *mut f32,
             vec_size,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
 
@@ -753,13 +759,15 @@ fn test_smem_alignment_cross_module_runner(
         shared_mem_bytes: 256, // Enough for the test
     };
 
-    module
-        .test_smem_alignment_cross_module(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_smem_alignment_cross_module(
             (stream).as_ref(),
             config,
             d_output.cu_deviceptr() as *mut u64,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     // Synchronize to flush printf output
     stream.synchronize().expect("Sync failed");

--- a/crates/rustc-codegen-cuda/examples/dotprod/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/dotprod/src/main.rs
@@ -168,8 +168,9 @@ fn main() {
 
     let mut out_dev = DeviceBuffer::<i32>::zeroed(&stream, 4).unwrap();
 
-    module
-        .dotprod_test(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.dotprod_test(
             (stream).as_ref(),
             cfg,
             a4,
@@ -180,7 +181,8 @@ fn main() {
             b2,
             &mut out_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let results = out_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/dynamic_smem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/dynamic_smem/src/main.rs
@@ -250,8 +250,8 @@ fn main() {
             shared_mem_bytes: (N * core::mem::size_of::<f32>()) as u32,
         };
 
-        module
-            .dynamic_smem_basic((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.dynamic_smem_basic((stream).as_ref(), cfg, &data_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();
@@ -292,9 +292,11 @@ fn main() {
             shared_mem_bytes: (2 * N * core::mem::size_of::<f32>()) as u32,
         };
 
-        module
-            .dynamic_smem_partition((stream).as_ref(), cfg, &a_dev, &b_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.dynamic_smem_partition((stream).as_ref(), cfg, &a_dev, &b_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();
         println!("Output out[0..5] = {:?}", &out_result[0..5]);
@@ -330,9 +332,11 @@ fn main() {
             shared_mem_bytes: (N * core::mem::size_of::<f32>()) as u32,
         };
 
-        module
-            .dynamic_smem_explicit_align((stream).as_ref(), cfg, &data_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.dynamic_smem_explicit_align((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+        }
+        .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();
         println!("Output out[0..5] = {:?}", &out_result[0..5]);
@@ -375,9 +379,18 @@ fn main() {
             shared_mem_bytes: (3 * N * core::mem::size_of::<f32>()) as u32,
         };
 
-        module
-            .dynamic_smem_mixed_align((stream).as_ref(), cfg, &a_dev, &b_dev, &c_dev, &mut out_dev)
-            .expect("Kernel launch failed");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.dynamic_smem_mixed_align(
+                (stream).as_ref(),
+                cfg,
+                &a_dev,
+                &b_dev,
+                &c_dev,
+                &mut out_dev,
+            )
+        }
+        .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();
         println!("Output out[0..5] = {:?}", &out_result[0..5]);

--- a/crates/rustc-codegen-cuda/examples/elect_leader/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/elect_leader/src/main.rs
@@ -116,8 +116,8 @@ fn main() {
     let mut leader_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
     let mut elected_dev = DeviceBuffer::<u32>::zeroed(&stream, 32).unwrap();
 
-    module
-        .elect_full_warp((stream).as_ref(), cfg, &mut leader_dev, &mut elected_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.elect_full_warp((stream).as_ref(), cfg, &mut leader_dev, &mut elected_dev) }
         .expect("Kernel launch failed");
 
     let leader = leader_dev.to_host_vec(&stream).unwrap();
@@ -141,8 +141,8 @@ fn main() {
     println!("\n--- Test 2: is_elected_sync (upper-half subset) ---");
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
 
-    module
-        .elect_subset((stream).as_ref(), cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.elect_subset((stream).as_ref(), cfg, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out = out_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/src/main.rs
@@ -133,8 +133,8 @@ fn main() {
         .collect();
     let d_input = DeviceBuffer::from_host(&stream, &h_input).unwrap();
     let mut d_decoded = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .decode(stream.as_ref(), cfg, &d_input, &mut d_decoded)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.decode(stream.as_ref(), cfg, &d_input, &mut d_decoded) }
         .expect("launch decode");
     let decoded = d_decoded.to_host_vec(&stream).unwrap();
     for (i, (&got, want)) in decoded
@@ -152,9 +152,8 @@ fn main() {
     let h_src: Vec<u32> = (0..N as u32).collect();
     let d_src = DeviceBuffer::from_host(&stream, &h_src).unwrap();
     let mut d_encoded = DeviceBuffer::<E>::zeroed(&stream, N).unwrap();
-    module
-        .encode(stream.as_ref(), cfg, &d_src, &mut d_encoded)
-        .expect("launch encode");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.encode(stream.as_ref(), cfg, &d_src, &mut d_encoded) }.expect("launch encode");
     let encoded = d_encoded.to_host_vec(&stream).unwrap();
     for (i, v) in encoded.iter().enumerate() {
         let s = h_src[i];

--- a/crates/rustc-codegen-cuda/examples/enum_array_match/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_array_match/src/main.rs
@@ -152,8 +152,8 @@ fn main() {
         let want = expected_for_index(index);
 
         let mut d_out = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-        module
-            .match_runtime_index(stream.as_ref(), cfg, index, &mut d_out)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.match_runtime_index(stream.as_ref(), cfg, index, &mut d_out) }
             .expect("launch match_runtime_index");
         let got = d_out.to_host_vec(&stream).unwrap();
         for (tid, &g) in got.iter().enumerate() {
@@ -164,8 +164,8 @@ fn main() {
         }
 
         let mut d_out = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-        module
-            .match_deref_index(stream.as_ref(), cfg, index, &mut d_out)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.match_deref_index(stream.as_ref(), cfg, index, &mut d_out) }
             .expect("launch match_deref_index");
         let got = d_out.to_host_vec(&stream).unwrap();
         for (tid, &g) in got.iter().enumerate() {
@@ -181,8 +181,8 @@ fn main() {
         let want = expected_for_val(val);
 
         let mut d_out = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-        module
-            .match_const_index(stream.as_ref(), cfg, val, &mut d_out)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.match_const_index(stream.as_ref(), cfg, val, &mut d_out) }
             .expect("launch match_const_index");
         let got = d_out.to_host_vec(&stream).unwrap();
         for (tid, &g) in got.iter().enumerate() {

--- a/crates/rustc-codegen-cuda/examples/export_name_policy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/export_name_policy/src/main.rs
@@ -80,13 +80,15 @@ fn main() {
     const N: usize = 64;
     let mut out = DeviceBuffer::<u32>::zeroed(&stream, N).expect("failed to allocate output");
 
-    module
-        .export_name_policy(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.export_name_policy(
             stream.as_ref(),
             LaunchConfig::for_num_elems(N as u32),
             &mut out,
         )
-        .expect("export_name_policy launch failed");
+    }
+    .expect("export_name_policy launch failed");
 
     let got = out.to_host_vec(&stream).expect("failed to copy output");
     let failures = got

--- a/crates/rustc-codegen-cuda/examples/extern_libdevice/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/extern_libdevice/src/main.rs
@@ -102,7 +102,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_asin = DeviceBuffer::<f32>::zeroed(&stream, n)?;
     let mut out_acos = DeviceBuffer::<f32>::zeroed(&stream, n)?;
 
-    module.asin_acos(&stream, cfg, &xs_dev, &mut out_asin, &mut out_acos)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.asin_acos(&stream, cfg, &xs_dev, &mut out_asin, &mut out_acos) }?;
 
     let got_asin = out_asin.to_host_vec(&stream)?;
     let got_acos = out_acos.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
@@ -68,7 +68,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let mut out = DeviceBuffer::<f16>::zeroed(&stream, 1)?;
-        module.test_f16_store(&stream, cfg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_f16_store(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?[0].to_bits();
         let expected = f16::from_bits(0x3e00).to_bits();
         check("f16 load/store", got, expected, &mut passed, &mut failed);
@@ -76,7 +77,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
-        module.test_f16_ops(&stream, cfg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_f16_ops(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?;
 
         let one = f16::from_bits(0x3c00);

--- a/crates/rustc-codegen-cuda/examples/fcmp_ne_nan_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fcmp_ne_nan_smoke/src/main.rs
@@ -58,12 +58,15 @@ fn main() {
     let x = vec![f32::NAN, 1.0, 0.0, -1.0, f32::INFINITY];
     let xd = DeviceBuffer::from_host(&stream, &x).unwrap();
     let mut cd = DeviceBuffer::<f32>::zeroed(&stream, x.len()).unwrap();
-    m.is_nan(
-        &stream,
-        LaunchConfig::for_num_elems(x.len() as u32),
-        &xd,
-        &mut cd,
-    )
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        m.is_nan(
+            &stream,
+            LaunchConfig::for_num_elems(x.len() as u32),
+            &xd,
+            &mut cd,
+        )
+    }
     .expect("launch is_nan");
     let is_nan = cd.to_host_vec(&stream).unwrap();
     println!("input : {:?}", x);
@@ -77,13 +80,16 @@ fn main() {
     let ad = DeviceBuffer::from_host(&stream, &a).unwrap();
     let bd = DeviceBuffer::from_host(&stream, &b).unwrap();
     let mut nd = DeviceBuffer::<f32>::zeroed(&stream, a.len()).unwrap();
-    m.float_ne(
-        &stream,
-        LaunchConfig::for_num_elems(a.len() as u32),
-        &ad,
-        &bd,
-        &mut nd,
-    )
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        m.float_ne(
+            &stream,
+            LaunchConfig::for_num_elems(a.len() as u32),
+            &ad,
+            &bd,
+            &mut nd,
+        )
+    }
     .expect("launch float_ne");
     let ne = nd.to_host_vec(&stream).unwrap();
     println!("a     : {:?}", a);

--- a/crates/rustc-codegen-cuda/examples/field_array_assign/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/field_array_assign/src/main.rs
@@ -63,14 +63,16 @@ fn main() {
     let module = kernels::load(&ctx).expect("load module");
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .sum_packet(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.sum_packet(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             scale,
             &mut out_dev,
         )
-        .expect("kernel launch");
+    }
+    .expect("kernel launch");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
@@ -97,7 +97,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = -2.5_f32;
         let nan_arg = f32::NAN;
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
-        module.fmaxmin_f32_kernel(&stream, cfg, a, b, nan_arg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.fmaxmin_f32_kernel(&stream, cfg, a, b, nan_arg, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let expected: [u32; 4] = [
             a.max(b).to_bits(), // f32::max finite
@@ -120,7 +121,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = -2.5e10_f64;
         let nan_arg = f64::NAN;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 4)?;
-        module.fmaxmin_f64_kernel(&stream, cfg, a, b, nan_arg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.fmaxmin_f64_kernel(&stream, cfg, a, b, nan_arg, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let expected: [u64; 4] = [
             a.max(b).to_bits(),

--- a/crates/rustc-codegen-cuda/examples/fn_ptr_naming/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fn_ptr_naming/src/main.rs
@@ -72,9 +72,8 @@ fn main() {
     };
 
     let mut d_out = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .fn_ptr_eq(stream.as_ref(), cfg, &mut d_out)
-        .expect("launch fn_ptr_eq");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.fn_ptr_eq(stream.as_ref(), cfg, &mut d_out) }.expect("launch fn_ptr_eq");
     let got = d_out.to_host_vec(&stream).unwrap();
 
     let failures = got.iter().filter(|&&g| g != 1).count();

--- a/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
@@ -88,7 +88,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------- f32 ----------
     {
         let mut out = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
-        module.fp_special_literal_f32_kernel(&stream, cfg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.fp_special_literal_f32_kernel(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?;
         check_f32_specials(&got, &mut passed, &mut failed);
     }
@@ -96,7 +97,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------- f64 ----------
     {
         let mut out = DeviceBuffer::<f64>::zeroed(&stream, 4)?;
-        module.fp_special_literal_f64_kernel(&stream, cfg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.fp_special_literal_f64_kernel(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?;
         check_f64_specials(&got, &mut passed, &mut failed);
     }

--- a/crates/rustc-codegen-cuda/examples/function_item_call/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/function_item_call/src/main.rs
@@ -163,9 +163,11 @@ fn main() {
     let module = kernels::load(&ctx).expect("load module");
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .function_item_call(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
-        .expect("kernel launch");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.function_item_call(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+    }
+    .expect("kernel launch");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
     let expected: Vec<u32> = (0..N).map(|i| 11 * i as u32 + 1_049).collect();
@@ -175,14 +177,16 @@ fn main() {
     }
 
     let mut diverging_out = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
-    module
-        .diverging_callable(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.diverging_callable(
             &stream,
             LaunchConfig::for_num_elems(1),
             0,
             &mut diverging_out,
         )
-        .expect("diverging callable regression launch");
+    }
+    .expect("diverging callable regression launch");
     if diverging_out.to_host_vec(&stream).unwrap() != [0xd1ce] {
         eprintln!("FAIL: diverging callable regression took the wrong path");
         std::process::exit(1);

--- a/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
@@ -262,7 +262,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.test_cusimd((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cusimd((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<f32> = output_dev.to_host_vec(&stream)?;
@@ -301,7 +302,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.test_cusimd_u32((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_cusimd_u32((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<u32> = output_dev.to_host_vec(&stream)?;
@@ -331,7 +333,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.test_managed_barrier((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_managed_barrier((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<u32> = output_dev.to_host_vec(&stream)?;
@@ -362,7 +365,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.test_multi_barrier((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_multi_barrier((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<u32> = output_dev.to_host_vec(&stream)?;
@@ -393,7 +397,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             shared_mem_bytes: 0,
         };
 
-        module.test_double_buffered_barriers((stream).as_ref(), cfg, &mut output_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_double_buffered_barriers((stream).as_ref(), cfg, &mut output_dev) }?;
         stream.synchronize()?;
 
         let output: Vec<u32> = output_dev.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/gemm/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm/src/main.rs
@@ -140,8 +140,9 @@ fn main() {
 
     // Warmup
     println!("\nWarmup...");
-    module
-        .sgemm_naive(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.sgemm_naive(
             (stream).as_ref(),
             cfg,
             m_arg,
@@ -153,7 +154,8 @@ fn main() {
             BETA,
             &mut c_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
     stream.synchronize().unwrap();
 
     // Timed runs
@@ -161,8 +163,9 @@ fn main() {
     println!("Running {} iterations...", NUM_RUNS);
     let start = Instant::now();
     for _ in 0..NUM_RUNS {
-        module
-            .sgemm_naive(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.sgemm_naive(
                 (stream).as_ref(),
                 cfg,
                 m_arg,
@@ -174,7 +177,8 @@ fn main() {
                 BETA,
                 &mut c_dev,
             )
-            .expect("Kernel launch failed");
+        }
+        .expect("Kernel launch failed");
     }
     stream.synchronize().unwrap();
     let elapsed = start.elapsed();

--- a/crates/rustc-codegen-cuda/examples/generic/README.md
+++ b/crates/rustc-codegen-cuda/examples/generic/README.md
@@ -38,13 +38,16 @@ pub fn add<T: Copy + Add<Output = T>>(a: &[T], b: &[T], mut c: DisjointSlice<T>)
 ```rust
 // Type parameter on the typed module method forces monomorphization.
 let module = kernels::load(&ctx)?;
-module.scale::<f32>(
-    &stream,
-    LaunchConfig::for_num_elems(N as u32),
-    factor,
-    &input_dev,
-    &mut output_dev,
-)?;
+// SAFETY: this is a 1D launch and both buffers contain N elements.
+unsafe {
+    module.scale::<f32>(
+        &stream,
+        LaunchConfig::for_num_elems(N as u32),
+        factor,
+        &input_dev,
+        &mut output_dev,
+    )
+}?;
 ```
 
 ### How It Works
@@ -101,9 +104,10 @@ pub fn saxpy<T: Copy + Mul<Output = T> + Add<Output = T>>(
 }
 
 // Use with different types (fields abbreviated for clarity)
-// module.saxpy::<f32>(&stream, config, a, &x, &y, &mut out)?;
-// module.saxpy::<f64>(&stream, config, a, &x, &y, &mut out)?;
-// module.saxpy::<i32>(&stream, config, a, &x, &y, &mut out)?;
+// SAFETY: each raw config must be 1D and cover the supplied buffers.
+// unsafe { module.saxpy::<f32>(&stream, config, a, &x, &y, &mut out) }?;
+// unsafe { module.saxpy::<f64>(&stream, config, a, &x, &y, &mut out) }?;
+// unsafe { module.saxpy::<i32>(&stream, config, a, &x, &y, &mut out) }?;
 ```
 
 ### With Closures

--- a/crates/rustc-codegen-cuda/examples/generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/generic/src/main.rs
@@ -118,15 +118,17 @@ fn main() {
         let mut output_dev =
             DeviceBuffer::<f32>::zeroed(&stream, N).expect("Failed to alloc f32 output");
 
-        module
-            .scale::<f32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale::<f32>(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("scale::<f32> launch failed");
+        }
+        .expect("scale::<f32> launch failed");
 
         let output_host = output_dev
             .to_host_vec(&stream)
@@ -146,15 +148,17 @@ fn main() {
         let mut output_dev =
             DeviceBuffer::<i32>::zeroed(&stream, N).expect("Failed to alloc i32 output");
 
-        module
-            .scale::<i32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.scale::<i32>(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 factor,
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("scale::<i32> launch failed");
+        }
+        .expect("scale::<i32> launch failed");
 
         let output_host = output_dev
             .to_host_vec(&stream)
@@ -175,8 +179,9 @@ fn main() {
         let mut output_dev =
             DeviceBuffer::<f32>::zeroed(&stream, N).expect("Failed to alloc f32 output");
 
-        module
-            .closure_capture::<f32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.closure_capture::<f32>(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 bias,
@@ -184,7 +189,8 @@ fn main() {
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("closure_capture::<f32> launch failed");
+        }
+        .expect("closure_capture::<f32> launch failed");
 
         let output_host = output_dev
             .to_host_vec(&stream)
@@ -205,8 +211,9 @@ fn main() {
         let mut output_dev =
             DeviceBuffer::<i32>::zeroed(&stream, N).expect("Failed to alloc i32 output");
 
-        module
-            .closure_capture::<i32>(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.closure_capture::<i32>(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 bias,
@@ -214,7 +221,8 @@ fn main() {
                 &input_dev,
                 &mut output_dev,
             )
-            .expect("closure_capture::<i32> launch failed");
+        }
+        .expect("closure_capture::<i32> launch failed");
 
         let output_host = output_dev
             .to_host_vec(&stream)

--- a/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
@@ -315,7 +315,8 @@ impl GpuHashMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.insert_kernel(stream, cfg, &self.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.insert_kernel(stream, cfg, &self.slots, &keys_dev, &values_dev) }?;
 
         Ok(())
     }
@@ -345,14 +346,17 @@ impl GpuHashMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.try_insert_kernel(
-            stream,
-            cfg,
-            &self.slots,
-            &keys_dev,
-            &values_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.try_insert_kernel(
+                stream,
+                cfg,
+                &self.slots,
+                &keys_dev,
+                &values_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == 0).collect())
@@ -374,7 +378,8 @@ impl GpuHashMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.find_kernel(stream, cfg, &self.slots, &keys_dev, &mut out_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.find_kernel(stream, cfg, &self.slots, &keys_dev, &mut out_dev) }?;
 
         let out = out_dev.to_host_vec(stream)?;
         Ok(out)

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
@@ -319,20 +319,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = LaunchConfig::for_num_elems(n_keys as u32);
         row_b_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             })?;
 
         // ---- GPU INSERT — Protocol A -----------------------------------
         row_a_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                module.insert_kernel_proto_a(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel_proto_a(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             })?;
 
         // ---- Build a final B-protocol map for the find benches ----------
         unsafe { reset_table_async(&map, &stream)? };
-        module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)
+        }?;
         stream.synchronize()?;
 
         let cfg_warp = LaunchConfig::for_num_elems((n_keys * PROBE_TILE) as u32);
@@ -340,21 +345,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // ---- GPU LOOKUP (hits) — single-thread --------------------------
         row_single_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — warp-cooperative -----------------------
         row_warp_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — warp-cooperative, typed CG API ---------
         row_warp_typed_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             })?;
 
@@ -366,7 +376,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             },
         )?;
@@ -379,7 +390,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel_warp(&stream, cfg_warp, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             },
         )?;
@@ -392,7 +404,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_warp_typed(&stream, cfg_warp, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             },
         )?;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/lib.rs
@@ -1197,7 +1197,10 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)
+        }?;
 
         Ok(())
     }
@@ -1227,15 +1230,18 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.try_insert_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &values_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.try_insert_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &values_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1266,14 +1272,17 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.insert_kernel_proto_a(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &values_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel_proto_a(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &values_dev,
+            )
+        }?;
 
         Ok(())
     }
@@ -1302,15 +1311,18 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.try_insert_kernel_proto_a(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &values_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.try_insert_kernel_proto_a(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &values_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1332,14 +1344,17 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.find_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.find_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1371,14 +1386,17 @@ impl GpuSwissMap {
         // 256 means 8 warps per block, 8 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(PROBE_TILE as u32);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        module.find_kernel_warp(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.find_kernel_warp(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1400,14 +1418,17 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.delete_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.delete_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
@@ -324,7 +324,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = LaunchConfig::for_num_elems(n_keys as u32);
         row_b_insert[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             })?;
 
@@ -334,13 +335,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // to collapse. Should be within a few percent of `insert_kernel`.
         row_b_insert_dedup[col_idx] =
             bench_gpu_insert(&map, &keys_dev, &values_dev, n_keys, &stream, |m, k, v| {
-                module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             })?;
 
         // ---- Build a fresh map for the find benches ---------------------
         unsafe { reset_table_async(&map, &stream)? };
-        module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel(&stream, cfg, &map.ctrl, &map.slots, &keys_dev, &values_dev)
+        }?;
         stream.synchronize()?;
 
         let cfg_tile_32 = LaunchConfig::for_num_elems((n_keys * 32) as u32);
@@ -349,21 +354,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // ---- GPU LOOKUP (hits) — single-thread --------------------------
         row_single_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — tile_32 (full-warp, 1 query/warp) ------
         row_tile_32_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             })?;
 
         // ---- GPU LOOKUP (hits) — tile_16 (sub-warp, 2 queries/warp) -----
         row_tile_16_lookup[col_idx] =
             bench_gpu_find(&map, &keys_dev, &mut out_dev, n_keys, &stream, |m, k, o| {
-                module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             })?;
 
@@ -375,7 +387,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.find_kernel(&stream, cfg, &m.ctrl, &m.slots, k, o) }?;
                 Ok(())
             },
         )?;
@@ -388,7 +401,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_tile_32(&stream, cfg_tile_32, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             },
         )?;
@@ -401,7 +417,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             n_keys,
             &stream,
             |m, k, o| {
-                module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe {
+                    module.find_kernel_tile_16(&stream, cfg_tile_16, &m.ctrl, &m.slots, k, o)
+                }?;
                 Ok(())
             },
         )?;
@@ -543,7 +562,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             DEDUP_INPUT,
             &stream,
             |m, k, v| {
-                module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             },
         )?;
@@ -555,7 +575,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             DEDUP_INPUT,
             &stream,
             |m, k, v| {
-                module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v)?;
+                // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                unsafe { module.insert_kernel_dedup(&stream, cfg, &m.ctrl, &m.slots, k, v) }?;
                 Ok(())
             },
         )?;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/lib.rs
@@ -1136,7 +1136,10 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)
+        }?;
 
         Ok(())
     }
@@ -1175,7 +1178,10 @@ impl GpuSwissMap {
         let values_dev = DeviceBuffer::from_host(stream, values)?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.insert_kernel_dedup(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.insert_kernel_dedup(stream, cfg, &self.ctrl, &self.slots, &keys_dev, &values_dev)
+        }?;
 
         Ok(())
     }
@@ -1205,15 +1211,18 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.try_insert_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &values_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.try_insert_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &values_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())
@@ -1235,14 +1244,17 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.find_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.find_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1274,14 +1286,17 @@ impl GpuSwissMap {
         // block size 256 means 8 tiles per block, 8 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(32);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        module.find_kernel_tile_32(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.find_kernel_tile_32(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1316,14 +1331,17 @@ impl GpuSwissMap {
         // block size 256 means 16 tiles per block, 16 keys per block.
         let total_threads = (keys.len() as u32).saturating_mul(16);
         let cfg = LaunchConfig::for_num_elems(total_threads);
-        module.find_kernel_tile_16(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.find_kernel_tile_16(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         Ok(out_dev.to_host_vec(stream)?)
     }
@@ -1378,7 +1396,10 @@ impl GpuSwissMap {
 
         let rehash_threads = self.capacity.min(REHASH_MAX_THREADS) as u32;
         let cfg = LaunchConfig::for_num_elems(rehash_threads);
-        module.rehash_kernel(stream, cfg, &self.ctrl, &self.slots, &new_ctrl, &new_slots)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.rehash_kernel(stream, cfg, &self.ctrl, &self.slots, &new_ctrl, &new_slots)
+        }?;
 
         self.ctrl = new_ctrl;
         self.slots = new_slots;
@@ -1439,14 +1460,17 @@ impl GpuSwissMap {
         let mut out_dev = DeviceBuffer::<u32>::zeroed(stream, keys.len())?;
 
         let cfg = LaunchConfig::for_num_elems(keys.len() as u32);
-        module.delete_kernel(
-            stream,
-            cfg,
-            &self.ctrl,
-            &self.slots,
-            &keys_dev,
-            &mut out_dev,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.delete_kernel(
+                stream,
+                cfg,
+                &self.ctrl,
+                &self.slots,
+                &keys_dev,
+                &mut out_dev,
+            )
+        }?;
 
         let raw = out_dev.to_host_vec(stream)?;
         Ok(raw.into_iter().map(|x| x == FLAG_FRESH_OR_OK).collect())

--- a/crates/rustc-codegen-cuda/examples/hello_constant/README.md
+++ b/crates/rustc-codegen-cuda/examples/hello_constant/README.md
@@ -32,6 +32,7 @@ Unlike slice parameters, raw pointers are passed directly without (ptr, len) pai
 ### Simple Launch
 
 ```rust
+// SAFETY: one thread writes through a valid one-element device pointer.
 unsafe {
     module.hello_constant(
         stream.as_ref(),

--- a/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
@@ -105,15 +105,17 @@ fn main() {
     let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     // Launch kernel
-    module
-        .vecadd_with_helper(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.vecadd_with_helper(
             (stream).as_ref(),
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     // Get results
     let c_host = c_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/host_closure/README.md
+++ b/crates/rustc-codegen-cuda/examples/host_closure/README.md
@@ -29,13 +29,16 @@ pub fn map<T: Copy, F: Fn(T) -> T + Copy>(f: F, input: &[T], mut out: DisjointSl
 ```rust
 let factor = 2.5f32;
 
-module.map::<f32, _>(
-    stream.as_ref(),
-    LaunchConfig::for_num_elems(N as u32),
-    move |x: f32| x * factor, // _ infers closure type
-    &input_dev,
-    &mut output_dev,
-)?;
+// SAFETY: this is a 1D launch and both buffers contain N elements.
+unsafe {
+    module.map::<f32, _>(
+        stream.as_ref(),
+        LaunchConfig::for_num_elems(N as u32),
+        move |x: f32| x * factor, // _ infers closure type
+        &input_dev,
+        &mut output_dev,
+    )
+}?;
 ```
 
 ### How Capture Extraction Works
@@ -109,13 +112,16 @@ kernel<<<1, N>>>(scale, input, output);
 
 ```rust
 let factor = 5.0f32;
-module.map::<f32, _>(
-    stream.as_ref(),
-    LaunchConfig::for_num_elems(N as u32),
-    move |x: f32| x * factor,
-    &input,
-    &mut output,
-)?;
+// SAFETY: this is a 1D launch and both buffers contain N elements.
+unsafe {
+    module.map::<f32, _>(
+        stream.as_ref(),
+        LaunchConfig::for_num_elems(N as u32),
+        move |x: f32| x * factor,
+        &input,
+        &mut output,
+    )
+}?;
 // The typed launch method passes the closure value as a kernel argument
 ```
 
@@ -156,26 +162,32 @@ For `map::<f32, {closure capturing factor}>`:
 
 ```rust
 let threshold = 0.5f32;
-module.map::<f32, _>(
-    stream.as_ref(),
-    cfg,
-    move |x: f32| if x > threshold { 1.0 } else { 0.0 },
-    &input,
-    &mut output,
-)?;
+// SAFETY: cfg is 1D and covers both buffers.
+unsafe {
+    module.map::<f32, _>(
+        stream.as_ref(),
+        cfg,
+        move |x: f32| if x > threshold { 1.0 } else { 0.0 },
+        &input,
+        &mut output,
+    )
+}?;
 ```
 
 ### Runtime Configuration
 
 ```rust
 fn launch_with_config(scale: f32, offset: f32, ...) {
-    module.map::<f32, _>(
-        stream.as_ref(),
-        cfg,
-        move |x: f32| x * scale + offset,
-        &input,
-        &mut output,
-    )?;
+    // SAFETY: cfg is 1D and covers both buffers.
+    unsafe {
+        module.map::<f32, _>(
+            stream.as_ref(),
+            cfg,
+            move |x: f32| x * scale + offset,
+            &input,
+            &mut output,
+        )
+    }?;
 }
 ```
 
@@ -184,11 +196,14 @@ fn launch_with_config(scale: f32, offset: f32, ...) {
 ```rust
 let f = |x: f32| x.sin();
 let g = |x: f32| x * 2.0;
-module.map::<f32, _>(
-    stream.as_ref(),
-    cfg,
-    move |x: f32| g(f(x)), // sin(x) * 2
-    &input,
-    &mut output,
-)?;
+// SAFETY: cfg is 1D and covers both buffers.
+unsafe {
+    module.map::<f32, _>(
+        stream.as_ref(),
+        cfg,
+        move |x: f32| g(f(x)), // sin(x) * 2
+        &input,
+        &mut output,
+    )
+}?;
 ```

--- a/crates/rustc-codegen-cuda/examples/host_closure/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/host_closure/src/main.rs
@@ -226,13 +226,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             output_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-            typed_module.$typed_method::<f32, _>(
-                stream.as_ref(),
-                LaunchConfig::for_num_elems(N as u32),
-                $closure,
-                &input_dev,
-                &mut output_dev,
-            )?;
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe {
+                typed_module.$typed_method::<f32, _>(
+                    stream.as_ref(),
+                    LaunchConfig::for_num_elems(N as u32),
+                    $closure,
+                    &input_dev,
+                    &mut output_dev,
+                )
+            }?;
             let output_host = output_dev.to_host_vec(&stream)?;
             verify_output(
                 concat!("typed launch ", $label),
@@ -244,11 +247,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             output_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-            cuda_launch_async! {
-                kernel: $kernel,
-                module: module,
-                config: LaunchConfig::for_num_elems(N as u32),
-                args: [$closure, slice(input_dev), slice_mut(output_dev)]
+            // SAFETY: this is a 1D launch and each kernel guards its 1D index
+            // against the length carried by the output slice.
+            unsafe {
+                cuda_launch_async! {
+                    kernel: $kernel,
+                    module: module,
+                    config: LaunchConfig::for_num_elems(N as u32),
+                    args: [$closure, slice(input_dev), slice_mut(output_dev)]
+                }
             }
             .sync_on(&stream)?;
             let output_host = output_dev.to_host_vec(&stream)?;
@@ -262,14 +269,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             output_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
-            typed_module
-                .$typed_async_method::<f32, _>(
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe {
+                typed_module.$typed_async_method::<f32, _>(
                     LaunchConfig::for_num_elems(N as u32),
                     $closure,
                     &input_dev,
                     &mut output_dev,
-                )?
-                .sync_on(&stream)?;
+                )
+            }?
+            .sync_on(&stream)?;
             let output_host = output_dev.to_host_vec(&stream)?;
             verify_output(
                 concat!("typed async launch ", $label),
@@ -582,11 +591,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!((0..N).all(|i| result_4[i] == input[i] * factor + 4));
 
         let mut output_8 = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        cuda_launch_async! {
-            kernel: kernels::map_with_const::<_, 8>,
-            module: module,
-            config: LaunchConfig::for_num_elems(N as u32),
-            args: [move |x: u32| x * factor, slice(input_dev_u32), slice_mut(output_8)]
+        // SAFETY: `map_with_const` uses a guarded 1D index and this config has
+        // no active Y or Z dimensions.
+        unsafe {
+            cuda_launch_async! {
+                kernel: kernels::map_with_const::<_, 8>,
+                module: module,
+                config: LaunchConfig::for_num_elems(N as u32),
+                args: [move |x: u32| x * factor, slice(input_dev_u32), slice_mut(output_8)]
+            }
         }
         .sync_on(&stream)?;
         let result_8 = output_8.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
@@ -49,8 +49,9 @@ fn main() {
         .expect("Failed to load PTX module");
     let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
-    module
-        .copy_2d_const_width(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.copy_2d_const_width(
             &stream,
             LaunchConfig {
                 grid_dim: (1, HEIGHT as u32, 1),
@@ -61,7 +62,8 @@ fn main() {
             &mut output_dev,
             HEIGHT as u32,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let output_host = output_dev.to_host_vec(&stream).unwrap();
     for i in 0..(WIDTH * HEIGHT) {

--- a/crates/rustc-codegen-cuda/examples/inline_ptx/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/inline_ptx/src/main.rs
@@ -45,9 +45,11 @@ fn main() {
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .inline_ptx_kernel(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.inline_ptx_kernel(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+    }
+    .expect("Kernel launch failed");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
     for (i, got) in out.iter().copied().enumerate() {

--- a/crates/rustc-codegen-cuda/examples/lanemask_scan/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/lanemask_scan/src/main.rs
@@ -125,8 +125,8 @@ fn main() {
     println!("\n--- Test 1: lanemask_lt() per lane ---");
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-    module
-        .lanemask_lt_values((stream).as_ref(), cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.lanemask_lt_values((stream).as_ref(), cfg, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
@@ -151,8 +151,8 @@ fn main() {
     let data_dev = DeviceBuffer::from_host(&stream, &data_host).unwrap();
     let mut ranks_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-    module
-        .warp_compact_rank((stream).as_ref(), cfg, &data_dev, &mut ranks_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_compact_rank((stream).as_ref(), cfg, &data_dev, &mut ranks_dev) }
         .expect("Kernel launch failed");
 
     let ranks = ranks_dev.to_host_vec(&stream).unwrap();
@@ -191,8 +191,8 @@ fn main() {
         shared_mem_bytes: 0,
     };
 
-    module
-        .all_lanemasks((stream).as_ref(), cfg1, &mut all_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.all_lanemasks((stream).as_ref(), cfg1, &mut all_dev) }
         .expect("Kernel launch failed");
 
     let all = all_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/legacy_nvvm_pointer_shapes/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/legacy_nvvm_pointer_shapes/src/main.rs
@@ -162,12 +162,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let values_dev = DeviceBuffer::from_host(&stream, &values)?;
     let mut out_dev = DeviceBuffer::<[u64; 2]>::zeroed(&stream, N)?;
 
-    module.pointer_shapes(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &values_dev,
-        &mut out_dev,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.pointer_shapes(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &values_dev,
+            &mut out_dev,
+        )
+    }?;
 
     let got = out_dev.to_host_vec(&stream)?;
     let mut failures = 0usize;

--- a/crates/rustc-codegen-cuda/examples/libdevice_math/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/libdevice_math/src/main.rs
@@ -75,13 +75,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dev_y = DeviceBuffer::from_host(&stream, &host_y)?;
     let mut dev_out = DeviceBuffer::from_host(&stream, &[0.0f32; 4])?;
 
-    module.swiglu_libdevice(
-        &stream,
-        LaunchConfig::for_num_elems(4),
-        &dev_x,
-        &dev_y,
-        &mut dev_out,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.swiglu_libdevice(
+            &stream,
+            LaunchConfig::for_num_elems(4),
+            &dev_x,
+            &dev_y,
+            &mut dev_out,
+        )
+    }?;
 
     let actual = dev_out.to_host_vec(&stream)?;
     let expected: Vec<f32> = host_x
@@ -108,13 +111,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let atan2_y_dev = DeviceBuffer::from_host(&stream, &atan2_y)?;
     let mut math_out = DeviceBuffer::<[f32; 7]>::zeroed(&stream, math_x.len())?;
 
-    module.math_functions(
-        &stream,
-        LaunchConfig::for_num_elems(math_x.len() as u32),
-        &math_x_dev,
-        &atan2_y_dev,
-        &mut math_out,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.math_functions(
+            &stream,
+            LaunchConfig::for_num_elems(math_x.len() as u32),
+            &math_x_dev,
+            &atan2_y_dev,
+            &mut math_out,
+        )
+    }?;
 
     let actual = math_out.to_host_vec(&stream)?;
     const ULP_LIMIT: u32 = 4;

--- a/crates/rustc-codegen-cuda/examples/libm_math/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/libm_math/src/main.rs
@@ -99,22 +99,26 @@ fn main() {
     let mut o64_dev = DeviceBuffer::<f64>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .libm_f32(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.libm_f32(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &x32_dev,
             &mut o32_dev,
         )
-        .expect("libm_f32 launch failed");
-    module
-        .libm_f64(
+    }
+    .expect("libm_f32 launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.libm_f64(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &x64_dev,
             &mut o64_dev,
         )
-        .expect("libm_f64 launch failed");
+    }
+    .expect("libm_f64 launch failed");
 
     let o32 = o32_dev.to_host_vec(&stream).unwrap();
     let o64 = o64_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/math_atan/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/math_atan/src/main.rs
@@ -139,10 +139,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_atan2_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
     let mut out_atan_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
 
-    module.atan2_f32(&stream, cfg, &ys32, &xs32, &mut out_atan2_f32)?;
-    module.atan_f32(&stream, cfg, &ys32, &mut out_atan_f32)?;
-    module.atan2_f64(&stream, cfg, &ys64, &xs64, &mut out_atan2_f64)?;
-    module.atan_f64(&stream, cfg, &ys64, &mut out_atan_f64)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.atan2_f32(&stream, cfg, &ys32, &xs32, &mut out_atan2_f32) }?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.atan_f32(&stream, cfg, &ys32, &mut out_atan_f32) }?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.atan2_f64(&stream, cfg, &ys64, &xs64, &mut out_atan2_f64) }?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.atan_f64(&stream, cfg, &ys64, &mut out_atan_f64) }?;
 
     let got_atan2_f32 = out_atan2_f32.to_host_vec(&stream)?;
     let got_atan_f32 = out_atan_f32.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/math_hyperbolic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/math_hyperbolic/src/main.rs
@@ -194,7 +194,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let [a, b, c, d, e, f, g, h, i] = &mut out64[..] else {
             unreachable!()
         };
-        module.hyper_f64(&stream, cfg, &xs64, &ys64, a, b, c, d, e, f, g, h, i)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.hyper_f64(&stream, cfg, &xs64, &ys64, a, b, c, d, e, f, g, h, i) }?;
     }
     let got64: Vec<Vec<f64>> = out64
         .iter()
@@ -211,7 +212,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let [a, b, c, d, e, f, g, h, i] = &mut out32[..] else {
             unreachable!()
         };
-        module.hyper_f32(&stream, cfg, &xs32, &ys32, a, b, c, d, e, f, g, h, i)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.hyper_f32(&stream, cfg, &xs32, &ys32, a, b, c, d, e, f, g, h, i) }?;
     }
     let got32: Vec<Vec<f32>> = out32
         .iter()

--- a/crates/rustc-codegen-cuda/examples/math_tan/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/math_tan/src/main.rs
@@ -113,8 +113,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut out_tan_f32 = DeviceBuffer::<f32>::zeroed(&stream, n)?;
     let mut out_tan_f64 = DeviceBuffer::<f64>::zeroed(&stream, n)?;
 
-    module.tan_f32(&stream, cfg, &xs32, &mut out_tan_f32)?;
-    module.tan_f64(&stream, cfg, &xs64, &mut out_tan_f64)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.tan_f32(&stream, cfg, &xs32, &mut out_tan_f32) }?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.tan_f64(&stream, cfg, &xs64, &mut out_tan_f64) }?;
 
     let got_tan_f32 = out_tan_f32.to_host_vec(&stream)?;
     let got_tan_f64 = out_tan_f64.to_host_vec(&stream)?;

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/src/main.rs
@@ -1095,8 +1095,8 @@ fn test_fft_config_query(
     };
 
     let output_ptr = d_output.cu_deviceptr() as *mut i32;
-    module
-        .query_fft_config((stream).as_ref(), config, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.query_fft_config((stream).as_ref(), config, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1140,8 +1140,8 @@ fn test_gemm_config_query(
     };
 
     let output_ptr = d_output.cu_deviceptr() as *mut i32;
-    module
-        .query_gemm_config((stream).as_ref(), config, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.query_gemm_config((stream).as_ref(), config, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1196,8 +1196,8 @@ fn debug_copy_through_local_runner(
 
     let input_ptr = d_input.cu_deviceptr() as *const f32;
     let output_ptr = d_output.cu_deviceptr() as *mut f32;
-    module
-        .debug_copy_through_local((stream).as_ref(), config, input_ptr, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.debug_copy_through_local((stream).as_ref(), config, input_ptr, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1258,8 +1258,8 @@ fn debug_extern_double_global_runner(
     };
 
     let inout_ptr = d_inout.cu_deviceptr() as *mut f32;
-    module
-        .debug_extern_double_global((stream).as_ref(), config, inout_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.debug_extern_double_global((stream).as_ref(), config, inout_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_inout.to_host_vec(&stream).unwrap();
@@ -1317,8 +1317,8 @@ fn debug_extern_double_runner(
 
     let input_ptr = d_input.cu_deviceptr() as *const f32;
     let output_ptr = d_output.cu_deviceptr() as *mut f32;
-    module
-        .debug_extern_double((stream).as_ref(), config, input_ptr, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.debug_extern_double((stream).as_ref(), config, input_ptr, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1383,8 +1383,8 @@ fn test_fft_8_roundtrip_runner(
 
     let input_ptr = d_input.cu_deviceptr() as *const f32;
     let output_ptr = d_output.cu_deviceptr() as *mut f32;
-    module
-        .test_fft_8_roundtrip((stream).as_ref(), config, input_ptr, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_fft_8_roundtrip((stream).as_ref(), config, input_ptr, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1443,8 +1443,8 @@ fn test_fft_16_roundtrip_runner(
 
     let input_ptr = d_input.cu_deviceptr() as *const f32;
     let output_ptr = d_output.cu_deviceptr() as *mut f32;
-    module
-        .test_fft_16_roundtrip((stream).as_ref(), config, input_ptr, output_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_fft_16_roundtrip((stream).as_ref(), config, input_ptr, output_ptr) }
         .expect("Kernel launch failed");
 
     let h_output = d_output.to_host_vec(&stream).unwrap();
@@ -1514,8 +1514,8 @@ fn test_gemm_32x32x32_runner(
     let a_ptr = d_a.cu_deviceptr() as *const f32;
     let b_ptr = d_b.cu_deviceptr() as *const f32;
     let c_ptr = d_c.cu_deviceptr() as *mut f32;
-    module
-        .test_gemm_32x32x32((stream).as_ref(), config, a_ptr, b_ptr, c_ptr)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_gemm_32x32x32((stream).as_ref(), config, a_ptr, b_ptr, c_ptr) }
         .expect("Kernel launch failed");
 
     let h_c = d_c.to_host_vec(&stream).unwrap();
@@ -1596,9 +1596,19 @@ fn test_gemm_32x32x32_alphabeta_runner(
     let a_ptr = d_a.cu_deviceptr() as *const f32;
     let b_ptr = d_b.cu_deviceptr() as *const f32;
     let c_ptr = d_c.cu_deviceptr() as *mut f32;
-    module
-        .test_gemm_32x32x32_alphabeta((stream).as_ref(), config, alpha, a_ptr, b_ptr, beta, c_ptr)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.test_gemm_32x32x32_alphabeta(
+            (stream).as_ref(),
+            config,
+            alpha,
+            a_ptr,
+            b_ptr,
+            beta,
+            c_ptr,
+        )
+    }
+    .expect("Kernel launch failed");
 
     let h_result = d_c.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -68,8 +68,8 @@ fn main() {
         block_dim: (N as u32, 1, 1),
         shared_mem_bytes: 0,
     };
-    module
-        .swap_kernel(stream.as_ref(), config, &d_a, &d_b, &mut d_out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.swap_kernel(stream.as_ref(), config, &d_a, &d_b, &mut d_out) }
         .expect("Kernel launch failed");
 
     let out = d_out.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/ne_bytes_transmute/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ne_bytes_transmute/src/main.rs
@@ -137,7 +137,8 @@ fn main() {
     {
         let bytes_d = DeviceBuffer::from_host(&stream, &word_bytes).unwrap();
         let mut out_d = DeviceBuffer::<u32>::zeroed(&stream, n).unwrap();
-        m.u32_from_ne_bytes(&stream, cfg, &bytes_d, &mut out_d)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { m.u32_from_ne_bytes(&stream, cfg, &bytes_d, &mut out_d) }
             .expect("launch u32_from_ne_bytes");
         let got = out_d.to_host_vec(&stream).unwrap();
         ok &= check("u32::from_ne_bytes", &got, &words);
@@ -147,7 +148,8 @@ fn main() {
     {
         let words_d = DeviceBuffer::from_host(&stream, &words).unwrap();
         let mut out_d = DeviceBuffer::<u32>::zeroed(&stream, n).unwrap();
-        m.u32_to_ne_bytes(&stream, cfg, &words_d, &mut out_d)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { m.u32_to_ne_bytes(&stream, cfg, &words_d, &mut out_d) }
             .expect("launch u32_to_ne_bytes");
         let got = out_d.to_host_vec(&stream).unwrap();
         let expect: Vec<u32> = words.iter().map(|w| repack(w.to_ne_bytes())).collect();
@@ -158,7 +160,8 @@ fn main() {
     {
         let bytes_d = DeviceBuffer::from_host(&stream, &float_bytes).unwrap();
         let mut out_d = DeviceBuffer::<f32>::zeroed(&stream, n).unwrap();
-        m.f32_from_ne_bytes(&stream, cfg, &bytes_d, &mut out_d)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { m.f32_from_ne_bytes(&stream, cfg, &bytes_d, &mut out_d) }
             .expect("launch f32_from_ne_bytes");
         let got: Vec<u32> = out_d
             .to_host_vec(&stream)
@@ -174,7 +177,8 @@ fn main() {
     {
         let floats_d = DeviceBuffer::from_host(&stream, &floats).unwrap();
         let mut out_d = DeviceBuffer::<u32>::zeroed(&stream, n).unwrap();
-        m.f32_to_ne_bytes(&stream, cfg, &floats_d, &mut out_d)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { m.f32_to_ne_bytes(&stream, cfg, &floats_d, &mut out_d) }
             .expect("launch f32_to_ne_bytes");
         let got = out_d.to_host_vec(&stream).unwrap();
         let expect: Vec<u32> = floats.iter().map(|v| repack(v.to_ne_bytes())).collect();
@@ -185,8 +189,8 @@ fn main() {
     {
         let floats_d = DeviceBuffer::from_host(&stream, &floats).unwrap();
         let mut out_d = DeviceBuffer::<u32>::zeroed(&stream, n).unwrap();
-        m.f32_to_bits(&stream, cfg, &floats_d, &mut out_d)
-            .expect("launch f32_to_bits");
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { m.f32_to_bits(&stream, cfg, &floats_d, &mut out_d) }.expect("launch f32_to_bits");
         let got = out_d.to_host_vec(&stream).unwrap();
         let expect: Vec<u32> = floats.iter().map(|v| v.to_bits()).collect();
         ok &= check("f32::to_bits      ", &got, &expect);

--- a/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
@@ -55,28 +55,32 @@ fn main() {
 
     // Square [[u32; 4]; 4], write [2][3].
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
-    module
-        .nested_index_assignment_kernel(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.nested_index_assignment_kernel(
             &stream,
             LaunchConfig::for_num_elems(1),
             2usize,
             3usize,
             &mut out_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
     assert_eq!(out_dev.to_host_vec(&stream).unwrap(), vec![0x5a00_0203]);
 
     // Non-square [[u32; 3]; 5], write the last element [4][2].
     let mut out_ns = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
-    module
-        .nested_index_assignment_nonsquare_kernel(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.nested_index_assignment_nonsquare_kernel(
             &stream,
             LaunchConfig::for_num_elems(1),
             4usize,
             2usize,
             &mut out_ns,
         )
-        .expect("Non-square kernel launch failed");
+    }
+    .expect("Non-square kernel launch failed");
     assert_eq!(out_ns.to_host_vec(&stream).unwrap(), vec![0x5a00_0402]);
 
     println!("PASS: nested runtime indexes assigned and read back correctly (square + non-square)");

--- a/crates/rustc-codegen-cuda/examples/numeric_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/numeric_stress/src/main.rs
@@ -217,7 +217,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 div: 0xFFFF_FFFE / 2 = 0x7FFF_FFFF
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u32_div_msb((stream).as_ref(), cfg, 0xFFFF_FFFEu32, 2u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u32_div_msb((stream).as_ref(), cfg, 0xFFFF_FFFEu32, 2u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 0x7FFF_FFFFu32 {
             println!("  [PASS] u32 div MSB: 0xFFFFFFFE / 2 = 0x{:08X}", r[0]);
@@ -236,7 +237,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 rem: 0xFFFF_FFFF % 10 = 5
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u32_rem_msb((stream).as_ref(), cfg, 0xFFFF_FFFFu32, 10u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_u32_rem_msb((stream).as_ref(), cfg, 0xFFFF_FFFFu32, 10u32, &mut out)
+        }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 5u32 {
             println!("  [PASS] u32 rem MSB: 0xFFFFFFFF % 10 = {}", r[0]);
@@ -252,13 +256,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u64 div: 0x8000_0000_0000_0000 / 2 = 0x4000_0000_0000_0000
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_u64_div_msb(
-            (stream).as_ref(),
-            cfg,
-            0x8000_0000_0000_0000u64,
-            2u64,
-            &mut out,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_u64_div_msb(
+                (stream).as_ref(),
+                cfg,
+                0x8000_0000_0000_0000u64,
+                2u64,
+                &mut out,
+            )
+        }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 0x4000_0000_0000_0000u64 {
             println!(
@@ -280,7 +287,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u64 rem: u64::MAX % 7 = 1
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_u64_rem_msb((stream).as_ref(), cfg, u64::MAX, 7u64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u64_rem_msb((stream).as_ref(), cfg, u64::MAX, 7u64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 1u64 {
             println!("  [PASS] u64 rem MSB: u64::MAX % 7 = {}", r[0]);
@@ -301,13 +309,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 gt: 0x8000_0000 > 0x7FFF_FFFF = true (1)
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u32_cmp_gt_msb(
-            (stream).as_ref(),
-            cfg,
-            0x8000_0000u32,
-            0x7FFF_FFFFu32,
-            &mut out,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_u32_cmp_gt_msb(
+                (stream).as_ref(),
+                cfg,
+                0x8000_0000u32,
+                0x7FFF_FFFFu32,
+                &mut out,
+            )
+        }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 1u32 {
             println!("  [PASS] u32 gt MSB: 0x80000000 > 0x7FFFFFFF = true");
@@ -326,7 +337,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u64 gt: u64::MAX > 0 = true (1)
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u64_cmp_gt_msb((stream).as_ref(), cfg, u64::MAX, 0u64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u64_cmp_gt_msb((stream).as_ref(), cfg, u64::MAX, 0u64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 1u32 {
             println!("  [PASS] u64 gt MSB: u64::MAX > 0 = true");
@@ -342,13 +354,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 lt: 0x7FFF_FFFF < 0x8000_0000 = true (1)
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u32_cmp_lt_msb(
-            (stream).as_ref(),
-            cfg,
-            0x7FFF_FFFFu32,
-            0x8000_0000u32,
-            &mut out,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_u32_cmp_lt_msb(
+                (stream).as_ref(),
+                cfg,
+                0x7FFF_FFFFu32,
+                0x8000_0000u32,
+                &mut out,
+            )
+        }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 1u32 {
             println!("  [PASS] u32 lt MSB: 0x7FFFFFFF < 0x80000000 = true");
@@ -372,7 +387,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // i32 shr: -8 >> 1 = -4
     {
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_i32_shr_negative((stream).as_ref(), cfg, -8i32, 1u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_i32_shr_negative((stream).as_ref(), cfg, -8i32, 1u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -4i32 {
             println!("  [PASS] i32 shr: -8 >> 1 = {}", r[0]);
@@ -388,7 +404,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // i64 shr: -1024 >> 3 = -128
     {
         let mut out = DeviceBuffer::<i64>::zeroed(&stream, N)?;
-        module.test_i64_shr_negative((stream).as_ref(), cfg, -1024i64, 3u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_i64_shr_negative((stream).as_ref(), cfg, -1024i64, 3u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -128i64 {
             println!("  [PASS] i64 shr: -1024 >> 3 = {}", r[0]);
@@ -410,16 +427,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let mut out_signed = DeviceBuffer::<i32>::zeroed(&stream, N)?;
         let mut out_unsigned = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_mixed_div(
-            (stream).as_ref(),
-            cfg,
-            -7i32,
-            2i32,
-            0xFFFF_FFFEu32,
-            2u32,
-            &mut out_signed,
-            &mut out_unsigned,
-        )?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_mixed_div(
+                (stream).as_ref(),
+                cfg,
+                -7i32,
+                2i32,
+                0xFFFF_FFFEu32,
+                2u32,
+                &mut out_signed,
+                &mut out_unsigned,
+            )
+        }?;
         let rs = out_signed.to_host_vec(&stream)?;
         let ru = out_unsigned.to_host_vec(&stream)?;
         let signed_ok = rs[0] == -3i32;
@@ -449,7 +469,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // u32 wrapping add: MAX + 1 = 0
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, N)?;
-        module.test_u32_wrapping_add((stream).as_ref(), cfg, u32::MAX, 1u32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u32_wrapping_add((stream).as_ref(), cfg, u32::MAX, 1u32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 0u32 {
             println!("  [PASS] u32 wrapping add: MAX + 1 = {}", r[0]);
@@ -465,7 +486,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // i32 wrapping mul: i32::MAX * 2 = -2
     {
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_i32_wrapping_mul((stream).as_ref(), cfg, i32::MAX, 2i32, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_i32_wrapping_mul((stream).as_ref(), cfg, i32::MAX, 2i32, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -2i32 {
             println!("  [PASS] i32 wrapping mul: MAX * 2 = {}", r[0]);
@@ -486,7 +508,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // widening chain: u8(0xFF) -> u32 -> u64 = 255
     {
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, N)?;
-        module.test_widening_chain((stream).as_ref(), cfg, 0xFFu8, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_widening_chain((stream).as_ref(), cfg, 0xFFu8, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == 255u64 {
             println!("  [PASS] widening chain: u8(0xFF) -> u32 -> u64 = {}", r[0]);
@@ -502,7 +525,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // narrowing signed: i64(-42) -> i32 = -42
     {
         let mut out = DeviceBuffer::<i32>::zeroed(&stream, N)?;
-        module.test_narrowing_signed((stream).as_ref(), cfg, -42i64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_narrowing_signed((stream).as_ref(), cfg, -42i64, &mut out) }?;
         let r = out.to_host_vec(&stream)?;
         if r[0] == -42i32 {
             println!("  [PASS] narrowing signed: i64(-42) -> i32 = {}", r[0]);

--- a/crates/rustc-codegen-cuda/examples/option_ref_transmute/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/option_ref_transmute/src/main.rs
@@ -115,14 +115,14 @@ fn main() {
     let d_input = DeviceBuffer::from_host(&stream, &host_input).unwrap();
 
     let mut d_xmute = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
-    module
-        .opt_ref_transmute(stream.as_ref(), cfg, &d_input, &mut d_xmute)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.opt_ref_transmute(stream.as_ref(), cfg, &d_input, &mut d_xmute) }
         .expect("launch opt_ref_transmute");
     let got_xmute = d_xmute.to_host_vec(&stream).unwrap();
 
     let mut d_ctrl = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
-    module
-        .opt_ref_control(stream.as_ref(), cfg, &d_input, &mut d_ctrl)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.opt_ref_control(stream.as_ref(), cfg, &d_input, &mut d_ctrl) }
         .expect("launch opt_ref_control");
     let got_ctrl = d_ctrl.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/src/main.rs
@@ -120,14 +120,14 @@ fn main() {
     };
 
     let mut d_u32 = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .opt_ref_unwrap_or_u32(stream.as_ref(), cfg, &mut d_u32)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.opt_ref_unwrap_or_u32(stream.as_ref(), cfg, &mut d_u32) }
         .expect("launch opt_ref_unwrap_or_u32");
     let got_u32 = d_u32.to_host_vec(&stream).unwrap();
 
     let mut d_f32 = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
-    module
-        .opt_ref_unwrap_or_f32(stream.as_ref(), cfg, &mut d_f32)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.opt_ref_unwrap_or_f32(stream.as_ref(), cfg, &mut d_f32) }
         .expect("launch opt_ref_unwrap_or_f32");
     let got_f32 = d_f32.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/ord_cmp/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ord_cmp/src/main.rs
@@ -256,8 +256,8 @@ fn main() {
 
     // cmp_kernel: full-width + narrow integer + char comparisons.
     let mut out = DeviceBuffer::<i32>::zeroed(&stream, 27).expect("failed to allocate output");
-    module
-        .cmp_kernel(stream.as_ref(), config, &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cmp_kernel(stream.as_ref(), config, &mut out) }
         .expect("cmp_kernel launch failed");
     let got = out.to_host_vec(&stream).expect("failed to copy output");
     let expected = [
@@ -268,24 +268,24 @@ fn main() {
 
     // cmp_cast_kernel: Ordering as i8 / as i32 must sign-extend to -1.
     let mut out = DeviceBuffer::<i32>::zeroed(&stream, 4).expect("failed to allocate output");
-    module
-        .cmp_cast_kernel(stream.as_ref(), config, &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cmp_cast_kernel(stream.as_ref(), config, &mut out) }
         .expect("cmp_cast_kernel launch failed");
     let got = out.to_host_vec(&stream).expect("failed to copy output");
     ok &= check("cmp_cast_kernel", &got, &[-1, -1, 1, 0]);
 
     // ordering_match_kernel: issue #146 shape; Less must take the Less arm.
     let mut out = DeviceBuffer::<i32>::zeroed(&stream, 1).expect("failed to allocate output");
-    module
-        .ordering_match_kernel(stream.as_ref(), config, &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.ordering_match_kernel(stream.as_ref(), config, &mut out) }
         .expect("ordering_match_kernel launch failed");
     let got = out.to_host_vec(&stream).expect("failed to copy output");
     ok &= check("ordering_match_kernel", &got, &[-1]);
 
     // enum_repr_kernel: sparse u16 tag + negative signed i8 tag.
     let mut out = DeviceBuffer::<i32>::zeroed(&stream, 4).expect("failed to allocate output");
-    module
-        .enum_repr_kernel(stream.as_ref(), config, &mut out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.enum_repr_kernel(stream.as_ref(), config, &mut out) }
         .expect("enum_repr_kernel launch failed");
     let got = out.to_host_vec(&stream).expect("failed to copy output");
     ok &= check("enum_repr_kernel", &got, &[100, 200, -5, -4]);

--- a/crates/rustc-codegen-cuda/examples/packed_atomic_add/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_atomic_add/src/main.rs
@@ -63,9 +63,13 @@ fn main() {
     let module = kernels::load(&ctx).expect("load embedded PTX");
     let counters = DeviceBuffer::<u32>::zeroed(&stream, COUNTERS).expect("allocate counters");
     let counters_ptr = counters.cu_deviceptr() as *mut u32;
-    module
-        .add_packed(&stream, LaunchConfig::for_num_elems(THREADS), counters_ptr)
-        .expect("launch add_packed");
+    // SAFETY: the launch covers THREADS items and counters_ptr addresses both
+    // packed counters for the lifetime of the synchronized kernel launch.
+    unsafe {
+        module
+            .add_packed(&stream, LaunchConfig::for_num_elems(THREADS), counters_ptr)
+            .expect("launch add_packed");
+    }
     stream.synchronize().expect("synchronize");
 
     let result = counters.to_host_vec(&stream).expect("copy counters");

--- a/crates/rustc-codegen-cuda/examples/place_read_fallbacks/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/place_read_fallbacks/src/main.rs
@@ -129,8 +129,8 @@ fn main() {
     let mut failures = 0usize;
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .enum_payload_read(&stream, cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.enum_payload_read(&stream, cfg, &mut out_dev) }
         .expect("enum_payload_read launch");
     let out = out_dev.to_host_vec(&stream).unwrap();
     let expected = [7, 108, 999, 11];
@@ -142,8 +142,8 @@ fn main() {
     }
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
-    module
-        .zst_reads(&stream, LaunchConfig::for_num_elems(1), &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.zst_reads(&stream, LaunchConfig::for_num_elems(1), &mut out_dev) }
         .expect("zst_reads launch");
     let out = out_dev.to_host_vec(&stream).unwrap();
     if out[0] != 59 {
@@ -152,8 +152,8 @@ fn main() {
     }
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .tuple_field_read(&stream, cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.tuple_field_read(&stream, cfg, &mut out_dev) }
         .expect("tuple_field_read launch");
     let out = out_dev.to_host_vec(&stream).unwrap();
     for (i, &got) in out.iter().enumerate() {

--- a/crates/rustc-codegen-cuda/examples/primitive_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/primitive_stress/src/main.rs
@@ -245,7 +245,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let mut out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
-        module.test_char(&stream, cfg, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_char(&stream, cfg, &mut out) }?;
         let result = out.to_host_vec(&stream)?[0];
         let expected = ('A' as u32)
             .wrapping_add('\u{1f980}' as u32)
@@ -264,7 +265,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210_u128;
         let c = -0x1234_5678_9abc_def_i128;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 4)?;
-        module.test_u128_i128(&stream, cfg, a, b, c, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_u128_i128(&stream, cfg, a, b, c, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let unsigned = a
             .wrapping_mul(3)
@@ -292,7 +294,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let a = 0x8000_1234_usize;
         let b = -12345_isize;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 2)?;
-        module.test_pointer_sized(&stream, cfg, a, b, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_pointer_sized(&stream, cfg, a, b, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let expected = [
             a.wrapping_mul(5)
@@ -314,7 +317,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let b = 0x0123_4567_89ab_cdef_u64;
         let c = 0x8020_0401_u32;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 7)?;
-        module.test_bit_intrinsics(&stream, cfg, a, b, c, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_bit_intrinsics(&stream, cfg, a, b, c, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let wide = a.rotate_left(17) ^ a.rotate_right(29) ^ a.swap_bytes() ^ a.reverse_bits();
         let wide_counts = (a.count_ones() as u64) | ((a.leading_zeros() as u64) << 32);
@@ -347,8 +351,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let u64_val = u64::MAX - 2;
         let i64_val = i64::MIN + 2;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 7)?;
-        module
-            .test_saturating_intrinsics(&stream, cfg, u8_val, i8_val, u64_val, i64_val, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.test_saturating_intrinsics(
+                &stream, cfg, u8_val, i8_val, u64_val, i64_val, &mut out,
+            )
+        }?;
         let result = out.to_host_vec(&stream)?;
         let expected = [
             u8_val.saturating_add(10) as u64,
@@ -372,7 +380,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let seed32 = 2.0_f32;
         let seed64 = 2.0_f64;
         let mut out = DeviceBuffer::<u64>::zeroed(&stream, 50)?;
-        module.test_float_math_intrinsics(&stream, cfg, seed32, seed64, &mut out)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_float_math_intrinsics(&stream, cfg, seed32, seed64, &mut out) }?;
         let result = out.to_host_vec(&stream)?;
         let expected = expected_float_math_bits(seed32, seed64);
         // Allow up to 2 ULPs for transcendentals: CUDA `libdevice` uses

--- a/crates/rustc-codegen-cuda/examples/printf/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/printf/src/main.rs
@@ -192,7 +192,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 1: Integer formats
     // ====================================================================
     println!("--- Test 1: Integer formats ---");
-    module.test_integers((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_integers((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 
@@ -200,7 +201,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 2: Float formats
     // ====================================================================
     println!("--- Test 2: Float formats ---");
-    module.test_floats((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_floats((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 
@@ -208,7 +210,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 3: Width and alignment
     // ====================================================================
     println!("--- Test 3: Width and alignment ---");
-    module.test_width_align((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_width_align((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 
@@ -216,7 +219,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 4: Sign and flags
     // ====================================================================
     println!("--- Test 4: Sign and flags ---");
-    module.test_flags((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_flags((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 
@@ -228,7 +232,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let data: Vec<f32> = vec![1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8];
         let data_dev = DeviceBuffer::from_host(&stream, &data)?;
 
-        module.test_thread_output((stream).as_ref(), cfg, &data_dev)?;
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_thread_output((stream).as_ref(), cfg, &data_dev) }?;
         stream.synchronize()?;
     }
     println!();
@@ -237,7 +242,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 6: Return value
     // ====================================================================
     println!("--- Test 6: Return value ---");
-    module.test_return_value((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_return_value((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 
@@ -245,7 +251,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 7: Boolean values
     // ====================================================================
     println!("--- Test 7: Boolean values ---");
-    module.test_booleans((stream).as_ref(), cfg)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_booleans((stream).as_ref(), cfg) }?;
     stream.synchronize()?;
     println!();
 

--- a/crates/rustc-codegen-cuda/examples/projected_place_read/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/projected_place_read/src/main.rs
@@ -96,15 +96,17 @@ fn main() {
 
     // row = 5 & 3 = 1; col = 6 & 1 = 0; out[0] = scratch[1][0]  => 3.0
     let mut out_dev = DeviceBuffer::<f64>::zeroed(&stream, 1).unwrap();
-    module
-        .projected_read_2d(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.projected_read_2d(
             &stream,
             LaunchConfig::for_num_elems(1),
             5usize,
             6usize,
             &mut out_dev,
         )
-        .expect("projected_read_2d launch");
+    }
+    .expect("projected_read_2d launch");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
     assert!(
@@ -115,15 +117,17 @@ fn main() {
 
     // value = 6 + 5 = 11
     let mut out_dev = DeviceBuffer::<f64>::zeroed(&stream, 1).unwrap();
-    module
-        .projected_read_struct_field(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.projected_read_struct_field(
             &stream,
             LaunchConfig::for_num_elems(1),
             6usize,
             5usize,
             &mut out_dev,
         )
-        .expect("projected_read_struct_field launch");
+    }
+    .expect("projected_read_struct_field launch");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
     assert!(

--- a/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
@@ -47,8 +47,9 @@ fn main() {
     let values_dev = DeviceBuffer::from_host(&stream, &values).unwrap();
     let mut out_dev = DeviceBuffer::<i64>::zeroed(&stream, SLOTS).unwrap();
 
-    module
-        .pointer_distances(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.pointer_distances(
             &stream,
             LaunchConfig::for_num_elems(1),
             &values_dev,
@@ -56,7 +57,8 @@ fn main() {
             hi,
             &mut out_dev,
         )
-        .expect("launch pointer_distances");
+    }
+    .expect("launch pointer_distances");
 
     let got = out_dev.to_host_vec(&stream).unwrap();
     let element_distance = (hi - lo) as i64;

--- a/crates/rustc-codegen-cuda/examples/redux_minmax/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/redux_minmax/src/main.rs
@@ -127,9 +127,11 @@ fn main() {
     let mut signed_dev = DeviceBuffer::<i32>::zeroed(&stream, 2).unwrap();
     let mut unsigned_dev = DeviceBuffer::<u32>::zeroed(&stream, 2).unwrap();
 
-    module
-        .redux_minmax_signedness((stream).as_ref(), cfg, &mut signed_dev, &mut unsigned_dev)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.redux_minmax_signedness((stream).as_ref(), cfg, &mut signed_dev, &mut unsigned_dev)
+    }
+    .expect("Kernel launch failed");
 
     let signed = signed_dev.to_host_vec(&stream).unwrap();
     let unsigned = unsigned_dev.to_host_vec(&stream).unwrap();
@@ -153,8 +155,8 @@ fn main() {
     println!("\n--- Test 2: redux.sync.and/or/xor ---");
     let mut bits_dev = DeviceBuffer::<u32>::zeroed(&stream, 3).unwrap();
 
-    module
-        .redux_bitwise((stream).as_ref(), cfg, &mut bits_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.redux_bitwise((stream).as_ref(), cfg, &mut bits_dev) }
         .expect("Kernel launch failed");
 
     let bits = bits_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/redux_sum/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/redux_sum/src/main.rs
@@ -110,8 +110,8 @@ fn main() {
     println!("\n--- Test 1: redux_sync_add over lane ids ---");
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, WARPS).unwrap();
 
-    module
-        .redux_lane_sum((stream).as_ref(), cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.redux_lane_sum((stream).as_ref(), cfg, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out_result = out_dev.to_host_vec(&stream).unwrap();
@@ -130,8 +130,8 @@ fn main() {
     let data_dev = DeviceBuffer::from_host(&stream, &data_host).unwrap();
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, WARPS).unwrap();
 
-    module
-        .redux_data_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.redux_data_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out_result = out_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -667,128 +667,114 @@ fn main() {
     let mut all_pass = true;
 
     all_pass &= run_and_report("test_unrolled_baseline", &stream, |s, cfg, i, o| {
-        module.test_unrolled_baseline(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_unrolled_baseline(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_closure_indexes_into_array",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_closure_indexes_into_array(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_closure_indexes_into_array(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_closure_indexes_via_match", &stream, |s, cfg, i, o| {
-        module
-            .test_closure_indexes_via_match(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_indexes_via_match(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_closure_into_struct_wrapper",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_closure_into_struct_wrapper(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_closure_into_struct_wrapper(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report(
         "test_closure_pre_loaded_outside",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_closure_pre_loaded_outside(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_closure_pre_loaded_outside(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_closure_node_ref_access", &stream, |s, cfg, i, o| {
-        module
-            .test_closure_node_ref_access(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_node_ref_access(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report("test_closure_with_shuffle", &stream, |s, cfg, i, o| {
-        module
-            .test_closure_with_shuffle(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_with_shuffle(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report("test_closure_two_shuffles", &stream, |s, cfg, i, o| {
-        module
-            .test_closure_two_shuffles(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_two_shuffles(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_two_shuffles_no_indexed_load",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_two_shuffles_no_indexed_load(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_two_shuffles_no_indexed_load(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_two_shuffles_raw_array", &stream, |s, cfg, i, o| {
-        module
-            .test_two_shuffles_raw_array(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_two_shuffles_raw_array(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_two_shuffles_no_transparent",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_two_shuffles_no_transparent(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_two_shuffles_no_transparent(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_two_shuffles_inlined", &stream, |s, cfg, i, o| {
-        module
-            .test_two_shuffles_inlined(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_two_shuffles_inlined(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_closure_shuffle_with_captures",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_closure_shuffle_with_captures(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_closure_shuffle_with_captures(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_closure_via_array_literal", &stream, |s, cfg, i, o| {
-        module
-            .test_closure_via_array_literal(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_via_array_literal(s, cfg, i, o) }.expect("launch")
     });
 
     // Address-walker regression kernels (PR #121 hardening).
     all_pass &= run_and_report("test_mut_ref_writethrough", &stream, |s, cfg, i, o| {
-        module
-            .test_mut_ref_writethrough(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_mut_ref_writethrough(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report("test_constant_index_tail", &stream, |s, cfg, i, o| {
-        module
-            .test_constant_index_tail(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_constant_index_tail(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report("test_raw_addr_of_const", &stream, |s, cfg, i, o| {
-        module.test_raw_addr_of_const(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_raw_addr_of_const(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report(
         "test_raw_addr_of_mut_writethrough",
         &stream,
         |s, cfg, i, o| {
-            module
-                .test_raw_addr_of_mut_writethrough(s, cfg, i, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_raw_addr_of_mut_writethrough(s, cfg, i, o) }.expect("launch")
         },
     );
     all_pass &= run_and_report("test_inline_never_node_fn", &stream, |s, cfg, i, o| {
-        module
-            .test_inline_never_node_fn(s, cfg, i, o)
-            .expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_inline_never_node_fn(s, cfg, i, o) }.expect("launch")
     });
     all_pass &= run_and_report("test_holder_deref_tail", &stream, |s, cfg, i, o| {
-        module.test_holder_deref_tail(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_holder_deref_tail(s, cfg, i, o) }.expect("launch")
     });
 
     if all_pass {

--- a/crates/rustc-codegen-cuda/examples/ref_operand_mul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_operand_mul/src/main.rs
@@ -107,8 +107,9 @@ fn run_ref_pieces_mul(module: &kernels::LoadedModule, stream: &Arc<CudaStream>) 
     };
 
     // a = (2, 3), b = (4, 5): prod = (8, 15), sq = (64, 225); sum = 289.
-    module
-        .ref_pieces_mul(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.ref_pieces_mul(
             stream.as_ref(),
             config,
             2_u32,
@@ -117,7 +118,8 @@ fn run_ref_pieces_mul(module: &kernels::LoadedModule, stream: &Arc<CudaStream>) 
             5_u32,
             &mut d_out,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let result = d_out.to_host_vec(stream).unwrap()[0];
     let expected = 289_u32;

--- a/crates/rustc-codegen-cuda/examples/repr_u32_enum_stride/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/repr_u32_enum_stride/src/main.rs
@@ -270,23 +270,27 @@ fn main() {
 
     // Control: plain u32 reads, stride 4 regardless of the fix.
     all_pass &= check("control_u32", &stream, &seq, &seq, |s, cfg, i, o| {
-        module.read_via_u32(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.read_via_u32(s, cfg, i, o) }.expect("launch")
     });
 
     // #[repr(u32)]: the original issue #118 shape. Buggy stride was 1.
     all_pass &= check("enum_ptr", &stream, &seq, &seq, |s, cfg, i, o| {
-        module.read_via_enum(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.read_via_enum(s, cfg, i, o) }.expect("launch")
     });
 
     // #[repr(C)]: tag is C int (4 bytes); repr().int cannot see this one.
     all_pass &= check("repr_c_enum", &stream, &seq, &seq, |s, cfg, i, o| {
-        module.read_via_repr_c_enum(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.read_via_repr_c_enum(s, cfg, i, o) }.expect("launch")
     });
 
     // Default repr, sparse discriminants: rustc picks a u32 tag.
     let sparse: Vec<u32> = vec![0, 1_000_000, 1_000_000, 0];
     all_pass &= check("sparse_enum", &stream, &sparse, &sparse, |s, cfg, i, o| {
-        module.read_via_sparse_enum(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.read_via_sparse_enum(s, cfg, i, o) }.expect("launch")
     });
 
     // Default repr, negative discriminant: SIGNED i8 tag; `as i32` must
@@ -298,13 +302,15 @@ fn main() {
         &stream,
         &neg_in,
         &neg_expected,
-        |s, cfg, i, o| module.read_via_neg_enum(s, cfg, i, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, i, o| unsafe { module.read_via_neg_enum(s, cfg, i, o) }.expect("launch"),
     );
 
     // #[repr(usize)]: pointer-width tag; stride 8 over a u64 buffer.
     let useq: Vec<u64> = (0..N as u64).collect();
     all_pass &= check("usize_enum", &stream, &useq, &seq, |s, cfg, i, o| {
-        module.read_via_usize_enum(s, cfg, i, o).expect("launch")
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.read_via_usize_enum(s, cfg, i, o) }.expect("launch")
     });
 
     println!();

--- a/crates/rustc-codegen-cuda/examples/set_discriminant/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/set_discriminant/src/main.rs
@@ -93,9 +93,11 @@ fn main() {
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .set_discriminant_kernel(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
-        .expect("Kernel launch failed");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.set_discriminant_kernel(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+    }
+    .expect("Kernel launch failed");
 
     let out_host = out_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/sharedmem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/sharedmem/src/main.rs
@@ -113,8 +113,8 @@ fn main() {
         let data_dev = DeviceBuffer::from_host(&stream, &data_host).unwrap();
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        module
-            .shared_test((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.shared_test((stream).as_ref(), cfg, &data_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();
@@ -148,8 +148,8 @@ fn main() {
         let b_dev = DeviceBuffer::from_host(&stream, &b_host).unwrap();
         let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-        module
-            .shared_dual((stream).as_ref(), cfg, &a_dev, &b_dev, &mut out_dev)
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.shared_dual((stream).as_ref(), cfg, &a_dev, &b_dev, &mut out_dev) }
             .expect("Kernel launch failed");
 
         let out_result = out_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/shuffle_64/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/shuffle_64/src/main.rs
@@ -151,8 +151,8 @@ fn main() {
     // ===== Test 1: u64 broadcast (idx) =====
     println!("\n--- Test 1: shuffle_u64 (idx broadcast of lane {SRC_LANE}) ---");
     let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, WARP).unwrap();
-    module
-        .shuffle_u64_broadcast((stream).as_ref(), cfg, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.shuffle_u64_broadcast((stream).as_ref(), cfg, &mut out_dev) }
         .expect("Kernel launch failed");
     let out = out_dev.to_host_vec(&stream).unwrap();
 
@@ -169,8 +169,8 @@ fn main() {
     // ===== Test 2: f64 butterfly reduction (bfly) =====
     println!("\n--- Test 2: shuffle_xor_f64 (butterfly sum) ---");
     let mut sum_dev = DeviceBuffer::<f64>::zeroed(&stream, WARP).unwrap();
-    module
-        .shuffle_f64_butterfly_sum((stream).as_ref(), cfg, &mut sum_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.shuffle_f64_butterfly_sum((stream).as_ref(), cfg, &mut sum_dev) }
         .expect("Kernel launch failed");
     let sums = sum_dev.to_host_vec(&stream).unwrap();
 
@@ -187,8 +187,8 @@ fn main() {
     println!("\n--- Test 3: shuffle_down_u64 / shuffle_up_u64 (delta 1) ---");
     let mut down_dev = DeviceBuffer::<u64>::zeroed(&stream, WARP).unwrap();
     let mut up_dev = DeviceBuffer::<u64>::zeroed(&stream, WARP).unwrap();
-    module
-        .shuffle_u64_neighbor((stream).as_ref(), cfg, &mut down_dev, &mut up_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.shuffle_u64_neighbor((stream).as_ref(), cfg, &mut down_dev, &mut up_dev) }
         .expect("Kernel launch failed");
     let down = down_dev.to_host_vec(&stream).unwrap();
     let up = up_dev.to_host_vec(&stream).unwrap();
@@ -228,8 +228,8 @@ fn main() {
     // ===== Test 4: masked half-warp broadcast (subset membermask) =====
     println!("\n--- Test 4: shuffle_u64_sync (two independent 16-lane halves) ---");
     let mut half_dev = DeviceBuffer::<u64>::zeroed(&stream, WARP).unwrap();
-    module
-        .shuffle_u64_halfwarp((stream).as_ref(), cfg, &mut half_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.shuffle_u64_halfwarp((stream).as_ref(), cfg, &mut half_dev) }
         .expect("Kernel launch failed");
     let half = half_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/src/main.rs
@@ -316,43 +316,50 @@ fn main() {
         "write_get_mut_map",
         &stream,
         |_| 42.0,
-        |s, cfg, o| module.write_get_mut_map(s, cfg, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, o| unsafe { module.write_get_mut_map(s, cfg, o) }.expect("launch"),
     );
     all_pass &= run_and_check(
         "write_get_mut_if_let",
         &stream,
         |i| 100.0 + i as f32,
-        |s, cfg, o| module.write_get_mut_if_let(s, cfg, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, o| unsafe { module.write_get_mut_if_let(s, cfg, o) }.expect("launch"),
     );
     all_pass &= run_and_check(
         "write_index_assign",
         &stream,
         |i| 7.0 + i as f32,
-        |s, cfg, o| module.write_index_assign(s, cfg, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, o| unsafe { module.write_index_assign(s, cfg, o) }.expect("launch"),
     );
     all_pass &= run_and_check(
         "write_slice_index_assign",
         &stream,
         |i| 3.0 * i as f32,
-        |s, cfg, o| module.write_slice_index_assign(s, cfg, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, o| unsafe { module.write_slice_index_assign(s, cfg, o) }.expect("launch"),
     );
     all_pass &= run_and_check(
         "write_mut_ref_index",
         &stream,
         |i| 50.0 - i as f32,
-        |s, cfg, o| module.write_mut_ref_index(s, cfg, o).expect("launch"),
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        |s, cfg, o| unsafe { module.write_mut_ref_index(s, cfg, o) }.expect("launch"),
     );
 
     // Struct-field variant has its own buffer shape; check it inline.
     {
         let mut dev_cells = DeviceBuffer::<[Cell; 2]>::zeroed(&stream, N).unwrap();
-        module
-            .write_struct_field_get_mut(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.write_struct_field_get_mut(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 &mut dev_cells,
             )
-            .expect("launch");
+        }
+        .expect("launch");
         let host_cells = dev_cells.to_host_vec(&stream).unwrap();
         let ok = host_cells.iter().all(|pair| {
             (0..2).all(|i| {
@@ -375,18 +382,16 @@ fn main() {
     // when a fat slice's element type is itself an array.
     all_pass &=
         run_nested_matrix_check("write_nested_slice_row_ref", &stream, 42.0, |s, cfg, o| {
-            module
-                .write_nested_slice_row_ref(s, cfg, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.write_nested_slice_row_ref(s, cfg, o) }.expect("launch")
         });
     all_pass &= run_nested_matrix_check(
         "write_nested_slice_const_row_ref",
         &stream,
         62.0,
         |s, cfg, o| {
-            module
-                .write_nested_slice_const_row_ref(s, cfg, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.write_nested_slice_const_row_ref(s, cfg, o) }.expect("launch")
         },
     );
     all_pass &= run_nested_matrix_check(
@@ -394,9 +399,8 @@ fn main() {
         &stream,
         52.0,
         |s, cfg, o| {
-            module
-                .write_nested_slice_row_assign(s, cfg, o)
-                .expect("launch")
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.write_nested_slice_row_assign(s, cfg, o) }.expect("launch")
         },
     );
 
@@ -405,13 +409,15 @@ fn main() {
     // column 2, not column 0.
     {
         let mut dev = DeviceBuffer::<[[f32; 3]; 2]>::zeroed(&stream, N).unwrap();
-        module
-            .write_nested_slice_wide_nonzero_col(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.write_nested_slice_wide_nonzero_col(
                 &stream,
                 LaunchConfig::for_num_elems(N as u32),
                 &mut dev,
             )
-            .expect("launch");
+        }
+        .expect("launch");
         let host = dev.to_host_vec(&stream).unwrap();
         let ok = host.iter().enumerate().all(|(lane, m)| {
             (m[0][0] - 10.0).abs() < 1e-6

--- a/crates/rustc-codegen-cuda/examples/slice_reslice/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/slice_reslice/src/main.rs
@@ -52,12 +52,15 @@ fn main() {
     let bytes_dev = DeviceBuffer::from_host(&stream, &bytes).unwrap();
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-    m.slice_reslice(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &bytes_dev,
-        &mut out_dev,
-    )
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        m.slice_reslice(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &bytes_dev,
+            &mut out_dev,
+        )
+    }
     .expect("launch slice_reslice");
 
     let out = out_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/step_by/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/step_by/src/main.rs
@@ -93,14 +93,13 @@ fn main() {
     };
 
     let mut d_out = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
-    module
-        .step_by_sum(stream.as_ref(), cfg, &mut d_out)
-        .expect("launch step_by_sum");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.step_by_sum(stream.as_ref(), cfg, &mut d_out) }.expect("launch step_by_sum");
     let got_step_by = d_out.to_host_vec(&stream).unwrap();
 
     let mut d_ctrl = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
-    module
-        .step_by_sum_control(stream.as_ref(), cfg, &mut d_ctrl)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.step_by_sum_control(stream.as_ref(), cfg, &mut d_ctrl) }
         .expect("launch step_by_sum_control");
     let got_ctrl = d_ctrl.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/struct_field_layout/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/struct_field_layout/src/main.rs
@@ -93,14 +93,16 @@ fn main() {
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .fill(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.fill(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &params_dev,
             &mut out_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let out_host = out_dev.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/tiled_gemm/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tiled_gemm/src/main.rs
@@ -192,8 +192,9 @@ fn main() {
 
     // Warmup
     println!("\nWarmup...");
-    module
-        .sgemm_tiled(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.sgemm_tiled(
             (stream).as_ref(),
             cfg,
             m_arg,
@@ -205,7 +206,8 @@ fn main() {
             BETA,
             &mut c_dev,
         )
-        .unwrap();
+    }
+    .unwrap();
     stream.synchronize().unwrap();
 
     // Timed runs
@@ -213,8 +215,9 @@ fn main() {
     println!("Running {} iterations...", NUM_RUNS);
     let start = Instant::now();
     for _ in 0..NUM_RUNS {
-        module
-            .sgemm_tiled(
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe {
+            module.sgemm_tiled(
                 (stream).as_ref(),
                 cfg,
                 m_arg,
@@ -226,7 +229,8 @@ fn main() {
                 BETA,
                 &mut c_dev,
             )
-            .unwrap();
+        }
+        .unwrap();
     }
     stream.synchronize().unwrap();
     let elapsed = start.elapsed();

--- a/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
@@ -300,14 +300,17 @@ fn run_tma_copy_test(
     // Get raw device pointer to TMA descriptor
     let tensor_map_ptr = dev_tensor_map.cu_deviceptr() as *const TmaDescriptor;
 
-    module.tma_copy_2d_test(
-        (stream).as_ref(),
-        cfg,
-        tensor_map_ptr,
-        &mut dev_output,
-        tile_x,
-        tile_y,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.tma_copy_2d_test(
+            (stream).as_ref(),
+            cfg,
+            tensor_map_ptr,
+            &mut dev_output,
+            tile_x,
+            tile_y,
+        )
+    }?;
 
     stream.synchronize()?;
 
@@ -385,7 +388,8 @@ fn run_tma_pipeline_test(
     // Get raw device pointer to TMA descriptor
     let tensor_map_ptr = dev_tensor_map.cu_deviceptr() as *const TmaDescriptor;
 
-    module.tma_pipeline_test((stream).as_ref(), cfg, tensor_map_ptr, &mut dev_output)?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.tma_pipeline_test((stream).as_ref(), cfg, tensor_map_ptr, &mut dev_output) }?;
 
     stream.synchronize()?;
 

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
@@ -235,14 +235,17 @@ fn run_tma_multicast_test(
 
     let tensor_map_ptr = dev_tensor_map.cu_deviceptr() as *const TmaDescriptor;
 
-    module.tma_multicast_test(
-        (stream).as_ref(),
-        cfg,
-        tensor_map_ptr,
-        &mut dev_output,
-        tile_x,
-        tile_y,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.tma_multicast_test(
+            (stream).as_ref(),
+            cfg,
+            tensor_map_ptr,
+            &mut dev_output,
+            tile_x,
+            tile_y,
+        )
+    }?;
 
     stream.synchronize()?;
 

--- a/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/src/main.rs
@@ -74,8 +74,8 @@ fn main() {
         block_dim: (N as u32, 1, 1),
         shared_mem_bytes: 0,
     };
-    module
-        .roundtrip(stream.as_ref(), config, &d_in, &mut d_out)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.roundtrip(stream.as_ref(), config, &d_in, &mut d_out) }
         .expect("Kernel launch failed");
 
     let out = d_out.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/tuple_return/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tuple_return/src/main.rs
@@ -57,13 +57,15 @@ fn main() {
         .expect("Failed to load PTX module");
     let module = kernels::from_module(module).expect("Failed to initialize typed module");
 
-    module
-        .run(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.run(
             (stream).as_ref(),
             LaunchConfig::for_num_elems(N as u32),
             &mut dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let host = dev.to_host_vec(&stream).unwrap();
     println!("output = {:?}", host);

--- a/crates/rustc-codegen-cuda/examples/union_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/union_aggregate/src/main.rs
@@ -362,8 +362,8 @@ fn main() {
     let module = kernels::load(&ctx).expect("load module");
 
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .union_aggregate(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.union_aggregate(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev) }
         .expect("kernel launch");
 
     let out = out_dev.to_host_vec(&stream).unwrap();
@@ -375,8 +375,9 @@ fn main() {
     }
 
     let mut argument_out = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
-    module
-        .union_argument(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.union_argument(
             &stream,
             LaunchConfig::for_num_elems(1),
             Bits {
@@ -384,7 +385,8 @@ fn main() {
             },
             &mut argument_out,
         )
-        .expect("union argument kernel launch");
+    }
+    .expect("union argument kernel launch");
     let argument_out = argument_out.to_host_vec(&stream).unwrap();
     if argument_out != [0x0102_0304] {
         eprintln!("FAIL union argument: got {argument_out:?}");

--- a/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
@@ -379,93 +379,90 @@ fn main() {
     };
 
     let mut d_full = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .full_unroll(stream.as_ref(), cfg, &mut d_full)
-        .expect("launch full_unroll");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_unroll(stream.as_ref(), cfg, &mut d_full) }.expect("launch full_unroll");
     let got_full = d_full.to_host_vec(&stream).unwrap();
 
     let trip: u32 = 10;
     let mut d_part = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_unroll(stream.as_ref(), cfg, &mut d_part, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_unroll(stream.as_ref(), cfg, &mut d_part, trip) }
         .expect("launch partial_unroll");
     let got_part = d_part.to_host_vec(&stream).unwrap();
 
     let mut d_fold = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_fold(stream.as_ref(), cfg, &mut d_fold, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_fold(stream.as_ref(), cfg, &mut d_fold, trip) }
         .expect("launch partial_fold");
     let got_fold = d_fold.to_host_vec(&stream).unwrap();
 
     let mut d_mod = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_mod(stream.as_ref(), cfg, &mut d_mod, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_mod(stream.as_ref(), cfg, &mut d_mod, trip) }
         .expect("launch partial_mod");
     let got_mod = d_mod.to_host_vec(&stream).unwrap();
 
     let mut d_fullmb = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .full_mb(stream.as_ref(), cfg, &mut d_fullmb)
-        .expect("launch full_mb");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_mb(stream.as_ref(), cfg, &mut d_fullmb) }.expect("launch full_mb");
     let got_fullmb = d_fullmb.to_host_vec(&stream).unwrap();
 
     let mut d_partmb = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_mb(stream.as_ref(), cfg, &mut d_partmb, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_mb(stream.as_ref(), cfg, &mut d_partmb, trip) }
         .expect("launch partial_mb");
     let got_partmb = d_partmb.to_host_vec(&stream).unwrap();
 
     let mut d_full_break = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .full_early_break(stream.as_ref(), cfg, &mut d_full_break)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_early_break(stream.as_ref(), cfg, &mut d_full_break) }
         .expect("launch full_early_break");
     let got_full_break = d_full_break.to_host_vec(&stream).unwrap();
 
     let mut d_continue = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_continue_paths(stream.as_ref(), cfg, &mut d_continue, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_continue_paths(stream.as_ref(), cfg, &mut d_continue, trip) }
         .expect("launch partial_continue_paths");
     let got_continue = d_continue.to_host_vec(&stream).unwrap();
 
     let mut d_partial_break = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .partial_early_break_skipped(stream.as_ref(), cfg, &mut d_partial_break, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_early_break_skipped(stream.as_ref(), cfg, &mut d_partial_break, trip) }
         .expect("launch partial_early_break_skipped");
     let got_partial_break = d_partial_break.to_host_vec(&stream).unwrap();
 
     let mut d_carried = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .carried_bound(stream.as_ref(), cfg, &mut d_carried, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.carried_bound(stream.as_ref(), cfg, &mut d_carried, trip) }
         .expect("launch carried_bound");
     let got_carried = d_carried.to_host_vec(&stream).unwrap();
 
     let mut d_nfull = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .nested_full(stream.as_ref(), cfg, &mut d_nfull, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.nested_full(stream.as_ref(), cfg, &mut d_nfull, trip) }
         .expect("launch nested_full");
     let got_nfull = d_nfull.to_host_vec(&stream).unwrap();
 
     let mut d_npart = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .nested_partial(stream.as_ref(), cfg, &mut d_npart, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.nested_partial(stream.as_ref(), cfg, &mut d_npart, trip) }
         .expect("launch nested_partial");
     let got_npart = d_npart.to_host_vec(&stream).unwrap();
 
     let mut d_nvar = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .nested_var_bound(stream.as_ref(), cfg, &mut d_nvar, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.nested_var_bound(stream.as_ref(), cfg, &mut d_nvar, trip) }
         .expect("launch nested_var_bound");
     let got_nvar = d_nvar.to_host_vec(&stream).unwrap();
 
     let mut d_ofull = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .outer_full(stream.as_ref(), cfg, &mut d_ofull)
-        .expect("launch outer_full");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.outer_full(stream.as_ref(), cfg, &mut d_ofull) }.expect("launch outer_full");
     let got_ofull = d_ofull.to_host_vec(&stream).unwrap();
 
     let mut d_opart = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
-    module
-        .outer_partial(stream.as_ref(), cfg, &mut d_opart, trip)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.outer_partial(stream.as_ref(), cfg, &mut d_opart, trip) }
         .expect("launch outer_partial");
     let got_opart = d_opart.to_host_vec(&stream).unwrap();
 

--- a/crates/rustc-codegen-cuda/examples/vecadd/README.md
+++ b/crates/rustc-codegen-cuda/examples/vecadd/README.md
@@ -46,17 +46,22 @@ generates the typed host-side loader and launch method.
 
 ```rust
 let module = kernels::load(&ctx)?;
-module.vecadd(
-    &stream,
-    LaunchConfig::for_num_elems(N as u32),
-    &a_dev,
-    &b_dev,
-    &mut c_dev,
-)?;
+// SAFETY: this is a 1D launch and all three buffers contain N elements.
+unsafe {
+    module.vecadd(
+        &stream,
+        LaunchConfig::for_num_elems(N as u32),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}?;
 ```
 
 The `vecadd` method is generated from the kernel signature, so the host call
 has autocomplete for the kernel name and typed `DeviceBuffer<T>` arguments.
+The raw configuration is still an explicit unsafe boundary because its launch
+dimensions are not tied to the kernel's 1D indexing model.
 
 ## Build and Run
 

--- a/crates/rustc-codegen-cuda/examples/vecadd/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vecadd/src/main.rs
@@ -73,15 +73,17 @@ fn main() {
 
     // Load the embedded PTX bundle and launch through the typed module API.
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    module
-        .vecadd(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.vecadd(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     // Get results
     let c_host = c_dev.to_host_vec(&stream).unwrap();

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -75,8 +75,9 @@ macro_rules! vector_suite {
                         .collect();
                     let in_dev = DeviceBuffer::from_host(stream, &input).unwrap();
                     let mut out_dev = DeviceBuffer::<$ty>::zeroed(stream, n).unwrap();
-                    module
-                        .$ty(stream, cfg, &in_dev, &mut out_dev)
+                    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+                    unsafe { module
+                        .$ty(stream, cfg, &in_dev, &mut out_dev) }
                         .expect(concat!(stringify!($ty), " launch"));
                     let out = out_dev.to_host_vec(stream).unwrap();
                     rows.push(Row {

--- a/crates/rustc-codegen-cuda/examples/volatile_memory/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/volatile_memory/src/main.rs
@@ -59,13 +59,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut scratch_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
 
-    module.round_trip(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &input_dev,
-        &mut scratch_dev,
-        &mut out_dev,
-    )?;
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.round_trip(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &input_dev,
+            &mut scratch_dev,
+            &mut out_dev,
+        )
+    }?;
 
     let out = out_dev.to_host_vec(&stream)?;
     assert_eq!(out, expected, "volatile_memory: kernel output mismatch");

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
@@ -154,8 +154,8 @@ fn main() {
     println!("\n--- Test 1: Butterfly Reduction (shuffle_xor) ---");
     let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, WARPS).unwrap();
 
-    module
-        .warp_reduce_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_reduce_sum((stream).as_ref(), cfg, &data_dev, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out_result = out_dev.to_host_vec(&stream).unwrap();
@@ -178,8 +178,8 @@ fn main() {
     println!("\n--- Test 2: Sequential Reduction (shuffle_down) ---");
     let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, WARPS).unwrap();
 
-    module
-        .warp_reduce_sum_down((stream).as_ref(), cfg, &data_dev, &mut out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_reduce_sum_down((stream).as_ref(), cfg, &data_dev, &mut out_dev) }
         .expect("Kernel launch failed");
 
     let out_result = out_dev.to_host_vec(&stream).unwrap();
@@ -202,14 +202,16 @@ fn main() {
     let broadcast_dev = DeviceBuffer::from_host(&stream, &broadcast_input).unwrap();
     let mut broadcast_out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-    module
-        .warp_broadcast(
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.warp_broadcast(
             (stream).as_ref(),
             cfg,
             &broadcast_dev,
             &mut broadcast_out_dev,
         )
-        .expect("Kernel launch failed");
+    }
+    .expect("Kernel launch failed");
 
     let broadcast_result = broadcast_out_dev.to_host_vec(&stream).unwrap();
 
@@ -249,8 +251,8 @@ fn main() {
     println!("\n--- Test 4: Lane ID ---");
     let mut lane_out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
-    module
-        .test_lane_id((stream).as_ref(), cfg, &mut lane_out_dev)
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.test_lane_id((stream).as_ref(), cfg, &mut lane_out_dev) }
         .expect("Kernel launch failed");
 
     let lane_result = lane_out_dev.to_host_vec(&stream).unwrap();

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -114,9 +114,11 @@ let bdim_x = thread::blockDim_x();     // u32
 when the computed column exceeds the stride — use it to skip the
 right-edge tail in non-aligned 2D kernels.
 
-`index_2d::<S>` is the safe default; the const generic encodes the stride
-in the witness type so two threads can't mint colliding indices by
-passing different strides. `index_2d_runtime` is the escape hatch for
+`index_2d::<S>` is the safe const-stride form; the const generic encodes the
+stride in the witness type so threads cannot use different strides.
+Dimensionality remains a host-side obligation: `index_1d` requires inactive
+Y/Z dimensions, and 2D indices require inactive Z. A matching
+`PreparedLaunch<K>` proves this; a raw launch is unsafe. `index_2d_runtime` is the escape hatch for
 launches whose stride is only known at runtime; the caller takes on the
 "every thread used the same stride" obligation by writing `unsafe`. Full
 discussion in [The Safety Model](../gpu-safety/the-safety-model.md).
@@ -369,7 +371,11 @@ let a = DeviceBuffer::from_host(&stream, &a_host).unwrap();
 let b = DeviceBuffer::from_host(&stream, &b_host).unwrap();
 let mut output = DeviceBuffer::<f32>::zeroed(&stream, n).unwrap();
 
-module.vecadd(&stream, LaunchConfig::for_num_elems(n), &a, &b, &mut output).unwrap();
+// SAFETY: this is a 1D launch and all buffers contain n elements.
+unsafe {
+    module.vecadd(&stream, LaunchConfig::for_num_elems(n), &a, &b, &mut output)
+}
+.unwrap();
 ```
 
 ### Typed Async
@@ -378,14 +384,20 @@ module.vecadd(&stream, LaunchConfig::for_num_elems(n), &a, &b, &mut output).unwr
 use cuda_async::device_operation::DeviceOperation;
 
 let module = kernels::load_async(0)?;
-let op = module.vecadd_async(LaunchConfig::for_num_elems(n), &a, &b, &mut output)?;
+// SAFETY: this is 1D, buffers contain n elements, and module/scheduler share a context.
+let op = unsafe {
+    module.vecadd_async(LaunchConfig::for_num_elems(n), &a, &b, &mut output)
+}?;
 
 op.sync()?;       // blocking
 // or: op.await?;  // async with tokio
 ```
 
-`cuda_launch!` and `cuda_launch_async!` remain available as lower-level APIs for
-explicit module loading and custom launch code.
+Raw generated calls are unsafe because `LaunchConfig` is not tied to a kernel.
+A kernel with `#[launch_contract]` instead uses `LaunchConfig1D/2D/3D` to create
+a checked `PreparedLaunch<K>`, then launches safely. `cuda_launch!` and
+`cuda_launch_async!` remain unsafe lower-level APIs for explicit module loading
+and custom launch code.
 
 ### LaunchConfig
 
@@ -417,7 +429,7 @@ debug::prof_trigger::<7>();     // Nsight profiler trigger
 | Module               | Description                                                      | Min SM   |
 |:---------------------|:-----------------------------------------------------------------|:---------|
 | `thread`             | Thread/block IDs, `index_1d`, `sync_threads`                     | All      |
-| `disjoint`           | `DisjointSlice<T>` — safe parallel writes                        | All      |
+| `disjoint`           | `DisjointSlice<T>` — typed writes completed by a launch proof    | All      |
 | `shared`             | `SharedArray<T, N>`, `DynamicSharedArray<T>`                     | All      |
 | `warp`               | Shuffle, vote, match, lane/warp ID                               | All      |
 | `atomic`             | Scoped atomics (device/block/system)                             | sm_70+   |

--- a/cuda-oxide-book/appendix/glossary.md
+++ b/cuda-oxide-book/appendix/glossary.md
@@ -64,8 +64,8 @@ with `zip!` (parallel) and `and_then` (sequential).
 
 A safe mutable output abstraction for kernels. Accepts only a
 `ThreadIndex` whose `IndexSpace` matches its own type parameter,
-providing bounds-checked `Option<&mut T>` returns. Prevents data races
-by construction — each thread can only write to its own element. The
+providing bounds-checked `Option<&mut T>` returns. With matching prepared
+launch geometry, each thread can only write to its own element. The
 `get_mut_indexed()` shortcut mints the witness and resolves it to a
 mutable reference in a single call.
 
@@ -114,6 +114,13 @@ functions for each concrete type used. cuda-oxide fully supports
 monomorphization on device — `scale::<f32>` and `scale::<f64>` each become
 separate PTX functions.
 
+## `PreparedLaunch<K>`
+
+A reusable host-side proof that a launch configuration was checked for the
+exact kernel `K`. Generated safe methods accept this branded value. Passing a
+raw `LaunchConfig` directly to a generated method is instead unsafe because it
+does not prove the kernel's indexing or resource requirements.
+
 ## Pliron
 
 An MLIR-inspired IR framework written in Rust, used as the intermediate
@@ -156,8 +163,8 @@ An opaque witness that can only be constructed by trusted index
 functions. Three forms:
 
 - `thread::index_1d() -> ThreadIndex<'_, Index1D>`. Always returns a
-  witness; unconditionally unique per thread
-  (`threadIdx.x < blockDim.x` is hardware-enforced).
+  witness. It is unique only when block and grid Y/Z dimensions are 1;
+  a `domain = 1` prepared launch proves this.
 - `thread::index_2d::<S>() -> Option<ThreadIndex<'_, Index2D<S>>>`. The
   row stride is a const generic, so a `DisjointSlice<T, Index2D<S>>`
   only accepts a witness with the matching `S` -- mixing strides is a

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -110,8 +110,9 @@ layout-aware field decoding rather than the primitive byte-slicing rule.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| `DisjointSlice<T, IndexSpace>` | **Full** | Bounds-checked parallel write output slice. `get_mut` and `get_mut_indexed` return `Option<&mut T>`. The `IndexSpace` type parameter rejects mismatched 2D strides at compile time. |
-| `ThreadIndex<'kernel, IndexSpace>` | **Full** | Opaque witness only constructable by trusted index functions. `!Send + !Sync + !Copy + !Clone`, `'kernel`-scoped — non-transferable across threads, can't outlive the kernel body. |
+| `DisjointSlice<T, IndexSpace>` | **Full** | Bounds-checked parallel write output slice. `IndexSpace` rejects mismatched layouts; uniqueness also requires matching prepared launch geometry (or a raw unsafe proof). |
+| `ThreadIndex<'kernel, IndexSpace>` | **Full** | Opaque, non-transferable witness. `index_1d` uniqueness requires inactive Y/Z dimensions, proven by a `domain = 1` prepared launch or by the caller of a raw unsafe launch. |
+| `PreparedLaunch<K>` | **Full** | Checked, reusable launch geometry branded for the exact kernel. Raw `LaunchConfig` generated methods are unsafe. |
 | `ManagedBarrier` Typestate | **Full** | Compile-time barrier lifecycle: `Uninit → Ready → Invalidated`. Invalid transitions are compile errors. |
 
 ## Runtime Library: Atomics
@@ -135,7 +136,7 @@ layout-aware field decoding rather than the primitive byte-slicing rule.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| Thread/Block/Grid Intrinsics | **Full** | `threadIdx`, `blockIdx`, `blockDim`, `gridDim`. `index_1d()` and `index_2d::<S>()` (const stride) are type-safe; `index_2d_runtime(s)` is the `unsafe` escape hatch when the stride is only known at launch time. See [The Safety Model](../gpu-safety/the-safety-model.md). |
+| Thread/Block/Grid Intrinsics | **Full** | `threadIdx`, `blockIdx`, `blockDim`, `gridDim`. Index witnesses are layout-typed; their uniqueness also depends on matching launch dimensionality. `index_2d_runtime(s)` adds a caller-proved stride. See [The Safety Model](../gpu-safety/the-safety-model.md). |
 | Block Synchronization | **Full** | `sync_threads()` — thread block barrier. |
 | Async Barriers (mbarrier) | **Full** | Hardware async barriers for Hopper+: init, arrive, test_wait, try_wait, inval. |
 | Cluster Synchronization | **Full** | `cluster_sync()` for all blocks in a cluster. sm_90+. |
@@ -173,8 +174,10 @@ layout-aware field decoding rather than the primitive byte-slicing rule.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| `#[cuda_module]` Typed Launch | **Full** | Embedded module loading with typed sync/async launch methods. |
+| `#[cuda_module]` Typed Launch | **Full** | Embedded module loading with typed sync/async arguments. Raw configuration methods are unsafe. |
+| `#[launch_contract]` / `PreparedLaunch<K>` | **Full** | Checked dimensionality, exact block shape, resources, capabilities, context, and kernel identity. |
 | `cuda_launch!` Macro | **Full** | Unsafe lower-level launch for runtime-loaded modules; requires `unsafe { }`. |
+| `cuda_launch_async!` Macro | **Full** | Unsafe lower-level lazy launch; requires `unsafe { }`. |
 | `#[launch_bounds]` | **Full** | Occupancy hints: max threads per block, min blocks per SM. |
 | `#[cluster_launch]` | **Full** | Compile-time cluster dimensions. Emits `.reqnctapercluster` in PTX. |
 

--- a/cuda-oxide-book/async-programming/combinators-and-composition.md
+++ b/cuda-oxide-book/async-programming/combinators-and-composition.md
@@ -254,6 +254,8 @@ every combinator working together. This function returns a single
 `DeviceOperation` describing the entire forward pass for one batch:
 
 ```rust
+use cuda_async::launch::{AsyncKernelLaunchBuilder, OwnedAsyncKernelLaunch};
+
 fn forward_pass(
     batch: Vec<f32>,
     w0: Arc<DeviceBox<[f32]>>,
@@ -265,39 +267,48 @@ fn forward_pass(
         // Stage 1: GEMM — hidden = input × W0
         .and_then(move |(input, hidden, output)| {
             let func = module.load_function("sgemm_naive").unwrap();
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch
-                .push_args((DIM as u32, DIM as u32, DIM as u32,
-                            1.0f32,
-                            input.cu_deviceptr(), input.len() as u64,
-                            w0.cu_deviceptr(), w0.len() as u64,
-                            0.0f32,
-                            hidden.cu_deviceptr(), hidden.len() as u64))
-                .set_launch_config(gemm_cfg);
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((DIM as u32, DIM as u32, DIM as u32,
+                               1.0f32,
+                               input.cu_deviceptr(), input.len() as u64,
+                               w0.cu_deviceptr(), w0.len() as u64,
+                               0.0f32,
+                               hidden.cu_deviceptr(), hidden.len() as u64));
+            // SAFETY: packet/config match sgemm_naive, the scheduler uses the
+            // module's context, and the owned wrapper retains its allocations.
+            let launch = unsafe { builder.finalize_unchecked(gemm_cfg) };
+            let launch = OwnedAsyncKernelLaunch::new(launch, (input, w0, hidden));
             // Kernel returns (). Carry forward the buffers we still need.
-            launch.and_then(move |()| value((hidden, output, w1, module)))
+            launch.and_then(move |(_input, _w0, hidden)| {
+                value((hidden, output, w1, module))
+            })
         })
         // Stage 2: MatVec — output = hidden × W1
         .and_then(move |(hidden, output, w1, module)| {
             let func = module.load_function("matvec_naive").unwrap();
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch
-                .push_args((DIM as u32, DIM as u32,
-                            hidden.cu_deviceptr(), hidden.len() as u64,
-                            w1.cu_deviceptr(), w1.len() as u64,
-                            output.cu_deviceptr(), output.len() as u64))
-                .set_launch_config(matvec_cfg);
-            launch.and_then(move |()| value((output, module)))
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((DIM as u32, DIM as u32,
+                               hidden.cu_deviceptr(), hidden.len() as u64,
+                               w1.cu_deviceptr(), w1.len() as u64,
+                               output.cu_deviceptr(), output.len() as u64));
+            // SAFETY: packet/config match matvec_naive, the scheduler uses the
+            // module's context, and the owned wrapper retains its allocations.
+            let launch = unsafe { builder.finalize_unchecked(matvec_cfg) };
+            let launch = OwnedAsyncKernelLaunch::new(launch, (hidden, w1, output));
+            launch.and_then(move |(_hidden, _w1, output)| {
+                value((output, module))
+            })
         })
         // Stage 3: ReLU — result = max(0, output)
         .and_then(move |(output, module)| {
             let func = module.load_function("relu").unwrap();
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch
-                .push_args((output.cu_deviceptr(), output.len() as u64,
-                            output.cu_deviceptr(), output.len() as u64))
-                .set_launch_config(relu_cfg);
-            launch.and_then(move |()| value(output))
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((output.cu_deviceptr(), output.len() as u64,
+                               output.cu_deviceptr(), output.len() as u64));
+            // SAFETY: packet/config match relu, the scheduler uses the module's
+            // context, and the owned wrapper retains output.
+            let launch = unsafe { builder.finalize_unchecked(relu_cfg) };
+            OwnedAsyncKernelLaunch::new(launch, output)
         })
         // Stage 4: download result to host
         .and_then(d2h)
@@ -317,6 +328,13 @@ Study how data flows through this pipeline:
 The entire function returns `impl DeviceOperation<Output = Vec<f32>>`. Nothing
 has executed. You can `.sync()` it, `.await` it, or hand it to `tokio::spawn`
 and let the scheduling policy figure out which stream to use.
+
+`AsyncKernelLaunchBuilder` is inert and safe to populate. Only
+`finalize_unchecked(raw_config)` crosses the unsafe boundary and creates a
+runnable operation. `OwnedAsyncKernelLaunch` keeps each stage's buffers alive
+until that launch returns them. Application code should prefer generated
+owned-async methods with `PreparedLaunch<K>`; the low-level form above is useful
+when a module is loaded by name and no generated contract is available.
 
 ## Quick reference
 

--- a/cuda-oxide-book/async-programming/concurrent-execution.md
+++ b/cuda-oxide-book/async-programming/concurrent-execution.md
@@ -118,7 +118,7 @@ work yet) and hand it to `tokio::spawn`:
         let pipeline = zip!(h2d(batch_data), zeros(DIM * DIM), zeros(DIM))
             .and_then(move |(input, hidden, output)| {
                 // Stage 1: GEMM — hidden = input × W0
-                // ... build AsyncKernelLaunch, push args, chain with and_then ...
+                // ... build + finalize an owned launch, then chain with and_then ...
             })
             .and_then(move |(hidden, output, w1, module)| {
                 // Stage 2: MatVec — output = hidden × W1

--- a/cuda-oxide-book/async-programming/images/combinator-dataflow.svg
+++ b/cuda-oxide-book/async-programming/images/combinator-dataflow.svg
@@ -96,8 +96,8 @@
       <rect x="3" y="8" width="3" height="94" rx="1" fill="#f97583" opacity="0.6"/>
       <text x="20" y="30" font-size="14" font-weight="700" fill="#f97583">Stage 1: GEMM</text>
       <text x="126" y="30" font-size="12" fill="#b1bac4">&#x2014; hidden = input &#xD7; W0</text>
-      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunch::new(sgemm_naive)</text>
-      <text x="20" y="76" font-size="11" fill="#9ca3af">Kernel returns () &#x2014; carry forward buffers with value()</text>
+      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunchBuilder::new(sgemm_naive)</text>
+      <text x="20" y="76" font-size="11" fill="#9ca3af">unsafe finalize_unchecked(gemm_cfg) &#x2192; owned operation</text>
       <rect x="280" y="86" width="244" height="20" rx="4" fill="rgba(249, 117, 131, 0.12)"/>
       <text x="402" y="100" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="9" fill="#f97583">value((hidden, output, w1, module))</text>
     </g>
@@ -113,8 +113,8 @@
       <rect x="3" y="8" width="3" height="94" rx="1" fill="#e8912d" opacity="0.6"/>
       <text x="20" y="30" font-size="14" font-weight="700" fill="#e8912d">Stage 2: MatVec</text>
       <text x="146" y="30" font-size="12" fill="#b1bac4">&#x2014; output = hidden &#xD7; W1</text>
-      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunch::new(matvec_naive)</text>
-      <text x="20" y="76" font-size="11" fill="#9ca3af">Carry forward only what next stage needs</text>
+      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunchBuilder::new(matvec_naive)</text>
+      <text x="20" y="76" font-size="11" fill="#9ca3af">unsafe finalize_unchecked(matvec_cfg) &#x2192; owned operation</text>
       <rect x="400" y="86" width="124" height="20" rx="4" fill="rgba(232, 145, 45, 0.12)"/>
       <text x="462" y="100" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="9" fill="#e8912d">value(output)</text>
     </g>
@@ -130,8 +130,8 @@
       <rect x="3" y="8" width="3" height="94" rx="1" fill="#d2a8ff" opacity="0.6"/>
       <text x="20" y="30" font-size="14" font-weight="700" fill="#d2a8ff">Stage 3: ReLU</text>
       <text x="116" y="30" font-size="12" fill="#b1bac4">&#x2014; result = max(0, output)</text>
-      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunch::new(relu)</text>
-      <text x="20" y="76" font-size="11" fill="#9ca3af">In-place operation on output buffer</text>
+      <text x="20" y="54" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">AsyncKernelLaunchBuilder::new(relu)</text>
+      <text x="20" y="76" font-size="11" fill="#9ca3af">unsafe finalize_unchecked(relu_cfg) &#x2192; owned operation</text>
       <rect x="400" y="86" width="124" height="20" rx="4" fill="rgba(210, 168, 255, 0.12)"/>
       <text x="462" y="100" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="9" fill="#d2a8ff">value(output)</text>
     </g>

--- a/cuda-oxide-book/async-programming/images/device-operation-lifecycle.svg
+++ b/cuda-oxide-book/async-programming/images/device-operation-lifecycle.svg
@@ -44,11 +44,11 @@
 
       <!-- Code block -->
       <rect x="12" y="74" width="224" height="110" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-      <text x="24" y="96" font-family="'RobotoMono', monospace" font-size="11" fill="#79c0ff">cuda_launch_async! {</text>
+      <text x="24" y="96" font-family="'RobotoMono', monospace" font-size="11" fill="#79c0ff">unsafe { cuda_launch_async! {</text>
       <text x="24" y="114" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">  kernel: vecadd,</text>
       <text x="24" y="132" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">  module: module,</text>
       <text x="24" y="150" font-family="'RobotoMono', monospace" font-size="11" fill="#c9d1d9">  config: cfg,</text>
-      <text x="24" y="168" font-family="'RobotoMono', monospace" font-size="11" fill="#79c0ff">}</text>
+      <text x="24" y="168" font-family="'RobotoMono', monospace" font-size="11" fill="#79c0ff">} }</text>
 
       <!-- Type badge -->
       <rect x="24" y="198" width="200" height="28" rx="6" fill="rgba(121, 192, 255, 0.15)" stroke="#79c0ff" stroke-width="1"/>

--- a/cuda-oxide-book/async-programming/scheduling-and-streams.md
+++ b/cuda-oxide-book/async-programming/scheduling-and-streams.md
@@ -170,7 +170,7 @@ the GPU works).
 Here is the full journey of an operation from construction to completion:
 
 ```text
-module.kernel_async(...)       ← build the recipe (no GPU work)
+module.kernel_async(&prepared, ...)  ← build a checked recipe (no GPU work)
         │
         ▼
   AsyncKernelLaunch            ← a DeviceOperation, lazy and stream-agnostic
@@ -245,16 +245,19 @@ let buf_b = DeviceBuffer::from_host(&main, &data_b)?;
 let child_1 = main.fork()?;
 let child_2 = main.fork()?;
 
-// Run independent work in parallel
-module.process(&child_1, cfg, &mut buf_a)?;
-module.process(&child_2, cfg, &mut buf_b)?;
+// SAFETY: cfg matches process's indexing/resources and both buffers' bounds.
+// Run independent work in parallel.
+unsafe {
+    module.process(&child_1, cfg, &mut buf_a)?;
+    module.process(&child_2, cfg, &mut buf_b)?;
+}
 
 // Join: main waits for both children
 main.join(&child_1)?;
 main.join(&child_2)?;
 
-// Now safe to use buf_a and buf_b on main
-module.combine(&main, cfg, &buf_a, &buf_b)?;
+// SAFETY: cfg matches combine's indexing/resources and both input bounds.
+unsafe { module.combine(&main, cfg, &buf_a, &buf_b) }?;
 ```
 
 The GPU timeline for this looks like:
@@ -297,7 +300,8 @@ explicit flags to enable timing:
 use cuda_bindings::CUevent_flags_enum::CU_EVENT_DEFAULT;
 
 let start = stream.record_event(Some(CU_EVENT_DEFAULT))?;
-module.my_kernel(&stream, config)?;
+// SAFETY: config and arguments satisfy my_kernel's requirements.
+unsafe { module.my_kernel(&stream, config) }?;
 let end = stream.record_event(Some(CU_EVENT_DEFAULT))?;
 end.synchronize()?;
 println!("Kernel took {:.2} ms", start.elapsed_ms(&end)?);
@@ -316,7 +320,7 @@ advanced optimization.
 
 | Situation                                     | Recommended approach                                 |
 |:----------------------------------------------|:-----------------------------------------------------|
-| Simple script, one kernel                     | `module.kernel_async(...).sync()`                    |
+| Simple script, one contracted kernel          | `module.kernel_async(&prepared, ...).sync()`         |
 | Multi-stage pipeline (GEMM → ReLU → D2H)      | `and_then` chain, policy picks one stream            |
 | Independent batches running concurrently      | `tokio::spawn` each batch, round-robin distributes   |
 | Debugging a suspected stream-ordering bug     | Switch to `SingleStream`                             |

--- a/cuda-oxide-book/async-programming/the-device-operation-model.md
+++ b/cuda-oxide-book/async-programming/the-device-operation-model.md
@@ -82,7 +82,16 @@ init_device_contexts(0, 1)?;
 
 // Build the recipe (no GPU work yet)
 let module = kernels::load_async(0)?;
-let op = module.vecadd_async(LaunchConfig::for_num_elems(1024), &a_dev, &b_dev, &mut c_dev)?;
+// SAFETY: this is 1D, buffers contain 1024 elements, and module/scheduler
+// both use device 0's context.
+let op = unsafe {
+    module.vecadd_async(
+        LaunchConfig::for_num_elems(1024),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}?;
 
 // Now cook it: pick a stream, launch, wait for the result
 op.sync()?;
@@ -92,6 +101,15 @@ At the point where `op` is created, nothing has happened on the GPU. The method
 builds an `AsyncKernelLaunch` value that remembers which function to call, what
 arguments to pass, and how to configure the grid -- but it does not touch any
 stream. It is a recipe card sitting on the counter.
+
+The `unsafe` is about accepting an unproved raw `LaunchConfig`, not about
+building lazily. A contracted kernel uses a checked `PreparedLaunch<K>` and a
+safe generated async method:
+
+```text
+raw config -> unsafe async recipe
+prepared K -> safe async recipe for K
+```
 
 When you call `.sync()`, the scheduling policy picks a stream from its pool,
 submits the kernel, and blocks until the stream is idle. That single line is
@@ -193,9 +211,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_device_contexts(0, 1)?;
 
     let module = kernels::load_async(0)?;
-    module
-        .vecadd_async(LaunchConfig::for_num_elems(1024), &a_dev, &b_dev, &mut c_dev)?
-        .await?;
+    // SAFETY: this is 1D, buffers contain 1024 elements, and module/scheduler
+    // both use device 0's context.
+    unsafe {
+        module.vecadd_async(
+            LaunchConfig::for_num_elems(1024),
+            &a_dev,
+            &b_dev,
+            &mut c_dev,
+        )
+    }?
+    .await?;
 
     Ok(())
 }
@@ -300,8 +326,10 @@ helpers that slot cleanly into `and_then` chains.
 
 :::{tip}
 `with_context` is the escape hatch for raw driver calls that need a
-`CUstream`. For kernel launches, prefer generated async launch methods because
-they handle argument marshalling and buffer lifetimes.
+`CUstream`. For kernel launches, prefer contracted generated async methods:
+they handle argument marshalling and buffer lifetimes, and accept a checked
+`PreparedLaunch<K>`. Uncontracted generated methods still require an unsafe
+raw-launch proof.
 :::
 
 ## How the GPU tells Rust it is done

--- a/cuda-oxide-book/compiler/architecture-overview.md
+++ b/cuda-oxide-book/compiler/architecture-overview.md
@@ -307,7 +307,7 @@ handles before cuda-oxide ever sees the code:
 | :---------------- | :------------------------------------------------------------------------------------|
 | Type checking     | Catch errors before GPU compilation -- no cryptic PTX assembler failures             |
 | Lifetime tracking | Safety guarantees that span the host/device boundary                                 |
-| Borrow checking   | Prevent data races at compile time, even across GPU threads                          |
+| Borrow checking   | Enforce ordinary Rust aliasing; GPU-wide writes add `DisjointSlice` and launch proofs |
 | Monomorphization  | Generics "just work" on the GPU -- `map<f32, _>` becomes a concrete PTX kernel       |
 | MIR optimization  | Inlining, constant propagation, dead code elimination -- all applied before we begin |
 | Trait resolution  | Trait objects are resolved, vtables are gone, everything is static dispatch          |

--- a/cuda-oxide-book/compiler/mir-importer.md
+++ b/cuda-oxide-book/compiler/mir-importer.md
@@ -233,7 +233,7 @@ attention:
 | `bool`                | `IntegerType(1)`              | 1-bit integer, as is tradition       |
 | `(A, B, C)`           | `MirTupleType`                | Heterogeneous product type           |
 | `&[T]`                | `MirSliceType`                | Pointer + length                     |
-| `DisjointSlice<T>`    | `MirDisjointSliceType`        | Safety-verified mutable slice        |
+| `DisjointSlice<T>`    | `MirDisjointSliceType`        | Bounds-checked, typed-index mutable slice |
 | `struct Foo`          | `MirStructType`               | With field offsets from rustc layout |
 | `*mut T` / `*const T` | `MirPtrType`                  | With GPU address space               |
 | `enum Option<T>`      | `MirEnumType`                 | Discriminant + variants              |

--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -59,7 +59,7 @@ The dialect defines seven custom types that mirror Rust's compound types:
 | `mir.array`          | `mir.array<f32, 256>`                                     | Fixed-size arrays                                             |
 | `mir.struct`         | `mir.struct<"Point", [f32, f32]>`                         | Named structs with layout info                                |
 | `mir.slice`          | `mir.slice<f32, addrspace: 1>`                            | Fat pointers (ptr + length)                                   |
-| `mir.disjoint_slice` | `mir.disjoint_slice<f32>`                                 | Safety-checked slice -- each thread accesses a unique element |
+| `mir.disjoint_slice` | `mir.disjoint_slice<f32>`                                 | Bounds-checked slice carrying a typed index space              |
 | `mir.enum`           | `mir.enum<"Option_i32", [("None", []), ("Some", [i32])]>` | Rust enums with discriminant and variant payloads             |
 
 The address spaces on `mir.ptr` and `mir.slice` track where data lives in
@@ -140,11 +140,10 @@ Examples of what gets checked:
 - `mir.store` verifies that the value type matches the pointee type of the
   pointer.
 
-The `DisjointSlice` safety guarantee ("one thread, one element") is enforced
-at the type-system level via `ThreadIndex` -- only hardware-derived thread
-indices can access the slice. There is no separate compiler pass for
-disjoint-access verification; the safety comes from the Rust type system
-and `cuda-device`'s API design.
+`DisjointSlice` accepts only a matching `ThreadIndex`, so the type system checks
+the device-side index space. Host launch geometry completes the uniqueness
+proof through `PreparedLaunch<K>` or an unsafe raw-launch obligation. There is
+no separate disjoint-access compiler pass; the safety comes from these APIs.
 
 ---
 

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -92,15 +92,17 @@ fn main() {
     let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
     let module = kernels::load(&ctx).expect("Failed to load embedded module");
-    module
-        .vecadd(
+    // SAFETY: `for_num_elems` is 1D and all three buffers contain N elements.
+    unsafe {
+        module.vecadd(
             &stream,
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
         )
-        .unwrap();
+    }
+    .unwrap();
 
     let c_host = c_dev.to_host_vec(&stream).unwrap();
     let errors = (0..N)
@@ -146,13 +148,25 @@ The `#[device]` attribute exists but serves a different purpose: it marks a func
 
 ```rust
 let module = kernels::load(&ctx)?;
-module.vecadd(&stream, LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?;
+// SAFETY: this is a 1D launch and all three buffers contain N elements.
+unsafe {
+    module.vecadd(
+        &stream,
+        LaunchConfig::for_num_elems(N as u32),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}?;
 ```
 
 The loader reads the embedded device artifact from the host binary, caches kernel
 function handles, and exposes each `#[kernel]` as a Rust method. The method
 signature mirrors the kernel signature, with device slices mapped to
-`DeviceBuffer` borrows.
+`DeviceBuffer` borrows. This checks argument types, but a raw `LaunchConfig`
+does not prove that a 1D-index kernel was given a 1D launch. Raw generated
+launch methods are therefore unsafe. A declared launch contract enables the
+safe prepared path shown in [Launching Kernels](../gpu-programming/launching-kernels.md).
 
 `load_kernel_module` and `cuda_launch!` remain available as lower-level APIs
 for manual sidecar artifact loading and custom launch code. `cuda_launch!`
@@ -164,7 +178,7 @@ be wrapped in `unsafe { }`.
 Slices cross the host/device ABI as their `(ptr, len)` components -- the host passes them as two kernel arguments, and the device compiler reassembles the slice in the entry block. Structs and closures by value travel as one byval `.param` instead, so the host packet pushes the whole aggregate as a single slot (this matches what the launcher actually does and avoids mismatches with field-by-field declarations). All of this is fully transparent -- the kernel signature still looks like ordinary Rust:
 
 ```text
-Host:   module.vecadd(..., &data, ...)
+Host:   unsafe { module.vecadd(&stream, raw_config, &data, ...) }
           → extracts (ptr, len) for the slice, passes two args
 
 PTX:    .entry kernel(.param .u64 ptr, .param .u64 len, ...)
@@ -256,14 +270,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?;
 
     // 4. Launch -- returns a lazy DeviceOperation, no GPU work yet.
-    module
-        .vecadd_async(
+    // SAFETY: this is 1D, buffers contain N elements, and module/scheduler
+    // both use device 0's context.
+    unsafe {
+        module.vecadd_async(
             LaunchConfig::for_num_elems(N as u32),
             &a_dev,
             &b_dev,
             &mut c_dev,
-        )?
-        .sync()?;  // Block until the GPU finishes.
+        )
+    }?
+    .sync()?;  // Block until the GPU finishes.
 
     // 5. Copy results back to host.
     let mut c_host = vec![0.0f32; N];

--- a/cuda-oxide-book/gpu-programming/closures-and-generics.md
+++ b/cuda-oxide-book/gpu-programming/closures-and-generics.md
@@ -65,15 +65,17 @@ entry point:
 ```rust
 use cuda_core::LaunchConfig;
 
-module
-    .scale::<f32>(
+// SAFETY: config is 1D and both buffers cover every launched index.
+unsafe {
+    module.scale::<f32>(
         &stream,
         LaunchConfig::for_num_elems(N as u32),
         2.0f32,
         &input_dev,
         &mut output_dev,
     )
-    .expect("Launch failed");
+}
+.expect("Launch failed");
 ```
 
 The generated method forces monomorphization of `scale::<f32>` so the
@@ -102,8 +104,11 @@ add_value::<8> -> add_value_TID_<hash B>
 Use ordinary Rust turbofish syntax on the generated launch method:
 
 ```rust
-module.add_value::<4>(&stream, config, &mut output)?;
-module.add_value::<{ Config::VALUE }>(&stream, config, &mut output)?;
+// SAFETY: config matches the kernels' 1D indexing and output bounds.
+unsafe {
+    module.add_value::<4>(&stream, config, &mut output)?;
+    module.add_value::<{ Config::VALUE }>(&stream, config, &mut output)?;
+}
 ```
 
 The older `#[kernel(f32, i32)]` convenience form only supports one type
@@ -131,9 +136,11 @@ Launch with a closure:
 
 ```rust
 let factor = 3i32;
-module
-    .map::<_>(&stream, config, move |x| x * factor, &input_dev, &mut output_dev)
-    .expect("Launch failed");
+// SAFETY: config is 1D and both buffers cover every launched index.
+unsafe {
+    module.map::<_>(&stream, config, move |x| x * factor, &input_dev, &mut output_dev)
+}
+.expect("Launch failed");
 ```
 
 ### How closure arguments travel
@@ -275,8 +282,8 @@ pub mod kernels {
 use my_kernels::kernels;
 
 let module = kernels::load(&ctx)?;
-module
-    .vecadd(&stream, config, &a, &b, &mut c)
+// SAFETY: config is 1D and all three buffers cover every launched index.
+unsafe { module.vecadd(&stream, config, &a, &b, &mut c) }
     .expect("Launch failed");
 ```
 

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -93,7 +93,9 @@ A common workflow for catching device-side errors:
 
 ```rust
 // Launch kernel
-module.vecadd(&stream, config, &a, &b, &mut c).expect("Launch failed");
+// SAFETY: config matches vecadd's 1D indexing and all buffer bounds.
+unsafe { module.vecadd(&stream, config, &a, &b, &mut c) }
+    .expect("Launch failed");
 
 // Synchronize and check for traps
 stream.synchronize().expect("Kernel trapped -- check gpu_assert! conditions");
@@ -111,7 +113,8 @@ The synchronous launch path returns
 `Result<(), DriverError>`. The `DriverError` wraps a CUDA driver result code:
 
 ```rust
-match module.vecadd(&stream, config, &a, &b, &mut c) {
+// SAFETY: config matches vecadd's 1D indexing and all buffer bounds.
+match unsafe { module.vecadd(&stream, config, &a, &b, &mut c) } {
     Ok(()) => { /* launched successfully */ }
     Err(e) => eprintln!("Launch failed: {e}"),
 }
@@ -455,7 +458,7 @@ for the full profiling toolkit.
 
 | Pitfall                          | Symptom                                    | Fix                                                              |
 |:---------------------------------|:-------------------------------------------|:-----------------------------------------------------------------|
-| Race condition on output buffer  | Wrong results, non-deterministic           | Use `DisjointSlice` instead of raw `*mut T`                      |
+| Race condition on output buffer  | Wrong results, non-deterministic           | Use `DisjointSlice` plus matching prepared launch geometry      |
 | Missing `sync_threads()`         | Stale shared memory reads                  | Add barrier between writes and reads                             |
 | Wrong `shared_mem_bytes`         | `LAUNCH_OUT_OF_RESOURCES` or garbage data  | Match `LaunchConfig` to actual `DynamicSharedArray` usage        |
 | Out-of-bounds with raw pointers  | Trap or silent corruption                  | Use `DisjointSlice::get_mut` for bounds checking                 |

--- a/cuda-oxide-book/gpu-programming/execution-model.md
+++ b/cuda-oxide-book/gpu-programming/execution-model.md
@@ -52,9 +52,10 @@ pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
 }
 ```
 
-`thread::index_1d()` computes `blockIdx.x * blockDim.x + threadIdx.x` -- the
-global flat index that maps each thread to exactly one array element. This is the
-common case for 1D data-parallel kernels.
+`thread::index_1d()` computes `blockIdx.x * blockDim.x + threadIdx.x`. It maps
+threads to distinct array elements when grid and block Y/Z dimensions are 1.
+That is the common shape for 1D data-parallel kernels; a `domain = 1` prepared
+launch proves it.
 
 For cases where you need individual components, cuda-oxide exposes the raw
 accessors:
@@ -177,20 +178,36 @@ let cfg = LaunchConfig {
 };
 ```
 
-Then pass it to the generated launch method:
+Then pass it to the generated raw launch method. The call is unsafe because
+`LaunchConfig` itself does not prove that hidden Y/Z dimensions are inactive:
 
 ```rust
-module
-    .vecadd(&stream, LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)
-    .expect("Kernel launch failed");
+// SAFETY: `for_num_elems` is 1D and all three buffers contain N elements.
+unsafe {
+    module.vecadd(
+        &stream,
+        LaunchConfig::for_num_elems(N as u32),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}
+.expect("Kernel launch failed");
 ```
 
 Or with the async API:
 
 ```rust
-module
-    .vecadd_async(LaunchConfig::for_num_elems(N as u32), &a_dev, &b_dev, &mut c_dev)?
-    .sync()?;
+// SAFETY: this is 1D, buffers contain N elements, and module/scheduler share a context.
+unsafe {
+    module.vecadd_async(
+        LaunchConfig::for_num_elems(N as u32),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}?
+.sync()?;
 ```
 
 (execution-choosing-block-size)=

--- a/cuda-oxide-book/gpu-programming/launching-kernels.md
+++ b/cuda-oxide-book/gpu-programming/launching-kernels.md
@@ -37,12 +37,20 @@ In practice, `#[cuda_module]` handles steps 2--5 behind a generated Rust API.
 You normally interact with context creation, `kernels::load`, and a typed method
 call.
 
-## `#[cuda_module]` -- typed launch
+## `#[cuda_module]` -- typed arguments
 
 Wrap kernels in an inline `#[cuda_module]` module to generate a typed loader and
-one method per `#[kernel]`. The method is "synchronous" in the CUDA sense: you
-provide a specific stream and the kernel is enqueued immediately, though GPU
-execution still overlaps the host until you synchronize.
+one method per `#[kernel]`. The generated signature checks kernel arguments,
+but a raw `LaunchConfig` does not prove the kernel's indexing shape or resource
+requirements. The raw launch method is therefore unsafe.
+
+```text
+raw LaunchConfig   -> unsafe launch
+PreparedLaunch<K>  -> safe launch of exactly K
+```
+
+"Synchronous" here means that you provide a stream and enqueue immediately;
+GPU execution can still overlap the host until you synchronize.
 
 ```rust
 use cuda_device::{cuda_module, kernel, thread, DisjointSlice};
@@ -71,9 +79,11 @@ fn main() {
     let b = DeviceBuffer::from_host(&stream, &[2.0f32; 1024]).unwrap();
     let mut c = DeviceBuffer::<f32>::zeroed(&stream, 1024).unwrap();
 
-    module
-        .vecadd(&stream, LaunchConfig::for_num_elems(1024), &a, &b, &mut c)
-        .expect("Kernel launch failed");
+    // SAFETY: this is a 1D launch and all three buffers contain 1024 elements.
+    unsafe {
+        module.vecadd(&stream, LaunchConfig::for_num_elems(1024), &a, &b, &mut c)
+    }
+    .expect("Kernel launch failed");
 
     let result = c.to_host_vec(&stream).unwrap();
     assert_eq!(result[0], 3.0);
@@ -86,7 +96,7 @@ fn main() {
 |:-----------------------|:------------------------------------|
 | `#[cuda_module]`       | Generates loader and launch methods |
 | `kernels::load(&ctx)`  | Loads the embedded artifact bundle  |
-| `module.vecadd(...)`   | Enqueues a typed kernel launch      |
+| `module.vecadd(...)`   | Type-checks arguments; raw config requires `unsafe` |
 | `LaunchConfig`         | Grid/block dimensions and smem      |
 
 ### Argument mapping
@@ -102,10 +112,48 @@ The generated method maps kernel parameters to host values:
 
 ### Return value
 
-Typed launch methods return `Result<(), DriverError>`. The `Ok` case means the
+Raw typed launch methods return `Result<(), DriverError>`. The `Ok` case means the
 kernel was successfully **enqueued** -- not that it finished. To check for
 runtime errors (e.g., out-of-bounds trap), synchronize the stream or context
 afterward.
+
+## Safe prepared launches
+
+Declare the kernel's geometry when it is part of correctness:
+
+```rust
+use cuda_core::LaunchConfig1D;
+use cuda_device::{cuda_module, kernel, launch_bounds, launch_contract, thread, DisjointSlice};
+
+#[cuda_module]
+mod contracted {
+    use super::*;
+
+    #[kernel]
+    #[launch_bounds(256)]
+    #[launch_contract(domain = 1, block = (256, 1, 1))]
+    pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        if let Some(c_elem) = c.get_mut(idx) {
+            *c_elem = a[idx.get()] + b[idx.get()];
+        }
+    }
+}
+
+let module = contracted::load(&ctx)?;
+let config = LaunchConfig1D::new(4, 256, 0);
+let prepared = module.prepare_vecadd(config)?;
+module.vecadd(&stream, &prepared, &a, &b, &mut c)?;
+```
+
+`prepare_vecadd` checks the exact block shape, device limits, dynamic shared
+memory, context, and any cluster/cooperative requirements. `LaunchConfig1D`
+cannot represent active Y/Z dimensions, and `PreparedLaunch<vecadd>` cannot be
+used with another kernel. Preparation may fail; once it succeeds, the branded
+launch can be reused safely.
+
+For a contracted kernel, the raw escape hatch is named `vecadd_unchecked` and
+remains unsafe. Uncontracted kernels expose only unsafe raw launch methods.
 
 ## `cuda_launch!` -- unsafe lower-level launch
 
@@ -125,8 +173,8 @@ use cuda_host::{cuda_launch, load_kernel_module};
 
 let module = load_kernel_module(&ctx, "vecadd").unwrap();
 
-// SAFETY: args match vecadd's signature (three slices); a, b, c are live
-// device buffers.
+// SAFETY: args match vecadd, buffers are live, and the config is 1D with
+// bounds guarded by c.get_mut(idx).
 unsafe {
     cuda_launch! {
         kernel: vecadd,
@@ -166,7 +214,7 @@ such as `sm_90a`, or for running newer-GPU artifacts on older GPUs.
 The driver must also support the PTX version produced by the selected toolkit.
 CUDA error 222 means the toolkit is too new for the driver's PTX JIT; select a
 compatible toolkit or upgrade the driver. The
-[installation guide](../getting-started/installation.md#installation-toolkit-driver-compatibility)
+{ref}`installation guide <installation-toolkit-driver-compatibility>`
 explains why this can differ from the normal LLVM-to-PTX path.
 
 ## `LaunchConfig`
@@ -198,8 +246,8 @@ let config = LaunchConfig::for_num_elems(N as u32);
 ```
 
 This uses 256 threads per block and computes the grid size via ceiling
-division: `grid_x = (N + 255) / 256`. It's the right default for most
-element-wise operations.
+division: `grid_x = (N + 255) / 256`. It is a convenient 1D shape, but it is
+still raw data; only preparation ties a configuration to a kernel.
 
 ### 2D and 3D configurations
 
@@ -240,12 +288,15 @@ use cuda_async::device_operation::DeviceOperation;
 init_device_contexts(0, 1)?;
 let module = kernels::load_async(0)?;
 
-let op = module.vecadd_async(
-    LaunchConfig::for_num_elems(1024),
-    &a_dev,
-    &b_dev,
-    &mut c_dev,
-)?;
+// SAFETY: this is 1D, buffers contain 1024 elements, and module/scheduler share a context.
+let op = unsafe {
+    module.vecadd_async(
+        LaunchConfig::for_num_elems(1024),
+        &a_dev,
+        &b_dev,
+        &mut c_dev,
+    )
+}?;
 
 // Execute and wait
 op.sync()?;
@@ -257,12 +308,15 @@ future:
 ```rust
 use std::future::IntoFuture;
 
-let op = module.vecadd_async_owned(
-    LaunchConfig::for_num_elems(1024),
-    a_dev,
-    b_dev,
-    c_dev,
-)?;
+// SAFETY: this is 1D, owned buffers contain 1024 elements, and contexts match.
+let op = unsafe {
+    module.vecadd_async_owned(
+        LaunchConfig::for_num_elems(1024),
+        a_dev,
+        b_dev,
+        c_dev,
+    )
+}?;
 
 let (a_dev, b_dev, c_dev) = tokio::spawn(op.into_future()).await??;
 ```
@@ -286,10 +340,11 @@ owned typed shape:
   spawned task owns the allocation until completion
 ```
 
-`cuda_launch_async!` remains as a lower-level migration API, but prefer the
-generated borrowed or owned methods for new code. Raw pointer async launches are
-only correct when the caller can prove the pointed-to allocation outlives the
-lazy operation.
+For a contracted kernel, both async forms accept `&PreparedLaunch<K>` and are
+safe. `cuda_launch_async!` remains a lower-level unsafe migration API; its
+invocation must be inside an `unsafe` block. Raw pointer async launches are only
+correct when the caller can prove that the allocation outlives the lazy
+operation.
 
 ### `.sync()` vs `.await`
 
@@ -346,7 +401,8 @@ On the host, the launch uses `launch_kernel_ex` (the extended launch API) with
 cluster dimensions. `cuda_launch!` supports this via the `cluster_dim` field:
 
 ```rust
-// SAFETY: args match cluster_kernel's signature; out_dev is a live buffer.
+// SAFETY: args/config match cluster_kernel, including its 4-block cluster;
+// out_dev stays live through synchronization.
 unsafe {
     cuda_launch! {
         kernel: cluster_kernel,
@@ -395,7 +451,8 @@ mod kernels {
 }
 
 let module = kernels::load(&ctx)?;
-module.grid_sync_kernel(&stream, config, &mut out_dev)?; // cooperative launch
+// SAFETY: config satisfies the kernel's indexing, residency, and output bounds.
+unsafe { module.grid_sync_kernel(&stream, config, &mut out_dev) }?;
 ```
 
 Unlike `#[cluster_launch]`, the attribute changes nothing in the PTX; it only

--- a/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
+++ b/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
@@ -222,7 +222,8 @@ prevents two threads from writing to the same location.
 
 cuda-oxide provides `DisjointSlice<T, IndexSpace>` as a safe alternative. It
 wraps a mutable slice and only allows writes through a `ThreadIndex` whose
-`IndexSpace` matches its own, ensuring each thread accesses a unique element:
+`IndexSpace` matches its own. Combined with matching prepared launch geometry,
+this ensures each thread accesses a unique element:
 
 ```rust
 use cuda_device::{kernel, DisjointSlice};
@@ -263,6 +264,17 @@ hardware**: every thread in a block receives a unique `threadIdx` from the GPU's
 warp scheduler. For 1D grid launches (where only the x dimension is used), the
 global index derived from `blockIdx.x * blockDim.x + threadIdx.x` is unique
 across the entire grid.
+
+That last statement is conditional: `index_1d()` ignores Y and Z. A 2D grid
+would repeat the same X-derived index for every Y coordinate.
+
+```text
+PreparedLaunch(domain=1) -> Y/Z inactive -> safe DisjointSlice writes
+raw LaunchConfig         -> caller proves Y/Z inactive -> unsafe launch
+```
+
+The witness proves the device-side index space; the prepared launch proves the
+host-side geometry. Both are needed for a fully safe launch.
 
 The witness is also `!Send + !Sync + !Copy + !Clone`, and its `'kernel`
 lifetime is borrowed from a stack-local scope the macros inject -- so a

--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -8,8 +8,8 @@ pointing at the same output buffer. The borrow checker was not designed for
 this.
 
 cuda-oxide solves the problem in layers. The common case -- one thread writes
-one element -- is safe by construction, no `unsafe` required. The uncommon
-cases -- shared memory, warp shuffles, hardware intrinsics -- require
+one element under a checked launch contract -- is safe by construction.
+Uncommon cases -- shared memory, warp shuffles, hardware intrinsics -- require
 `unsafe` with documented contracts. And the frontier cases -- TMA, tensor
 cores, cluster-level communication -- are fully manual, matching the
 complexity of the hardware they control.
@@ -26,7 +26,7 @@ compiler can verify:
 
 | Tier       | Description                                             | `unsafe` Required? |
 |:-----------|:--------------------------------------------------------|:-------------------|
-| **Tier 1** | Safe by construction -- the type system prevents misuse | No                 |
+| **Tier 1** | Safe kernel body plus a checked `PreparedLaunch`         | No                 |
 | **Tier 2** | Explicit `unsafe` with clear safety contracts           | Yes, scoped        |
 | **Tier 3** | Raw hardware intrinsics -- full user responsibility     | Yes, pervasive     |
 
@@ -41,8 +41,8 @@ rarely leave Tier 2.
 
 ### The core idea: `DisjointSlice<T>` + `ThreadIndex`
 
-The primary safety abstraction is a pair of types that together guarantee
-race-free parallel writes without `unsafe` at the call site:
+The primary device-side safety abstraction is a pair of types that together
+support race-free parallel writes:
 
 - **`ThreadIndex<'kernel, IndexSpace>`** -- an opaque witness around a
   `usize`, with no public constructor. The only way to obtain one is
@@ -58,7 +58,7 @@ race-free parallel writes without `unsafe` at the call site:
   matches its own. Returns `Option<&mut T>` -- `None` for out-of-bounds
   indices.
 
-Put them together and you get a kernel with zero `unsafe`:
+Put them together and you get a kernel body with zero `unsafe`:
 
 ```rust
 use cuda_device::{kernel, DisjointSlice};
@@ -88,20 +88,27 @@ pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
 }
 ```
 
-Safety follows from four facts:
+Safety follows from five facts:
 
-1. `index_1d()` produces a unique value per thread (hardware guarantee:
-   `threadIdx.x < blockDim.x`, so the linear index
-   `blockIdx.x * blockDim.x + threadIdx.x` is unique across the grid).
+1. `index_1d()` uses only X coordinates. Its value is unique when block and
+   grid Y/Z dimensions are all 1. A `domain = 1` prepared launch proves that;
+   a raw launch must prove it in its `unsafe` block.
 2. `get_mut()` is bounds-checked -- out-of-range threads get `None`.
 3. The `IndexSpace` parameter ties each witness to its layout: a
    `DisjointSlice<T, Index2D<128>>` will not accept a
    `ThreadIndex<'_, Index2D<256>>` -- mixing strides is a compile error.
 4. The witness is `!Send + !Sync + !Copy + !Clone` and `'kernel`-scoped,
    so threads cannot launder each other's indices through shared memory.
+5. A checked `PreparedLaunch<K>` ties the host geometry to the exact kernel.
 
 The borrow checker sees a single `&mut T` per thread. The hardware
-guarantees the indices are disjoint. The type system ties the two together.
+provides the coordinates; the launch proof makes their linearization disjoint.
+The type system ties the device and host proofs together.
+
+```text
+1D prepared launch: Y=Z=1 -> index_1d values are unique -> safe get_mut
+raw 2D launch:       grid/block Y > 1 repeats X indices -> caller-unsafe
+```
 
 ### Trusted index functions
 
@@ -110,7 +117,7 @@ are the constructors cuda-oxide provides:
 
 | Function                      | Formula                                 | Return Type                                            | Notes                                            |
 |:------------------------------|:----------------------------------------|:-------------------------------------------------------|:-------------------------------------------------|
-| `index_1d()`                  | `blockIdx.x * blockDim.x + threadIdx.x` | `ThreadIndex<'kernel, Index1D>`                        | Unconditionally unique per thread                |
+| `index_1d()`                  | `blockIdx.x * blockDim.x + threadIdx.x` | `ThreadIndex<'kernel, Index1D>`                        | Unique only for a 1D launch (Y/Z inactive)        |
 | `index_2d::<S>()`             | `row * S + col`                         | `Option<ThreadIndex<'kernel, Index2D<S>>>`             | Const stride; mixing strides is a compile error  |
 | `unsafe index_2d_runtime(s)`  | `row * s + col`                         | `Option<ThreadIndex<'kernel, Runtime2DIndex>>`         | Caller asserts every thread used the same `s`    |
 | `index_2d_row()`              | `blockIdx.y * blockDim.y + threadIdx.y` | `usize`                                                | Component accessor, not a witness constructor    |
@@ -119,6 +126,8 @@ are the constructors cuda-oxide provides:
 `index_2d_row()` and `index_2d_col()` return plain `usize` -- they give
 you the components for arithmetic, but cannot be used to index into a
 `DisjointSlice`. Only the linearized result earns a `ThreadIndex`.
+Likewise, 2D uniqueness assumes the launch has no active Z dimension. A
+`domain = 2` prepared launch proves that; a raw launch must assert it.
 
 ### How `index_2d` is type-safe
 
@@ -216,14 +225,16 @@ guards against reading garbage from the input matrices.
 
 ### What makes a kernel Tier 1
 
-A kernel is fully safe -- Tier 1 -- when:
+A kernel and its launch are fully safe -- Tier 1 -- when:
 
 1. All mutable output access goes through `DisjointSlice::get_mut(ThreadIndex)`
 2. All inputs are shared immutable references (`&[T]`)
 3. No shared memory, no raw pointers, no intrinsics beyond thread indexing
+4. The host uses a matching checked `PreparedLaunch<K>`
 
 Examples in this tier include `vecadd`, `helper_fn`, `generic`, `host_closure`,
-and the naive GEMM kernels in the `gemm` and `async_mlp` examples.
+and the naive GEMM kernels in the `gemm` and `async_mlp` examples when launched
+through matching contracts. Their raw `LaunchConfig` paths remain unsafe.
 
 ---
 
@@ -376,7 +387,7 @@ provides on the CPU is also enforced on the GPU:
 | Guarantee                            | How It Works                                                                                                                                             |
 |:-------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Ownership and borrowing**          | Lifetime errors, use-after-free, and aliasing violations caught at compile time                                                                          |
-| **Safe parallel writes**             | `DisjointSlice<T>` + `ThreadIndex` -- type-level proof that writes do not race                                                                           |
+| **Safe parallel writes**             | `DisjointSlice<T>` + `ThreadIndex` + matching prepared geometry prove that writes do not race                                                            |
 | **Explicit `unsafe` scoping**        | Raw pointer access requires `unsafe`, making obligations visible and auditable                                                                           |
 | **Convergent attribute enforcement** | Sync primitives (barriers, fences, shuffles) marked `convergent` in the IR, preventing the optimizer from moving or duplicating them across control flow |
 
@@ -484,7 +495,8 @@ The rules:
 
 - Use `DisjointSlice` for all mutable outputs.
 - Use `&[T]` for all read-only inputs.
-- For 1D grids, default to `get_mut_indexed()`. If you need the index for
+- For 1D grids, declare `launch_contract(domain = 1, ...)` and use a prepared
+  launch. Inside the kernel, default to `get_mut_indexed()`. If you need the index for
   arithmetic against multiple slices, fall back to the explicit pair:
   `let idx = thread::index_1d(); slice.get_mut(idx)`.
 - For const-stride 2D grids, parameterise the slice as
@@ -496,7 +508,9 @@ The rules:
 - Always bounds-check via `get_mut()` / `get_mut_indexed()` (both return
   `Option`).
 
-If your kernel compiles without `unsafe`, it is race-free by construction.
+If the kernel body compiles without `unsafe`, it satisfies the device-side
+part of the proof. Race freedom also requires a matching prepared launch, or
+an explicit unsafe proof for a raw configuration.
 
 ### When you need `unsafe`
 
@@ -541,7 +555,7 @@ the code until the argument is obvious, or use a safe API instead.
 | Property                                                        | Status                                               |
 |:----------------------------------------------------------------|:-----------------------------------------------------|
 | Borrow checker on device code                                   | Enforced (real `rustc` frontend)                     |
-| Safe 1D parallel writes (`DisjointSlice + index_1d`)            | Enforced                                             |
+| Safe 1D parallel writes (`DisjointSlice + index_1d`)            | Enforced with a `domain = 1` prepared launch         |
 | Safe 2D parallel writes -- const stride                         | Enforced (`Index2D<S>` mismatch is a compile error)  |
 | Safe 2D parallel writes -- runtime stride                       | Caller-asserted via `unsafe index_2d_runtime`        |
 | `ThreadIndex` non-transferable across threads (smem laundering) | Enforced (`!Send + !Sync + !Copy + !Clone + 'kernel`)|
@@ -559,7 +573,7 @@ prevent. Until the macro rejects `&mut [T]` outright (or rewrites it to
 `DisjointSlice`), treat any kernel that takes one as if every line in it
 were `unsafe`.
 
-The safety model is designed to make the common case safe by default while
-providing explicit escape hatches for everything else. Write your kernel,
-let the type system catch the races, and save `unsafe` for the parts where
-you genuinely know something the compiler does not.
+The safety model is designed to make the common case safe through a kernel
+body plus a prepared launch, while providing explicit escape hatches for
+everything else. Use `unsafe` only when you are supplying a proof that the
+compiler and launch contract do not carry.

--- a/cuda-oxide-book/index.md
+++ b/cuda-oxide-book/index.md
@@ -52,9 +52,11 @@ fn main() {
     let b = DeviceBuffer::from_host(&stream, &[2.0f32; 1024]).unwrap();
     let mut c = DeviceBuffer::<f32>::zeroed(&stream, 1024).unwrap();
 
-    module
-        .vecadd(&stream, LaunchConfig::for_num_elems(1024), &a, &b, &mut c)
-        .unwrap();
+    // SAFETY: this is a 1D launch and all three buffers contain 1024 elements.
+    unsafe {
+        module.vecadd(&stream, LaunchConfig::for_num_elems(1024), &a, &b, &mut c)
+    }
+    .unwrap();
 
     let result = c.to_host_vec(&stream).unwrap();
     assert_eq!(result[0], 3.0);
@@ -66,6 +68,10 @@ Build and run with `cargo oxide run vecadd` upon installing the [prerequisites](
 :::{note}
 `#[cuda_module]` embeds the generated device artifact into the host binary and
 generates a typed `kernels::load` function plus one launch method per kernel.
+Kernel arguments are type-checked. A raw `LaunchConfig` call is still unsafe
+because the configuration does not prove the kernel's indexing shape or
+resource requirements. A declared launch contract provides the safe
+`PreparedLaunch` path described in [Launching Kernels](gpu-programming/launching-kernels.md).
 The lower-level `load_kernel_module` and unsafe `cuda_launch!` APIs remain
 available when you need to load a specific sidecar artifact or build custom
 launch code.

--- a/cuda-oxide-book/projects/async-mlp-pipeline.md
+++ b/cuda-oxide-book/projects/async-mlp-pipeline.md
@@ -133,9 +133,10 @@ pub fn sgemm_naive(
 ```
 
 Each thread computes one element of the output matrix. The 2D thread index
-maps directly to the (row, col) position. `DisjointSlice<f32>` is the safe
-mutable view — it guarantees at compile time that each thread writes to a
-distinct element, so no data race, no `unsafe`.
+maps directly to the (row, col) position. `DisjointSlice` checks bounds and
+requires the matching index-space type. The remaining proof is explicit: every
+thread uses the same runtime stride, Z is inactive, and the raw 2D launch shape
+matches the kernel.
 
 :::{tip}
 This is intentionally a *naive* GEMM — one thread, one element, no shared
@@ -187,7 +188,7 @@ pub fn relu(input: &[f32], mut output: DisjointSlice<f32>) {
 
 Elementwise `max(0, x)`. In the pipeline, `input` and `output` point to the
 same buffer — a perfectly valid in-place pattern since each thread reads and
-writes the same index.
+writes the same index and the launch is 1D.
 
 ### What to notice
 
@@ -196,7 +197,7 @@ A few patterns that recur across all three kernels:
 | Pattern                                   | What it does                                                                                               |
 | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------|
 | `thread::index_1d()` / `index_2d::<S>()`  | Computes the global thread index from block/grid dimensions                                                |
-| `DisjointSlice<f32>`                      | Safe mutable output — compiler guarantees no aliasing                                                      |
+| `DisjointSlice<f32>`                      | Bounds-checked mutable output; launch geometry completes the uniqueness proof                              |
 | `if let Some(elem) = slice.get_mut(idx)`  | Bounds check that silences threads beyond the data size                                                    |
 | `while` loops instead of `for`            | Stylistic choice — `for` loops with ranges also work on device, but `while` makes the loop bounds explicit |
 
@@ -336,43 +337,58 @@ copies.
 This is where the magic lives. For each batch, we build a four-stage chain:
 
 ```rust
+    use cuda_async::launch::{AsyncKernelLaunchBuilder, OwnedAsyncKernelLaunch};
+
     let pipeline = zip!(h2d(batch_data), zeros(DIM * DIM), zeros(DIM))
         .and_then(move |(input, hidden, output)| {
             // Stage 1: GEMM — hidden = input @ W0
             let func = module.load_function("sgemm_naive").unwrap();
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch.push_args((
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((
                 DIM as u32, DIM as u32, DIM as u32,
                 1.0f32,
                 input.cu_deviceptr(), input.len() as u64,
                 w0.cu_deviceptr(), w0.len() as u64,
                 0.0f32,
                 hidden.cu_deviceptr(), hidden.len() as u64,
-            )).set_launch_config(gemm_cfg);
-            launch.and_then(move |()| value((hidden, output, w1, module)))
+            ));
+            // SAFETY: packet/config match sgemm_naive, the scheduler uses the
+            // module's context, and the owned wrapper retains its allocations.
+            let launch = unsafe { builder.finalize_unchecked(gemm_cfg) };
+            let launch = OwnedAsyncKernelLaunch::new(launch, (input, w0, hidden));
+            launch.and_then(move |(_input, _w0, hidden)| {
+                value((hidden, output, w1, module))
+            })
         })
         .and_then(move |(hidden, output, w1, module)| {
             // Stage 2: MatVec — output = hidden @ W1
             let func = module.load_function("matvec_naive").unwrap();
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch.push_args((
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((
                 DIM as u32, DIM as u32,
                 hidden.cu_deviceptr(), hidden.len() as u64,
                 w1.cu_deviceptr(), w1.len() as u64,
                 output.cu_deviceptr(), output.len() as u64,
-            )).set_launch_config(matvec_cfg);
-            launch.and_then(move |()| value((output, module)))
+            ));
+            // SAFETY: packet/config match matvec_naive, the scheduler uses the
+            // module's context, and the owned wrapper retains its allocations.
+            let launch = unsafe { builder.finalize_unchecked(matvec_cfg) };
+            let launch = OwnedAsyncKernelLaunch::new(launch, (hidden, w1, output));
+            launch.and_then(move |(_hidden, _w1, output)| value((output, module)))
         })
         .and_then(move |(output, module)| {
             // Stage 3: ReLU — result = max(0, output)
             let func = module.load_function("relu").unwrap();
             let relu_out: DeviceBox<[f32]> = output;
-            let mut launch = AsyncKernelLaunch::new(Arc::new(func));
-            launch.push_args((
+            let mut builder = AsyncKernelLaunchBuilder::new(Arc::new(func));
+            builder.push_args((
                 relu_out.cu_deviceptr(), relu_out.len() as u64,
                 relu_out.cu_deviceptr(), relu_out.len() as u64,
-            )).set_launch_config(relu_cfg);
-            launch.and_then(move |()| value(relu_out))
+            ));
+            // SAFETY: packet/config match relu, the scheduler uses the module's
+            // context, and the owned wrapper retains output.
+            let launch = unsafe { builder.finalize_unchecked(relu_cfg) };
+            OwnedAsyncKernelLaunch::new(launch, relu_out)
         })
         .and_then(d2h);
 ```
@@ -403,6 +419,12 @@ required for `zip!` to work.
 **In-place ReLU.** Stage 3 passes `relu_out` as both `input` and `output`
 to the kernel. Since each thread reads `input[idx]` and writes `output[idx]`
 at the same index, this is safe — no thread reads another's write.
+
+**Raw launch boundary.** The builder is inert. `finalize_unchecked` is where
+the raw packet and geometry become runnable, so each call has a local safety
+proof. `OwnedAsyncKernelLaunch` keeps its buffers alive. Prefer generated
+owned-async methods with `PreparedLaunch<K>` when the kernel declares a launch
+contract.
 
 ### Step 4: Spawn and collect
 


### PR DESCRIPTION
## Summary

Make a safe host launch prove that its geometry and resources match the exact
compiled kernel. Raw launch configurations remain available through an
explicit unsafe path.

The bug is easiest to see with `thread::index_1d()`:

```text
block_dim = (8, 2, 1)

thread y=0:  x=0 1 2 3 4 5 6 7 -> index 0 1 2 3 4 5 6 7
thread y=1:  x=0 1 2 3 4 5 6 7 -> index 0 1 2 3 4 5 6 7
                                           ^ indexes repeat

thread (x=7, y=0) --+
                      +--> output[7]  <- two writers
thread (x=7, y=1) --+
```

Both indexes are in bounds, so a bounds check cannot catch this. Before this
PR, a safe generated host method accepted the raw 2-D `LaunchConfig`.

## Safe and raw paths

The kernel declares its assumptions once:

```rust
#[kernel]
#[launch_bounds(256)]
#[launch_contract(
    domain = 1,
    block = (256, 1, 1),
    dynamic_shared = 0,
)]
pub fn mixed_abi(/* ... */, mut output: DisjointSlice<f32>) { /* ... */ }
```

The host prepares and reuses a checked launch:

```rust
let prepared = module.prepare_mixed_abi(
    LaunchConfig1D::new(blocks, 256, 0),
)?;

module.mixed_abi(&stream, &prepared, /* arguments */)?;
```

```text
LaunchConfig1D
      | contract + live CUDA checks
      v
PreparedLaunch<mixed_abi>
      | immutable and tied to this exact kernel specialization
      v
safe launch

raw LaunchConfig -----------------------------> unsafe launch
```

Wrong rank and wrong kernel proof are compile errors. Preparation rejects
wrong block/shared-memory requirements, live device or function limits,
compute capability, cluster/cooperative residency, and context mismatches.

## Launch bounds are not launch contracts

`#[launch_bounds(256, 2)]` already existed. It tells the device compiler that a
block has at most 256 total threads and asks it to target at least two resident
blocks per SM. It does not choose an exact block shape.

```text
launch_bounds(256)          compiler side -> at most 256 total threads
launch_contract block=256   host side     -> exactly (256, 1, 1)
```

## Breaking changes

- Uncontracted generated sync, borrowed-async, and owned-async methods keep
  their names but now require an unsafe call.
- `cuda_launch_async!` now exposes the same unsafe raw-launch obligation.
- Direct async construction moves from mutable `AsyncKernelLaunch` setters to
  `AsyncKernelLaunchBuilder -> unsafe finalize_unchecked -> immutable launch`.
- Custom `KernelSliceArg` / `KernelSliceArgMut` implementations require
  `unsafe impl`; custom async kernel arguments must be `Send`.

The low-level `cuda-core` launch functions and `cuda_launch!` were already
unsafe. `LaunchConfig` itself remains safe inert data. There is no
kernel-argument ABI change, and `thread::index_1d()` keeps the same formula.

## What changed

- Add rank-preserving `LaunchConfig1D`, `LaunchConfig2D`, and `LaunchConfig3D`.
- Add immutable `LaunchContractSpec` and kernel-branded `PreparedLaunch<K>`.
- Generate preparation, safe prepared sync/async methods, and unsafe raw escape
  hatches.
- Validate exact/max block requirements, dynamic shared memory and alignment,
  live device/function limits, compute capability, clusters, cooperative
  residency, and stream context.
- Cross-check contracted writable `DisjointSlice` parameters against the
  declared launch domain.
- Propagate the strongest dynamic-shared alignment through ordinary and
  generic device call graphs before LLVM inlining.
- Migrate examples, templates, READMEs, and the book to the safe/raw split.

## Boundary

The contract is an author declaration; cuda-oxide does not infer the kernel's
algorithm, pointer validity, or problem-shape rules. A source `unsafe fn`
kernel still generates an unsafe prepared method. Loading a contracted module
also remains unsafe because the caller must attest that the PTX matches the
generated Rust markers.

This PR does **not** add the 32-bit coordinates and proof-carrying device views
from #319, or the compile-time policy vocabulary from #320.

After the PTX provenance promise, safe code cannot launch a 1-D contracted
kernel with hidden Y/Z dimensions. Bypassing that proof requires an explicit
unsafe call.

Closes #115.

## Testing

- [x] All live CI checks pass at `6adb4ba`
- [x] Unit, integration, compile-fail, doctest, clippy, and rustdoc coverage
- [x] `scripts/smoketest.sh --compile-only --no-color`: **131/131 passed**
- [x] CPU-only PTX verification of launch bounds and shared-memory alignment
- [ ] GPU execution (not available in this environment)
