### PR TITLE
Add cargo oxide sanitize for NVIDIA Compute Sanitizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "clap",
  "libnvvm-sys",
  "nvjitlink-sys",
+ "serde_json",
  "toml",
 ]
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ cargo oxide run host_closure
 # Show full compilation pipeline (Rust MIR → dialect-mir → mem2reg → LLVM dialect → LLVM IR → PTX)
 cargo oxide pipeline vecadd
 
+# Run CUDA correctness checks
+cargo oxide sanitize vecadd --tool memcheck
+
 # Debug with cuda-gdb
 cargo oxide debug vecadd --tui
 ```
@@ -115,7 +118,7 @@ cargo oxide debug vecadd --tui
 
 ### Requirements
 
-- **cargo-oxide** — cargo subcommand that drives the build pipeline (`cargo oxide run`, `build`, `debug`, etc.)
+- **cargo-oxide** — cargo subcommand that drives the build pipeline (`cargo oxide run`, `build`, `sanitize`, `debug`, etc.)
 - **Rust nightly** with `rust-src` and `rustc-dev` and `llvm-tools` components (pinned in `rust-toolchain.toml`)
 - **CUDA Toolkit** (12.x+)
 - **Clang + libclang dev headers** (`clang-21` / `libclang-common-21-dev`) — needed by `bindgen` when building the host `cuda-bindings` crate
@@ -214,6 +217,9 @@ cargo oxide doctor
 
 # Build and run an example end-to-end
 cargo oxide run vecadd
+
+# Run the same example under NVIDIA Compute Sanitizer
+cargo oxide sanitize vecadd
 ```
 
 `cargo oxide doctor` validates your Rust toolchain, CUDA toolkit, LLVM, and

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -20,4 +20,5 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
+serde_json = "1"
 toml = "1"

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -31,6 +31,7 @@ cargo oxide test                    # cargo test with cuda-oxide defaults
 cargo oxide test -- -p my_app       # arbitrary cargo test through cuda-oxide
 cargo oxide pipeline vecadd         # verbose pipeline dump
                                     # (MIR -> dialect-mir -> LLVM dialect -> LLVM IR -> PTX)
+cargo oxide sanitize vecadd         # build + run under NVIDIA Compute Sanitizer
 cargo oxide debug vecadd --tui      # build + launch cuda-gdb
 cargo oxide fmt                     # format all crates
 cargo oxide fmt --check             # check formatting
@@ -43,14 +44,15 @@ cargo oxide setup                   # explicitly build the codegen backend
 | Flag                         | Applies to                       | Description                                     |
 |------------------------------|----------------------------------|-------------------------------------------------|
 | `--emit-nvvm-ir`             | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
-| `--arch <sm_XX>`             | run, build, test, pipeline, emit-ltoir | Target architecture override          |
-| `--features <F>`             | run, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
+| `--arch <sm_XX>`             | run, sanitize, build, test, pipeline, emit-ltoir | Target architecture override |
+| `--features <F>`             | run, sanitize, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
+| `--tool <T>`                 | sanitize                         | Compute Sanitizer tool: `memcheck`, `racecheck`, `initcheck`, or `synccheck` |
 | `-o, --output <P>`           | emit-ltoir                       | Output path for the `.ltoir` artifact           |
 | `--cargo-target-dir <PATH>`  | build/test passthrough           | Cargo target directory                          |
 | `--device-codegen-crate <LIST>` | build/test passthrough        | Comma-separated device owner crate filter       |
 | `--device-cfg <NAME>`        | build/test passthrough           | Append `--cfg NAME` to rustflags                |
-| `-v, --verbose`              | run, build, test, emit-ltoir     | Show detailed compilation output                |
-| `--no-fmad`                  | run, build, pipeline             | Disable FMA contraction (keep separate mul+add) |
+| `-v, --verbose`              | run, sanitize, build, test, emit-ltoir | Show detailed compilation output           |
+| `--no-fmad`                  | run, sanitize, build, pipeline   | Disable FMA contraction (keep separate mul+add) |
 | `--async`                    | new                              | Use the async template                          |
 | `--cgdb`                     | debug                            | Use cgdb instead of cuda-gdb                    |
 | `--tui`                      | debug                            | Use GDB's TUI interface                         |
@@ -93,6 +95,27 @@ configured location, and then builds/runs the host crate normally.
 `cutile_inter_kernel` uses this path:
 the host crate is a cutile-rs program, while `simt/` is a cuda-oxide SIMT PTX
 crate loaded by the host at runtime.
+
+### `cargo oxide sanitize <example>`
+
+Builds an example like `cargo oxide run`, then executes the produced release
+binary under NVIDIA Compute Sanitizer. `memcheck` is the default tool; use
+`--tool racecheck`, `--tool initcheck`, or `--tool synccheck` for shared-memory
+hazard, uninitialized global-memory, or synchronization checks.
+
+```bash
+cargo oxide sanitize vecadd --arch sm_75
+cargo oxide sanitize sharedmem --tool racecheck
+cargo oxide sanitize debug --tool synccheck -- --kernel-name kns=sync
+cargo oxide sanitize vecadd -- --leak-check full
+cargo oxide sanitize my_app -- --leak-check full -- --app-flag value
+```
+
+Arguments after the first `--` are passed to `compute-sanitizer` before the
+executable. A second `--` splits target program arguments, matching
+`compute-sanitizer [options] [your-program] [your-program-options]`.
+NVIDIA recommends treating the tools as complementary: `racecheck`,
+`initcheck`, and `synccheck` do not replace `memcheck` memory-access checking.
 
 ### `cargo oxide build <example>`
 

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -52,7 +52,7 @@ cargo oxide setup                   # explicitly build the codegen backend
 | `--device-codegen-crate <LIST>` | build/test passthrough        | Comma-separated device owner crate filter       |
 | `--device-cfg <NAME>`        | build/test passthrough           | Append `--cfg NAME` to rustflags                |
 | `-v, --verbose`              | run, sanitize, build, test, emit-ltoir | Show detailed compilation output           |
-| `--no-fmad`                  | run, sanitize, build, pipeline   | Disable FMA contraction (keep separate mul+add) |
+| `--no-fmad`                  | run, sanitize, build, pipeline   | Request separate mul+add; backend limitation tracked in [#315](https://github.com/NVlabs/cuda-oxide/issues/315) |
 | `--async`                    | new                              | Use the async template                          |
 | `--cgdb`                     | debug                            | Use cgdb instead of cuda-gdb                    |
 | `--tui`                      | debug                            | Use GDB's TUI interface                         |
@@ -63,10 +63,10 @@ artifacts are architecture-specific. Without an override, `run` detects the
 local GPU, while `build` and `pipeline` use the compiler's feature-based target
 so they remain useful for cross-compilation.
 
-`--no-fmad` disables FMA contraction for kernels that rely on two separate
-roundings (e.g. Dekker's algorithm, 2Sum). Equivalent to `CUDA_OXIDE_NO_FMA=1`.
-By default, FMA contraction is on (matching nvcc's `--fmad=true`): `fmul+fadd`
-pairs fuse into a single `fma.rn.f32` for fewer instructions and one rounding.
+`--no-fmad` forwards the same experimental request as
+`CUDA_OXIDE_NO_FMA=1`. The current IR-level `contract` flag can still fuse
+`fmul+fadd`, so code that requires two separate roundings must not rely on this
+request until [#315](https://github.com/NVlabs/cuda-oxide/issues/315) is fixed.
 
 ## Commands
 
@@ -114,6 +114,20 @@ cargo oxide sanitize my_app -- --leak-check full -- --app-flag value
 Arguments after the first `--` are passed to `compute-sanitizer` before the
 executable. A second `--` splits target program arguments, matching
 `compute-sanitizer [options] [your-program] [your-program-options]`.
+
+`sanitize` uses Cargo's reported executable artifact, so custom binary names,
+workspace layouts, configured target directories, and host target triples do
+not require path guessing. Device line tables are enabled by default while
+normal optimization remains on.
+
+Compute Sanitizer's own error exit code defaults to zero. This command supplies
+`--error-exitcode 86` unless you pass an explicit value, so tool findings fail
+scripts and CI. If you intentionally pass `--error-exitcode 0`, inspect the
+printed report; a zero process status no longer implies that the report was
+clean. Options such as `--check-exit-code no` and `--require-cuda-init no` also
+weaken what a zero status proves. The wrapper reports completion and reminds
+you to inspect the sanitizer output instead of declaring the report clean from
+status alone.
 NVIDIA recommends treating the tools as complementary: `racecheck`,
 `initcheck`, and `synccheck` do not replace `memcheck` memory-access checking.
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -314,6 +314,10 @@ pub fn codegen_sanitize(
             verbose,
             target_arch,
             detected_device_arch.as_deref(),
+            InteropDeviceBuildOptions {
+                no_fmad,
+                sanitizer_line_tables: true,
+            },
         );
         let binary = build_host_cargo(ctx, example, &example_dir, features, bin, verbose);
         run_compute_sanitizer(
@@ -377,6 +381,12 @@ struct DeviceCrateConfig {
     artifact_name: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct InteropDeviceBuildOptions {
+    no_fmad: bool,
+    sanitizer_line_tables: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn codegen_run_interop(
     ctx: &Context,
@@ -410,6 +420,7 @@ fn codegen_run_interop(
         verbose,
         arch,
         detected_device_arch,
+        InteropDeviceBuildOptions::default(),
     );
     run_host_cargo(ctx, example, example_dir, "run", features, bin, verbose);
 }
@@ -437,7 +448,15 @@ fn codegen_build_interop(
 
     // `build` may cross-compile for another machine, so no device-arch hint:
     // only an explicit `--arch` pins the target here.
-    build_interop_device_crates(ctx, example_dir, interop, verbose, arch, None);
+    build_interop_device_crates(
+        ctx,
+        example_dir,
+        interop,
+        verbose,
+        arch,
+        None,
+        InteropDeviceBuildOptions::default(),
+    );
     run_host_cargo(ctx, example, example_dir, "build", features, None, verbose);
 }
 
@@ -456,6 +475,7 @@ fn build_interop_device_crates(
     verbose: bool,
     arch: Option<&str>,
     detected_device_arch: Option<&str>,
+    options: InteropDeviceBuildOptions,
 ) {
     for device_crate in &interop.device_crates {
         build_interop_device_crate(
@@ -465,10 +485,12 @@ fn build_interop_device_crates(
             verbose,
             arch,
             detected_device_arch,
+            options,
         );
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_interop_device_crate(
     ctx: &Context,
     example_dir: &Path,
@@ -476,6 +498,7 @@ fn build_interop_device_crate(
     verbose: bool,
     arch: Option<&str>,
     detected_device_arch: Option<&str>,
+    options: InteropDeviceBuildOptions,
 ) {
     let manifest_path = example_dir.join(&device_crate.manifest_path);
     let manifest_path = manifest_path.canonicalize().unwrap_or_else(|e| {
@@ -512,8 +535,22 @@ fn build_interop_device_crate(
         .arg(&manifest_path)
         .current_dir(device_dir);
 
-    apply_common_codegen_env(&mut cmd, ctx, verbose, false);
-    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
+    apply_interop_device_codegen_options(&mut cmd, ctx, verbose, options);
+    let fingerprinted_cfgs = options
+        .sanitizer_line_tables
+        .then(|| {
+            sanitize_codegen_fingerprint_cfg(
+                ctx,
+                verbose,
+                options.no_fmad,
+                arch,
+                detected_device_arch,
+                Some(&ptx_dir),
+            )
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    apply_codegen_rustflags(&mut cmd, ctx, false, &fingerprinted_cfgs);
     // This is an internal artifact contract, so it must override a project
     // `[env]` default for the same variable.
     cmd.env("CUDA_OXIDE_PTX_DIR", &ptx_dir);
@@ -614,7 +651,10 @@ fn codegen_build_host_binary(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
-    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
+    apply_default_sanitizer_line_tables(&mut cmd, ctx);
+    let fingerprint =
+        sanitize_codegen_fingerprint_cfg(ctx, verbose, no_fmad, arch, detected_device_arch, None);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[fingerprint]);
     apply_output_mode(&mut cmd, false, arch);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
 
@@ -625,13 +665,13 @@ fn codegen_build_host_binary(
     }
     println!();
 
-    let status = cmd.status().expect("Failed to run cargo build");
-    if !status.success() {
-        eprintln!("\nBuild failed with exit code: {:?}", status.code());
-        std::process::exit(status.code().unwrap_or(1));
-    }
-
-    release_binary_path(ctx, example_dir, bin)
+    let preferred_bin = bin
+        .map(str::to_string)
+        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
+    run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(|message| {
+        eprintln!("\nBuild failed: {message}");
+        std::process::exit(1);
+    })
 }
 
 fn build_host_cargo(
@@ -666,89 +706,165 @@ fn build_host_cargo(
         cmd.env("CUDA_OXIDE_VERBOSE", "1");
     }
 
-    let status = cmd.status().expect("Failed to run host cargo build");
-    if !status.success() {
-        eprintln!(
-            "\nHost cargo build failed with exit code: {:?}",
-            status.code()
-        );
-        std::process::exit(status.code().unwrap_or(1));
-    }
-
-    release_binary_path(ctx, example_dir, bin)
-}
-
-fn release_binary_path(ctx: &Context, package_dir: &Path, bin: Option<&str>) -> PathBuf {
-    let binary_name = bin
+    let preferred_bin = bin
         .map(str::to_string)
-        .unwrap_or_else(|| default_run_or_package_name(&package_dir.join("Cargo.toml")));
-    let target_dir = cargo_target_dir(ctx, package_dir);
-    let binary = target_dir
-        .join("release")
-        .join(format!("{binary_name}{}", std::env::consts::EXE_SUFFIX));
-
-    if !binary.exists() {
-        eprintln!(
-            "Error: expected release binary was not produced at {}",
-            binary.display()
-        );
-        eprintln!("If this package has multiple binaries, pass --bin <name>.");
+        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
+    run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(|message| {
+        eprintln!("\nHost cargo build failed: {message}");
         std::process::exit(1);
-    }
-
-    binary
+    })
 }
 
-fn cargo_target_dir(ctx: &Context, package_dir: &Path) -> PathBuf {
-    let target = std::env::var_os("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .or_else(|| project_config_env(ctx, "CARGO_TARGET_DIR").map(PathBuf::from))
-        .unwrap_or_else(|| package_dir.join("target"));
+fn run_cargo_build_for_executable(
+    cmd: &mut Command,
+    preferred_bin: Option<&str>,
+) -> Result<PathBuf, String> {
+    cmd.arg("--message-format=json-render-diagnostics");
+    let output = cmd
+        .output()
+        .map_err(|error| format!("could not start Cargo: {error}"))?;
 
-    if target.is_absolute() {
-        target
-    } else {
-        package_dir.join(target)
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.is_empty() {
+        eprint!("{stderr}");
     }
+
+    let mut executables = BTreeMap::<PathBuf, String>::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let message: serde_json::Value = match serde_json::from_str(line) {
+            Ok(message) => message,
+            Err(_) => {
+                if !line.is_empty() {
+                    println!("{line}");
+                }
+                continue;
+            }
+        };
+
+        if let Some(rendered) = message
+            .get("message")
+            .and_then(|message| message.get("rendered"))
+            .and_then(|rendered| rendered.as_str())
+        {
+            eprint!("{rendered}");
+        }
+
+        if message.get("reason").and_then(|reason| reason.as_str()) != Some("compiler-artifact") {
+            continue;
+        }
+        let is_binary = message
+            .get("target")
+            .and_then(|target| target.get("kind"))
+            .and_then(|kind| kind.as_array())
+            .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("bin")));
+        if !is_binary {
+            continue;
+        }
+        let Some(path) = message.get("executable").and_then(|path| path.as_str()) else {
+            continue;
+        };
+        let Some(name) = message
+            .get("target")
+            .and_then(|target| target.get("name"))
+            .and_then(|name| name.as_str())
+        else {
+            continue;
+        };
+        executables.insert(PathBuf::from(path), name.to_string());
+    }
+
+    if !output.status.success() {
+        return Err(format!("Cargo exited with status {}", output.status));
+    }
+
+    if executables.len() == 1 {
+        return Ok(executables.into_keys().next().expect("one executable"));
+    }
+
+    if let Some(preferred_bin) = preferred_bin {
+        let mut matches = executables
+            .iter()
+            .filter(|(_, name)| name.as_str() == preferred_bin)
+            .map(|(path, _)| path.clone());
+        if let Some(path) = matches.next()
+            && matches.next().is_none()
+        {
+            return Ok(path);
+        }
+    }
+
+    if executables.is_empty() {
+        return Err("Cargo produced no executable binary artifact".to_string());
+    }
+
+    let choices = executables
+        .iter()
+        .map(|(path, name)| format!("{name} ({})", path.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "Cargo produced multiple executable binaries: {choices}; pass --bin <name>"
+    ))
 }
 
-fn default_run_or_package_name(manifest_path: &Path) -> String {
-    let source = std::fs::read_to_string(manifest_path).unwrap_or_else(|e| {
-        eprintln!(
-            "Error: could not read manifest {}: {}",
-            manifest_path.display(),
-            e
-        );
-        std::process::exit(1);
-    });
-    let document: toml::Value = toml::from_str(&source).unwrap_or_else(|e| {
-        eprintln!(
-            "Error: could not parse manifest {}: {}",
-            manifest_path.display(),
-            e
-        );
-        std::process::exit(1);
-    });
-    let package = document.get("package").unwrap_or_else(|| {
-        eprintln!(
-            "Error: manifest {} is missing [package]",
-            manifest_path.display()
-        );
-        std::process::exit(1);
-    });
-
+fn preferred_binary_name(manifest_path: &Path) -> Option<String> {
+    let source = std::fs::read_to_string(manifest_path).ok()?;
+    let document: toml::Value = toml::from_str(&source).ok()?;
+    let package = document.get("package")?;
     package
         .get("default-run")
         .or_else(|| package.get("name"))
         .and_then(|value| value.as_str())
         .map(str::to_string)
-        .unwrap_or_else(|| {
-            eprintln!(
-                "Error: manifest {} is missing package.name",
-                manifest_path.display()
-            );
-            std::process::exit(1);
-        })
+}
+
+const DEFAULT_SANITIZER_ERROR_EXITCODE: &str = "86";
+
+#[derive(Debug, PartialEq, Eq)]
+struct SanitizerInvocationArgs {
+    args: Vec<String>,
+    uses_default_error_exitcode: bool,
+    status_checks_weakened: bool,
+}
+
+fn sanitizer_invocation_args(sanitizer_args: &[String]) -> SanitizerInvocationArgs {
+    let has_explicit_error_exitcode = sanitizer_args
+        .iter()
+        .any(|arg| arg == "--error-exitcode" || arg.starts_with("--error-exitcode="));
+    if has_explicit_error_exitcode {
+        return SanitizerInvocationArgs {
+            args: sanitizer_args.to_vec(),
+            uses_default_error_exitcode: false,
+            status_checks_weakened: sanitizer_option_is_no(sanitizer_args, "check-exit-code")
+                || sanitizer_option_is_no(sanitizer_args, "require-cuda-init"),
+        };
+    }
+
+    let mut args = Vec::with_capacity(sanitizer_args.len() + 2);
+    args.extend([
+        "--error-exitcode".to_string(),
+        DEFAULT_SANITIZER_ERROR_EXITCODE.to_string(),
+    ]);
+    args.extend_from_slice(sanitizer_args);
+    SanitizerInvocationArgs {
+        args,
+        uses_default_error_exitcode: true,
+        status_checks_weakened: sanitizer_option_is_no(sanitizer_args, "check-exit-code")
+            || sanitizer_option_is_no(sanitizer_args, "require-cuda-init"),
+    }
+}
+
+fn sanitizer_option_is_no(args: &[String], name: &str) -> bool {
+    let option = format!("--{name}");
+    let equals_prefix = format!("{option}=");
+    args.iter().enumerate().any(|(index, arg)| {
+        arg.strip_prefix(&equals_prefix)
+            .is_some_and(|value| value.eq_ignore_ascii_case("no"))
+            || (arg == &option
+                && args
+                    .get(index + 1)
+                    .is_some_and(|value| value.eq_ignore_ascii_case("no")))
+    })
 }
 
 fn run_compute_sanitizer(
@@ -759,7 +875,8 @@ fn run_compute_sanitizer(
     application_args: &[String],
     binary: &Path,
 ) {
-    let compute_sanitizer = find_executable(
+    let compute_sanitizer = find_cuda_toolkit_executable(
+        ctx,
         "compute-sanitizer",
         &[
             "/usr/local/cuda/bin/compute-sanitizer",
@@ -775,19 +892,20 @@ fn run_compute_sanitizer(
         std::process::exit(1);
     });
 
+    let invocation_args = sanitizer_invocation_args(sanitizer_args);
     let mut cmd = Command::new(compute_sanitizer);
     cmd.args(["--tool", tool])
-        .args(sanitizer_args)
+        .args(&invocation_args.args)
         .arg(binary)
         .args(application_args)
         .current_dir(example_dir);
     apply_config_env(&mut cmd, ctx);
     apply_ld_library_path(&mut cmd, ctx);
 
-    let forwarded_args = if sanitizer_args.is_empty() {
+    let forwarded_args = if invocation_args.args.is_empty() {
         String::new()
     } else {
-        format!(" {}", sanitizer_args.join(" "))
+        format!(" {}", invocation_args.args.join(" "))
     };
     let displayed_application_args = if application_args.is_empty() {
         String::new()
@@ -810,7 +928,20 @@ fn run_compute_sanitizer(
     }
 
     println!();
-    println!("✓ Compute Sanitizer completed without reported errors");
+    println!("Compute Sanitizer completed with exit code 0.");
+    if !invocation_args.uses_default_error_exitcode {
+        println!(
+            "An explicit --error-exitcode was supplied, so it controls whether findings fail the command."
+        );
+    }
+    if invocation_args.status_checks_weakened {
+        println!(
+            "The supplied sanitizer options can allow target or CUDA-initialization failures to exit 0."
+        );
+    }
+    println!(
+        "Inspect the sanitizer report above; exit status alone is not a clean-report assertion."
+    );
 }
 
 // =============================================================================
@@ -1241,14 +1372,53 @@ fn passthrough_codegen_fingerprint_with_env(
     // command lines or diagnostics.
     let mut hash = 0xcbf29ce484222325_u64;
     for (key, value) in effective_env {
-        for bytes in [key.as_bytes(), value.as_bytes()] {
-            for byte in (bytes.len() as u64).to_le_bytes().iter().chain(bytes) {
-                hash ^= u64::from(*byte);
-                hash = hash.wrapping_mul(0x100000001b3);
-            }
-        }
+        update_codegen_fingerprint_hash(&mut hash, key.as_bytes());
+        update_codegen_fingerprint_hash(&mut hash, value.as_bytes());
     }
     format!("{hash:016x}")
+}
+
+fn update_codegen_fingerprint_hash(hash: &mut u64, bytes: &[u8]) {
+    for byte in (bytes.len() as u64).to_le_bytes().iter().chain(bytes) {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(0x100000001b3);
+    }
+}
+
+/// Put sanitizer-only output settings into an otherwise-unused cfg so Cargo
+/// recompiles every selected Rust target, including `src/bin/*` and virtual
+/// workspace members. Cargo does not fingerprint arbitrary backend env vars.
+fn sanitize_codegen_fingerprint_cfg(
+    ctx: &Context,
+    verbose: bool,
+    no_fmad: bool,
+    target_arch: Option<&str>,
+    detected_device_arch: Option<&str>,
+    ptx_dir: Option<&Path>,
+) -> String {
+    let opts = CargoPassthroughOptions {
+        verbose,
+        emit_nvvm_ir: false,
+        arch: target_arch,
+        features: None,
+        cargo_target_dir: None,
+        device_codegen_crate: None,
+        device_cfgs: &[],
+        no_fmad,
+    };
+    let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch);
+    let mut hash = 0xcbf29ce484222325_u64;
+    for bytes in [
+        "sanitize-line-tables-v1".as_bytes(),
+        base.as_bytes(),
+        detected_device_arch.unwrap_or("").as_bytes(),
+    ] {
+        update_codegen_fingerprint_hash(&mut hash, bytes);
+    }
+    if let Some(ptx_dir) = ptx_dir {
+        update_codegen_fingerprint_hash(&mut hash, ptx_dir.as_os_str().as_encoded_bytes());
+    }
+    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
 }
 
 fn backend_artifact_identity(path: &Path) -> String {
@@ -2009,7 +2179,7 @@ pub fn doctor(ctx: &Context) {
 fn cuda_toolkit_root(mut get_env: impl FnMut(&str) -> Option<String>) -> String {
     ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
         .iter()
-        .find_map(|var| get_env(var))
+        .find_map(|var| get_env(var).filter(|value| !value.trim().is_empty()))
         .unwrap_or_else(|| "/usr/local/cuda".to_string())
 }
 
@@ -2477,6 +2647,29 @@ fn apply_common_codegen_env(cmd: &mut Command, ctx: &Context, verbose: bool, no_
         cmd.env("CUDA_OXIDE_NO_FMA", "1");
     }
     apply_ld_library_path(cmd, ctx);
+}
+
+/// Give Compute Sanitizer source line attribution without disabling normal
+/// device optimization. An explicit process or project setting remains
+/// authoritative, including an intentional `CUDA_OXIDE_DEBUG=off`.
+fn apply_default_sanitizer_line_tables(cmd: &mut Command, ctx: &Context) {
+    if std::env::var_os("CUDA_OXIDE_DEBUG").is_none()
+        && project_config_env(ctx, "CUDA_OXIDE_DEBUG").is_none()
+    {
+        cmd.env("CUDA_OXIDE_DEBUG", "line-tables");
+    }
+}
+
+fn apply_interop_device_codegen_options(
+    cmd: &mut Command,
+    ctx: &Context,
+    verbose: bool,
+    options: InteropDeviceBuildOptions,
+) {
+    apply_common_codegen_env(cmd, ctx, verbose, options.no_fmad);
+    if options.sanitizer_line_tables {
+        apply_default_sanitizer_line_tables(cmd, ctx);
+    }
 }
 
 /// Forward the auto-detected GPU arch as a *hint* via `CUDA_OXIDE_DEVICE_ARCH`.
@@ -3007,6 +3200,37 @@ fn find_executable(name: &str, fallback_paths: &[&str]) -> Option<PathBuf> {
     None
 }
 
+/// Locate a CUDA Toolkit executable using the same configured toolkit roots as
+/// `doctor`, after the user's PATH and before generic system fallbacks.
+fn find_cuda_toolkit_executable(
+    ctx: &Context,
+    name: &str,
+    fallback_paths: &[&str],
+) -> Option<PathBuf> {
+    if let Some(path) = find_executable(name, &[]) {
+        return Some(path);
+    }
+
+    let toolkit = cuda_toolkit_root(|key| {
+        std::env::var(key)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| project_config_env(ctx, key).map(str::to_owned))
+    });
+    let configured = PathBuf::from(toolkit).join("bin").join(name);
+    if configured.exists() {
+        return Some(configured);
+    }
+
+    for path in fallback_paths {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3080,7 +3304,7 @@ mod tests {
     }
 
     #[test]
-    fn default_run_or_package_name_prefers_default_run() {
+    fn preferred_binary_name_prefers_default_run() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time before unix epoch")
@@ -3104,12 +3328,15 @@ edition = "2024"
         )
         .unwrap();
 
-        assert_eq!(default_run_or_package_name(&manifest), "main_bin");
+        assert_eq!(
+            preferred_binary_name(&manifest).as_deref(),
+            Some("main_bin")
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
-    fn release_binary_path_uses_configured_relative_target_dir() {
+    fn cargo_json_selects_custom_bin_in_configured_target_dir() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time before unix epoch")
@@ -3120,6 +3347,8 @@ edition = "2024"
             unique
         ));
         std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(root.join(".cargo")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("Cargo.toml"),
             r#"
@@ -3127,25 +3356,215 @@ edition = "2024"
 name = "package-bin"
 version = "0.1.0"
 edition = "2024"
+
+[[bin]]
+name = "actual-bin"
+path = "src/main.rs"
 "#,
         )
         .unwrap();
-        let binary = root
-            .join("configured-target")
-            .join("release")
-            .join(format!("chosen{}", std::env::consts::EXE_SUFFIX));
-        std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
-        std::fs::write(&binary, b"fake executable").unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            root.join(".cargo/config.toml"),
+            "[build]\ntarget-dir = \"configured-target\"\n",
+        )
+        .unwrap();
 
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release"]).current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, Some("package-bin")).unwrap();
+
+        assert!(binary.exists());
+        let expected_name = format!("actual-bin{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
+        assert!(
+            binary
+                .components()
+                .any(|part| part.as_os_str() == "configured-target")
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_selects_single_binary_from_virtual_workspace() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_sanitize_workspace_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let member = root.join("member");
+        std::fs::create_dir_all(member.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"member\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            member.join("Cargo.toml"),
+            r#"
+[package]
+name = "workspace-package"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "workspace-bin"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(member.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        assert_eq!(preferred_binary_name(&root.join("Cargo.toml")), None);
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release"]).current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, None).unwrap();
+
+        let expected_name = format!("workspace-bin{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn sanitizer_adds_nonzero_error_exitcode_by_default() {
+        let invocation =
+            sanitizer_invocation_args(&["--leak-check".to_string(), "full".to_string()]);
+
+        assert_eq!(
+            invocation.args,
+            ["--error-exitcode", "86", "--leak-check", "full"]
+        );
+        assert!(invocation.uses_default_error_exitcode);
+        assert!(!invocation.status_checks_weakened);
+    }
+
+    #[test]
+    fn sanitizer_preserves_explicit_zero_error_exitcode_without_claiming_detection() {
+        let separated = sanitizer_invocation_args(&[
+            "--error-exitcode".to_string(),
+            "0".to_string(),
+            "--leak-check".to_string(),
+        ]);
+        let equals = sanitizer_invocation_args(&["--error-exitcode=0".to_string()]);
+        let repeated = sanitizer_invocation_args(&[
+            "--error-exitcode=86".to_string(),
+            "--error-exitcode=0".to_string(),
+        ]);
+
+        assert_eq!(separated.args, ["--error-exitcode", "0", "--leak-check"]);
+        assert!(!separated.uses_default_error_exitcode);
+        assert!(!separated.status_checks_weakened);
+        assert_eq!(equals.args, ["--error-exitcode=0"]);
+        assert!(!equals.uses_default_error_exitcode);
+        assert_eq!(repeated.args, ["--error-exitcode=86", "--error-exitcode=0"]);
+        assert!(!repeated.uses_default_error_exitcode);
+    }
+
+    #[test]
+    fn sanitizer_detects_options_that_weaken_success_status() {
+        for args in [
+            vec!["--check-exit-code=no".to_string()],
+            vec!["--check-exit-code".to_string(), "no".to_string()],
+            vec!["--require-cuda-init=no".to_string()],
+            vec!["--require-cuda-init".to_string(), "NO".to_string()],
+        ] {
+            let invocation = sanitizer_invocation_args(&args);
+            assert!(invocation.status_checks_weakened, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn sanitize_interop_codegen_defaults_to_line_tables_and_forwards_no_fmad() {
+        let ctx = test_context(OxideConfig::default());
+        let mut cmd = Command::new("cargo");
+
+        apply_interop_device_codegen_options(
+            &mut cmd,
+            &ctx,
+            false,
+            InteropDeviceBuildOptions {
+                no_fmad: true,
+                sanitizer_line_tables: true,
+            },
+        );
+
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_NO_FMA").as_deref(), Some("1"));
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_DEBUG").as_deref(),
+            Some("line-tables")
+        );
+
+        let fingerprint = sanitize_codegen_fingerprint_cfg(
+            &ctx,
+            false,
+            true,
+            Some("sm_80"),
+            None,
+            Some(Path::new("/tmp/generated-ptx")),
+        );
+        apply_codegen_rustflags(&mut cmd, &ctx, false, &[fingerprint]);
+        let encoded = command_env(&cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
+        assert!(has_codegen_env_fingerprint(&decoded_rustflags(&encoded)));
+    }
+
+    #[test]
+    fn sanitize_fingerprint_tracks_output_affecting_settings() {
+        let ctx = test_context(OxideConfig::default());
+        let base = sanitize_codegen_fingerprint_cfg(&ctx, false, false, None, Some("sm_80"), None);
+
+        for changed in [
+            sanitize_codegen_fingerprint_cfg(&ctx, false, true, None, Some("sm_80"), None),
+            sanitize_codegen_fingerprint_cfg(&ctx, false, false, None, Some("sm_90"), None),
+            sanitize_codegen_fingerprint_cfg(&ctx, false, false, Some("sm_80"), None, None),
+            sanitize_codegen_fingerprint_cfg(
+                &ctx,
+                false,
+                false,
+                None,
+                Some("sm_80"),
+                Some(Path::new("/tmp/generated-ptx")),
+            ),
+        ] {
+            assert_ne!(base, changed);
+        }
+    }
+
+    #[test]
+    fn sanitizer_tool_lookup_uses_project_cuda_toolkit_root() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_sanitizer_tool_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let tool = root.join("bin/cuda-oxide-test-sanitizer");
+        std::fs::create_dir_all(tool.parent().unwrap()).unwrap();
+        std::fs::write(&tool, b"fake tool").unwrap();
         let ctx = test_context(OxideConfig {
             env: vec![(
-                "CARGO_TARGET_DIR".to_string(),
-                "configured-target".to_string(),
+                "CUDA_TOOLKIT_PATH".to_string(),
+                root.to_string_lossy().into_owned(),
             )],
             ..OxideConfig::default()
         });
 
-        assert_eq!(release_binary_path(&ctx, &root, Some("chosen")), binary);
+        assert_eq!(
+            find_cuda_toolkit_executable(&ctx, "cuda-oxide-test-sanitizer", &[]),
+            Some(tool)
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -3733,6 +4152,13 @@ MY_BUILD_FLAG = "configured"
         let home_only =
             cuda_toolkit_root(|var| (var == "CUDA_HOME").then(|| "/cuda/home".to_string()));
         assert_eq!(home_only, "/cuda/home");
+
+        let empty_toolkit_path = cuda_toolkit_root(|var| match var {
+            "CUDA_TOOLKIT_PATH" => Some("  ".to_string()),
+            "CUDA_HOME" => Some("/cuda/home".to_string()),
+            _ => None,
+        });
+        assert_eq!(empty_toolkit_path, "/cuda/home");
 
         assert_eq!(cuda_toolkit_root(|_| None), "/usr/local/cuda");
     }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -266,6 +266,101 @@ pub fn codegen_run(
 }
 
 // =============================================================================
+// Sanitize command
+// =============================================================================
+
+/// Build an example and run the produced host binary under NVIDIA Compute
+/// Sanitizer.
+#[allow(clippy::too_many_arguments)]
+pub fn codegen_sanitize(
+    ctx: &Context,
+    example: &str,
+    tool: &str,
+    sanitizer_args: &[String],
+    application_args: &[String],
+    verbose: bool,
+    arch: Option<&str>,
+    features: Option<&str>,
+    bin: Option<&str>,
+    no_fmad: bool,
+) {
+    let example_dir = if ctx.is_workspace {
+        resolve_example_dir(ctx, example)
+    } else {
+        ctx.workspace_root.clone()
+    };
+
+    let interop = load_interop_config(&example_dir);
+    let target_arch = configured_arch(ctx, arch);
+    let detected_device_arch = detect_run_target_arch(target_arch, false);
+
+    if let Some(interop) = interop.filter(|config| !config.device_crates.is_empty()) {
+        println!("=========================================");
+        println!("RUSTC-CODEGEN-CUDA SANITIZE INTEROP: {}", example);
+        println!("=========================================");
+        if let Some(kind) = &interop.kind {
+            println!("Interop kind: {}", kind);
+        }
+        if let Some(dev) = detected_device_arch.as_deref() {
+            println!("Detected GPU arch: {dev} (via nvidia-smi)");
+        }
+        println!("Compute Sanitizer tool: {tool}");
+        println!();
+
+        build_interop_device_crates(
+            ctx,
+            &example_dir,
+            &interop,
+            verbose,
+            target_arch,
+            detected_device_arch.as_deref(),
+        );
+        let binary = build_host_cargo(ctx, example, &example_dir, features, bin, verbose);
+        run_compute_sanitizer(
+            ctx,
+            &example_dir,
+            tool,
+            sanitizer_args,
+            application_args,
+            &binary,
+        );
+        return;
+    }
+
+    clean_generated_files(&example_dir, example);
+
+    println!("=========================================");
+    println!("RUSTC-CODEGEN-CUDA SANITIZE: {}", example);
+    println!("=========================================");
+    if let Some(dev) = detected_device_arch.as_deref() {
+        println!("Detected GPU arch: {dev} (via nvidia-smi)");
+    }
+    println!("Compute Sanitizer tool: {tool}");
+    println!();
+
+    touch_main_rs(&example_dir);
+    let binary = codegen_build_host_binary(
+        ctx,
+        example,
+        &example_dir,
+        verbose,
+        target_arch,
+        detected_device_arch.as_deref(),
+        features,
+        bin,
+        no_fmad,
+    );
+    run_compute_sanitizer(
+        ctx,
+        &example_dir,
+        tool,
+        sanitizer_args,
+        application_args,
+        &binary,
+    );
+}
+
+// =============================================================================
 // Interop host/device workflow
 // =============================================================================
 
@@ -494,6 +589,228 @@ fn run_host_cargo(
         );
         std::process::exit(status.code().unwrap_or(1));
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn codegen_build_host_binary(
+    ctx: &Context,
+    example: &str,
+    example_dir: &Path,
+    verbose: bool,
+    arch: Option<&str>,
+    detected_device_arch: Option<&str>,
+    features: Option<&str>,
+    bin: Option<&str>,
+    no_fmad: bool,
+) -> PathBuf {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--release"]).current_dir(example_dir);
+
+    if let Some(bin) = bin {
+        cmd.args(["--bin", bin]);
+    }
+    if let Some(features) = features {
+        cmd.args(["--features", features]);
+    }
+
+    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
+    apply_codegen_rustflags(&mut cmd, ctx, false, &[]);
+    apply_output_mode(&mut cmd, false, arch);
+    apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
+
+    if let Some(bin) = bin {
+        println!("Building {} (bin: {})...", example, bin);
+    } else {
+        println!("Building {}...", example);
+    }
+    println!();
+
+    let status = cmd.status().expect("Failed to run cargo build");
+    if !status.success() {
+        eprintln!("\nBuild failed with exit code: {:?}", status.code());
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    release_binary_path(ctx, example_dir, bin)
+}
+
+fn build_host_cargo(
+    ctx: &Context,
+    example: &str,
+    example_dir: &Path,
+    features: Option<&str>,
+    bin: Option<&str>,
+    verbose: bool,
+) -> PathBuf {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--release"]).current_dir(example_dir);
+
+    if let Some(bin) = bin {
+        cmd.args(["--bin", bin]);
+    }
+    if let Some(features) = features {
+        cmd.args(["--features", features]);
+    }
+
+    apply_config_env(&mut cmd, ctx);
+    apply_ld_library_path(&mut cmd, ctx);
+
+    if let Some(bin) = bin {
+        println!("Building host crate {} (bin: {})...", example, bin);
+    } else {
+        println!("Building host crate {}...", example);
+    }
+    println!();
+
+    if verbose {
+        cmd.env("CUDA_OXIDE_VERBOSE", "1");
+    }
+
+    let status = cmd.status().expect("Failed to run host cargo build");
+    if !status.success() {
+        eprintln!(
+            "\nHost cargo build failed with exit code: {:?}",
+            status.code()
+        );
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    release_binary_path(ctx, example_dir, bin)
+}
+
+fn release_binary_path(ctx: &Context, package_dir: &Path, bin: Option<&str>) -> PathBuf {
+    let binary_name = bin
+        .map(str::to_string)
+        .unwrap_or_else(|| default_run_or_package_name(&package_dir.join("Cargo.toml")));
+    let target_dir = cargo_target_dir(ctx, package_dir);
+    let binary = target_dir
+        .join("release")
+        .join(format!("{binary_name}{}", std::env::consts::EXE_SUFFIX));
+
+    if !binary.exists() {
+        eprintln!(
+            "Error: expected release binary was not produced at {}",
+            binary.display()
+        );
+        eprintln!("If this package has multiple binaries, pass --bin <name>.");
+        std::process::exit(1);
+    }
+
+    binary
+}
+
+fn cargo_target_dir(ctx: &Context, package_dir: &Path) -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .or_else(|| project_config_env(ctx, "CARGO_TARGET_DIR").map(PathBuf::from))
+        .unwrap_or_else(|| package_dir.join("target"));
+
+    if target.is_absolute() {
+        target
+    } else {
+        package_dir.join(target)
+    }
+}
+
+fn default_run_or_package_name(manifest_path: &Path) -> String {
+    let source = std::fs::read_to_string(manifest_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read manifest {}: {}",
+            manifest_path.display(),
+            e
+        );
+        std::process::exit(1);
+    });
+    let document: toml::Value = toml::from_str(&source).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not parse manifest {}: {}",
+            manifest_path.display(),
+            e
+        );
+        std::process::exit(1);
+    });
+    let package = document.get("package").unwrap_or_else(|| {
+        eprintln!(
+            "Error: manifest {} is missing [package]",
+            manifest_path.display()
+        );
+        std::process::exit(1);
+    });
+
+    package
+        .get("default-run")
+        .or_else(|| package.get("name"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Error: manifest {} is missing package.name",
+                manifest_path.display()
+            );
+            std::process::exit(1);
+        })
+}
+
+fn run_compute_sanitizer(
+    ctx: &Context,
+    example_dir: &Path,
+    tool: &str,
+    sanitizer_args: &[String],
+    application_args: &[String],
+    binary: &Path,
+) {
+    let compute_sanitizer = find_executable(
+        "compute-sanitizer",
+        &[
+            "/usr/local/cuda/bin/compute-sanitizer",
+            "/opt/cuda/bin/compute-sanitizer",
+            "/usr/bin/compute-sanitizer",
+        ],
+    )
+    .unwrap_or_else(|| {
+        eprintln!("Error: compute-sanitizer not found.");
+        eprintln!(
+            "It is installed with the CUDA Toolkit; run `cargo oxide doctor` to check CUDA setup."
+        );
+        std::process::exit(1);
+    });
+
+    let mut cmd = Command::new(compute_sanitizer);
+    cmd.args(["--tool", tool])
+        .args(sanitizer_args)
+        .arg(binary)
+        .args(application_args)
+        .current_dir(example_dir);
+    apply_config_env(&mut cmd, ctx);
+    apply_ld_library_path(&mut cmd, ctx);
+
+    let forwarded_args = if sanitizer_args.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", sanitizer_args.join(" "))
+    };
+    let displayed_application_args = if application_args.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", application_args.join(" "))
+    };
+    println!(
+        "Running compute-sanitizer --tool {tool}{forwarded_args} {}{displayed_application_args}...",
+        binary.display()
+    );
+    println!();
+
+    let status = cmd.status().expect("Failed to run compute-sanitizer");
+    if !status.success() {
+        eprintln!(
+            "\nCompute Sanitizer failed with exit code: {:?}",
+            status.code()
+        );
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    println!();
+    println!("✓ Compute Sanitizer completed without reported errors");
 }
 
 // =============================================================================
@@ -2759,6 +3076,76 @@ mod tests {
             std::fs::read(&cached_cubin).unwrap(),
             b"persistent cache entry"
         );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn default_run_or_package_name_prefers_default_run() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_default_run_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let manifest = root.join("Cargo.toml");
+        std::fs::write(
+            &manifest,
+            r#"
+[package]
+name = "multi-bin-package"
+default-run = "main_bin"
+version = "0.1.0"
+edition = "2024"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(default_run_or_package_name(&manifest), "main_bin");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn release_binary_path_uses_configured_relative_target_dir() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cargo_oxide_sanitize_binary_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "package-bin"
+version = "0.1.0"
+edition = "2024"
+"#,
+        )
+        .unwrap();
+        let binary = root
+            .join("configured-target")
+            .join("release")
+            .join(format!("chosen{}", std::env::consts::EXE_SUFFIX));
+        std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        std::fs::write(&binary, b"fake executable").unwrap();
+
+        let ctx = test_context(OxideConfig {
+            env: vec![(
+                "CARGO_TARGET_DIR".to_string(),
+                "configured-target".to_string(),
+            )],
+            ..OxideConfig::default()
+        });
+
+        assert_eq!(release_binary_path(&ctx, &root, Some("chosen")), binary);
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -14,6 +14,7 @@
 //! cargo oxide run vecadd              # build + run an example
 //! cargo oxide build vecadd            # build only
 //! cargo oxide pipeline vecadd         # verbose pipeline dump
+//! cargo oxide sanitize vecadd         # run under NVIDIA Compute Sanitizer
 //! cargo oxide debug vecadd --tui      # build + cuda-gdb
 //! cargo oxide new my_kernel            # scaffold a standalone project
 //! cargo oxide new my_kernel --async   # scaffold with async template
@@ -22,7 +23,7 @@
 //! cargo oxide setup                   # explicitly build/install backend
 //! ```
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 mod backend;
@@ -76,6 +77,36 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+    },
+    /// Build and run an example or project under NVIDIA Compute Sanitizer
+    Sanitize {
+        /// Example name (required in workspace, optional for standalone projects)
+        example: Option<String>,
+        /// Compute Sanitizer tool to run
+        #[arg(long, value_enum, default_value_t = SanitizerTool::Memcheck)]
+        tool: SanitizerTool,
+        /// Target architecture (e.g., sm_90, sm_100, sm_120). When omitted,
+        /// `sanitize` uses the same local-GPU target detection as `run`.
+        #[arg(long)]
+        arch: Option<String>,
+        /// Comma-separated list of features to enable
+        #[arg(long)]
+        features: Option<String>,
+        /// Pick a specific binary in a multi-bin package
+        #[arg(long)]
+        bin: Option<String>,
+        /// Show verbose compilation output
+        #[arg(short, long)]
+        verbose: bool,
+        /// Disable FMA contraction (default: on, matching nvcc --fmad=true).
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        #[arg(long)]
+        no_fmad: bool,
+        /// Additional arguments passed to compute-sanitizer before the binary.
+        /// Use a second `--` inside this list to pass arguments to the target
+        /// program after the binary.
+        #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
+        sanitizer_args: Vec<String>,
     },
     /// Build an example or project (compile only, don't run)
     Build {
@@ -205,6 +236,32 @@ enum Commands {
     Setup,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum SanitizerTool {
+    Memcheck,
+    Racecheck,
+    Initcheck,
+    Synccheck,
+}
+
+impl SanitizerTool {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Memcheck => "memcheck",
+            Self::Racecheck => "racecheck",
+            Self::Initcheck => "initcheck",
+            Self::Synccheck => "synccheck",
+        }
+    }
+}
+
+fn split_sanitizer_and_application_args(args: &[String]) -> (Vec<String>, Vec<String>) {
+    match args.iter().position(|arg| arg == "--") {
+        Some(separator) => (args[..separator].to_vec(), args[separator + 1..].to_vec()),
+        None => (args.to_vec(), Vec::new()),
+    }
+}
+
 fn has_passthrough_separator(args: &[String]) -> bool {
     args.iter().skip(2).any(|arg| arg == "--")
 }
@@ -257,6 +314,33 @@ fn main() {
                 &example,
                 verbose,
                 emit_nvvm_ir,
+                arch.as_deref(),
+                features.as_deref(),
+                bin.as_deref(),
+                no_fmad,
+            );
+        }
+        Commands::Sanitize {
+            example,
+            tool,
+            arch,
+            features,
+            bin,
+            verbose,
+            no_fmad,
+            sanitizer_args,
+        } => {
+            let ctx = commands::resolve_context();
+            let example = resolve_example_name(example, &ctx, "sanitize");
+            let (sanitizer_args, application_args) =
+                split_sanitizer_and_application_args(&sanitizer_args);
+            commands::codegen_sanitize(
+                &ctx,
+                &example,
+                tool.as_str(),
+                &sanitizer_args,
+                &application_args,
+                verbose,
                 arch.as_deref(),
                 features.as_deref(),
                 bin.as_deref(),
@@ -511,6 +595,65 @@ mod tests {
             panic!("expected build command");
         };
         assert!(cargo_args.is_empty());
+    }
+
+    #[test]
+    fn sanitize_parser_accepts_tool_and_trailing_sanitizer_args() {
+        let cli = Cli::try_parse_from([
+            "cargo-oxide",
+            "sanitize",
+            "vecadd",
+            "--tool",
+            "racecheck",
+            "--",
+            "--kernel-name",
+            "kns=vecadd",
+        ])
+        .expect("sanitize command should parse");
+
+        let Commands::Sanitize {
+            example,
+            tool,
+            sanitizer_args,
+            ..
+        } = cli.command
+        else {
+            panic!("expected sanitize command");
+        };
+        assert_eq!(example.as_deref(), Some("vecadd"));
+        assert_eq!(tool, SanitizerTool::Racecheck);
+        assert_eq!(sanitizer_args, strings(&["--kernel-name", "kns=vecadd"]));
+    }
+
+    #[test]
+    fn sanitize_args_split_at_second_separator_for_application_args() {
+        let raw_args = strings(&[
+            "--leak-check",
+            "full",
+            "--",
+            "--case",
+            "oob",
+            "--verbose-target",
+        ]);
+
+        let (sanitizer_args, application_args) = split_sanitizer_and_application_args(&raw_args);
+
+        assert_eq!(sanitizer_args, strings(&["--leak-check", "full"]));
+        assert_eq!(
+            application_args,
+            strings(&["--case", "oob", "--verbose-target"])
+        );
+    }
+
+    #[test]
+    fn sanitize_parser_defaults_to_memcheck() {
+        let cli = Cli::try_parse_from(["cargo-oxide", "sanitize", "vecadd"])
+            .expect("sanitize command should parse");
+
+        let Commands::Sanitize { tool, .. } = cli.command else {
+            panic!("expected sanitize command");
+        };
+        assert_eq!(tool, SanitizerTool::Memcheck);
     }
 
     #[test]

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -98,8 +98,8 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
-        /// Disable FMA contraction (default: on, matching nvcc --fmad=true).
-        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        /// Forward the experimental no-FMA request to device codegen.
+        /// Also settable via CUDA_OXIDE_NO_FMA=1; see issue #315.
         #[arg(long)]
         no_fmad: bool,
         /// Additional arguments passed to compute-sanitizer before the binary.

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -443,4 +443,4 @@ debug::prof_trigger::<7>();     // Nsight profiler trigger
 | `cuda-core`       | Safe RAII wrappers (`CudaContext`, `CudaStream`, `DeviceBuffer<T>`)    |
 | `cuda-async`      | `DeviceOperation`, `DeviceFuture`, `DeviceBox<T>`                      |
 | `cuda-bindings`   | Raw `bindgen` FFI to `cuda.h`                                          |
-| `cargo-oxide`     | Cargo subcommand (`cargo oxide run`, `build`, `debug`)                 |
+| `cargo-oxide`     | Cargo subcommand (`cargo oxide run`, `build`, `sanitize`, `debug`)     |

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -178,6 +178,9 @@ cargo oxide run <example>
 # Show the full compilation pipeline (MIR → LLVM IR → PTX)
 cargo oxide pipeline <example>
 
+# Run under NVIDIA Compute Sanitizer
+cargo oxide sanitize <example> --tool memcheck
+
 # Debug with cuda-gdb
 cargo oxide debug <example> --tui
 

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -94,6 +94,7 @@ layout-aware field decoding rather than the primitive byte-slicing rule.
 | LTOIR Linking | **Full** | Device-side LTO via libNVVM and nvJitLink. |
 | Float Math Intrinsics (libdevice) | **Full** | Rust `f32`/`f64` math methods (`sin`, `cos`, `exp`, `pow`, `sqrt`, ...) lower to CUDA libdevice (`__nv_*`) on pre-Blackwell and Blackwell GPUs. cuda-oxide selects the matching NVVM IR syntax automatically. On Blackwell, the runtime can also JIT PTX produced from a standard pre-Blackwell target such as `sm_86`. |
 | Pipeline Inspection | **Full** | `cargo oxide pipeline <example>` shows imported and post-`mem2reg` MIR, LLVM dialect, exported LLVM IR, and PTX. |
+| Compute Sanitizer Wrapper | **Full** | `cargo oxide sanitize <example>` builds the example and runs the host binary under NVIDIA Compute Sanitizer (`memcheck`, `racecheck`, `initcheck`, or `synccheck`). |
 | cuda-gdb Source Debugging | **Full** | `cargo oxide debug` builds device debug information on the PTX path and launches `cuda-gdb`. Legacy NVVM IR does not yet support debug metadata. |
 | cuda-gdb Local / Argument Inspection | **Partial** | `CUDA_OXIDE_DEBUG=full` is a `-G`-style build (optimization off, locals kept in memory) so `info args`/`info locals` show real values for scalars, pointers/references, and structs/tuples/arrays with their fields. Enums, ABI-split bare slices, closures, and projections (`x.0`) are not yet described. |
 

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -339,6 +339,30 @@ synchronization usage. Extra arguments after `--` are passed directly to
 `compute-sanitizer` before the executable; use a second `--` to pass arguments
 to the target program after the executable.
 
+The command enables optimized device line tables by default so findings can
+name Rust source files and lines. An explicit `CUDA_OXIDE_DEBUG` process or
+project setting still wins.
+
+Compute Sanitizer normally exits with status zero even when it reports a tool
+finding. `cargo oxide sanitize` therefore supplies `--error-exitcode 86` by
+default, making findings fail scripts and CI. An explicit sanitizer argument
+overrides that default:
+
+```bash
+# Intentionally keep a zero exit status and inspect the printed report.
+cargo oxide sanitize vecadd -- --error-exitcode 0
+```
+
+Options such as `--check-exit-code no` and `--require-cuda-init no` weaken what
+a zero status proves. The wrapper therefore never declares the report clean
+from process status alone; it reports completion and leaves the sanitizer
+output visible for inspection.
+
+The `--no-fmad` CLI flag is forwarded through both ordinary and interop builds,
+but it only requests the existing compiler behavior. It does not by itself
+resolve the backend contraction limitation tracked in
+[#315](https://github.com/NVlabs/cuda-oxide/issues/315).
+
 Run `memcheck` first when investigating memory safety. The other tools are
 complementary and do not perform full memory-access checking.
 

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -321,6 +321,27 @@ inspect the GPU state.
 Guard it with a compile-time flag or only use it during debugging sessions.
 :::
 
+## `cargo oxide sanitize` -- Compute Sanitizer
+
+For memory and synchronization correctness checks, run the same build path under
+NVIDIA Compute Sanitizer:
+
+```bash
+cargo oxide sanitize vecadd
+cargo oxide sanitize sharedmem --tool racecheck
+cargo oxide sanitize debug --tool synccheck -- --kernel-name kns=clock
+cargo oxide sanitize my_app -- --leak-check full -- --app-flag value
+```
+
+`memcheck` is the default tool. Use `racecheck` for shared-memory hazards,
+`initcheck` for uninitialized global-memory reads, and `synccheck` for invalid
+synchronization usage. Extra arguments after `--` are passed directly to
+`compute-sanitizer` before the executable; use a second `--` to pass arguments
+to the target program after the executable.
+
+Run `memcheck` first when investigating memory safety. The other tools are
+complementary and do not perform full memory-access checking.
+
 ## `cargo oxide doctor` -- environment validation
 
 Before debugging kernel failures, verify your environment is correctly set up:


### PR DESCRIPTION
## Summary

Adds `cargo oxide sanitize`, which builds the selected host executable and runs
it under NVIDIA Compute Sanitizer with `memcheck`, `racecheck`, `initcheck`, or
`synccheck`.

The command uses Cargo's reported executable artifact, enables optimized device
line tables by default, and makes sanitizer findings fail scripts by supplying
a nonzero error exit code unless the user explicitly overrides it.

Related to #315, but does not fix or close it: `--no-fmad` now reaches interop
device builds, while the backend's IR-level contraction behavior remains open.

## What changed

### Command and argument forwarding

- Adds `cargo oxide sanitize [example] --tool <tool>` for workspace and
  standalone projects.
- Passes arguments before the second `--` to Compute Sanitizer and arguments
  after it to the target application.
- Preserves explicit tool options while defaulting `--error-exitcode` to 86.
- Never declares a report clean from exit status alone, and warns when explicit
  options weaken what a zero status proves.

### Cargo artifact discovery

- Parses Cargo's stable `compiler-artifact.executable` JSON message instead of
  guessing `<target-dir>/release/<package-name>`.
- Supports custom binary names, `default-run`, configured target directories,
  host target triples, and single-binary virtual workspaces.
- Gives a clear `--bin` error when Cargo produces multiple ambiguous binaries.

### Debug and interop behavior

- Enables `CUDA_OXIDE_DEBUG=line-tables` by default without disabling normal
  optimization; explicit process/project settings still win.
- Fingerprints output-affecting codegen settings in rustflags so custom bins and
  virtual-workspace members cannot reuse stale PTX.
- Forwards the CLI `--no-fmad` request through interop device-crate builds.
- Finds Compute Sanitizer through PATH, configured CUDA toolkit roots, and
  standard Linux fallback paths.

### Documentation and tests

- Documents the tools, separators, exit behavior, line tables, and #315 caveat.
- Adds real Cargo subprocess tests for custom bins, configured target dirs, and
  virtual workspaces, plus focused status/fingerprint/tool-discovery tests.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p cargo-oxide --all-targets` (58 passed)
- [x] No-toolkit CI environment: empty `CUDA_TOOLKIT_PATH` correctly falls
  through to project configuration
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo deny check`
- [x] Real vecadd compile with `.file` / `.loc` PTX line information
- [x] Fake sanitizer finding exits 86 by default
- [x] Explicit zero/error-check-weakening options produce a generic completion
  message rather than a false clean-report claim
- [x] Custom-bin and virtual-workspace stale-build adversarial tests
- [ ] Runtime execution with NVIDIA Compute Sanitizer on a physical GPU

## Checklist

- [x] Contributor authorship preserved
- [x] Every PR commit has DCO sign-off
- [x] User documentation updated
- [x] No `crates/cuda-bindings/` files changed
