### PR TITLE
Add prmt.b32 byte permute intrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,9 +638,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hi_sparse_bitset"
-version = "0.8.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad02fc3cac722c3c44c3ed708f6653e7d149b7912f7342fc1e8530455f84f0eb"
+checksum = "8a5cdb951ab0e73a8c17811e2589545e26907a34e8660d35d27d85512f16d4c6"
 dependencies = [
  "wide",
 ]

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -27,6 +27,7 @@ pub mod disjoint;
 pub mod dotprod;
 pub mod fence;
 pub mod grid;
+pub mod prmt;
 pub mod ptx;
 pub mod shared;
 pub mod tcgen05;

--- a/crates/cuda-device/src/prmt.rs
+++ b/crates/cuda-device/src/prmt.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte permute intrinsic (`prmt.b32`).
+//!
+//! Selects 4 individual bytes from the concatenated 8-byte value `{b, a}`
+//! based on the control word, useful for arbitrary byte-level data
+//! rearrangement on all GPU architectures.
+//!
+//! # `prmt.b32`
+//!
+//! Each nibble of `control` (bits 3:0, 7:4, 11:8, 15:12) selects one byte
+//! from the 8-byte value `{b, a}` (byte 0 = LSB of `a`, byte 7 = MSB of `b`).
+//! Bit 3 of each nibble selects the sign: 0 = byte value, 1 = sign-extend
+//! from bit 7.
+//!
+//! # Supported on
+//!
+//! - All architectures (SM 1.0+, PTX ISA 1.0+)
+
+/// Byte permute: select 4 bytes from the concatenation of `a` and `b`.
+///
+/// Each nibble of `control` (bits 3:0, 7:4, 11:8, 15:12) selects one byte
+/// from the 8-byte value `{b, a}` (byte 0 = LSB of `a`, byte 7 = MSB of `b`).
+/// Bit 3 of each nibble selects the sign: 0 = byte value, 1 = sign-extend
+/// from bit 7.
+///
+/// # PTX
+///
+/// ```ptx
+/// prmt.b32 %d, %a, %b, %c;
+/// ```
+#[inline(never)]
+#[must_use]
+pub fn prmt(a: u32, b: u32, control: u32) -> u32 {
+    let _ = (a, b, control);
+    unreachable!("prmt called outside CUDA kernel context")
+}

--- a/crates/dialect-nvvm/src/ops/mod.rs
+++ b/crates/dialect-nvvm/src/ops/mod.rs
@@ -108,6 +108,7 @@ mod dotprod;
 mod grid;
 mod ldmatrix;
 mod mbarrier;
+mod prmt;
 mod shared;
 mod stmatrix;
 mod tcgen05;
@@ -132,6 +133,7 @@ pub use dotprod::*;
 pub use grid::*;
 pub use ldmatrix::*;
 pub use mbarrier::*;
+pub use prmt::*;
 pub use shared::*;
 pub use stmatrix::*;
 pub use tcgen05::*;
@@ -166,4 +168,5 @@ pub fn register(ctx: &mut Context) {
     debug::register(ctx);
     dotprod::register(ctx);
     wmma::register(ctx);
+    prmt::register(ctx);
 }

--- a/crates/dialect-nvvm/src/ops/prmt.rs
+++ b/crates/dialect-nvvm/src/ops/prmt.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte permute operation (`prmt.b32`).
+//!
+//! A single-thread, non-convergent byte permute instruction lowered to
+//! inline PTX. Available on all architectures (SM 1.0+, PTX ISA 1.0+).
+
+use pliron::{
+    builtin::op_interfaces::{NOpdsInterface, NResultsInterface},
+    builtin::types::IntegerType,
+    common_traits::Verify,
+    context::Context,
+    context::Ptr,
+    location::Located,
+    op::Op,
+    operation::Operation,
+    result::Error,
+    r#type::Typed,
+    verify_err,
+};
+use pliron_derive::pliron_op;
+
+/// Byte permute: select 4 bytes from the concatenation of `a` and `b`.
+///
+/// Each nibble of `control` (bits 3:0, 7:4, 11:8, 15:12) selects one byte
+/// from the 8-byte value `{b, a}` (byte 0 = LSB of `a`, byte 7 = MSB of `b`).
+///
+/// PTX: `prmt.b32 $0, $1, $2, $3;` (available on all architectures)
+///
+/// # Operands
+///
+/// - `a` (u32): first source word
+/// - `b` (u32): second source word
+/// - `control` (u32): byte selector
+///
+/// # Results
+///
+/// - `d` (u32): permuted result
+#[pliron_op(
+    name = "nvvm.prmt",
+    format,
+    interfaces = [NOpdsInterface<3>, NResultsInterface<1>],
+)]
+pub struct PrmtOp;
+
+impl PrmtOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        PrmtOp { op }
+    }
+}
+
+impl Verify for PrmtOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+
+        if op.operands().count() != 3 || op.get_num_results() != 1 {
+            return verify_err!(op.loc(), "nvvm.prmt requires three operands and one result");
+        }
+
+        for (name, ty) in [
+            ("operand 0", op.get_operand(0).get_type(ctx)),
+            ("operand 1", op.get_operand(1).get_type(ctx)),
+            ("operand 2", op.get_operand(2).get_type(ctx)),
+            ("result", op.get_result(0).get_type(ctx)),
+        ] {
+            let ty_ref = ty.deref(ctx);
+            let Some(integer) = ty_ref.downcast_ref::<IntegerType>() else {
+                return verify_err!(op.loc(), "nvvm.prmt {} must be a 32-bit integer", name);
+            };
+            if integer.width() != 32 {
+                return verify_err!(op.loc(), "nvvm.prmt {} must be a 32-bit integer", name);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Register the prmt operation with the context.
+pub(super) fn register(ctx: &mut Context) {
+    PrmtOp::register(ctx);
+}

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -7,13 +7,14 @@ use dialect_mir::types::MirPtrType;
 use dialect_nvvm::ops::{
     Barrier0Op, ElectSyncOp, FmaBf16x2Op, LdmatrixX2Op, MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op,
     MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MmaM16N8K32S32S8Op, MovmatrixTransB16Op,
-    NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, ReadPtxSregDynamicSmemSizeOp, ReadPtxSregGridIdOp,
-    ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
-    ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp, ReadPtxSregNwarpIdOp,
-    ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp, ReadPtxSregWarpIdOp,
-    ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp, ReduxSyncOrOp, ReduxSyncUmaxOp,
-    ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op, ShflSyncDownI64Op, ShflSyncIdxI64Op,
-    ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp,
+    NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, PrmtOp, ReadPtxSregDynamicSmemSizeOp,
+    ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp,
+    ReadPtxSregLanemaskGtOp, ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp,
+    ReadPtxSregNwarpIdOp, ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp,
+    ReadPtxSregWarpIdOp, ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp,
+    ReduxSyncOrOp, ReduxSyncUmaxOp, ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op,
+    ShflSyncDownI64Op, ShflSyncIdxI64Op, ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp,
+    ThreadfenceOp, ThreadfenceSystemOp,
 };
 use pliron::{
     basic_block::BasicBlock,
@@ -1154,4 +1155,77 @@ fn test_shfl_sync_i64_construct_and_verify() {
         );
         assert!(verify_op(&ShflSyncIdxI64Op::new(bad), &ctx).is_err());
     }
+}
+
+#[test]
+fn test_prmt_op_verifies_three_i32_operands_and_one_i32_result() {
+    let mut ctx = Context::new();
+    dialect_nvvm::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let f32_ty = FP32Type::get(&ctx);
+    let block = BasicBlock::new(
+        &mut ctx,
+        None,
+        vec![i32_ty.into(), i64_ty.into(), f32_ty.into()],
+    );
+    let i32_value = block.deref(&ctx).get_argument(0);
+    let i64_value = block.deref(&ctx).get_argument(1);
+    let f32_value = block.deref(&ctx).get_argument(2);
+
+    // Valid: 3 i32 operands [a, b, control], 1 i32 result [d].
+    let valid = Operation::new(
+        &mut ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![i32_value, i32_value, i32_value],
+        vec![],
+        0,
+    );
+    verify_op(&PrmtOp::new(valid), &ctx).expect("prmt must accept 3 i32 operands and 1 i32 result");
+
+    // Bad operand type: i64 instead of i32.
+    let bad_operand = Operation::new(
+        &mut ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![i32_value, i64_value, i32_value],
+        vec![],
+        0,
+    );
+    verify_op(&PrmtOp::new(bad_operand), &ctx).expect_err("prmt must reject i64 operand");
+
+    // Bad result type: f32 instead of i32.
+    let bad_result = Operation::new(
+        &mut ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![f32_ty.into()],
+        vec![i32_value, i32_value, i32_value],
+        vec![],
+        0,
+    );
+    verify_op(&PrmtOp::new(bad_result), &ctx).expect_err("prmt must reject f32 result");
+
+    // Bad operand arity: 2 instead of 3.
+    let bad_arity = Operation::new(
+        &mut ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![i32_value, i32_value],
+        vec![],
+        0,
+    );
+    verify_op(&PrmtOp::new(bad_arity), &ctx).expect_err("prmt must reject wrong operand count");
+
+    // Bad f32 operand: non-integer type.
+    let bad_f32_operand = Operation::new(
+        &mut ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![i32_ty.into()],
+        vec![f32_value, i32_value, i32_value],
+        vec![],
+        0,
+    );
+    verify_op(&PrmtOp::new(bad_f32_operand), &ctx).expect_err("prmt must reject f32 operand");
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
@@ -50,6 +50,7 @@ pub mod float_math;
 pub mod indexing;
 pub mod ldmatrix;
 pub mod memory;
+pub mod prmt;
 pub mod saturating;
 pub mod sync;
 pub mod tcgen05;

--- a/crates/mir-importer/src/translator/terminator/intrinsics/prmt.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/prmt.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte permute intrinsic (`prmt.b32`).
+//!
+//! Translates `cuda_device::prmt::prmt` calls into the `dialect-nvvm` prmt
+//! operation.
+
+use super::super::helpers::emit_store_result_and_goto;
+use crate::error::{TranslationErr, TranslationResult};
+use crate::translator::rvalue;
+use crate::translator::values::ValueMap;
+use dialect_nvvm::ops::PrmtOp;
+use pliron::basic_block::BasicBlock;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::input_err;
+use pliron::location::{Located, Location};
+use pliron::op::Op;
+use pliron::operation::Operation;
+use rustc_public::mir;
+
+/// Emit `prmt`: byte permute from concatenation of `a` and `b`.
+///
+/// Args: `(a: u32, b: u32, control: u32)`. Returns: `u32`.
+pub fn emit_prmt(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "prmt expects 3 arguments (a: u32, b: u32, control: u32), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut last_op = prev_op;
+
+    let (a_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (b_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let (control_val, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
+    last_op = last_op_after;
+
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let prmt_op = Operation::new(
+        ctx,
+        PrmtOp::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![a_val, b_val, control_val],
+        vec![],
+        0,
+    );
+    prmt_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        prmt_op.insert_after(ctx, prev);
+    } else {
+        prmt_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = prmt_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        prmt_op,
+        value_map,
+        block_map,
+        loc,
+        "prmt call without target block",
+    )
+}

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -4198,6 +4198,21 @@ fn try_dispatch_intrinsic(
             loc,
         )?)),
         // =================================================================
+        // Byte permute (from intrinsics::prmt)
+        // =================================================================
+        "cuda_device::prmt::prmt" => Ok(Some(intrinsics::prmt::emit_prmt(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        // =================================================================
         // bf16x2 packed arithmetic (from intrinsics::bf16x2)
         // =================================================================
         "cuda_device::bf16x2::fma_relu_bf16x2" => {

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -62,23 +62,24 @@ use dialect_nvvm::ops::{
     MinBf16x2Op, MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op,
     MmaM16N8K32S32S8Op, MovmatrixTransB16Op, MulBf16x2Op, NanosleepOp, NegBf16x2Op,
     NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
-    NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
-    ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
-    ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp, ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp,
-    ReadPtxSregDynamicSmemSizeOp, ReadPtxSregEnvReg1Op, ReadPtxSregEnvReg2Op,
-    ReadPtxSregGlobaltimerOp, ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp,
-    ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp, ReadPtxSregLanemaskLeOp,
-    ReadPtxSregLanemaskLtOp, ReadPtxSregNclusterIdOp, ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp,
-    ReadPtxSregNctaidZOp, ReadPtxSregNsmIdOp, ReadPtxSregNtidXOp, ReadPtxSregNtidYOp,
-    ReadPtxSregNtidZOp, ReadPtxSregNwarpIdOp, ReadPtxSregSmIdOp, ReadPtxSregTidXOp,
-    ReadPtxSregTidYOp, ReadPtxSregTidZOp, ReadPtxSregTotalSmemSizeOp, ReadPtxSregWarpIdOp,
-    ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp, ReduxSyncOrOp, ReduxSyncUmaxOp,
-    ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncBflyI64Op,
-    ShflSyncDownF32Op, ShflSyncDownI32Op, ShflSyncDownI64Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op,
-    ShflSyncIdxI64Op, ShflSyncUpF32Op, ShflSyncUpI32Op, ShflSyncUpI64Op, StmatrixM8n8X2Op,
-    StmatrixM8n8X2TransOp, StmatrixM8n8X4Op, StmatrixM8n8X4TransOp, SubBf16x2Op, Tcgen05AllocCg2Op,
-    Tcgen05AllocOp, Tcgen05CommitCg2Op, Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp,
+    NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, PrmtOp, ReadPtxSregClock64Op,
+    ReadPtxSregClockOp, ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp,
+    ReadPtxSregClusterCtaidZOp, ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp,
+    ReadPtxSregClusterNctaidYOp, ReadPtxSregClusterNctaidZOp, ReadPtxSregCtaidXOp,
+    ReadPtxSregCtaidYOp, ReadPtxSregCtaidZOp, ReadPtxSregDynamicSmemSizeOp, ReadPtxSregEnvReg1Op,
+    ReadPtxSregEnvReg2Op, ReadPtxSregGlobaltimerOp, ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp,
+    ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
+    ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNclusterIdOp,
+    ReadPtxSregNctaidXOp, ReadPtxSregNctaidYOp, ReadPtxSregNctaidZOp, ReadPtxSregNsmIdOp,
+    ReadPtxSregNtidXOp, ReadPtxSregNtidYOp, ReadPtxSregNtidZOp, ReadPtxSregNwarpIdOp,
+    ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTidYOp, ReadPtxSregTidZOp,
+    ReadPtxSregTotalSmemSizeOp, ReadPtxSregWarpIdOp, ReduxSyncAddOp, ReduxSyncAndOp,
+    ReduxSyncMaxOp, ReduxSyncMinOp, ReduxSyncOrOp, ReduxSyncUmaxOp, ReduxSyncUminOp,
+    ReduxSyncXorOp, ShflSyncBflyF32Op, ShflSyncBflyI32Op, ShflSyncBflyI64Op, ShflSyncDownF32Op,
+    ShflSyncDownI32Op, ShflSyncDownI64Op, ShflSyncIdxF32Op, ShflSyncIdxI32Op, ShflSyncIdxI64Op,
+    ShflSyncUpF32Op, ShflSyncUpI32Op, ShflSyncUpI64Op, StmatrixM8n8X2Op, StmatrixM8n8X2TransOp,
+    StmatrixM8n8X4Op, StmatrixM8n8X4TransOp, SubBf16x2Op, Tcgen05AllocCg2Op, Tcgen05AllocOp,
+    Tcgen05CommitCg2Op, Tcgen05CommitMulticastCg2Op, Tcgen05CommitOp,
     Tcgen05CommitSharedClusterCg2Op, Tcgen05CommitSharedClusterOp, Tcgen05CpSmemToTmemCg2Op,
     Tcgen05CpSmemToTmemOp, Tcgen05DeallocCg2Op, Tcgen05DeallocOp, Tcgen05FenceAfterThreadSyncOp,
     Tcgen05FenceBeforeThreadSyncOp, Tcgen05Ld16x256bPureOp, Tcgen05Ld16x256bX8PureOp,
@@ -3378,6 +3379,20 @@ impl MirToLlvmConversion for Dp2aU32Op {
             self.get_operation(),
             operands_info,
         )
+    }
+}
+
+// ---- NVVM byte permute op -------------------------------------------------
+
+#[op_interface_impl]
+impl MirToLlvmConversion for PrmtOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::prmt::convert_prmt(ctx, rewriter, self.get_operation(), operands_info)
     }
 }
 

--- a/crates/mir-lower/src/convert/intrinsics/mod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mod.rs
@@ -83,6 +83,7 @@ pub mod debug;
 pub mod dotprod;
 pub mod ldmatrix;
 pub mod mbarrier;
+pub mod prmt;
 pub mod stmatrix;
 pub mod tcgen05;
 pub mod tma;

--- a/crates/mir-lower/src/convert/intrinsics/prmt.rs
+++ b/crates/mir-lower/src/convert/intrinsics/prmt.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte permute intrinsic conversion (`prmt.b32`).
+//!
+//! Lowered to inline PTX assembly (non-convergent, pure).
+
+use llvm_export::ops::{self as llvm, AsmKind, InlineAsmOpExt};
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::inserter::Inserter;
+use pliron::irbuild::rewriter::Rewriter;
+use pliron::op::Op;
+use pliron::operation::Operation;
+use pliron::result::Result;
+
+/// Convert `nvvm.prmt` to inline PTX.
+///
+/// `prmt.b32 %d, %a, %b, %c;` (per-thread data movement, non-convergent, pure).
+pub(crate) fn convert_prmt(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() < 3 {
+        return pliron::input_err_noloc!("prmt requires 3 operands");
+    }
+
+    let a_val = operands[0];
+    let b_val = operands[1];
+    let control_val = operands[2];
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+
+    let inline_asm = llvm::InlineAsmOp::build(
+        ctx,
+        i32_ty.into(),
+        vec![a_val, b_val, control_val],
+        "prmt.b32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        AsmKind::Pure,
+    );
+
+    let asm_op = inline_asm.get_operation();
+    rewriter.insert_operation(ctx, asm_op);
+    rewriter.replace_operation(ctx, op, asm_op);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use dialect_mir::ops as mir;
+    use dialect_nvvm::ops::PrmtOp;
+    use llvm_export::ops::{self as llvm, AsmKind};
+    use pliron::basic_block::BasicBlock;
+    use pliron::builtin::attributes::TypeAttr;
+    use pliron::builtin::op_interfaces::SymbolOpInterface;
+    use pliron::builtin::ops::ModuleOp;
+    use pliron::builtin::types::{FunctionType, IntegerType, Signedness};
+    use pliron::context::{Context, Ptr};
+    use pliron::irbuild::dialect_conversion::{
+        DialectConversion, DialectConversionRewriter, OperandsInfo, apply_dialect_conversion,
+    };
+    use pliron::linked_list::ContainsLinkedList;
+    use pliron::op::Op;
+    use pliron::operation::Operation;
+    use pliron::result::Result;
+    use pliron::r#type::TypeHandle;
+
+    use crate::conversion_interface::MirToLlvmConversion;
+
+    /// A minimal conversion that converts `PrmtOp` via its `MirToLlvmConversion` impl.
+    struct PrmtConversion;
+
+    impl DialectConversion for PrmtConversion {
+        fn can_convert_op(&self, ctx: &Context, op: Ptr<Operation>) -> bool {
+            Operation::get_opid(op, ctx) == PrmtOp::get_opid_static()
+        }
+
+        fn can_convert_type(&self, _ctx: &Context, _ty: TypeHandle) -> bool {
+            false
+        }
+
+        fn convert_type(&mut self, _ctx: &mut Context, ty: TypeHandle) -> Result<TypeHandle> {
+            Ok(ty)
+        }
+
+        fn rewrite(
+            &mut self,
+            ctx: &mut Context,
+            rewriter: &mut DialectConversionRewriter,
+            op: Ptr<Operation>,
+            operands_info: &OperandsInfo,
+        ) -> Result<()> {
+            let prmt = Operation::get_op::<PrmtOp>(op, ctx).expect("expected PrmtOp");
+            prmt.convert(ctx, rewriter, operands_info)
+        }
+    }
+
+    fn make_ctx() -> Context {
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        dialect_nvvm::register(&mut ctx);
+        crate::register(&mut ctx);
+        ctx
+    }
+
+    fn build_test_module_with_prmt(ctx: &mut Context) -> Ptr<Operation> {
+        let module = ModuleOp::new(ctx, "test_module".try_into().unwrap());
+        let module_ptr = module.get_operation();
+
+        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+        let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+        let func_ty = FunctionType::get(ctx, vec![i32_ty.into(); 3], vec![]);
+
+        let func_op_ptr = Operation::new(
+            ctx,
+            mir::MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let func = mir::MirFuncOp::new(ctx, func_op_ptr, TypeAttr::new(func_ty.into()));
+        func.set_symbol_name(ctx, "test_fn".try_into().unwrap());
+
+        let region = func.get_operation().deref(ctx).get_region(0);
+        let entry = BasicBlock::new(ctx, None, vec![i32_ty.into(); 3]);
+        entry.insert_at_back(region, ctx);
+
+        let a = entry.deref(ctx).get_argument(0);
+        let b = entry.deref(ctx).get_argument(1);
+        let control = entry.deref(ctx).get_argument(2);
+
+        // Build PrmtOp.
+        let prmt_op = Operation::new(
+            ctx,
+            PrmtOp::get_concrete_op_info(),
+            vec![u32_ty.into()],
+            vec![a, b, control],
+            vec![],
+            0,
+        );
+        prmt_op.insert_at_front(entry, ctx);
+
+        let module_region = module_ptr.deref(ctx).get_region(0);
+        let module_block = module_region.deref(ctx).iter(ctx).next().unwrap();
+        func.get_operation().insert_at_back(module_block, ctx);
+
+        module_ptr
+    }
+
+    #[test]
+    fn test_prmt_lowers_to_inline_asm() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_test_module_with_prmt(&mut ctx);
+
+        // Run the conversion.
+        let mut conversion = PrmtConversion;
+        apply_dialect_conversion(&mut ctx, &mut conversion, module_ptr)
+            .expect("prmt conversion should succeed");
+
+        // Navigate to the function body.
+        let module_region = module_ptr.deref(&ctx).get_region(0);
+        let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+        let func_op = module_block
+            .deref(&ctx)
+            .iter(&ctx)
+            .next()
+            .expect("function should exist");
+        let func =
+            Operation::get_op::<mir::MirFuncOp>(func_op, &ctx).expect("should be a MirFuncOp");
+        let func_region = func.get_operation().deref(&ctx).get_region(0);
+        let entry = func_region.deref(&ctx).iter(&ctx).next().unwrap();
+
+        // Find InlineAsmOps in the entry block.
+        let asm_ops: Vec<llvm::InlineAsmOp> = entry
+            .deref(&ctx)
+            .iter(&ctx)
+            .filter_map(|op: Ptr<Operation>| Operation::get_op::<llvm::InlineAsmOp>(op, &ctx))
+            .collect();
+        assert_eq!(asm_ops.len(), 1, "expected exactly one InlineAsmOp");
+
+        let asm = &asm_ops[0];
+
+        // Verify the PTX template.
+        assert_eq!(
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|s| String::from((*s).clone()))
+                .as_deref(),
+            Some("prmt.b32 $0, $1, $2, $3;")
+        );
+
+        // Verify the constraints.
+        assert_eq!(
+            asm.get_attr_inline_asm_constraints(&ctx)
+                .map(|s| String::from((*s).clone()))
+                .as_deref(),
+            Some("=r,r,r,r")
+        );
+
+        // Verify it uses pure (no side effects, not convergent).
+        assert_eq!(
+            llvm::asm_kind_opt(&ctx, asm),
+            Some(AsmKind::Pure),
+            "prmt should use Pure asm kind"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the PTX `prmt.b32` byte-permute instruction across all four compiler layers (`cuda-device`, `dialect-nvvm`, `mir-importer`, `mir-lower`).

```ptx
prmt.b32 %d, %a, %b, %c;
```

The `prmt` instruction selects and rearranges four bytes from two 32-bit source registers according to a control mask, producing a single 32-bit result. Each 4-bit nibble of the control value indexes one of the eight source bytes (four from each operand). This is the foundation for efficient byte manipulation in quantization, dequantization, and format conversion kernels.

Available on all SM architectures (no minimum floor).

Part of tracking issue #274 (Phase 4).

## What changed

- `cuda-device`: Added `prmt` module with `prmt_b32` user-facing stub.
- `dialect-nvvm`: Added `PrmtOp` operation with verifier tests (3 operands, 1 result, register-only).
- `mir-importer`: Added dispatch table entry and `prmt` intrinsic emitter module.
- `mir-lower`: Added lowering conversion using inline asm with `=r,r,r,r` constraints.
- Lowering test for the `prmt.b32` instruction.

## Testing

- [x] `cargo fmt --check` clean
- [x] `cargo test -p dialect-nvvm --all-targets` — verifier tests pass
- [x] `cargo test -p mir-lower --all-targets` — lowering tests pass
- [ ] `cargo oxide run` e2e on GPU

## Checklist

- [x] Signed-off-by DCO trailer
- [x] No `crates/cuda-bindings/` changes
- [x] SPDX headers on new source files