### PR TITLE
fix: honor --no-fmad throughout device codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 *.ptx
 *.ltoir
 *.target
+*.options
 .ltoir_arch
 *.ll
 *.bc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "clap",
  "libnvvm-sys",
  "nvjitlink-sys",
+ "oxide-artifacts",
  "serde_json",
  "toml",
 ]
@@ -787,6 +788,7 @@ dependencies = [
  "mir-transforms",
  "nvvm-transforms",
  "once_cell",
+ "oxide-artifacts",
  "pliron",
  "pliron-derive",
  "rustc-hash",

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -20,5 +20,6 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
+oxide-artifacts = { workspace = true }
 serde_json = "1"
 toml = "1"

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -52,7 +52,7 @@ cargo oxide setup                   # explicitly build the codegen backend
 | `--device-codegen-crate <LIST>` | build/test passthrough        | Comma-separated device owner crate filter       |
 | `--device-cfg <NAME>`        | build/test passthrough           | Append `--cfg NAME` to rustflags                |
 | `-v, --verbose`              | run, sanitize, build, test, emit-ltoir | Show detailed compilation output           |
-| `--no-fmad`                  | run, sanitize, build, pipeline   | Request separate mul+add; backend limitation tracked in [#315](https://github.com/NVlabs/cuda-oxide/issues/315) |
+| `--no-fmad`                  | run, sanitize, build, emit-ltoir, pipeline | Keep ordinary multiply and add/subtract operations separate |
 | `--async`                    | new                              | Use the async template                          |
 | `--cgdb`                     | debug                            | Use cgdb instead of cuda-gdb                    |
 | `--tui`                      | debug                            | Use GDB's TUI interface                         |
@@ -63,10 +63,13 @@ artifacts are architecture-specific. Without an override, `run` detects the
 local GPU, while `build` and `pipeline` use the compiler's feature-based target
 so they remain useful for cross-compilation.
 
-`--no-fmad` forwards the same experimental request as
-`CUDA_OXIDE_NO_FMA=1`. The current IR-level `contract` flag can still fuse
-`fmul+fadd`, so code that requires two separate roundings must not rely on this
-request until [#315](https://github.com/NVlabs/cuda-oxide/issues/315) is fixed.
+`--no-fmad` (or `CUDA_OXIDE_NO_FMA=1`) disables implicit contraction of an
+ordinary multiply followed by an add or subtract, so the two operations round
+separately. Explicit fused operations such as `f32::mul_add` remain fused.
+For NVVM IR and LTOIR, cuda-oxide records the policy in matching `.options`
+and versioned `.target` files and passes `-fma=0` through libNVVM and
+nvJitLink. Keep both sidecars with the artifact when another build system
+consumes it.
 
 ## Commands
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -204,6 +204,7 @@ pub fn codegen_run(
             detected_device_arch.as_deref(),
             features,
             bin,
+            no_fmad,
         );
         return;
     }
@@ -387,6 +388,15 @@ struct InteropDeviceBuildOptions {
     sanitizer_line_tables: bool,
 }
 
+impl InteropDeviceBuildOptions {
+    fn standard(no_fmad: bool) -> Self {
+        Self {
+            no_fmad,
+            sanitizer_line_tables: false,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn codegen_run_interop(
     ctx: &Context,
@@ -399,6 +409,7 @@ fn codegen_run_interop(
     detected_device_arch: Option<&str>,
     features: Option<&str>,
     bin: Option<&str>,
+    no_fmad: bool,
 ) {
     reject_interop_nvvm_ir(emit_nvvm_ir);
 
@@ -420,7 +431,7 @@ fn codegen_run_interop(
         verbose,
         arch,
         detected_device_arch,
-        InteropDeviceBuildOptions::default(),
+        InteropDeviceBuildOptions::standard(no_fmad),
     );
     run_host_cargo(ctx, example, example_dir, "run", features, bin, verbose);
 }
@@ -435,6 +446,7 @@ fn codegen_build_interop(
     emit_nvvm_ir: bool,
     arch: Option<&str>,
     features: Option<&str>,
+    no_fmad: bool,
 ) {
     reject_interop_nvvm_ir(emit_nvvm_ir);
 
@@ -455,7 +467,7 @@ fn codegen_build_interop(
         verbose,
         arch,
         None,
-        InteropDeviceBuildOptions::default(),
+        InteropDeviceBuildOptions::standard(no_fmad),
     );
     run_host_cargo(ctx, example, example_dir, "build", features, None, verbose);
 }
@@ -981,6 +993,7 @@ pub fn codegen_build(
             emit_nvvm_ir,
             target_arch,
             features,
+            no_fmad,
         );
         return;
     }
@@ -1026,7 +1039,8 @@ pub fn codegen_build(
 /// halves into one command for the Tile-to-SIMT interop workflow (#96): it
 /// builds the crate in NVVM IR mode, then compiles the emitted `<crate>.ll`
 /// with libNVVM `-gen-lto` and writes `<crate>.ltoir` (or `output`) plus the
-/// matching `.target` file used for runtime loading.
+/// matching `.target` and `.options` files used for runtime loading and final
+/// nvJitLink policy.
 ///
 /// `arch` is required because LTOIR is architecture-specific. It accepts
 /// `sm_XX`, `compute_XX`, or a bare `XX`, all mapped to libNVVM's
@@ -1038,6 +1052,7 @@ pub fn emit_ltoir(
     features: Option<&str>,
     output: Option<&Path>,
     verbose: bool,
+    no_fmad: bool,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -1060,11 +1075,18 @@ pub fn emit_ltoir(
     let sm_arch = parsed_arch.sm();
 
     // Step 1: build in NVVM IR mode so the backend writes `<crate>.ll` as
-    // libNVVM-ready NVVM IR. codegen_build exits on build failure. FMA
-    // contraction stays at its default (on) for the LTOIR build. Pass
+    // libNVVM-ready NVVM IR. codegen_build exits on build failure. Pass
     // quiet=true so the intermediate "✓ Build succeeded" line is suppressed;
     // emit_ltoir prints its own unified summary at the end.
-    codegen_build(ctx, example, verbose, true, Some(&sm_arch), features, false);
+    codegen_build(
+        ctx,
+        example,
+        verbose,
+        true,
+        Some(&sm_arch),
+        features,
+        no_fmad,
+    );
 
     // Step 2: compile that NVVM IR to LTOIR via libNVVM -gen-lto.
     let ll_path = example_dir.join(format!("{example}.ll"));
@@ -1075,14 +1097,53 @@ pub fn emit_ltoir(
         );
         std::process::exit(1);
     });
+    let source_options_path = ll_path.with_extension("options");
+    let source_options = std::fs::read_to_string(&source_options_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read emitted compile options at {}: {e}",
+            source_options_path.display()
+        );
+        std::process::exit(1);
+    });
+    let compile_options = oxide_artifacts::ArtifactCompileOptions::from_sidecar_text(
+        &source_options,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!(
+            "Error: invalid emitted compile options at {}: {e}",
+            source_options_path.display()
+        );
+        std::process::exit(1);
+    });
 
     let compute_arch = parsed_arch.compute();
-    let ltoir = compile_nvvm_to_ltoir(&ir, example, &parsed_arch);
+    let ltoir = compile_nvvm_to_ltoir(
+        &ir,
+        example,
+        &parsed_arch,
+        compile_options.fma_contraction_enabled(),
+    );
 
     // Step 3: write the artifact.
     let out_path = output
         .map(Path::to_path_buf)
         .unwrap_or_else(|| example_dir.join(format!("{example}.ltoir")));
+    for metadata_path in [
+        out_path.with_extension("target"),
+        out_path.with_extension("options"),
+    ] {
+        match std::fs::remove_file(&metadata_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                eprintln!(
+                    "Error: could not clear stale LTOIR metadata {}: {error}",
+                    metadata_path.display()
+                );
+                std::process::exit(1);
+            }
+        }
+    }
     std::fs::write(&out_path, &ltoir).unwrap_or_else(|e| {
         eprintln!(
             "Error: could not write LTOIR to {}: {e}",
@@ -1090,8 +1151,23 @@ pub fn emit_ltoir(
         );
         std::process::exit(1);
     });
+    let options_path = out_path.with_extension("options");
+    std::fs::write(&options_path, compile_options.sidecar_text()).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not write LTOIR compile options to {}: {e}",
+            options_path.display()
+        );
+        std::process::exit(1);
+    });
     let target_path = out_path.with_extension("target");
-    std::fs::write(&target_path, format!("{sm_arch}\n")).unwrap_or_else(|e| {
+    std::fs::write(
+        &target_path,
+        format!(
+            "{sm_arch}\n{}\n",
+            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+        ),
+    )
+    .unwrap_or_else(|e| {
         eprintln!(
             "Error: could not write LTOIR target metadata to {}: {e}",
             target_path.display()
@@ -1123,7 +1199,12 @@ fn parse_nvvm_arch(arch: &str) -> Result<libnvvm_sys::CudaArch, libnvvm_sys::Cud
 /// Compile NVVM IR text to binary LTOIR with libNVVM `-gen-lto`. Exits with a
 /// diagnostic on any libNVVM failure (the program log is attached to the error).
 ///
-fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, arch: &libnvvm_sys::CudaArch) -> Vec<u8> {
+fn compile_nvvm_to_ltoir(
+    ir: &[u8],
+    name: &str,
+    arch: &libnvvm_sys::CudaArch,
+    allow_fma_contraction: bool,
+) -> Vec<u8> {
     let nvvm = libnvvm_sys::LibNvvm::load().unwrap_or_else(|e| {
         eprintln!("Error: could not load libNVVM: {e}");
         eprintln!("libNVVM ships with the CUDA Toolkit at <CUDA>/nvvm/lib64/libnvvm.so.");
@@ -1202,8 +1283,13 @@ fn compile_nvvm_to_ltoir(ir: &[u8], name: &str, arch: &libnvvm_sys::CudaArch) ->
         eprintln!("Error: libNVVM verification failed: {e}");
         std::process::exit(1);
     });
+    let fma_opt = if allow_fma_contraction {
+        "-fma=1"
+    } else {
+        "-fma=0"
+    };
     program
-        .compile(&[&arch_opt, "-gen-lto"])
+        .compile(&[&arch_opt, "-gen-lto", fma_opt])
         .unwrap_or_else(|e| {
             eprintln!("Error: libNVVM -gen-lto compilation failed: {e}");
             std::process::exit(1);
@@ -2918,6 +3004,7 @@ fn clean_generated_files(example_dir: &Path, example: &str) {
         "ltoir",
         "cubin",
         "target",
+        "options",
         "cubin.target",
     ] {
         let file = example_dir.join(format!("{}.{}", stem, ext));
@@ -3515,6 +3602,22 @@ path = "src/main.rs"
         apply_codegen_rustflags(&mut cmd, &ctx, false, &[fingerprint]);
         let encoded = command_env(&cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
         assert!(has_codegen_env_fingerprint(&decoded_rustflags(&encoded)));
+    }
+
+    #[test]
+    fn standard_interop_codegen_forwards_no_fmad_without_debug_override() {
+        let ctx = test_context(OxideConfig::default());
+        let mut cmd = Command::new("cargo");
+
+        apply_interop_device_codegen_options(
+            &mut cmd,
+            &ctx,
+            false,
+            InteropDeviceBuildOptions::standard(true),
+        );
+
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_NO_FMA").as_deref(), Some("1"));
+        assert_eq!(command_env(&cmd, "CUDA_OXIDE_DEBUG"), None);
     }
 
     #[test]

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -98,8 +98,8 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
-        /// Forward the experimental no-FMA request to device codegen.
-        /// Also settable via CUDA_OXIDE_NO_FMA=1; see issue #315.
+        /// Disable implicit FMA contraction in device codegen.
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
         /// Additional arguments passed to compute-sanitizer before the binary.
@@ -166,7 +166,8 @@ enum Commands {
     ///
     /// Produces the SIMT artifact a tile or C++ kernel links against
     /// (NVVM IR emission followed by libNVVM `-gen-lto`), writing
-    /// `<crate>.ltoir`. See the Tile-to-SIMT interop tracker (#96).
+    /// `<crate>.ltoir` plus target/options sidecars. See the Tile-to-SIMT
+    /// interop tracker (#96).
     EmitLtoir {
         /// Crate name (required in workspace, optional for standalone projects)
         example: Option<String>,
@@ -183,6 +184,10 @@ enum Commands {
         /// Show verbose compilation output
         #[arg(short, long)]
         verbose: bool,
+        /// Disable implicit FMA contraction in both libNVVM and nvJitLink.
+        /// Also settable via CUDA_OXIDE_NO_FMA=1.
+        #[arg(long)]
+        no_fmad: bool,
     },
     /// Show the full compilation pipeline (MIR -> PTX/NVVM IR) with verbose output
     Pipeline {
@@ -435,6 +440,7 @@ fn main() {
             features,
             output,
             verbose,
+            no_fmad,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "emit-ltoir");
@@ -445,6 +451,7 @@ fn main() {
                 features.as_deref(),
                 output.as_deref(),
                 verbose,
+                no_fmad,
             );
         }
         Commands::Pipeline {

--- a/crates/cuda-core/src/embedded.rs
+++ b/crates/cuda-core/src/embedded.rs
@@ -7,7 +7,9 @@
 
 use crate::{CudaContext, CudaModule, DriverError};
 use oxide_artifacts::ArtifactError;
-pub use oxide_artifacts::{ArtifactPayloadKind, OwnedArtifactBundle};
+pub use oxide_artifacts::{
+    ArtifactCompileOptions, ArtifactPayloadKind, COMPILE_OPTIONS_TARGET_MARKER, OwnedArtifactBundle,
+};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -161,6 +163,7 @@ mod tests {
         let bundle = OwnedArtifactBundle {
             name: "demo".to_string(),
             target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
             payloads: Vec::new(),
             entries: Vec::new(),
         };
@@ -173,6 +176,7 @@ mod tests {
         let bundle = OwnedArtifactBundle {
             name: "demo".to_string(),
             target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
             payloads: vec![OwnedArtifactPayload {
                 kind: ArtifactPayloadKind::Ptx,
                 name: "demo.ptx".to_string(),
@@ -191,6 +195,7 @@ mod tests {
         let bundle = OwnedArtifactBundle {
             name: "demo".to_string(),
             target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
             payloads: vec![OwnedArtifactPayload {
                 kind: ArtifactPayloadKind::Cubin,
                 name: "demo.cubin".to_string(),

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -7,8 +7,9 @@
 
 use crate::ltoir;
 pub use cuda_core::embedded::{
-    ArtifactPayloadKind, EmbeddedModule, OwnedArtifactBundle, artifact_bundles_from_binary_path,
-    artifact_bundles_from_current_exe, embedded_modules_from_current_exe,
+    ArtifactCompileOptions, ArtifactPayloadKind, EmbeddedModule, OwnedArtifactBundle,
+    artifact_bundles_from_binary_path, artifact_bundles_from_current_exe,
+    embedded_modules_from_current_exe,
 };
 use cuda_core::{CudaContext, CudaModule, DriverError};
 use std::sync::Arc;
@@ -147,13 +148,20 @@ fn load_bundle(
     if let Some(nvvm_ir) = bundle.payload(ArtifactPayloadKind::NvvmIr) {
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
+        let allow_fma_contraction = bundle.compile_options.fma_contraction_enabled();
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => {
-                ltoir::build_cubin_from_nvvm_ir(nvvm_ir, &bundle.name, &emitted.sm())?
-            }
-            ltoir::ExecutionRoute::PtxBridge => {
-                ltoir::build_ptx_from_nvvm_ir(nvvm_ir, &bundle.name, &emitted.sm())?
-            }
+            ltoir::ExecutionRoute::Cubin => ltoir::build_cubin_from_nvvm_ir_with_options(
+                nvvm_ir,
+                &bundle.name,
+                &emitted.sm(),
+                allow_fma_contraction,
+            )?,
+            ltoir::ExecutionRoute::PtxBridge => ltoir::build_ptx_from_nvvm_ir_with_options(
+                nvvm_ir,
+                &bundle.name,
+                &emitted.sm(),
+                allow_fma_contraction,
+            )?,
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }
@@ -161,13 +169,20 @@ fn load_bundle(
     if let Some(ltoir) = bundle.payload(ArtifactPayloadKind::Ltoir) {
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
+        let allow_fma_contraction = bundle.compile_options.fma_contraction_enabled();
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => {
-                ltoir::link_ltoir_to_cubin(ltoir, &bundle.name, &emitted.sm())?
-            }
-            ltoir::ExecutionRoute::PtxBridge => {
-                ltoir::link_ltoir_to_ptx(ltoir, &bundle.name, &emitted.sm())?
-            }
+            ltoir::ExecutionRoute::Cubin => ltoir::link_ltoir_to_cubin_with_options(
+                ltoir,
+                &bundle.name,
+                &emitted.sm(),
+                allow_fma_contraction,
+            )?,
+            ltoir::ExecutionRoute::PtxBridge => ltoir::link_ltoir_to_ptx_with_options(
+                ltoir,
+                &bundle.name,
+                &emitted.sm(),
+                allow_fma_contraction,
+            )?,
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }
@@ -210,6 +225,7 @@ mod tests {
         OwnedArtifactBundle {
             name: "demo".to_string(),
             target: target.to_string(),
+            compile_options: ArtifactCompileOptions::new(),
             payloads: Vec::new(),
             entries: Vec::new(),
         }

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -37,8 +37,10 @@
 //!   `<root>/lib64/libnvJitLink.so`.
 //! - **libdevice**: `CUDA_OXIDE_LIBDEVICE` env var, then
 //!   `<root>/nvvm/libdevice/libdevice.10.bc` for the same roots.
-//! - **Artifact target**: the emitted `<name>.target` file, then the explicit
-//!   `CUDA_OXIDE_TARGET` override (set by `cargo oxide --arch=<sm_XX>`).
+//! - **Artifact target and options**: the emitted `<name>.target` records the
+//!   source architecture. Versioned targets require `<name>.options`, which
+//!   preserves the FMA policy through libNVVM and nvJitLink. The explicit
+//!   `CUDA_OXIDE_TARGET` override remains the fallback for legacy artifacts.
 //!   The CUDA context is queried separately for the GPU that will execute the
 //!   module.
 //!
@@ -49,8 +51,9 @@
 //! Blackwell PTX bridge keep their normal paths.
 //!
 //! An entry is keyed by the exact input bytes, normalized target, module names,
-//! ordered compiler/linker options, libdevice bytes, and SHA-256 digests of the
-//! exact loaded `libnvvm.so` and `libnvJitLink.so` files. Unknown tool identity
+//! ordered compiler/linker options (including FMA policy), libdevice bytes,
+//! and SHA-256 digests of the exact loaded `libnvvm.so` and
+//! `libnvJitLink.so` files. Unknown tool identity
 //! disables reuse. Entries are published atomically below
 //! `.oxide-artifacts/ltoir-cubin-cache/v1` and are rechecked before their owned
 //! bytes are passed to the CUDA driver. The first fingerprinted compiler and
@@ -73,6 +76,7 @@
 use crate::ltoir_cache::{
     BuiltArtifacts, CacheKeyBuilder, CacheResult, cache_or_build, digest_file_handle,
 };
+use cuda_core::embedded::{ArtifactCompileOptions, COMPILE_OPTIONS_TARGET_MARKER};
 use cuda_core::{CudaContext, CudaModule, DriverError};
 use libnvvm_sys::{CudaArch, CudaArchParseError, LibNvvm, NvvmError, Program};
 use nvjitlink_sys::{InputType, LibNvJitLink, Linker, NvJitLinkError};
@@ -82,7 +86,7 @@ use thiserror::Error;
 
 // Bump this whenever an unlisted compiler/linker input or pipeline semantic
 // changes. Explicit options are also part of each key below.
-const CACHE_RECIPE: &[u8] = b"cuda-host/native-ltoir-cubin/v1";
+const CACHE_RECIPE: &[u8] = b"cuda-host/native-ltoir-cubin/v2";
 
 struct LoadedNvvmTool {
     library: Arc<LibNvvm>,
@@ -125,6 +129,15 @@ pub enum LtoirError {
         ir_path: PathBuf,
         emitted: String,
         requested: String,
+    },
+
+    /// An NVVM IR compile-options sidecar contained an unsupported value.
+    #[error("invalid cuda-oxide compile metadata in {path}: {value}")]
+    InvalidCompileOptions {
+        /// Path to the malformed sidecar.
+        path: PathBuf,
+        /// Trimmed sidecar contents.
+        value: String,
     },
 
     /// An artifact is not compatible with the context's GPU.
@@ -240,6 +253,7 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
         path: ll_path.to_path_buf(),
         source,
     })?;
+    let allow_fma_contraction = read_fma_contraction_option(ll_path)?;
     validate_ir_target_sidecar(ll_path, arch)?;
     // Record the supplied target for older or manually created `.ll` files.
     // The sibling `.ltoir` can then be loaded after the `.ll` is removed.
@@ -253,12 +267,13 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
     let ltoir_path = dir.join(format!("{stem}.ltoir"));
     let cubin_path = dir.join(format!("{stem}.cubin"));
 
-    let cached = cached_nvvm_ir_to_cubin(
+    let cached = cached_nvvm_ir_to_cubin_with_options(
         dir,
         &ll_bytes,
         &ll_path.display().to_string(),
         &ltoir_path.display().to_string(),
         arch,
+        allow_fma_contraction,
     )?;
     let ltoir = cached
         .ltoir
@@ -294,10 +309,22 @@ pub fn build_cubin_from_nvvm_ir(
     module_name: &str,
     arch: &str,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_cubin_from_nvvm_ir_with_options(nvvm_ir, module_name, arch, true)
+}
+
+/// Compile NVVM IR bytes to a loadable cubin while preserving the artifact's
+/// floating-point contraction policy.
+pub fn build_cubin_from_nvvm_ir_with_options(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    arch: &str,
+    allow_fma_contraction: bool,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    let ltoir = compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch)?;
+    let ltoir =
+        compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch, allow_fma_contraction)?;
     let ltoir_name = format!("{module_name}.ltoir");
-    link_ltoir_to_cubin_parsed(&ltoir, &ltoir_name, &arch)
+    link_ltoir_to_cubin_parsed_with_options(&ltoir, &ltoir_name, &arch, allow_fma_contraction)
 }
 
 /// Compile NVVM IR bytes to forward-compatible PTX.
@@ -310,10 +337,22 @@ pub fn build_ptx_from_nvvm_ir(
     module_name: &str,
     arch: &str,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_ptx_from_nvvm_ir_with_options(nvvm_ir, module_name, arch, true)
+}
+
+/// Compile NVVM IR bytes to forward-compatible PTX while preserving the
+/// artifact's floating-point contraction policy.
+pub fn build_ptx_from_nvvm_ir_with_options(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    arch: &str,
+    allow_fma_contraction: bool,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    let ltoir = compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch)?;
+    let ltoir =
+        compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch, allow_fma_contraction)?;
     let ltoir_name = format!("{module_name}.ltoir");
-    link_ltoir_to_ptx_parsed(&ltoir, &ltoir_name, &arch)
+    link_ltoir_to_ptx_parsed_with_options(&ltoir, &ltoir_name, &arch, allow_fma_contraction)
 }
 
 /// Link a single LTOIR payload to a loadable cubin image in memory.
@@ -322,8 +361,19 @@ pub fn link_ltoir_to_cubin(
     module_name: &str,
     arch: &str,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_cubin_with_options(ltoir, module_name, arch, true)
+}
+
+/// Link a single LTOIR payload to a cubin while preserving the artifact's
+/// floating-point contraction policy.
+pub fn link_ltoir_to_cubin_with_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &str,
+    allow_fma_contraction: bool,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_cubin_parsed(ltoir, module_name, &arch)
+    link_ltoir_to_cubin_parsed_with_options(ltoir, module_name, &arch, allow_fma_contraction)
 }
 
 /// Link one LTOIR payload to forward-compatible PTX.
@@ -335,61 +385,99 @@ pub fn link_ltoir_to_ptx(
     module_name: &str,
     arch: &str,
 ) -> Result<Vec<u8>, LtoirError> {
-    let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_ptx_parsed(ltoir, module_name, &arch)
+    link_ltoir_to_ptx_with_options(ltoir, module_name, arch, true)
 }
 
-fn link_ltoir_to_cubin_parsed(
+/// Link one LTOIR payload to forward-compatible PTX while preserving the
+/// artifact's floating-point contraction policy.
+pub fn link_ltoir_to_ptx_with_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &str,
+    allow_fma_contraction: bool,
+) -> Result<Vec<u8>, LtoirError> {
+    let arch: CudaArch = arch.parse()?;
+    link_ltoir_to_ptx_parsed_with_options(ltoir, module_name, &arch, allow_fma_contraction)
+}
+
+fn link_ltoir_to_cubin_parsed_with_options(
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let nvj = LibNvJitLink::load()?;
-    link_ltoir_to_cubin_with(&nvj, ltoir, module_name, arch)
+    link_ltoir_to_cubin_with_tool_options(&nvj, ltoir, module_name, arch, allow_fma_contraction)
 }
 
-fn link_ltoir_to_cubin_with(
+fn link_ltoir_to_cubin_with_tool_options(
     nvj: &LibNvJitLink,
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let arch_opt = format!("-arch={}", arch.sm());
-    let mut linker = Linker::new(nvj, &[&arch_opt, "-lto"])?;
+    let options = nvjitlink_lto_options(&arch_opt, false, allow_fma_contraction);
+    let mut linker = Linker::new(nvj, &options)?;
     linker.add(InputType::Ltoir, ltoir, module_name)?;
     Ok(linker.finish()?)
 }
 
-fn link_ltoir_to_ptx_parsed(
+fn link_ltoir_to_ptx_parsed_with_options(
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let nvj = LibNvJitLink::load()?;
-    link_ltoir_to_ptx_with(&nvj, ltoir, module_name, arch)
+    link_ltoir_to_ptx_with_tool_options(&nvj, ltoir, module_name, arch, allow_fma_contraction)
 }
 
-fn link_ltoir_to_ptx_with(
+fn link_ltoir_to_ptx_with_tool_options(
     nvj: &LibNvJitLink,
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let arch_opt = format!("-arch={}", arch.sm());
-    let mut linker = Linker::new(nvj, &[&arch_opt, "-lto", "-ptx"])?;
+    let options = nvjitlink_lto_options(&arch_opt, true, allow_fma_contraction);
+    let mut linker = Linker::new(nvj, &options)?;
     linker.add(InputType::Ltoir, ltoir, module_name)?;
     Ok(linker.finish_ptx()?)
+}
+
+fn nvjitlink_lto_options(arch_opt: &str, emit_ptx: bool, allow_fma_contraction: bool) -> Vec<&str> {
+    let mut options = vec![arch_opt, "-lto"];
+    if emit_ptx {
+        options.push("-ptx");
+    }
+    options.push(if allow_fma_contraction {
+        "-fma=1"
+    } else {
+        "-fma=0"
+    });
+    options
 }
 
 fn compile_nvvm_ir_to_ltoir_parsed(
     nvvm_ir: &[u8],
     module_name: &str,
     arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let libdevice_bytes = read_libdevice_bytes()?;
     let nvvm = LibNvvm::load()?;
     validate_nvvm_frontend(&nvvm, arch)?;
-    compile_nvvm_ir_to_ltoir_with(&nvvm, nvvm_ir, module_name, arch, &libdevice_bytes)
+    compile_nvvm_ir_to_ltoir_with(
+        &nvvm,
+        nvvm_ir,
+        module_name,
+        arch,
+        &libdevice_bytes,
+        allow_fma_contraction,
+    )
 }
 
 fn read_libdevice_bytes() -> Result<Vec<u8>, LtoirError> {
@@ -432,6 +520,7 @@ fn compile_nvvm_ir_to_ltoir_with(
     module_name: &str,
     arch: &CudaArch,
     libdevice_bytes: &[u8],
+    allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
     let mut prog = Program::new(nvvm)?;
     // Add libdevice first so the kernel module's __nv_* references are
@@ -443,15 +532,45 @@ fn compile_nvvm_ir_to_ltoir_with(
 
     let arch_opt = format!("-arch={}", arch.compute());
     prog.verify(&[&arch_opt])?;
-    Ok(prog.compile(&[&arch_opt, "-gen-lto"])?)
+    let options = nvvm_compile_options(&arch_opt, allow_fma_contraction);
+    Ok(prog.compile(&options)?)
 }
 
+fn nvvm_compile_options(arch_opt: &str, allow_fma_contraction: bool) -> Vec<&str> {
+    let mut options = vec![arch_opt, "-gen-lto"];
+    options.push(if allow_fma_contraction {
+        "-fma=1"
+    } else {
+        "-fma=0"
+    });
+    options
+}
+
+#[cfg(test)]
 fn cached_nvvm_ir_to_cubin(
     source_dir: &Path,
     nvvm_ir: &[u8],
     nvvm_module_name: &str,
     ltoir_module_name: &str,
     arch: &CudaArch,
+) -> Result<CacheResult, LtoirError> {
+    cached_nvvm_ir_to_cubin_with_options(
+        source_dir,
+        nvvm_ir,
+        nvvm_module_name,
+        ltoir_module_name,
+        arch,
+        true,
+    )
+}
+
+fn cached_nvvm_ir_to_cubin_with_options(
+    source_dir: &Path,
+    nvvm_ir: &[u8],
+    nvvm_module_name: &str,
+    ltoir_module_name: &str,
+    arch: &CudaArch,
+    allow_fma_contraction: bool,
 ) -> Result<CacheResult, LtoirError> {
     let libdevice = read_libdevice_bytes()?;
     let nvvm = load_nvvm_tool()?;
@@ -460,14 +579,14 @@ fn cached_nvvm_ir_to_cubin(
 
     let key = nvvm.digest.and_then(|nvvm_digest| {
         nvj.digest.map(|nvjitlink_digest| {
-            nvvm_ir_cubin_cache_key(
+            nvvm_ir_cubin_cache_key_with_options(
                 nvvm_ir,
                 nvvm_module_name,
                 ltoir_module_name,
                 arch,
                 &libdevice,
-                &nvvm_digest,
-                &nvjitlink_digest,
+                (&nvvm_digest, &nvjitlink_digest),
+                allow_fma_contraction,
             )
         })
     });
@@ -479,8 +598,15 @@ fn cached_nvvm_ir_to_cubin(
             nvvm_module_name,
             arch,
             &libdevice,
+            allow_fma_contraction,
         )?;
-        let cubin = link_ltoir_to_cubin_with(&nvj.library, &ltoir, ltoir_module_name, arch)?;
+        let cubin = link_ltoir_to_cubin_with_tool_options(
+            &nvj.library,
+            &ltoir,
+            ltoir_module_name,
+            arch,
+            allow_fma_contraction,
+        )?;
         Ok(BuiltArtifacts::new(cubin, Some(ltoir)))
     };
 
@@ -492,19 +618,36 @@ fn cached_nvvm_ir_to_cubin(
     Ok(result)
 }
 
+#[cfg(test)]
 fn cached_ltoir_to_cubin(
     source_dir: &Path,
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
 ) -> Result<CacheResult, LtoirError> {
+    cached_ltoir_to_cubin_with_options(source_dir, ltoir, module_name, arch, true)
+}
+
+fn cached_ltoir_to_cubin_with_options(
+    source_dir: &Path,
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+    allow_fma_contraction: bool,
+) -> Result<CacheResult, LtoirError> {
     let nvj = load_nvjitlink_tool()?;
-    let key = nvj
-        .digest
-        .map(|digest| ltoir_cubin_cache_key(ltoir, module_name, arch, &digest));
+    let key = nvj.digest.map(|digest| {
+        ltoir_cubin_cache_key_with_options(ltoir, module_name, arch, &digest, allow_fma_contraction)
+    });
     let build = || -> Result<BuiltArtifacts, LtoirError> {
-        link_ltoir_to_cubin_with(&nvj.library, ltoir, module_name, arch)
-            .map(|cubin| BuiltArtifacts::new(cubin, None))
+        link_ltoir_to_cubin_with_tool_options(
+            &nvj.library,
+            ltoir,
+            module_name,
+            arch,
+            allow_fma_contraction,
+        )
+        .map(|cubin| BuiltArtifacts::new(cubin, None))
     };
 
     let result = match key {
@@ -612,6 +755,7 @@ fn report_changed_tool(label: &str) {
     }
 }
 
+#[cfg(test)]
 fn nvvm_ir_cubin_cache_key(
     nvvm_ir: &[u8],
     nvvm_module_name: &str,
@@ -621,6 +765,27 @@ fn nvvm_ir_cubin_cache_key(
     libnvvm_digest: &[u8; 32],
     nvjitlink_digest: &[u8; 32],
 ) -> [u8; 32] {
+    nvvm_ir_cubin_cache_key_with_options(
+        nvvm_ir,
+        nvvm_module_name,
+        ltoir_module_name,
+        arch,
+        libdevice,
+        (libnvvm_digest, nvjitlink_digest),
+        true,
+    )
+}
+
+fn nvvm_ir_cubin_cache_key_with_options(
+    nvvm_ir: &[u8],
+    nvvm_module_name: &str,
+    ltoir_module_name: &str,
+    arch: &CudaArch,
+    libdevice: &[u8],
+    tool_digests: (&[u8; 32], &[u8; 32]),
+    allow_fma_contraction: bool,
+) -> [u8; 32] {
+    let (libnvvm_digest, nvjitlink_digest) = tool_digests;
     let nvvm_arch = format!("-arch={}", arch.compute());
     let linker_arch = format!("-arch={}", arch.sm());
     CacheKeyBuilder::new()
@@ -635,20 +800,47 @@ fn nvvm_ir_cubin_cache_key(
         .field("nvvm-verify-option", nvvm_arch.as_bytes())
         .field("nvvm-compile-option", nvvm_arch.as_bytes())
         .field("nvvm-compile-option", b"-gen-lto")
+        .field(
+            "nvvm-fma-policy",
+            if allow_fma_contraction {
+                &b"-fma=1"[..]
+            } else {
+                &b"-fma=0"[..]
+            },
+        )
         .field("nvjitlink-input-kind", b"ltoir")
         .field("nvjitlink-module-name", ltoir_module_name.as_bytes())
         .field("nvjitlink-option", linker_arch.as_bytes())
         .field("nvjitlink-option", b"-lto")
+        .field(
+            "nvjitlink-fma-policy",
+            if allow_fma_contraction {
+                &b"-fma=1"[..]
+            } else {
+                &b"-fma=0"[..]
+            },
+        )
         .field("libnvvm-sha256", libnvvm_digest)
         .field("libnvjitlink-sha256", nvjitlink_digest)
         .finish()
 }
 
+#[cfg(test)]
 fn ltoir_cubin_cache_key(
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
     nvjitlink_digest: &[u8; 32],
+) -> [u8; 32] {
+    ltoir_cubin_cache_key_with_options(ltoir, module_name, arch, nvjitlink_digest, true)
+}
+
+fn ltoir_cubin_cache_key_with_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+    nvjitlink_digest: &[u8; 32],
+    allow_fma_contraction: bool,
 ) -> [u8; 32] {
     let linker_arch = format!("-arch={}", arch.sm());
 
@@ -661,6 +853,14 @@ fn ltoir_cubin_cache_key(
         .field("nvjitlink-module-name", module_name.as_bytes())
         .field("nvjitlink-option", linker_arch.as_bytes())
         .field("nvjitlink-option", b"-lto")
+        .field(
+            "nvjitlink-fma-policy",
+            if allow_fma_contraction {
+                &b"-fma=1"[..]
+            } else {
+                &b"-fma=0"[..]
+            },
+        )
         .field("libnvjitlink-sha256", nvjitlink_digest)
         .finish()
 }
@@ -751,8 +951,13 @@ pub fn load_kernel_module(
                 }
                 ExecutionRoute::PtxBridge => {
                     let nvvm_ir = read_artifact(&ll)?;
-                    let ptx =
-                        build_ptx_from_nvvm_ir(&nvvm_ir, &ll.display().to_string(), &emitted.sm())?;
+                    let allow_fma_contraction = read_fma_contraction_option(&ll)?;
+                    let ptx = build_ptx_from_nvvm_ir_with_options(
+                        &nvvm_ir,
+                        &ll.display().to_string(),
+                        &emitted.sm(),
+                        allow_fma_contraction,
+                    )?;
                     Ok(ctx.load_module_from_image(&ptx)?)
                 }
             }
@@ -761,19 +966,24 @@ pub fn load_kernel_module(
             let emitted = target_arch_for_artifact(&ltoir)?;
             let execution = execution_arch_for_context(ctx)?;
             let bytes = read_artifact(&ltoir)?;
+            let allow_fma_contraction = read_fma_contraction_option(&ltoir)?;
             let image = match execution_route(&emitted, &execution)? {
                 ExecutionRoute::Cubin => {
-                    cached_ltoir_to_cubin(
+                    cached_ltoir_to_cubin_with_options(
                         ltoir.parent().unwrap_or_else(|| Path::new(".")),
                         &bytes,
                         &ltoir.display().to_string(),
                         &emitted,
+                        allow_fma_contraction,
                     )?
                     .cubin
                 }
-                ExecutionRoute::PtxBridge => {
-                    link_ltoir_to_ptx_parsed(&bytes, &ltoir.display().to_string(), &emitted)?
-                }
+                ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_options(
+                    &bytes,
+                    &ltoir.display().to_string(),
+                    &emitted,
+                    allow_fma_contraction,
+                )?,
             };
             Ok(ctx.load_module_from_image(&image)?)
         }
@@ -923,10 +1133,52 @@ fn emitted_target_path(ll_path: &Path) -> PathBuf {
     ll_path.with_extension("target")
 }
 
+fn emitted_compile_options_path(ll_path: &Path) -> PathBuf {
+    ll_path.with_extension("options")
+}
+
+fn read_fma_contraction_option(ll_path: &Path) -> Result<bool, LtoirError> {
+    let path = emitted_compile_options_path(ll_path);
+    match std::fs::read_to_string(&path) {
+        Ok(value) => ArtifactCompileOptions::from_sidecar_text(&value)
+            .map(|options| options.fma_contraction_enabled())
+            .map_err(|error| LtoirError::InvalidCompileOptions {
+                path,
+                value: error.to_string(),
+            }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(source) => Err(LtoirError::Io { path, source }),
+    }
+}
+
 fn read_emitted_target(ll_path: &Path) -> Result<Option<CudaArch>, LtoirError> {
     let path = emitted_target_path(ll_path);
     match std::fs::read_to_string(&path) {
-        Ok(target) => Ok(Some(target.trim().parse()?)),
+        Ok(target) => {
+            let mut lines = target.lines();
+            let arch = lines.next().unwrap_or_default().parse()?;
+            match (lines.next(), lines.next()) {
+                (None, None) => Ok(Some(arch)),
+                (Some(marker), None) if marker == COMPILE_OPTIONS_TARGET_MARKER => {
+                    let options_path = emitted_compile_options_path(ll_path);
+                    if !options_path.try_exists().map_err(|source| LtoirError::Io {
+                        path: options_path.clone(),
+                        source,
+                    })? {
+                        return Err(LtoirError::InvalidCompileOptions {
+                            path: options_path,
+                            value: "required sidecar is missing".to_string(),
+                        });
+                    }
+                    read_fma_contraction_option(ll_path)?;
+                    Ok(Some(arch))
+                }
+                _ => Err(LtoirError::InvalidCompileOptions {
+                    path,
+                    value: target.trim().to_string(),
+                }),
+            }
+        }
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(source) => Err(LtoirError::Io { path, source }),
     }
@@ -951,8 +1203,17 @@ fn write_artifact_target_sidecar(
     target: &CudaArch,
 ) -> Result<(), LtoirError> {
     let path = emitted_target_path(artifact_path);
-    std::fs::write(&path, format!("{}\n", target.sm()))
-        .map_err(|source| LtoirError::Io { path, source })
+    let options_path = emitted_compile_options_path(artifact_path);
+    let contents = if options_path.try_exists().map_err(|source| LtoirError::Io {
+        path: options_path.clone(),
+        source,
+    })? {
+        read_fma_contraction_option(artifact_path)?;
+        format!("{}\n{COMPILE_OPTIONS_TARGET_MARKER}\n", target.sm())
+    } else {
+        format!("{}\n", target.sm())
+    };
+    std::fs::write(&path, contents).map_err(|source| LtoirError::Io { path, source })
 }
 
 fn read_artifact(path: &Path) -> Result<Vec<u8>, LtoirError> {
@@ -1045,6 +1306,57 @@ mod tests {
         assert!(matches!(mismatch, LtoirError::TargetMismatch { .. }));
 
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn versioned_target_requires_valid_compile_options() {
+        let dir = temp_dir("versioned_compile_options");
+        std::fs::create_dir_all(&dir).unwrap();
+        let ll = dir.join("kernel.ll");
+        std::fs::write(&ll, "; test\n").unwrap();
+        std::fs::write(
+            dir.join("kernel.target"),
+            format!("sm_86\n{COMPILE_OPTIONS_TARGET_MARKER}\n"),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            read_emitted_target(&ll),
+            Err(LtoirError::InvalidCompileOptions { .. })
+        ));
+
+        let options = ArtifactCompileOptions::new().with_fma_contraction(false);
+        std::fs::write(dir.join("kernel.options"), options.sidecar_text()).unwrap();
+        assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
+        assert!(!read_fma_contraction_option(&ll).unwrap());
+
+        std::fs::write(dir.join("kernel.options"), "fma-contraction=off\n").unwrap();
+        assert!(matches!(
+            read_emitted_target(&ll),
+            Err(LtoirError::InvalidCompileOptions { .. })
+        ));
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn nvidia_lto_options_set_fma_policy_explicitly() {
+        assert_eq!(
+            nvvm_compile_options("-arch=compute_86", true),
+            ["-arch=compute_86", "-gen-lto", "-fma=1"]
+        );
+        assert_eq!(
+            nvvm_compile_options("-arch=compute_86", false),
+            ["-arch=compute_86", "-gen-lto", "-fma=0"]
+        );
+        assert_eq!(
+            nvjitlink_lto_options("-arch=sm_86", false, false),
+            ["-arch=sm_86", "-lto", "-fma=0"]
+        );
+        assert_eq!(
+            nvjitlink_lto_options("-arch=sm_86", true, true),
+            ["-arch=sm_86", "-lto", "-ptx", "-fma=1"]
+        );
     }
 
     #[test]
@@ -1339,6 +1651,19 @@ mod tests {
             ),
             "architecture suffixes must remain part of the key"
         );
+        assert_ne!(
+            original,
+            nvvm_ir_cubin_cache_key_with_options(
+                b"nvvm ir",
+                "kernel.ll",
+                "kernel.ltoir",
+                &arch,
+                b"libdevice",
+                (&nvvm, &nvjitlink),
+                false,
+            ),
+            "FMA policy changes both libNVVM and nvJitLink output"
+        );
     }
 
     #[test]
@@ -1367,6 +1692,11 @@ mod tests {
         assert_ne!(
             original,
             ltoir_cubin_cache_key(b"ltoir", "kernel.ltoir", &arch, &[6_u8; 32])
+        );
+        assert_ne!(
+            original,
+            ltoir_cubin_cache_key_with_options(b"ltoir", "kernel.ltoir", &arch, &nvjitlink, false,),
+            "FMA policy changes nvJitLink LTO output"
         );
         assert_ne!(
             original,

--- a/crates/mir-importer/Cargo.toml
+++ b/crates/mir-importer/Cargo.toml
@@ -18,6 +18,7 @@ mir-lower = { workspace = true }
 mir-transforms = { workspace = true }
 nvvm-transforms = { workspace = true }
 libnvvm-sys = { workspace = true }
+oxide-artifacts = { workspace = true }
 thiserror = { workspace = true }
 linkme = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/mir-importer/README.md
+++ b/crates/mir-importer/README.md
@@ -45,15 +45,22 @@ variables remain in stable memory locations for cuda-gdb.
 4. **Unroll** — Apply supported `#[unroll]` and `#[unroll(N)]` requests to the
    SSA form.
 5. **Lower and export** — Convert `dialect-mir` → LLVM dialect (via `mir-lower`)
-   and export LLVM IR. Float ops carry the `contract` fast-math flag so NVPTX
-   can fuse `fmul+fadd` into `fma.rn.f32` (matching nvcc's `--fmad=true`).
+   and export LLVM IR. By default, ordinary float operations carry the
+   `contract` fast-math flag so NVPTX can fuse `fmul+fadd` into `fma.rn.f32`
+   (matching nvcc's `--fmad=true`). `--no-fmad` omits that permission.
 6. **Optimize** — Run `opt -O2` (via `LlvmToolchain`) on the exported IR.
    Skipped for full-debug builds (`-G`) so locals stay inspectable under
    cuda-gdb. Override with `CUDA_OXIDE_NO_OPT=1`.
 7. **Generate** — Invoke `llc -fp-contract=fast` for PTX (or emit NVVM IR).
    The `-fp-contract=fast` flag activates the NVPTX backend's FMA contract
-   mode; pair with the IR `contract` flag from step 5. Disable with
-   `CUDA_OXIDE_NO_FMA=1` or `cargo oxide run --no-fmad`.
+   mode; pair with the IR `contract` flag from step 5. Disable both gates with
+   `CUDA_OXIDE_NO_FMA=1` or `cargo oxide run --no-fmad`. Explicit fused
+   operations such as `f32::mul_add` remain fused.
+
+NVVM IR and LTOIR defer final code generation. Their versioned `.target` file
+requires the sibling `.options` file, which tells cuda-host, libNVVM, and
+nvJitLink whether to use `-fma=0` or `-fma=1`. Copy both sidecars with the
+artifact; a missing required sidecar is an error rather than a silent fallback.
 
 ## Output Modes
 

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -176,6 +176,9 @@ pub struct CompilationResult {
     pub artifact_kind: CompilationArtifactKind,
     /// GPU target architecture used (e.g., `sm_90a`, `sm_80`).
     pub target: String,
+    /// Floating-point contraction policy that later compilation stages must
+    /// preserve.
+    pub allow_fma_contraction: bool,
 }
 
 /// Configuration for the compilation pipeline.
@@ -218,6 +221,11 @@ pub struct PipelineConfig {
     pub device_arch_hint: Option<String>,
     /// Device debug metadata tier.
     pub debug_kind: DebugKind,
+    /// Whether ordinary floating-point multiply/add or multiply/subtract
+    /// expressions may contract into fused operations.
+    ///
+    /// Explicit fused operations, such as `f32::mul_add`, are unaffected.
+    pub allow_fma_contraction: bool,
 }
 
 impl Default for PipelineConfig {
@@ -232,6 +240,7 @@ impl Default for PipelineConfig {
             target_arch: None,
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            allow_fma_contraction: true,
         }
     }
 }
@@ -435,7 +444,7 @@ pub fn run_pipeline(
     if config.verbose {
         eprintln!("\n=== Lowering dialect-mir → LLVM dialect ===");
     }
-    lower_to_llvm(&mut ctx, module_op_ptr)?;
+    lower_to_llvm(&mut ctx, module_op_ptr, config.allow_fma_contraction)?;
 
     // Detect CUDA libdevice usage.
     //
@@ -567,6 +576,13 @@ pub fn run_pipeline(
             .as_ref()
             .expect("NVVM target was resolved before export")
             .sm();
+        write_nvvm_compile_options_sidecar(
+            &config.output_dir,
+            &config.output_name,
+            config.allow_fma_contraction,
+        )?;
+        // Publish the target last: its version marker is the completion record
+        // that says the sibling options file is required.
         write_nvvm_target_sidecar(&config.output_dir, &config.output_name, &target)?;
         Ok(CompilationResult {
             artifact_path: ll_path.clone(),
@@ -574,6 +590,7 @@ pub fn run_pipeline(
             ll_path,
             ptx_path,
             target,
+            allow_fma_contraction: config.allow_fma_contraction,
         })
     } else {
         if config.verbose {
@@ -582,7 +599,12 @@ pub fn run_pipeline(
         let ptx_path = config
             .output_dir
             .join(format!("{}.ptx", config.output_name));
-        let target = generate_ptx(&ll_path, &ptx_path, config.debug_kind)?;
+        let target = generate_ptx(
+            &ll_path,
+            &ptx_path,
+            config.debug_kind,
+            config.allow_fma_contraction,
+        )?;
         if config.verbose {
             eprintln!(
                 "✓ PTX written to {} (target: {})",
@@ -597,6 +619,7 @@ pub fn run_pipeline(
             ll_path,
             ptx_path,
             target,
+            allow_fma_contraction: config.allow_fma_contraction,
         })
     }
 }
@@ -699,10 +722,20 @@ fn append_to_module(ctx: &Context, module_op_ptr: Ptr<Operation>, func_op_ptr: P
 /// `dialect-mir`/`dialect-nvvm` op to its LLVM dialect equivalent. The LLVM
 /// dialect auto-registers when the `Context` is created, so no explicit
 /// registration is needed here.
-fn lower_to_llvm(ctx: &mut Context, module_op_ptr: Ptr<Operation>) -> Result<(), PipelineError> {
+fn lower_to_llvm(
+    ctx: &mut Context,
+    module_op_ptr: Ptr<Operation>,
+    allow_fma_contraction: bool,
+) -> Result<(), PipelineError> {
     mir_lower::register(ctx);
 
-    match mir_lower::lower_mir_to_llvm(ctx, module_op_ptr) {
+    match mir_lower::lower_mir_to_llvm_with_options(
+        ctx,
+        module_op_ptr,
+        mir_lower::LoweringOptions {
+            allow_fma_contraction,
+        },
+    ) {
         Ok(()) => Ok(()),
         // Format with `ctx` so the failing op's location/span survives.
         Err(e) => Err(PipelineError::Lowering(e.disp(ctx).to_string())),
@@ -909,9 +942,32 @@ fn write_nvvm_target_sidecar(
     target: &str,
 ) -> Result<(), PipelineError> {
     let path = output_dir.join(format!("{output_name}.target"));
-    std::fs::write(&path, format!("{target}\n")).map_err(|error| {
+    std::fs::write(
+        &path,
+        format!(
+            "{target}\n{}\n",
+            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+        ),
+    )
+    .map_err(|error| {
         PipelineError::Export(format!(
             "failed to record NVVM target in {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn write_nvvm_compile_options_sidecar(
+    output_dir: &Path,
+    output_name: &str,
+    allow_fma_contraction: bool,
+) -> Result<(), PipelineError> {
+    let path = output_dir.join(format!("{output_name}.options"));
+    let options =
+        oxide_artifacts::ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction);
+    std::fs::write(&path, options.sidecar_text()).map_err(|error| {
+        PipelineError::Export(format!(
+            "failed to record NVVM compile options in {}: {error}",
             path.display()
         ))
     })
@@ -921,7 +977,15 @@ fn clear_stale_compilation_artifacts(
     output_dir: &Path,
     output_name: &str,
 ) -> Result<(), PipelineError> {
-    for suffix in ["ll", "ptx", "target", "ltoir", "cubin", "cubin.target"] {
+    for suffix in [
+        "ll",
+        "ptx",
+        "target",
+        "options",
+        "ltoir",
+        "cubin",
+        "cubin.target",
+    ] {
         let path = output_dir.join(format!("{output_name}.{suffix}"));
         match std::fs::remove_file(&path) {
             Ok(()) => {}
@@ -2162,6 +2226,7 @@ fn generate_ptx(
     ll_path: &Path,
     ptx_path: &Path,
     debug_kind: DebugKind,
+    allow_fma_contraction: bool,
 ) -> Result<String, PipelineError> {
     // Explicit, hard override: `--arch` or a parent-set `CUDA_OXIDE_TARGET`.
     let explicit_override = std::env::var("CUDA_OXIDE_TARGET").ok();
@@ -2273,8 +2338,9 @@ fn generate_ptx(
     // Fuse fmul+fadd/fsub into fma.rn.f32, matching nvcc's default --fmad=true.
     // The IR-side `contract` flag (set by add_fastmath_flags in mir-lower) grants
     // permission; this llc flag activates the NVPTX backend's contract mode.
-    // Set CUDA_OXIDE_NO_FMA=1 or pass --no-fmad to cargo oxide to opt out.
-    if std::env::var("CUDA_OXIDE_NO_FMA").is_err() {
+    // The same compilation-wide policy controls the IR permission and this
+    // backend gate, so the two stages cannot disagree about contraction.
+    if allow_fma_contraction {
         llc_cmd.arg("-fp-contract=fast");
     }
     let result = llc_cmd.arg(llc_input).arg("-o").arg(ptx_path).output();
@@ -2459,6 +2525,7 @@ mod tests {
         assert_eq!(config.target_arch, None);
         assert_eq!(config.device_arch_hint, None);
         assert_eq!(config.debug_kind, DebugKind::Off);
+        assert!(config.allow_fma_contraction);
     }
 
     #[test]
@@ -2473,7 +2540,15 @@ mod tests {
             unique
         ));
         fs::create_dir_all(&root).unwrap();
-        for suffix in ["ll", "ptx", "target", "ltoir", "cubin", "cubin.target"] {
+        for suffix in [
+            "ll",
+            "ptx",
+            "target",
+            "options",
+            "ltoir",
+            "cubin",
+            "cubin.target",
+        ] {
             fs::write(root.join(format!("kernel.{suffix}")), b"stale").unwrap();
         }
         let cached_cubin =
@@ -2483,7 +2558,15 @@ mod tests {
 
         clear_stale_compilation_artifacts(&root, "kernel").unwrap();
 
-        for suffix in ["ll", "ptx", "target", "ltoir", "cubin", "cubin.target"] {
+        for suffix in [
+            "ll",
+            "ptx",
+            "target",
+            "options",
+            "ltoir",
+            "cubin",
+            "cubin.target",
+        ] {
             assert!(!root.join(format!("kernel.{suffix}")).exists(), "{suffix}");
         }
         assert_eq!(
@@ -2551,6 +2634,7 @@ mod tests {
             target_arch: Some("sm_86".to_string()),
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            allow_fma_contraction: false,
         };
 
         let result = run_pipeline(&[], &[], &config).expect("pipeline run");
@@ -2562,7 +2646,16 @@ mod tests {
         assert_eq!(result.target, "sm_86");
         assert_eq!(
             fs::read_to_string(output_dir.join("empty.target")).unwrap(),
-            "sm_86\n"
+            format!(
+                "sm_86\n{}\n",
+                oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+            )
+        );
+        assert_eq!(
+            fs::read_to_string(output_dir.join("empty.options")).unwrap(),
+            oxide_artifacts::ArtifactCompileOptions::new()
+                .with_fma_contraction(false)
+                .sidecar_text()
         );
 
         fs::remove_dir_all(&root).expect("clean up temp output dir");
@@ -2589,6 +2682,7 @@ mod tests {
             target_arch: Some("sm_86".to_string()),
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            allow_fma_contraction: true,
         };
         let externs = [DeviceExternDecl {
             export_name: "consume_float".to_string(),

--- a/crates/mir-lower/src/context.rs
+++ b/crates/mir-lower/src/context.rs
@@ -11,6 +11,43 @@
 
 use rustc_hash::FxHashMap;
 
+use crate::LoweringOptions;
+use pliron::context::Context;
+
+mod options_storage {
+    pliron::dict_key!(LOWERING_OPTIONS_KEY, "cuda_oxide_mir_lower_options");
+}
+
+/// Store the options for the active lowering pass in pliron's per-compilation
+/// context. Conversion interfaces only receive the context, so this keeps
+/// policy explicit without consulting process-global environment variables in
+/// individual operation converters.
+pub(crate) fn set_lowering_options(ctx: &mut Context, options: LoweringOptions) {
+    if let Some(index) = ctx
+        .aux_data_map
+        .get(&*options_storage::LOWERING_OPTIONS_KEY)
+        .copied()
+    {
+        ctx.aux_data[index] = Box::new(options);
+    } else {
+        let index = ctx.aux_data.insert(Box::new(options));
+        ctx.aux_data_map
+            .insert(options_storage::LOWERING_OPTIONS_KEY.clone(), index);
+    }
+}
+
+/// Read options for the active lowering pass.
+///
+/// The default preserves the historical behavior for callers that use the
+/// original `lower_mir_to_llvm` entry point.
+pub(crate) fn lowering_options(ctx: &Context) -> LoweringOptions {
+    ctx.aux_data_map
+        .get(&*options_storage::LOWERING_OPTIONS_KEY)
+        .and_then(|index| ctx.aux_data[*index].downcast_ref::<LoweringOptions>())
+        .copied()
+        .unwrap_or_default()
+}
+
 /// Map from shared memory allocation keys to their LLVM global symbol names.
 ///
 /// In CUDA kernels, shared memory is declared as module-level globals with

--- a/crates/mir-lower/src/convert/ops/arithmetic.rs
+++ b/crates/mir-lower/src/convert/ops/arithmetic.rs
@@ -113,17 +113,23 @@ fn is_signed_int_op(
     }
 }
 
-/// Add fastmath flags to a floating-point operation.
+/// Add the configured fast-math flags to a floating-point operation.
 ///
-/// Sets ONLY `contract`, which lets the NVPTX backend fuse an `fmul`
-/// feeding an `fadd`/`fsub` into a single `fma.rn.f32`. This matches
-/// nvcc's default `--fmad=true`: the one fast-math relaxation NVIDIA
-/// enables out of the box. The only IEEE deviation is the single (more
-/// accurate) rounding of the fused op. We deliberately do NOT set
-/// reassoc/nnan/ninf/nsz/arcp, so results stay bit-comparable to a
-/// contracted reference (no algebraic reordering).
+/// By default this sets ONLY `contract`, which lets the NVPTX backend fuse an
+/// `fmul` feeding an `fadd`/`fsub` into a single `fma.rn.f32`. This matches
+/// nvcc's default `--fmad=true`: the one fast-math relaxation NVIDIA enables
+/// out of the box. When the caller disables contraction, no fast-math
+/// permission is granted and multiply/add operations round separately.
+///
+/// We deliberately never set reassoc/nnan/ninf/nsz/arcp, so results stay
+/// bit-comparable to the selected contracted or uncontracted reference.
 fn add_fastmath_flags(ctx: &mut Context, op: Ptr<Operation>) {
-    let flags = FastmathFlagsAttr(FastmathFlags::CONTRACT);
+    let flags = if crate::context::lowering_options(ctx).allow_fma_contraction {
+        FastmathFlags::CONTRACT
+    } else {
+        FastmathFlags::empty()
+    };
+    let flags = FastmathFlagsAttr(flags);
     let key: pliron::identifier::Identifier = "llvm_fast_math_flags".try_into().unwrap();
     op.deref_mut(ctx).attributes.set(key, flags);
 }
@@ -879,5 +885,68 @@ mod tests {
             FastmathFlags::CONTRACT,
             "float add must carry exactly the contract fast-math flag"
         );
+    }
+
+    /// Disabling contraction removes the IR-level permission from both sides
+    /// of a multiply-add chain. The backend command-line gate alone is not
+    /// sufficient when either instruction still carries `contract`.
+    #[test]
+    fn no_fma_contraction_omits_contract_flags_from_mul_add_sub_chains() {
+        let mut ctx = make_ctx();
+        let f32_ty: TypeHandle = pliron::builtin::types::FP32Type::get(&ctx).into();
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![f32_ty, f32_ty, f32_ty], vec![]);
+        let lhs = block.deref(&ctx).get_argument(0);
+        let rhs = block.deref(&ctx).get_argument(1);
+        let addend = block.deref(&ctx).get_argument(2);
+
+        let mul_op = Operation::new(
+            &mut ctx,
+            mir::MirMulOp::get_concrete_op_info(),
+            vec![f32_ty],
+            vec![lhs, rhs],
+            vec![],
+            0,
+        );
+        let product = mul_op.deref(&ctx).get_result(0);
+        mul_op.insert_at_back(block, &ctx);
+
+        let add_op = Operation::new(
+            &mut ctx,
+            mir::MirAddOp::get_concrete_op_info(),
+            vec![f32_ty],
+            vec![product, addend],
+            vec![],
+            0,
+        );
+        add_op.insert_at_back(block, &ctx);
+
+        let sub_op = Operation::new(
+            &mut ctx,
+            mir::MirSubOp::get_concrete_op_info(),
+            vec![f32_ty],
+            vec![product, addend],
+            vec![],
+            0,
+        );
+        sub_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm_with_options(
+            &mut ctx,
+            module_ptr,
+            crate::LoweringOptions {
+                allow_fma_contraction: false,
+            },
+        )
+        .expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let fmul = find_first::<llvm::FMulOp>(&ctx, &body).expect("expected one llvm.fmul");
+        let fadd = find_first::<llvm::FAddOp>(&ctx, &body).expect("expected one llvm.fadd");
+        let fsub = find_first::<llvm::FSubOp>(&ctx, &body).expect("expected one llvm.fsub");
+        assert_eq!(fmul.fast_math_flags(&ctx).0, FastmathFlags::empty());
+        assert_eq!(fadd.fast_math_flags(&ctx).0, FastmathFlags::empty());
+        assert_eq!(fsub.fast_math_flags(&ctx).0, FastmathFlags::empty());
     }
 }

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -1047,10 +1047,16 @@ fn convert_rust_float_math_intrinsic(
 /// verification. Replacing the call with a binop here gives LLVM the explicit
 /// `fast` fast-math flag set promised by the Rust intrinsic contract, so f32
 /// and f64 monomorphizations both work without per-type intrinsic dispatch.
-fn fast_float_intrinsic_flags() -> FastmathFlagsAttr {
+/// A compilation-wide no-FMA request removes only the contraction permission;
+/// all other finite-input relaxations remain intact.
+fn fast_float_intrinsic_flags(ctx: &Context) -> FastmathFlagsAttr {
     // pliron-llvm's `FastmathFlagsAttr::default()` is `FastmathFlags::empty()`;
     // `core::intrinsics::f*_fast` needs the explicit LLVM `fast` flag group.
-    FastmathFlags::FAST.into()
+    let mut flags = FastmathFlags::FAST;
+    if !crate::context::lowering_options(ctx).allow_fma_contraction {
+        flags.remove(FastmathFlags::CONTRACT);
+    }
+    flags.into()
 }
 
 fn lower_fast_binop(
@@ -1068,7 +1074,7 @@ fn lower_fast_binop(
         }
     };
 
-    let flags = fast_float_intrinsic_flags();
+    let flags = fast_float_intrinsic_flags(ctx);
     let llvm_op = match binop {
         FastFloatBinop::Add => {
             llvm::FAddOp::new_with_fast_math_flags(ctx, lhs, rhs, flags).get_operation()
@@ -1471,6 +1477,23 @@ fn resolve_device_extern_symbol(callee_name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn no_fma_policy_removes_only_contract_from_fast_float_intrinsics() {
+        let mut ctx = Context::new();
+        crate::context::set_lowering_options(
+            &mut ctx,
+            crate::LoweringOptions {
+                allow_fma_contraction: false,
+            },
+        );
+
+        let flags = fast_float_intrinsic_flags(&ctx).0;
+        assert!(!flags.contains(FastmathFlags::CONTRACT));
+        assert!(flags.contains(FastmathFlags::REASSOC));
+        assert!(flags.contains(FastmathFlags::NNAN));
+        assert!(flags.contains(FastmathFlags::NINF));
+    }
 
     #[test]
     fn test_resolve_device_extern_symbol() {

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -154,6 +154,24 @@ use type_conversion_interface::MirConvertibleType;
 // DialectConversion driver
 // ============================================================================
 
+/// Options controlling the `dialect-mir` to LLVM dialect lowering pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LoweringOptions {
+    /// Whether ordinary floating-point multiply/add or multiply/subtract
+    /// expressions may contract into fused operations.
+    ///
+    /// This does not affect explicit fused operations such as `f32::mul_add`.
+    pub allow_fma_contraction: bool,
+}
+
+impl Default for LoweringOptions {
+    fn default() -> Self {
+        Self {
+            allow_fma_contraction: true,
+        }
+    }
+}
+
 /// `dialect-mir` → LLVM dialect conversion driver.
 ///
 /// Implements pliron's `DialectConversion` trait. The `rewrite` method uses
@@ -302,6 +320,19 @@ impl DialectConversion for MirToLlvmConversionDriver {
 ///
 /// `Ok(())` if all operations were successfully converted.
 pub fn lower_mir_to_llvm(ctx: &mut Context, module_op: Ptr<Operation>) -> Result<()> {
+    lower_mir_to_llvm_with_options(ctx, module_op, LoweringOptions::default())
+}
+
+/// Runs the `dialect-mir` → LLVM dialect lowering pass with explicit options.
+///
+/// Use this entry point when the caller needs compilation-wide floating-point
+/// policy such as disabling implicit FMA contraction.
+pub fn lower_mir_to_llvm_with_options(
+    ctx: &mut Context,
+    module_op: Ptr<Operation>,
+    options: LoweringOptions,
+) -> Result<()> {
+    context::set_lowering_options(ctx, options);
     let mut conversion = MirToLlvmConversionDriver {
         shared_globals: FxHashMap::default(),
         device_globals: FxHashMap::default(),

--- a/crates/oxide-artifacts/src/lib.rs
+++ b/crates/oxide-artifacts/src/lib.rs
@@ -15,11 +15,86 @@ pub const ARTIFACT_SECTION_NAME: &str = ".oxart";
 #[cfg(feature = "object-write")]
 const ARTIFACT_ANCHOR_SECTION_NAME: &str = ".oxlink";
 pub const ARTIFACT_MAGIC: [u8; 8] = *b"OXIDEART";
-pub const ARTIFACT_VERSION: u16 = 1;
+pub const ARTIFACT_VERSION: u16 = 2;
+const LEGACY_ARTIFACT_VERSION: u16 = 1;
 
 const HEADER_BYTES: usize = 32;
 const PAYLOAD_RECORD_BYTES: usize = 24;
 const ENTRY_RECORD_BYTES: usize = 24;
+
+const OPTION_NO_FMA_CONTRACTION: u64 = 1 << 0;
+const KNOWN_COMPILE_OPTIONS: u64 = OPTION_NO_FMA_CONTRACTION;
+
+/// Marker written on the second line of a versioned NVVM/LTOIR `.target`
+/// sidecar. Its presence makes older one-line readers reject the artifact
+/// instead of silently ignoring required compile policy.
+pub const COMPILE_OPTIONS_TARGET_MARKER: &str = "compile-options=v1";
+
+const COMPILE_OPTIONS_SIDECAR_HEADER: &str = "cuda-oxide-compile-options-v1";
+const COMPILE_OPTIONS_FMA_ON: &str = "cuda-oxide-compile-options-v1\nfma-contraction=on\n";
+const COMPILE_OPTIONS_FMA_OFF: &str = "cuda-oxide-compile-options-v1\nfma-contraction=off\n";
+
+/// Compilation policy that must remain attached to a device artifact until
+/// its final machine-code generation step.
+///
+/// A zero value preserves the historical defaults, which keeps version-1
+/// bundles emitted before this field was used fully compatible.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ArtifactCompileOptions(u64);
+
+impl ArtifactCompileOptions {
+    /// Construct the historical default policy.
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    /// Record whether ordinary floating-point multiply/add expressions may
+    /// contract into fused operations.
+    pub const fn with_fma_contraction(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.0 &= !OPTION_NO_FMA_CONTRACTION;
+        } else {
+            self.0 |= OPTION_NO_FMA_CONTRACTION;
+        }
+        self
+    }
+
+    /// Whether ordinary floating-point multiply/add expressions may contract.
+    pub const fn fma_contraction_enabled(self) -> bool {
+        self.0 & OPTION_NO_FMA_CONTRACTION == 0
+    }
+
+    fn from_bits(bits: u64) -> Result<Self, ArtifactError> {
+        if bits & !KNOWN_COMPILE_OPTIONS != 0 {
+            return Err(ArtifactError::UnsupportedCompileOptions(bits));
+        }
+        Ok(Self(bits))
+    }
+
+    const fn bits(self) -> u64 {
+        self.0
+    }
+
+    /// Encode this policy for a sibling `.options` file.
+    pub const fn sidecar_text(self) -> &'static str {
+        if self.fma_contraction_enabled() {
+            COMPILE_OPTIONS_FMA_ON
+        } else {
+            COMPILE_OPTIONS_FMA_OFF
+        }
+    }
+
+    /// Parse a complete version-1 `.options` file.
+    pub fn from_sidecar_text(value: &str) -> Result<Self, ArtifactError> {
+        match value {
+            COMPILE_OPTIONS_FMA_ON => Ok(Self::new()),
+            COMPILE_OPTIONS_FMA_OFF => Ok(Self::new().with_fma_contraction(false)),
+            _ => Err(ArtifactError::MalformedCompileOptions(format!(
+                "expected `{COMPILE_OPTIONS_SIDECAR_HEADER}` with exactly one `fma-contraction=on|off` setting"
+            ))),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ArtifactPayloadKind {
@@ -112,6 +187,7 @@ impl<'a> ArtifactEntrySpec<'a> {
 pub struct ArtifactBundleSpec<'a> {
     pub name: &'a str,
     pub target: &'a str,
+    pub compile_options: ArtifactCompileOptions,
     pub payloads: Vec<ArtifactPayloadSpec<'a>>,
     pub entries: Vec<ArtifactEntrySpec<'a>>,
 }
@@ -121,6 +197,7 @@ impl<'a> ArtifactBundleSpec<'a> {
         Self {
             name,
             target,
+            compile_options: ArtifactCompileOptions::new(),
             payloads: Vec::new(),
             entries: Vec::new(),
         }
@@ -128,6 +205,11 @@ impl<'a> ArtifactBundleSpec<'a> {
 
     pub fn with_payload(mut self, payload: ArtifactPayloadSpec<'a>) -> Self {
         self.payloads.push(payload);
+        self
+    }
+
+    pub fn with_compile_options(mut self, options: ArtifactCompileOptions) -> Self {
+        self.compile_options = options;
         self
     }
 
@@ -155,6 +237,7 @@ pub struct ArtifactEntry<'a> {
 pub struct ArtifactBundle<'a> {
     pub name: &'a str,
     pub target: &'a str,
+    pub compile_options: ArtifactCompileOptions,
     pub payloads: Vec<ArtifactPayload<'a>>,
     pub entries: Vec<ArtifactEntry<'a>>,
 }
@@ -190,6 +273,7 @@ pub struct OwnedArtifactEntry {
 pub struct OwnedArtifactBundle {
     pub name: String,
     pub target: String,
+    pub compile_options: ArtifactCompileOptions,
     pub payloads: Vec<OwnedArtifactPayload>,
     pub entries: Vec<OwnedArtifactEntry>,
 }
@@ -212,6 +296,7 @@ impl<'a> From<ArtifactBundle<'a>> for OwnedArtifactBundle {
         Self {
             name: bundle.name.to_string(),
             target: bundle.target.to_string(),
+            compile_options: bundle.compile_options,
             payloads: bundle
                 .payloads
                 .into_iter()
@@ -245,6 +330,8 @@ pub enum ArtifactError {
     Truncated(&'static str),
     BadMagic,
     UnsupportedVersion(u16),
+    UnsupportedCompileOptions(u64),
+    MalformedCompileOptions(String),
     UnsupportedPayloadKind(u16),
     UnsupportedEntryKind(u16),
     InvalidUtf8(&'static str),
@@ -266,6 +353,15 @@ impl fmt::Display for ArtifactError {
             Self::BadMagic => f.write_str("embedded artifact has bad magic"),
             Self::UnsupportedVersion(version) => {
                 write!(f, "unsupported embedded artifact version {version}")
+            }
+            Self::UnsupportedCompileOptions(bits) => {
+                write!(
+                    f,
+                    "unsupported embedded artifact compile-options bits {bits:#x}"
+                )
+            }
+            Self::MalformedCompileOptions(message) => {
+                write!(f, "malformed cuda-oxide compile options: {message}")
             }
             Self::UnsupportedPayloadKind(kind) => {
                 write!(f, "unsupported embedded artifact payload kind {kind}")
@@ -340,7 +436,15 @@ pub fn build_artifact_blob(spec: &ArtifactBundleSpec<'_>) -> Result<Vec<u8>, Art
 
     let total_len = checked_u32(out.len(), "total length")?;
     out[0..8].copy_from_slice(&ARTIFACT_MAGIC);
-    write_u16(&mut out, 8, ARTIFACT_VERSION);
+    // Keep default-policy bundles on v1 for backward compatibility. A bundle
+    // that carries required compile policy uses v2 so an older reader rejects
+    // it instead of silently ignoring the semantic flag.
+    let version = if spec.compile_options == ArtifactCompileOptions::new() {
+        LEGACY_ARTIFACT_VERSION
+    } else {
+        ARTIFACT_VERSION
+    };
+    write_u16(&mut out, 8, version);
     write_u16(&mut out, 10, HEADER_BYTES as u16);
     write_u32(&mut out, 12, total_len);
     write_u16(&mut out, 16, checked_u16(spec.name.len(), "name length")?);
@@ -359,6 +463,7 @@ pub fn build_artifact_blob(spec: &ArtifactBundleSpec<'_>) -> Result<Vec<u8>, Art
         22,
         checked_u16(spec.entries.len(), "entry count")?,
     );
+    write_u64(&mut out, 24, spec.compile_options.bits());
 
     Ok(out)
 }
@@ -383,7 +488,7 @@ pub fn parse_artifact_blob(bytes: &[u8]) -> Result<ArtifactBundle<'_>, ArtifactE
         return Err(ArtifactError::BadMagic);
     }
     let version = read_u16(bytes, 8)?;
-    if version != ARTIFACT_VERSION {
+    if !matches!(version, LEGACY_ARTIFACT_VERSION | ARTIFACT_VERSION) {
         return Err(ArtifactError::UnsupportedVersion(version));
     }
     let header_len = read_u16(bytes, 10)? as usize;
@@ -406,6 +511,11 @@ pub fn parse_artifact_blob(bytes: &[u8]) -> Result<ArtifactBundle<'_>, ArtifactE
     let target_len = read_u16(bytes, 18)? as usize;
     let payload_count = read_u16(bytes, 20)? as usize;
     let entry_count = read_u16(bytes, 22)? as usize;
+    let compile_options = if version == LEGACY_ARTIFACT_VERSION {
+        ArtifactCompileOptions::new()
+    } else {
+        ArtifactCompileOptions::from_bits(read_u64(bytes, 24)?)?
+    };
 
     let mut cursor = HEADER_BYTES;
     let name = read_str(bytes, cursor, name_len, "bundle name")?;
@@ -468,6 +578,7 @@ pub fn parse_artifact_blob(bytes: &[u8]) -> Result<ArtifactBundle<'_>, ArtifactE
     Ok(ArtifactBundle {
         name,
         target,
+        compile_options,
         payloads,
         entries,
     })
@@ -815,11 +926,13 @@ mod tests {
     #[test]
     fn artifact_blob_round_trips_ptx_payload() {
         let blob = sample_blob();
+        assert_eq!(read_u16(&blob, 8).unwrap(), LEGACY_ARTIFACT_VERSION);
         let bundles = parse_artifact_section(&blob).unwrap();
 
         assert_eq!(bundles.len(), 1);
         assert_eq!(bundles[0].name, "demo");
         assert_eq!(bundles[0].target, "sm_90");
+        assert!(bundles[0].compile_options.fma_contraction_enabled());
         assert_eq!(
             bundles[0].payload(ArtifactPayloadKind::Ptx),
             Some(&b"ptx"[..])
@@ -834,6 +947,7 @@ mod tests {
     fn artifact_blob_round_trips_non_ptx_payload_kinds() {
         let blob = build_artifact_blob(
             &ArtifactBundleSpec::new("demo", "sm_90")
+                .with_compile_options(ArtifactCompileOptions::new().with_fma_contraction(false))
                 .with_payload(ArtifactPayloadSpec::new(
                     ArtifactPayloadKind::NvvmIr,
                     "demo.ll",
@@ -851,9 +965,11 @@ mod tests {
                 )),
         )
         .unwrap();
+        assert_eq!(read_u16(&blob, 8).unwrap(), ARTIFACT_VERSION);
         let bundles = parse_artifact_section(&blob).unwrap();
 
         assert_eq!(bundles.len(), 1);
+        assert!(!bundles[0].compile_options.fma_contraction_enabled());
         assert_eq!(
             bundles[0].payload(ArtifactPayloadKind::NvvmIr),
             Some(&b"nvvm ir"[..])
@@ -869,6 +985,42 @@ mod tests {
     }
 
     #[test]
+    fn legacy_v1_bundle_defaults_to_fma_contraction() {
+        let mut blob = sample_blob();
+        write_u16(&mut blob, 8, LEGACY_ARTIFACT_VERSION);
+        // Version 1 reserved these bytes. A new reader must ignore them and
+        // preserve the historical default rather than assigning new meaning.
+        write_u64(&mut blob, 24, OPTION_NO_FMA_CONTRACTION);
+
+        let bundle = parse_artifact_blob(&blob).unwrap();
+        assert!(bundle.compile_options.fma_contraction_enabled());
+    }
+
+    #[test]
+    fn version_2_rejects_unknown_compile_option_bits() {
+        let mut blob = sample_blob();
+        write_u16(&mut blob, 8, ARTIFACT_VERSION);
+        write_u64(&mut blob, 24, 1 << 63);
+
+        assert!(matches!(
+            parse_artifact_blob(&blob),
+            Err(ArtifactError::UnsupportedCompileOptions(bits)) if bits == 1 << 63
+        ));
+    }
+
+    #[test]
+    fn compile_options_sidecar_round_trips_both_policies() {
+        for allow_fma_contraction in [true, false] {
+            let expected =
+                ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction);
+            let parsed =
+                ArtifactCompileOptions::from_sidecar_text(expected.sidecar_text()).unwrap();
+            assert_eq!(parsed, expected);
+        }
+        assert!(ArtifactCompileOptions::from_sidecar_text("fma-contraction=off\n").is_err());
+    }
+
+    #[test]
     fn artifact_section_ignores_trailing_zero_padding() {
         let mut section = sample_blob();
         section.extend_from_slice(&[0; HEADER_BYTES]);
@@ -880,10 +1032,11 @@ mod tests {
 
     #[test]
     fn artifact_section_parses_concatenated_blobs() {
-        let first = build_artifact_blob(&ArtifactBundleSpec::new("a", "sm_80").with_payload(
+        let mut first = build_artifact_blob(&ArtifactBundleSpec::new("a", "sm_80").with_payload(
             ArtifactPayloadSpec::new(ArtifactPayloadKind::Ptx, "a.ptx", b"a"),
         ))
         .unwrap();
+        write_u16(&mut first, 8, LEGACY_ARTIFACT_VERSION);
         let second = build_artifact_blob(&ArtifactBundleSpec::new("b", "sm_90").with_payload(
             ArtifactPayloadSpec::new(ArtifactPayloadKind::Ptx, "b.ptx", b"b"),
         ))
@@ -949,9 +1102,15 @@ mod tests {
     #[cfg(all(feature = "object-read", feature = "object-write"))]
     #[test]
     fn host_object_round_trips_section_on_supported_formats() {
-        let blob = build_artifact_blob(&ArtifactBundleSpec::new("demo", "sm_90").with_payload(
-            ArtifactPayloadSpec::new(ArtifactPayloadKind::Ptx, "demo.ptx", b"ptx"),
-        ))
+        let blob = build_artifact_blob(
+            &ArtifactBundleSpec::new("demo", "sm_90")
+                .with_compile_options(ArtifactCompileOptions::new().with_fma_contraction(false))
+                .with_payload(ArtifactPayloadSpec::new(
+                    ArtifactPayloadKind::Ptx,
+                    "demo.ptx",
+                    b"ptx",
+                )),
+        )
         .unwrap();
 
         for target in ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"] {
@@ -962,6 +1121,7 @@ mod tests {
                 bundles[0].payload(ArtifactPayloadKind::Ptx),
                 Some(&b"ptx"[..])
             );
+            assert!(!bundles[0].compile_options.fma_contraction_enabled());
         }
     }
 

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "mir-transforms",
  "nvvm-transforms",
  "once_cell",
+ "oxide-artifacts",
  "pliron",
  "pliron-derive",
  "rustc-hash",

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -316,8 +316,24 @@ fn build_tools(example_dir: &Path) -> Result<(), String> {
     let tools_dir = example_dir.join("tools");
     let compile_ltoir = tools_dir.join("compile_ltoir");
     let link_ltoir = tools_dir.join("link_ltoir");
+    let compile_source = tools_dir.join("compile_ltoir.c");
+    let link_source = tools_dir.join("link_ltoir.c");
+    let options_header = tools_dir.join("compile_options.h");
+    let build_script = tools_dir.join("build_tools.sh");
 
-    if compile_ltoir.exists() && link_ltoir.exists() {
+    let compile_sources = [
+        compile_source.as_path(),
+        options_header.as_path(),
+        build_script.as_path(),
+    ];
+    let link_sources = [
+        link_source.as_path(),
+        options_header.as_path(),
+        build_script.as_path(),
+    ];
+    if !file_needs_rebuild(&compile_ltoir, &compile_sources)
+        && !file_needs_rebuild(&link_ltoir, &link_sources)
+    {
         return Ok(());
     }
 
@@ -380,6 +396,7 @@ fn build_external_ltoir(example_dir: &Path) -> Result<(), String> {
 /// `cargo oxide run device_ffi_test --emit-nvvm-ir --arch=<your_arch>`  (e.g., sm_120)
 fn compile_cuda_oxide_ltoir(example_dir: &Path) -> Result<(), String> {
     let ll_file = example_dir.join("device_ffi_test.ll");
+    let options_file = example_dir.join("device_ffi_test.options");
     let ltoir_file = example_dir.join("device_ffi_test.ltoir");
     let tools_dir = example_dir.join("tools");
 
@@ -392,7 +409,7 @@ fn compile_cuda_oxide_ltoir(example_dir: &Path) -> Result<(), String> {
         ));
     }
 
-    if !file_needs_rebuild(&ltoir_file, &[&ll_file]) {
+    if !file_needs_rebuild(&ltoir_file, &[&ll_file, &options_file]) {
         return Ok(());
     }
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/README.md
@@ -45,6 +45,10 @@ Compiles LLVM IR to LTOIR using libNVVM with `-gen-lto`:
 ./compile_ltoir kernel.ll sm_90 kernel.ltoir
 ```
 
+The tool reads `<input>.options` when present, passes the recorded `-fma=0` or
+`-fma=1` policy to libNVVM, and writes matching `.options` and versioned
+`.target` files beside the LTOIR output. Keep those sidecars with the LTOIR.
+
 ### link_ltoir
 
 Links multiple LTOIR files into a single cubin:
@@ -58,6 +62,10 @@ Links multiple LTOIR files into a single cubin:
     ../external_device_funcs.ltoir \
     ../cccl_wrappers.ltoir
 ```
+
+The linker reads every input's `.options` file. If any input disables FMA
+contraction, the whole nvJitLink LTO step uses `-fma=0`; inputs without
+metadata retain the legacy `-fma=1` default.
 
 ### launch_cubin (legacy)
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/compile_ltoir.c
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/compile_ltoir.c
@@ -22,12 +22,16 @@
  * before compiling, so any `__nv_*` math symbols in the input are resolved
  * during this step. The resulting LTOIR is self-contained and `link_ltoir`
  * does not need to add libdevice separately.
+ *
+ * A sibling <input>.options file selects -fma=0 or -fma=1. The tool writes
+ * matching .options and versioned .target files beside the output LTOIR.
  */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <nvvm.h>
+#include "compile_options.h"
 
 /**
  * Check an NVVM result and exit with error message if it failed.
@@ -72,6 +76,7 @@ int main(int argc, char** argv) {
     const char* arch = argv[2];
     const char* outputFile = NULL;
     const char* libdeviceFile = NULL;
+    int allowFmaContraction = 1;
 
     // Positional output file is optional and must come before --libdevice.
     int argi = 3;
@@ -86,6 +91,10 @@ int main(int argc, char** argv) {
             fprintf(stderr, "Error: unknown argument: %s\n", argv[argi]);
             return 1;
         }
+    }
+
+    if (cuda_oxide_read_fma_policy(inputFile, &allowFmaContraction) != 0) {
+        return 1;
     }
 
     // Print libNVVM version info
@@ -112,7 +121,12 @@ int main(int argc, char** argv) {
     size_t size = ftell(f);
     fseek(f, 0, SEEK_SET);
     char* buffer = malloc(size + 1);
-    fread(buffer, 1, size, f);
+    if (!buffer || fread(buffer, 1, size, f) != size) {
+        fprintf(stderr, "Error: Cannot read %s\n", inputFile);
+        fclose(f);
+        free(buffer);
+        return 1;
+    }
     buffer[size] = '\0';
     fclose(f);
     printf("Read %zu bytes from %s\n", size, inputFile);
@@ -138,7 +152,14 @@ int main(int argc, char** argv) {
         libdeviceSize = ftell(lf);
         fseek(lf, 0, SEEK_SET);
         libdeviceBuffer = malloc(libdeviceSize);
-        fread(libdeviceBuffer, 1, libdeviceSize, lf);
+        if (!libdeviceBuffer || fread(libdeviceBuffer, 1, libdeviceSize, lf) != libdeviceSize) {
+            fprintf(stderr, "Error: Cannot read libdevice file %s\n", libdeviceFile);
+            fclose(lf);
+            nvvmDestroyProgram(&prog);
+            free(buffer);
+            free(libdeviceBuffer);
+            return 1;
+        }
         fclose(lf);
         printf("Read %zu bytes of libdevice from %s\n", libdeviceSize, libdeviceFile);
 
@@ -188,11 +209,12 @@ int main(int argc, char** argv) {
 
     const char* options[] = {
         archOption,
-        "-gen-lto"  // Generate LTOIR for link-time optimization
+        "-gen-lto",  // Generate LTOIR for link-time optimization
+        allowFmaContraction ? "-fma=1" : "-fma=0"
     };
-    int numOptions = 2;
+    int numOptions = 3;
 
-    printf("Compiling with options: %s %s\n", options[0], options[1]);
+    printf("Compiling with options: %s %s %s\n", options[0], options[1], options[2]);
 
     // Compile
     nvvmResult compileResult = nvvmCompileProgram(prog, numOptions, options);
@@ -222,27 +244,33 @@ int main(int argc, char** argv) {
     check_nvvm(nvvmGetCompiledResult(prog, result), "nvvmGetCompiledResult", prog);
 
     // Save LTOIR
-    if (outputFile) {
-        FILE* out = fopen(outputFile, "wb");
-        if (out) {
-            fwrite(result, 1, resultSize, out);
-            fclose(out);
-            printf("Saved LTOIR to: %s\n", outputFile);
-        } else {
-            fprintf(stderr, "Error: Cannot write to %s\n", outputFile);
+    char autoOutput[4096];
+    if (!outputFile) {
+        const char* dot = strrchr(inputFile, '.');
+        size_t stemLength = dot ? (size_t)(dot - inputFile) : strlen(inputFile);
+        if (stemLength + sizeof(".ltoir") > sizeof(autoOutput)) {
+            fprintf(stderr, "Error: output path is too long\n");
+            return 1;
         }
-    } else {
-        // Generate output filename from input
-        char autoOutput[256];
-        snprintf(autoOutput, sizeof(autoOutput), "%.*s.ltoir",
-                 (int)(strrchr(inputFile, '.') - inputFile), inputFile);
-        FILE* out = fopen(autoOutput, "wb");
-        if (out) {
-            fwrite(result, 1, resultSize, out);
-            fclose(out);
-            printf("Saved LTOIR to: %s\n", autoOutput);
-        }
+        memcpy(autoOutput, inputFile, stemLength);
+        memcpy(autoOutput + stemLength, ".ltoir", sizeof(".ltoir"));
+        outputFile = autoOutput;
     }
+    if (cuda_oxide_clear_compile_metadata(outputFile) != 0) {
+        return 1;
+    }
+    FILE* out = fopen(outputFile, "wb");
+    if (!out || fwrite(result, 1, resultSize, out) != resultSize || fclose(out) != 0) {
+        fprintf(stderr, "Error: Cannot write to %s\n", outputFile);
+        return 1;
+    }
+    if (cuda_oxide_write_fma_policy(outputFile, allowFmaContraction) != 0) {
+        return 1;
+    }
+    if (cuda_oxide_write_target_metadata(outputFile, arch) != 0) {
+        return 1;
+    }
+    printf("Saved LTOIR to: %s\n", outputFile);
 
     // Cleanup
     free(result);

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/compile_options.h
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/compile_options.h
@@ -1,0 +1,177 @@
+#ifndef CUDA_OXIDE_COMPILE_OPTIONS_H
+#define CUDA_OXIDE_COMPILE_OPTIONS_H
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#define CUDA_OXIDE_OPTIONS_HEADER "cuda-oxide-compile-options-v1\n"
+#define CUDA_OXIDE_OPTIONS_FMA_ON CUDA_OXIDE_OPTIONS_HEADER "fma-contraction=on\n"
+#define CUDA_OXIDE_OPTIONS_FMA_OFF CUDA_OXIDE_OPTIONS_HEADER "fma-contraction=off\n"
+
+static inline int cuda_oxide_sibling_path(const char* artifact, const char* extension,
+                                          char* output, size_t capacity) {
+    const char* slash = strrchr(artifact, '/');
+    const char* dot = strrchr(artifact, '.');
+    size_t stem_length = strlen(artifact);
+    if (dot && (!slash || dot > slash)) {
+        stem_length = (size_t)(dot - artifact);
+    }
+    size_t extension_length = strlen(extension);
+    if (stem_length + extension_length + 1 > capacity) {
+        return -1;
+    }
+    memcpy(output, artifact, stem_length);
+    memcpy(output + stem_length, extension, extension_length + 1);
+    return 0;
+}
+
+/* Return 1 when .options is required, 0 for legacy/no target, and -1 on error. */
+static inline int cuda_oxide_target_requires_options(const char* artifact) {
+    char path[4096];
+    if (cuda_oxide_sibling_path(artifact, ".target", path, sizeof(path)) != 0) {
+        fprintf(stderr, "Error: target path is too long for %s\n", artifact);
+        return -1;
+    }
+
+    FILE* file = fopen(path, "rb");
+    if (!file) {
+        if (errno == ENOENT) return 0;
+        fprintf(stderr, "Error: Cannot open target metadata %s\n", path);
+        return -1;
+    }
+    char value[256];
+    size_t length = fread(value, 1, sizeof(value) - 1, file);
+    int too_long = !feof(file);
+    int read_failed = ferror(file);
+    fclose(file);
+    value[length] = '\0';
+    if (read_failed || too_long) {
+        fprintf(stderr, "Error: Cannot read target metadata %s\n", path);
+        return -1;
+    }
+
+    char* newline = strchr(value, '\n');
+    if (!newline || newline == value) {
+        fprintf(stderr, "Error: Malformed target metadata %s\n", path);
+        return -1;
+    }
+    const char* remainder = newline + 1;
+    if (*remainder == '\0') return 0;
+    if (strcmp(remainder, "compile-options=v1\n") == 0) return 1;
+
+    fprintf(stderr, "Error: Unsupported target metadata in %s\n", path);
+    return -1;
+}
+
+/* Missing metadata means a legacy artifact, whose historical default is on. */
+static inline int cuda_oxide_read_fma_policy(const char* artifact, int* allow_fma_contraction) {
+    char path[4096];
+    if (cuda_oxide_sibling_path(artifact, ".options", path, sizeof(path)) != 0) {
+        fprintf(stderr, "Error: compile-options path is too long for %s\n", artifact);
+        return -1;
+    }
+
+    int options_required = cuda_oxide_target_requires_options(artifact);
+    if (options_required < 0) return -1;
+
+    FILE* file = fopen(path, "rb");
+    if (!file) {
+        if (errno == ENOENT) {
+            if (options_required) {
+                fprintf(stderr, "Error: Target metadata requires missing compile options %s\n",
+                        path);
+                return -1;
+            }
+            *allow_fma_contraction = 1;
+            return 0;
+        }
+        fprintf(stderr, "Error: Cannot open compile options %s\n", path);
+        return -1;
+    }
+
+    char value[128];
+    size_t length = fread(value, 1, sizeof(value) - 1, file);
+    int too_long = !feof(file);
+    int read_failed = ferror(file);
+    fclose(file);
+    value[length] = '\0';
+    if (read_failed || too_long) {
+        fprintf(stderr, "Error: Cannot read compile options %s\n", path);
+        return -1;
+    }
+
+    if (strcmp(value, CUDA_OXIDE_OPTIONS_FMA_ON) == 0) {
+        *allow_fma_contraction = 1;
+        return 0;
+    }
+    if (strcmp(value, CUDA_OXIDE_OPTIONS_FMA_OFF) == 0) {
+        *allow_fma_contraction = 0;
+        return 0;
+    }
+
+    fprintf(stderr, "Error: Unsupported cuda-oxide compile options in %s\n", path);
+    return -1;
+}
+
+static inline int cuda_oxide_write_fma_policy(const char* artifact,
+                                              int allow_fma_contraction) {
+    char path[4096];
+    if (cuda_oxide_sibling_path(artifact, ".options", path, sizeof(path)) != 0) {
+        fprintf(stderr, "Error: compile-options path is too long for %s\n", artifact);
+        return -1;
+    }
+
+    FILE* file = fopen(path, "wb");
+    if (!file) {
+        fprintf(stderr, "Error: Cannot write compile options %s\n", path);
+        return -1;
+    }
+    const char* value = allow_fma_contraction ? CUDA_OXIDE_OPTIONS_FMA_ON
+                                               : CUDA_OXIDE_OPTIONS_FMA_OFF;
+    size_t length = strlen(value);
+    int failed = fwrite(value, 1, length, file) != length || fclose(file) != 0;
+    if (failed) {
+        fprintf(stderr, "Error: Cannot write compile options %s\n", path);
+        return -1;
+    }
+    return 0;
+}
+
+static inline int cuda_oxide_clear_compile_metadata(const char* artifact) {
+    const char* extensions[] = {".target", ".options"};
+    for (size_t i = 0; i < sizeof(extensions) / sizeof(extensions[0]); i++) {
+        char path[4096];
+        if (cuda_oxide_sibling_path(artifact, extensions[i], path, sizeof(path)) != 0) {
+            fprintf(stderr, "Error: metadata path is too long for %s\n", artifact);
+            return -1;
+        }
+        if (remove(path) != 0 && errno != ENOENT) {
+            fprintf(stderr, "Error: Cannot clear stale metadata %s\n", path);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* Write this completion marker only after the sibling .options file exists. */
+static inline int cuda_oxide_write_target_metadata(const char* artifact, const char* arch) {
+    char path[4096];
+    if (cuda_oxide_sibling_path(artifact, ".target", path, sizeof(path)) != 0) {
+        fprintf(stderr, "Error: target path is too long for %s\n", artifact);
+        return -1;
+    }
+    FILE* file = fopen(path, "wb");
+    if (!file) {
+        fprintf(stderr, "Error: Cannot write target metadata %s\n", path);
+        return -1;
+    }
+    int failed = fprintf(file, "%s\ncompile-options=v1\n", arch) < 0 || fclose(file) != 0;
+    if (failed) {
+        fprintf(stderr, "Error: Cannot write target metadata %s\n", path);
+        return -1;
+    }
+    return 0;
+}
+
+#endif

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/link_ltoir.c
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/tools/link_ltoir.c
@@ -16,12 +16,16 @@
  * Example:
  *   ./link_ltoir -arch=sm_120 -o merged.cubin \
  *       device_ffi_test.ltoir external_device_funcs.ltoir
+ *
+ * Sibling .options files preserve cuda-oxide's FMA policy. If any input
+ * disables contraction, the complete nvJitLink LTO step uses -fma=0.
  */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <nvJitLink.h>
+#include "compile_options.h"
 
 #define MAX_INPUTS 32
 
@@ -97,7 +101,11 @@ char* read_file(const char* path, size_t* size_out) {
     fseek(f, 0, SEEK_SET);
 
     char* data = (char*)malloc(size);
-    fread(data, 1, size, f);
+    if (!data || fread(data, 1, size, f) != size) {
+        fclose(f);
+        free(data);
+        return NULL;
+    }
     fclose(f);
 
     *size_out = size;
@@ -128,6 +136,7 @@ int main(int argc, char** argv) {
     int verbose = 0;
     const char* input_files[MAX_INPUTS];
     int num_inputs = 0;
+    int allow_fma_contraction = 1;
 
     // Parse arguments
     for (int i = 1; i < argc; i++) {
@@ -159,6 +168,15 @@ int main(int argc, char** argv) {
         print_usage(argv[0]);
         return 1;
     }
+    for (int i = 0; i < num_inputs; i++) {
+        int input_allows_fma = 1;
+        if (cuda_oxide_read_fma_policy(input_files[i], &input_allows_fma) != 0) {
+            return 1;
+        }
+        if (!input_allows_fma) {
+            allow_fma_contraction = 0;
+        }
+    }
 
     printf("=== nvJitLink LTOIR Linker ===\n");
     printf("Architecture: %s\n", arch);
@@ -171,9 +189,12 @@ int main(int argc, char** argv) {
 
     const char* options[] = {
         arch_opt,
-        "-lto"
+        "-lto",
+        allow_fma_contraction ? "-fma=1" : "-fma=0"
     };
-    int num_options = 2;
+    int num_options = 3;
+
+    printf("FMA contraction: %s\n", allow_fma_contraction ? "on" : "off");
 
     nvJitLinkHandle handle;
     nvJitLinkResult result = nvJitLinkCreate(&handle, num_options, options);

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/src/main.rs
@@ -706,8 +706,24 @@ fn build_tools(example_dir: &Path) -> Result<(), String> {
     let tools_dir = example_dir.join("tools");
     let compile_ltoir = tools_dir.join("compile_ltoir");
     let link_ltoir = tools_dir.join("link_ltoir");
+    let compile_source = tools_dir.join("compile_ltoir.c");
+    let link_source = tools_dir.join("link_ltoir.c");
+    let options_header = tools_dir.join("compile_options.h");
+    let build_script = tools_dir.join("build_tools.sh");
 
-    if compile_ltoir.exists() && link_ltoir.exists() {
+    let compile_sources = [
+        compile_source.as_path(),
+        options_header.as_path(),
+        build_script.as_path(),
+    ];
+    let link_sources = [
+        link_source.as_path(),
+        options_header.as_path(),
+        build_script.as_path(),
+    ];
+    if !file_needs_rebuild(&compile_ltoir, &compile_sources)
+        && !file_needs_rebuild(&link_ltoir, &link_sources)
+    {
         return Ok(());
     }
 
@@ -741,6 +757,7 @@ fn build_external_ltoir(example_dir: &Path, mathdx_root: &Path) -> Result<(), St
 /// Compiles cuda-oxide LLVM IR (.ll) to LTOIR using libNVVM.
 fn compile_cuda_oxide_ltoir(example_dir: &Path) -> Result<(), String> {
     let ll_file = example_dir.join("mathdx_ffi_test.ll");
+    let options_file = example_dir.join("mathdx_ffi_test.options");
     let ltoir_file = example_dir.join("mathdx_ffi_test.ltoir");
     let tools_dir = example_dir.join("tools");
 
@@ -753,7 +770,7 @@ fn compile_cuda_oxide_ltoir(example_dir: &Path) -> Result<(), String> {
         ));
     }
 
-    if !file_needs_rebuild(&ltoir_file, &[&ll_file]) {
+    if !file_needs_rebuild(&ltoir_file, &[&ll_file, &options_file]) {
         return Ok(());
     }
 

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -242,6 +242,9 @@ pub struct DeviceCodegenResult {
     pub ptx_content: Option<String>,
     /// Device artifact payload selected for embedding.
     pub artifact: Option<DeviceCodegenArtifact>,
+    /// Whether later compilation stages may contract ordinary floating-point
+    /// multiply/add expressions.
+    pub allow_fma_contraction: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -669,6 +672,11 @@ pub fn generate_device_code<'tcx>(
         let debug_kind = device_debug_kind(tcx.sess.opts.debuginfo);
         let target_arch = std::env::var("CUDA_OXIDE_TARGET").ok();
         let device_arch_hint = std::env::var("CUDA_OXIDE_DEVICE_ARCH").ok();
+        let allow_fma_contraction = std::env::var_os("CUDA_OXIDE_NO_FMA").is_none();
+
+        if verbose && !allow_fma_contraction {
+            eprintln!("[device_codegen] FMA contraction disabled");
+        }
 
         // Create pipeline config
         let pipeline_config = mir_importer::PipelineConfig {
@@ -681,6 +689,7 @@ pub fn generate_device_code<'tcx>(
             target_arch,
             device_arch_hint,
             debug_kind,
+            allow_fma_contraction,
         };
 
         // Run the cuda-oxide pipeline!
@@ -727,6 +736,7 @@ pub fn generate_device_code<'tcx>(
                     target: compilation_result.target,
                     ptx_content,
                     artifact,
+                    allow_fma_contraction: compilation_result.allow_fma_contraction,
                 })
             }
             Err(pipeline_err) => Err(DeviceCodegenError::PtxGeneration(format!(
@@ -856,6 +866,7 @@ mod tests {
             artifact_path: ll_path,
             artifact_kind: mir_importer::CompilationArtifactKind::NvvmIr,
             target: "sm_90".to_string(),
+            allow_fma_contraction: false,
         };
 
         let artifact = read_compilation_artifact(&result).unwrap().unwrap();
@@ -881,6 +892,7 @@ mod tests {
             artifact_path: cubin_path,
             artifact_kind: mir_importer::CompilationArtifactKind::Cubin,
             target: "sm_90".to_string(),
+            allow_fma_contraction: true,
         };
 
         let artifact = read_compilation_artifact(&result).unwrap().unwrap();

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -802,7 +802,18 @@ fn write_device_artifact_object(
             oxide_artifacts::ArtifactPayloadKind::Cubin
         }
     };
+    let compile_options = if matches!(
+        artifact.kind,
+        device_codegen::DeviceCodegenArtifactKind::NvvmIr
+            | device_codegen::DeviceCodegenArtifactKind::Ltoir
+    ) {
+        oxide_artifacts::ArtifactCompileOptions::new()
+            .with_fma_contraction(result.allow_fma_contraction)
+    } else {
+        oxide_artifacts::ArtifactCompileOptions::new()
+    };
     let mut spec = oxide_artifacts::ArtifactBundleSpec::new(&bundle_name, &result.target)
+        .with_compile_options(compile_options)
         .with_payload(oxide_artifacts::ArtifactPayloadSpec::new(
             payload_kind,
             &artifact.name,

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -358,10 +358,14 @@ a zero status proves. The wrapper therefore never declares the report clean
 from process status alone; it reports completion and leaves the sanitizer
 output visible for inspection.
 
-The `--no-fmad` CLI flag is forwarded through both ordinary and interop builds,
-but it only requests the existing compiler behavior. It does not by itself
-resolve the backend contraction limitation tracked in
-[#315](https://github.com/NVlabs/cuda-oxide/issues/315).
+The `--no-fmad` CLI flag is forwarded through both ordinary and interop builds.
+It keeps ordinary multiply and add/subtract operations separate, with one
+rounding per operation. Explicit fused operations such as `f32::mul_add`
+remain fused.
+
+NVVM IR and LTOIR builds also produce `.options` and versioned `.target`
+sidecars. Keep both files with the artifact so later libNVVM and nvJitLink
+steps preserve the same FMA policy.
 
 Run `memcheck` first when investigating memory safety. The other tools are
 complementary and do not perform full memory-access checking.

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -430,8 +430,15 @@ verdict_compile() {
     fi
     if [[ -s "${ex_dir}/${artifact}.ll" ]]; then
         local target_file="${ex_dir}/${artifact}.target"
-        if [[ -s "${target_file}" ]] && grep -qE '^sm_[0-9]+[af]?$' "${target_file}"; then
-            echo "PASS (compiled NVVM IR for $(tr -d '[:space:]' < "${target_file}"))"
+        local target
+        target="$(sed -n '1p' "${target_file}" 2>/dev/null)"
+        if [[ "${target}" =~ ^sm_[0-9]+[af]?$ ]]; then
+            if grep -qx 'compile-options=v1' "${target_file}" && \
+               [[ ! -s "${ex_dir}/${artifact}.options" ]]; then
+                echo "FAIL (versioned NVVM IR target is missing its .options sidecar)"
+                return 1
+            fi
+            echo "PASS (compiled NVVM IR for ${target})"
             return 0
         fi
         echo "FAIL (NVVM IR emitted without a concrete .target sidecar)"


### PR DESCRIPTION
## Summary

`--no-fmad` currently removes llc's global contraction option, but cuda-oxide
still marks ordinary floating-point multiply/add/subtract instructions with
LLVM's per-instruction `contract` flag. That permission wins, so default and
`--no-fmad` builds can emit identical `fma.rn` PTX.

This change makes the policy explicit and carries it through every device-code
path:

```text
Before: --no-fmad -> `contract` IR -> fma.rn.f32
After:  --no-fmad -> plain IR      -> mul.rn.f32 + add.rn.f32

Explicit `mul_add` remains fused in both modes.
```

Closes #315.

## What changed

### MIR lowering and direct PTX

- Adds per-compilation lowering options instead of reading process state in
  individual conversion patterns.
- Omits `contract` from ordinary floating-point arithmetic under `--no-fmad`.
- Preserves the other fast-math flags on `core::intrinsics::f*_fast` while
  removing only contraction permission.
- Uses the same effective policy for LLVM IR and the llc
  `-fp-contract=fast` option.

### Deferred compilation and interop

- Carries the effective policy through NVVM IR and LTOIR artifacts, embedded
  device code, `cargo oxide emit-ltoir`, metadata-driven interop builds, and
  the C helper tools used by the interop examples.
- Passes an explicit `-fma=0` or `-fma=1` to both libNVVM and nvJitLink. This
  prevents link-time optimization from reintroducing contraction later.
- Includes the policy in both native-code cache keys and bumps the cache
  recipe.

### Artifact compatibility

- Adds one shared, strict `.options` sidecar format. Writers publish it before
  the `.target` completion marker; required-but-missing or malformed metadata
  is an error rather than silently changing arithmetic.
- Keeps legacy/default embedded bundles at version 1, where zero means the
  historical contraction-enabled behavior.
- Uses a version 2 bundle and a negative `NO_FMA` bit for policy-bearing
  artifacts. Old readers reject that version instead of accepting it while
  ignoring `--no-fmad`; new readers reject unknown option bits.

## Testing

- [x] Reproduced #315 on `main`: default and `--no-fmad` PTX were byte-identical,
      both with LLVM `contract` and `fma.rn.f32`.
- [x] Direct pipeline: `--no-fmad` emits separate multiply/add PTX and SASS;
      default mode still emits FMA; `ptxas` accepts both.
- [x] Deferred libNVVM + nvJitLink pipeline: ordinary multiply/add stays
      separate with `-fma=0`, while explicit `mul_add` remains fused.
- [x] Local `sm_120a` GPU run: all 50 `primitive_stress` floating-point checks
      pass, including explicit `f32` and `f64` `mul_add` cases.
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check --all-targets --locked` and
      `cargo clippy --all-targets -- -D warnings` in `rustc-codegen-cuda`
- [x] Affected unit/integration tests for `cargo-oxide`, `cuda-host`,
      `mir-importer`, `mir-lower`, and `oxide-artifacts`
- [x] Workspace doctests excluding `cuda-bindings`, plus workspace rustdoc with
      warnings denied
- [x] Both C interop helpers compile as C11 with all warnings denied

The unmodified generated `cuda-bindings` crate still has a pre-existing
workspace-doctest failure where CUDA header prose containing `\p stream` is
interpreted as Rust code. No `cuda-bindings` files are changed here.

## Checklist

- [x] No `cuda-bindings` files changed
- [x] New public behavior is documented
- [x] Compatibility behavior is covered by frozen-v1, v2, unknown-bit,
      sidecar, embedded-object, and cache-key tests
- [x] Signed off
