### PR TITLE
Fix cargo oxide debug executable discovery

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -45,7 +45,8 @@ cargo oxide setup                   # explicitly build the codegen backend
 |------------------------------|----------------------------------|-------------------------------------------------|
 | `--emit-nvvm-ir`             | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
 | `--arch <sm_XX>`             | run, sanitize, build, test, pipeline, emit-ltoir | Target architecture override |
-| `--features <F>`             | run, sanitize, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
+| `--features <F>`             | run, sanitize, debug, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
+| `--bin <NAME>`               | run, sanitize, debug                | Specific binary target to build/run      |
 | `--tool <T>`                 | sanitize                         | Compute Sanitizer tool: `memcheck`, `racecheck`, `initcheck`, or `synccheck` |
 | `-o, --output <P>`           | emit-ltoir                       | Output path for the `.ltoir` artifact           |
 | `--cargo-target-dir <PATH>`  | build/test passthrough           | Cargo target directory                          |
@@ -216,7 +217,13 @@ cargo oxide pipeline device_ffi_test --emit-nvvm-ir --arch sm_120
 
 ### `cargo oxide debug <example>`
 
-Builds with debug info (`-C debuginfo=2`) and launches cuda-gdb. Supports `--tui` for GDB's TUI mode and `--cgdb` for the cgdb frontend.
+Builds with debug info (`-C debuginfo=2`) and launches cuda-gdb. Supports
+`--tui` for GDB's TUI mode and `--cgdb` for the cgdb frontend.
+
+`debug` uses Cargo's reported executable artifact, so custom binary names,
+`package.default-run`, configured target directories, host target triples, and
+virtual workspaces do not require path guessing. Use `--bin <name>` when a
+package has multiple binaries and no unambiguous default.
 
 ### `cargo oxide new <name> [--async]`
 

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -115,9 +115,7 @@ pub fn find_or_build_backend(workspace_root: &Path, configured_backend: Option<&
     // 3. Local repo
     let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
     if codegen_crate.is_dir() {
-        let so_path = codegen_crate.join("target/debug/librustc_codegen_cuda.so");
-        build_backend_from_source(&codegen_crate);
-        return so_path;
+        return build_backend_from_source(&codegen_crate);
     }
 
     // 4. Cached .so. Only honored when it isn't older than the running
@@ -357,19 +355,13 @@ fn invalidate_cache(cache_dir: &Path) {
 }
 
 /// Builds the backend from a local source tree.
-pub fn build_backend_from_source(codegen_crate: &Path) {
+pub fn build_backend_from_source(codegen_crate: &Path) -> PathBuf {
     println!("Building rustc-codegen-cuda backend...");
 
     let rustc_sysroot = get_rustc_sysroot();
     let lib_path = rustc_sysroot.as_ref().map(|s| format!("{}/lib", s));
 
-    let mut cmd = Command::new("cargo");
-    cmd.args(["build"]).current_dir(codegen_crate);
-
-    if let Some(ref path) = lib_path {
-        cmd.env("LIBRARY_PATH", build_library_path(path));
-        cmd.env("LD_LIBRARY_PATH", build_ld_library_path(path));
-    }
+    let mut cmd = backend_build_command(codegen_crate, lib_path.as_deref());
 
     let status = cmd.status().expect("Failed to run cargo build");
 
@@ -384,6 +376,23 @@ pub fn build_backend_from_source(codegen_crate: &Path) {
     } else {
         eprintln!("Warning: Expected .so not found at {}", so_path.display());
     }
+    so_path
+}
+
+fn backend_build_command(codegen_crate: &Path, rustc_lib_path: Option<&str>) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build"]).current_dir(codegen_crate);
+    // `cargo oxide debug/run/sanitize` may be launched with an application
+    // CARGO_TARGET_DIR. The backend has a stable repo/cache location contract,
+    // so force the backend build back to `<codegen_crate>/target`.
+    cmd.env("CARGO_TARGET_DIR", "target");
+
+    if let Some(path) = rustc_lib_path {
+        cmd.env("LIBRARY_PATH", build_library_path(path));
+        cmd.env("LD_LIBRARY_PATH", build_ld_library_path(path));
+    }
+
+    cmd
 }
 
 /// Returns the cache directory for cuda-oxide artifacts: `~/.cargo/cuda-oxide/`.
@@ -442,9 +451,7 @@ fn auto_fetch_and_build() -> PathBuf {
     }
 
     let codegen_crate = src_dir.join("crates/rustc-codegen-cuda");
-    build_backend_from_source(&codegen_crate);
-
-    let built_so = codegen_crate.join("target/debug/librustc_codegen_cuda.so");
+    let built_so = build_backend_from_source(&codegen_crate);
     if built_so.exists() {
         std::fs::copy(&built_so, &so_path).expect("Failed to copy backend to cache");
         write_toolchain_fingerprint(&cache_dir);
@@ -492,9 +499,27 @@ pub fn build_ld_library_path(sysroot_lib: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::time::{Duration, SystemTime};
+
+    /// The codegen backend is part of the cuda-oxide toolchain, not the
+    /// application being debugged/sanitized. A user-supplied
+    /// `CARGO_TARGET_DIR` for the application must therefore not change where
+    /// cargo-oxide builds or looks for `librustc_codegen_cuda.so`.
+    #[test]
+    fn backend_build_command_removes_application_cargo_target_dir() {
+        let command = backend_build_command(Path::new("/tmp/codegen"), Some("/tmp/rustc/lib"));
+
+        let cargo_target_dir = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("CARGO_TARGET_DIR"))
+            .map(|(_, value)| value);
+
+        assert_eq!(cargo_target_dir.flatten(), Some(OsStr::new("target")));
+        assert_eq!(command.get_current_dir(), Some(Path::new("/tmp/codegen")));
+    }
 
     /// A cached `.so` whose mtime predates the running test binary should
     /// be reported stale. The test binary is `current_exe()`, which was

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -164,7 +164,8 @@ pub fn find_or_build_backend(workspace_root: &Path, configured_backend: Option<&
 ///    so the caller can report the configured-but-absent path.
 /// 2. Project config (`.cargo/cuda-oxide.toml`), returned even when missing
 ///    so the caller can report the configured-but-absent path.
-/// 3. Local repo build path (`crates/rustc-codegen-cuda/target/debug/...`).
+/// 3. Local repo host build path
+///    (`crates/rustc-codegen-cuda/target/<host>/debug/...`).
 /// 4. Cache path at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`.
 ///
 /// `cargo oxide doctor` uses this so that a diagnostic run never triggers a
@@ -180,7 +181,7 @@ pub fn backend_so_candidate(workspace_root: &Path, configured_backend: Option<&P
 
     let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
     if codegen_crate.is_dir() {
-        return codegen_crate.join("target/debug/librustc_codegen_cuda.so");
+        return backend_so_path_candidate(&codegen_crate);
     }
 
     cache_directory()
@@ -273,6 +274,13 @@ fn current_toolchain_fingerprint() -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Host target triple of the active rustc, as reported by `rustc -vV`.
+fn active_host_triple() -> Option<String> {
+    current_toolchain_fingerprint()?
+        .lines()
+        .find_map(|line| line.strip_prefix("host: ").map(str::to_owned))
+}
+
 /// True when the cached backend records a toolchain fingerprint that differs
 /// from the active toolchain. Conservative: if the active fingerprint cannot be
 /// read, or no fingerprint was recorded (a cache predating this check), returns
@@ -362,30 +370,59 @@ pub fn build_backend_from_source(codegen_crate: &Path) -> PathBuf {
     let lib_path = rustc_sysroot.as_ref().map(|s| format!("{}/lib", s));
 
     let mut cmd = backend_build_command(codegen_crate, lib_path.as_deref());
+    let output = cmd.output().unwrap_or_else(|error| {
+        eprintln!("Failed to run cargo build for rustc-codegen-cuda: {error}");
+        std::process::exit(1);
+    });
 
-    let status = cmd.status().expect("Failed to run cargo build");
+    render_cargo_diagnostics(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.is_empty() {
+        eprint!("{stderr}");
+    }
 
-    if !status.success() {
+    if !output.status.success() {
         eprintln!("Failed to build rustc-codegen-cuda");
-        std::process::exit(status.code().unwrap_or(1));
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
-    let so_path = codegen_crate.join("target/debug/librustc_codegen_cuda.so");
-    if so_path.exists() {
-        println!("✓ Backend built: {}", so_path.display());
-    } else {
-        eprintln!("Warning: Expected .so not found at {}", so_path.display());
+    let so_path =
+        backend_artifact_from_cargo_output(codegen_crate, &output.stdout).unwrap_or_else(|error| {
+            eprintln!("Backend build succeeded, but {error}");
+            std::process::exit(1);
+        });
+    if !so_path.is_file() {
+        eprintln!(
+            "Backend build reported {}, but that file does not exist",
+            so_path.display()
+        );
+        std::process::exit(1);
     }
+    println!("✓ Backend built: {}", so_path.display());
     so_path
 }
 
 fn backend_build_command(codegen_crate: &Path, rustc_lib_path: Option<&str>) -> Command {
+    let codegen_crate = absolute_path(codegen_crate);
+    let target_dir = codegen_crate.join("target");
     let mut cmd = Command::new("cargo");
-    cmd.args(["build"]).current_dir(codegen_crate);
-    // `cargo oxide debug/run/sanitize` may be launched with an application
-    // CARGO_TARGET_DIR. The backend has a stable repo/cache location contract,
-    // so force the backend build back to `<codegen_crate>/target`.
-    cmd.env("CARGO_TARGET_DIR", "target");
+    cmd.args([
+        "build",
+        "--lib",
+        "--target",
+        "host-tuple",
+        "--message-format=json-render-diagnostics",
+        "--target-dir",
+    ])
+    .arg(&target_dir)
+    .current_dir(&codegen_crate);
+
+    // The backend is a host rustc plugin, not an application artifact. Keep it
+    // out of an application's target directory and override both
+    // CARGO_BUILD_TARGET and `[build] target`: an explicit `--target
+    // host-tuple` makes Cargo compile the dylib for the running toolchain.
+    cmd.env("CARGO_TARGET_DIR", &target_dir);
+    cmd.env_remove("CARGO_BUILD_TARGET");
 
     if let Some(path) = rustc_lib_path {
         cmd.env("LIBRARY_PATH", build_library_path(path));
@@ -393,6 +430,115 @@ fn backend_build_command(codegen_crate: &Path, rustc_lib_path: Option<&str>) -> 
     }
 
     cmd
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+fn backend_dylib_filename() -> String {
+    format!(
+        "{}rustc_codegen_cuda{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    )
+}
+
+fn backend_so_path_candidate(codegen_crate: &Path) -> PathBuf {
+    let target_dir = codegen_crate.join("target");
+    let profile_dir = active_host_triple()
+        .map(|host| target_dir.join(host).join("debug"))
+        .unwrap_or_else(|| target_dir.join("debug"));
+    profile_dir.join(backend_dylib_filename())
+}
+
+fn render_cargo_diagnostics(stdout: &[u8]) {
+    for line in String::from_utf8_lossy(stdout).lines() {
+        let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
+            if !line.is_empty() {
+                println!("{line}");
+            }
+            continue;
+        };
+        if let Some(rendered) = message
+            .get("message")
+            .and_then(|message| message.get("rendered"))
+            .and_then(|rendered| rendered.as_str())
+        {
+            eprint!("{rendered}");
+        }
+    }
+}
+
+/// Select the backend path Cargo reported for this exact manifest and dylib
+/// target. There is deliberately no guessed-path fallback: a successful Cargo
+/// exit without this artifact must fail instead of loading an older file left
+/// in `target/debug` by a previous host build.
+fn backend_artifact_from_cargo_output(
+    codegen_crate: &Path,
+    stdout: &[u8],
+) -> Result<PathBuf, String> {
+    let expected_manifest = codegen_crate
+        .join("Cargo.toml")
+        .canonicalize()
+        .map_err(|error| format!("could not resolve backend manifest: {error}"))?;
+    let expected_filename = backend_dylib_filename();
+    let mut artifacts = Vec::new();
+
+    for line in String::from_utf8_lossy(stdout).lines() {
+        let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if message.get("reason").and_then(|reason| reason.as_str()) != Some("compiler-artifact") {
+            continue;
+        }
+        let manifest_matches = message
+            .get("manifest_path")
+            .and_then(|path| path.as_str())
+            .and_then(|path| Path::new(path).canonicalize().ok())
+            .is_some_and(|path| path == expected_manifest);
+        let target_matches = message
+            .get("target")
+            .and_then(|target| target.get("name"))
+            .and_then(|name| name.as_str())
+            == Some("rustc_codegen_cuda")
+            && message
+                .get("target")
+                .and_then(|target| target.get("kind"))
+                .and_then(|kind| kind.as_array())
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("dylib")));
+        if !manifest_matches || !target_matches {
+            continue;
+        }
+
+        let Some(filenames) = message.get("filenames").and_then(|files| files.as_array()) else {
+            continue;
+        };
+        for filename in filenames.iter().filter_map(|file| file.as_str()) {
+            let path = PathBuf::from(filename);
+            if path.file_name() == Some(std::ffi::OsStr::new(&expected_filename))
+                && !artifacts.contains(&path)
+            {
+                artifacts.push(path);
+            }
+        }
+    }
+
+    match artifacts.as_slice() {
+        [artifact] => Ok(artifact.clone()),
+        [] => Err(format!(
+            "Cargo reported no `{expected_filename}` artifact for rustc_codegen_cuda"
+        )),
+        _ => Err(format!(
+            "Cargo reported multiple `{expected_filename}` artifacts for rustc_codegen_cuda"
+        )),
+    }
 }
 
 /// Returns the cache directory for cuda-oxide artifacts: `~/.cargo/cuda-oxide/`.
@@ -509,16 +655,81 @@ mod tests {
     /// `CARGO_TARGET_DIR` for the application must therefore not change where
     /// cargo-oxide builds or looks for `librustc_codegen_cuda.so`.
     #[test]
-    fn backend_build_command_removes_application_cargo_target_dir() {
+    fn backend_build_command_isolates_target_dir_and_forces_the_host() {
         let command = backend_build_command(Path::new("/tmp/codegen"), Some("/tmp/rustc/lib"));
 
         let cargo_target_dir = command
             .get_envs()
-            .find(|(key, _)| *key == OsStr::new("CARGO_TARGET_DIR"))
-            .map(|(_, value)| value);
+            .find_map(|(key, value)| (key == OsStr::new("CARGO_TARGET_DIR")).then_some(value));
+        let cargo_build_target = command
+            .get_envs()
+            .find_map(|(key, value)| (key == OsStr::new("CARGO_BUILD_TARGET")).then_some(value));
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
 
-        assert_eq!(cargo_target_dir.flatten(), Some(OsStr::new("target")));
+        assert_eq!(
+            cargo_target_dir.flatten(),
+            Some(OsStr::new("/tmp/codegen/target"))
+        );
+        assert_eq!(cargo_build_target, Some(None));
         assert_eq!(command.get_current_dir(), Some(Path::new("/tmp/codegen")));
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--target", "host-tuple"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--target-dir", "/tmp/codegen/target"])
+        );
+        assert!(
+            args.iter()
+                .any(|arg| arg == "--message-format=json-render-diagnostics")
+        );
+    }
+
+    #[test]
+    fn backend_artifact_uses_cargos_host_path_not_a_stale_legacy_path() {
+        let root = tempdir();
+        let codegen = root.join("crates/rustc-codegen-cuda");
+        std::fs::create_dir_all(&codegen).unwrap();
+        std::fs::write(
+            codegen.join("Cargo.toml"),
+            "[package]\nname='rustc_codegen_cuda'\n",
+        )
+        .unwrap();
+
+        let stale = codegen.join("target/debug").join(backend_dylib_filename());
+        let fresh = codegen
+            .join("target/x86_64-unknown-linux-gnu/debug")
+            .join(backend_dylib_filename());
+        std::fs::create_dir_all(stale.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(fresh.parent().unwrap()).unwrap();
+        std::fs::write(&stale, b"stale backend").unwrap();
+        std::fs::write(&fresh, b"fresh host backend").unwrap();
+
+        let message = serde_json::json!({
+            "reason": "compiler-artifact",
+            "manifest_path": codegen.join("Cargo.toml"),
+            "target": {
+                "kind": ["dylib"],
+                "name": "rustc_codegen_cuda"
+            },
+            "filenames": [fresh]
+        });
+        let output = format!("{message}\n");
+
+        assert_eq!(
+            backend_artifact_from_cargo_output(&codegen, output.as_bytes()).unwrap(),
+            fresh
+        );
+
+        let no_artifact = b"{\"reason\":\"build-finished\",\"success\":true}\n";
+        assert!(
+            backend_artifact_from_cargo_output(&codegen, no_artifact).is_err(),
+            "a stale target/debug dylib must never be used when Cargo did not report it"
+        );
     }
 
     /// A cached `.so` whose mtime predates the running test binary should

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -677,10 +677,7 @@ fn codegen_build_host_binary(
     }
     println!();
 
-    let preferred_bin = bin
-        .map(str::to_string)
-        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
-    run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(|message| {
+    run_cargo_build_for_executable(&mut cmd, example_dir, bin).unwrap_or_else(|message| {
         eprintln!("\nBuild failed: {message}");
         std::process::exit(1);
     })
@@ -718,10 +715,7 @@ fn build_host_cargo(
         cmd.env("CUDA_OXIDE_VERBOSE", "1");
     }
 
-    let preferred_bin = bin
-        .map(str::to_string)
-        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
-    run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(|message| {
+    run_cargo_build_for_executable(&mut cmd, example_dir, bin).unwrap_or_else(|message| {
         eprintln!("\nHost cargo build failed: {message}");
         std::process::exit(1);
     })
@@ -729,8 +723,11 @@ fn build_host_cargo(
 
 fn run_cargo_build_for_executable(
     cmd: &mut Command,
-    preferred_bin: Option<&str>,
+    manifest_dir: &Path,
+    explicit_bin: Option<&str>,
 ) -> Result<PathBuf, String> {
+    let selection = cargo_executable_selection(manifest_dir, explicit_bin)?;
+
     cmd.arg("--message-format=json-render-diagnostics");
     let output = cmd
         .output()
@@ -741,7 +738,7 @@ fn run_cargo_build_for_executable(
         eprint!("{stderr}");
     }
 
-    let mut executables = BTreeMap::<PathBuf, String>::new();
+    let mut executables = Vec::<CargoExecutableArtifact>::new();
     for line in String::from_utf8_lossy(&output.stdout).lines() {
         let message: serde_json::Value = match serde_json::from_str(line) {
             Ok(message) => message,
@@ -775,6 +772,12 @@ fn run_cargo_build_for_executable(
         let Some(path) = message.get("executable").and_then(|path| path.as_str()) else {
             continue;
         };
+        let Some(package_id) = message
+            .get("package_id")
+            .and_then(|package_id| package_id.as_str())
+        else {
+            continue;
+        };
         let Some(name) = message
             .get("target")
             .and_then(|target| target.get("name"))
@@ -782,52 +785,187 @@ fn run_cargo_build_for_executable(
         else {
             continue;
         };
-        executables.insert(PathBuf::from(path), name.to_string());
+        executables.push(CargoExecutableArtifact {
+            package_id: package_id.to_string(),
+            target_name: name.to_string(),
+            path: PathBuf::from(path),
+        });
     }
 
     if !output.status.success() {
         return Err(format!("Cargo exited with status {}", output.status));
     }
 
-    if executables.len() == 1 {
-        return Ok(executables.into_keys().next().expect("one executable"));
-    }
-
-    if let Some(preferred_bin) = preferred_bin {
-        let mut matches = executables
-            .iter()
-            .filter(|(_, name)| name.as_str() == preferred_bin)
-            .map(|(path, _)| path.clone());
-        if let Some(path) = matches.next()
-            && matches.next().is_none()
-        {
-            return Ok(path);
-        }
-    }
-
-    if executables.is_empty() {
-        return Err("Cargo produced no executable binary artifact".to_string());
-    }
-
-    let choices = executables
-        .iter()
-        .map(|(path, name)| format!("{name} ({})", path.display()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    Err(format!(
-        "Cargo produced multiple executable binaries: {choices}; pass --bin <name>"
-    ))
+    select_cargo_executable_artifact(&selection, &executables)
 }
 
-fn preferred_binary_name(manifest_path: &Path) -> Option<String> {
-    let source = std::fs::read_to_string(manifest_path).ok()?;
-    let document: toml::Value = toml::from_str(&source).ok()?;
-    let package = document.get("package")?;
-    package
-        .get("default-run")
-        .or_else(|| package.get("name"))
-        .and_then(|value| value.as_str())
-        .map(str::to_string)
+#[derive(Debug, PartialEq, Eq)]
+struct CargoExecutableSelection {
+    package_id: String,
+    package_name: String,
+    target_name: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CargoExecutableArtifact {
+    package_id: String,
+    target_name: String,
+    path: PathBuf,
+}
+
+fn cargo_executable_selection(
+    manifest_dir: &Path,
+    explicit_bin: Option<&str>,
+) -> Result<CargoExecutableSelection, String> {
+    let metadata = cargo_metadata(manifest_dir)?;
+    let manifest_path = manifest_dir.join("Cargo.toml");
+    let manifest_path = manifest_path
+        .canonicalize()
+        .map_err(|error| format!("could not resolve {}: {error}", manifest_path.display()))?;
+
+    let packages = metadata
+        .get("packages")
+        .and_then(|packages| packages.as_array())
+        .ok_or_else(|| "Cargo metadata did not include packages".to_string())?;
+
+    let selected_package = packages
+        .iter()
+        .find(|package| {
+            package
+                .get("manifest_path")
+                .and_then(|path| path.as_str())
+                .and_then(|path| PathBuf::from(path).canonicalize().ok())
+                .is_some_and(|path| path == manifest_path)
+        })
+        .or_else(|| {
+            let default_members = metadata
+                .get("workspace_default_members")
+                .and_then(|members| members.as_array())?;
+            if default_members.len() != 1 {
+                return None;
+            }
+            let default_package_id = default_members.first()?.as_str()?;
+            packages.iter().find(|package| {
+                package.get("id").and_then(|id| id.as_str()) == Some(default_package_id)
+            })
+        })
+        .ok_or_else(|| {
+            "could not determine the Cargo package to debug; pass --bin in a package directory or configure a single workspace default member".to_string()
+        })?;
+
+    cargo_executable_selection_from_package(selected_package, explicit_bin)
+}
+
+fn cargo_metadata(manifest_dir: &Path) -> Result<serde_json::Value, String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version=1", "--no-deps"])
+        .current_dir(manifest_dir)
+        .output()
+        .map_err(|error| format!("could not start cargo metadata: {error}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "cargo metadata failed with status {}{}{}",
+            output.status,
+            if stderr.is_empty() { "" } else { ": " },
+            stderr.trim()
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("could not parse cargo metadata JSON: {error}"))
+}
+
+fn cargo_executable_selection_from_package(
+    package: &serde_json::Value,
+    explicit_bin: Option<&str>,
+) -> Result<CargoExecutableSelection, String> {
+    let package_id = package
+        .get("id")
+        .and_then(|id| id.as_str())
+        .ok_or_else(|| "Cargo metadata package is missing id".to_string())?;
+    let package_name = package
+        .get("name")
+        .and_then(|name| name.as_str())
+        .ok_or_else(|| "Cargo metadata package is missing name".to_string())?;
+    let bin_targets = package
+        .get("targets")
+        .and_then(|targets| targets.as_array())
+        .ok_or_else(|| format!("Cargo metadata for package `{package_name}` is missing targets"))?
+        .iter()
+        .filter_map(|target| {
+            let is_binary = target
+                .get("kind")
+                .and_then(|kind| kind.as_array())
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("bin")));
+            is_binary
+                .then(|| target.get("name").and_then(|name| name.as_str()))
+                .flatten()
+        })
+        .collect::<Vec<_>>();
+
+    let target_name = if let Some(explicit_bin) = explicit_bin {
+        if !bin_targets.contains(&explicit_bin) {
+            return Err(format!(
+                "package `{package_name}` has no binary target named `{explicit_bin}`"
+            ));
+        }
+        explicit_bin
+    } else if let Some(default_run) = package.get("default_run").and_then(|name| name.as_str()) {
+        if !bin_targets.contains(&default_run) {
+            return Err(format!(
+                "package `{package_name}` default-run `{default_run}` is not a binary target"
+            ));
+        }
+        default_run
+    } else {
+        match bin_targets.as_slice() {
+            [target] => target,
+            [] => {
+                return Err(format!(
+                    "package `{package_name}` has no executable binary target"
+                ));
+            }
+            _ => {
+                let choices = bin_targets.join(", ");
+                return Err(format!(
+                    "package `{package_name}` has multiple binary targets: {choices}; pass --bin <name>"
+                ));
+            }
+        }
+    };
+
+    Ok(CargoExecutableSelection {
+        package_id: package_id.to_string(),
+        package_name: package_name.to_string(),
+        target_name: target_name.to_string(),
+    })
+}
+
+fn select_cargo_executable_artifact(
+    selection: &CargoExecutableSelection,
+    executables: &[CargoExecutableArtifact],
+) -> Result<PathBuf, String> {
+    let matches = executables
+        .iter()
+        .filter(|artifact| {
+            artifact.package_id == selection.package_id
+                && artifact.target_name == selection.target_name
+        })
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [artifact] => Ok(artifact.path.clone()),
+        [] => Err(format!(
+            "Cargo produced no executable artifact for package `{}` target `{}`",
+            selection.package_name, selection.target_name
+        )),
+        _ => Err(format!(
+            "Cargo produced multiple executable artifacts for package `{}` target `{}`",
+            selection.package_name, selection.target_name
+        )),
+    }
 }
 
 const DEFAULT_SANITIZER_ERROR_EXITCODE: &str = "86";
@@ -1781,15 +1919,11 @@ pub fn codegen_debug(
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
     apply_ld_library_path(&mut cmd, ctx);
 
-    let preferred_bin = bin
-        .map(str::to_string)
-        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
-    let binary = run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(
-        |message| {
+    let binary =
+        run_cargo_build_for_executable(&mut cmd, &example_dir, bin).unwrap_or_else(|message| {
             eprintln!("Failed to build {example}: {message}");
             std::process::exit(1);
-        },
-    );
+        });
     if !binary.exists() {
         eprintln!(
             "Error: Cargo reported executable artifact {}, but it does not exist",
@@ -3372,6 +3506,14 @@ mod tests {
         }
     }
 
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), unique))
+    }
+
     #[test]
     fn artifact_stem_normalizes_hyphens_like_cargo() {
         assert_eq!(artifact_stem("rustlantis-smoke"), "rustlantis_smoke");
@@ -3411,48 +3553,43 @@ mod tests {
     }
 
     #[test]
-    fn preferred_binary_name_prefers_default_run() {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "cargo_oxide_default_run_{}_{}",
-            std::process::id(),
-            unique
-        ));
+    fn cargo_metadata_selection_prefers_default_run() {
+        let root = unique_temp_dir("cargo_oxide_default_run");
         std::fs::create_dir_all(&root).unwrap();
-        let manifest = root.join("Cargo.toml");
         std::fs::write(
-            &manifest,
+            root.join("Cargo.toml"),
             r#"
 [package]
 name = "multi-bin-package"
 default-run = "main_bin"
 version = "0.1.0"
 edition = "2024"
+
+[[bin]]
+name = "main_bin"
+path = "src/main.rs"
+
+[[bin]]
+name = "other_bin"
+path = "src/other.rs"
 "#,
         )
         .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join("src/other.rs"), "fn main() {}\n").unwrap();
 
-        assert_eq!(
-            preferred_binary_name(&manifest).as_deref(),
-            Some("main_bin")
-        );
+        let selection = cargo_executable_selection(&root, None).unwrap();
+        assert!(selection.package_id.starts_with("path+file://"));
+        assert!(selection.package_id.contains("multi-bin-package@0.1.0"));
+        assert_eq!(selection.package_name, "multi-bin-package");
+        assert_eq!(selection.target_name, "main_bin");
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn cargo_json_selects_custom_bin_in_configured_target_dir() {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "cargo_oxide_artifact_binary_{}_{}",
-            std::process::id(),
-            unique
-        ));
+        let root = unique_temp_dir("cargo_oxide_artifact_binary");
         std::fs::create_dir_all(&root).unwrap();
         std::fs::create_dir_all(root.join(".cargo")).unwrap();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -3479,7 +3616,7 @@ path = "src/main.rs"
 
         let mut cmd = Command::new("cargo");
         cmd.args(["build", "--release"]).current_dir(&root);
-        let binary = run_cargo_build_for_executable(&mut cmd, Some("package-bin")).unwrap();
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, None).unwrap();
 
         assert!(binary.exists());
         let expected_name = format!("actual-bin{}", std::env::consts::EXE_SUFFIX);
@@ -3497,15 +3634,7 @@ path = "src/main.rs"
 
     #[test]
     fn cargo_json_selects_single_binary_from_virtual_workspace() {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "cargo_oxide_artifact_workspace_{}_{}",
-            std::process::id(),
-            unique
-        ));
+        let root = unique_temp_dir("cargo_oxide_artifact_workspace");
         let member = root.join("member");
         std::fs::create_dir_all(member.join("src")).unwrap();
         std::fs::write(
@@ -3529,10 +3658,9 @@ path = "src/main.rs"
         .unwrap();
         std::fs::write(member.join("src/main.rs"), "fn main() {}\n").unwrap();
 
-        assert_eq!(preferred_binary_name(&root.join("Cargo.toml")), None);
         let mut cmd = Command::new("cargo");
         cmd.args(["build", "--release"]).current_dir(&root);
-        let binary = run_cargo_build_for_executable(&mut cmd, None).unwrap();
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, None).unwrap();
 
         let expected_name = format!("workspace-bin{}", std::env::consts::EXE_SUFFIX);
         assert_eq!(
@@ -3540,6 +3668,159 @@ path = "src/main.rs"
             Some(expected_name.as_str())
         );
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_honors_virtual_workspace_default_member_default_run() {
+        let root = unique_temp_dir("cargo_oxide_artifact_default_member");
+        let app = root.join("app");
+        let ignored = root.join("ignored");
+        std::fs::create_dir_all(app.join("src")).unwrap();
+        std::fs::create_dir_all(ignored.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"ignored\"]\ndefault-members = [\"app\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            app.join("Cargo.toml"),
+            r#"
+[package]
+name = "selected-package"
+default-run = "chosen-bin"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "chosen-bin"
+path = "src/chosen.rs"
+
+[[bin]]
+name = "other-bin"
+path = "src/other.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(app.join("src/chosen.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(app.join("src/other.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            ignored.join("Cargo.toml"),
+            r#"
+[package]
+name = "ignored-package"
+version = "0.1.0"
+edition = "2024"
+"#,
+        )
+        .unwrap();
+        std::fs::write(ignored.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release"]).current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, None).unwrap();
+
+        let expected_name = format!("chosen-bin{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_errors_when_requested_bin_was_not_built() {
+        let root = unique_temp_dir("cargo_oxide_artifact_missing_bin");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "package-bin"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "actual-bin"
+path = "src/actual.rs"
+
+[[bin]]
+name = "other-bin"
+path = "src/other.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("src/actual.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join("src/other.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release", "--bin", "actual-bin"])
+            .current_dir(&root);
+        let error = run_cargo_build_for_executable(&mut cmd, &root, Some("other-bin"))
+            .expect_err("requested but unbuilt binary should be rejected");
+
+        assert!(error.contains("target `other-bin`"), "{error}");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_errors_when_default_run_was_not_built() {
+        let root = unique_temp_dir("cargo_oxide_artifact_missing_default_run");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "package-bin"
+default-run = "default-bin"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "default-bin"
+path = "src/default.rs"
+
+[[bin]]
+name = "other-bin"
+path = "src/other.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("src/default.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join("src/other.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release", "--bin", "other-bin"])
+            .current_dir(&root);
+        let error = run_cargo_build_for_executable(&mut cmd, &root, None)
+            .expect_err("unbuilt default-run binary should be rejected");
+
+        assert!(error.contains("target `default-bin`"), "{error}");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn artifact_selection_ignores_executable_artifacts_from_other_packages() {
+        let selection = CargoExecutableSelection {
+            package_id: "app 0.1.0".to_string(),
+            package_name: "app".to_string(),
+            target_name: "app-bin".to_string(),
+        };
+        let artifacts = vec![
+            CargoExecutableArtifact {
+                package_id: "build-tool 0.1.0".to_string(),
+                target_name: "app-bin".to_string(),
+                path: PathBuf::from("/tmp/build-tool/app-bin"),
+            },
+            CargoExecutableArtifact {
+                package_id: "app 0.1.0".to_string(),
+                target_name: "helper-bin".to_string(),
+                path: PathBuf::from("/tmp/app/helper-bin"),
+            },
+        ];
+
+        let error = select_cargo_executable_artifact(&selection, &artifacts)
+            .expect_err("foreign package artifacts must not be selected");
+        assert!(error.contains("package `app` target `app-bin`"), "{error}");
     }
 
     #[test]

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -801,9 +801,15 @@ fn run_cargo_build_for_executable(
 
 #[derive(Debug, PartialEq, Eq)]
 struct CargoExecutableSelection {
+    packages: Vec<CargoSelectedPackage>,
+    explicit_bin: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CargoSelectedPackage {
     package_id: String,
     package_name: String,
-    target_name: String,
+    default_run: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -828,32 +834,86 @@ fn cargo_executable_selection(
         .and_then(|packages| packages.as_array())
         .ok_or_else(|| "Cargo metadata did not include packages".to_string())?;
 
-    let selected_package = packages
-        .iter()
-        .find(|package| {
-            package
-                .get("manifest_path")
-                .and_then(|path| path.as_str())
-                .and_then(|path| PathBuf::from(path).canonicalize().ok())
-                .is_some_and(|path| path == manifest_path)
-        })
-        .or_else(|| {
-            let default_members = metadata
-                .get("workspace_default_members")
-                .and_then(|members| members.as_array())?;
-            if default_members.len() != 1 {
-                return None;
-            }
-            let default_package_id = default_members.first()?.as_str()?;
-            packages.iter().find(|package| {
-                package.get("id").and_then(|id| id.as_str()) == Some(default_package_id)
-            })
-        })
-        .ok_or_else(|| {
-            "could not determine the Cargo package to debug; pass --bin in a package directory or configure a single workspace default member".to_string()
-        })?;
+    let selected_packages = cargo_selected_packages(&metadata, packages, &manifest_path)?;
+    let packages = selected_packages
+        .into_iter()
+        .map(cargo_selected_package)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(CargoExecutableSelection {
+        packages,
+        explicit_bin: explicit_bin.map(str::to_owned),
+    })
+}
 
-    cargo_executable_selection_from_package(selected_package, explicit_bin)
+/// Return the packages Cargo selects for a command launched from
+/// `manifest_path`.
+///
+/// At a workspace root, Cargo uses `workspace.default-members` even when the
+/// root manifest also contains a `[package]`. Inside a member directory, Cargo
+/// instead selects that member. `cargo metadata` has already resolved the
+/// workspace defaults for us, so mirror that distinction here.
+fn cargo_selected_packages<'a>(
+    metadata: &serde_json::Value,
+    packages: &'a [serde_json::Value],
+    manifest_path: &Path,
+) -> Result<Vec<&'a serde_json::Value>, String> {
+    let workspace_root = metadata
+        .get("workspace_root")
+        .and_then(|path| path.as_str())
+        .ok_or_else(|| "Cargo metadata did not include workspace_root".to_string())?;
+    let workspace_manifest = PathBuf::from(workspace_root).join("Cargo.toml");
+    let workspace_manifest = workspace_manifest.canonicalize().map_err(|error| {
+        format!(
+            "could not resolve workspace manifest {}: {error}",
+            workspace_manifest.display()
+        )
+    })?;
+
+    if manifest_path != workspace_manifest {
+        let package = packages
+            .iter()
+            .find(|package| cargo_package_manifest_matches(package, manifest_path))
+            .ok_or_else(|| {
+                format!(
+                    "could not determine the Cargo package for {}",
+                    manifest_path.display()
+                )
+            })?;
+        return Ok(vec![package]);
+    }
+
+    let default_members = metadata
+        .get("workspace_default_members")
+        .and_then(|members| members.as_array())
+        .ok_or_else(|| "Cargo metadata did not include workspace_default_members".to_string())?;
+    if default_members.is_empty() {
+        return Err("Cargo selected no workspace default members".to_string());
+    }
+
+    default_members
+        .iter()
+        .map(|member| {
+            let package_id = member.as_str().ok_or_else(|| {
+                "Cargo metadata contained a non-string workspace default member".to_string()
+            })?;
+            packages
+                .iter()
+                .find(|package| cargo_package_id(package).ok() == Some(package_id))
+                .ok_or_else(|| {
+                    format!(
+                        "Cargo workspace default member `{package_id}` was missing from metadata packages"
+                    )
+                })
+        })
+        .collect()
+}
+
+fn cargo_package_manifest_matches(package: &serde_json::Value, manifest_path: &Path) -> bool {
+    package
+        .get("manifest_path")
+        .and_then(|path| path.as_str())
+        .and_then(|path| PathBuf::from(path).canonicalize().ok())
+        .is_some_and(|path| path == manifest_path)
 }
 
 fn cargo_metadata(manifest_dir: &Path) -> Result<serde_json::Value, String> {
@@ -877,69 +937,28 @@ fn cargo_metadata(manifest_dir: &Path) -> Result<serde_json::Value, String> {
         .map_err(|error| format!("could not parse cargo metadata JSON: {error}"))
 }
 
-fn cargo_executable_selection_from_package(
-    package: &serde_json::Value,
-    explicit_bin: Option<&str>,
-) -> Result<CargoExecutableSelection, String> {
-    let package_id = package
+fn cargo_package_id(package: &serde_json::Value) -> Result<&str, String> {
+    package
         .get("id")
         .and_then(|id| id.as_str())
-        .ok_or_else(|| "Cargo metadata package is missing id".to_string())?;
-    let package_name = package
+        .ok_or_else(|| "Cargo metadata package is missing id".to_string())
+}
+
+fn cargo_package_name(package: &serde_json::Value) -> Result<&str, String> {
+    package
         .get("name")
         .and_then(|name| name.as_str())
-        .ok_or_else(|| "Cargo metadata package is missing name".to_string())?;
-    let bin_targets = package
-        .get("targets")
-        .and_then(|targets| targets.as_array())
-        .ok_or_else(|| format!("Cargo metadata for package `{package_name}` is missing targets"))?
-        .iter()
-        .filter_map(|target| {
-            let is_binary = target
-                .get("kind")
-                .and_then(|kind| kind.as_array())
-                .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("bin")));
-            is_binary
-                .then(|| target.get("name").and_then(|name| name.as_str()))
-                .flatten()
-        })
-        .collect::<Vec<_>>();
+        .ok_or_else(|| "Cargo metadata package is missing name".to_string())
+}
 
-    let target_name = if let Some(explicit_bin) = explicit_bin {
-        if !bin_targets.contains(&explicit_bin) {
-            return Err(format!(
-                "package `{package_name}` has no binary target named `{explicit_bin}`"
-            ));
-        }
-        explicit_bin
-    } else if let Some(default_run) = package.get("default_run").and_then(|name| name.as_str()) {
-        if !bin_targets.contains(&default_run) {
-            return Err(format!(
-                "package `{package_name}` default-run `{default_run}` is not a binary target"
-            ));
-        }
-        default_run
-    } else {
-        match bin_targets.as_slice() {
-            [target] => target,
-            [] => {
-                return Err(format!(
-                    "package `{package_name}` has no executable binary target"
-                ));
-            }
-            _ => {
-                let choices = bin_targets.join(", ");
-                return Err(format!(
-                    "package `{package_name}` has multiple binary targets: {choices}; pass --bin <name>"
-                ));
-            }
-        }
-    };
-
-    Ok(CargoExecutableSelection {
-        package_id: package_id.to_string(),
-        package_name: package_name.to_string(),
-        target_name: target_name.to_string(),
+fn cargo_selected_package(package: &serde_json::Value) -> Result<CargoSelectedPackage, String> {
+    Ok(CargoSelectedPackage {
+        package_id: cargo_package_id(package)?.to_string(),
+        package_name: cargo_package_name(package)?.to_string(),
+        default_run: package
+            .get("default_run")
+            .and_then(|name| name.as_str())
+            .map(str::to_owned),
     })
 }
 
@@ -947,25 +966,116 @@ fn select_cargo_executable_artifact(
     selection: &CargoExecutableSelection,
     executables: &[CargoExecutableArtifact],
 ) -> Result<PathBuf, String> {
-    let matches = executables
-        .iter()
-        .filter(|artifact| {
-            artifact.package_id == selection.package_id
-                && artifact.target_name == selection.target_name
-        })
-        .collect::<Vec<_>>();
+    if let Some(explicit_bin) = selection.explicit_bin.as_deref() {
+        let matches = selection
+            .packages
+            .iter()
+            .flat_map(|package| {
+                executables
+                    .iter()
+                    .filter(move |artifact| {
+                        artifact.package_id == package.package_id
+                            && artifact.target_name == explicit_bin
+                    })
+                    .map(move |artifact| (package, artifact))
+            })
+            .collect::<Vec<_>>();
+        return match matches.as_slice() {
+            [(_, artifact)] => Ok(artifact.path.clone()),
+            [] => Err(format!(
+                "Cargo produced no executable artifact for target `{explicit_bin}` in selected packages {}",
+                selected_package_names(selection)
+            )),
+            matches => Err(format!(
+                "Cargo produced executable target `{explicit_bin}` for multiple selected packages: {}; run from a package directory",
+                matches
+                    .iter()
+                    .map(|(package, _)| package.package_name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )),
+        };
+    }
 
-    match matches.as_slice() {
-        [artifact] => Ok(artifact.path.clone()),
+    let mut candidates = Vec::new();
+    for package in &selection.packages {
+        let artifacts = executables
+            .iter()
+            .filter(|artifact| artifact.package_id == package.package_id)
+            .collect::<Vec<_>>();
+
+        if let Some(default_run) = package.default_run.as_deref() {
+            let matches = artifacts
+                .iter()
+                .copied()
+                .filter(|artifact| artifact.target_name == default_run)
+                .collect::<Vec<_>>();
+            match matches.as_slice() {
+                [artifact] => candidates.push((package, *artifact)),
+                [] => {
+                    return Err(format!(
+                        "Cargo produced no executable artifact for package `{}` default-run target `{default_run}`",
+                        package.package_name
+                    ));
+                }
+                _ => {
+                    return Err(format!(
+                        "Cargo produced multiple executable artifacts for package `{}` default-run `{default_run}`",
+                        package.package_name
+                    ));
+                }
+            }
+            continue;
+        }
+
+        // A selected package without an emitted binary may simply be a
+        // library-only workspace member. A package with `default-run` is
+        // handled above: silently skipping its missing target could launch a
+        // different default member's program instead.
+        if artifacts.is_empty() {
+            continue;
+        }
+
+        match artifacts.as_slice() {
+            [artifact] => candidates.push((package, *artifact)),
+            artifacts => {
+                let choices = artifacts
+                    .iter()
+                    .map(|artifact| artifact.target_name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(format!(
+                    "Cargo produced multiple executable targets for package `{}`: {choices}; pass --bin <name>",
+                    package.package_name
+                ));
+            }
+        }
+    }
+
+    match candidates.as_slice() {
+        [(_, artifact)] => Ok(artifact.path.clone()),
         [] => Err(format!(
-            "Cargo produced no executable artifact for package `{}` target `{}`",
-            selection.package_name, selection.target_name
+            "Cargo produced no executable artifact for selected packages {}",
+            selected_package_names(selection)
         )),
-        _ => Err(format!(
-            "Cargo produced multiple executable artifacts for package `{}` target `{}`",
-            selection.package_name, selection.target_name
+        candidates => Err(format!(
+            "Cargo produced executables for multiple selected packages: {}; pass --bin <name> that is unique among them",
+            candidates
+                .iter()
+                .map(|(package, _)| package.package_name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         )),
     }
+}
+
+fn selected_package_names(selection: &CargoExecutableSelection) -> String {
+    selection
+        .packages
+        .iter()
+        .map(|package| package.package_name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 const DEFAULT_SANITIZER_ERROR_EXITCODE: &str = "86";
@@ -3580,10 +3690,54 @@ path = "src/other.rs"
         std::fs::write(root.join("src/other.rs"), "fn main() {}\n").unwrap();
 
         let selection = cargo_executable_selection(&root, None).unwrap();
-        assert!(selection.package_id.starts_with("path+file://"));
-        assert!(selection.package_id.contains("multi-bin-package@0.1.0"));
-        assert_eq!(selection.package_name, "multi-bin-package");
-        assert_eq!(selection.target_name, "main_bin");
+        assert_eq!(selection.packages.len(), 1);
+        let package = &selection.packages[0];
+        assert!(package.package_id.starts_with("path+file://"));
+        assert!(package.package_id.contains("multi-bin-package@0.1.0"));
+        assert_eq!(package.package_name, "multi-bin-package");
+        assert_eq!(package.default_run.as_deref(), Some("main_bin"));
+        assert_eq!(selection.explicit_bin, None);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_ignores_bins_disabled_by_required_features() {
+        let root = unique_temp_dir("cargo_oxide_artifact_required_features");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "feature-gated-bins"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+extra = []
+
+[[bin]]
+name = "always"
+path = "src/always.rs"
+
+[[bin]]
+name = "gated"
+path = "src/gated.rs"
+required-features = ["extra"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("src/always.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join("src/gated.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release"]).current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, None).unwrap();
+
+        let expected_name = format!("always{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -3728,6 +3882,213 @@ edition = "2024"
     }
 
     #[test]
+    fn cargo_json_honors_nonvirtual_workspace_default_member() {
+        let root = unique_temp_dir("cargo_oxide_artifact_nonvirtual_default_member");
+        let member = root.join("member");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(member.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "workspace-root-package"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+members = ["member"]
+default-members = ["member"]
+resolver = "2"
+
+[[bin]]
+name = "root-bin"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            member.join("Cargo.toml"),
+            r#"
+[package]
+name = "selected-member"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "member-bin"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(member.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release"]).current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, None).unwrap();
+
+        let expected_name = format!("member-bin{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cargo_json_explicit_bin_selects_one_of_multiple_default_members() {
+        let root = unique_temp_dir("cargo_oxide_artifact_multiple_default_members");
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(first.join("src")).unwrap();
+        std::fs::create_dir_all(second.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"first\", \"second\"]\ndefault-members = [\"first\", \"second\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            first.join("Cargo.toml"),
+            r#"
+[package]
+name = "first-package"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "first-bin"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(first.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            second.join("Cargo.toml"),
+            r#"
+[package]
+name = "second-package"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "chosen-bin"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::write(second.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args(["build", "--release", "--bin", "chosen-bin"])
+            .current_dir(&root);
+        let binary = run_cargo_build_for_executable(&mut cmd, &root, Some("chosen-bin")).unwrap();
+
+        let expected_name = format!("chosen-bin{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(
+            binary.file_name().and_then(OsStr::to_str),
+            Some(expected_name.as_str())
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn explicit_bin_must_be_unique_across_selected_packages() {
+        let selection = CargoExecutableSelection {
+            packages: vec![
+                CargoSelectedPackage {
+                    package_id: "first-package 0.1.0".to_string(),
+                    package_name: "first-package".to_string(),
+                    default_run: None,
+                },
+                CargoSelectedPackage {
+                    package_id: "second-package 0.1.0".to_string(),
+                    package_name: "second-package".to_string(),
+                    default_run: None,
+                },
+            ],
+            explicit_bin: Some("shared-bin".to_string()),
+        };
+        let artifacts = vec![
+            CargoExecutableArtifact {
+                package_id: "first-package 0.1.0".to_string(),
+                target_name: "shared-bin".to_string(),
+                path: PathBuf::from("/tmp/first/shared-bin"),
+            },
+            CargoExecutableArtifact {
+                package_id: "second-package 0.1.0".to_string(),
+                target_name: "shared-bin".to_string(),
+                path: PathBuf::from("/tmp/second/shared-bin"),
+            },
+        ];
+
+        let error = select_cargo_executable_artifact(&selection, &artifacts)
+            .expect_err("the binary name does not uniquely identify an artifact");
+
+        assert!(error.contains("multiple selected packages"), "{error}");
+        assert!(error.contains("first-package"), "{error}");
+        assert!(error.contains("second-package"), "{error}");
+    }
+
+    #[test]
+    fn one_executable_package_is_selected_alongside_library_only_defaults() {
+        let selection = CargoExecutableSelection {
+            packages: vec![
+                CargoSelectedPackage {
+                    package_id: "library-package 0.1.0".to_string(),
+                    package_name: "library-package".to_string(),
+                    default_run: None,
+                },
+                CargoSelectedPackage {
+                    package_id: "application-package 0.1.0".to_string(),
+                    package_name: "application-package".to_string(),
+                    default_run: None,
+                },
+            ],
+            explicit_bin: None,
+        };
+        let artifact = CargoExecutableArtifact {
+            package_id: "application-package 0.1.0".to_string(),
+            target_name: "application-bin".to_string(),
+            path: PathBuf::from("/tmp/application/application-bin"),
+        };
+
+        assert_eq!(
+            select_cargo_executable_artifact(&selection, &[artifact]).unwrap(),
+            PathBuf::from("/tmp/application/application-bin")
+        );
+    }
+
+    #[test]
+    fn unbuilt_default_run_is_not_skipped_for_another_selected_package() {
+        let selection = CargoExecutableSelection {
+            packages: vec![
+                CargoSelectedPackage {
+                    package_id: "first-package 0.1.0".to_string(),
+                    package_name: "first-package".to_string(),
+                    default_run: Some("gated-bin".to_string()),
+                },
+                CargoSelectedPackage {
+                    package_id: "second-package 0.1.0".to_string(),
+                    package_name: "second-package".to_string(),
+                    default_run: None,
+                },
+            ],
+            explicit_bin: None,
+        };
+        let artifacts = [CargoExecutableArtifact {
+            package_id: "second-package 0.1.0".to_string(),
+            target_name: "other-bin".to_string(),
+            path: PathBuf::from("/tmp/second/other-bin"),
+        }];
+
+        let error = select_cargo_executable_artifact(&selection, &artifacts)
+            .expect_err("a missing default-run must not fall back to another package");
+
+        assert!(error.contains("first-package"), "{error}");
+        assert!(error.contains("target `gated-bin`"), "{error}");
+    }
+
+    #[test]
     fn cargo_json_errors_when_requested_bin_was_not_built() {
         let root = unique_temp_dir("cargo_oxide_artifact_missing_bin");
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -3801,9 +4162,12 @@ path = "src/other.rs"
     #[test]
     fn artifact_selection_ignores_executable_artifacts_from_other_packages() {
         let selection = CargoExecutableSelection {
-            package_id: "app 0.1.0".to_string(),
-            package_name: "app".to_string(),
-            target_name: "app-bin".to_string(),
+            packages: vec![CargoSelectedPackage {
+                package_id: "app 0.1.0".to_string(),
+                package_name: "app".to_string(),
+                default_run: None,
+            }],
+            explicit_bin: Some("app-bin".to_string()),
         };
         let artifacts = vec![
             CargoExecutableArtifact {
@@ -3820,7 +4184,8 @@ path = "src/other.rs"
 
         let error = select_cargo_executable_artifact(&selection, &artifacts)
             .expect_err("foreign package artifacts must not be selected");
-        assert!(error.contains("package `app` target `app-bin`"), "{error}");
+        assert!(error.contains("target `app-bin`"), "{error}");
+        assert!(error.contains("selected packages app"), "{error}");
     }
 
     #[test]

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -1708,10 +1708,13 @@ pub fn codegen_debug(
     ctx: &Context,
     example: &str,
     arch: Option<&str>,
+    features: Option<&str>,
+    bin: Option<&str>,
     use_cgdb: bool,
     use_tui: bool,
 ) {
-    let cuda_gdb = find_executable(
+    let cuda_gdb = find_cuda_toolkit_executable(
+        ctx,
         "cuda-gdb",
         &[
             "/usr/local/cuda/bin/cuda-gdb",
@@ -1722,8 +1725,10 @@ pub fn codegen_debug(
     .unwrap_or_else(|| {
         eprintln!("Error: cuda-gdb not found!");
         eprintln!();
-        eprintln!("Make sure CUDA toolkit is installed and cuda-gdb is in your PATH:");
+        eprintln!("Make sure CUDA toolkit is installed and cuda-gdb is in your PATH");
+        eprintln!("or configured CUDA toolkit root:");
         eprintln!("  export PATH=\"/usr/local/cuda/bin:$PATH\"");
+        eprintln!("  export CUDA_TOOLKIT_PATH=/usr/local/cuda");
         std::process::exit(1);
     });
 
@@ -1746,7 +1751,11 @@ pub fn codegen_debug(
     let target_arch = configured_arch(ctx, arch);
     let detected_device_arch = detect_run_target_arch(target_arch, false);
 
-    println!("Building {} with debug info...", example);
+    if let Some(bin) = bin {
+        println!("Building {} (bin: {}) with debug info...", example, bin);
+    } else {
+        println!("Building {} with debug info...", example);
+    }
     if let Some(dev) = detected_device_arch.as_deref() {
         println!("Detected GPU arch: {dev} (via nvidia-smi)");
     }
@@ -1758,6 +1767,13 @@ pub fn codegen_debug(
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release"]).current_dir(&example_dir);
 
+    if let Some(bin) = bin {
+        cmd.args(["--bin", bin]);
+    }
+    if let Some(features) = features {
+        cmd.args(["--features", features]);
+    }
+
     apply_config_env(&mut cmd, ctx);
     apply_codegen_rustflags(&mut cmd, ctx, true, &[]);
     cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "2");
@@ -1765,15 +1781,20 @@ pub fn codegen_debug(
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
     apply_ld_library_path(&mut cmd, ctx);
 
-    let status = cmd.status().expect("Failed to run cargo build");
-    if !status.success() {
-        eprintln!("Failed to build {}", example);
-        std::process::exit(status.code().unwrap_or(1));
-    }
-
-    let binary = example_dir.join("target/release").join(example);
+    let preferred_bin = bin
+        .map(str::to_string)
+        .or_else(|| preferred_binary_name(&example_dir.join("Cargo.toml")));
+    let binary = run_cargo_build_for_executable(&mut cmd, preferred_bin.as_deref()).unwrap_or_else(
+        |message| {
+            eprintln!("Failed to build {example}: {message}");
+            std::process::exit(1);
+        },
+    );
     if !binary.exists() {
-        eprintln!("Error: Binary not found at {:?}", binary);
+        eprintln!(
+            "Error: Cargo reported executable artifact {}, but it does not exist",
+            binary.display()
+        );
         std::process::exit(1);
     }
 
@@ -3428,7 +3449,7 @@ edition = "2024"
             .expect("system time before unix epoch")
             .as_nanos();
         let root = std::env::temp_dir().join(format!(
-            "cargo_oxide_sanitize_binary_{}_{}",
+            "cargo_oxide_artifact_binary_{}_{}",
             std::process::id(),
             unique
         ));
@@ -3481,7 +3502,7 @@ path = "src/main.rs"
             .expect("system time before unix epoch")
             .as_nanos();
         let root = std::env::temp_dir().join(format!(
-            "cargo_oxide_sanitize_workspace_{}_{}",
+            "cargo_oxide_artifact_workspace_{}_{}",
             std::process::id(),
             unique
         ));

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -214,6 +214,12 @@ enum Commands {
         /// in the environment for a non-interactive override.
         #[arg(long)]
         arch: Option<String>,
+        /// Cargo features to enable
+        #[arg(long)]
+        features: Option<String>,
+        /// Specific binary target to build and debug
+        #[arg(long)]
+        bin: Option<String>,
         /// Use cgdb frontend (better source view, vim keys)
         #[arg(long)]
         cgdb: bool,
@@ -468,12 +474,22 @@ fn main() {
         Commands::Debug {
             example,
             arch,
+            features,
+            bin,
             cgdb,
             tui,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "debug");
-            commands::codegen_debug(&ctx, &example, arch.as_deref(), cgdb, tui);
+            commands::codegen_debug(
+                &ctx,
+                &example,
+                arch.as_deref(),
+                features.as_deref(),
+                bin.as_deref(),
+                cgdb,
+                tui,
+            );
         }
         Commands::Fmt { check } => {
             let ctx = commands::resolve_context();
@@ -661,6 +677,36 @@ mod tests {
             panic!("expected sanitize command");
         };
         assert_eq!(tool, SanitizerTool::Memcheck);
+    }
+
+    #[test]
+    fn debug_parser_accepts_bin_and_features() {
+        let cli = Cli::try_parse_from([
+            "cargo-oxide",
+            "debug",
+            "my_app",
+            "--bin",
+            "debug-target",
+            "--features",
+            "foo,bar",
+            "--tui",
+        ])
+        .expect("debug command should parse");
+
+        let Commands::Debug {
+            example,
+            features,
+            bin,
+            tui,
+            ..
+        } = cli.command
+        else {
+            panic!("expected debug command");
+        };
+        assert_eq!(example.as_deref(), Some("my_app"));
+        assert_eq!(bin.as_deref(), Some("debug-target"));
+        assert_eq!(features.as_deref(), Some("foo,bar"));
+        assert!(tui);
     }
 
     #[test]

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -312,6 +312,12 @@ frame; select the kernel frame (`frame 1`) to inspect kernel locals.
 4. Inspect threads: `cuda thread`, `cuda block`, `cuda warp`
 5. Print variables: `print idx`, `print *c_elem`
 
+`cargo oxide debug` selects the executable from Cargo's build artifact
+metadata instead of assuming `target/release/<example>`. That keeps debugging
+working with custom binary names, `package.default-run`, configured target
+directories, host target triples, and virtual workspaces. Use `--bin <name>`
+when a package has multiple binaries and no unambiguous default.
+
 For programmatic breakpoints, use `debug::breakpoint()` in your kernel code.
 When cuda-gdb hits the `brkpt` instruction, it pauses execution and lets you
 inspect the GPU state.


### PR DESCRIPTION
## Summary

Make `cargo oxide debug` launch the executable Cargo actually built instead of guessing a path under `target/release`. The same artifact-selection helper is also used by the run and sanitizer paths.

```text
Before: Cargo builds one package/target -> cargo-oxide may launch another path
After:  Cargo metadata selects packages -> Cargo JSON selects the exact executable
```

This also adds `debug --bin` / `--features` support and resolves `cuda-gdb` through the configured CUDA toolkit.

## What changed

### Executable selection

- Read Cargo metadata to determine the current package or workspace default members.
- Keep each emitted executable's Cargo `package_id` and target name.
- Honor `package.default-run` and an explicit `--bin` only when Cargo emitted that exact artifact.
- Allow a unique `--bin` to disambiguate multiple default members.
- Ignore library-only members and executable artifacts from dependencies or other packages.
- Treat zero or multiple matching artifacts as an error instead of silently choosing another program.
- Choose from Cargo's emitted artifacts rather than metadata target declarations, so bins disabled by `required-features` are handled correctly.

### Backend build isolation

- Build `rustc_codegen_cuda` explicitly for Cargo's host tuple in its own absolute target directory.
- Remove inherited application `CARGO_BUILD_TARGET` settings from the backend build.
- Read the exact backend dylib path from Cargo's JSON output.
- Reject missing or ambiguous backend artifacts; there is no fallback to a stale guessed `target/debug` path.
- Make `cargo oxide doctor` report the corresponding host-triple path.

### CLI and documentation

- Add `cargo oxide debug --bin <name>` and `--features <features>`.
- Use the configured CUDA toolkit when locating `cuda-gdb`.
- Document the new debug behavior in the cargo-oxide README and book.

## Safety and failure behavior

The selection rule is deliberately strict:

```text
selected Cargo packages
        -> emitted bin artifacts
        -> --bin / default-run filter
        -> exactly one executable, or a clear error
```

This prevents a successful build from causing cuda-oxide to debug a stale binary, a build-tool artifact, or a different workspace member.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p cargo-oxide` (72 tests)
- [x] `cargo clippy -p cargo-oxide --all-targets -- -D warnings`
- [x] `cargo check --workspace --locked`
- [x] `git diff --check`
- [x] Real backend `setup` with an invalid inherited `CARGO_BUILD_TARGET` and a separate application `CARGO_TARGET_DIR`
- [x] `cargo oxide doctor` resolves the host-triple backend path
- [ ] GPU execution (not required for this host-tooling change)

Regression coverage includes configured target directories, custom bin names, virtual and non-virtual workspace defaults, multiple default members, `default-run`, library-only members, dependency artifacts, duplicate bin names, missing requested targets, `required-features`, and stale backend-path rejection.
