### PR TITLE
Add mma.sync.aligned.m16n8k16 f16 tensor core intrinsic

### DIFF
--- a/crates/cuda-device/src/wmma.rs
+++ b/crates/cuda-device/src/wmma.rs
@@ -221,8 +221,32 @@ pub unsafe fn mma_m16n8k16_f32_bf16(c: [f32; 4], a: [u32; 4], b: [u32; 2]) -> [f
 /// 16×8. Each lane supplies its fragments in registers and receives four f32
 /// result registers. The call itself does not access memory or act as a fence.
 ///
-/// `a[j / 2]` and `b[j / 2]` pack logical element `j` in low-to-high 16-bit
-/// order. The lane-to-element mapping is the same as [`mma_m16n8k16_f32_bf16`].
+/// The Rust arrays use the same order as the PTX register lists below:
+///
+/// - `c[0..4]` contains `%c0..%c3`, one `.f32` accumulator per element. The
+///   returned array contains `%d0..%d3` in the same order.
+/// - `a[0..4]` contains `%a0..%a3`, and `b[0..2]` contains `%b0..%b1`.
+///   Each `u32` is a raw `.b32` carrier holding two `.f16` values; element
+///   `j` is in `a[j / 2]` or `b[j / 2]`, low 16 bits before high 16 bits.
+///
+/// For lane `lane`, let `group = lane / 4` and `thread = lane % 4`:
+///
+/// ```text
+/// A element j=0..7:
+///   row = group       for j in {0,1,4,5}; otherwise group + 8
+///   col = thread*2 + (j&1) + (if j >= 4 { 8 } else { 0 })
+///
+/// B element j=0..3:
+///   row = thread*2 + (j&1) + (if j >= 2 { 8 } else { 0 })
+///   col = group
+///
+/// C/D register j=0..3:
+///   row = group + (if j >= 2 { 8 } else { 0 })
+///   col = thread*2 + (j&1)
+/// ```
+///
+/// These coordinates are the `.row.col` layout: A is row-major and B is
+/// column-major.
 ///
 /// # PTX
 ///
@@ -236,11 +260,12 @@ pub unsafe fn mma_m16n8k16_f32_bf16(c: [f32; 4], a: [u32; 4], b: [u32; 2]) -> [f
 ///
 /// # Safety
 ///
-/// - All 32 lanes must execute the same call with the same qualifiers. Calling
-///   from divergent control flow, or after any lane has exited, is undefined
-///   behavior.
+/// - All 32 lanes must execute the same `mma.sync.aligned` instruction with
+///   the same qualifiers. Calling from divergent control flow, or after any
+///   lane has exited, is undefined behavior.
 /// - `c`, `a`, and `b` must contain the calling lane's fragments in the layout
-///   described in [`mma_m16n8k16_f32_bf16`].
+///   above. A different array order or layout computes a different matrix
+///   operation.
 /// - Requires `sm_80+` and PTX ISA 7.0+. cuda-oxide selects both floors
 ///   automatically and rejects an explicit lower target.
 #[inline(never)]

--- a/crates/cuda-device/src/wmma.rs
+++ b/crates/cuda-device/src/wmma.rs
@@ -214,6 +214,42 @@ pub unsafe fn mma_m16n8k16_f32_bf16(c: [f32; 4], a: [u32; 4], b: [u32; 2]) -> [f
     unreachable!("mma_m16n8k16_f32_bf16 called outside CUDA kernel context")
 }
 
+/// Multiply one warp-distributed F16 tile and add an f32 accumulator.
+///
+/// Together, the 32 lanes compute `D = A × B + C` for row-major `A` with
+/// shape 16×16, column-major `B` with shape 16×8, and `C`/`D` with shape
+/// 16×8. Each lane supplies its fragments in registers and receives four f32
+/// result registers. The call itself does not access memory or act as a fence.
+///
+/// `a[j / 2]` and `b[j / 2]` pack logical element `j` in low-to-high 16-bit
+/// order. The lane-to-element mapping is the same as [`mma_m16n8k16_f32_bf16`].
+///
+/// # PTX
+///
+/// ```ptx
+/// mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+///     {%d0, %d1, %d2, %d3},
+///     {%a0, %a1, %a2, %a3},
+///     {%b0, %b1},
+///     {%c0, %c1, %c2, %c3};
+/// ```
+///
+/// # Safety
+///
+/// - All 32 lanes must execute the same call with the same qualifiers. Calling
+///   from divergent control flow, or after any lane has exited, is undefined
+///   behavior.
+/// - `c`, `a`, and `b` must contain the calling lane's fragments in the layout
+///   described in [`mma_m16n8k16_f32_bf16`].
+/// - Requires `sm_80+` and PTX ISA 7.0+. cuda-oxide selects both floors
+///   automatically and rejects an explicit lower target.
+#[inline(never)]
+#[must_use]
+pub unsafe fn mma_m16n8k16_f32_f16(c: [f32; 4], a: [u32; 4], b: [u32; 2]) -> [f32; 4] {
+    let _ = (c, a, b);
+    unreachable!("mma_m16n8k16_f32_f16 called outside CUDA kernel context")
+}
+
 /// Warp MMA: D = A x B + C (m8n8k4, f64 output, f64 inputs).
 ///
 /// Performs an 8x8x4 double-precision matrix multiplication using tensor cores.

--- a/crates/dialect-nvvm/src/ops/wmma.rs
+++ b/crates/dialect-nvvm/src/ops/wmma.rs
@@ -161,6 +161,93 @@ impl MmaM16N8K16F32Bf16Op {
     }
 }
 
+/// Register-only warp MMA: m16n8k16 with f32 accumulator and f16 inputs.
+///
+/// # Operands
+///
+/// - operands 0-3: four f32 C accumulator registers
+/// - operands 4-7: four i32 A fragment registers, each packing two F16 values
+/// - operands 8-9: two i32 B fragment registers, each packing two F16 values
+///
+/// # Results
+///
+/// - results 0-3: four f32 D accumulator registers
+#[pliron_op(
+    name = "nvvm.mma_m16n8k16_f32_f16",
+    format,
+    interfaces = [NOpdsInterface<10>, NResultsInterface<4>],
+)]
+pub struct MmaM16N8K16F32F16Op;
+
+impl Verify for MmaM16N8K16F32F16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let operands: Vec<_> = op.operands().collect();
+
+        if operands.len() != 10 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.mma_m16n8k16_f32_f16 requires 10 register operands, got {}",
+                operands.len()
+            );
+        }
+
+        for (index, operand) in operands.iter().take(4).enumerate() {
+            let ty = operand.get_type(ctx);
+            if ty.deref(ctx).downcast_ref::<FP32Type>().is_none() {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k16_f32_f16 C operand {} must be f32",
+                    index
+                );
+            }
+        }
+
+        for (index, operand) in operands.iter().enumerate().skip(4) {
+            let ty = operand.get_type(ctx);
+            let ty = ty.deref(ctx);
+            let Some(integer) = ty.downcast_ref::<IntegerType>() else {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k16_f32_f16 packed operand {} must be i32",
+                    index
+                );
+            };
+            if integer.width() != 32 {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k16_f32_f16 packed operand {} must be i32",
+                    index
+                );
+            }
+        }
+
+        if op.get_num_results() != 4 {
+            return verify_err!(op.loc(), "nvvm.mma_m16n8k16_f32_f16 requires 4 f32 results");
+        }
+
+        for index in 0..4 {
+            let ty = op.get_result(index).get_type(ctx);
+            if ty.deref(ctx).downcast_ref::<FP32Type>().is_none() {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k16_f32_f16 result {} must be f32",
+                    index
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl MmaM16N8K16F32F16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K16F32F16Op { op }
+    }
+}
+
 /// Warp MMA: m8n8k4 with f64 accumulator and f64 inputs.
 ///
 /// # Operands
@@ -228,5 +315,6 @@ impl MmaM8N8K4F64Op {
 pub(super) fn register(ctx: &mut Context) {
     MovmatrixTransB16Op::register(ctx);
     MmaM16N8K16F32Bf16Op::register(ctx);
+    MmaM16N8K16F32F16Op::register(ctx);
     MmaM8N8K4F64Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -6,14 +6,14 @@
 use dialect_mir::types::MirPtrType;
 use dialect_nvvm::ops::{
     Barrier0Op, ElectSyncOp, FmaBf16x2Op, LdmatrixX2Op, MmaM8N8K4F64Op, MmaM16N8K16F32Bf16Op,
-    MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, ReadPtxSregDynamicSmemSizeOp,
-    ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp,
-    ReadPtxSregLanemaskGtOp, ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp,
-    ReadPtxSregNwarpIdOp, ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp,
-    ReadPtxSregWarpIdOp, ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp,
-    ReduxSyncOrOp, ReduxSyncUmaxOp, ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op,
-    ShflSyncDownI64Op, ShflSyncIdxI64Op, ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp,
-    ThreadfenceOp, ThreadfenceSystemOp,
+    MmaM16N8K16F32F16Op, MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
+    ReadPtxSregDynamicSmemSizeOp, ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp,
+    ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
+    ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp, ReadPtxSregNwarpIdOp,
+    ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp, ReadPtxSregWarpIdOp,
+    ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp, ReduxSyncOrOp, ReduxSyncUmaxOp,
+    ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op, ShflSyncDownI64Op, ShflSyncIdxI64Op,
+    ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp,
 };
 use pliron::{
     basic_block::BasicBlock,
@@ -212,6 +212,101 @@ fn test_mma_m16n8k16_bf16_verifies_exact_register_signature() {
         0,
     );
     assert!(verify_op(&MmaM16N8K16F32Bf16Op::new(bad_arity), &ctx).is_err());
+}
+
+#[test]
+fn test_mma_m16n8k16_f16_verifies_exact_register_signature() {
+    let mut ctx = Context::new();
+    dialect_nvvm::register(&mut ctx);
+
+    let f32_ty = FP32Type::get(&ctx);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let block = BasicBlock::new(
+        &mut ctx,
+        None,
+        vec![f32_ty.into(), i32_ty.into(), i64_ty.into()],
+    );
+    let f32_value = block.deref(&ctx).get_argument(0);
+    let i32_value = block.deref(&ctx).get_argument(1);
+    let i64_value = block.deref(&ctx).get_argument(2);
+
+    let operands = || {
+        (0..4)
+            .map(|_| f32_value)
+            .chain((0..6).map(|_| i32_value))
+            .collect()
+    };
+    let valid = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        operands(),
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(valid), &ctx).is_ok());
+
+    let bad_c_operands = (0..4)
+        .map(|index| if index == 0 { i32_value } else { f32_value })
+        .chain((0..6).map(|_| i32_value))
+        .collect();
+    let bad_c = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        bad_c_operands,
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(bad_c), &ctx).is_err());
+
+    let bad_packed_operands = (0..4)
+        .map(|_| f32_value)
+        .chain((0..6).map(|index| if index == 0 { i64_value } else { i32_value }))
+        .collect();
+    let bad_packed = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        bad_packed_operands,
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(bad_packed), &ctx).is_err());
+
+    let bad_result_type = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(), f32_ty.into(), f32_ty.into(), i32_ty.into()],
+        operands(),
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(bad_result_type), &ctx).is_err());
+
+    let bad_operand_arity = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        (0..4)
+            .map(|_| f32_value)
+            .chain((0..5).map(|_| i32_value))
+            .collect(),
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(bad_operand_arity), &ctx).is_err());
+
+    let bad_result_arity = Operation::new(
+        &mut ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 3],
+        operands(),
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K16F32F16Op::new(bad_result_arity), &ctx).is_err());
 }
 
 /// The `(constructor, TypeId)` pair returned by `get_concrete_op_info()`.

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -1259,6 +1259,17 @@ fn contains_mma_m8n8k4_f64_features(contents: &str) -> bool {
     contains_instruction_mnemonic(contents, "mma.sync.aligned.m8n8k4.row.col.f64.f64.f64.f64")
 }
 
+/// Checks the dense F16 MMA form added by the typed device intrinsic.
+///
+/// MMA shapes and types have different architecture and PTX ISA floors, so
+/// this intentionally matches the complete operation-specific mnemonic.
+fn contains_mma_m16n8k16_f32_f16_features(contents: &str) -> bool {
+    contains_instruction_mnemonic(
+        contents,
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32",
+    )
+}
+
 fn contains_instruction_mnemonic(contents: &str, mnemonic: &str) -> bool {
     contents.match_indices(mnemonic).any(|(index, _)| {
         let preceding = &contents[..index];
@@ -1348,6 +1359,7 @@ fn contains_sm80_features(contents: &str) -> bool {
         || contents.contains("cp.async.wait_all")
         || contents.contains("cp.async.wait.all")
         || contains_mma_m16n8k16_f32_bf16_features(contents)
+        || contains_mma_m16n8k16_f32_f16_features(contents)
 }
 
 /// Checks for TMA/mbarrier instructions (Hopper+ compatible with Blackwell).
@@ -1782,6 +1794,7 @@ fn detect_module_requirements_in_llvm_text(contents: &str) -> ModuleRequirements
     if contains_mbarrier_features(contents)
         || contents.contains("redux.sync")
         || contains_mma_m16n8k16_f32_bf16_features(contents)
+        || contains_mma_m16n8k16_f32_f16_features(contents)
         || contains_mma_m8n8k4_f64_features(contents)
     {
         ptx_isa = ptx_isa.max(PtxIsaRequirement::Ptx70);
@@ -3044,6 +3057,83 @@ mod tests {
         ] {
             assert!(
                 !contains_mma_m16n8k16_f32_bf16_features(near_miss),
+                "matched {near_miss:?}"
+            );
+        }
+
+        let combined = format!(
+            "{mnemonic}\n{}",
+            "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;"
+        );
+        assert_eq!(
+            detect_module_requirements_in_llvm_text(&combined),
+            ModuleRequirements {
+                features: DetectedFeatures::Sm80 | DetectedFeatures::Movmatrix,
+                ptx_isa: PtxIsaRequirement::Ptx78,
+            }
+        );
+    }
+
+    #[test]
+    fn dense_f16_mma_detection_applies_exact_sm80_and_ptx70_floors() {
+        let mnemonic = "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};";
+        for spelling in [
+            mnemonic,
+            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32\t{$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32\\09{$0}, {$1}, {$2}, {$3};",
+            ";mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "prefix\\0Amma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "\"mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "{mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "$L:mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "/* comment */mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "@p mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "@!%p\\09mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+        ] {
+            assert!(
+                contains_mma_m16n8k16_f32_f16_features(spelling),
+                "missed {spelling:?}"
+            );
+        }
+
+        let requirements = detect_module_requirements_in_llvm_text(mnemonic);
+        assert_eq!(
+            requirements,
+            ModuleRequirements {
+                features: DetectedFeatures::Sm80,
+                ptx_isa: PtxIsaRequirement::Ptx70,
+            }
+        );
+        assert_eq!(select_target(requirements.features).unwrap(), "sm_80");
+
+        let lower_target =
+            resolve_ptx_target(Some("sm_75"), None, requirements.features).unwrap_err();
+        assert!(
+            lower_target
+                .to_string()
+                .contains("cannot lower detected feature Sm80"),
+            "{lower_target}"
+        );
+        let (target, _) = resolve_ptx_target(Some("sm_80"), None, requirements.features).unwrap();
+        assert_eq!(target, "sm_80");
+
+        for near_miss in [
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sp.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32x {$0}, {$1}, {$2}, {$3};",
+            "not_mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "$mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "%mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "@mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "!mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "@!mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "not$mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            "/mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+            ")mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {$0}, {$1}, {$2}, {$3};",
+        ] {
+            assert!(
+                !contains_mma_m16n8k16_f32_f16_features(near_miss),
                 "matched {near_miss:?}"
             );
         }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
@@ -14,7 +14,9 @@ use dialect_mir::{
     ops::{MirConstructArrayOp, MirExtractFieldOp},
     types::MirArrayType,
 };
-use dialect_nvvm::ops::{MmaM8N8K4F64Op, MmaM16N8K16F32Bf16Op, MovmatrixTransB16Op};
+use dialect_nvvm::ops::{
+    MmaM8N8K4F64Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MovmatrixTransB16Op,
+};
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -288,6 +290,144 @@ pub fn emit_mma_m16n8k16_f32_bf16(
         block_map,
         loc,
         "mma_m16n8k16_f32_bf16 call without target block",
+    )
+}
+
+/// Emit `mma_m16n8k16_f32_f16` as a register-producing dialect operation.
+///
+/// Args:
+/// - `args[0]`: `[f32; 4]` C accumulator registers
+/// - `args[1]`: `[u32; 4]` packed A fragment registers
+/// - `args[2]`: `[u32; 2]` packed B fragment registers
+///
+/// Returns: `[f32; 4]` D accumulator registers.
+pub fn emit_mma_m16n8k16_f32_f16(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k16_f32_f16 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let f32_ty = FP32Type::get(ctx);
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let (c_array, last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (c_registers, last_op) = extract_array_registers(
+        ctx,
+        c_array,
+        f32_ty.into(),
+        4,
+        block_ptr,
+        last_op,
+        loc.clone(),
+        "C",
+    )?;
+
+    let (a_array, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        Some(last_op),
+        loc.clone(),
+    )?;
+    let (a_registers, last_op) = extract_array_registers(
+        ctx,
+        a_array,
+        u32_ty.into(),
+        4,
+        block_ptr,
+        last_op_after,
+        loc.clone(),
+        "A",
+    )?;
+
+    let (b_array, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        Some(last_op),
+        loc.clone(),
+    )?;
+    let (b_registers, last_op) = extract_array_registers(
+        ctx,
+        b_array,
+        u32_ty.into(),
+        2,
+        block_ptr,
+        last_op_after,
+        loc.clone(),
+        "B",
+    )?;
+
+    let mut operands = c_registers;
+    operands.extend(a_registers);
+    operands.extend(b_registers);
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+    mma_op.insert_after(ctx, last_op);
+
+    let d_registers = (0..4)
+        .map(|index| mma_op.deref(ctx).get_result(index))
+        .collect();
+    let array_ty = MirArrayType::get(ctx, f32_ty.into(), 4);
+    let d_array = Operation::new(
+        ctx,
+        MirConstructArrayOp::get_concrete_op_info(),
+        vec![array_ty.into()],
+        d_registers,
+        vec![],
+        0,
+    );
+    d_array.deref_mut(ctx).set_loc(loc.clone());
+    d_array.insert_after(ctx, mma_op);
+    let result = d_array.deref(ctx).get_result(0);
+
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        d_array,
+        value_map,
+        block_map,
+        loc,
+        "mma_m16n8k16_f32_f16 call without target block",
     )
 }
 

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
@@ -125,7 +125,7 @@ fn extract_array_registers(
         return input_err!(
             loc,
             TranslationErr::unsupported(format!(
-                "mma_m16n8k16_f32_bf16 {fragment_name} fragment must be an array of {expected_len} scalar registers"
+                "MMA {fragment_name} fragment must be an array of {expected_len} scalar registers"
             ))
         );
     }
@@ -647,18 +647,25 @@ mod tests {
             );
         }
 
+        let message = extract_array_registers(
+            &mut ctx,
+            array,
+            f32_ty.into(),
+            2,
+            block,
+            Some(last_op),
+            Location::Unknown,
+            "B",
+        )
+        .expect_err("invalid fragment must report an error")
+        .to_string();
         assert!(
-            extract_array_registers(
-                &mut ctx,
-                array,
-                f32_ty.into(),
-                2,
-                block,
-                Some(last_op),
-                Location::Unknown,
-                "B",
-            )
-            .is_err()
+            message.contains("MMA B fragment must be an array of 2 scalar registers"),
+            "unexpected fragment diagnostic: {message}"
+        );
+        assert!(
+            !message.contains("bf16") && !message.contains("tf32") && !message.contains("f16"),
+            "shared fragment diagnostics must not name a different MMA operation: {message}"
         );
     }
 }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3672,6 +3672,20 @@ fn try_dispatch_intrinsic(
                 loc,
             )?))
         }
+        "cuda_device::wmma::mma_m16n8k16_f32_f16" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k16_f32_f16(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
         "cuda_device::wmma::mma_m8n8k4_f64" => Ok(Some(intrinsics::wmma::emit_mma_m8n8k4_f64(
             ctx,
             body,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -59,15 +59,15 @@ use dialect_nvvm::ops::{
     MbarrierArriveExpectTxClusterOp, MbarrierArriveExpectTxSharedOp, MbarrierArriveSharedOp,
     MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
     MbarrierTryWaitParityClusterOp, MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp,
-    MinBf16x2Op, MmaM8N8K4F64Op, MmaM16N8K16F32Bf16Op, MovmatrixTransB16Op, MulBf16x2Op,
-    NanosleepOp, NegBf16x2Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp,
-    NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op,
-    ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp,
-    ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp,
-    ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp,
-    ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregDynamicSmemSizeOp, ReadPtxSregEnvReg1Op,
-    ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp,
-    ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
+    MinBf16x2Op, MmaM8N8K4F64Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MovmatrixTransB16Op,
+    MulBf16x2Op, NanosleepOp, NegBf16x2Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
+    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp,
+    ReadPtxSregClock64Op, ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp,
+    ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp,
+    ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp,
+    ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregDynamicSmemSizeOp,
+    ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregGridIdOp,
+    ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
     ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNclusterIdOp,
     ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNsmIdOp,
     ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregNwarpIdOp,
@@ -2734,6 +2734,23 @@ impl MirToLlvmConversion for MmaM16N8K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wmma::convert_mma_m16n8k16_f32_bf16(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K16F32F16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k16_f32_f16(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wmma.rs
@@ -105,6 +105,56 @@ pub(crate) fn convert_mma_m16n8k16_f32_bf16(
     Ok(())
 }
 
+/// Convert `mma_m16n8k16_f32_f16` to one register-only inline PTX operation.
+///
+/// Operand order is C[0..4], A[0..4], B[0..2]. The four D registers are
+/// returned as an LLVM struct and then split back into the dialect op's four
+/// SSA results. There are no hidden pointer, stack, load, or store operands.
+pub(crate) fn convert_mma_m16n8k16_f32_f16(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 10 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k16_f32_f16 requires 10 register operands, got {}",
+            operands.len()
+        );
+    }
+
+    let f32_ty = FP32Type::get(ctx);
+    let result_ty = llvm_types::StructType::get_unnamed(ctx, vec![f32_ty.into(); 4]);
+    let template = concat!(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 ",
+        "{$0, $1, $2, $3}, ",
+        "{$8, $9, $10, $11}, ",
+        "{$12, $13}, ",
+        "{$4, $5, $6, $7};"
+    );
+    let constraints = "=f,=f,=f,=f,f,f,f,f,r,r,r,r,r,r";
+    let inline_asm = inline_asm_convergent(
+        ctx,
+        rewriter,
+        result_ty.into(),
+        operands,
+        template,
+        constraints,
+    );
+
+    let aggregate = inline_asm.deref(ctx).get_result(0);
+    let mut results = Vec::with_capacity(4);
+    for index in 0..4 {
+        let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![index as u32])
+            .map_err(|error| pliron::input_error_noloc!("{}", error))?;
+        rewriter.insert_operation(ctx, extract.get_operation());
+        results.push(extract.get_operation().deref(ctx).get_result(0));
+    }
+    rewriter.replace_operation_with_values(ctx, op, results);
+    Ok(())
+}
+
 /// Convert `mma_m8n8k4_f64` to inline PTX assembly.
 ///
 /// The operation consumes the two C registers plus A and B directly, and

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -3316,6 +3316,113 @@ fn test_mma_m16n8k16_f32_bf16_lowers_to_inline_asm() -> Result<(), anyhow::Error
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// mma.sync m16n8k16 f16 intrinsic lowering test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mma_m16n8k16_f32_f16_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let f32_ty = pliron::builtin::types::FP32Type::get(&ctx);
+    let i32_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        32,
+        pliron::builtin::types::Signedness::Signless,
+    );
+    let argument_types = (0..4)
+        .map(|_| f32_ty.into())
+        .chain((0..6).map(|_| i32_ty.into()))
+        .collect();
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, argument_types);
+    let operands = (0..10)
+        .map(|index| entry.deref(&ctx).get_argument(index))
+        .collect();
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 4],
+        operands,
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let mut found = 0;
+    let module_region = module_ptr.deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    for module_op in module_block.deref(&ctx).iter(&ctx) {
+        let Some(function) = Operation::get_op::<llvm::FuncOp>(module_op, &ctx) else {
+            continue;
+        };
+        if function.get_symbol_name(&ctx).to_string() != "kernel_func" {
+            continue;
+        }
+        let body = function.get_operation().deref(&ctx).get_region(0);
+        for block in body.deref(&ctx).iter(&ctx) {
+            for body_op in block.deref(&ctx).iter(&ctx) {
+                let Some(asm) = Operation::get_op::<llvm::InlineAsmOp>(body_op, &ctx) else {
+                    continue;
+                };
+                let template = asm
+                    .get_attr_inline_asm_template(&ctx)
+                    .map(|value| String::from((*value).clone()));
+                let constraints = asm
+                    .get_attr_inline_asm_constraints(&ctx)
+                    .map(|value| String::from((*value).clone()));
+                if !template.as_deref().is_some_and(|t| {
+                    t.contains("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32")
+                }) {
+                    continue;
+                }
+                found += 1;
+                let template = template.expect("MMA inline asm must have a template");
+                assert_eq!(
+                    template,
+                    concat!(
+                        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 ",
+                        "{$0, $1, $2, $3}, ",
+                        "{$8, $9, $10, $11}, ",
+                        "{$12, $13}, ",
+                        "{$4, $5, $6, $7};"
+                    )
+                );
+                for forbidden in [".reg", "ld.", "st.", "["] {
+                    assert!(
+                        !template.contains(forbidden),
+                        "register-only MMA must not contain {forbidden:?}: {template}"
+                    );
+                }
+                assert_eq!(
+                    constraints.as_deref(),
+                    Some("=f,=f,=f,=f,f,f,f,f,r,r,r,r,r,r")
+                );
+                assert_eq!(
+                    llvm::asm_kind_opt(&ctx, &asm),
+                    Some(llvm::AsmKind::Convergent)
+                );
+                assert_eq!(
+                    body_op.deref(&ctx).get_num_operands(),
+                    10,
+                    "expected C, A, and B scalar register operands"
+                );
+                assert_eq!(
+                    body_op.deref(&ctx).get_num_results(),
+                    1,
+                    "LLVM inline asm returns the four D registers as one struct"
+                );
+            }
+        }
+    }
+
+    assert_eq!(found, 1, "expected one mma.sync inline-asm operation");
+    Ok(())
+}
+
 #[test]
 fn test_packed_atomic_add_lowers_to_exact_side_effecting_ptx() -> Result<(), anyhow::Error> {
     use dialect_mir::types::MirPtrType;

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
@@ -10,49 +10,60 @@ Rust device libraries that are consumed by CUDA C++ via LTOIR linking.
 
 ## Test Coverage
 
-| # | Test                       | What It Verifies                                                         |
-|---|----------------------------|--------------------------------------------------------------------------|
-| 1 | Simple device functions    | `fast_sqrt`, `clamp_f32` appear as `.func` in PTX                        |
-| 2 | Transitive calls           | `safe_sqrt` (calls `fast_sqrt` + `clamp_f32`) is collected               |
-| 3 | Generic device function    | `fma_f32` (concrete wrapper around generic `fma<T>`) compiles            |
-| 4 | GPU intrinsics             | `get_global_thread_id` (uses `thread::index_1d()`) compiles              |
-| 5 | Multiple monomorphizations | Both `fma_f32` and `fma_i32` instantiations present                      |
-| 6 | Uninstantiated generic     | Generic `unused_generic<T>` is correctly **absent** (not monomorphized)  |
-| 7 | No `.entry` directives     | All functions are `.func`, not `.entry` (no kernels)                     |
-| 8 | Clean export names         | No reserved `cuda_oxide_device_<hash>_` prefix in PTX function names     |
+| # | Check | What It Verifies |
+|---|---|---|
+| 1 | `fast_sqrt` | A simple standalone device function appears in PTX |
+| 2 | `clamp_f32` | A second independent device function appears in PTX |
+| 3 | `safe_sqrt` | Transitive calls collect both helper functions |
+| 4 | `fma_f32` | A concrete f32 wrapper monomorphizes `fma<T>` |
+| 5 | `fma_i32` | A second concrete type produces another monomorphization |
+| 6 | `get_global_thread_id` | Device thread-index intrinsics compile |
+| 7 | `mma_m16n8k16_f32_f16_stub` | The public F16 MMA stub reaches the device pipeline |
+| 8 | Exact F16 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` |
+| 9 | `lerp` absent | An uninstantiated generic is not compiled |
+| 10 | No `.entry` directives | Every emitted symbol is a device `.func`, not a kernel |
 
 ## How to Run
 
 ```bash
 # From workspace root
-cargo oxide run standalone_device_fn
+cargo oxide run standalone_device_fn --arch sm_80
 ```
+
+The explicit target keeps this regression on the MMA instruction's minimum
+supported architecture and PTX ISA: `sm_80` with PTX 7.0.
 
 Expected output:
 
 ```text
-=== Standalone Device Function Compilation ===
+=== Standalone Device Function Example ===
 
-PTX generated: standalone_device_fn.ptx (...)
-  1. PASS  fast_sqrt found in PTX
-  2. PASS  clamp_f32 found in PTX
+PTX file: standalone_device_fn.ptx (... bytes)
+  PASS  fast_sqrt — Test 1: simple standalone fn
+  PASS  clamp_f32 — Test 1: simple standalone fn
   ...
-  8. PASS  No .entry directives (all are .func)
+  PASS  mma_m16n8k16_f32_f16_stub — Test 5: F16 warp-MMA stub
+  PASS  exact F16 warp-MMA instruction emitted
+  PASS  lerp absent — Test 3b: uninstantiated generic not compiled
+  PASS  No .entry directives (all are .func)
 
-SUCCESS: 8/8 tests passed
+SUCCESS: 10/10 tests passed — all device functions compiled to PTX!
 ```
 
 ## How It Works
 
-1. The `#[device]` macro renames functions with the reserved `cuda_oxide_device_<hash>_` prefix
-   (owned by `crates/reserved-oxide-symbols/`).
-   and generates an `#[inline(always)]` wrapper with the original name
+1. The `#[device]` macro renames functions with the reserved
+   `cuda_oxide_device_<hash>_` prefix (owned by
+   `crates/reserved-oxide-symbols/`) and generates an `#[inline(always)]`
+   wrapper with the original name.
 2. The collector (`rustc-codegen-cuda/src/collector.rs`) detects standalone
    `#[device]` functions as compilation roots when no `#[kernel]` is present
 3. The LLVM export layer strips the `cuda_oxide_device_<hash>_` prefix for clean
    names in the final output
 4. Generic `#[device]` functions are only compiled if monomorphized by a
    concrete call site (standard Rust monomorphization rules)
+5. The F16 MMA wrapper forces the public stub through MIR import and lowering;
+   the host then checks the exact PTX instruction text
 
 ## Related
 

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
@@ -156,11 +156,7 @@ pub fn get_global_thread_id() -> usize {
 /// The caller must satisfy [`mma_m16n8k16_f32_f16`]'s warp participation and
 /// lane-fragment layout contract.
 #[device]
-pub unsafe fn mma_m16n8k16_f32_f16_stub(
-    c: [f32; 4],
-    a: [u32; 4],
-    b: [u32; 2],
-) -> [f32; 4] {
+pub unsafe fn mma_m16n8k16_f32_f16_stub(c: [f32; 4], a: [u32; 4], b: [u32; 2]) -> [f32; 4] {
     unsafe { mma_m16n8k16_f32_f16(c, a, b) }
 }
 
@@ -196,10 +192,7 @@ fn main() {
             "get_global_thread_id",
             "Test 4: device fn with GPU intrinsics",
         ),
-        (
-            "mma_m16n8k16_f32_f16_stub",
-            "Test 5: F16 warp-MMA stub",
-        ),
+        ("mma_m16n8k16_f32_f16_stub", "Test 5: F16 warp-MMA stub"),
     ];
 
     let mut passed = 0;

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
@@ -16,12 +16,13 @@
 //!
 //! 1. Simple standalone device functions (no kernel, no GPU intrinsics)
 //! 2. Device function calling another device function (transitive collection)
-//! 3. Generic logic via concrete device function wrappers
+//! 3. Generic logic via concrete wrappers, including multiple monomorphizations
 //! 4. Device function using GPU intrinsics (thread indexing)
-//! 5. Multiple monomorphizations of the same generic
+//! 5. Raw F16 warp-MMA lowering through the complete PTX pipeline
 
 use cuda_device::device;
 use cuda_device::thread;
+use cuda_device::wmma::mma_m16n8k16_f32_f16;
 
 // =============================================================================
 // TEST 1: Simple standalone device functions
@@ -142,6 +143,28 @@ pub fn get_global_thread_id() -> usize {
 }
 
 // =============================================================================
+// TEST 5: Raw warp-MMA stub through the complete compiler pipeline
+//
+// The host never calls this function. Compiling it proves that the public
+// cuda-device stub is recognized by mir-importer and lowered to exact PTX.
+// =============================================================================
+
+/// Emits one register-only F16 tensor-core MMA instruction.
+///
+/// # Safety
+///
+/// The caller must satisfy [`mma_m16n8k16_f32_f16`]'s warp participation and
+/// lane-fragment layout contract.
+#[device]
+pub unsafe fn mma_m16n8k16_f32_f16_stub(
+    c: [f32; 4],
+    a: [u32; 4],
+    b: [u32; 2],
+) -> [f32; 4] {
+    unsafe { mma_m16n8k16_f32_f16(c, a, b) }
+}
+
+// =============================================================================
 // HOST CODE - Verifies PTX was generated correctly
 // =============================================================================
 
@@ -173,6 +196,10 @@ fn main() {
             "get_global_thread_id",
             "Test 4: device fn with GPU intrinsics",
         ),
+        (
+            "mma_m16n8k16_f32_f16_stub",
+            "Test 5: F16 warp-MMA stub",
+        ),
     ];
 
     let mut passed = 0;
@@ -186,6 +213,15 @@ fn main() {
             println!("  FAIL  {} — {}", func_name, description);
             failed += 1;
         }
+    }
+
+    let f16_mma = "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32";
+    if ptx_content.contains(f16_mma) {
+        println!("  PASS  exact F16 warp-MMA instruction emitted");
+        passed += 1;
+    } else {
+        println!("  FAIL  exact F16 warp-MMA instruction missing");
+        failed += 1;
     }
 
     // Test 3b: Verify uninstantiated generic does NOT appear in PTX
@@ -211,7 +247,7 @@ fn main() {
 
     println!();
     if failed == 0 {
-        let total = tests.len() + 2; // +1 for lerp-absent check, +1 for no-.entry check
+        let total = tests.len() + 3; // +1 MMA, +1 lerp absent, +1 no .entry
         println!(
             "SUCCESS: {}/{} tests passed — all device functions compiled to PTX!",
             passed, total


### PR DESCRIPTION
## Summary

Adds the raw Ampere F16 warp-level matrix multiply-accumulate operation:

```ptx
mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
    {%d0, %d1, %d2, %d3},
    {%a0, %a1, %a2, %a3},
    {%b0, %b1},
    {%c0, %c1, %c2, %c3};
```

This is the low-level, unsafe register atom used to build typed matrix and tile APIs. It partially addresses tracking issue #274; it does not close the issue.

## What changed

- Added the `cuda-device` stub `mma_m16n8k16_f32_f16`.
- Added the dialect-nvvm operation, MIR importer handling, register-only convergent lowering, and PTX 7.0 / `sm_80` target detection.
- Documented the exact per-lane A/B/C/D coordinates, Rust-array-to-PTX register order, packed F16 order, and warp participation contract.
- Made the shared MMA fragment diagnostic operation-neutral.
- Added positive and negative operation-verifier tests.
- Added a checked-in device-stub -> MIR importer -> lowering -> PTX regression.

## Safety and register contract

```text
each lane: C[f32 x4] + A[b32 x4] * B[b32 x2]
                         |
                         v
                     D[f32 x4]
```

All 32 lanes must execute the same instruction with the same qualifiers, with no lane exited. A and B are raw `.b32` carriers containing two F16 values each in low-to-high order. Passing another lane layout computes a different matrix operation. The instruction requires PTX ISA 7.0 and `sm_80` or newer.

## Testing

- [x] `cargo test -p cuda-device --lib`
- [x] `cargo test -p dialect-nvvm --all-targets` (17 passed)
- [x] `cargo test -p mir-importer --lib` (66 passed)
- [x] `cargo test -p mir-lower --all-targets` (85 unit + 40 integration passed)
- [x] Focused strict clippy, formatting, and diff checks
- [x] `cargo oxide run standalone_device_fn --arch sm_80` (10/10)
- [x] Generated exact PTX 7.0 / `sm_80`; CUDA 13.3 `ptxas` accepted it
- [x] Explicit `sm_75` compilation rejected the operation with the required `sm_80` floor
- [ ] Full-warp numerical comparison on a GPU, including Compute Sanitizer

## Checklist

- [ ] Original contributor commit has the required DCO `Signed-off-by` trailer
- [x] Maintainer follow-up commit is signed off
- [x] No `crates/cuda-bindings/` changes
- [x] Public unsafe contract and compiler regression coverage included

