### PR TITLE
feat(codegen): opt-in build-time cubin materialization for embedded artifacts

### DIFF
--- a/.github/workflows/examples-compile.yml
+++ b/.github/workflows/examples-compile.yml
@@ -22,7 +22,9 @@ jobs:
     # backend build + shared dep tree + per-example
     # device codegen. Typically well under an hour with the shared
     # CARGO_TARGET_DIR; the timeout leaves headroom for cold runners.
-    timeout-minutes: 60
+    # Leave job-level headroom around the 50-minute full compile and the
+    # focused 10-minute materialization gate, plus toolkit/LLVM setup.
+    timeout-minutes: 75
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -36,7 +38,11 @@ jobs:
           cuda: "13.1.1"
           method: network
           sub-packages: '["nvcc", "cudart-dev"]'
-          non-cuda-sub-packages: '["libcurand-dev"]'
+          # nvJitLink is packaged separately from cuda-nvcc on Linux. Keep it
+          # in this already-toolkit-backed job so the materialization gate
+          # below exercises the real public command without adding work to
+          # the latency-sensitive fmt job.
+          non-cuda-sub-packages: '["libcurand-dev", "libnvjitlink-dev"]'
 
       # The device pipeline shells out to LLVM's llc/opt for PTX
       # generation. LLVM 21 is the documented floor for the intrinsics we
@@ -82,6 +88,52 @@ jobs:
           export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
 
           scripts/smoketest.sh --compile-only --no-color
+
+      - name: Default PTX and opt-in cubin artifacts are distinct
+        timeout-minutes: 10
+        env:
+          CUDA_TOOLKIT_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
+          CUDA_OXIDE_LLC: /usr/bin/llc-21
+          CARGO_TARGET_DIR: ${{ runner.temp }}/examples-shared-target
+        run: |
+          set -euo pipefail
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${CUDA_TOOLKIT_PATH}/lib64:${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+
+          assert_embedded_artifact() {
+            local binary="$1"
+            local expected_version="$2"
+            local expected_kind="$3"
+            local expected_target="$4"
+            local section_file="${RUNNER_TEMP}/vecadd-${expected_kind}.oxart"
+            objcopy --dump-section ".oxart=${section_file}" "${binary}"
+
+            local version name_len target_len target record_offset kind data_offset magic
+            version="$(od -An -tu2 -j8 -N2 "${section_file}" | tr -d '[:space:]')"
+            name_len="$(od -An -tu2 -j16 -N2 "${section_file}" | tr -d '[:space:]')"
+            target_len="$(od -An -tu2 -j18 -N2 "${section_file}" | tr -d '[:space:]')"
+            target="$(od -An -tc -j$((32 + name_len)) -N"${target_len}" "${section_file}" | tr -d '[:space:]')"
+            record_offset=$((32 + name_len + target_len))
+            kind="$(od -An -tu2 -j"${record_offset}" -N2 "${section_file}" | tr -d '[:space:]')"
+            data_offset="$(od -An -tu4 -j$((record_offset + 4)) -N4 "${section_file}" | tr -d '[:space:]')"
+
+            test "${version}" = "${expected_version}"
+            test "${target}" = "${expected_target}"
+            test "${kind}" = "${expected_kind}"
+            if [ "${expected_kind}" = "512" ]; then
+              magic="$(od -An -tx1 -j"${data_offset}" -N4 "${section_file}" | tr -d '[:space:]')"
+              test "${magic}" = "7f454c46"
+            fi
+          }
+
+          cargo oxide build vecadd --arch sm_86
+          assert_embedded_artifact "${CARGO_TARGET_DIR}/release/vecadd" 1 256 sm_86
+
+          cargo oxide build vecadd --materialize-cubin --arch sm_86
+          # Default compile policy remains wire-compatible artifact v1; the
+          # payload kind is what must change from PTX (256) to cubin (512).
+          assert_embedded_artifact "${CARGO_TARGET_DIR}/release/vecadd" 1 512 sm_86
 
       - name: Upload failure logs
         if: failure()

--- a/.github/workflows/examples-compile.yml
+++ b/.github/workflows/examples-compile.yml
@@ -18,7 +18,7 @@ jobs:
   examples-compile:
     name: compile all examples (device pipeline, GPU-less)
     runs-on: ubuntu-latest
-    # 141 example crates as of the generated-intrinsics vertical slice:
+    # 145 example crates as of the scoped-cache repair:
     # backend build + shared dep tree + per-example
     # device codegen. Typically well under an hour with the shared
     # CARGO_TARGET_DIR; the timeout leaves headroom for cold runners.
@@ -89,7 +89,7 @@ jobs:
 
           scripts/smoketest.sh --compile-only --no-color
 
-      - name: Default PTX and opt-in cubin artifacts are distinct
+      - name: Artifact modes keep shared Cargo dependencies fresh
         timeout-minutes: 10
         env:
           CUDA_TOOLKIT_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
@@ -127,19 +127,75 @@ jobs:
             fi
           }
 
-          cargo oxide build vecadd --arch sm_86
+          assert_only_expected_rebuilt() {
+            local log="$1"
+            local allowed="$2"
+            shift 2
+            local unexpected
+            unexpected="$(
+              sed -nE 's/^[[:space:]]*Compiling ([^[:space:]]+).*/\1/p' "${log}" \
+                | sort -u \
+                | grep -Ev "${allowed}" \
+                || true
+            )"
+            if [ -n "${unexpected}" ]; then
+              echo "Codegen mode change rebuilt shared dependencies:" >&2
+              echo "${unexpected}" >&2
+              return 1
+            fi
+            local package
+            for package in "$@"; do
+              if ! grep -Eq "^[[:space:]]*Compiling ${package}([[:space:]]|$)" "${log}"; then
+                echo "Expected ${package} to rebuild, but it stayed fresh" >&2
+                return 1
+              fi
+            done
+          }
+
+          cargo oxide build vecadd --arch sm_86 2>&1 \
+            | tee "${RUNNER_TEMP}/vecadd-ptx-build.log"
+          assert_only_expected_rebuilt \
+            "${RUNNER_TEMP}/vecadd-ptx-build.log" '^vecadd$' vecadd
           assert_embedded_artifact "${CARGO_TARGET_DIR}/release/vecadd" 1 256 sm_86
 
-          cargo oxide build vecadd --materialize-cubin --arch sm_86
+          cargo oxide build vecadd --materialize-cubin --arch sm_86 2>&1 \
+            | tee "${RUNNER_TEMP}/vecadd-cubin-build.log"
+          assert_only_expected_rebuilt \
+            "${RUNNER_TEMP}/vecadd-cubin-build.log" '^vecadd$' vecadd
           # Default compile policy remains wire-compatible artifact v1; the
           # payload kind is what must change from PTX (256) to cubin (512).
           assert_embedded_artifact "${CARGO_TARGET_DIR}/release/vecadd" 1 512 sm_86
+
+          # Switching back must invalidate vecadd's device artifact without
+          # throwing away the shared host dependency cache.
+          cargo oxide build vecadd --arch sm_86 2>&1 \
+            | tee "${RUNNER_TEMP}/vecadd-ptx-return-build.log"
+          assert_only_expected_rebuilt \
+            "${RUNNER_TEMP}/vecadd-ptx-return-build.log" '^vecadd$' vecadd
+          assert_embedded_artifact "${CARGO_TARGET_DIR}/release/vecadd" 1 256 sm_86
+
+          # A kernel-producing path dependency must be invalidated too, while
+          # ordinary CUDA/host dependencies remain reusable.
+          cargo oxide build cross_crate_kernel --arch sm_86 2>&1 \
+            | tee "${RUNNER_TEMP}/cross-crate-sm86-build.log"
+          assert_only_expected_rebuilt \
+            "${RUNNER_TEMP}/cross-crate-sm86-build.log" \
+            '^(kernel-lib|cross_crate_kernel)$' kernel-lib cross_crate_kernel
+
+          cargo oxide build cross_crate_kernel --arch sm_90 2>&1 \
+            | tee "${RUNNER_TEMP}/cross-crate-sm90-build.log"
+          assert_only_expected_rebuilt \
+            "${RUNNER_TEMP}/cross-crate-sm90-build.log" \
+            '^(kernel-lib|cross_crate_kernel)$' kernel-lib cross_crate_kernel
 
       - name: Upload failure logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: smoketest-compile-logs
-          path: ${{ runner.temp }}/smoketest-logs/
+          path: |
+            ${{ runner.temp }}/smoketest-logs/
+            ${{ runner.temp }}/vecadd-*-build.log
+            ${{ runner.temp }}/cross-crate-*-build.log
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
         #   * `cuda-bindings` — generated sys bindings covered transitively.
         #   * `fuzzer` — differential-testing infra with no unit tests.
         #   * `rustc-codegen-cuda` — its own [workspace] that links against
-        #     `rustc-private` dylibs; covered by the dedicated clippy job.
+        #     `rustc-private` dylibs; covered by the separate job below.
         include:
           - package: cuda-intrinsics-gen
           - package: cuda-intrinsics
@@ -55,6 +55,10 @@ jobs:
           # live-toolkit tests remain explicitly ignored on stock runners.
           - package: libnvvm-sys
           - package: nvjitlink-sys
+          # Driverless shared libNVVM/nvJitLink policy. Its default suite is
+          # pure and validates options, provenance, and cubin structure; the
+          # live-toolkit smoke test remains explicitly ignored.
+          - package: cuda-artifact-finalizer
           # pure-Rust kernel-launch helpers + tcgen05 tiling tables
           - package: cuda-host
             needs_cuda: true
@@ -140,6 +144,26 @@ jobs:
           out="$(cargo run -p cargo-oxide -- doctor 2>&1)" || true
           printf '%s\n' "${out}"
           printf '%s\n' "${out}" | grep -q "CUDA headers (cuda.h)"
+
+  rustc-codegen-cuda-unit-tests:
+    name: cargo test --lib (rustc-codegen-cuda)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # This standalone workspace uses rustc-private APIs, so run its tests
+      # directly rather than pretending the root package matrix covers them.
+      # The live CUDA-tool tests remain ignored; these regressions need no GPU
+      # or toolkit installation.
+      - name: Run codegen-backend unit tests
+        working-directory: crates/rustc-codegen-cuda
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          cargo test --lib
 
   generated-intrinsics:
     name: generated intrinsics are current and ABI-compatible

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "libnvvm-sys",
  "nvjitlink-sys",
  "oxide-artifacts",
+ "reserved-oxide-symbols",
  "serde_json",
  "sha2",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,10 +200,12 @@ name = "cargo-oxide"
 version = "0.2.1"
 dependencies = [
  "clap",
+ "cuda-artifact-finalizer",
  "libnvvm-sys",
  "nvjitlink-sys",
  "oxide-artifacts",
  "serde_json",
+ "sha2",
  "toml",
 ]
 
@@ -339,6 +341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-async"
 version = "0.2.1"
 dependencies = [
@@ -381,13 +393,12 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-async",
  "cuda-core",
  "cuda-device",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/cuda-intrinsics",
     "crates/cuda-intrinsics-gen",
     "crates/cuda-device",
+    "crates/cuda-artifact-finalizer",
     "crates/cuda-host",
     "crates/cuda-macros",
     "crates/llvm-export",
@@ -62,6 +63,7 @@ cuda-oxide-codegen = { path = "crates/cuda-oxide-codegen" }
 mir-transforms = { path = "crates/mir-transforms" }
 nvvm-transforms = { path = "crates/nvvm-transforms" }
 cuda-device = { path = "crates/cuda-device" }
+cuda-artifact-finalizer = { path = "crates/cuda-artifact-finalizer" }
 cuda-host = { path = "crates/cuda-host" }
 cuda-macros = { path = "crates/cuda-macros" }
 cuda-bindings = { path = "crates/cuda-bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,9 @@ dyn-clone = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "visit", "visit-mut"] }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
+
+# `cargo oxide` runs through the workspace's dev-profile Cargo alias. Its
+# backend fingerprint hashes a large debug shared object on every invocation;
+# optimize only SHA-256 so exact content fingerprinting remains inexpensive.
+[profile.dev.package.sha2]
+opt-level = 3

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -18,8 +18,10 @@ path = "src/main.rs"
 # crates and are fine.
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+cuda-artifact-finalizer = { workspace = true }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
 oxide-artifacts = { workspace = true }
 serde_json = "1"
+sha2 = { workspace = true }
 toml = "1"

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -22,6 +22,7 @@ cuda-artifact-finalizer = { workspace = true }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
 oxide-artifacts = { workspace = true }
+reserved-oxide-symbols = { workspace = true }
 serde_json = "1"
 sha2 = { workspace = true }
 toml = "1"

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -25,6 +25,7 @@ cargo oxide new my_project          # scaffold a new cuda-oxide project
 cargo oxide new my_project --async  # scaffold with async template (tokio + cuda-async)
 cargo oxide run vecadd              # build + run an example
 cargo oxide build vecadd            # compile only (no run)
+cargo oxide build vecadd --materialize-cubin --arch sm_120  # embed native cubin
 cargo oxide emit-ltoir vecadd --arch sm_100  # device code -> .ltoir (Tile/SIMT interop)
 cargo oxide build -- -p my_app      # arbitrary cargo build through cuda-oxide
 cargo oxide test                    # cargo test with cuda-oxide defaults
@@ -43,6 +44,7 @@ cargo oxide setup                   # explicitly build the codegen backend
 
 | Flag                         | Applies to                       | Description                                     |
 |------------------------------|----------------------------------|-------------------------------------------------|
+| `--materialize-cubin`        | run, sanitize, build, test, pipeline, debug | Finalize and embed target-specific native GPU code during the host build |
 | `--emit-nvvm-ir`             | run, build, pipeline             | Generate NVVM IR for libNVVM                    |
 | `--arch <sm_XX>`             | run, sanitize, build, test, pipeline, emit-ltoir | Target architecture override |
 | `--features <F>`             | run, sanitize, debug, build, build passthrough, emit-ltoir | Comma-separated cargo features to enable |
@@ -71,6 +73,28 @@ For NVVM IR and LTOIR, cuda-oxide records the policy in matching `.options`
 and versioned `.target` files and passes `-fma=0` through libNVVM and
 nvJitLink. Keep both sidecars with the artifact when another build system
 consumes it.
+
+`--materialize-cubin` moves the remaining libNVVM and nvJitLink work into the
+host build. The executable embeds a native cubin, so deployment does not need
+libNVVM, nvJitLink, or a first-load compilation step. This trades portability
+for startup simplicity: the cubin is pinned to the requested architecture and
+cannot use cuda-oxide's load-time PTX bridge on a newer GPU.
+
+```bash
+cargo oxide build vecadd --materialize-cubin --arch sm_120
+```
+
+A concrete architecture and a build-host CUDA Toolkit (libNVVM, nvJitLink, and
+libdevice) are required. cargo-oxide fingerprints the exact compiler inputs and
+rechecks them inside the backend; use the wrapper flag instead of setting
+`CUDA_OXIDE_MATERIALIZE_CUBIN` around raw Cargo. That variable is an internal
+wrapper/backend signal, not a supported user interface: raw Cargo may reuse a
+previous artifact without running the backend, and a backend invocation without
+the wrapper's fingerprint is rejected. Generic `#[cuda_module]`
+kernels, `#[device] extern` declarations, and metadata-interop examples are
+rejected because their run-time multi-artifact linking is not yet represented
+by this single-cubin path. Materialization is also a final-output mode, so it
+cannot be combined with `--emit-nvvm-ir` or `emit-ltoir`.
 
 ## Commands
 

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -190,10 +190,12 @@ package with several targets, embedded bundles still use the package name, so
 an excluded target's loader could otherwise find a selected sibling target's
 bundle.
 
-Passthrough builds include the effective codegen settings and backend build in
-Cargo's rustc fingerprint. Changing the target, output mode, FMA policy, owner
-list, configured codegen environment, or backend `.so` therefore regenerates
-device artifacts instead of reusing a stale Cargo result.
+Passthrough builds use two Cargo cache boundaries. The exact backend `.so`
+identity is global because that backend compiles every crate. CUDA procedural
+macros track target, output mode, FMA policy, owner list, materializer
+provenance, and configured codegen environment only in crates that can own or
+instantiate device code. Changing those settings therefore regenerates device
+artifacts without recompiling unrelated host-only dependencies.
 
 ### `cargo oxide emit-ltoir <crate>`
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -14,10 +14,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::backend;
+use sha2::Digest as _;
 
-const MATERIALIZE_ENV: &str = "CUDA_OXIDE_MATERIALIZE_CUBIN";
-const EXPECTED_PROVENANCE_ENV: &str = "CUDA_OXIDE_INTERNAL_MATERIALIZER_PROVENANCE";
-const MATERIALIZER_PROVENANCE_CFG: &str = "cuda_oxide_internal_materializer_provenance";
+const MATERIALIZE_ENV: &str = reserved_oxide_symbols::MATERIALIZE_CUBIN_ENV;
+const EXPECTED_PROVENANCE_ENV: &str = reserved_oxide_symbols::MATERIALIZER_PROVENANCE_ENV;
+const CODEGEN_FINGERPRINT_ENV: &str = reserved_oxide_symbols::CODEGEN_FINGERPRINT_ENV;
+const DEVICE_CODEGEN_CRATE_ENV: &str = reserved_oxide_symbols::DEVICE_CODEGEN_CRATE_ENV;
+const BACKEND_IDENTITY_CFG: &str = "cuda_oxide_internal_backend_identity";
+const LEGACY_CODEGEN_FINGERPRINT_CFG: &str = "cuda_oxide_internal_codegen_env";
+const LEGACY_MATERIALIZER_PROVENANCE_CFG: &str = "cuda_oxide_internal_materializer_provenance";
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct MaterializationMode {
@@ -38,20 +43,6 @@ impl MaterializationMode {
                 .env("CUDA_OXIDE_EMIT_NVVM_IR", "1");
         }
     }
-}
-
-fn fingerprinted_codegen_cfgs(
-    base_fingerprint: String,
-    materialization: &MaterializationMode,
-) -> Vec<String> {
-    let mut cfgs = vec![base_fingerprint];
-    if let Some(provenance) = &materialization.provenance {
-        // Keep the complete SHA-256 in rustc's command line. The ordinary
-        // environment fingerprint also hashes it, but this full value avoids
-        // reducing exact tool identity to that hash's 64-bit collision space.
-        cfgs.push(format!("{MATERIALIZER_PROVENANCE_CFG}=\"{provenance}\""));
-    }
-    cfgs
 }
 
 fn prepare_materialization(
@@ -424,7 +415,7 @@ pub fn codegen_run(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
-    let fingerprint = standard_codegen_fingerprint_cfg(
+    let fingerprint = standard_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
@@ -433,12 +424,12 @@ pub fn codegen_run(
         detected_device_arch.as_deref(),
         &materialization,
     );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
-    apply_codegen_rustflags(
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
@@ -757,7 +748,7 @@ fn build_interop_device_crate(
         .current_dir(device_dir);
 
     apply_interop_device_codegen_options(&mut cmd, ctx, verbose, options);
-    let fingerprint = interop_codegen_fingerprint_cfg(
+    let fingerprint = interop_codegen_fingerprint(
         ctx,
         verbose,
         options.no_fmad,
@@ -767,12 +758,12 @@ fn build_interop_device_crate(
         options.sanitizer_line_tables,
         materialization,
     );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, materialization);
-    apply_codegen_rustflags(
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     // This is an internal artifact contract, so it must override a project
     // `[env]` default for the same variable.
@@ -876,7 +867,7 @@ fn codegen_build_host_binary(
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
     apply_default_sanitizer_line_tables(&mut cmd, ctx);
-    let fingerprint = sanitize_codegen_fingerprint_cfg(
+    let fingerprint = sanitize_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
@@ -885,12 +876,12 @@ fn codegen_build_host_binary(
         None,
         materialization,
     );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, materialization);
-    apply_codegen_rustflags(
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     apply_output_mode(&mut cmd, false, arch, materialization);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
@@ -1492,7 +1483,7 @@ pub fn codegen_build(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
-    let fingerprint = standard_codegen_fingerprint_cfg(
+    let fingerprint = standard_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
@@ -1501,12 +1492,12 @@ pub fn codegen_build(
         None,
         &materialization,
     );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
-    apply_codegen_rustflags(
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
 
@@ -1804,11 +1795,11 @@ fn configured_device_codegen_crates(
     ctx: &Context,
     explicit: Option<&str>,
 ) -> Result<Option<String>, String> {
-    let inherited = std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE").ok();
+    let inherited = std::env::var(DEVICE_CODEGEN_CRATE_ENV).ok();
     resolve_device_codegen_crates(
         explicit,
         inherited.as_deref(),
-        project_config_env(ctx, "CUDA_OXIDE_DEVICE_CODEGEN_CRATE"),
+        project_config_env(ctx, DEVICE_CODEGEN_CRATE_ENV),
     )
 }
 
@@ -1861,10 +1852,6 @@ fn passthrough_codegen_fingerprint_with_env(
     inherited_env: &BTreeMap<String, Vec<u8>>,
 ) -> String {
     let mut effective_env = BTreeMap::new();
-    effective_env.insert(
-        "__CUDA_OXIDE_BACKEND_ARTIFACT".to_string(),
-        backend_artifact_identity(&ctx.backend_so).into_bytes(),
-    );
 
     // Project-configured CUDA_OXIDE_* variables are defaults. Mirror the same
     // parent override rule as `apply_config_env` so changes that can affect
@@ -1884,12 +1871,18 @@ fn passthrough_codegen_fingerprint_with_env(
     }
     // Capture backend settings inherited outside project config, including
     // current and future CUDA_OXIDE_* switches.
-    for (key, value) in inherited_env
-        .iter()
-        .filter(|(key, _)| key.starts_with("CUDA_OXIDE_"))
-    {
+    for (key, value) in inherited_env.iter().filter(|(key, _)| {
+        key.starts_with("CUDA_OXIDE_") && key.as_str() != CODEGEN_FINGERPRINT_ENV
+    }) {
         effective_env.insert(key.clone(), value.clone());
     }
+
+    // These are wrapper-owned semantic values. Normalize away inherited
+    // false/stale handshakes before inserting the effective materialization
+    // state below, so no-op values do not create distinct Cargo identities.
+    effective_env.remove(CODEGEN_FINGERPRINT_ENV);
+    effective_env.remove(MATERIALIZE_ENV);
+    effective_env.remove(EXPECTED_PROVENANCE_ENV);
 
     if opts.verbose {
         effective_env.insert("CUDA_OXIDE_VERBOSE".to_string(), b"1".to_vec());
@@ -1915,33 +1908,39 @@ fn passthrough_codegen_fingerprint_with_env(
     }
     if let Some(owner_filter) = owner_filter {
         effective_env.insert(
-            "CUDA_OXIDE_DEVICE_CODEGEN_CRATE".to_string(),
+            DEVICE_CODEGEN_CRATE_ENV.to_string(),
             owner_filter.as_bytes().to_vec(),
         );
     }
 
-    // Stable FNV-1a over length-delimited key/value pairs. The cfg carries
-    // only the digest, so backend settings are not included verbatim in rustc
-    // command lines or diagnostics.
-    let mut hash = 0xcbf29ce484222325_u64;
+    // SHA-256 over length-delimited key/value pairs. The complete digest is
+    // tracked by device-owning procedural macros, so settings are neither
+    // exposed verbatim in diagnostics nor reduced to a small collision space.
+    let mut hash = sha2::Sha256::new();
     for (key, value) in effective_env {
         update_codegen_fingerprint_hash(&mut hash, key.as_bytes());
         update_codegen_fingerprint_hash(&mut hash, &value);
     }
-    format!("{hash:016x}")
+    finish_codegen_fingerprint(hash)
 }
 
-fn update_codegen_fingerprint_hash(hash: &mut u64, bytes: &[u8]) {
-    for byte in (bytes.len() as u64).to_le_bytes().iter().chain(bytes) {
-        *hash ^= u64::from(*byte);
-        *hash = hash.wrapping_mul(0x100000001b3);
-    }
+fn update_codegen_fingerprint_hash(hash: &mut sha2::Sha256, bytes: &[u8]) {
+    use sha2::Digest as _;
+
+    hash.update((bytes.len() as u64).to_le_bytes());
+    hash.update(bytes);
 }
 
-/// Put sanitizer-only output settings into an otherwise-unused cfg so Cargo
-/// recompiles every selected Rust target, including `src/bin/*` and virtual
-/// workspace members. Cargo does not fingerprint arbitrary backend env vars.
-fn sanitize_codegen_fingerprint_cfg(
+fn finish_codegen_fingerprint(hash: sha2::Sha256) -> String {
+    use sha2::Digest as _;
+
+    let digest: [u8; 32] = hash.finalize().into();
+    digest_hex(&digest)
+}
+
+/// Track sanitizer-only device output settings in crates that declare device
+/// code, without invalidating their host-only dependency graph.
+fn sanitize_codegen_fingerprint(
     ctx: &Context,
     verbose: bool,
     no_fmad: bool,
@@ -1962,7 +1961,7 @@ fn sanitize_codegen_fingerprint_cfg(
         materialize_cubin: materialization.enabled(),
     };
     let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch, materialization);
-    let mut hash = 0xcbf29ce484222325_u64;
+    let mut hash = sha2::Sha256::new();
     for bytes in [
         "sanitize-line-tables-v1".as_bytes(),
         base.as_bytes(),
@@ -1973,10 +1972,10 @@ fn sanitize_codegen_fingerprint_cfg(
     if let Some(ptx_dir) = ptx_dir {
         update_codegen_fingerprint_hash(&mut hash, ptx_dir.as_os_str().as_encoded_bytes());
     }
-    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
+    finish_codegen_fingerprint(hash)
 }
 
-fn standard_codegen_fingerprint_cfg(
+fn standard_codegen_fingerprint(
     ctx: &Context,
     verbose: bool,
     no_fmad: bool,
@@ -1997,7 +1996,7 @@ fn standard_codegen_fingerprint_cfg(
         materialize_cubin: materialization.enabled(),
     };
     let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch, materialization);
-    let mut hash = 0xcbf29ce484222325_u64;
+    let mut hash = sha2::Sha256::new();
     for bytes in [
         "standard-codegen-v1".as_bytes(),
         base.as_bytes(),
@@ -2005,11 +2004,39 @@ fn standard_codegen_fingerprint_cfg(
     ] {
         update_codegen_fingerprint_hash(&mut hash, bytes);
     }
-    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
+    finish_codegen_fingerprint(hash)
+}
+
+fn pipeline_codegen_fingerprint(
+    ctx: &Context,
+    no_fmad: bool,
+    emit_nvvm_ir: bool,
+    target_arch: Option<&str>,
+    materialization: &MaterializationMode,
+) -> String {
+    let base = standard_codegen_fingerprint(
+        ctx,
+        true,
+        no_fmad,
+        emit_nvvm_ir,
+        target_arch,
+        None,
+        materialization,
+    );
+    let mut hash = sha2::Sha256::new();
+    for value in [
+        base.as_str(),
+        "CUDA_OXIDE_SHOW_RUSTC_MIR=1",
+        "CUDA_OXIDE_DUMP_MIR=1",
+        "CUDA_OXIDE_DUMP_LLVM=1",
+    ] {
+        update_codegen_fingerprint_hash(&mut hash, value.as_bytes());
+    }
+    finish_codegen_fingerprint(hash)
 }
 
 #[allow(clippy::too_many_arguments)]
-fn interop_codegen_fingerprint_cfg(
+fn interop_codegen_fingerprint(
     ctx: &Context,
     verbose: bool,
     no_fmad: bool,
@@ -2019,7 +2046,7 @@ fn interop_codegen_fingerprint_cfg(
     sanitizer_line_tables: bool,
     materialization: &MaterializationMode,
 ) -> String {
-    let base = standard_codegen_fingerprint_cfg(
+    let base = standard_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
@@ -2028,7 +2055,7 @@ fn interop_codegen_fingerprint_cfg(
         detected_device_arch,
         materialization,
     );
-    let mut hash = 0xcbf29ce484222325_u64;
+    let mut hash = sha2::Sha256::new();
     for bytes in [
         "interop-codegen-v1".as_bytes(),
         base.as_bytes(),
@@ -2041,31 +2068,45 @@ fn interop_codegen_fingerprint_cfg(
     ] {
         update_codegen_fingerprint_hash(&mut hash, bytes);
     }
-    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
+    finish_codegen_fingerprint(hash)
 }
 
-fn backend_artifact_identity(path: &Path) -> String {
+fn backend_artifact_digest(path: &Path) -> Result<String, String> {
     use sha2::{Digest, Sha256};
     use std::io::Read;
 
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let path = canonical.to_string_lossy();
-    let Ok(mut file) = std::fs::File::open(&canonical) else {
-        return format!("{path}|unreadable");
-    };
+    let mut hasher = Sha256::new();
+    if path == Path::new("llvm") {
+        hasher.update(b"rustc built-in LLVM backend");
+        let digest: [u8; 32] = hasher.finalize().into();
+        return Ok(digest_hex(&digest));
+    }
+
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| format!("could not resolve backend {}: {error}", path.display()))?;
+    let mut file = std::fs::File::open(&canonical).map_err(|error| {
+        format!(
+            "could not open backend {} for fingerprinting: {error}",
+            canonical.display()
+        )
+    })?;
     let mut hasher = Sha256::new();
     let mut chunk = [0_u8; 64 * 1024];
     loop {
-        let Ok(read) = file.read(&mut chunk) else {
-            return format!("{path}|unreadable");
-        };
+        let read = file.read(&mut chunk).map_err(|error| {
+            format!(
+                "could not read backend {} for fingerprinting: {error}",
+                canonical.display()
+            )
+        })?;
         if read == 0 {
             break;
         }
         hasher.update(&chunk[..read]);
     }
     let digest: [u8; 32] = hasher.finalize().into();
-    format!("{path}|sha256={}", digest_hex(&digest))
+    Ok(digest_hex(&digest))
 }
 
 fn cargo_passthrough_command(
@@ -2078,11 +2119,8 @@ fn cargo_passthrough_command(
     let materialization =
         prepare_materialization(ctx, opts.materialize_cubin, opts.arch, opts.emit_nvvm_ir);
     let owner_filter = configured_device_codegen_crates(ctx, opts.device_codegen_crate)?;
-    let mut fingerprinted_device_cfgs = opts.device_cfgs.to_vec();
-    // Cargo does not fingerprint arbitrary child environment variables. An
-    // otherwise-unused cfg makes every effective codegen setting part of the
-    // rustc command line, so changing target/output/FMA/filter settings reruns
-    // the backend instead of silently reusing stale PTX or NVVM IR.
+    // Device-owning macros track this identity in their crate dep-info. Keep it
+    // out of global rustflags so host-only dependencies retain one cache key.
     let fingerprint = passthrough_codegen_fingerprint(
         ctx,
         opts,
@@ -2090,10 +2128,6 @@ fn cargo_passthrough_command(
         target_arch,
         &materialization,
     );
-    fingerprinted_device_cfgs.push(format!("cuda_oxide_internal_codegen_env=\"{fingerprint}\""));
-    if let Some(provenance) = &materialization.provenance {
-        fingerprinted_device_cfgs.push(format!("{MATERIALIZER_PROVENANCE_CFG}=\"{provenance}\""));
-    }
     let mut cmd = Command::new("cargo");
     cmd.arg(cargo_subcommand.as_str());
     if let Some(features) = opts.features {
@@ -2104,18 +2138,19 @@ fn cargo_passthrough_command(
     // Project configuration provides defaults. Explicit wrapper flags and
     // internal compiler requirements are applied afterward and therefore win.
     apply_common_codegen_env(&mut cmd, ctx, opts.verbose, opts.no_fmad);
-    apply_codegen_rustflags(
+    apply_codegen_configuration(
         &mut cmd,
         ctx,
         cargo_subcommand.codegen_profile(),
-        &fingerprinted_device_cfgs,
-    );
+        opts.device_cfgs,
+        &fingerprint,
+    )?;
 
     if let Some(cargo_target_dir) = opts.cargo_target_dir {
         cmd.env("CARGO_TARGET_DIR", cargo_target_dir);
     }
     if let Some(owner_filter) = owner_filter {
-        cmd.env("CUDA_OXIDE_DEVICE_CODEGEN_CRATE", owner_filter);
+        cmd.env(DEVICE_CODEGEN_CRATE_ENV, owner_filter);
     }
     apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch, &materialization);
     Ok(cmd)
@@ -2248,21 +2283,14 @@ pub fn codegen_show_pipeline(
     cmd.args(["build", "--release"]).current_dir(&example_dir);
 
     apply_config_env(&mut cmd, ctx);
-    let fingerprint = standard_codegen_fingerprint_cfg(
-        ctx,
-        true,
-        no_fmad,
-        emit_nvvm_ir,
-        target_arch,
-        None,
-        &materialization,
-    );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
-    apply_codegen_rustflags(
+    let fingerprint =
+        pipeline_codegen_fingerprint(ctx, no_fmad, emit_nvvm_ir, target_arch, &materialization);
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     cmd.env("CUDA_OXIDE_VERBOSE", "1");
     cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
@@ -2375,7 +2403,7 @@ pub fn codegen_debug(
     }
 
     apply_config_env(&mut cmd, ctx);
-    let fingerprint = standard_codegen_fingerprint_cfg(
+    let fingerprint = standard_codegen_fingerprint(
         ctx,
         false,
         false,
@@ -2384,12 +2412,12 @@ pub fn codegen_debug(
         detected_device_arch.as_deref(),
         &materialization,
     );
-    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
-    apply_codegen_rustflags(
+    apply_codegen_configuration_or_exit(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLikeWithDebugInfo,
-        &fingerprinted_cfgs,
+        &[],
+        &fingerprint,
     );
     cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "2");
     apply_output_mode(&mut cmd, false, target_arch, &materialization);
@@ -3296,6 +3324,7 @@ fn build_encoded_rustflags_with_existing(
         flags.extend(existing.split_whitespace().map(str::to_string));
     }
     flags.extend(explicit_rustflags.iter().cloned());
+    strip_wrapper_owned_codegen_cfgs(&mut flags);
     flags.push(format!("-Zcodegen-backend={}", backend_so.display()));
     if matches!(
         profile,
@@ -3316,6 +3345,45 @@ fn build_encoded_rustflags_with_existing(
     flags.join(&ENCODED_RUSTFLAGS_SEPARATOR.to_string())
 }
 
+fn strip_wrapper_owned_codegen_cfgs(flags: &mut Vec<String>) {
+    fn is_wrapper_owned_cfg(value: &str) -> bool {
+        [
+            LEGACY_CODEGEN_FINGERPRINT_CFG,
+            LEGACY_MATERIALIZER_PROVENANCE_CFG,
+        ]
+        .iter()
+        .any(|name| {
+            value
+                .strip_prefix(name)
+                .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('='))
+        })
+    }
+
+    let mut retained = Vec::with_capacity(flags.len());
+    let mut index = 0;
+    while index < flags.len() {
+        let flag = &flags[index];
+        if flag == "--cfg"
+            && flags
+                .get(index + 1)
+                .is_some_and(|value| is_wrapper_owned_cfg(value))
+        {
+            index += 2;
+            continue;
+        }
+        if flag
+            .strip_prefix("--cfg=")
+            .is_some_and(is_wrapper_owned_cfg)
+        {
+            index += 1;
+            continue;
+        }
+        retained.push(flag.clone());
+        index += 1;
+    }
+    *flags = retained;
+}
+
 fn apply_codegen_rustflags(
     cmd: &mut Command,
     ctx: &Context,
@@ -3327,6 +3395,42 @@ fn apply_codegen_rustflags(
         build_encoded_rustflags(ctx, profile, device_cfgs),
     )
     .env_remove("RUSTFLAGS");
+}
+
+/// Apply the two deliberately different Cargo cache boundaries:
+///
+/// - the exact backend binary is global because it compiles every crate;
+/// - mode/architecture/tool settings are an env dependency recorded only by
+///   CUDA macros in crates that can own or instantiate device code.
+fn apply_codegen_configuration(
+    cmd: &mut Command,
+    ctx: &Context,
+    profile: CodegenProfilePolicy,
+    user_device_cfgs: &[String],
+    codegen_fingerprint: &str,
+) -> Result<(), String> {
+    let backend_digest = backend_artifact_digest(&ctx.backend_so)?;
+    let mut global_cfgs = Vec::with_capacity(user_device_cfgs.len() + 1);
+    global_cfgs.push(format!("{BACKEND_IDENTITY_CFG}=\"{backend_digest}\""));
+    global_cfgs.extend(user_device_cfgs.iter().cloned());
+
+    apply_codegen_rustflags(cmd, ctx, profile, &global_cfgs);
+    cmd.env(CODEGEN_FINGERPRINT_ENV, codegen_fingerprint);
+    Ok(())
+}
+
+fn apply_codegen_configuration_or_exit(
+    cmd: &mut Command,
+    ctx: &Context,
+    profile: CodegenProfilePolicy,
+    user_device_cfgs: &[String],
+    codegen_fingerprint: &str,
+) {
+    apply_codegen_configuration(cmd, ctx, profile, user_device_cfgs, codegen_fingerprint)
+        .unwrap_or_else(|error| {
+            eprintln!("Error: {error}");
+            std::process::exit(1);
+        });
 }
 
 /// Set environment variables for the codegen backend.
@@ -4004,12 +4108,59 @@ mod tests {
         encoded.split(ENCODED_RUSTFLAGS_SEPARATOR).collect()
     }
 
-    fn has_codegen_env_fingerprint(flags: &[&str]) -> bool {
+    fn has_backend_identity_cfg(flags: &[&str]) -> bool {
         flags.windows(2).any(|pair| {
             pair[0] == "--cfg"
-                && pair[1].starts_with("cuda_oxide_internal_codegen_env=\"")
+                && pair[1].starts_with("cuda_oxide_internal_backend_identity=\"")
                 && pair[1].ends_with('"')
         })
+    }
+
+    fn is_sha256(value: &str) -> bool {
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    }
+
+    fn cargo_artifact_freshness(
+        ctx: &Context,
+        opts: &CargoPassthroughOptions<'_>,
+        materializer_provenance: Option<&str>,
+    ) -> BTreeMap<String, bool> {
+        let mut cmd = cargo_passthrough_command(
+            ctx,
+            CargoPassthroughSubcommand::Build,
+            opts,
+            &["--message-format=json-render-diagnostics".to_string()],
+        )
+        .unwrap();
+        if let Some(provenance) = materializer_provenance {
+            // Exercise a non-canonical spelling accepted by the backend. The
+            // macro must still track exact provenance rather than keying that
+            // dependency on the wrapper's canonical `1` spelling.
+            cmd.env(MATERIALIZE_ENV, "true");
+            cmd.env(EXPECTED_PROVENANCE_ENV, provenance);
+        }
+        let output = cmd.output().expect("failed to run Cargo cache probe");
+        assert!(
+            output.status.success(),
+            "Cargo cache probe failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        String::from_utf8(output.stdout)
+            .expect("Cargo JSON must be UTF-8")
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|message| message["reason"] == "compiler-artifact")
+            .filter_map(|message| {
+                Some((
+                    message["target"]["name"].as_str()?.to_string(),
+                    message["fresh"].as_bool()?,
+                ))
+            })
+            .collect()
     }
 
     fn test_context(config: OxideConfig) -> Context {
@@ -4017,7 +4168,7 @@ mod tests {
             workspace_root: PathBuf::from("/tmp/cargo-oxide-test-workspace"),
             codegen_crate: PathBuf::from("/tmp/cargo-oxide-test-codegen"),
             examples_dir: PathBuf::from("/tmp/cargo-oxide-test-examples"),
-            backend_so: PathBuf::from("/tmp/backend path/librustc_codegen_cuda.so"),
+            backend_so: PathBuf::from("llvm"),
             is_workspace: false,
             config,
         }
@@ -4734,7 +4885,7 @@ path = "src/other.rs"
             Some("line-tables")
         );
 
-        let fingerprint = sanitize_codegen_fingerprint_cfg(
+        let fingerprint = sanitize_codegen_fingerprint(
             &ctx,
             false,
             true,
@@ -4743,14 +4894,20 @@ path = "src/other.rs"
             Some(Path::new("/tmp/generated-ptx")),
             &MaterializationMode::default(),
         );
-        apply_codegen_rustflags(
+        apply_codegen_configuration(
             &mut cmd,
             &ctx,
             CodegenProfilePolicy::ReleaseLike,
-            &[fingerprint],
-        );
+            &[],
+            &fingerprint,
+        )
+        .unwrap();
         let encoded = command_env(&cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
-        assert!(has_codegen_env_fingerprint(&decoded_rustflags(&encoded)));
+        assert!(has_backend_identity_cfg(&decoded_rustflags(&encoded)));
+        assert_eq!(
+            command_env(&cmd, CODEGEN_FINGERPRINT_ENV).as_deref(),
+            Some(fingerprint.as_str())
+        );
     }
 
     #[test]
@@ -4772,7 +4929,7 @@ path = "src/other.rs"
     #[test]
     fn sanitize_fingerprint_tracks_output_affecting_settings() {
         let ctx = test_context(OxideConfig::default());
-        let base = sanitize_codegen_fingerprint_cfg(
+        let base = sanitize_codegen_fingerprint(
             &ctx,
             false,
             false,
@@ -4783,7 +4940,7 @@ path = "src/other.rs"
         );
 
         for changed in [
-            sanitize_codegen_fingerprint_cfg(
+            sanitize_codegen_fingerprint(
                 &ctx,
                 false,
                 true,
@@ -4792,7 +4949,7 @@ path = "src/other.rs"
                 None,
                 &MaterializationMode::default(),
             ),
-            sanitize_codegen_fingerprint_cfg(
+            sanitize_codegen_fingerprint(
                 &ctx,
                 false,
                 false,
@@ -4801,7 +4958,7 @@ path = "src/other.rs"
                 None,
                 &MaterializationMode::default(),
             ),
-            sanitize_codegen_fingerprint_cfg(
+            sanitize_codegen_fingerprint(
                 &ctx,
                 false,
                 false,
@@ -4810,7 +4967,7 @@ path = "src/other.rs"
                 None,
                 &MaterializationMode::default(),
             ),
-            sanitize_codegen_fingerprint_cfg(
+            sanitize_codegen_fingerprint(
                 &ctx,
                 false,
                 false,
@@ -4822,6 +4979,25 @@ path = "src/other.rs"
         ] {
             assert_ne!(base, changed);
         }
+    }
+
+    #[test]
+    fn pipeline_diagnostics_have_a_distinct_device_fingerprint() {
+        let ctx = test_context(OxideConfig::default());
+        let materialization = MaterializationMode::default();
+        let standard = standard_codegen_fingerprint(
+            &ctx,
+            true,
+            false,
+            false,
+            Some("sm_86"),
+            None,
+            &materialization,
+        );
+        let pipeline =
+            pipeline_codegen_fingerprint(&ctx, false, false, Some("sm_86"), &materialization);
+
+        assert_ne!(standard, pipeline);
     }
 
     #[test]
@@ -4972,6 +5148,45 @@ path = "src/other.rs"
     }
 
     #[test]
+    fn encoded_rustflags_remove_legacy_global_codegen_fingerprints() {
+        let encoded = [
+            "--cfg",
+            "cuda_oxide_internal_codegen_env=\"inherited\"",
+            "--cfg=cuda_oxide_internal_materializer_provenance=\"inherited\"",
+            "--cfg",
+            "keep_inherited",
+        ]
+        .join(&ENCODED_RUSTFLAGS_SEPARATOR.to_string());
+        let rustflags = build_encoded_rustflags_with_existing(
+            Path::new("/tmp/librustc_codegen_cuda.so"),
+            CodegenProfilePolicy::ReleaseLike,
+            &[
+                "--cfg".to_string(),
+                "cuda_oxide_internal_codegen_env=\"configured\"".to_string(),
+                "--cfg".to_string(),
+                "keep_configured".to_string(),
+            ],
+            &[
+                "--cfg".to_string(),
+                "cuda_oxide_internal_materializer_provenance=\"explicit\"".to_string(),
+                "--cfg".to_string(),
+                "keep_explicit".to_string(),
+            ],
+            Some(&encoded),
+            None,
+        );
+        let flags = decoded_rustflags(&rustflags);
+
+        assert!(!flags.iter().any(|flag| {
+            flag.contains(LEGACY_CODEGEN_FINGERPRINT_CFG)
+                || flag.contains(LEGACY_MATERIALIZER_PROVENANCE_CFG)
+        }));
+        for retained in ["keep_configured", "keep_inherited", "keep_explicit"] {
+            assert!(flags.contains(&retained));
+        }
+    }
+
+    #[test]
     fn debug_profile_retains_release_defaults_and_adds_debuginfo() {
         let rustflags = build_encoded_rustflags_with_existing(
             Path::new("/tmp/librustc_codegen_cuda.so"),
@@ -5111,7 +5326,14 @@ MY_BUILD_FLAG = "configured"
                 .windows(2)
                 .any(|pair| pair == ["--cfg", "model=\"alpha beta\""])
         );
-        assert!(has_codegen_env_fingerprint(&flags));
+        assert!(has_backend_identity_cfg(&flags));
+        assert!(!flags.iter().any(|flag| {
+            flag.contains("cuda_oxide_internal_codegen_env")
+                || flag.contains("cuda_oxide_internal_materializer_provenance")
+        }));
+        assert!(is_sha256(
+            &command_env(&cmd, CODEGEN_FINGERPRINT_ENV).unwrap()
+        ));
         assert!(
             cmd.get_envs()
                 .any(|(key, value)| key == OsStr::new("RUSTFLAGS") && value.is_none())
@@ -5141,6 +5363,227 @@ MY_BUILD_FLAG = "configured"
                 .collect::<Vec<_>>(),
             ["test"]
         );
+    }
+
+    #[test]
+    fn architecture_and_output_mode_do_not_change_global_rustflags() {
+        let ctx = test_context(OxideConfig::default());
+        let base = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: Some("sm_80"),
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+            materialize_cubin: false,
+        };
+        let base_cmd =
+            cargo_passthrough_command(&ctx, CargoPassthroughSubcommand::Build, &base, &[]).unwrap();
+        let different_mode = CargoPassthroughOptions {
+            emit_nvvm_ir: true,
+            arch: Some("sm_90"),
+            ..base
+        };
+        let different_cmd = cargo_passthrough_command(
+            &ctx,
+            CargoPassthroughSubcommand::Build,
+            &different_mode,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(
+            command_env(&base_cmd, "CARGO_ENCODED_RUSTFLAGS"),
+            command_env(&different_cmd, "CARGO_ENCODED_RUSTFLAGS"),
+            "architecture/output switches must not invalidate every dependency"
+        );
+        assert_ne!(
+            command_env(&base_cmd, CODEGEN_FINGERPRINT_ENV),
+            command_env(&different_cmd, CODEGEN_FINGERPRINT_ENV),
+            "device owners still need a distinct Cargo identity"
+        );
+    }
+
+    #[test]
+    fn codegen_mode_changes_rebuild_only_the_tracked_device_owner() {
+        let root = unique_temp_dir("cargo_oxide_scoped_codegen_fingerprint");
+        let target = root.join("target");
+        for path in [
+            root.join("shared-dep/src"),
+            root.join("tracked-macro/src"),
+            root.join("device-owner/src"),
+            root.join("device-consumer/src"),
+        ] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"[workspace]
+resolver = "3"
+members = ["shared-dep", "tracked-macro", "device-owner", "device-consumer"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("shared-dep/Cargo.toml"),
+            r#"[package]
+name = "shared-dep"
+version = "0.0.0"
+edition = "2024"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("shared-dep/src/lib.rs"),
+            "pub fn shared_value() -> u32 { 42 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tracked-macro/Cargo.toml"),
+            r#"[package]
+name = "tracked-macro"
+version = "0.0.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tracked-macro/src/lib.rs"),
+            format!(
+                r#"#![feature(proc_macro_tracked_env)]
+extern crate proc_macro;
+
+#[proc_macro]
+pub fn track_codegen(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {{
+    let _ = proc_macro::tracked::env_var({CODEGEN_FINGERPRINT_ENV:?});
+    let _ = proc_macro::tracked::env_var({MATERIALIZE_ENV:?});
+    let _ = proc_macro::tracked::env_var({EXPECTED_PROVENANCE_ENV:?});
+    "()".parse().unwrap()
+}}
+"#
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("device-owner/Cargo.toml"),
+            r#"[package]
+name = "device-owner"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+shared-dep = { path = "../shared-dep" }
+tracked-macro = { path = "../tracked-macro" }
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("device-owner/src/lib.rs"),
+            "const _: () = tracked_macro::track_codegen!();\npub fn device_value() -> u32 { shared_dep::shared_value() }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("device-consumer/Cargo.toml"),
+            r#"[package]
+name = "device-consumer"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+device-owner = { path = "../device-owner" }
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("device-consumer/src/main.rs"),
+            "fn main() { assert_eq!(device_owner::device_value(), 42); }\n",
+        )
+        .unwrap();
+
+        let ctx = Context {
+            workspace_root: root.clone(),
+            codegen_crate: root.join("unused-codegen-source"),
+            examples_dir: root.join("unused-examples"),
+            backend_so: PathBuf::from("llvm"),
+            is_workspace: false,
+            config: OxideConfig::default(),
+        };
+        let base = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: Some("sm_80"),
+            features: None,
+            cargo_target_dir: Some(&target),
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+            materialize_cubin: false,
+        };
+
+        let cold = cargo_artifact_freshness(&ctx, &base, None);
+        assert_eq!(cold.get("shared_dep"), Some(&false));
+        assert_eq!(cold.get("tracked_macro"), Some(&false));
+        assert_eq!(cold.get("device_owner"), Some(&false));
+        assert_eq!(cold.get("device-consumer"), Some(&false));
+
+        let warm = cargo_artifact_freshness(&ctx, &base, None);
+        assert_eq!(warm.get("shared_dep"), Some(&true));
+        assert_eq!(warm.get("tracked_macro"), Some(&true));
+        assert_eq!(warm.get("device_owner"), Some(&true));
+        assert_eq!(warm.get("device-consumer"), Some(&true));
+
+        let different_arch = CargoPassthroughOptions {
+            arch: Some("sm_90"),
+            ..base
+        };
+        let arch_switch = cargo_artifact_freshness(&ctx, &different_arch, None);
+        assert_eq!(arch_switch.get("shared_dep"), Some(&true));
+        assert_eq!(arch_switch.get("tracked_macro"), Some(&true));
+        assert_eq!(arch_switch.get("device_owner"), Some(&false));
+        assert_eq!(arch_switch.get("device-consumer"), Some(&false));
+
+        let different_output = CargoPassthroughOptions {
+            emit_nvvm_ir: true,
+            ..different_arch
+        };
+        let output_switch = cargo_artifact_freshness(&ctx, &different_output, None);
+        assert_eq!(output_switch.get("shared_dep"), Some(&true));
+        assert_eq!(output_switch.get("tracked_macro"), Some(&true));
+        assert_eq!(output_switch.get("device_owner"), Some(&false));
+        assert_eq!(output_switch.get("device-consumer"), Some(&false));
+
+        let repeated_output = cargo_artifact_freshness(&ctx, &different_output, None);
+        assert_eq!(repeated_output.get("shared_dep"), Some(&true));
+        assert_eq!(repeated_output.get("tracked_macro"), Some(&true));
+        assert_eq!(repeated_output.get("device_owner"), Some(&true));
+        assert_eq!(repeated_output.get("device-consumer"), Some(&true));
+
+        let provenance_switch = cargo_artifact_freshness(
+            &ctx,
+            &different_output,
+            Some("11d91fbe164094f6242d44103d0fb01968b96c6d8f48f124eac8fa73a307a657"),
+        );
+        assert_eq!(provenance_switch.get("shared_dep"), Some(&true));
+        assert_eq!(provenance_switch.get("tracked_macro"), Some(&true));
+        assert_eq!(provenance_switch.get("device_owner"), Some(&false));
+        assert_eq!(provenance_switch.get("device-consumer"), Some(&false));
+
+        let changed_provenance = cargo_artifact_freshness(
+            &ctx,
+            &different_output,
+            Some("5b11618c2e44027877d0cd4d0cfd10afed5ef262876791e483ec58f4c5569139"),
+        );
+        assert_eq!(changed_provenance.get("shared_dep"), Some(&true));
+        assert_eq!(changed_provenance.get("tracked_macro"), Some(&true));
+        assert_eq!(changed_provenance.get("device_owner"), Some(&false));
+        assert_eq!(changed_provenance.get("device-consumer"), Some(&false));
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
@@ -5312,7 +5755,7 @@ MY_BUILD_FLAG = "configured"
     }
 
     #[test]
-    fn passthrough_fingerprint_tracks_backend_rebuild_at_same_path() {
+    fn global_backend_identity_tracks_rebuild_at_same_path() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time before unix epoch")
@@ -5330,26 +5773,17 @@ MY_BUILD_FLAG = "configured"
 
         let mut ctx = test_context(OxideConfig::default());
         ctx.backend_so = backend.clone();
-        let opts = CargoPassthroughOptions {
-            verbose: false,
-            emit_nvvm_ir: false,
-            arch: None,
-            features: None,
-            cargo_target_dir: None,
-            device_codegen_crate: None,
-            device_cfgs: &[],
-            no_fmad: false,
-            materialize_cubin: false,
-        };
-        let inherited_env = BTreeMap::new();
-        let before = passthrough_codegen_fingerprint_with_env(
+        let fingerprint = "42".repeat(32);
+        let mut before_cmd = Command::new("cargo");
+        apply_codegen_configuration(
+            &mut before_cmd,
             &ctx,
-            &opts,
-            None,
-            None,
-            &MaterializationMode::default(),
-            &inherited_env,
-        );
+            CodegenProfilePolicy::ReleaseLike,
+            &[],
+            &fingerprint,
+        )
+        .unwrap();
+        let before = command_env(&before_cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
         // Preserve the weak metadata identity that used to be fingerprinted:
         // only the bytes differ.
         std::fs::write(&backend, b"other").unwrap();
@@ -5362,16 +5796,22 @@ MY_BUILD_FLAG = "configured"
         let replacement = std::fs::metadata(&backend).unwrap();
         assert_eq!(replacement.len(), original.len());
         assert_eq!(replacement.modified().unwrap(), original_modified);
-        let after = passthrough_codegen_fingerprint_with_env(
+        let mut after_cmd = Command::new("cargo");
+        apply_codegen_configuration(
+            &mut after_cmd,
             &ctx,
-            &opts,
-            None,
-            None,
-            &MaterializationMode::default(),
-            &inherited_env,
-        );
+            CodegenProfilePolicy::ReleaseLike,
+            &[],
+            &fingerprint,
+        )
+        .unwrap();
+        let after = command_env(&after_cmd, "CARGO_ENCODED_RUSTFLAGS").unwrap();
 
         assert_ne!(before, after);
+        assert_eq!(
+            command_env(&before_cmd, CODEGEN_FINGERPRINT_ENV),
+            command_env(&after_cmd, CODEGEN_FINGERPRINT_ENV)
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -5504,14 +5944,6 @@ MY_BUILD_FLAG = "configured"
         assert_eq!(
             command_env(&cmd, EXPECTED_PROVENANCE_ENV).as_deref(),
             Some("4242424242424242424242424242424242424242424242424242424242424242")
-        );
-        assert_eq!(
-            fingerprinted_codegen_cfgs("base=\"hash\"".to_string(), &materialization),
-            [
-                "base=\"hash\"".to_string(),
-                "cuda_oxide_internal_materializer_provenance=\"4242424242424242424242424242424242424242424242424242424242424242\""
-                    .to_string(),
-            ]
         );
     }
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -15,6 +15,170 @@ use std::process::Command;
 
 use crate::backend;
 
+const MATERIALIZE_ENV: &str = "CUDA_OXIDE_MATERIALIZE_CUBIN";
+const EXPECTED_PROVENANCE_ENV: &str = "CUDA_OXIDE_INTERNAL_MATERIALIZER_PROVENANCE";
+const MATERIALIZER_PROVENANCE_CFG: &str = "cuda_oxide_internal_materializer_provenance";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct MaterializationMode {
+    provenance: Option<String>,
+}
+
+impl MaterializationMode {
+    fn enabled(&self) -> bool {
+        self.provenance.is_some()
+    }
+
+    fn apply(&self, cmd: &mut Command) {
+        if let Some(provenance) = &self.provenance {
+            // These override inherited/project values: they are a single
+            // wrapper-generated handshake tied to this Cargo invocation.
+            cmd.env(MATERIALIZE_ENV, "1")
+                .env(EXPECTED_PROVENANCE_ENV, provenance)
+                .env("CUDA_OXIDE_EMIT_NVVM_IR", "1");
+        }
+    }
+}
+
+fn fingerprinted_codegen_cfgs(
+    base_fingerprint: String,
+    materialization: &MaterializationMode,
+) -> Vec<String> {
+    let mut cfgs = vec![base_fingerprint];
+    if let Some(provenance) = &materialization.provenance {
+        // Keep the complete SHA-256 in rustc's command line. The ordinary
+        // environment fingerprint also hashes it, but this full value avoids
+        // reducing exact tool identity to that hash's 64-bit collision space.
+        cfgs.push(format!("{MATERIALIZER_PROVENANCE_CFG}=\"{provenance}\""));
+    }
+    cfgs
+}
+
+fn prepare_materialization(
+    ctx: &Context,
+    cli_requested: bool,
+    cli_arch: Option<&str>,
+    emit_nvvm_ir: bool,
+) -> MaterializationMode {
+    prepare_materialization_result(ctx, cli_requested, cli_arch, emit_nvvm_ir).unwrap_or_else(
+        |error| {
+            eprintln!("Error: {error}");
+            std::process::exit(2);
+        },
+    )
+}
+
+fn prepare_materialization_result(
+    ctx: &Context,
+    cli_requested: bool,
+    cli_arch: Option<&str>,
+    emit_nvvm_ir: bool,
+) -> Result<MaterializationMode, String> {
+    let enabled = if cli_requested {
+        true
+    } else if let Some(value) = std::env::var_os(MATERIALIZE_ENV) {
+        let value = value
+            .into_string()
+            .map_err(|_| format!("{MATERIALIZE_ENV} is not valid Unicode"))?;
+        parse_strict_bool(MATERIALIZE_ENV, &value)?
+    } else if let Some(value) = project_config_env(ctx, MATERIALIZE_ENV) {
+        parse_strict_bool(MATERIALIZE_ENV, value)?
+    } else {
+        false
+    };
+    if !enabled {
+        return Ok(MaterializationMode::default());
+    }
+    if emit_nvvm_ir {
+        return Err(
+            "--materialize-cubin cannot be combined with --emit-nvvm-ir; one requests a final cubin and the other requests NVVM IR"
+                .to_string(),
+        );
+    }
+
+    let arch = configured_arch_label(ctx, cli_arch).ok_or_else(|| {
+        "--materialize-cubin requires --arch, CUDA_OXIDE_TARGET, or a configured default-arch"
+            .to_string()
+    })?;
+    let _: cuda_artifact_finalizer::CudaArch = arch
+        .parse()
+        .map_err(|error| format!("invalid materialization target {arch:?}: {error}"))?;
+
+    Ok(MaterializationMode {
+        provenance: Some(discover_materializer_provenance(ctx)?),
+    })
+}
+
+fn discover_materializer_provenance(ctx: &Context) -> Result<String, String> {
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("could not locate cargo-oxide executable: {error}"))?;
+    let mut command = materializer_discovery_command(ctx, &executable);
+    let output = command
+        .output()
+        .map_err(|error| format!("could not start CUDA materializer discovery: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "CUDA materializer discovery failed: {}",
+            stderr.trim()
+        ));
+    }
+    let provenance = String::from_utf8(output.stdout)
+        .map_err(|_| "CUDA materializer discovery returned non-UTF-8 output".to_string())?;
+    let provenance = provenance.trim();
+    if provenance.len() != 64
+        || !provenance
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(format!(
+            "CUDA materializer discovery returned an invalid provenance digest: {provenance:?}"
+        ));
+    }
+    Ok(provenance.to_string())
+}
+
+fn materializer_discovery_command(ctx: &Context, executable: &Path) -> Command {
+    let mut command = Command::new(executable);
+    command.arg("__materializer-provenance");
+    apply_config_env(&mut command, ctx);
+    apply_ld_library_path(&mut command, ctx);
+    command
+}
+
+pub fn print_materializer_provenance() {
+    let finalizer = cuda_artifact_finalizer::Finalizer::discover().unwrap_or_else(|error| {
+        eprintln!("could not discover CUDA artifact finalizer: {error}");
+        std::process::exit(1);
+    });
+    let provenance = finalizer.provenance_digest().unwrap_or_else(|| {
+        eprintln!(
+            "the loaded libNVVM or nvJitLink library cannot be tied to an exact file; refusing materialization because Cargo could not fingerprint the compiler inputs"
+        );
+        std::process::exit(1);
+    });
+    println!("{}", digest_hex(&provenance));
+}
+
+fn parse_strict_bool(name: &str, value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!(
+            "{name} must be a boolean (accepted true values: 1, true, yes, on; false values: 0, false, no, off), got {value:?}"
+        )),
+    }
+}
+
+fn digest_hex(digest: &[u8; 32]) -> String {
+    use std::fmt::Write;
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    hex
+}
+
 /// Project-local cuda-oxide defaults loaded from `.cargo/cuda-oxide.toml`.
 #[derive(Debug, Clone, Default)]
 pub struct OxideConfig {
@@ -166,6 +330,7 @@ pub fn codegen_run(
     features: Option<&str>,
     bin: Option<&str>,
     no_fmad: bool,
+    materialize_cubin: bool,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -177,6 +342,7 @@ pub fn codegen_run(
 
     let output_format = format_label(emit_nvvm_ir);
     let target_arch = configured_arch(ctx, arch);
+    let materialization = prepare_materialization(ctx, materialize_cubin, arch, emit_nvvm_ir);
     // Target precedence for `cargo oxide run` (highest first):
     //   1. --arch <sm_XX>            explicit user override   -> CUDA_OXIDE_TARGET
     //   2. CUDA_OXIDE_TARGET=<sm_XX> explicit env override (from the parent)
@@ -190,7 +356,8 @@ pub fn codegen_run(
     // We only detect for `run`, not `build`/`pipeline`: `run` loads the cubin
     // on the local GPU, whereas those may legitimately cross-compile for
     // another machine.
-    let detected_device_arch = detect_run_target_arch(target_arch, emit_nvvm_ir);
+    let detected_device_arch =
+        detect_run_target_arch(target_arch, emit_nvvm_ir || materialization.enabled());
 
     if let Some(interop) = interop.filter(|config| !config.device_crates.is_empty()) {
         codegen_run_interop(
@@ -205,6 +372,7 @@ pub fn codegen_run(
             features,
             bin,
             no_fmad,
+            &materialization,
         );
         return;
     }
@@ -215,7 +383,15 @@ pub fn codegen_run(
     println!("RUSTC-CODEGEN-CUDA: {}", example);
     println!("=========================================");
     println!();
-    if emit_nvvm_ir {
+    if materialization.enabled() {
+        println!("Output format: materialized cubin");
+        println!(
+            "Target arch: {}",
+            configured_arch_label(ctx, arch)
+                .expect("materialization requires a configured architecture")
+        );
+        println!();
+    } else if emit_nvvm_ir {
         println!("Output format: {}", output_format);
         println!(
             "Target arch: {}",
@@ -248,8 +424,23 @@ pub fn codegen_run(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
-    apply_codegen_rustflags(&mut cmd, ctx, CodegenProfilePolicy::ReleaseLike, &[]);
-    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
+    let fingerprint = standard_codegen_fingerprint_cfg(
+        ctx,
+        verbose,
+        no_fmad,
+        emit_nvvm_ir,
+        target_arch,
+        detected_device_arch.as_deref(),
+        &materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
+    apply_codegen_rustflags(
+        &mut cmd,
+        ctx,
+        CodegenProfilePolicy::ReleaseLike,
+        &fingerprinted_cfgs,
+    );
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
 
     if let Some(bin) = bin {
@@ -284,6 +475,7 @@ pub fn codegen_sanitize(
     features: Option<&str>,
     bin: Option<&str>,
     no_fmad: bool,
+    materialize_cubin: bool,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -293,9 +485,11 @@ pub fn codegen_sanitize(
 
     let interop = load_interop_config(&example_dir);
     let target_arch = configured_arch(ctx, arch);
-    let detected_device_arch = detect_run_target_arch(target_arch, false);
+    let materialization = prepare_materialization(ctx, materialize_cubin, arch, false);
+    let detected_device_arch = detect_run_target_arch(target_arch, materialization.enabled());
 
     if let Some(interop) = interop.filter(|config| !config.device_crates.is_empty()) {
+        reject_interop_output_mode(false, &materialization);
         println!("=========================================");
         println!("RUSTC-CODEGEN-CUDA SANITIZE INTEROP: {}", example);
         println!("=========================================");
@@ -319,6 +513,7 @@ pub fn codegen_sanitize(
                 no_fmad,
                 sanitizer_line_tables: true,
             },
+            &materialization,
         );
         let binary = build_host_cargo(ctx, example, &example_dir, features, bin, verbose);
         run_compute_sanitizer(
@@ -354,6 +549,7 @@ pub fn codegen_sanitize(
         features,
         bin,
         no_fmad,
+        &materialization,
     );
     run_compute_sanitizer(
         ctx,
@@ -410,8 +606,9 @@ fn codegen_run_interop(
     features: Option<&str>,
     bin: Option<&str>,
     no_fmad: bool,
+    materialization: &MaterializationMode,
 ) {
-    reject_interop_nvvm_ir(emit_nvvm_ir);
+    reject_interop_output_mode(emit_nvvm_ir, materialization);
 
     println!("=========================================");
     println!("RUSTC-CODEGEN-CUDA INTEROP: {}", example);
@@ -432,6 +629,7 @@ fn codegen_run_interop(
         arch,
         detected_device_arch,
         InteropDeviceBuildOptions::standard(no_fmad),
+        materialization,
     );
     run_host_cargo(ctx, example, example_dir, "run", features, bin, verbose);
 }
@@ -447,8 +645,9 @@ fn codegen_build_interop(
     arch: Option<&str>,
     features: Option<&str>,
     no_fmad: bool,
+    materialization: &MaterializationMode,
 ) {
-    reject_interop_nvvm_ir(emit_nvvm_ir);
+    reject_interop_output_mode(emit_nvvm_ir, materialization);
 
     println!("=========================================");
     println!("RUSTC-CODEGEN-CUDA INTEROP BUILD: {}", example);
@@ -468,11 +667,17 @@ fn codegen_build_interop(
         arch,
         None,
         InteropDeviceBuildOptions::standard(no_fmad),
+        materialization,
     );
     run_host_cargo(ctx, example, example_dir, "build", features, None, verbose);
 }
 
-fn reject_interop_nvvm_ir(emit_nvvm_ir: bool) {
+fn reject_interop_output_mode(emit_nvvm_ir: bool, materialization: &MaterializationMode) {
+    if materialization.enabled() {
+        eprintln!("Error: --materialize-cubin is not supported for metadata interop examples yet.");
+        eprintln!("Interop host crates currently consume PTX files from nested device crates.");
+        std::process::exit(2);
+    }
     if emit_nvvm_ir {
         eprintln!("Error: --emit-nvvm-ir is not supported for metadata interop examples yet.");
         eprintln!("Interop host crates embed PTX artifacts produced by nested device crates.");
@@ -480,6 +685,7 @@ fn reject_interop_nvvm_ir(emit_nvvm_ir: bool) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_interop_device_crates(
     ctx: &Context,
     example_dir: &Path,
@@ -488,6 +694,7 @@ fn build_interop_device_crates(
     arch: Option<&str>,
     detected_device_arch: Option<&str>,
     options: InteropDeviceBuildOptions,
+    materialization: &MaterializationMode,
 ) {
     for device_crate in &interop.device_crates {
         build_interop_device_crate(
@@ -498,6 +705,7 @@ fn build_interop_device_crates(
             arch,
             detected_device_arch,
             options,
+            materialization,
         );
     }
 }
@@ -511,6 +719,7 @@ fn build_interop_device_crate(
     arch: Option<&str>,
     detected_device_arch: Option<&str>,
     options: InteropDeviceBuildOptions,
+    materialization: &MaterializationMode,
 ) {
     let manifest_path = example_dir.join(&device_crate.manifest_path);
     let manifest_path = manifest_path.canonicalize().unwrap_or_else(|e| {
@@ -548,20 +757,17 @@ fn build_interop_device_crate(
         .current_dir(device_dir);
 
     apply_interop_device_codegen_options(&mut cmd, ctx, verbose, options);
-    let fingerprinted_cfgs = options
-        .sanitizer_line_tables
-        .then(|| {
-            sanitize_codegen_fingerprint_cfg(
-                ctx,
-                verbose,
-                options.no_fmad,
-                arch,
-                detected_device_arch,
-                Some(&ptx_dir),
-            )
-        })
-        .into_iter()
-        .collect::<Vec<_>>();
+    let fingerprint = interop_codegen_fingerprint_cfg(
+        ctx,
+        verbose,
+        options.no_fmad,
+        arch,
+        detected_device_arch,
+        &ptx_dir,
+        options.sanitizer_line_tables,
+        materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, materialization);
     apply_codegen_rustflags(
         &mut cmd,
         ctx,
@@ -571,7 +777,7 @@ fn build_interop_device_crate(
     // This is an internal artifact contract, so it must override a project
     // `[env]` default for the same variable.
     cmd.env("CUDA_OXIDE_PTX_DIR", &ptx_dir);
-    apply_output_mode(&mut cmd, false, arch);
+    apply_output_mode(&mut cmd, false, arch, materialization);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
 
     let status = cmd.status().expect("Failed to build interop device crate");
@@ -656,6 +862,7 @@ fn codegen_build_host_binary(
     features: Option<&str>,
     bin: Option<&str>,
     no_fmad: bool,
+    materialization: &MaterializationMode,
 ) -> PathBuf {
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release"]).current_dir(example_dir);
@@ -669,15 +876,23 @@ fn codegen_build_host_binary(
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
     apply_default_sanitizer_line_tables(&mut cmd, ctx);
-    let fingerprint =
-        sanitize_codegen_fingerprint_cfg(ctx, verbose, no_fmad, arch, detected_device_arch, None);
+    let fingerprint = sanitize_codegen_fingerprint_cfg(
+        ctx,
+        verbose,
+        no_fmad,
+        arch,
+        detected_device_arch,
+        None,
+        materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, materialization);
     apply_codegen_rustflags(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLike,
-        &[fingerprint],
+        &fingerprinted_cfgs,
     );
-    apply_output_mode(&mut cmd, false, arch);
+    apply_output_mode(&mut cmd, false, arch, materialization);
     apply_device_arch_hint(&mut cmd, arch, detected_device_arch);
 
     if let Some(bin) = bin {
@@ -1223,6 +1438,7 @@ fn run_compute_sanitizer(
 /// Same as [`codegen_run`] but uses `cargo build --release` instead of
 /// `cargo run`. Useful for cross-compilation or when the target hardware
 /// (e.g., Blackwell tensor cores) isn't available on the build machine.
+#[allow(clippy::too_many_arguments)]
 pub fn codegen_build(
     ctx: &Context,
     example: &str,
@@ -1231,8 +1447,10 @@ pub fn codegen_build(
     arch: Option<&str>,
     features: Option<&str>,
     no_fmad: bool,
+    materialize_cubin: bool,
 ) {
     let target_arch = configured_arch(ctx, arch);
+    let materialization = prepare_materialization(ctx, materialize_cubin, arch, emit_nvvm_ir);
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
     } else {
@@ -1252,6 +1470,7 @@ pub fn codegen_build(
             target_arch,
             features,
             no_fmad,
+            &materialization,
         );
         return;
     }
@@ -1273,8 +1492,23 @@ pub fn codegen_build(
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
-    apply_codegen_rustflags(&mut cmd, ctx, CodegenProfilePolicy::ReleaseLike, &[]);
-    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
+    let fingerprint = standard_codegen_fingerprint_cfg(
+        ctx,
+        verbose,
+        no_fmad,
+        emit_nvvm_ir,
+        target_arch,
+        None,
+        &materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
+    apply_codegen_rustflags(
+        &mut cmd,
+        ctx,
+        CodegenProfilePolicy::ReleaseLike,
+        &fingerprinted_cfgs,
+    );
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
 
     println!("Building {}...", example);
     println!();
@@ -1344,6 +1578,7 @@ pub fn emit_ltoir(
         Some(&sm_arch),
         features,
         no_fmad,
+        false,
     );
 
     // Step 2: compile that NVVM IR to LTOIR via libNVVM -gen-lto.
@@ -1375,12 +1610,7 @@ pub fn emit_ltoir(
     });
 
     let compute_arch = parsed_arch.compute();
-    let ltoir = compile_nvvm_to_ltoir(
-        &ir,
-        example,
-        &parsed_arch,
-        compile_options.fma_contraction_enabled(),
-    );
+    let ltoir = compile_nvvm_to_ltoir(&ir, example, &parsed_arch, compile_options);
 
     // Step 3: write the artifact.
     let out_path = output
@@ -1445,7 +1675,9 @@ pub fn emit_ltoir(
 ///
 /// Accepts `sm_XX` (the form `--arch` and the rest of cargo-oxide use),
 /// `compute_XX` (passed through), or a bare `XX`.
-fn parse_nvvm_arch(arch: &str) -> Result<libnvvm_sys::CudaArch, libnvvm_sys::CudaArchParseError> {
+fn parse_nvvm_arch(
+    arch: &str,
+) -> Result<cuda_artifact_finalizer::CudaArch, cuda_artifact_finalizer::CudaArchParseError> {
     let normalized = if arch.starts_with("sm_") || arch.starts_with("compute_") {
         arch.to_string()
     } else {
@@ -1460,98 +1692,38 @@ fn parse_nvvm_arch(arch: &str) -> Result<libnvvm_sys::CudaArch, libnvvm_sys::Cud
 fn compile_nvvm_to_ltoir(
     ir: &[u8],
     name: &str,
-    arch: &libnvvm_sys::CudaArch,
-    allow_fma_contraction: bool,
+    arch: &cuda_artifact_finalizer::CudaArch,
+    compile_options: oxide_artifacts::ArtifactCompileOptions,
 ) -> Vec<u8> {
-    let nvvm = libnvvm_sys::LibNvvm::load().unwrap_or_else(|e| {
-        eprintln!("Error: could not load libNVVM: {e}");
+    let compiler = cuda_artifact_finalizer::NvvmCompiler::discover().unwrap_or_else(|e| {
+        eprintln!("Error: could not initialize the CUDA artifact compiler: {e}");
         eprintln!("libNVVM ships with the CUDA Toolkit at <CUDA>/nvvm/lib64/libnvvm.so.");
         eprintln!("Run `cargo oxide doctor` to check your toolkit setup.");
         std::process::exit(1);
     });
-    let ir_version = nvvm.ir_version().unwrap_or_else(|e| {
-        eprintln!("Error: could not query libNVVM's accepted IR version: {e}");
-        std::process::exit(1);
-    });
-    if (ir_version.ir_major, ir_version.ir_minor) != (2, 0) {
-        eprintln!(
-            "Error: installed libNVVM accepts NVVM IR {}.{}, but cuda-oxide emits NVVM IR 2.0",
-            ir_version.ir_major, ir_version.ir_minor
-        );
-        std::process::exit(1);
-    }
-    if let Some(llvm_major) = nvvm.llvm_version(arch).unwrap_or_else(|e| {
-        eprintln!(
-            "Error: could not query libNVVM's LLVM dialect for {}: {e}",
-            arch.compute()
-        );
-        std::process::exit(1);
-    }) {
-        let mismatch = if arch.uses_legacy_llvm() {
-            llvm_major != 7
-        } else {
-            llvm_major == 7
-        };
-        if mismatch {
-            let expected = if arch.uses_legacy_llvm() {
-                "legacy LLVM 7 typed-pointer"
-            } else {
-                "modern opaque-pointer"
-            };
-            eprintln!(
-                "Error: libNVVM reports LLVM {llvm_major} for {}, but cuda-oxide selected the {expected} dialect",
-                arch.compute()
-            );
-            std::process::exit(1);
-        }
-    }
-    let mut program = libnvvm_sys::Program::new(&nvvm).unwrap_or_else(|e| {
-        eprintln!("Error: nvvmCreateProgram failed: {e}");
-        std::process::exit(1);
-    });
-
-    // Add libdevice before the kernel module so any __nv_* math calls (exp,
-    // sin, cos, etc.) are resolved at LTOIR compile time, matching the pattern
-    // used by NVCC and cuda-host's own LTOIR path.
-    let libdevice_path = libnvvm_sys::find_libdevice().unwrap_or_else(|e| {
-        eprintln!("Error: could not locate libdevice.10.bc: {e}");
-        eprintln!("Set CUDA_OXIDE_LIBDEVICE, CUDA_TOOLKIT_PATH, or CUDA_HOME.");
-        std::process::exit(1);
-    });
-    let libdevice_bytes = std::fs::read(&libdevice_path).unwrap_or_else(|e| {
-        eprintln!(
-            "Error: could not read libdevice at {}: {e}",
-            libdevice_path.display()
-        );
-        std::process::exit(1);
-    });
-    program
-        .add_module(&libdevice_bytes, "libdevice.10.bc")
-        .unwrap_or_else(|e| {
-            eprintln!("Error: libNVVM rejected libdevice module: {e}");
-            std::process::exit(1);
-        });
-
-    program.add_module(ir, name).unwrap_or_else(|e| {
-        eprintln!("Error: libNVVM rejected the NVVM IR module: {e}");
-        std::process::exit(1);
-    });
-    let arch_opt = format!("-arch={}", arch.compute());
-    program.verify(&[&arch_opt]).unwrap_or_else(|e| {
-        eprintln!("Error: libNVVM verification failed: {e}");
-        std::process::exit(1);
-    });
-    let fma_opt = if allow_fma_contraction {
-        "-fma=1"
-    } else {
-        "-fma=0"
-    };
-    program
-        .compile(&[&arch_opt, "-gen-lto", fma_opt])
+    let options = finalization_options_from_artifact(arch, compile_options);
+    compiler
+        .compile_nvvm_ir_to_ltoir(name, ir, &options)
         .unwrap_or_else(|e| {
             eprintln!("Error: libNVVM -gen-lto compilation failed: {e}");
             std::process::exit(1);
         })
+}
+
+fn finalization_options_from_artifact(
+    arch: &cuda_artifact_finalizer::CudaArch,
+    compile_options: oxide_artifacts::ArtifactCompileOptions,
+) -> cuda_artifact_finalizer::FinalizationOptions {
+    let debug = match compile_options.debug_policy() {
+        oxide_artifacts::ArtifactDebugPolicy::None => cuda_artifact_finalizer::DebugPolicy::None,
+        oxide_artifacts::ArtifactDebugPolicy::LineTables => {
+            cuda_artifact_finalizer::DebugPolicy::LineTables
+        }
+        oxide_artifacts::ArtifactDebugPolicy::Full => cuda_artifact_finalizer::DebugPolicy::Full,
+    };
+    cuda_artifact_finalizer::FinalizationOptions::new(arch.clone())
+        .with_fma_contraction(compile_options.fma_contraction_enabled())
+        .with_debug_policy(debug)
 }
 
 /// Options for `cargo oxide build -- ...` / `cargo oxide test -- ...`.
@@ -1565,6 +1737,7 @@ pub struct CargoPassthroughOptions<'a> {
     pub device_codegen_crate: Option<&'a str>,
     pub device_cfgs: &'a [String],
     pub no_fmad: bool,
+    pub materialize_cubin: bool,
 }
 
 /// Cargo operations supported by the passthrough path.
@@ -1660,15 +1833,23 @@ fn passthrough_codegen_fingerprint(
     opts: &CargoPassthroughOptions<'_>,
     owner_filter: Option<&str>,
     target_arch: Option<&str>,
+    materialization: &MaterializationMode,
 ) -> String {
-    let inherited_env: BTreeMap<String, Option<String>> = std::env::vars_os()
+    let inherited_env: BTreeMap<String, Vec<u8>> = std::env::vars_os()
         .filter_map(|(key, value)| {
             key.into_string()
                 .ok()
-                .map(|key| (key, value.into_string().ok()))
+                .map(|key| (key, value.as_encoded_bytes().to_vec()))
         })
         .collect();
-    passthrough_codegen_fingerprint_with_env(ctx, opts, owner_filter, target_arch, &inherited_env)
+    passthrough_codegen_fingerprint_with_env(
+        ctx,
+        opts,
+        owner_filter,
+        target_arch,
+        materialization,
+        &inherited_env,
+    )
 }
 
 fn passthrough_codegen_fingerprint_with_env(
@@ -1676,12 +1857,13 @@ fn passthrough_codegen_fingerprint_with_env(
     opts: &CargoPassthroughOptions<'_>,
     owner_filter: Option<&str>,
     target_arch: Option<&str>,
-    inherited_env: &BTreeMap<String, Option<String>>,
+    materialization: &MaterializationMode,
+    inherited_env: &BTreeMap<String, Vec<u8>>,
 ) -> String {
     let mut effective_env = BTreeMap::new();
     effective_env.insert(
         "__CUDA_OXIDE_BACKEND_ARTIFACT".to_string(),
-        backend_artifact_identity(&ctx.backend_so),
+        backend_artifact_identity(&ctx.backend_so).into_bytes(),
     );
 
     // Project-configured CUDA_OXIDE_* variables are defaults. Mirror the same
@@ -1691,50 +1873,50 @@ fn passthrough_codegen_fingerprint_with_env(
         if !key.starts_with("CUDA_OXIDE_") {
             continue;
         }
-        match inherited_env.get(key) {
-            Some(Some(value)) => {
-                effective_env.insert(key.clone(), value.clone());
-            }
-            // `apply_config_env` sees the non-Unicode parent value through
-            // var_os and does not replace it; backend readers using `var`
-            // ignore it, so there is no effective Unicode value to hash.
-            Some(None) => {}
-            None => {
-                effective_env.insert(key.clone(), configured_value.clone());
-            }
+        if let Some(value) = inherited_env.get(key) {
+            // Keep the platform encoding. Presence-only backend switches such
+            // as CUDA_OXIDE_NO_FMA remain effective even when their value is
+            // not Unicode, so dropping those bytes could reuse stale code.
+            effective_env.insert(key.clone(), value.clone());
+        } else {
+            effective_env.insert(key.clone(), configured_value.as_bytes().to_vec());
         }
     }
     // Capture backend settings inherited outside project config, including
     // current and future CUDA_OXIDE_* switches.
     for (key, value) in inherited_env
         .iter()
-        .filter(|(key, value)| key.starts_with("CUDA_OXIDE_") && value.is_some())
+        .filter(|(key, _)| key.starts_with("CUDA_OXIDE_"))
     {
-        effective_env.insert(
-            key.clone(),
-            value
-                .as_ref()
-                .expect("filtered to Unicode environment values")
-                .clone(),
-        );
+        effective_env.insert(key.clone(), value.clone());
     }
 
     if opts.verbose {
-        effective_env.insert("CUDA_OXIDE_VERBOSE".to_string(), "1".to_string());
+        effective_env.insert("CUDA_OXIDE_VERBOSE".to_string(), b"1".to_vec());
     }
     if opts.no_fmad {
-        effective_env.insert("CUDA_OXIDE_NO_FMA".to_string(), "1".to_string());
+        effective_env.insert("CUDA_OXIDE_NO_FMA".to_string(), b"1".to_vec());
     }
-    if opts.emit_nvvm_ir {
-        effective_env.insert("CUDA_OXIDE_EMIT_NVVM_IR".to_string(), "1".to_string());
+    if opts.emit_nvvm_ir || materialization.enabled() {
+        effective_env.insert("CUDA_OXIDE_EMIT_NVVM_IR".to_string(), b"1".to_vec());
+    }
+    if let Some(provenance) = &materialization.provenance {
+        effective_env.insert(MATERIALIZE_ENV.to_string(), b"1".to_vec());
+        effective_env.insert(
+            EXPECTED_PROVENANCE_ENV.to_string(),
+            provenance.as_bytes().to_vec(),
+        );
     }
     if let Some(target_arch) = target_arch {
-        effective_env.insert("CUDA_OXIDE_TARGET".to_string(), target_arch.to_string());
+        effective_env.insert(
+            "CUDA_OXIDE_TARGET".to_string(),
+            target_arch.as_bytes().to_vec(),
+        );
     }
     if let Some(owner_filter) = owner_filter {
         effective_env.insert(
             "CUDA_OXIDE_DEVICE_CODEGEN_CRATE".to_string(),
-            owner_filter.to_string(),
+            owner_filter.as_bytes().to_vec(),
         );
     }
 
@@ -1744,7 +1926,7 @@ fn passthrough_codegen_fingerprint_with_env(
     let mut hash = 0xcbf29ce484222325_u64;
     for (key, value) in effective_env {
         update_codegen_fingerprint_hash(&mut hash, key.as_bytes());
-        update_codegen_fingerprint_hash(&mut hash, value.as_bytes());
+        update_codegen_fingerprint_hash(&mut hash, &value);
     }
     format!("{hash:016x}")
 }
@@ -1766,6 +1948,7 @@ fn sanitize_codegen_fingerprint_cfg(
     target_arch: Option<&str>,
     detected_device_arch: Option<&str>,
     ptx_dir: Option<&Path>,
+    materialization: &MaterializationMode,
 ) -> String {
     let opts = CargoPassthroughOptions {
         verbose,
@@ -1776,8 +1959,9 @@ fn sanitize_codegen_fingerprint_cfg(
         device_codegen_crate: None,
         device_cfgs: &[],
         no_fmad,
+        materialize_cubin: materialization.enabled(),
     };
-    let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch);
+    let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch, materialization);
     let mut hash = 0xcbf29ce484222325_u64;
     for bytes in [
         "sanitize-line-tables-v1".as_bytes(),
@@ -1792,19 +1976,96 @@ fn sanitize_codegen_fingerprint_cfg(
     format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
 }
 
+fn standard_codegen_fingerprint_cfg(
+    ctx: &Context,
+    verbose: bool,
+    no_fmad: bool,
+    emit_nvvm_ir: bool,
+    target_arch: Option<&str>,
+    detected_device_arch: Option<&str>,
+    materialization: &MaterializationMode,
+) -> String {
+    let opts = CargoPassthroughOptions {
+        verbose,
+        emit_nvvm_ir,
+        arch: target_arch,
+        features: None,
+        cargo_target_dir: None,
+        device_codegen_crate: None,
+        device_cfgs: &[],
+        no_fmad,
+        materialize_cubin: materialization.enabled(),
+    };
+    let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch, materialization);
+    let mut hash = 0xcbf29ce484222325_u64;
+    for bytes in [
+        "standard-codegen-v1".as_bytes(),
+        base.as_bytes(),
+        detected_device_arch.unwrap_or("").as_bytes(),
+    ] {
+        update_codegen_fingerprint_hash(&mut hash, bytes);
+    }
+    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn interop_codegen_fingerprint_cfg(
+    ctx: &Context,
+    verbose: bool,
+    no_fmad: bool,
+    target_arch: Option<&str>,
+    detected_device_arch: Option<&str>,
+    ptx_dir: &Path,
+    sanitizer_line_tables: bool,
+    materialization: &MaterializationMode,
+) -> String {
+    let base = standard_codegen_fingerprint_cfg(
+        ctx,
+        verbose,
+        no_fmad,
+        false,
+        target_arch,
+        detected_device_arch,
+        materialization,
+    );
+    let mut hash = 0xcbf29ce484222325_u64;
+    for bytes in [
+        "interop-codegen-v1".as_bytes(),
+        base.as_bytes(),
+        if sanitizer_line_tables {
+            b"line-tables"
+        } else {
+            b"default-debug"
+        },
+        ptx_dir.as_os_str().as_encoded_bytes(),
+    ] {
+        update_codegen_fingerprint_hash(&mut hash, bytes);
+    }
+    format!("cuda_oxide_internal_codegen_env=\"{hash:016x}\"")
+}
+
 fn backend_artifact_identity(path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let path = canonical.to_string_lossy();
-    let Ok(metadata) = std::fs::metadata(&canonical) else {
-        return format!("{path}|missing");
+    let Ok(mut file) = std::fs::File::open(&canonical) else {
+        return format!("{path}|unreadable");
     };
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-    format!("{path}|{}|{modified}", metadata.len())
+    let mut hasher = Sha256::new();
+    let mut chunk = [0_u8; 64 * 1024];
+    loop {
+        let Ok(read) = file.read(&mut chunk) else {
+            return format!("{path}|unreadable");
+        };
+        if read == 0 {
+            break;
+        }
+        hasher.update(&chunk[..read]);
+    }
+    let digest: [u8; 32] = hasher.finalize().into();
+    format!("{path}|sha256={}", digest_hex(&digest))
 }
 
 fn cargo_passthrough_command(
@@ -1814,15 +2075,25 @@ fn cargo_passthrough_command(
     cargo_args: &[String],
 ) -> Result<Command, String> {
     let target_arch = configured_arch(ctx, opts.arch);
+    let materialization =
+        prepare_materialization(ctx, opts.materialize_cubin, opts.arch, opts.emit_nvvm_ir);
     let owner_filter = configured_device_codegen_crates(ctx, opts.device_codegen_crate)?;
     let mut fingerprinted_device_cfgs = opts.device_cfgs.to_vec();
     // Cargo does not fingerprint arbitrary child environment variables. An
     // otherwise-unused cfg makes every effective codegen setting part of the
     // rustc command line, so changing target/output/FMA/filter settings reruns
     // the backend instead of silently reusing stale PTX or NVVM IR.
-    let fingerprint =
-        passthrough_codegen_fingerprint(ctx, opts, owner_filter.as_deref(), target_arch);
+    let fingerprint = passthrough_codegen_fingerprint(
+        ctx,
+        opts,
+        owner_filter.as_deref(),
+        target_arch,
+        &materialization,
+    );
     fingerprinted_device_cfgs.push(format!("cuda_oxide_internal_codegen_env=\"{fingerprint}\""));
+    if let Some(provenance) = &materialization.provenance {
+        fingerprinted_device_cfgs.push(format!("{MATERIALIZER_PROVENANCE_CFG}=\"{provenance}\""));
+    }
     let mut cmd = Command::new("cargo");
     cmd.arg(cargo_subcommand.as_str());
     if let Some(features) = opts.features {
@@ -1846,7 +2117,7 @@ fn cargo_passthrough_command(
     if let Some(owner_filter) = owner_filter {
         cmd.env("CUDA_OXIDE_DEVICE_CODEGEN_CRATE", owner_filter);
     }
-    apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch);
+    apply_output_mode(&mut cmd, opts.emit_nvvm_ir, target_arch, &materialization);
     Ok(cmd)
 }
 
@@ -1920,13 +2191,19 @@ pub fn codegen_show_pipeline(
     emit_nvvm_ir: bool,
     arch: Option<&str>,
     no_fmad: bool,
+    materialize_cubin: bool,
 ) {
     let target_arch = configured_arch(ctx, arch);
+    let materialization = prepare_materialization(ctx, materialize_cubin, arch, emit_nvvm_ir);
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
     } else {
         ctx.workspace_root.clone()
     };
+
+    if load_interop_config(&example_dir).is_some_and(|config| !config.device_crates.is_empty()) {
+        reject_interop_output_mode(emit_nvvm_ir, &materialization);
+    }
 
     clean_generated_files(&example_dir, example);
 
@@ -1935,13 +2212,24 @@ pub fn codegen_show_pipeline(
     println!("=========================================");
     println!();
     let target_arch_label = configured_arch_label(ctx, arch);
-    match (emit_nvvm_ir, target_arch_label.as_deref()) {
-        (true, Some(target_arch)) => println!("Output format: NVVM IR (arch: {})", target_arch),
-        (false, Some(target_arch)) => {
+    match (
+        materialization.enabled(),
+        emit_nvvm_ir,
+        target_arch_label.as_deref(),
+    ) {
+        (true, _, Some(target_arch)) => {
+            println!("Output format: materialized cubin (arch: {target_arch})")
+        }
+        (false, true, Some(target_arch)) => {
+            println!("Output format: NVVM IR (arch: {})", target_arch)
+        }
+        (false, false, Some(target_arch)) => {
             println!("Output format: PTX (arch override: {})", target_arch)
         }
-        (false, None) => println!("Output format: PTX (auto-detected arch)"),
-        (true, None) => unreachable!("--emit-nvvm-ir requires a configured architecture"),
+        (false, false, None) => println!("Output format: PTX (auto-detected arch)"),
+        (true, _, None) | (false, true, None) => {
+            unreachable!("IR/final materialization requires a configured architecture")
+        }
     }
     println!();
     println!("Required flags (applied via CARGO_ENCODED_RUSTFLAGS):");
@@ -1960,7 +2248,22 @@ pub fn codegen_show_pipeline(
     cmd.args(["build", "--release"]).current_dir(&example_dir);
 
     apply_config_env(&mut cmd, ctx);
-    apply_codegen_rustflags(&mut cmd, ctx, CodegenProfilePolicy::ReleaseLike, &[]);
+    let fingerprint = standard_codegen_fingerprint_cfg(
+        ctx,
+        true,
+        no_fmad,
+        emit_nvvm_ir,
+        target_arch,
+        None,
+        &materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
+    apply_codegen_rustflags(
+        &mut cmd,
+        ctx,
+        CodegenProfilePolicy::ReleaseLike,
+        &fingerprinted_cfgs,
+    );
     cmd.env("CUDA_OXIDE_VERBOSE", "1");
     cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
     cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
@@ -1969,7 +2272,7 @@ pub fn codegen_show_pipeline(
         cmd.env("CUDA_OXIDE_NO_FMA", "1");
     }
 
-    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch);
+    apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
     apply_ld_library_path(&mut cmd, ctx);
 
     println!("Building {}...", example);
@@ -1995,6 +2298,7 @@ pub fn codegen_show_pipeline(
 /// flags, then launches the debugger on the resulting binary. Prints a
 /// quick-reference cheat sheet for common cuda-gdb commands before handing
 /// control to the debugger.
+#[allow(clippy::too_many_arguments)]
 pub fn codegen_debug(
     ctx: &Context,
     example: &str,
@@ -2003,7 +2307,19 @@ pub fn codegen_debug(
     bin: Option<&str>,
     use_cgdb: bool,
     use_tui: bool,
+    materialize_cubin: bool,
 ) {
+    let example_dir = if ctx.is_workspace {
+        resolve_example_dir(ctx, example)
+    } else {
+        ctx.workspace_root.clone()
+    };
+    let target_arch = configured_arch(ctx, arch);
+    let materialization = prepare_materialization(ctx, materialize_cubin, arch, false);
+    if load_interop_config(&example_dir).is_some_and(|config| !config.device_crates.is_empty()) {
+        reject_interop_output_mode(false, &materialization);
+    }
+
     let cuda_gdb = find_cuda_toolkit_executable(
         ctx,
         "cuda-gdb",
@@ -2033,14 +2349,7 @@ pub fn codegen_debug(
         None
     };
 
-    let example_dir = if ctx.is_workspace {
-        resolve_example_dir(ctx, example)
-    } else {
-        ctx.workspace_root.clone()
-    };
-
-    let target_arch = configured_arch(ctx, arch);
-    let detected_device_arch = detect_run_target_arch(target_arch, false);
+    let detected_device_arch = detect_run_target_arch(target_arch, materialization.enabled());
 
     if let Some(bin) = bin {
         println!("Building {} (bin: {}) with debug info...", example, bin);
@@ -2066,14 +2375,24 @@ pub fn codegen_debug(
     }
 
     apply_config_env(&mut cmd, ctx);
+    let fingerprint = standard_codegen_fingerprint_cfg(
+        ctx,
+        false,
+        false,
+        false,
+        target_arch,
+        detected_device_arch.as_deref(),
+        &materialization,
+    );
+    let fingerprinted_cfgs = fingerprinted_codegen_cfgs(fingerprint, &materialization);
     apply_codegen_rustflags(
         &mut cmd,
         ctx,
         CodegenProfilePolicy::ReleaseLikeWithDebugInfo,
-        &[],
+        &fingerprinted_cfgs,
     );
     cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "2");
-    apply_output_mode(&mut cmd, false, target_arch);
+    apply_output_mode(&mut cmd, false, target_arch, &materialization);
     apply_device_arch_hint(&mut cmd, target_arch, detected_device_arch.as_deref());
     apply_ld_library_path(&mut cmd, ctx);
 
@@ -3015,13 +3334,19 @@ fn apply_codegen_rustflags(
 /// `arch` is an explicit pin (`--arch`); it becomes `CUDA_OXIDE_TARGET`, the
 /// hard override the backend honors as-is. The auto-detected GPU arch is *not*
 /// routed here -- see [`apply_device_arch_hint`].
-fn apply_output_mode(cmd: &mut Command, emit_nvvm_ir: bool, arch: Option<&str>) {
+fn apply_output_mode(
+    cmd: &mut Command,
+    emit_nvvm_ir: bool,
+    arch: Option<&str>,
+    materialization: &MaterializationMode,
+) {
     if let Some(target_arch) = arch {
         cmd.env("CUDA_OXIDE_TARGET", target_arch);
     }
-    if emit_nvvm_ir {
+    if emit_nvvm_ir || materialization.enabled() {
         cmd.env("CUDA_OXIDE_EMIT_NVVM_IR", "1");
     }
+    materialization.apply(cmd);
 }
 
 fn configured_arch<'a>(ctx: &'a Context, cli_arch: Option<&'a str>) -> Option<&'a str> {
@@ -3707,6 +4032,76 @@ mod tests {
     }
 
     #[test]
+    fn strict_materialization_boolean_rejects_presence_only_values() {
+        for value in ["1", "true", " YES ", "on"] {
+            assert!(parse_strict_bool(MATERIALIZE_ENV, value).unwrap());
+        }
+        for value in ["0", "false", " NO ", "off"] {
+            assert!(!parse_strict_bool(MATERIALIZE_ENV, value).unwrap());
+        }
+        for value in ["", "enabled", "2"] {
+            let error = parse_strict_bool(MATERIALIZE_ENV, value).unwrap_err();
+            assert!(error.contains("must be a boolean"), "{error}");
+        }
+    }
+
+    #[test]
+    fn materialization_rejects_nvvm_ir_as_a_competing_final_output() {
+        let error = prepare_materialization_result(
+            &test_context(OxideConfig::default()),
+            true,
+            Some("sm_90"),
+            true,
+        )
+        .expect_err("the two user-facing final output modes must conflict");
+
+        assert!(error.contains("cannot be combined with --emit-nvvm-ir"));
+    }
+
+    #[test]
+    fn materializer_discovery_uses_the_same_project_tool_environment_as_rustc() {
+        let configured_libdevice = "/configured/cuda/nvvm/libdevice/libdevice.10.bc";
+        let ctx = test_context(OxideConfig {
+            env: vec![
+                (
+                    "CUDA_OXIDE_LIBDEVICE".to_string(),
+                    configured_libdevice.to_string(),
+                ),
+                (
+                    "CUDA_TOOLKIT_PATH".to_string(),
+                    "/configured/cuda".to_string(),
+                ),
+                (
+                    "LD_LIBRARY_PATH".to_string(),
+                    "/configured/cuda/lib64".to_string(),
+                ),
+            ],
+            ..OxideConfig::default()
+        });
+        let discovery = materializer_discovery_command(&ctx, Path::new("/fake/cargo-oxide"));
+        let mut rustc_child = Command::new("cargo");
+        apply_common_codegen_env(&mut rustc_child, &ctx, false, false);
+
+        for key in [
+            "CUDA_OXIDE_LIBDEVICE",
+            "CUDA_TOOLKIT_PATH",
+            "LD_LIBRARY_PATH",
+        ] {
+            assert_eq!(
+                command_env(&discovery, key),
+                command_env(&rustc_child, key),
+                "discovery and rustc must see the same {key}"
+            );
+        }
+        if std::env::var_os("CUDA_OXIDE_LIBDEVICE").is_none() {
+            assert_eq!(
+                command_env(&discovery, "CUDA_OXIDE_LIBDEVICE").as_deref(),
+                Some(configured_libdevice)
+            );
+        }
+    }
+
+    #[test]
     fn artifact_stem_normalizes_hyphens_like_cargo() {
         assert_eq!(artifact_stem("rustlantis-smoke"), "rustlantis_smoke");
         assert_eq!(artifact_stem("vecadd"), "vecadd");
@@ -4346,6 +4741,7 @@ path = "src/other.rs"
             Some("sm_80"),
             None,
             Some(Path::new("/tmp/generated-ptx")),
+            &MaterializationMode::default(),
         );
         apply_codegen_rustflags(
             &mut cmd,
@@ -4376,12 +4772,44 @@ path = "src/other.rs"
     #[test]
     fn sanitize_fingerprint_tracks_output_affecting_settings() {
         let ctx = test_context(OxideConfig::default());
-        let base = sanitize_codegen_fingerprint_cfg(&ctx, false, false, None, Some("sm_80"), None);
+        let base = sanitize_codegen_fingerprint_cfg(
+            &ctx,
+            false,
+            false,
+            None,
+            Some("sm_80"),
+            None,
+            &MaterializationMode::default(),
+        );
 
         for changed in [
-            sanitize_codegen_fingerprint_cfg(&ctx, false, true, None, Some("sm_80"), None),
-            sanitize_codegen_fingerprint_cfg(&ctx, false, false, None, Some("sm_90"), None),
-            sanitize_codegen_fingerprint_cfg(&ctx, false, false, Some("sm_80"), None, None),
+            sanitize_codegen_fingerprint_cfg(
+                &ctx,
+                false,
+                true,
+                None,
+                Some("sm_80"),
+                None,
+                &MaterializationMode::default(),
+            ),
+            sanitize_codegen_fingerprint_cfg(
+                &ctx,
+                false,
+                false,
+                None,
+                Some("sm_90"),
+                None,
+                &MaterializationMode::default(),
+            ),
+            sanitize_codegen_fingerprint_cfg(
+                &ctx,
+                false,
+                false,
+                Some("sm_80"),
+                None,
+                None,
+                &MaterializationMode::default(),
+            ),
             sanitize_codegen_fingerprint_cfg(
                 &ctx,
                 false,
@@ -4389,6 +4817,7 @@ path = "src/other.rs"
                 None,
                 Some("sm_80"),
                 Some(Path::new("/tmp/generated-ptx")),
+                &MaterializationMode::default(),
             ),
         ] {
             assert_ne!(base, changed);
@@ -4464,6 +4893,7 @@ path = "src/other.rs"
             device_codegen_crate: None,
             device_cfgs: &[],
             no_fmad: false,
+            materialize_cubin: false,
         };
         for cargo_args in [
             vec!["--release".to_string()],
@@ -4626,6 +5056,7 @@ MY_BUILD_FLAG = "configured"
             device_codegen_crate: Some("gpu-kernels, math_gpu"),
             device_cfgs: &device_cfgs,
             no_fmad: false,
+            materialize_cubin: false,
         };
         let cargo_args = vec![
             "-p".to_string(),
@@ -4699,6 +5130,7 @@ MY_BUILD_FLAG = "configured"
             device_codegen_crate: None,
             device_cfgs: &[],
             no_fmad: false,
+            materialize_cubin: false,
         };
 
         let cmd =
@@ -4743,6 +5175,7 @@ MY_BUILD_FLAG = "configured"
             device_codegen_crate: None,
             device_cfgs: &[],
             no_fmad: false,
+            materialize_cubin: false,
         };
         let inherited_env = BTreeMap::new();
         let base_hash = passthrough_codegen_fingerprint_with_env(
@@ -4750,6 +5183,7 @@ MY_BUILD_FLAG = "configured"
             &base,
             None,
             Some("sm_80"),
+            &MaterializationMode::default(),
             &inherited_env,
         );
 
@@ -4780,6 +5214,7 @@ MY_BUILD_FLAG = "configured"
                 &arch,
                 None,
                 Some("sm_90"),
+                &MaterializationMode::default(),
                 &inherited_env,
             )
         );
@@ -4790,6 +5225,7 @@ MY_BUILD_FLAG = "configured"
                 &emit,
                 None,
                 Some("sm_80"),
+                &MaterializationMode::default(),
                 &inherited_env,
             )
         );
@@ -4800,6 +5236,7 @@ MY_BUILD_FLAG = "configured"
                 &no_fmad,
                 None,
                 Some("sm_80"),
+                &MaterializationMode::default(),
                 &inherited_env,
             )
         );
@@ -4810,6 +5247,7 @@ MY_BUILD_FLAG = "configured"
                 &base,
                 Some("gpu_kernel"),
                 Some("sm_80"),
+                &MaterializationMode::default(),
                 &inherited_env,
             )
         );
@@ -4820,9 +5258,57 @@ MY_BUILD_FLAG = "configured"
                 &base,
                 None,
                 Some("sm_80"),
+                &MaterializationMode::default(),
                 &inherited_env,
             )
         );
+        let materialized = MaterializationMode {
+            provenance: Some("ab".repeat(32)),
+        };
+        assert_ne!(
+            base_hash,
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &base,
+                None,
+                Some("sm_80"),
+                &materialized,
+                &inherited_env,
+            ),
+            "exact CUDA-tool provenance must change Cargo's rustc fingerprint"
+        );
+    }
+
+    #[test]
+    fn passthrough_fingerprint_tracks_non_unicode_presence_switch_bytes() {
+        let ctx = test_context(OxideConfig::default());
+        let opts = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: Some("sm_80"),
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+            materialize_cubin: false,
+        };
+        let fingerprint = |inherited_env: &BTreeMap<String, Vec<u8>>| {
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                &opts,
+                None,
+                Some("sm_80"),
+                &MaterializationMode::default(),
+                inherited_env,
+            )
+        };
+        let absent = BTreeMap::new();
+        let first = BTreeMap::from([("CUDA_OXIDE_NO_FMA".to_string(), vec![0xff])]);
+        let second = BTreeMap::from([("CUDA_OXIDE_NO_FMA".to_string(), vec![0xfe])]);
+
+        assert_ne!(fingerprint(&absent), fingerprint(&first));
+        assert_ne!(fingerprint(&first), fingerprint(&second));
     }
 
     #[test]
@@ -4839,6 +5325,8 @@ MY_BUILD_FLAG = "configured"
         std::fs::create_dir_all(&root).unwrap();
         let backend = root.join("librustc_codegen_cuda.so");
         std::fs::write(&backend, b"first").unwrap();
+        let original = std::fs::metadata(&backend).unwrap();
+        let original_modified = original.modified().unwrap();
 
         let mut ctx = test_context(OxideConfig::default());
         ctx.backend_so = backend.clone();
@@ -4851,13 +5339,37 @@ MY_BUILD_FLAG = "configured"
             device_codegen_crate: None,
             device_cfgs: &[],
             no_fmad: false,
+            materialize_cubin: false,
         };
         let inherited_env = BTreeMap::new();
-        let before =
-            passthrough_codegen_fingerprint_with_env(&ctx, &opts, None, None, &inherited_env);
-        std::fs::write(&backend, b"second-build-is-larger").unwrap();
-        let after =
-            passthrough_codegen_fingerprint_with_env(&ctx, &opts, None, None, &inherited_env);
+        let before = passthrough_codegen_fingerprint_with_env(
+            &ctx,
+            &opts,
+            None,
+            None,
+            &MaterializationMode::default(),
+            &inherited_env,
+        );
+        // Preserve the weak metadata identity that used to be fingerprinted:
+        // only the bytes differ.
+        std::fs::write(&backend, b"other").unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&backend)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+        let replacement = std::fs::metadata(&backend).unwrap();
+        assert_eq!(replacement.len(), original.len());
+        assert_eq!(replacement.modified().unwrap(), original_modified);
+        let after = passthrough_codegen_fingerprint_with_env(
+            &ctx,
+            &opts,
+            None,
+            None,
+            &MaterializationMode::default(),
+            &inherited_env,
+        );
 
         assert_ne!(before, after);
         std::fs::remove_dir_all(root).unwrap();
@@ -4909,10 +5421,43 @@ MY_BUILD_FLAG = "configured"
     }
 
     #[test]
+    fn emit_ltoir_preserves_fma_and_debug_policy_for_libnvvm() {
+        let arch = parse_nvvm_arch("sm_90").unwrap();
+        for (artifact_debug, finalizer_debug) in [
+            (
+                oxide_artifacts::ArtifactDebugPolicy::None,
+                cuda_artifact_finalizer::DebugPolicy::None,
+            ),
+            (
+                oxide_artifacts::ArtifactDebugPolicy::LineTables,
+                cuda_artifact_finalizer::DebugPolicy::LineTables,
+            ),
+            (
+                oxide_artifacts::ArtifactDebugPolicy::Full,
+                cuda_artifact_finalizer::DebugPolicy::Full,
+            ),
+        ] {
+            let artifact_options = oxide_artifacts::ArtifactCompileOptions::new()
+                .with_fma_contraction(false)
+                .with_debug_policy(artifact_debug);
+            let finalizer_options = finalization_options_from_artifact(&arch, artifact_options);
+
+            assert_eq!(finalizer_options.target(), &arch);
+            assert!(!finalizer_options.allow_fma_contraction());
+            assert_eq!(finalizer_options.debug_policy(), finalizer_debug);
+        }
+    }
+
+    #[test]
     fn apply_output_mode_sets_target_for_arch_override() {
         let mut cmd = Command::new("cargo");
 
-        apply_output_mode(&mut cmd, false, Some("sm_120"));
+        apply_output_mode(
+            &mut cmd,
+            false,
+            Some("sm_120"),
+            &MaterializationMode::default(),
+        );
 
         assert_eq!(
             command_env(&cmd, "CUDA_OXIDE_TARGET").as_deref(),
@@ -4925,7 +5470,12 @@ MY_BUILD_FLAG = "configured"
     fn apply_output_mode_sets_nvvm_ir_flag_and_target() {
         let mut cmd = Command::new("cargo");
 
-        apply_output_mode(&mut cmd, true, Some("sm_100a"));
+        apply_output_mode(
+            &mut cmd,
+            true,
+            Some("sm_100a"),
+            &MaterializationMode::default(),
+        );
 
         assert_eq!(
             command_env(&cmd, "CUDA_OXIDE_TARGET").as_deref(),
@@ -4938,10 +5488,38 @@ MY_BUILD_FLAG = "configured"
     }
 
     #[test]
+    fn materialization_forces_nvvm_ir_and_exact_provenance_handshake() {
+        let mut cmd = Command::new("cargo");
+        let materialization = MaterializationMode {
+            provenance: Some("42".repeat(32)),
+        };
+
+        apply_output_mode(&mut cmd, false, Some("sm_90"), &materialization);
+
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_EMIT_NVVM_IR").as_deref(),
+            Some("1")
+        );
+        assert_eq!(command_env(&cmd, MATERIALIZE_ENV).as_deref(), Some("1"));
+        assert_eq!(
+            command_env(&cmd, EXPECTED_PROVENANCE_ENV).as_deref(),
+            Some("4242424242424242424242424242424242424242424242424242424242424242")
+        );
+        assert_eq!(
+            fingerprinted_codegen_cfgs("base=\"hash\"".to_string(), &materialization),
+            [
+                "base=\"hash\"".to_string(),
+                "cuda_oxide_internal_materializer_provenance=\"4242424242424242424242424242424242424242424242424242424242424242\""
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn apply_output_mode_leaves_auto_detect_ptx_unset() {
         let mut cmd = Command::new("cargo");
 
-        apply_output_mode(&mut cmd, false, None);
+        apply_output_mode(&mut cmd, false, None, &MaterializationMode::default());
 
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_TARGET"), None);
         assert_eq!(command_env(&cmd, "CUDA_OXIDE_EMIT_NVVM_IR"), None);
@@ -4985,7 +5563,7 @@ MY_BUILD_FLAG = "configured"
     fn debug_output_mode_forwards_detected_gpu_hint() {
         let mut cmd = Command::new("cargo");
 
-        apply_output_mode(&mut cmd, false, None);
+        apply_output_mode(&mut cmd, false, None, &MaterializationMode::default());
         apply_device_arch_hint(&mut cmd, None, Some("sm_120a"));
 
         assert_eq!(
@@ -5000,7 +5578,12 @@ MY_BUILD_FLAG = "configured"
     fn debug_output_mode_honors_explicit_arch_override() {
         let mut cmd = Command::new("cargo");
 
-        apply_output_mode(&mut cmd, false, Some("sm_90"));
+        apply_output_mode(
+            &mut cmd,
+            false,
+            Some("sm_90"),
+            &MaterializationMode::default(),
+        );
         apply_device_arch_hint(&mut cmd, Some("sm_90"), Some("sm_120a"));
 
         assert_eq!(

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -23,7 +23,7 @@
 //! cargo oxide setup                   # explicitly build/install backend
 //! ```
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use std::path::PathBuf;
 
 mod backend;
@@ -42,6 +42,11 @@ mod commands;
     version
 )]
 struct Cli {
+    /// Compile embedded NVVM IR to a target-specific cubin during the build.
+    /// Requires an explicit/configured architecture and exact CUDA-tool
+    /// provenance. The final binary then does not need libNVVM or nvJitLink.
+    #[arg(long, global = true)]
+    materialize_cubin: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -49,6 +54,10 @@ struct Cli {
 /// Available subcommands for `cargo oxide`.
 #[derive(Subcommand)]
 enum Commands {
+    /// Internal helper: discover exact CUDA compiler provenance in the same
+    /// startup environment that will be given to Cargo/rustc.
+    #[command(name = "__materializer-provenance", hide = true)]
+    MaterializerProvenance,
     /// Build and run an example or project
     Run {
         /// Example name (required in workspace, optional for standalone projects)
@@ -291,6 +300,60 @@ fn use_build_passthrough(
         || has_cargo_args
 }
 
+fn validate_materialization_cli(cli: &Cli) -> Result<(), String> {
+    if !cli.materialize_cubin {
+        return Ok(());
+    }
+
+    match &cli.command {
+        Commands::Run {
+            emit_nvvm_ir: true,
+            ..
+        }
+        | Commands::Build {
+            emit_nvvm_ir: true,
+            ..
+        }
+        | Commands::Pipeline {
+            emit_nvvm_ir: true,
+            ..
+        } => Err(
+            "--materialize-cubin cannot be combined with --emit-nvvm-ir; one requests a final cubin and the other requests NVVM IR"
+                .to_string(),
+        ),
+        Commands::Run { .. }
+        | Commands::Sanitize { .. }
+        | Commands::Build { .. }
+        | Commands::Test { .. }
+        | Commands::Pipeline { .. }
+        | Commands::Debug { .. } => Ok(()),
+        Commands::EmitLtoir { .. } => Err(
+            "--materialize-cubin cannot be combined with emit-ltoir; one emits a final cubin and the other emits linkable LTOIR"
+                .to_string(),
+        ),
+        Commands::Fmt { .. } => Err(
+            "--materialize-cubin cannot be used with fmt because fmt does not compile device code"
+                .to_string(),
+        ),
+        Commands::New { .. } => Err(
+            "--materialize-cubin cannot be used with new because new does not compile device code"
+                .to_string(),
+        ),
+        Commands::Doctor => Err(
+            "--materialize-cubin cannot be used with doctor because doctor does not compile device code"
+                .to_string(),
+        ),
+        Commands::Setup => Err(
+            "--materialize-cubin cannot be used with setup because setup only builds the codegen backend"
+                .to_string(),
+        ),
+        Commands::MaterializerProvenance => Err(
+            "--materialize-cubin cannot be passed to the internal materializer discovery helper"
+                .to_string(),
+        ),
+    }
+}
+
 fn main() {
     // Handle both invocation methods:
     // 1. Cargo subcommand: `cargo oxide run vecadd` → argv = ["cargo-oxide", "oxide", "run", "vecadd"]
@@ -306,8 +369,17 @@ fn main() {
 
     let explicit_passthrough = has_passthrough_separator(&effective_args);
     let cli = Cli::parse_from(effective_args);
+    if let Err(error) = validate_materialization_cli(&cli) {
+        Cli::command()
+            .error(ErrorKind::ArgumentConflict, error)
+            .exit();
+    }
+    let materialize_cubin = cli.materialize_cubin;
 
     match cli.command {
+        Commands::MaterializerProvenance => {
+            commands::print_materializer_provenance();
+        }
         Commands::Run {
             example,
             emit_nvvm_ir,
@@ -319,7 +391,13 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "run");
-            validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
+            validate_output_arch(
+                &ctx,
+                &example,
+                emit_nvvm_ir,
+                materialize_cubin,
+                arch.as_deref(),
+            );
             commands::codegen_run(
                 &ctx,
                 &example,
@@ -329,6 +407,7 @@ fn main() {
                 features.as_deref(),
                 bin.as_deref(),
                 no_fmad,
+                materialize_cubin,
             );
         }
         Commands::Sanitize {
@@ -343,6 +422,7 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "sanitize");
+            validate_output_arch(&ctx, &example, false, materialize_cubin, arch.as_deref());
             let (sanitizer_args, application_args) =
                 split_sanitizer_and_application_args(&sanitizer_args);
             commands::codegen_sanitize(
@@ -356,6 +436,7 @@ fn main() {
                 features.as_deref(),
                 bin.as_deref(),
                 no_fmad,
+                materialize_cubin,
             );
         }
         Commands::Build {
@@ -380,7 +461,13 @@ fn main() {
             );
             if !passthrough {
                 let example = resolve_example_name(example, &ctx, "build");
-                validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
+                validate_output_arch(
+                    &ctx,
+                    &example,
+                    emit_nvvm_ir,
+                    materialize_cubin,
+                    arch.as_deref(),
+                );
                 commands::codegen_build(
                     &ctx,
                     &example,
@@ -389,6 +476,7 @@ fn main() {
                     arch.as_deref(),
                     features.as_deref(),
                     no_fmad,
+                    materialize_cubin,
                 );
             } else {
                 if example.is_some() {
@@ -397,7 +485,13 @@ fn main() {
                     );
                     std::process::exit(2);
                 }
-                validate_nvvm_ir_arch(&ctx, "cargo build", emit_nvvm_ir, arch.as_deref());
+                validate_output_arch(
+                    &ctx,
+                    "cargo build",
+                    emit_nvvm_ir,
+                    materialize_cubin,
+                    arch.as_deref(),
+                );
                 commands::codegen_cargo_passthrough(
                     &ctx,
                     commands::CargoPassthroughSubcommand::Build,
@@ -410,6 +504,7 @@ fn main() {
                         device_codegen_crate: device_codegen_crate.as_deref(),
                         device_cfgs: &device_cfgs,
                         no_fmad,
+                        materialize_cubin,
                     },
                     &cargo_args,
                 );
@@ -424,6 +519,13 @@ fn main() {
             cargo_args,
         } => {
             let ctx = commands::resolve_context();
+            validate_output_arch(
+                &ctx,
+                "cargo test",
+                false,
+                materialize_cubin,
+                arch.as_deref(),
+            );
             commands::codegen_cargo_passthrough(
                 &ctx,
                 commands::CargoPassthroughSubcommand::Test,
@@ -436,6 +538,7 @@ fn main() {
                     device_codegen_crate: device_codegen_crate.as_deref(),
                     device_cfgs: &device_cfgs,
                     no_fmad: false,
+                    materialize_cubin,
                 },
                 &cargo_args,
             );
@@ -468,8 +571,21 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "pipeline");
-            validate_nvvm_ir_arch(&ctx, &example, emit_nvvm_ir, arch.as_deref());
-            commands::codegen_show_pipeline(&ctx, &example, emit_nvvm_ir, arch.as_deref(), no_fmad);
+            validate_output_arch(
+                &ctx,
+                &example,
+                emit_nvvm_ir,
+                materialize_cubin,
+                arch.as_deref(),
+            );
+            commands::codegen_show_pipeline(
+                &ctx,
+                &example,
+                emit_nvvm_ir,
+                arch.as_deref(),
+                no_fmad,
+                materialize_cubin,
+            );
         }
         Commands::Debug {
             example,
@@ -481,6 +597,7 @@ fn main() {
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "debug");
+            validate_output_arch(&ctx, &example, false, materialize_cubin, arch.as_deref());
             commands::codegen_debug(
                 &ctx,
                 &example,
@@ -489,6 +606,7 @@ fn main() {
                 bin.as_deref(),
                 cgdb,
                 tui,
+                materialize_cubin,
             );
         }
         Commands::Fmt { check } => {
@@ -541,14 +659,20 @@ fn resolve_example_name(name: Option<String>, ctx: &commands::Context, subcomman
 ///
 /// NVVM IR output is architecture-specific, so omitting every target source
 /// would produce an unusable artifact. Exits with a descriptive error.
-fn validate_nvvm_ir_arch(
+fn validate_output_arch(
     ctx: &commands::Context,
     example: &str,
     emit_nvvm_ir: bool,
+    materialize_cubin: bool,
     arch: Option<&str>,
 ) {
-    if emit_nvvm_ir && !commands::has_configured_arch(ctx, arch) {
-        eprintln!("Error: --emit-nvvm-ir requires a target architecture");
+    if (emit_nvvm_ir || materialize_cubin) && !commands::has_configured_arch(ctx, arch) {
+        let option = if materialize_cubin {
+            "--materialize-cubin"
+        } else {
+            "--emit-nvvm-ir"
+        };
+        eprintln!("Error: {option} requires a target architecture");
         eprintln!();
         eprintln!("NVVM IR output is architecture-specific. Pass --arch, set");
         eprintln!("CUDA_OXIDE_TARGET, or configure default-arch. For example:");
@@ -556,7 +680,7 @@ fn validate_nvvm_ir_arch(
         eprintln!("  --arch sm_100    Blackwell");
         eprintln!();
         eprintln!("Example:");
-        eprintln!("  cargo oxide run {} --emit-nvvm-ir --arch sm_120", example);
+        eprintln!("  cargo oxide run {example} {option} --arch sm_120");
         std::process::exit(1);
     }
 }
@@ -600,6 +724,74 @@ mod tests {
             cargo_args,
             strings(&["-p", "gpu-app", "--test", "smoke", "--", "--nocapture"])
         );
+    }
+
+    #[test]
+    fn materialize_cubin_is_a_global_codegen_option() {
+        let after_subcommand = Cli::try_parse_from([
+            "cargo-oxide",
+            "build",
+            "demo",
+            "--materialize-cubin",
+            "--arch",
+            "sm_90",
+        ])
+        .unwrap();
+        assert!(after_subcommand.materialize_cubin);
+        assert!(validate_materialization_cli(&after_subcommand).is_ok());
+
+        let before_subcommand = Cli::try_parse_from([
+            "cargo-oxide",
+            "--materialize-cubin",
+            "test",
+            "--arch",
+            "sm_90",
+        ])
+        .unwrap();
+        assert!(before_subcommand.materialize_cubin);
+        assert!(validate_materialization_cli(&before_subcommand).is_ok());
+    }
+
+    #[test]
+    fn materialize_cubin_rejects_non_codegen_subcommands() {
+        for args in [
+            &["cargo-oxide", "fmt", "--materialize-cubin"][..],
+            &["cargo-oxide", "new", "demo", "--materialize-cubin"],
+            &["cargo-oxide", "doctor", "--materialize-cubin"],
+            &["cargo-oxide", "setup", "--materialize-cubin"],
+            &[
+                "cargo-oxide",
+                "emit-ltoir",
+                "demo",
+                "--arch",
+                "sm_90",
+                "--materialize-cubin",
+            ],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("global flag should parse first");
+            let error = validate_materialization_cli(&cli)
+                .expect_err("materialization must be rejected for this subcommand");
+            assert!(error.contains("--materialize-cubin"), "{error}");
+        }
+    }
+
+    #[test]
+    fn materialize_cubin_rejects_explicit_nvvm_ir_output() {
+        for subcommand in ["run", "build", "pipeline"] {
+            let cli = Cli::try_parse_from([
+                "cargo-oxide",
+                subcommand,
+                "demo",
+                "--emit-nvvm-ir",
+                "--materialize-cubin",
+                "--arch",
+                "sm_90",
+            ])
+            .unwrap();
+            let error = validate_materialization_cli(&cli)
+                .expect_err("two distinct final output modes must conflict");
+            assert!(error.contains("cannot be combined with --emit-nvvm-ir"));
+        }
     }
 
     #[test]

--- a/crates/cuda-artifact-finalizer/Cargo.toml
+++ b/crates/cuda-artifact-finalizer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+edition.workspace = true
+description = "Driver-independent NVVM IR and LTOIR finalization for cuda-oxide"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+libnvvm-sys = { workspace = true }
+nvjitlink-sys = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -1,0 +1,304 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Driver-independent CUDA artifact finalization.
+//!
+//! This crate is the single owner of cuda-oxide's libNVVM and nvJitLink
+//! compilation policy. It deliberately does not link the CUDA Driver. Both
+//! build-time materialization and runtime fallback use the same typed target,
+//! FMA, debug, input-order, validation, and provenance rules.
+
+mod link;
+mod nvvm;
+mod options;
+mod provenance;
+mod validation;
+
+pub use libnvvm_sys::{CudaArch, CudaArchParseError, LibdeviceNotFound, NvvmError, find_libdevice};
+pub use link::LtoLinker;
+pub use nvjitlink_sys::NvJitLinkError;
+pub use nvvm::NvvmCompiler;
+pub use options::{DebugPolicy, FinalizationOptions, FinalizerOutput, NamedInput};
+pub use provenance::{ToolProvenance, recipe_digest};
+pub use validation::is_valid_cubin;
+
+use provenance::common_provenance_digest;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Failures while compiling NVVM IR or linking LTOIR.
+#[derive(Debug, Error)]
+pub enum FinalizerError {
+    /// libNVVM failed to load, validate, or compile.
+    #[error("libnvvm: {0}")]
+    Nvvm(#[from] libnvvm_sys::NvvmError),
+
+    /// nvJitLink failed to load or link.
+    #[error("nvJitLink: {0}")]
+    NvJitLink(#[from] nvjitlink_sys::NvJitLinkError),
+
+    /// `libdevice.10.bc` could not be found.
+    #[error(
+        "Could not locate libdevice.10.bc. Set CUDA_OXIDE_LIBDEVICE, CUDA_TOOLKIT_PATH, or CUDA_HOME, or install the CUDA Toolkit. Tried:\n  {tried}"
+    )]
+    LibdeviceNotFound {
+        /// Newline-separated discovery paths.
+        tried: String,
+    },
+
+    /// A finalizer input could not be read.
+    #[error("Failed reading {path}: {source}")]
+    Io {
+        /// Path that could not be read.
+        path: PathBuf,
+        /// Underlying filesystem failure.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The installed toolkit does not accept cuda-oxide's NVVM IR version.
+    #[error("installed libNVVM accepts NVVM IR {major}.{minor}, but cuda-oxide emits NVVM IR 2.0")]
+    UnsupportedNvvmIrVersion { major: i32, minor: i32 },
+
+    /// Runtime toolkit dialect discovery disagreed with the target policy.
+    #[error(
+        "libNVVM reports LLVM {llvm_major} for {target}, which disagrees with cuda-oxide's expected {expected} dialect"
+    )]
+    DialectMismatch {
+        target: String,
+        llvm_major: i32,
+        expected: &'static str,
+    },
+
+    /// A diagnostic input name cannot be represented by the CUDA C APIs.
+    #[error("CUDA artifact input name contains an interior NUL byte: {name:?}")]
+    InvalidInputName { name: String },
+
+    /// A supplied compiler or linker input contained no bytes.
+    #[error("CUDA artifact input is empty: {name}")]
+    EmptyInput { name: String },
+
+    /// nvJitLink was invoked without an input module.
+    #[error("at least one ordered LTOIR input is required")]
+    NoLinkInputs,
+
+    /// nvJitLink returned bytes that are not a complete CUDA ELF image.
+    #[error("nvJitLink returned an invalid or truncated cubin")]
+    InvalidCubin,
+
+    /// nvJitLink returned no PTX bytes.
+    #[error("nvJitLink returned an empty PTX artifact")]
+    EmptyPtx,
+
+    /// A pinned CUDA compiler DSO changed around an operation. Its output can
+    /// no longer be attributed to the provenance used by Cargo or a cache key.
+    #[error(
+        "the pinned {tool} file changed before or during CUDA artifact finalization; refusing the unverified output"
+    )]
+    ToolIdentityChanged { tool: &'static str },
+}
+
+/// Complete NVVM IR to cubin/PTX finalizer.
+#[derive(Clone)]
+pub struct Finalizer {
+    compiler: NvvmCompiler,
+    linker: LtoLinker,
+}
+
+impl Finalizer {
+    /// Discover libNVVM, libdevice, and nvJitLink without loading the Driver.
+    pub fn discover() -> Result<Self, FinalizerError> {
+        Ok(Self {
+            compiler: NvvmCompiler::discover()?,
+            linker: LtoLinker::discover()?,
+        })
+    }
+
+    /// Compile one NVVM IR module and return a validated target-specific cubin.
+    pub fn materialize_nvvm_ir(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        options: &FinalizationOptions,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        let ltoir = self
+            .compiler
+            .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
+        let ltoir_name = format!("{module_name}.ltoir");
+        self.linker.link_ltoir(
+            &[NamedInput::new(&ltoir_name, &ltoir)],
+            options,
+            FinalizerOutput::Cubin,
+        )
+    }
+
+    /// Link ordered LTOIR modules to cubin or PTX.
+    pub fn link_ltoir(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        self.linker.link_ltoir(inputs, options, output)
+    }
+
+    /// Compiler component, including exact libdevice bytes and provenance.
+    pub fn compiler(&self) -> &NvvmCompiler {
+        &self.compiler
+    }
+
+    /// Ordered LTOIR linker component.
+    pub fn linker(&self) -> &LtoLinker {
+        &self.linker
+    }
+
+    /// Exact discovered tool and libdevice digests.
+    pub fn provenance(&self) -> ToolProvenance {
+        ToolProvenance {
+            libnvvm_sha256: self.compiler.libnvvm_digest(),
+            nvjitlink_sha256: self.linker.nvjitlink_digest(),
+            libdevice_sha256: self.compiler.libdevice_digest(),
+        }
+    }
+
+    /// Exact full-pipeline provenance, or `None` if a loaded DSO is unknown.
+    pub fn provenance_digest(&self) -> Option<[u8; 32]> {
+        let provenance = self.provenance();
+        Some(common_provenance_digest(
+            &provenance.libnvvm_sha256?,
+            &provenance.nvjitlink_sha256?,
+            &provenance.libdevice_sha256,
+        ))
+    }
+
+    /// Digest the full NVVM IR to output recipe, including ordered options.
+    pub fn nvvm_ir_artifact_digest(
+        &self,
+        module_name: &str,
+        ltoir_module_name: &str,
+        nvvm_ir: &[u8],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
+        nvvm_ir_artifact_digest_with_provenance(
+            module_name,
+            ltoir_module_name,
+            nvvm_ir,
+            options,
+            output,
+            self.provenance(),
+        )
+    }
+}
+
+/// Digest a complete finalization plan from already-established provenance.
+///
+/// This is useful to fingerprint Cargo work before executing the plan. It
+/// returns `None` unless both loaded tool identities are exact.
+pub fn nvvm_ir_artifact_digest_with_provenance(
+    module_name: &str,
+    ltoir_module_name: &str,
+    nvvm_ir: &[u8],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    provenance: ToolProvenance,
+) -> Option<[u8; 32]> {
+    let compiler_digest = nvvm::nvvm_ir_artifact_digest_parts(
+        module_name,
+        nvvm_ir,
+        options,
+        &provenance.libdevice_sha256,
+        &provenance.libnvvm_sha256?,
+    );
+    let linker_digest = link::ltoir_artifact_digest_parts(
+        &[NamedInput::new(ltoir_module_name, &compiler_digest)],
+        options,
+        output,
+        &provenance.nvjitlink_sha256?,
+    );
+    Some(
+        provenance::StableDigest::new()
+            .field("recipe", recipe_digest())
+            .field("route", b"nvvm-ir-to-final-output")
+            .field("compiler-plan", compiler_digest)
+            .field("linker-plan", linker_digest)
+            .finish(),
+    )
+}
+
+/// Digest an ordered LTOIR link from an established exact linker identity.
+pub fn ltoir_artifact_digest_with_provenance(
+    inputs: &[NamedInput<'_>],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    nvjitlink_sha256: &[u8; 32],
+) -> [u8; 32] {
+    link::ltoir_artifact_digest_parts(inputs, options, output, nvjitlink_sha256)
+}
+
+fn validate_name(name: &str) -> Result<(), FinalizerError> {
+    if name.as_bytes().contains(&0) {
+        Err(FinalizerError::InvalidInputName {
+            name: name.to_string(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod live_tests {
+    use super::*;
+
+    const LEGACY_NVVM_IR: &[u8] = br#"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+define void @kernel() {
+entry:
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!nvvmir.version = !{!1}
+!0 = !{void ()* @kernel, !"kernel", i32 1}
+!1 = !{i32 2, i32 0, i32 3, i32 1}
+"#;
+
+    #[test]
+    #[ignore = "requires discoverable CUDA Toolkit libNVVM, nvJitLink, and libdevice"]
+    fn live_pipeline_emits_valid_cubin_and_ptx_for_both_fma_policies() {
+        let finalizer = Finalizer::discover().unwrap();
+        assert!(finalizer.provenance_digest().is_some());
+        let target: CudaArch = "sm_86".parse().unwrap();
+
+        for (allow_fma, debug) in [
+            (false, DebugPolicy::None),
+            (false, DebugPolicy::LineTables),
+            (true, DebugPolicy::Full),
+        ] {
+            let options = FinalizationOptions::new(target.clone())
+                .with_fma_contraction(allow_fma)
+                .with_debug_policy(debug);
+            let ltoir = finalizer
+                .compiler()
+                .compile_nvvm_ir_to_ltoir("kernel.ll", LEGACY_NVVM_IR, &options)
+                .unwrap();
+            assert!(!ltoir.is_empty());
+            let input = [NamedInput::new("kernel.ltoir", &ltoir)];
+            let cubin = finalizer
+                .link_ltoir(&input, &options, FinalizerOutput::Cubin)
+                .unwrap();
+            assert!(is_valid_cubin(&cubin));
+            let ptx = finalizer
+                .link_ltoir(&input, &options, FinalizerOutput::Ptx)
+                .unwrap();
+            assert!(
+                ptx.windows(b".version".len())
+                    .any(|part| part == b".version")
+            );
+        }
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/link.rs
+++ b/crates/cuda-artifact-finalizer/src/link.rs
@@ -1,0 +1,260 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::nvvm::{loaded_tool_digest, report_changed_tool};
+use crate::options::{FinalizationOptions, FinalizerOutput, NamedInput};
+use crate::provenance::{
+    StableDigest, digest_file_handle, linker_provenance_digest, recipe_digest,
+    with_revalidated_tool_identity,
+};
+use crate::validation::is_valid_cubin;
+use crate::{FinalizerError, validate_name};
+use nvjitlink_sys::{InputType, LibNvJitLink, Linker};
+use std::sync::{Arc, Mutex, OnceLock};
+
+struct LoadedLinkerTool {
+    library: Arc<LibNvJitLink>,
+    digest: Option<[u8; 32]>,
+}
+
+static LINKER_TOOL: OnceLock<Arc<LoadedLinkerTool>> = OnceLock::new();
+static LINKER_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Driver-independent ordered LTOIR linker.
+#[derive(Clone)]
+pub struct LtoLinker {
+    tool: Arc<LoadedLinkerTool>,
+}
+
+impl LtoLinker {
+    /// Discover and pin nvJitLink without loading libNVVM or the CUDA Driver.
+    pub fn discover() -> Result<Self, FinalizerError> {
+        Ok(Self {
+            tool: load_linker_tool()?,
+        })
+    }
+
+    /// Digest of the exact loaded nvJitLink file, when its identity is known.
+    pub fn nvjitlink_digest(&self) -> Option<[u8; 32]> {
+        let digest = self.tool.digest?;
+        if self.tool.library.loaded_file_if_unchanged().is_some() {
+            Some(digest)
+        } else {
+            report_changed_tool("nvJitLink");
+            None
+        }
+    }
+
+    /// Exact route provenance, or `None` when the loaded DSO is unidentifiable.
+    pub fn provenance_digest(&self) -> Option<[u8; 32]> {
+        self.nvjitlink_digest()
+            .map(|digest| linker_provenance_digest(&digest))
+    }
+
+    /// Link one or more LTOIR modules in the exact supplied order.
+    pub fn link_ltoir(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        validate_inputs(inputs)?;
+        with_revalidated_tool_identity(
+            "nvJitLink",
+            self.tool.digest,
+            || current_linker_tool_digest(&self.tool),
+            || {
+                let option_storage = options.nvjitlink_options(output);
+                let option_refs = option_storage
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>();
+                let mut linker = Linker::new(&self.tool.library, &option_refs)?;
+                for input in inputs {
+                    linker.add(InputType::Ltoir, input.bytes, input.name)?;
+                }
+                let image = match output {
+                    FinalizerOutput::Cubin => linker.finish()?,
+                    FinalizerOutput::Ptx => linker.finish_ptx()?,
+                };
+                if output == FinalizerOutput::Cubin && !is_valid_cubin(&image) {
+                    return Err(FinalizerError::InvalidCubin);
+                }
+                if output == FinalizerOutput::Ptx && image.is_empty() {
+                    return Err(FinalizerError::EmptyPtx);
+                }
+                Ok(image)
+            },
+        )
+    }
+
+    /// Digest every semantic input to an ordered LTOIR link.
+    pub fn artifact_digest(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
+        let nvjitlink = self.nvjitlink_digest()?;
+        Some(ltoir_artifact_digest_parts(
+            inputs, options, output, &nvjitlink,
+        ))
+    }
+}
+
+fn current_linker_tool_digest(tool: &LoadedLinkerTool) -> Option<[u8; 32]> {
+    let file = tool.library.loaded_file_if_unchanged()?;
+    digest_file_handle(file).ok()
+}
+
+fn validate_inputs(inputs: &[NamedInput<'_>]) -> Result<(), FinalizerError> {
+    if inputs.is_empty() {
+        return Err(FinalizerError::NoLinkInputs);
+    }
+    for input in inputs {
+        validate_name(input.name)?;
+        if input.bytes.is_empty() {
+            return Err(FinalizerError::EmptyInput {
+                name: input.name.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn load_linker_tool() -> Result<Arc<LoadedLinkerTool>, FinalizerError> {
+    if let Some(loaded) = LINKER_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+    let _guard = LINKER_TOOL_LOAD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(loaded) = LINKER_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+
+    let library = LibNvJitLink::load_for_cache()?;
+    let digest = loaded_tool_digest("nvJitLink", library.loaded_file_if_unchanged());
+    let digest = if digest.is_some() && library.loaded_file_if_unchanged().is_none() {
+        report_changed_tool("nvJitLink");
+        None
+    } else {
+        digest
+    };
+    let loaded = Arc::new(LoadedLinkerTool {
+        library: Arc::new(library),
+        digest,
+    });
+    let _ = LINKER_TOOL.set(Arc::clone(&loaded));
+    Ok(loaded)
+}
+
+pub(crate) fn ltoir_artifact_digest_parts(
+    inputs: &[NamedInput<'_>],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    nvjitlink_digest: &[u8; 32],
+) -> [u8; 32] {
+    let output_name = match output {
+        FinalizerOutput::Cubin => b"elf-cubin".as_slice(),
+        FinalizerOutput::Ptx => b"ptx".as_slice(),
+    };
+    let mut digest = StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("route", b"ltoir-to-output")
+        .field("output", output_name);
+    for input in inputs {
+        digest = digest
+            .field("ltoir-name", input.name.as_bytes())
+            .field("ltoir", input.bytes);
+    }
+    for option in options.nvjitlink_options(output) {
+        digest = digest.field("nvjitlink-option", option.as_bytes());
+    }
+    digest
+        .field("libnvjitlink-sha256", nvjitlink_digest)
+        .finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_digest_preserves_input_order_names_output_and_policy() {
+        let options = FinalizationOptions::new("sm_120".parse().unwrap());
+        let a = NamedInput::new("a.ltoir", b"a");
+        let b = NamedInput::new("b.ltoir", b"b");
+        let baseline =
+            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[7; 32]);
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(&[b, a], &options, FinalizerOutput::Cubin, &[7; 32])
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &[NamedInput::new("renamed.ltoir", b"a"), b],
+                &options,
+                FinalizerOutput::Cubin,
+                &[7; 32]
+            )
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &[a, b],
+                &FinalizationOptions::new("sm_90".parse().unwrap()),
+                FinalizerOutput::Cubin,
+                &[7; 32]
+            )
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &[a, b],
+                &options
+                    .clone()
+                    .with_debug_policy(crate::DebugPolicy::LineTables),
+                FinalizerOutput::Cubin,
+                &[7; 32]
+            )
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[8; 32])
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Ptx, &[7; 32])
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &[a, b],
+                &options.clone().with_fma_contraction(false),
+                FinalizerOutput::Cubin,
+                &[7; 32]
+            )
+        );
+    }
+
+    #[test]
+    fn input_validation_rejects_zero_inputs_empty_data_and_nul_names() {
+        assert!(matches!(
+            validate_inputs(&[]),
+            Err(FinalizerError::NoLinkInputs)
+        ));
+        assert!(matches!(
+            validate_inputs(&[NamedInput::new("empty", b"")]),
+            Err(FinalizerError::EmptyInput { .. })
+        ));
+        assert!(matches!(
+            validate_inputs(&[NamedInput::new("bad\0name", b"x")]),
+            Err(FinalizerError::InvalidInputName { .. })
+        ));
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/nvvm.rs
+++ b/crates/cuda-artifact-finalizer/src/nvvm.rs
@@ -1,0 +1,300 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::options::FinalizationOptions;
+use crate::provenance::{
+    StableDigest, compiler_provenance_digest, digest_bytes, digest_file_handle, recipe_digest,
+    with_revalidated_tool_identity,
+};
+use crate::{FinalizerError, validate_name};
+use libnvvm_sys::{LibNvvm, Program, find_libdevice};
+use std::sync::{Arc, Mutex, OnceLock};
+
+struct LoadedNvvmTool {
+    library: Arc<LibNvvm>,
+    digest: Option<[u8; 32]>,
+}
+
+static NVVM_TOOL: OnceLock<Arc<LoadedNvvmTool>> = OnceLock::new();
+static NVVM_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Driver-independent libNVVM compiler with exact libdevice provenance.
+#[derive(Clone)]
+pub struct NvvmCompiler {
+    tool: Arc<LoadedNvvmTool>,
+    libdevice: Arc<[u8]>,
+    libdevice_digest: [u8; 32],
+}
+
+impl NvvmCompiler {
+    /// Discover and pin libNVVM, then read the selected libdevice bytes.
+    pub fn discover() -> Result<Self, FinalizerError> {
+        let path = find_libdevice().map_err(|libnvvm_sys::LibdeviceNotFound { tried }| {
+            FinalizerError::LibdeviceNotFound { tried }
+        })?;
+        let libdevice = std::fs::read(&path).map_err(|source| FinalizerError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let libdevice_digest = digest_bytes(&libdevice);
+        Ok(Self {
+            tool: load_nvvm_tool()?,
+            libdevice: libdevice.into(),
+            libdevice_digest,
+        })
+    }
+
+    /// Digest of the exact loaded libNVVM file, when its identity is known.
+    pub fn libnvvm_digest(&self) -> Option<[u8; 32]> {
+        let digest = self.tool.digest?;
+        if self.tool.library.loaded_file_if_unchanged().is_some() {
+            Some(digest)
+        } else {
+            report_changed_tool("libNVVM");
+            None
+        }
+    }
+
+    /// Digest of the exact libdevice bytes that will be compiled.
+    pub fn libdevice_digest(&self) -> [u8; 32] {
+        self.libdevice_digest
+    }
+
+    /// Exact route provenance, or `None` when the loaded DSO is unidentifiable.
+    pub fn provenance_digest(&self) -> Option<[u8; 32]> {
+        self.libnvvm_digest()
+            .map(|digest| compiler_provenance_digest(&digest, &self.libdevice_digest))
+    }
+
+    /// Compile one NVVM IR module plus libdevice into LTOIR.
+    pub fn compile_nvvm_ir_to_ltoir(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        options: &FinalizationOptions,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        validate_name(module_name)?;
+        if nvvm_ir.is_empty() {
+            return Err(FinalizerError::EmptyInput {
+                name: module_name.to_string(),
+            });
+        }
+        with_revalidated_tool_identity(
+            "libNVVM",
+            self.tool.digest,
+            || current_nvvm_tool_digest(&self.tool),
+            || {
+                validate_nvvm_frontend(&self.tool.library, options)?;
+
+                let mut program = Program::new(&self.tool.library)?;
+                // libdevice must precede user IR so the plan, diagnostics, and
+                // provenance all use one deterministic module order.
+                program.add_module(&self.libdevice, "libdevice.10.bc")?;
+                program.add_module(nvvm_ir, module_name)?;
+
+                let verify = options.nvvm_verify_options();
+                let verify_refs = verify.iter().map(String::as_str).collect::<Vec<_>>();
+                program.verify(&verify_refs)?;
+                let compile = options.nvvm_compile_options();
+                let compile_refs = compile.iter().map(String::as_str).collect::<Vec<_>>();
+                Ok(program.compile(&compile_refs)?)
+            },
+        )
+    }
+
+    /// Digest every semantic input to the NVVM IR to LTOIR stage.
+    pub fn artifact_digest(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        options: &FinalizationOptions,
+    ) -> Option<[u8; 32]> {
+        let libnvvm = self.libnvvm_digest()?;
+        Some(nvvm_ir_artifact_digest_parts(
+            module_name,
+            nvvm_ir,
+            options,
+            &self.libdevice_digest,
+            &libnvvm,
+        ))
+    }
+}
+
+fn current_nvvm_tool_digest(tool: &LoadedNvvmTool) -> Option<[u8; 32]> {
+    let file = tool.library.loaded_file_if_unchanged()?;
+    digest_file_handle(file).ok()
+}
+
+fn validate_nvvm_frontend(
+    nvvm: &LibNvvm,
+    options: &FinalizationOptions,
+) -> Result<(), FinalizerError> {
+    let ir_version = nvvm.ir_version()?;
+    if (ir_version.ir_major, ir_version.ir_minor) != (2, 0) {
+        return Err(FinalizerError::UnsupportedNvvmIrVersion {
+            major: ir_version.ir_major,
+            minor: ir_version.ir_minor,
+        });
+    }
+    let arch = options.target();
+    if let Some(llvm_major) = nvvm.llvm_version(arch)? {
+        let mismatch = if arch.uses_legacy_llvm() {
+            llvm_major != 7
+        } else {
+            llvm_major == 7
+        };
+        if mismatch {
+            return Err(FinalizerError::DialectMismatch {
+                target: arch.compute(),
+                llvm_major,
+                expected: if arch.uses_legacy_llvm() {
+                    "legacy LLVM 7"
+                } else {
+                    "modern opaque-pointer"
+                },
+            });
+        }
+    }
+    Ok(())
+}
+
+fn load_nvvm_tool() -> Result<Arc<LoadedNvvmTool>, FinalizerError> {
+    if let Some(loaded) = NVVM_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+    let _guard = NVVM_TOOL_LOAD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(loaded) = NVVM_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+
+    let library = LibNvvm::load_for_cache()?;
+    let digest = loaded_tool_digest("libNVVM", library.loaded_file_if_unchanged());
+    let digest = if digest.is_some() && library.loaded_file_if_unchanged().is_none() {
+        report_changed_tool("libNVVM");
+        None
+    } else {
+        digest
+    };
+    let loaded = Arc::new(LoadedNvvmTool {
+        library: Arc::new(library),
+        digest,
+    });
+    let _ = NVVM_TOOL.set(Arc::clone(&loaded));
+    Ok(loaded)
+}
+
+pub(crate) fn loaded_tool_digest(label: &str, file: Option<&std::fs::File>) -> Option<[u8; 32]> {
+    let Some(file) = file else {
+        if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
+            eprintln!(
+                "cuda-oxide: {label} has no exact loaded-file identity; disabling artifact reuse"
+            );
+        }
+        return None;
+    };
+    match digest_file_handle(file) {
+        Ok(digest) => Some(digest),
+        Err(error) => {
+            if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
+                eprintln!(
+                    "cuda-oxide: could not fingerprint loaded {label} ({error}); disabling artifact reuse"
+                );
+            }
+            None
+        }
+    }
+}
+
+pub(crate) fn report_changed_tool(label: &str) {
+    if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
+        eprintln!(
+            "cuda-oxide: {label} changed while it was fingerprinted; disabling artifact reuse"
+        );
+    }
+}
+
+pub(crate) fn nvvm_ir_artifact_digest_parts(
+    module_name: &str,
+    nvvm_ir: &[u8],
+    options: &FinalizationOptions,
+    libdevice_digest: &[u8; 32],
+    libnvvm_digest: &[u8; 32],
+) -> [u8; 32] {
+    let mut digest = StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("route", b"nvvm-ir-to-ltoir")
+        .field("module-name", module_name.as_bytes())
+        .field("module", nvvm_ir)
+        .field("module-order", b"libdevice.10.bc,user-nvvm-ir")
+        .field("libdevice-sha256", libdevice_digest);
+    for option in options.nvvm_verify_options() {
+        digest = digest.field("nvvm-verify-option", option.as_bytes());
+    }
+    for option in options.nvvm_compile_options() {
+        digest = digest.field("nvvm-compile-option", option.as_bytes());
+    }
+    digest.field("libnvvm-sha256", libnvvm_digest).finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nvvm_digest_covers_module_name_bytes_options_and_libdevice() {
+        let options = FinalizationOptions::new("sm_90".parse().unwrap());
+        let baseline =
+            nvvm_ir_artifact_digest_parts("kernel.ll", b"ir", &options, &[1; 32], &[2; 32]);
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts("other.ll", b"ir", &options, &[1; 32], &[2; 32])
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts("kernel.ll", b"changed", &options, &[1; 32], &[2; 32])
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts(
+                "kernel.ll",
+                b"ir",
+                &options.clone().with_fma_contraction(false),
+                &[1; 32],
+                &[2; 32]
+            )
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts("kernel.ll", b"ir", &options, &[3; 32], &[2; 32])
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts("kernel.ll", b"ir", &options, &[1; 32], &[4; 32])
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts(
+                "kernel.ll",
+                b"ir",
+                &FinalizationOptions::new("sm_120".parse().unwrap()),
+                &[1; 32],
+                &[2; 32]
+            )
+        );
+        assert_ne!(
+            baseline,
+            nvvm_ir_artifact_digest_parts(
+                "kernel.ll",
+                b"ir",
+                &options.with_debug_policy(crate::DebugPolicy::Full),
+                &[1; 32],
+                &[2; 32]
+            )
+        );
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use libnvvm_sys::CudaArch;
+
+/// Amount of device debug information preserved during finalization.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum DebugPolicy {
+    /// Do not request debug information from the CUDA compiler tools.
+    #[default]
+    None,
+    /// Preserve source line mappings without disabling optimization.
+    LineTables,
+    /// Emit full debug information and disable libNVVM optimization.
+    Full,
+}
+
+/// Typed options shared by the libNVVM and nvJitLink stages.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FinalizationOptions {
+    target: CudaArch,
+    allow_fma_contraction: bool,
+    debug: DebugPolicy,
+}
+
+impl FinalizationOptions {
+    /// Start with cuda-oxide's ordinary optimized compilation policy.
+    pub fn new(target: CudaArch) -> Self {
+        Self {
+            target,
+            allow_fma_contraction: true,
+            debug: DebugPolicy::None,
+        }
+    }
+
+    /// Select whether multiply-add contraction is permitted.
+    #[must_use]
+    pub fn with_fma_contraction(mut self, allow: bool) -> Self {
+        self.allow_fma_contraction = allow;
+        self
+    }
+
+    /// Select the device debug-information policy.
+    #[must_use]
+    pub fn with_debug_policy(mut self, debug: DebugPolicy) -> Self {
+        self.debug = debug;
+        self
+    }
+
+    /// Concrete CUDA architecture used by both compiler stages.
+    pub fn target(&self) -> &CudaArch {
+        &self.target
+    }
+
+    /// Whether multiply-add contraction is permitted.
+    pub fn allow_fma_contraction(&self) -> bool {
+        self.allow_fma_contraction
+    }
+
+    /// Device debug-information policy.
+    pub fn debug_policy(&self) -> DebugPolicy {
+        self.debug
+    }
+
+    pub(crate) fn nvvm_verify_options(&self) -> Vec<String> {
+        vec![format!("-arch={}", self.target.compute())]
+    }
+
+    pub(crate) fn nvvm_compile_options(&self) -> Vec<String> {
+        let mut options = vec![
+            format!("-arch={}", self.target.compute()),
+            "-gen-lto".to_string(),
+            self.fma_option().to_string(),
+        ];
+        if self.debug == DebugPolicy::Full {
+            options.push("-g".to_string());
+            options.push("-opt=0".to_string());
+        }
+        options
+    }
+
+    pub(crate) fn nvjitlink_options(&self, output: FinalizerOutput) -> Vec<String> {
+        let mut options = vec![format!("-arch={}", self.target.sm()), "-lto".to_string()];
+        if output == FinalizerOutput::Ptx {
+            options.push("-ptx".to_string());
+        }
+        options.push(self.fma_option().to_string());
+        match self.debug {
+            DebugPolicy::None => {}
+            DebugPolicy::LineTables => options.push("-lineinfo".to_string()),
+            DebugPolicy::Full => options.push("-g".to_string()),
+        }
+        options
+    }
+
+    fn fma_option(&self) -> &'static str {
+        if self.allow_fma_contraction {
+            "-fma=1"
+        } else {
+            "-fma=0"
+        }
+    }
+}
+
+/// Final artifact requested from nvJitLink.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FinalizerOutput {
+    /// Native, target-specific CUDA ELF image.
+    Cubin,
+    /// Forward-compatible PTX assembly.
+    Ptx,
+}
+
+/// One named linker input. Slice order is preserved exactly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NamedInput<'a> {
+    /// Name shown by CUDA-tool diagnostics and included in provenance.
+    pub name: &'a str,
+    /// Complete LTOIR input bytes.
+    pub bytes: &'a [u8],
+}
+
+impl<'a> NamedInput<'a> {
+    /// Construct a named input without copying its bytes.
+    pub const fn new(name: &'a str, bytes: &'a [u8]) -> Self {
+        Self { name, bytes }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_order_preserves_target_lto_output_fma_and_debug_policy() {
+        let target: CudaArch = "sm_90a".parse().unwrap();
+        let base = FinalizationOptions::new(target).with_fma_contraction(false);
+
+        assert_eq!(
+            base.nvvm_compile_options(),
+            ["-arch=compute_90a", "-gen-lto", "-fma=0"]
+        );
+        assert_eq!(
+            base.nvjitlink_options(FinalizerOutput::Cubin),
+            ["-arch=sm_90a", "-lto", "-fma=0"]
+        );
+        assert_eq!(
+            base.clone()
+                .with_debug_policy(DebugPolicy::LineTables)
+                .nvjitlink_options(FinalizerOutput::Ptx),
+            ["-arch=sm_90a", "-lto", "-ptx", "-fma=0", "-lineinfo"]
+        );
+        assert_eq!(
+            base.clone()
+                .with_debug_policy(DebugPolicy::LineTables)
+                .nvvm_compile_options(),
+            ["-arch=compute_90a", "-gen-lto", "-fma=0"]
+        );
+        assert_eq!(
+            base.clone()
+                .with_debug_policy(DebugPolicy::Full)
+                .nvvm_compile_options(),
+            ["-arch=compute_90a", "-gen-lto", "-fma=0", "-g", "-opt=0"]
+        );
+        assert_eq!(
+            base.with_debug_policy(DebugPolicy::Full)
+                .nvjitlink_options(FinalizerOutput::Cubin),
+            ["-arch=sm_90a", "-lto", "-fma=0", "-g"]
+        );
+    }
+
+    #[test]
+    fn fma_policy_is_explicit_in_both_stages() {
+        let target: CudaArch = "sm_120".parse().unwrap();
+        for allow in [false, true] {
+            let options = FinalizationOptions::new(target.clone()).with_fma_contraction(allow);
+            let expected = if allow { "-fma=1" } else { "-fma=0" };
+            assert_eq!(
+                options
+                    .nvvm_compile_options()
+                    .iter()
+                    .filter(|option| option.starts_with("-fma="))
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                [expected]
+            );
+            assert_eq!(
+                options
+                    .nvjitlink_options(FinalizerOutput::Cubin)
+                    .iter()
+                    .filter(|option| option.starts_with("-fma="))
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                [expected]
+            );
+        }
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/provenance.rs
+++ b/crates/cuda-artifact-finalizer/src/provenance.rs
@@ -1,0 +1,384 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io;
+#[cfg(not(unix))]
+use std::io::{Read, Seek, SeekFrom};
+use std::time::SystemTime;
+
+use crate::FinalizerError;
+
+const DIGEST_DOMAIN: &[u8] = b"cuda-oxide/artifact-finalizer/digest/v1";
+// Bump this recipe version whenever tool invocation, option translation,
+// input ordering, output validation, or other output-affecting semantics
+// change. Cache keys and the cargo-oxide/backend handshake rely on it.
+const RECIPE: &[u8] = b"cuda-oxide/artifact-finalizer/recipe/v1";
+
+/// Exact compiler inputs discovered alongside the loaded CUDA tools.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ToolProvenance {
+    /// SHA-256 of the exact loaded libNVVM file, if it can be proven.
+    pub libnvvm_sha256: Option<[u8; 32]>,
+    /// SHA-256 of the exact loaded nvJitLink file, if it can be proven.
+    pub nvjitlink_sha256: Option<[u8; 32]>,
+    /// SHA-256 of the exact libdevice bytes added to libNVVM.
+    pub libdevice_sha256: [u8; 32],
+}
+
+/// Stable identity of the finalizer algorithm itself.
+pub fn recipe_digest() -> [u8; 32] {
+    Sha256::digest(RECIPE).into()
+}
+
+pub(crate) fn digest_bytes(bytes: &[u8]) -> [u8; 32] {
+    Sha256::digest(bytes).into()
+}
+
+/// Run one CUDA-tool operation between exact checks of its retained DSO.
+///
+/// An unavailable initial digest is allowed for runtime fallback, whose cache
+/// is disabled separately. When an exact digest exists (and therefore may be
+/// part of Cargo's fingerprint or a cache key), the complete retained file is
+/// rehashed immediately before and after the operation. The post-check runs
+/// even when the tool call itself returned an error.
+pub(crate) fn with_revalidated_tool_identity<T>(
+    tool: &'static str,
+    expected: Option<[u8; 32]>,
+    mut current_digest: impl FnMut() -> Option<[u8; 32]>,
+    operation: impl FnOnce() -> Result<T, FinalizerError>,
+) -> Result<T, FinalizerError> {
+    let Some(expected) = expected else {
+        return operation();
+    };
+    if current_digest() != Some(expected) {
+        return Err(FinalizerError::ToolIdentityChanged { tool });
+    }
+
+    let result = operation();
+    if current_digest() != Some(expected) {
+        return Err(FinalizerError::ToolIdentityChanged { tool });
+    }
+    result
+}
+
+/// Hash a retained CUDA-tool descriptor and reject a concurrent replacement.
+pub(crate) fn digest_file_handle(file: &File) -> io::Result<[u8; 32]> {
+    digest_file_handle_with_post_read(file, || {})
+}
+
+fn digest_file_handle_with_post_read(
+    file: &File,
+    post_read: impl FnOnce(),
+) -> io::Result<[u8; 32]> {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "tool fingerprint input is not a regular file",
+        ));
+    }
+    let snapshot = FileSnapshot::capture(&metadata)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+
+        let mut offset = 0_u64;
+        loop {
+            let read = match file.read_at(&mut buffer, offset) {
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                result => result?,
+            };
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+            offset = offset
+                .checked_add(read as u64)
+                .ok_or_else(|| io::Error::other("tool file length overflow"))?;
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let mut reader = file.try_clone()?;
+        reader.seek(SeekFrom::Start(0))?;
+        loop {
+            let read = reader.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+    }
+
+    let digest = hasher.finalize().into();
+    post_read();
+    if FileSnapshot::capture(&file.metadata()?)? != snapshot {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "tool file changed while it was fingerprinted",
+        ));
+    }
+    Ok(digest)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct FileSnapshot {
+    len: u64,
+    modified: SystemTime,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    change_time: (i64, i64),
+}
+
+impl FileSnapshot {
+    fn capture(metadata: &fs::Metadata) -> io::Result<Self> {
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+
+        Ok(Self {
+            len: metadata.len(),
+            modified: metadata.modified()?,
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            change_time: (metadata.ctime(), metadata.ctime_nsec()),
+        })
+    }
+}
+
+/// Unambiguous ordered digest used for recipes, provenance, and artifacts.
+pub(crate) struct StableDigest {
+    hasher: Sha256,
+}
+
+impl StableDigest {
+    pub(crate) fn new() -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(DIGEST_DOMAIN);
+        Self { hasher }
+    }
+
+    pub(crate) fn field(mut self, tag: &str, value: impl AsRef<[u8]>) -> Self {
+        let tag = tag.as_bytes();
+        let value = value.as_ref();
+        self.hasher.update([1]);
+        self.hasher.update(length_prefix(tag.len()));
+        self.hasher.update(tag);
+        self.hasher.update(length_prefix(value.len()));
+        self.hasher.update(value);
+        self
+    }
+
+    pub(crate) fn finish(mut self) -> [u8; 32] {
+        self.hasher.update([0xff]);
+        self.hasher.finalize().into()
+    }
+}
+
+fn length_prefix(length: usize) -> [u8; 8] {
+    u64::try_from(length)
+        .expect("digest fields cannot exceed u64::MAX bytes")
+        .to_be_bytes()
+}
+
+pub(crate) fn common_provenance_digest(
+    libnvvm: &[u8; 32],
+    nvjitlink: &[u8; 32],
+    libdevice: &[u8; 32],
+) -> [u8; 32] {
+    StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("libnvvm-sha256", libnvvm)
+        .field("libnvjitlink-sha256", nvjitlink)
+        .field("libdevice-sha256", libdevice)
+        .finish()
+}
+
+pub(crate) fn compiler_provenance_digest(libnvvm: &[u8; 32], libdevice: &[u8; 32]) -> [u8; 32] {
+    StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("route", b"nvvm-ir-to-ltoir")
+        .field("libnvvm-sha256", libnvvm)
+        .field("libdevice-sha256", libdevice)
+        .finish()
+}
+
+pub(crate) fn linker_provenance_digest(nvjitlink: &[u8; 32]) -> [u8; 32] {
+    StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("route", b"ltoir-to-output")
+        .field("libnvjitlink-sha256", nvjitlink)
+        .finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn provenance_is_route_specific_and_content_sensitive() {
+        let nvvm = [1; 32];
+        let linker = [2; 32];
+        let libdevice = [3; 32];
+        assert_ne!(
+            compiler_provenance_digest(&nvvm, &libdevice),
+            linker_provenance_digest(&linker)
+        );
+        assert_ne!(
+            common_provenance_digest(&nvvm, &linker, &libdevice),
+            common_provenance_digest(&nvvm, &linker, &[4; 32])
+        );
+    }
+
+    #[test]
+    fn stable_digest_distinguishes_field_boundaries_and_order() {
+        let left = StableDigest::new()
+            .field("input", b"ab")
+            .field("input", b"c")
+            .finish();
+        let different_boundaries = StableDigest::new()
+            .field("input", b"a")
+            .field("input", b"bc")
+            .finish();
+        let reversed = StableDigest::new()
+            .field("input", b"c")
+            .field("input", b"ab")
+            .finish();
+        assert_ne!(left, different_boundaries);
+        assert_ne!(left, reversed);
+    }
+
+    #[test]
+    fn post_call_tool_change_rejects_the_operation_result() {
+        let expected = [7; 32];
+        let changed = [8; 32];
+        let checks = Cell::new(0_u32);
+        let operation_calls = Cell::new(0_u32);
+
+        let error = with_revalidated_tool_identity(
+            "test CUDA tool",
+            Some(expected),
+            || {
+                let check = checks.get();
+                checks.set(check + 1);
+                Some(if check == 0 { expected } else { changed })
+            },
+            || {
+                operation_calls.set(operation_calls.get() + 1);
+                Ok(b"must not be accepted".to_vec())
+            },
+        )
+        .expect_err("a post-call identity change must discard successful output");
+
+        assert!(matches!(
+            error,
+            FinalizerError::ToolIdentityChanged {
+                tool: "test CUDA tool"
+            }
+        ));
+        assert_eq!(checks.get(), 2, "identity must be checked on both sides");
+        assert_eq!(operation_calls.get(), 1, "the seam models a post-call race");
+    }
+
+    #[test]
+    fn tool_digest_stays_bound_to_open_file_after_path_replacement() {
+        let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "cuda-artifact-finalizer-provenance-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("tool.so");
+        let replacement = directory.join("replacement.so");
+        std::fs::write(&path, b"tool version one").unwrap();
+        std::fs::write(&replacement, b"tool version two").unwrap();
+
+        let opened = File::open(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::rename(&replacement, &path).unwrap();
+
+        assert_eq!(
+            digest_file_handle(&opened).unwrap(),
+            digest_bytes(b"tool version one")
+        );
+        assert_eq!(
+            digest_file_handle(&File::open(&path).unwrap()).unwrap(),
+            digest_bytes(b"tool version two")
+        );
+
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn tool_digest_changes_after_in_place_content_change() {
+        let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "cuda-artifact-finalizer-in-place-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("tool.so");
+        std::fs::write(&path, b"tool bytes version one").unwrap();
+        #[cfg(unix)]
+        let original_inode = {
+            use std::os::unix::fs::MetadataExt;
+            path.metadata().unwrap().ino()
+        };
+        let original = digest_file_handle(&File::open(&path).unwrap()).unwrap();
+
+        std::fs::write(&path, b"tool bytes version two").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(path.metadata().unwrap().ino(), original_inode);
+        }
+        let changed = digest_file_handle(&File::open(&path).unwrap()).unwrap();
+
+        assert_eq!(original, digest_bytes(b"tool bytes version one"));
+        assert_eq!(changed, digest_bytes(b"tool bytes version two"));
+        assert_ne!(original, changed);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn metadata_change_between_read_and_validation_rejects_digest() {
+        let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "cuda-artifact-finalizer-mid-hash-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("tool.so");
+        std::fs::write(&path, b"tool bytes before hash").unwrap();
+        let opened = File::open(&path).unwrap();
+
+        let error = digest_file_handle_with_post_read(&opened, || {
+            std::fs::write(&path, b"tool bytes changed during hash and now longer").unwrap();
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            error.to_string(),
+            "tool file changed while it was fingerprinted"
+        );
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/validation.rs
+++ b/crates/cuda-artifact-finalizer/src/validation.rs
@@ -1,0 +1,256 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const ELF64_HEADER_LENGTH: usize = 64;
+const ELF64_PROGRAM_HEADER_LENGTH: u16 = 56;
+const ELF64_SECTION_HEADER_LENGTH: u16 = 64;
+
+/// Check that bytes are a complete 64-bit little-endian CUDA executable ELF.
+///
+/// This validates every declared table and file-backed range, so a truncated
+/// ELF prefix cannot be accepted as a cubin.
+pub fn is_valid_cubin(bytes: &[u8]) -> bool {
+    if bytes.len() < ELF64_HEADER_LENGTH
+        || !bytes.starts_with(b"\x7fELF")
+        || bytes[4] != 2
+        || bytes[5] != 1
+        || bytes[6] != 1
+        || read_u16(bytes, 16) != Some(2)
+        || read_u16(bytes, 18) != Some(190)
+        || read_u32(bytes, 20) != Some(1)
+        || read_u16(bytes, 52) != Some(ELF64_HEADER_LENGTH as u16)
+    {
+        return false;
+    }
+
+    let Some(program_offset) = read_u64(bytes, 32) else {
+        return false;
+    };
+    let Some(section_offset) = read_u64(bytes, 40) else {
+        return false;
+    };
+    let Some(program_entry_size) = read_u16(bytes, 54) else {
+        return false;
+    };
+    let Some(program_count) = read_u16(bytes, 56) else {
+        return false;
+    };
+    let Some(section_entry_size) = read_u16(bytes, 58) else {
+        return false;
+    };
+    let Some(section_count) = read_u16(bytes, 60) else {
+        return false;
+    };
+    let Some(section_name_index) = read_u16(bytes, 62) else {
+        return false;
+    };
+
+    if program_count == u16::MAX || (program_count == 0 && section_count == 0) {
+        return false;
+    }
+    let program_table = if program_count == 0 {
+        if program_offset != 0 || !matches!(program_entry_size, 0 | ELF64_PROGRAM_HEADER_LENGTH) {
+            return false;
+        }
+        None
+    } else {
+        if program_entry_size != ELF64_PROGRAM_HEADER_LENGTH {
+            return false;
+        }
+        table_bounds(
+            program_offset,
+            program_entry_size,
+            program_count,
+            bytes.len(),
+        )
+    };
+    let section_table = if section_count == 0 {
+        if section_offset != 0
+            || section_name_index != 0
+            || !matches!(section_entry_size, 0 | ELF64_SECTION_HEADER_LENGTH)
+        {
+            return false;
+        }
+        None
+    } else {
+        if section_entry_size != ELF64_SECTION_HEADER_LENGTH
+            || (section_name_index != 0 && section_name_index >= section_count)
+        {
+            return false;
+        }
+        table_bounds(
+            section_offset,
+            section_entry_size,
+            section_count,
+            bytes.len(),
+        )
+    };
+    if program_count != 0 && program_table.is_none()
+        || section_count != 0 && section_table.is_none()
+    {
+        return false;
+    }
+
+    let mut has_meaningful_contents = false;
+    if let Some((start, _)) = program_table {
+        for index in 0..usize::from(program_count) {
+            let header = start + index * usize::from(program_entry_size);
+            let Some(program_type) = read_u32(bytes, header) else {
+                return false;
+            };
+            let Some(file_offset) = read_u64(bytes, header + 8) else {
+                return false;
+            };
+            let Some(file_size) = read_u64(bytes, header + 32) else {
+                return false;
+            };
+            let Some(memory_size) = read_u64(bytes, header + 40) else {
+                return false;
+            };
+            if !file_range_is_valid(file_offset, file_size, bytes.len()) {
+                return false;
+            }
+            if program_type == 1 {
+                if file_size > memory_size {
+                    return false;
+                }
+                has_meaningful_contents |= file_size != 0;
+            }
+        }
+    }
+
+    if let Some((start, _)) = section_table {
+        for index in 0..usize::from(section_count) {
+            let header = start + index * usize::from(section_entry_size);
+            let Some(section_type) = read_u32(bytes, header + 4) else {
+                return false;
+            };
+            let Some(file_offset) = read_u64(bytes, header + 24) else {
+                return false;
+            };
+            let Some(file_size) = read_u64(bytes, header + 32) else {
+                return false;
+            };
+            if section_type != 8 && !file_range_is_valid(file_offset, file_size, bytes.len()) {
+                return false;
+            }
+            // Section zero is the mandatory null entry. A cubin needs actual
+            // file-backed contents beyond an otherwise-valid ELF shell.
+            if index != 0 && section_type != 0 && section_type != 8 && file_size != 0 {
+                has_meaningful_contents = true;
+            }
+        }
+    }
+
+    has_meaningful_contents
+}
+
+fn table_bounds(
+    offset: u64,
+    entry_size: u16,
+    count: u16,
+    file_len: usize,
+) -> Option<(usize, usize)> {
+    if offset < ELF64_HEADER_LENGTH as u64 {
+        return None;
+    }
+    let length = u64::from(entry_size).checked_mul(u64::from(count))?;
+    let end = offset.checked_add(length)?;
+    if end > file_len as u64 {
+        return None;
+    }
+    Some((usize::try_from(offset).ok()?, usize::try_from(end).ok()?))
+}
+
+fn file_range_is_valid(offset: u64, length: u64, file_len: usize) -> bool {
+    offset
+        .checked_add(length)
+        .is_some_and(|end| end <= file_len as u64)
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        bytes.get(offset..offset + 2)?.try_into().ok()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        bytes.get(offset..offset + 4)?.try_into().ok()?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(
+        bytes.get(offset..offset + 8)?.try_into().ok()?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_cubin() -> Vec<u8> {
+        const PAYLOAD_LENGTH: usize = 4;
+        let section_table_length = 2 * usize::from(ELF64_SECTION_HEADER_LENGTH);
+        let payload_offset = ELF64_HEADER_LENGTH + section_table_length;
+        let mut bytes = vec![0; payload_offset + PAYLOAD_LENGTH];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[6] = 1;
+        bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&190_u16.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[40..48].copy_from_slice(&(ELF64_HEADER_LENGTH as u64).to_le_bytes());
+        bytes[52..54].copy_from_slice(&(ELF64_HEADER_LENGTH as u16).to_le_bytes());
+        bytes[58..60].copy_from_slice(&ELF64_SECTION_HEADER_LENGTH.to_le_bytes());
+        bytes[60..62].copy_from_slice(&2_u16.to_le_bytes());
+        let section = ELF64_HEADER_LENGTH + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[section + 4..section + 8].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[section + 24..section + 32].copy_from_slice(&(payload_offset as u64).to_le_bytes());
+        bytes[section + 32..section + 40].copy_from_slice(&(PAYLOAD_LENGTH as u64).to_le_bytes());
+        bytes[payload_offset..].copy_from_slice(b"CUDA");
+        bytes
+    }
+
+    fn program_only_cubin(memory_size: u64) -> Vec<u8> {
+        const PAYLOAD_LENGTH: usize = 4;
+        let payload_offset = ELF64_HEADER_LENGTH + usize::from(ELF64_PROGRAM_HEADER_LENGTH);
+        let mut bytes = vec![0; payload_offset + PAYLOAD_LENGTH];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[6] = 1;
+        bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&190_u16.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[32..40].copy_from_slice(&(ELF64_HEADER_LENGTH as u64).to_le_bytes());
+        bytes[52..54].copy_from_slice(&(ELF64_HEADER_LENGTH as u16).to_le_bytes());
+        bytes[54..56].copy_from_slice(&ELF64_PROGRAM_HEADER_LENGTH.to_le_bytes());
+        bytes[56..58].copy_from_slice(&1_u16.to_le_bytes());
+        let program = ELF64_HEADER_LENGTH;
+        bytes[program..program + 4].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[program + 8..program + 16].copy_from_slice(&(payload_offset as u64).to_le_bytes());
+        bytes[program + 32..program + 40].copy_from_slice(&(PAYLOAD_LENGTH as u64).to_le_bytes());
+        bytes[program + 40..program + 48].copy_from_slice(&memory_size.to_le_bytes());
+        bytes[payload_offset..].copy_from_slice(b"CUDA");
+        bytes
+    }
+
+    #[test]
+    fn validates_complete_cuda_elf_and_rejects_truncation() {
+        let cubin = minimal_cubin();
+        assert!(is_valid_cubin(&cubin));
+        assert!(!is_valid_cubin(&cubin[..cubin.len() - 1]));
+        let mut shell =
+            cubin[..ELF64_HEADER_LENGTH + usize::from(ELF64_SECTION_HEADER_LENGTH)].to_vec();
+        shell[60..62].copy_from_slice(&1_u16.to_le_bytes());
+        assert!(!is_valid_cubin(&shell));
+        assert!(is_valid_cubin(&program_only_cubin(4)));
+        assert!(!is_valid_cubin(&program_only_cubin(3)));
+        assert!(!is_valid_cubin(b"\x7fELF"));
+    }
+}

--- a/crates/cuda-core/src/embedded.rs
+++ b/crates/cuda-core/src/embedded.rs
@@ -8,7 +8,8 @@
 use crate::{CudaContext, CudaModule, DriverError};
 use oxide_artifacts::ArtifactError;
 pub use oxide_artifacts::{
-    ArtifactCompileOptions, ArtifactPayloadKind, COMPILE_OPTIONS_TARGET_MARKER, OwnedArtifactBundle,
+    ArtifactCompileOptions, ArtifactDebugPolicy, ArtifactPayloadKind,
+    COMPILE_OPTIONS_TARGET_MARKER, OwnedArtifactBundle,
 };
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/crates/cuda-host/Cargo.toml
+++ b/crates/cuda-host/Cargo.toml
@@ -11,8 +11,7 @@ repository.workspace = true
 half = { workspace = true }
 cuda-macros = { workspace = true }
 cuda-core = { workspace = true }
-libnvvm-sys = { workspace = true }
-nvjitlink-sys = { workspace = true }
+cuda-artifact-finalizer = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 cuda-async = { workspace = true, optional = true }

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -301,6 +301,20 @@ The first compiler/linker handles are retained for the process lifetime;
 restart the process to select another toolkit or after replacing one in place.
 Remove the `.oxide-artifacts` directory to clear all cached entries.
 
+The driver-independent `cuda-artifact-finalizer` crate owns the shared
+libNVVM/nvJitLink policy. Runtime loading and build-time materialization
+therefore use the same target, FMA, debug, input-order, provenance, and cubin
+validation rules.
+
+Deferred NVVM IR and LTOIR keep those policies in `<module>.options`. Existing
+v1 sidecars record FMA contraction and imply no debug information; v2 sidecars
+also record line-table or full-debug preservation. Missing sidecars on legacy,
+unversioned artifacts retain the historical default of FMA enabled and no
+debug information. In-memory callers can use the
+`*_with_compile_options` helpers to carry the complete policy. The older
+`*_with_options(..., allow_fma_contraction)` helpers remain available and use
+no debug information.
+
 ## Tiling Utilities (tcgen05)
 
 Host-side layout transformations for Blackwell tensor cores. tcgen05 requires

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -148,19 +148,18 @@ fn load_bundle(
     if let Some(nvvm_ir) = bundle.payload(ArtifactPayloadKind::NvvmIr) {
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
-        let allow_fma_contraction = bundle.compile_options.fma_contraction_enabled();
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::build_cubin_from_nvvm_ir_with_options(
+            ltoir::ExecutionRoute::Cubin => ltoir::build_cubin_from_nvvm_ir_with_compile_options(
                 nvvm_ir,
                 &bundle.name,
                 &emitted.sm(),
-                allow_fma_contraction,
+                bundle.compile_options,
             )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::build_ptx_from_nvvm_ir_with_options(
+            ltoir::ExecutionRoute::PtxBridge => ltoir::build_ptx_from_nvvm_ir_with_compile_options(
                 nvvm_ir,
                 &bundle.name,
                 &emitted.sm(),
-                allow_fma_contraction,
+                bundle.compile_options,
             )?,
         };
         return Ok(ctx.load_module_from_image(&image)?);
@@ -169,19 +168,18 @@ fn load_bundle(
     if let Some(ltoir) = bundle.payload(ArtifactPayloadKind::Ltoir) {
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
-        let allow_fma_contraction = bundle.compile_options.fma_contraction_enabled();
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::link_ltoir_to_cubin_with_options(
+            ltoir::ExecutionRoute::Cubin => ltoir::link_ltoir_to_cubin_with_compile_options(
                 ltoir,
                 &bundle.name,
                 &emitted.sm(),
-                allow_fma_contraction,
+                bundle.compile_options,
             )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::link_ltoir_to_ptx_with_options(
+            ltoir::ExecutionRoute::PtxBridge => ltoir::link_ltoir_to_ptx_with_compile_options(
                 ltoir,
                 &bundle.name,
                 &emitted.sm(),
-                allow_fma_contraction,
+                bundle.compile_options,
             )?,
         };
         return Ok(ctx.load_module_from_image(&image)?);
@@ -194,7 +192,7 @@ fn load_bundle(
 
 fn target_arch_for_bundle(
     bundle: &OwnedArtifactBundle,
-) -> Result<libnvvm_sys::CudaArch, ltoir::LtoirError> {
+) -> Result<cuda_artifact_finalizer::CudaArch, ltoir::LtoirError> {
     let explicit = std::env::var("CUDA_OXIDE_TARGET").ok();
     target_arch_for_bundle_with_explicit(bundle, explicit.as_deref())
 }
@@ -202,13 +200,13 @@ fn target_arch_for_bundle(
 fn target_arch_for_bundle_with_explicit(
     bundle: &OwnedArtifactBundle,
     explicit_target: Option<&str>,
-) -> Result<libnvvm_sys::CudaArch, ltoir::LtoirError> {
+) -> Result<cuda_artifact_finalizer::CudaArch, ltoir::LtoirError> {
     ltoir::resolve_source_target(concrete_bundle_target(&bundle.target)?, explicit_target)
 }
 
 fn concrete_bundle_target(
     target: &str,
-) -> Result<Option<libnvvm_sys::CudaArch>, ltoir::LtoirError> {
+) -> Result<Option<cuda_artifact_finalizer::CudaArch>, ltoir::LtoirError> {
     match target {
         // Compatibility for artifacts emitted before concrete NVVM targets
         // were recorded. New bundles must never use these sentinels.

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -24,8 +24,8 @@
 //!   directory and selects PTX, cubin, NVVM IR, or LTOIR using the recorded
 //!   artifact mode. Use this for normal module loading.
 //!
-//! All work is done via [`libnvvm_sys`] and [`nvjitlink_sys`] (`dlopen` of
-//! `libnvvm.so` and `libnvJitLink.so` from the CUDA Toolkit). No external
+//! All compilation work is delegated to [`cuda_artifact_finalizer`] (`dlopen`
+//! of `libnvvm.so` and `libnvJitLink.so` from the CUDA Toolkit). No external
 //! C tools are required, no symlinked `tools/` directory, no boilerplate.
 //!
 //! # Discovery
@@ -39,10 +39,11 @@
 //!   `<root>/nvvm/libdevice/libdevice.10.bc` for the same roots.
 //! - **Artifact target and options**: the emitted `<name>.target` records the
 //!   source architecture. Versioned targets require `<name>.options`, which
-//!   preserves the FMA policy through libNVVM and nvJitLink. The explicit
-//!   `CUDA_OXIDE_TARGET` override remains the fallback for legacy artifacts.
-//!   The CUDA context is queried separately for the GPU that will execute the
-//!   module.
+//!   preserves FMA and debug policy through libNVVM and nvJitLink. Version-1
+//!   sidecars imply no debug output; version 2 records line-table or full-debug
+//!   preservation. The explicit `CUDA_OXIDE_TARGET` override remains the
+//!   fallback for legacy artifacts. The CUDA context is queried separately for
+//!   the GPU that will execute the module.
 //!
 //! # Native cubin cache
 //!
@@ -51,8 +52,8 @@
 //! Blackwell PTX bridge keep their normal paths.
 //!
 //! An entry is keyed by the exact input bytes, normalized target, module names,
-//! ordered compiler/linker options (including FMA policy), libdevice bytes,
-//! and SHA-256 digests of the exact loaded `libnvvm.so` and
+//! ordered compiler/linker options (including FMA and debug policy), libdevice
+//! bytes, and SHA-256 digests of the exact loaded `libnvvm.so` and
 //! `libnvJitLink.so` files. Unknown tool identity
 //! disables reuse. Entries are published atomically below
 //! `.oxide-artifacts/ltoir-cubin-cache/v1` and are rechecked before their owned
@@ -73,35 +74,24 @@
 //! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 
-use crate::ltoir_cache::{
-    BuiltArtifacts, CacheKeyBuilder, CacheResult, cache_or_build, digest_file_handle,
+use crate::ltoir_cache::{BuiltArtifacts, CacheResult, cache_or_build};
+use cuda_artifact_finalizer::{
+    CudaArch, CudaArchParseError, FinalizationOptions, Finalizer, FinalizerError, FinalizerOutput,
+    LtoLinker, NamedInput, NvJitLinkError, NvvmError,
 };
-use cuda_core::embedded::{ArtifactCompileOptions, COMPILE_OPTIONS_TARGET_MARKER};
+#[cfg(test)]
+use cuda_artifact_finalizer::{
+    ToolProvenance, ltoir_artifact_digest_with_provenance, nvvm_ir_artifact_digest_with_provenance,
+};
+use cuda_core::embedded::{
+    ArtifactCompileOptions, ArtifactDebugPolicy, COMPILE_OPTIONS_TARGET_MARKER,
+};
 use cuda_core::{CudaContext, CudaModule, DriverError};
-use libnvvm_sys::{CudaArch, CudaArchParseError, LibNvvm, NvvmError, Program};
-use nvjitlink_sys::{InputType, LibNvJitLink, Linker, NvJitLinkError};
+#[cfg(test)]
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 use thiserror::Error;
-
-// Bump this whenever an unlisted compiler/linker input or pipeline semantic
-// changes. Explicit options are also part of each key below.
-const CACHE_RECIPE: &[u8] = b"cuda-host/native-ltoir-cubin/v2";
-
-struct LoadedNvvmTool {
-    library: Arc<LibNvvm>,
-    digest: Option<[u8; 32]>,
-}
-
-struct LoadedNvJitLinkTool {
-    library: Arc<LibNvJitLink>,
-    digest: Option<[u8; 32]>,
-}
-
-static NVVM_TOOL: OnceLock<Arc<LoadedNvvmTool>> = OnceLock::new();
-static NVJITLINK_TOOL: OnceLock<Arc<LoadedNvJitLinkTool>> = OnceLock::new();
-static NVVM_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
-static NVJITLINK_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
 
 // ============================================================================
 // Errors
@@ -214,6 +204,35 @@ pub enum LtoirError {
     /// pipeline produced a cubin.
     #[error("CUDA driver: {0}")]
     Driver(#[from] DriverError),
+
+    /// The shared driver-independent finalizer rejected an invalid plan or
+    /// malformed tool output.
+    #[error(transparent)]
+    Finalizer(FinalizerError),
+}
+
+impl From<FinalizerError> for LtoirError {
+    fn from(error: FinalizerError) -> Self {
+        match error {
+            FinalizerError::Nvvm(error) => Self::Nvvm(error),
+            FinalizerError::NvJitLink(error) => Self::NvJitLink(error),
+            FinalizerError::LibdeviceNotFound { tried } => Self::LibdeviceNotFound { tried },
+            FinalizerError::Io { path, source } => Self::Io { path, source },
+            FinalizerError::UnsupportedNvvmIrVersion { major, minor } => {
+                Self::UnsupportedNvvmIrVersion { major, minor }
+            }
+            FinalizerError::DialectMismatch {
+                target,
+                llvm_major,
+                expected,
+            } => Self::DialectMismatch {
+                target,
+                llvm_major,
+                expected,
+            },
+            other => Self::Finalizer(other),
+        }
+    }
 }
 
 // ============================================================================
@@ -253,7 +272,7 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
         path: ll_path.to_path_buf(),
         source,
     })?;
-    let allow_fma_contraction = read_fma_contraction_option(ll_path)?;
+    let compile_options = read_compile_options(ll_path)?;
     validate_ir_target_sidecar(ll_path, arch)?;
     // Record the supplied target for older or manually created `.ll` files.
     // The sibling `.ltoir` can then be loaded after the `.ll` is removed.
@@ -267,13 +286,13 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
     let ltoir_path = dir.join(format!("{stem}.ltoir"));
     let cubin_path = dir.join(format!("{stem}.cubin"));
 
-    let cached = cached_nvvm_ir_to_cubin_with_options(
+    let cached = cached_nvvm_ir_to_cubin_with_compile_options(
         dir,
         &ll_bytes,
         &ll_path.display().to_string(),
         &ltoir_path.display().to_string(),
         arch,
-        allow_fma_contraction,
+        compile_options,
     )?;
     let ltoir = cached
         .ltoir
@@ -312,19 +331,36 @@ pub fn build_cubin_from_nvvm_ir(
     build_cubin_from_nvvm_ir_with_options(nvvm_ir, module_name, arch, true)
 }
 
-/// Compile NVVM IR bytes to a loadable cubin while preserving the artifact's
-/// floating-point contraction policy.
+/// Compile NVVM IR bytes to a loadable cubin with an explicit FMA policy.
+///
+/// This compatibility helper uses no debug information. Use
+/// [`build_cubin_from_nvvm_ir_with_compile_options`] when all deferred artifact
+/// policy must be preserved.
 pub fn build_cubin_from_nvvm_ir_with_options(
     nvvm_ir: &[u8],
     module_name: &str,
     arch: &str,
     allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_cubin_from_nvvm_ir_with_compile_options(
+        nvvm_ir,
+        module_name,
+        arch,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
+    )
+}
+
+/// Compile NVVM IR bytes to a cubin while preserving every deferred compile
+/// policy recorded with the artifact.
+pub fn build_cubin_from_nvvm_ir_with_compile_options(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    let ltoir =
-        compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch, allow_fma_contraction)?;
-    let ltoir_name = format!("{module_name}.ltoir");
-    link_ltoir_to_cubin_parsed_with_options(&ltoir, &ltoir_name, &arch, allow_fma_contraction)
+    let options = finalization_options(&arch, compile_options);
+    Ok(Finalizer::discover()?.materialize_nvvm_ir(module_name, nvvm_ir, &options)?)
 }
 
 /// Compile NVVM IR bytes to forward-compatible PTX.
@@ -340,19 +376,46 @@ pub fn build_ptx_from_nvvm_ir(
     build_ptx_from_nvvm_ir_with_options(nvvm_ir, module_name, arch, true)
 }
 
-/// Compile NVVM IR bytes to forward-compatible PTX while preserving the
-/// artifact's floating-point contraction policy.
+/// Compile NVVM IR bytes to forward-compatible PTX with an explicit FMA
+/// policy.
+///
+/// This compatibility helper uses no debug information. Use
+/// [`build_ptx_from_nvvm_ir_with_compile_options`] when all deferred artifact
+/// policy must be preserved.
 pub fn build_ptx_from_nvvm_ir_with_options(
     nvvm_ir: &[u8],
     module_name: &str,
     arch: &str,
     allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_ptx_from_nvvm_ir_with_compile_options(
+        nvvm_ir,
+        module_name,
+        arch,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
+    )
+}
+
+/// Compile NVVM IR bytes to PTX while preserving every deferred compile
+/// policy recorded with the artifact.
+pub fn build_ptx_from_nvvm_ir_with_compile_options(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    let ltoir =
-        compile_nvvm_ir_to_ltoir_parsed(nvvm_ir, module_name, &arch, allow_fma_contraction)?;
+    let finalizer = Finalizer::discover()?;
+    let options = finalization_options(&arch, compile_options);
+    let ltoir = finalizer
+        .compiler()
+        .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, &options)?;
     let ltoir_name = format!("{module_name}.ltoir");
-    link_ltoir_to_ptx_parsed_with_options(&ltoir, &ltoir_name, &arch, allow_fma_contraction)
+    Ok(finalizer.link_ltoir(
+        &[NamedInput::new(&ltoir_name, &ltoir)],
+        &options,
+        FinalizerOutput::Ptx,
+    )?)
 }
 
 /// Link a single LTOIR payload to a loadable cubin image in memory.
@@ -364,16 +427,35 @@ pub fn link_ltoir_to_cubin(
     link_ltoir_to_cubin_with_options(ltoir, module_name, arch, true)
 }
 
-/// Link a single LTOIR payload to a cubin while preserving the artifact's
-/// floating-point contraction policy.
+/// Link a single LTOIR payload to a cubin with an explicit FMA policy.
+///
+/// This compatibility helper uses no debug information. Use
+/// [`link_ltoir_to_cubin_with_compile_options`] when all deferred artifact
+/// policy must be preserved.
 pub fn link_ltoir_to_cubin_with_options(
     ltoir: &[u8],
     module_name: &str,
     arch: &str,
     allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_cubin_with_compile_options(
+        ltoir,
+        module_name,
+        arch,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
+    )
+}
+
+/// Link LTOIR to a cubin while preserving every deferred compile policy
+/// recorded with the artifact.
+pub fn link_ltoir_to_cubin_with_compile_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_cubin_parsed_with_options(ltoir, module_name, &arch, allow_fma_contraction)
+    link_ltoir_to_cubin_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
 }
 
 /// Link one LTOIR payload to forward-compatible PTX.
@@ -388,162 +470,95 @@ pub fn link_ltoir_to_ptx(
     link_ltoir_to_ptx_with_options(ltoir, module_name, arch, true)
 }
 
-/// Link one LTOIR payload to forward-compatible PTX while preserving the
-/// artifact's floating-point contraction policy.
+/// Link one LTOIR payload to forward-compatible PTX with an explicit FMA
+/// policy.
+///
+/// This compatibility helper uses no debug information. Use
+/// [`link_ltoir_to_ptx_with_compile_options`] when all deferred artifact policy
+/// must be preserved.
 pub fn link_ltoir_to_ptx_with_options(
     ltoir: &[u8],
     module_name: &str,
     arch: &str,
     allow_fma_contraction: bool,
 ) -> Result<Vec<u8>, LtoirError> {
-    let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_ptx_parsed_with_options(ltoir, module_name, &arch, allow_fma_contraction)
-}
-
-fn link_ltoir_to_cubin_parsed_with_options(
-    ltoir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-    allow_fma_contraction: bool,
-) -> Result<Vec<u8>, LtoirError> {
-    let nvj = LibNvJitLink::load()?;
-    link_ltoir_to_cubin_with_tool_options(&nvj, ltoir, module_name, arch, allow_fma_contraction)
-}
-
-fn link_ltoir_to_cubin_with_tool_options(
-    nvj: &LibNvJitLink,
-    ltoir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-    allow_fma_contraction: bool,
-) -> Result<Vec<u8>, LtoirError> {
-    let arch_opt = format!("-arch={}", arch.sm());
-    let options = nvjitlink_lto_options(&arch_opt, false, allow_fma_contraction);
-    let mut linker = Linker::new(nvj, &options)?;
-    linker.add(InputType::Ltoir, ltoir, module_name)?;
-    Ok(linker.finish()?)
-}
-
-fn link_ltoir_to_ptx_parsed_with_options(
-    ltoir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-    allow_fma_contraction: bool,
-) -> Result<Vec<u8>, LtoirError> {
-    let nvj = LibNvJitLink::load()?;
-    link_ltoir_to_ptx_with_tool_options(&nvj, ltoir, module_name, arch, allow_fma_contraction)
-}
-
-fn link_ltoir_to_ptx_with_tool_options(
-    nvj: &LibNvJitLink,
-    ltoir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-    allow_fma_contraction: bool,
-) -> Result<Vec<u8>, LtoirError> {
-    let arch_opt = format!("-arch={}", arch.sm());
-    let options = nvjitlink_lto_options(&arch_opt, true, allow_fma_contraction);
-    let mut linker = Linker::new(nvj, &options)?;
-    linker.add(InputType::Ltoir, ltoir, module_name)?;
-    Ok(linker.finish_ptx()?)
-}
-
-fn nvjitlink_lto_options(arch_opt: &str, emit_ptx: bool, allow_fma_contraction: bool) -> Vec<&str> {
-    let mut options = vec![arch_opt, "-lto"];
-    if emit_ptx {
-        options.push("-ptx");
-    }
-    options.push(if allow_fma_contraction {
-        "-fma=1"
-    } else {
-        "-fma=0"
-    });
-    options
-}
-
-fn compile_nvvm_ir_to_ltoir_parsed(
-    nvvm_ir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-    allow_fma_contraction: bool,
-) -> Result<Vec<u8>, LtoirError> {
-    let libdevice_bytes = read_libdevice_bytes()?;
-    let nvvm = LibNvvm::load()?;
-    validate_nvvm_frontend(&nvvm, arch)?;
-    compile_nvvm_ir_to_ltoir_with(
-        &nvvm,
-        nvvm_ir,
+    link_ltoir_to_ptx_with_compile_options(
+        ltoir,
         module_name,
         arch,
-        &libdevice_bytes,
-        allow_fma_contraction,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
     )
 }
 
-fn read_libdevice_bytes() -> Result<Vec<u8>, LtoirError> {
-    let path = find_libdevice()?;
-    std::fs::read(&path).map_err(|source| LtoirError::Io { path, source })
+/// Link LTOIR to PTX while preserving every deferred compile policy recorded
+/// with the artifact.
+pub fn link_ltoir_to_ptx_with_compile_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
+    let arch: CudaArch = arch.parse()?;
+    link_ltoir_to_ptx_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
 }
 
-fn validate_nvvm_frontend(nvvm: &LibNvvm, arch: &CudaArch) -> Result<(), LtoirError> {
-    let ir_version = nvvm.ir_version()?;
-    if (ir_version.ir_major, ir_version.ir_minor) != (2, 0) {
-        return Err(LtoirError::UnsupportedNvvmIrVersion {
-            major: ir_version.ir_major,
-            minor: ir_version.ir_minor,
-        });
-    }
-    if let Some(llvm_major) = nvvm.llvm_version(arch)? {
-        let mismatch = if arch.uses_legacy_llvm() {
-            llvm_major != 7
-        } else {
-            llvm_major == 7
-        };
-        if mismatch {
-            return Err(LtoirError::DialectMismatch {
-                target: arch.compute(),
-                llvm_major,
-                expected: if arch.uses_legacy_llvm() {
-                    "legacy LLVM 7"
-                } else {
-                    "modern opaque-pointer"
-                },
-            });
-        }
-    }
-    Ok(())
-}
-
-fn compile_nvvm_ir_to_ltoir_with(
-    nvvm: &LibNvvm,
-    nvvm_ir: &[u8],
+fn link_ltoir_to_cubin_parsed_with_compile_options(
+    ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
-    libdevice_bytes: &[u8],
-    allow_fma_contraction: bool,
+    compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
-    let mut prog = Program::new(nvvm)?;
-    // Add libdevice first so the kernel module's __nv_* references are
-    // resolved at compile time. Order doesn't strictly matter -- libNVVM
-    // does its own symbol resolution -- but this matches the pattern used
-    // by NVCC and the device_ffi_test C tools.
-    prog.add_module(libdevice_bytes, "libdevice.10.bc")?;
-    prog.add_module(nvvm_ir, module_name)?;
-
-    let arch_opt = format!("-arch={}", arch.compute());
-    prog.verify(&[&arch_opt])?;
-    let options = nvvm_compile_options(&arch_opt, allow_fma_contraction);
-    Ok(prog.compile(&options)?)
+    link_ltoir_with_shared_finalizer(
+        ltoir,
+        module_name,
+        arch,
+        compile_options,
+        FinalizerOutput::Cubin,
+    )
 }
 
-fn nvvm_compile_options(arch_opt: &str, allow_fma_contraction: bool) -> Vec<&str> {
-    let mut options = vec![arch_opt, "-gen-lto"];
-    options.push(if allow_fma_contraction {
-        "-fma=1"
-    } else {
-        "-fma=0"
-    });
-    options
+fn link_ltoir_to_ptx_parsed_with_compile_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_with_shared_finalizer(
+        ltoir,
+        module_name,
+        arch,
+        compile_options,
+        FinalizerOutput::Ptx,
+    )
+}
+
+fn link_ltoir_with_shared_finalizer(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+    compile_options: ArtifactCompileOptions,
+    output: FinalizerOutput,
+) -> Result<Vec<u8>, LtoirError> {
+    let options = finalization_options(arch, compile_options);
+    Ok(LtoLinker::discover()?.link_ltoir(
+        &[NamedInput::new(module_name, ltoir)],
+        &options,
+        output,
+    )?)
+}
+
+fn finalization_options(
+    arch: &CudaArch,
+    compile_options: ArtifactCompileOptions,
+) -> FinalizationOptions {
+    let debug = match compile_options.debug_policy() {
+        ArtifactDebugPolicy::None => cuda_artifact_finalizer::DebugPolicy::None,
+        ArtifactDebugPolicy::LineTables => cuda_artifact_finalizer::DebugPolicy::LineTables,
+        ArtifactDebugPolicy::Full => cuda_artifact_finalizer::DebugPolicy::Full,
+    };
+    FinalizationOptions::new(arch.clone())
+        .with_fma_contraction(compile_options.fma_contraction_enabled())
+        .with_debug_policy(debug)
 }
 
 #[cfg(test)]
@@ -554,58 +569,43 @@ fn cached_nvvm_ir_to_cubin(
     ltoir_module_name: &str,
     arch: &CudaArch,
 ) -> Result<CacheResult, LtoirError> {
-    cached_nvvm_ir_to_cubin_with_options(
+    cached_nvvm_ir_to_cubin_with_compile_options(
         source_dir,
         nvvm_ir,
         nvvm_module_name,
         ltoir_module_name,
         arch,
-        true,
+        ArtifactCompileOptions::new(),
     )
 }
 
-fn cached_nvvm_ir_to_cubin_with_options(
+fn cached_nvvm_ir_to_cubin_with_compile_options(
     source_dir: &Path,
     nvvm_ir: &[u8],
     nvvm_module_name: &str,
     ltoir_module_name: &str,
     arch: &CudaArch,
-    allow_fma_contraction: bool,
+    compile_options: ArtifactCompileOptions,
 ) -> Result<CacheResult, LtoirError> {
-    let libdevice = read_libdevice_bytes()?;
-    let nvvm = load_nvvm_tool()?;
-    validate_nvvm_frontend(&nvvm.library, arch)?;
-    let nvj = load_nvjitlink_tool()?;
-
-    let key = nvvm.digest.and_then(|nvvm_digest| {
-        nvj.digest.map(|nvjitlink_digest| {
-            nvvm_ir_cubin_cache_key_with_options(
-                nvvm_ir,
-                nvvm_module_name,
-                ltoir_module_name,
-                arch,
-                &libdevice,
-                (&nvvm_digest, &nvjitlink_digest),
-                allow_fma_contraction,
-            )
-        })
-    });
+    let finalizer = Finalizer::discover()?;
+    let options = finalization_options(arch, compile_options);
+    let key = finalizer.nvvm_ir_artifact_digest(
+        nvvm_module_name,
+        ltoir_module_name,
+        nvvm_ir,
+        &options,
+        FinalizerOutput::Cubin,
+    );
 
     let build = || -> Result<BuiltArtifacts, LtoirError> {
-        let ltoir = compile_nvvm_ir_to_ltoir_with(
-            &nvvm.library,
-            nvvm_ir,
-            nvvm_module_name,
-            arch,
-            &libdevice,
-            allow_fma_contraction,
-        )?;
-        let cubin = link_ltoir_to_cubin_with_tool_options(
-            &nvj.library,
-            &ltoir,
-            ltoir_module_name,
-            arch,
-            allow_fma_contraction,
+        let ltoir =
+            finalizer
+                .compiler()
+                .compile_nvvm_ir_to_ltoir(nvvm_module_name, nvvm_ir, &options)?;
+        let cubin = finalizer.link_ltoir(
+            &[NamedInput::new(ltoir_module_name, &ltoir)],
+            &options,
+            FinalizerOutput::Cubin,
         )?;
         Ok(BuiltArtifacts::new(cubin, Some(ltoir)))
     };
@@ -625,29 +625,31 @@ fn cached_ltoir_to_cubin(
     module_name: &str,
     arch: &CudaArch,
 ) -> Result<CacheResult, LtoirError> {
-    cached_ltoir_to_cubin_with_options(source_dir, ltoir, module_name, arch, true)
+    cached_ltoir_to_cubin_with_compile_options(
+        source_dir,
+        ltoir,
+        module_name,
+        arch,
+        ArtifactCompileOptions::new(),
+    )
 }
 
-fn cached_ltoir_to_cubin_with_options(
+fn cached_ltoir_to_cubin_with_compile_options(
     source_dir: &Path,
     ltoir: &[u8],
     module_name: &str,
     arch: &CudaArch,
-    allow_fma_contraction: bool,
+    compile_options: ArtifactCompileOptions,
 ) -> Result<CacheResult, LtoirError> {
-    let nvj = load_nvjitlink_tool()?;
-    let key = nvj.digest.map(|digest| {
-        ltoir_cubin_cache_key_with_options(ltoir, module_name, arch, &digest, allow_fma_contraction)
-    });
+    let linker = LtoLinker::discover()?;
+    let options = finalization_options(arch, compile_options);
+    let inputs = [NamedInput::new(module_name, ltoir)];
+    let key = linker.artifact_digest(&inputs, &options, FinalizerOutput::Cubin);
     let build = || -> Result<BuiltArtifacts, LtoirError> {
-        link_ltoir_to_cubin_with_tool_options(
-            &nvj.library,
-            ltoir,
-            module_name,
-            arch,
-            allow_fma_contraction,
-        )
-        .map(|cubin| BuiltArtifacts::new(cubin, None))
+        Ok(BuiltArtifacts::new(
+            linker.link_ltoir(&inputs, &options, FinalizerOutput::Cubin)?,
+            None,
+        ))
     };
 
     let result = match key {
@@ -656,103 +658,6 @@ fn cached_ltoir_to_cubin_with_options(
     };
     report_cache_result(&result);
     Ok(result)
-}
-
-fn load_nvvm_tool() -> Result<Arc<LoadedNvvmTool>, LtoirError> {
-    if let Some(loaded) = NVVM_TOOL.get() {
-        return Ok(Arc::clone(loaded));
-    }
-    let _load_guard = NVVM_TOOL_LOAD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(loaded) = NVVM_TOOL.get() {
-        return Ok(Arc::clone(loaded));
-    }
-
-    let library = LibNvvm::load_for_cache()?;
-    let digest = loaded_nvvm_digest(&library);
-    let loaded = Arc::new(LoadedNvvmTool {
-        library: Arc::new(library),
-        digest,
-    });
-    let _ = NVVM_TOOL.set(Arc::clone(&loaded));
-    Ok(loaded)
-}
-
-fn load_nvjitlink_tool() -> Result<Arc<LoadedNvJitLinkTool>, LtoirError> {
-    if let Some(loaded) = NVJITLINK_TOOL.get() {
-        return Ok(Arc::clone(loaded));
-    }
-    let _load_guard = NVJITLINK_TOOL_LOAD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(loaded) = NVJITLINK_TOOL.get() {
-        return Ok(Arc::clone(loaded));
-    }
-
-    let library = LibNvJitLink::load_for_cache()?;
-    let digest = loaded_nvjitlink_digest(&library);
-    let loaded = Arc::new(LoadedNvJitLinkTool {
-        library: Arc::new(library),
-        digest,
-    });
-    let _ = NVJITLINK_TOOL.set(Arc::clone(&loaded));
-    Ok(loaded)
-}
-
-fn loaded_nvvm_digest(nvvm: &LibNvvm) -> Option<[u8; 32]> {
-    let file = nvvm.loaded_file_if_unchanged();
-    let digest = loaded_tool_digest("libNVVM", file)?;
-    if nvvm.loaded_file_if_unchanged().is_some() {
-        Some(digest)
-    } else {
-        report_changed_tool("libNVVM");
-        None
-    }
-}
-
-fn loaded_nvjitlink_digest(nvj: &LibNvJitLink) -> Option<[u8; 32]> {
-    let file = nvj.loaded_file_if_unchanged();
-    let digest = loaded_tool_digest("nvJitLink", file)?;
-    if nvj.loaded_file_if_unchanged().is_some() {
-        Some(digest)
-    } else {
-        report_changed_tool("nvJitLink");
-        None
-    }
-}
-
-fn loaded_tool_digest(label: &str, file: Option<&std::fs::File>) -> Option<[u8; 32]> {
-    let Some(file) = file else {
-        if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
-            eprintln!(
-                "cuda-oxide: {label} has no exact loaded-file identity; bypassing the cubin cache"
-            );
-        }
-        return None;
-    };
-
-    match digest_file_handle(file) {
-        Ok(digest) => Some(digest),
-        Err(error) => {
-            if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
-                eprintln!(
-                    "cuda-oxide: could not fingerprint the loaded {label} file ({error}); bypassing the cubin cache"
-                );
-            }
-            None
-        }
-    }
-}
-
-fn report_changed_tool(label: &str) {
-    if std::env::var_os("CUDA_OXIDE_VERBOSE").is_some() {
-        eprintln!(
-            "cuda-oxide: {label} changed while it was fingerprinted; bypassing the cubin cache"
-        );
-    }
 }
 
 #[cfg(test)]
@@ -765,17 +670,18 @@ fn nvvm_ir_cubin_cache_key(
     libnvvm_digest: &[u8; 32],
     nvjitlink_digest: &[u8; 32],
 ) -> [u8; 32] {
-    nvvm_ir_cubin_cache_key_with_options(
+    nvvm_ir_cubin_cache_key_with_compile_options(
         nvvm_ir,
         nvvm_module_name,
         ltoir_module_name,
         arch,
         libdevice,
         (libnvvm_digest, nvjitlink_digest),
-        true,
+        ArtifactCompileOptions::new(),
     )
 }
 
+#[cfg(test)]
 fn nvvm_ir_cubin_cache_key_with_options(
     nvvm_ir: &[u8],
     nvvm_module_name: &str,
@@ -785,44 +691,41 @@ fn nvvm_ir_cubin_cache_key_with_options(
     tool_digests: (&[u8; 32], &[u8; 32]),
     allow_fma_contraction: bool,
 ) -> [u8; 32] {
+    nvvm_ir_cubin_cache_key_with_compile_options(
+        nvvm_ir,
+        nvvm_module_name,
+        ltoir_module_name,
+        arch,
+        libdevice,
+        tool_digests,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
+    )
+}
+
+#[cfg(test)]
+fn nvvm_ir_cubin_cache_key_with_compile_options(
+    nvvm_ir: &[u8],
+    nvvm_module_name: &str,
+    ltoir_module_name: &str,
+    arch: &CudaArch,
+    libdevice: &[u8],
+    tool_digests: (&[u8; 32], &[u8; 32]),
+    compile_options: ArtifactCompileOptions,
+) -> [u8; 32] {
     let (libnvvm_digest, nvjitlink_digest) = tool_digests;
-    let nvvm_arch = format!("-arch={}", arch.compute());
-    let linker_arch = format!("-arch={}", arch.sm());
-    CacheKeyBuilder::new()
-        .field("recipe", CACHE_RECIPE)
-        .field("route", b"nvvm-ir-to-native-cubin")
-        .field("output", b"elf-cubin")
-        .field("nvvm-ir", nvvm_ir)
-        .field("nvvm-module-name", nvvm_module_name.as_bytes())
-        .field("libdevice", libdevice)
-        .field("libdevice-module-name", b"libdevice.10.bc")
-        .field("module-order", b"libdevice,nvvm-ir")
-        .field("nvvm-verify-option", nvvm_arch.as_bytes())
-        .field("nvvm-compile-option", nvvm_arch.as_bytes())
-        .field("nvvm-compile-option", b"-gen-lto")
-        .field(
-            "nvvm-fma-policy",
-            if allow_fma_contraction {
-                &b"-fma=1"[..]
-            } else {
-                &b"-fma=0"[..]
-            },
-        )
-        .field("nvjitlink-input-kind", b"ltoir")
-        .field("nvjitlink-module-name", ltoir_module_name.as_bytes())
-        .field("nvjitlink-option", linker_arch.as_bytes())
-        .field("nvjitlink-option", b"-lto")
-        .field(
-            "nvjitlink-fma-policy",
-            if allow_fma_contraction {
-                &b"-fma=1"[..]
-            } else {
-                &b"-fma=0"[..]
-            },
-        )
-        .field("libnvvm-sha256", libnvvm_digest)
-        .field("libnvjitlink-sha256", nvjitlink_digest)
-        .finish()
+    nvvm_ir_artifact_digest_with_provenance(
+        nvvm_module_name,
+        ltoir_module_name,
+        nvvm_ir,
+        &finalization_options(arch, compile_options),
+        FinalizerOutput::Cubin,
+        ToolProvenance {
+            libnvvm_sha256: Some(*libnvvm_digest),
+            nvjitlink_sha256: Some(*nvjitlink_digest),
+            libdevice_sha256: Sha256::digest(libdevice).into(),
+        },
+    )
+    .expect("test provenance supplies exact CUDA tool identities")
 }
 
 #[cfg(test)]
@@ -832,9 +735,16 @@ fn ltoir_cubin_cache_key(
     arch: &CudaArch,
     nvjitlink_digest: &[u8; 32],
 ) -> [u8; 32] {
-    ltoir_cubin_cache_key_with_options(ltoir, module_name, arch, nvjitlink_digest, true)
+    ltoir_cubin_cache_key_with_compile_options(
+        ltoir,
+        module_name,
+        arch,
+        nvjitlink_digest,
+        ArtifactCompileOptions::new(),
+    )
 }
 
+#[cfg(test)]
 fn ltoir_cubin_cache_key_with_options(
     ltoir: &[u8],
     module_name: &str,
@@ -842,27 +752,29 @@ fn ltoir_cubin_cache_key_with_options(
     nvjitlink_digest: &[u8; 32],
     allow_fma_contraction: bool,
 ) -> [u8; 32] {
-    let linker_arch = format!("-arch={}", arch.sm());
+    ltoir_cubin_cache_key_with_compile_options(
+        ltoir,
+        module_name,
+        arch,
+        nvjitlink_digest,
+        ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction),
+    )
+}
 
-    CacheKeyBuilder::new()
-        .field("recipe", CACHE_RECIPE)
-        .field("route", b"standalone-ltoir-to-native-cubin")
-        .field("output", b"elf-cubin")
-        .field("ltoir", ltoir)
-        .field("nvjitlink-input-kind", b"ltoir")
-        .field("nvjitlink-module-name", module_name.as_bytes())
-        .field("nvjitlink-option", linker_arch.as_bytes())
-        .field("nvjitlink-option", b"-lto")
-        .field(
-            "nvjitlink-fma-policy",
-            if allow_fma_contraction {
-                &b"-fma=1"[..]
-            } else {
-                &b"-fma=0"[..]
-            },
-        )
-        .field("libnvjitlink-sha256", nvjitlink_digest)
-        .finish()
+#[cfg(test)]
+fn ltoir_cubin_cache_key_with_compile_options(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+    nvjitlink_digest: &[u8; 32],
+    compile_options: ArtifactCompileOptions,
+) -> [u8; 32] {
+    ltoir_artifact_digest_with_provenance(
+        &[NamedInput::new(module_name, ltoir)],
+        &finalization_options(arch, compile_options),
+        FinalizerOutput::Cubin,
+        nvjitlink_digest,
+    )
 }
 
 fn uncached_result(artifacts: BuiltArtifacts) -> CacheResult {
@@ -951,12 +863,12 @@ pub fn load_kernel_module(
                 }
                 ExecutionRoute::PtxBridge => {
                     let nvvm_ir = read_artifact(&ll)?;
-                    let allow_fma_contraction = read_fma_contraction_option(&ll)?;
-                    let ptx = build_ptx_from_nvvm_ir_with_options(
+                    let compile_options = read_compile_options(&ll)?;
+                    let ptx = build_ptx_from_nvvm_ir_with_compile_options(
                         &nvvm_ir,
                         &ll.display().to_string(),
                         &emitted.sm(),
-                        allow_fma_contraction,
+                        compile_options,
                     )?;
                     Ok(ctx.load_module_from_image(&ptx)?)
                 }
@@ -966,23 +878,23 @@ pub fn load_kernel_module(
             let emitted = target_arch_for_artifact(&ltoir)?;
             let execution = execution_arch_for_context(ctx)?;
             let bytes = read_artifact(&ltoir)?;
-            let allow_fma_contraction = read_fma_contraction_option(&ltoir)?;
+            let compile_options = read_compile_options(&ltoir)?;
             let image = match execution_route(&emitted, &execution)? {
                 ExecutionRoute::Cubin => {
-                    cached_ltoir_to_cubin_with_options(
+                    cached_ltoir_to_cubin_with_compile_options(
                         ltoir.parent().unwrap_or_else(|| Path::new(".")),
                         &bytes,
                         &ltoir.display().to_string(),
                         &emitted,
-                        allow_fma_contraction,
+                        compile_options,
                     )?
                     .cubin
                 }
-                ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_options(
+                ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_compile_options(
                     &bytes,
                     &ltoir.display().to_string(),
                     &emitted,
-                    allow_fma_contraction,
+                    compile_options,
                 )?,
             };
             Ok(ctx.load_module_from_image(&image)?)
@@ -1054,11 +966,14 @@ fn select_file_artifact(
 /// Returns [`LtoirError::LibdeviceNotFound`] with the full list of probed
 /// paths if nothing matches.
 ///
-/// Thin wrapper over [`libnvvm_sys::find_libdevice`], which owns the probe
+/// Thin wrapper over [`cuda_artifact_finalizer::find_libdevice`], which owns the probe
 /// (libdevice ships in the toolkit's `nvvm/` component next to `libnvvm.so`).
 pub fn find_libdevice() -> Result<PathBuf, LtoirError> {
-    libnvvm_sys::find_libdevice()
-        .map_err(|libnvvm_sys::LibdeviceNotFound { tried }| LtoirError::LibdeviceNotFound { tried })
+    cuda_artifact_finalizer::find_libdevice().map_err(
+        |cuda_artifact_finalizer::LibdeviceNotFound { tried }| LtoirError::LibdeviceNotFound {
+            tried,
+        },
+    )
 }
 
 /// Read and validate an explicit source target from `CUDA_OXIDE_TARGET`.
@@ -1137,16 +1052,18 @@ fn emitted_compile_options_path(ll_path: &Path) -> PathBuf {
     ll_path.with_extension("options")
 }
 
-fn read_fma_contraction_option(ll_path: &Path) -> Result<bool, LtoirError> {
+fn read_compile_options(ll_path: &Path) -> Result<ArtifactCompileOptions, LtoirError> {
     let path = emitted_compile_options_path(ll_path);
     match std::fs::read_to_string(&path) {
-        Ok(value) => ArtifactCompileOptions::from_sidecar_text(&value)
-            .map(|options| options.fma_contraction_enabled())
-            .map_err(|error| LtoirError::InvalidCompileOptions {
+        Ok(value) => ArtifactCompileOptions::from_sidecar_text(&value).map_err(|error| {
+            LtoirError::InvalidCompileOptions {
                 path,
                 value: error.to_string(),
-            }),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(true),
+            }
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            Ok(ArtifactCompileOptions::new())
+        }
         Err(source) => Err(LtoirError::Io { path, source }),
     }
 }
@@ -1170,7 +1087,7 @@ fn read_emitted_target(ll_path: &Path) -> Result<Option<CudaArch>, LtoirError> {
                             value: "required sidecar is missing".to_string(),
                         });
                     }
-                    read_fma_contraction_option(ll_path)?;
+                    read_compile_options(ll_path)?;
                     Ok(Some(arch))
                 }
                 _ => Err(LtoirError::InvalidCompileOptions {
@@ -1208,7 +1125,7 @@ fn write_artifact_target_sidecar(
         path: options_path.clone(),
         source,
     })? {
-        read_fma_contraction_option(artifact_path)?;
+        read_compile_options(artifact_path)?;
         format!("{}\n{COMPILE_OPTIONS_TARGET_MARKER}\n", target.sm())
     } else {
         format!("{}\n", target.sm())
@@ -1309,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn versioned_target_requires_valid_compile_options() {
+    fn versioned_target_accepts_v1_and_v2_compile_options() {
         let dir = temp_dir("versioned_compile_options");
         std::fs::create_dir_all(&dir).unwrap();
         let ll = dir.join("kernel.ll");
@@ -1325,10 +1242,33 @@ mod tests {
             Err(LtoirError::InvalidCompileOptions { .. })
         ));
 
-        let options = ArtifactCompileOptions::new().with_fma_contraction(false);
-        std::fs::write(dir.join("kernel.options"), options.sidecar_text()).unwrap();
+        let v1_options = ArtifactCompileOptions::new().with_fma_contraction(false);
+        assert!(
+            v1_options
+                .sidecar_text()
+                .starts_with("cuda-oxide-compile-options-v1\n")
+        );
+        std::fs::write(dir.join("kernel.options"), v1_options.sidecar_text()).unwrap();
         assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
-        assert!(!read_fma_contraction_option(&ll).unwrap());
+        assert_eq!(read_compile_options(&ll).unwrap(), v1_options);
+
+        let line_tables =
+            ArtifactCompileOptions::new().with_debug_policy(ArtifactDebugPolicy::LineTables);
+        assert!(
+            line_tables
+                .sidecar_text()
+                .starts_with("cuda-oxide-compile-options-v2\n")
+        );
+        std::fs::write(dir.join("kernel.options"), line_tables.sidecar_text()).unwrap();
+        assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
+        assert_eq!(read_compile_options(&ll).unwrap(), line_tables);
+
+        let full_debug = ArtifactCompileOptions::new()
+            .with_fma_contraction(false)
+            .with_debug_policy(ArtifactDebugPolicy::Full);
+        std::fs::write(dir.join("kernel.options"), full_debug.sidecar_text()).unwrap();
+        assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
+        assert_eq!(read_compile_options(&ll).unwrap(), full_debug);
 
         std::fs::write(dir.join("kernel.options"), "fma-contraction=off\n").unwrap();
         assert!(matches!(
@@ -1336,27 +1276,46 @@ mod tests {
             Err(LtoirError::InvalidCompileOptions { .. })
         ));
 
+        std::fs::remove_file(dir.join("kernel.options")).unwrap();
+        std::fs::write(dir.join("kernel.target"), "sm_86\n").unwrap();
+        assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
+        assert_eq!(
+            read_compile_options(&ll).unwrap(),
+            ArtifactCompileOptions::new(),
+            "legacy artifacts default to FMA enabled with no debug information"
+        );
+
         std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
-    fn nvidia_lto_options_set_fma_policy_explicitly() {
-        assert_eq!(
-            nvvm_compile_options("-arch=compute_86", true),
-            ["-arch=compute_86", "-gen-lto", "-fma=1"]
-        );
-        assert_eq!(
-            nvvm_compile_options("-arch=compute_86", false),
-            ["-arch=compute_86", "-gen-lto", "-fma=0"]
-        );
-        assert_eq!(
-            nvjitlink_lto_options("-arch=sm_86", false, false),
-            ["-arch=sm_86", "-lto", "-fma=0"]
-        );
-        assert_eq!(
-            nvjitlink_lto_options("-arch=sm_86", true, true),
-            ["-arch=sm_86", "-lto", "-ptx", "-fma=1"]
-        );
+    fn finalization_preserves_fma_and_debug_policy() {
+        let arch: CudaArch = "sm_90a".parse().unwrap();
+        for allow_fma in [false, true] {
+            for (artifact_debug, finalizer_debug) in [
+                (
+                    ArtifactDebugPolicy::None,
+                    cuda_artifact_finalizer::DebugPolicy::None,
+                ),
+                (
+                    ArtifactDebugPolicy::LineTables,
+                    cuda_artifact_finalizer::DebugPolicy::LineTables,
+                ),
+                (
+                    ArtifactDebugPolicy::Full,
+                    cuda_artifact_finalizer::DebugPolicy::Full,
+                ),
+            ] {
+                let artifact_options = ArtifactCompileOptions::new()
+                    .with_fma_contraction(allow_fma)
+                    .with_debug_policy(artifact_debug);
+                let finalizer_options = finalization_options(&arch, artifact_options);
+
+                assert_eq!(finalizer_options.target(), &arch);
+                assert_eq!(finalizer_options.allow_fma_contraction(), allow_fma);
+                assert_eq!(finalizer_options.debug_policy(), finalizer_debug);
+            }
+        }
     }
 
     #[test]
@@ -1664,6 +1623,31 @@ mod tests {
             ),
             "FMA policy changes both libNVVM and nvJitLink output"
         );
+
+        let line_tables = nvvm_ir_cubin_cache_key_with_compile_options(
+            b"nvvm ir",
+            "kernel.ll",
+            "kernel.ltoir",
+            &arch,
+            b"libdevice",
+            (&nvvm, &nvjitlink),
+            ArtifactCompileOptions::new().with_debug_policy(ArtifactDebugPolicy::LineTables),
+        );
+        let full_debug = nvvm_ir_cubin_cache_key_with_compile_options(
+            b"nvvm ir",
+            "kernel.ll",
+            "kernel.ltoir",
+            &arch,
+            b"libdevice",
+            (&nvvm, &nvjitlink),
+            ArtifactCompileOptions::new().with_debug_policy(ArtifactDebugPolicy::Full),
+        );
+        assert_ne!(original, line_tables, "line information changes the key");
+        assert_ne!(original, full_debug, "full debug changes the key");
+        assert_ne!(
+            line_tables, full_debug,
+            "line tables and full debug are distinct compiler policies"
+        );
     }
 
     #[test]
@@ -1697,6 +1681,26 @@ mod tests {
             original,
             ltoir_cubin_cache_key_with_options(b"ltoir", "kernel.ltoir", &arch, &nvjitlink, false,),
             "FMA policy changes nvJitLink LTO output"
+        );
+        let line_tables = ltoir_cubin_cache_key_with_compile_options(
+            b"ltoir",
+            "kernel.ltoir",
+            &arch,
+            &nvjitlink,
+            ArtifactCompileOptions::new().with_debug_policy(ArtifactDebugPolicy::LineTables),
+        );
+        let full_debug = ltoir_cubin_cache_key_with_compile_options(
+            b"ltoir",
+            "kernel.ltoir",
+            &arch,
+            &nvjitlink,
+            ArtifactCompileOptions::new().with_debug_policy(ArtifactDebugPolicy::Full),
+        );
+        assert_ne!(original, line_tables, "line information changes the key");
+        assert_ne!(original, full_debug, "full debug changes the key");
+        assert_ne!(
+            line_tables, full_debug,
+            "line tables and full debug are distinct linker policies"
         );
         assert_ne!(
             original,
@@ -1741,14 +1745,8 @@ entry:
         assert!(first_bytes.starts_with(b"\x7fELF"));
         assert_eq!(first, dir.join("kernel.cubin"));
 
-        let nvvm_a = load_nvvm_tool().unwrap();
-        let nvvm_b = load_nvvm_tool().unwrap();
-        assert!(Arc::ptr_eq(&nvvm_a, &nvvm_b));
-        assert!(nvvm_a.digest.is_some());
-        let nvjitlink_a = load_nvjitlink_tool().unwrap();
-        let nvjitlink_b = load_nvjitlink_tool().unwrap();
-        assert!(Arc::ptr_eq(&nvjitlink_a, &nvjitlink_b));
-        assert!(nvjitlink_a.digest.is_some());
+        let finalizer = Finalizer::discover().unwrap();
+        assert!(finalizer.provenance_digest().is_some());
 
         let second = build_cubin_from_ll(&ll, "compute_86").unwrap();
         assert_eq!(second, first, "normalized target spelling should hit");

--- a/crates/cuda-host/src/ltoir_cache.rs
+++ b/crates/cuda-host/src/ltoir_cache.rs
@@ -9,16 +9,13 @@
 //! LTOIR have all been checked. Callers always receive owned bytes and must
 //! load those bytes, rather than reopening a cache path after validation.
 
+use cuda_artifact_finalizer::is_valid_cubin;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
-#[cfg(not(unix))]
-use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::SystemTime;
 
-const CACHE_KEY_DOMAIN: &[u8] = b"cuda-oxide/ltoir-cubin-cache/key/v1";
 const CACHE_DIRECTORY: &str = "ltoir-cubin-cache";
 const CACHE_VERSION: &str = "v1";
 const MANIFEST_FILE: &str = "manifest.bin";
@@ -28,164 +25,18 @@ const MANIFEST_MAGIC: &[u8] = b"cuda-oxide-ltoir-cache-entry\0";
 const MANIFEST_VERSION: u32 = 1;
 const DIGEST_LENGTH: usize = 32;
 const MAX_CACHE_ARTIFACT_LENGTH: u64 = 1 << 30;
+#[cfg(test)]
 const ELF64_HEADER_LENGTH: usize = 64;
+#[cfg(test)]
 const ELF64_PROGRAM_HEADER_LENGTH: u16 = 56;
-const ELF64_SECTION_HEADER_LENGTH: u16 = 64;
 const MANIFEST_LENGTH: usize =
     MANIFEST_MAGIC.len() + 4 + DIGEST_LENGTH + 8 + DIGEST_LENGTH + 1 + 8 + DIGEST_LENGTH;
 
 static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
-#[derive(Debug, PartialEq, Eq)]
-struct FileSnapshot {
-    len: u64,
-    modified: SystemTime,
-    #[cfg(unix)]
-    device: u64,
-    #[cfg(unix)]
-    inode: u64,
-    #[cfg(unix)]
-    change_time: (i64, i64),
-}
-
-impl FileSnapshot {
-    fn capture(metadata: &fs::Metadata) -> io::Result<Self> {
-        #[cfg(unix)]
-        use std::os::unix::fs::MetadataExt;
-
-        Ok(Self {
-            len: metadata.len(),
-            modified: metadata.modified()?,
-            #[cfg(unix)]
-            device: metadata.dev(),
-            #[cfg(unix)]
-            inode: metadata.ino(),
-            #[cfg(unix)]
-            change_time: (metadata.ctime(), metadata.ctime_nsec()),
-        })
-    }
-}
 
 /// Hash bytes exactly as they appear in a cache input.
 pub(crate) fn digest_bytes(bytes: &[u8]) -> [u8; DIGEST_LENGTH] {
     Sha256::digest(bytes).into()
-}
-
-/// Hash the complete contents of a file.
-///
-/// Tool fingerprints should be taken from the same loaded library that is
-/// subsequently used to build the artifact. If that exact file cannot be
-/// identified or read, callers should skip the cache.
-#[cfg(test)]
-pub(crate) fn digest_file(path: &Path) -> io::Result<[u8; DIGEST_LENGTH]> {
-    let file = File::open(path)?;
-    digest_file_handle(&file)
-}
-
-/// Hash the complete contents of an already-open file without changing its
-/// shared cursor.
-///
-/// The retained CUDA-tool descriptor is the provenance boundary: pathname
-/// replacement cannot redirect these reads to another inode.
-pub(crate) fn digest_file_handle(file: &File) -> io::Result<[u8; DIGEST_LENGTH]> {
-    let metadata = file.metadata()?;
-    if !metadata.is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "tool fingerprint input is not a regular file",
-        ));
-    }
-    let snapshot = FileSnapshot::capture(&metadata)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 64 * 1024];
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::FileExt;
-
-        let mut offset = 0_u64;
-        loop {
-            let read = match file.read_at(&mut buffer, offset) {
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-                result => result?,
-            };
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-            offset = offset
-                .checked_add(read as u64)
-                .ok_or_else(|| io::Error::other("tool file length overflow"))?;
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        let mut reader = file.try_clone()?;
-        reader.seek(SeekFrom::Start(0))?;
-        loop {
-            let read = reader.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-    }
-
-    let digest = hasher.finalize().into();
-    let after = FileSnapshot::capture(&file.metadata()?)?;
-    if after != snapshot {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "tool file changed while it was fingerprinted",
-        ));
-    }
-    Ok(digest)
-}
-
-/// Builds an unambiguous cache key from ordered, tagged fields.
-///
-/// Both the tag and value are length-prefixed. Field order is significant,
-/// which preserves option ordering and prevents inputs such as `(ab, c)` and
-/// `(a, bc)` from producing the same byte stream before hashing.
-pub(crate) struct CacheKeyBuilder {
-    hasher: Sha256,
-}
-
-impl CacheKeyBuilder {
-    pub(crate) fn new() -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(CACHE_KEY_DOMAIN);
-        Self { hasher }
-    }
-
-    pub(crate) fn field(mut self, tag: &str, value: impl AsRef<[u8]>) -> Self {
-        let tag = tag.as_bytes();
-        let value = value.as_ref();
-
-        self.hasher.update([1]);
-        self.hasher.update(length_prefix(tag.len()));
-        self.hasher.update(tag);
-        self.hasher.update(length_prefix(value.len()));
-        self.hasher.update(value);
-        self
-    }
-
-    pub(crate) fn finish(mut self) -> [u8; DIGEST_LENGTH] {
-        self.hasher.update([0xff]);
-        self.hasher.finalize().into()
-    }
-}
-
-impl Default for CacheKeyBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-fn length_prefix(length: usize) -> [u8; 8] {
-    u64::try_from(length)
-        .expect("cache key fields cannot exceed u64::MAX bytes")
-        .to_be_bytes()
 }
 
 /// Fresh artifacts returned by the expensive compiler/linker pipeline.
@@ -269,7 +120,7 @@ where
     }
 
     let artifacts = build()?;
-    if !looks_like_cubin(&artifacts.cubin) {
+    if !is_valid_cubin(&artifacts.cubin) {
         return Ok(CacheResult::uncached(artifacts));
     }
 
@@ -367,7 +218,7 @@ fn read_valid_entry(
     let Some(cubin) = read_entry_file(&cubin_path, manifest.cubin_length)? else {
         return Ok(None);
     };
-    if digest_bytes(&cubin) != manifest.cubin_digest || !looks_like_cubin(&cubin) {
+    if digest_bytes(&cubin) != manifest.cubin_digest || !is_valid_cubin(&cubin) {
         return Ok(None);
     }
 
@@ -705,171 +556,6 @@ impl Drop for PendingDirectory {
     }
 }
 
-fn looks_like_cubin(bytes: &[u8]) -> bool {
-    // nvJitLink cubins are 64-bit, little-endian ET_EXEC ELF files for
-    // EM_CUDA (190). Validate all declared tables and file-backed ranges so a
-    // truncated ELF prefix never becomes a reusable cache entry.
-    if bytes.len() < ELF64_HEADER_LENGTH
-        || !bytes.starts_with(b"\x7fELF")
-        || bytes[4] != 2
-        || bytes[5] != 1
-        || bytes[6] != 1
-        || read_u16(bytes, 16) != Some(2)
-        || read_u16(bytes, 18) != Some(190)
-        || read_u32(bytes, 20) != Some(1)
-        || read_u16(bytes, 52) != Some(ELF64_HEADER_LENGTH as u16)
-    {
-        return false;
-    }
-
-    let Some(program_offset) = read_u64(bytes, 32) else {
-        return false;
-    };
-    let Some(section_offset) = read_u64(bytes, 40) else {
-        return false;
-    };
-    let Some(program_entry_size) = read_u16(bytes, 54) else {
-        return false;
-    };
-    let Some(program_count) = read_u16(bytes, 56) else {
-        return false;
-    };
-    let Some(section_entry_size) = read_u16(bytes, 58) else {
-        return false;
-    };
-    let Some(section_count) = read_u16(bytes, 60) else {
-        return false;
-    };
-    let Some(section_name_index) = read_u16(bytes, 62) else {
-        return false;
-    };
-
-    if program_count == u16::MAX || (program_count == 0 && section_count == 0) {
-        return false;
-    }
-    let program_table = if program_count == 0 {
-        if program_offset != 0 || !matches!(program_entry_size, 0 | ELF64_PROGRAM_HEADER_LENGTH) {
-            return false;
-        }
-        None
-    } else {
-        if program_entry_size != ELF64_PROGRAM_HEADER_LENGTH {
-            return false;
-        }
-        table_bounds(
-            program_offset,
-            program_entry_size,
-            program_count,
-            bytes.len(),
-        )
-    };
-    let section_table = if section_count == 0 {
-        // Extended section numbering is unnecessary for cubins and would
-        // require trusting section zero before its bounds were known.
-        if section_offset != 0
-            || section_name_index != 0
-            || !matches!(section_entry_size, 0 | ELF64_SECTION_HEADER_LENGTH)
-        {
-            return false;
-        }
-        None
-    } else {
-        if section_entry_size != ELF64_SECTION_HEADER_LENGTH
-            || (section_name_index != 0 && section_name_index >= section_count)
-        {
-            return false;
-        }
-        table_bounds(
-            section_offset,
-            section_entry_size,
-            section_count,
-            bytes.len(),
-        )
-    };
-    if program_count != 0 && program_table.is_none()
-        || section_count != 0 && section_table.is_none()
-    {
-        return false;
-    }
-
-    if let Some((start, _)) = program_table {
-        for index in 0..usize::from(program_count) {
-            let header = start + index * usize::from(program_entry_size);
-            let Some(file_offset) = read_u64(bytes, header + 8) else {
-                return false;
-            };
-            let Some(file_size) = read_u64(bytes, header + 32) else {
-                return false;
-            };
-            if !file_range_is_valid(file_offset, file_size, bytes.len()) {
-                return false;
-            }
-        }
-    }
-
-    if let Some((start, _)) = section_table {
-        for index in 0..usize::from(section_count) {
-            let header = start + index * usize::from(section_entry_size);
-            let Some(section_type) = read_u32(bytes, header + 4) else {
-                return false;
-            };
-            let Some(file_offset) = read_u64(bytes, header + 24) else {
-                return false;
-            };
-            let Some(file_size) = read_u64(bytes, header + 32) else {
-                return false;
-            };
-            // SHT_NOBITS occupies memory but has no bytes in the ELF image.
-            if section_type != 8 && !file_range_is_valid(file_offset, file_size, bytes.len()) {
-                return false;
-            }
-        }
-    }
-
-    true
-}
-
-fn table_bounds(
-    offset: u64,
-    entry_size: u16,
-    count: u16,
-    file_len: usize,
-) -> Option<(usize, usize)> {
-    if offset < ELF64_HEADER_LENGTH as u64 {
-        return None;
-    }
-    let length = u64::from(entry_size).checked_mul(u64::from(count))?;
-    let end = offset.checked_add(length)?;
-    if end > file_len as u64 {
-        return None;
-    }
-    Some((usize::try_from(offset).ok()?, usize::try_from(end).ok()?))
-}
-
-fn file_range_is_valid(offset: u64, length: u64, file_len: usize) -> bool {
-    offset
-        .checked_add(length)
-        .is_some_and(|end| end <= file_len as u64)
-}
-
-fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
-    Some(u16::from_le_bytes(
-        bytes.get(offset..offset + 2)?.try_into().ok()?,
-    ))
-}
-
-fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
-    Some(u32::from_le_bytes(
-        bytes.get(offset..offset + 4)?.try_into().ok()?,
-    ))
-}
-
-fn read_u64(bytes: &[u8], offset: usize) -> Option<u64> {
-    Some(u64::from_le_bytes(
-        bytes.get(offset..offset + 8)?.try_into().ok()?,
-    ))
-}
-
 fn hex_digest(digest: &[u8; DIGEST_LENGTH]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut result = String::with_capacity(DIGEST_LENGTH * 2);
@@ -883,7 +569,6 @@ fn hex_digest(digest: &[u8; DIGEST_LENGTH]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
     use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
@@ -961,11 +646,7 @@ mod tests {
     }
 
     fn test_key() -> [u8; DIGEST_LENGTH] {
-        CacheKeyBuilder::new()
-            .field("pipeline", b"test-v1")
-            .field("route", b"nvvm-ir-to-cubin")
-            .field("arch", b"sm_80")
-            .finish()
+        digest_bytes(b"cuda-host cache test key")
     }
 
     #[test]
@@ -1008,64 +689,13 @@ mod tests {
     }
 
     #[test]
-    fn digest_file_tracks_in_place_changes_and_inode_replacement() {
-        let dir = TestDirectory::new("digest-file");
-        let path = dir.path().join("tool.so");
-        fs::write(&path, b"exact tool bytes").unwrap();
-        let first = digest_file(&path).unwrap();
-        assert_eq!(first, digest_bytes(b"exact tool bytes"));
-        assert_eq!(digest_file(&path).unwrap(), first);
-
-        fs::write(&path, b"changed-tool-dat").unwrap();
-        let changed = digest_file(&path).unwrap();
-        assert_eq!(changed, digest_bytes(b"changed-tool-dat"));
-        assert_ne!(
-            changed, first,
-            "same-path content changes must change the digest"
-        );
-
-        let replacement = dir.path().join("replacement.so");
-        fs::write(&replacement, b"replaced-tool-da").unwrap();
-        fs::remove_file(&path).unwrap();
-        fs::rename(&replacement, &path).unwrap();
-        let replaced = digest_file(&path).unwrap();
-        assert_eq!(replaced, digest_bytes(b"replaced-tool-da"));
-        assert_ne!(
-            replaced, changed,
-            "inode replacement must change the digest"
-        );
-    }
-
-    #[test]
-    fn digest_file_handle_stays_bound_to_open_inode_after_replacement() {
-        let dir = TestDirectory::new("digest-open-file");
-        let path = dir.path().join("tool.so");
-        let replacement = dir.path().join("replacement.so");
-        fs::write(&path, b"tool version one").unwrap();
-        fs::write(&replacement, b"tool version two").unwrap();
-
-        let opened = File::open(&path).unwrap();
-        fs::remove_file(&path).unwrap();
-        fs::rename(&replacement, &path).unwrap();
-
-        assert_eq!(
-            digest_file_handle(&opened).unwrap(),
-            digest_bytes(b"tool version one")
-        );
-        assert_eq!(
-            digest_file(&path).unwrap(),
-            digest_bytes(b"tool version two")
-        );
-    }
-
-    #[test]
     fn cubin_validation_rejects_truncated_headers_and_out_of_bounds_tables() {
-        assert!(!looks_like_cubin(&truncated_cubin_prefix()));
-        assert!(looks_like_cubin(&fake_cubin(1)));
+        assert!(!is_valid_cubin(&truncated_cubin_prefix()));
+        assert!(is_valid_cubin(&fake_cubin(1)));
 
         let mut out_of_bounds = fake_cubin(2);
         out_of_bounds[32..40].copy_from_slice(&119_u64.to_le_bytes());
-        assert!(!looks_like_cubin(&out_of_bounds));
+        assert!(!is_valid_cubin(&out_of_bounds));
     }
 
     #[test]
@@ -1110,56 +740,6 @@ mod tests {
         assert_eq!(repaired.cubin, fake_cubin(21));
         assert!(repaired.immutable_cubin_path.is_some());
         assert_eq!(fs::read(outside).unwrap(), b"outside bytes");
-    }
-
-    #[test]
-    fn key_changes_for_every_input_and_is_unambiguous() {
-        let fields: [(&str, &[u8]); 8] = [
-            ("pipeline", b"pipeline-v1"),
-            ("route", b"nvvm-ir-to-cubin"),
-            ("arch", b"sm_80"),
-            ("module", b"kernel"),
-            ("option", b"-lto"),
-            ("source", b"source digest"),
-            ("libdevice", b"libdevice digest"),
-            ("tools", b"exact tool digests"),
-        ];
-
-        let build_key = |changed: Option<usize>| {
-            fields
-                .iter()
-                .enumerate()
-                .fold(CacheKeyBuilder::new(), |builder, (index, (tag, value))| {
-                    if changed == Some(index) {
-                        builder.field(tag, [*value, b" changed"].concat())
-                    } else {
-                        builder.field(tag, *value)
-                    }
-                })
-                .finish()
-        };
-
-        let original = build_key(None);
-        let changed = (0..fields.len()).map(|index| build_key(Some(index)));
-        let all = std::iter::once(original)
-            .chain(changed)
-            .collect::<HashSet<_>>();
-        assert_eq!(all.len(), fields.len() + 1);
-
-        let left = CacheKeyBuilder::new()
-            .field("part", b"ab")
-            .field("part", b"c")
-            .finish();
-        let right = CacheKeyBuilder::new()
-            .field("part", b"a")
-            .field("part", b"bc")
-            .finish();
-        let reordered = CacheKeyBuilder::new()
-            .field("part", b"c")
-            .field("part", b"ab")
-            .finish();
-        assert_ne!(left, right);
-        assert_ne!(left, reordered);
     }
 
     #[test]
@@ -1274,8 +854,8 @@ mod tests {
     #[test]
     fn complete_entries_swapped_between_keys_are_rejected() {
         let dir = TestDirectory::new("swapped-entries");
-        let key_a = CacheKeyBuilder::new().field("source", b"A").finish();
-        let key_b = CacheKeyBuilder::new().field("source", b"B").finish();
+        let key_a = digest_bytes(b"source A");
+        let key_b = digest_bytes(b"source B");
         cache_or_build(dir.path(), &key_a, || Ok::<_, ()>(artifacts(20))).unwrap();
         cache_or_build(dir.path(), &key_b, || Ok::<_, ()>(artifacts(21))).unwrap();
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -106,6 +106,7 @@ use quote::{format_ident, quote};
 use reserved_oxide_symbols::{
     DEVICE_EXTERN_PREFIX, DEVICE_PREFIX, INSTANTIATE_PREFIX, KERNEL_PREFIX, KERNEL_SCOPE_LOCAL,
     RESERVED_ROOT, artifact_anchor_symbol, artifact_anchor_symbol_v2, constant_symbol,
+    ptx_merge_required_marker,
 };
 use syn::{
     Expr, ExprCall, ExprMethodCall, ExprPath, FnArg, ForeignItem, GenericArgument, GenericParam,
@@ -727,18 +728,53 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
 
     let artifact_anchor_statements = cuda_module_artifact_anchor_statements(&transformed.kernels)?;
     let has_generic = transformed.kernels.iter().any(|k| k.is_generic);
+    let ptx_merge_required_markers = transformed.kernels.iter().filter_map(|kernel| {
+        if !kernel.is_generic {
+            return None;
+        }
+        let marker = internal_ident(&ptx_merge_required_marker(&kernel.fn_name.to_string()));
+        let cfg_attrs = &kernel.effective_cfg_attrs;
+        Some(quote! {
+            #(#cfg_attrs)*
+            // Consumed by the codegen collector. This enabled generic kernel
+            // requires run-time PTX bundle merging, which ahead-of-time cubin
+            // materialization cannot represent yet.
+            #[doc(hidden)]
+            #[used]
+            #[allow(dead_code, non_upper_case_globals)]
+            static #marker: u8 = 0;
+        })
+    });
+    let enable_generic_loader_statements = transformed.kernels.iter().filter_map(|kernel| {
+        if !kernel.is_generic {
+            return None;
+        }
+        let cfg_attrs = &kernel.effective_cfg_attrs;
+        Some(quote! {
+            #(#cfg_attrs)*
+            let _ = {
+                __cuda_oxide_has_enabled_generic_kernel = true;
+            };
+        })
+    });
     let has_launch_contract = transformed
         .kernels
         .iter()
         .any(|kernel| kernel.launch_contract.is_some());
     let module_loader = if has_generic {
-        // At least one kernel is generic: its PTX is emitted into the
-        // consuming binary's bundle, not this crate's bundle. Merge all
-        // PTX bundles from the executable so generic monomorphizations are
-        // visible regardless of which crate compiled them.
+        // A syntactically present generic kernel may be removed by cfg. Make
+        // the loader decision under the exact same effective cfg chain as its
+        // marker, so eligibility and run-time behavior cannot disagree.
         quote! {
-            let _ = name; // merged load ignores the crate-name hint
-            let module = ::cuda_host::load_all_ptx_bundles_merged(ctx)?;
+            #[allow(unused_mut)]
+            let mut __cuda_oxide_has_enabled_generic_kernel = false;
+            #(#enable_generic_loader_statements)*
+            let module = if __cuda_oxide_has_enabled_generic_kernel {
+                let _ = name; // merged load ignores the crate-name hint
+                ::cuda_host::load_all_ptx_bundles_merged(ctx)?
+            } else {
+                ::cuda_host::load_embedded_module(ctx, name)?
+            };
         }
     } else {
         quote! {
@@ -932,6 +968,7 @@ fn expand_cuda_module(module: ItemMod) -> syn::Result<TokenStream2> {
         #(#module_attrs)*
         #vis mod #ident {
             #(#module_items)*
+            #(#ptx_merge_required_markers)*
             #(#launch_contract_impls)*
 
             #[derive(Clone, Debug)]
@@ -6577,6 +6614,7 @@ fn expand_cuda_launch_async(input: CudaLaunchAsyncInput) -> TokenStream2 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reserved_oxide_symbols::PTX_MERGE_REQUIRED_PREFIX;
 
     /// Expands a `#[cuda_module]` body and returns the generated tokens as a
     /// whitespace-free string, so tests can assert on call paths without
@@ -6703,6 +6741,81 @@ mod tests {
         assert!(
             expanded.contains("mixed_ptx_name::<T,N>()"),
             "typed launch must forward type and const arguments to the name helper:\n{expanded}"
+        );
+        assert!(
+            expanded.contains(PTX_MERGE_REQUIRED_PREFIX),
+            "generic cuda_module must emit the compiler-visible PTX-merge marker:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn non_generic_cuda_module_does_not_emit_ptx_merge_marker() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn plain(output: &mut [u32]) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            !expanded.contains(PTX_MERGE_REQUIRED_PREFIX),
+            "non-generic cuda_module must remain eligible for cubin materialization:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn cfg_gated_generic_uses_the_same_gate_for_marker_and_loader() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn plain(output: &mut [u32]) {}
+
+                #[cfg(feature = "generic")]
+                #[kernel]
+                pub fn optional<T: Copy>(value: T) {}
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+        let marker = ptx_merge_required_marker("optional");
+
+        assert!(
+            expanded.contains(&format!(
+                "#[cfg(feature=\"generic\")]#[doc(hidden)]#[used]#[allow(dead_code,non_upper_case_globals)]static{marker}:u8=0"
+            )),
+            "marker must inherit the generic kernel's cfg:\n{expanded}"
+        );
+        assert!(
+            expanded.contains(
+                "#[cfg(feature=\"generic\")]let_={__cuda_oxide_has_enabled_generic_kernel=true;};"
+            ),
+            "loader selection must inherit the generic kernel's cfg:\n{expanded}"
+        );
+        assert!(
+            expanded.contains("if__cuda_oxide_has_enabled_generic_kernel{let_=name;::cuda_host::load_all_ptx_bundles_merged(ctx)?}else{::cuda_host::load_embedded_module(ctx,name)?}"),
+            "loader must fall back to the embedded artifact when no generic kernel is enabled:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn nested_generic_marker_inherits_every_ancestor_cfg() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[cfg(feature = "outer")]
+                mod nested {
+                    #[cfg(target_os = "linux")]
+                    #[kernel]
+                    pub fn map<T: Copy>(value: T) {}
+                }
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+        let marker = ptx_merge_required_marker("map");
+        assert!(
+            expanded.contains(&format!(
+                "#[cfg(feature=\"outer\")]#[cfg(target_os=\"linux\")]#[doc(hidden)]#[used]#[allow(dead_code,non_upper_case_globals)]static{marker}:u8=0"
+            )),
+            "root marker must use the nested kernel's effective cfg chain:\n{expanded}"
         );
     }
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#![feature(proc_macro_def_site)]
+#![feature(proc_macro_def_site, proc_macro_tracked_env)]
 
 mod device_copy;
 mod printf;
@@ -104,9 +104,10 @@ pub fn device_copy(input: TokenStream) -> TokenStream {
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use reserved_oxide_symbols::{
-    DEVICE_EXTERN_PREFIX, DEVICE_PREFIX, INSTANTIATE_PREFIX, KERNEL_PREFIX, KERNEL_SCOPE_LOCAL,
-    RESERVED_ROOT, artifact_anchor_symbol, artifact_anchor_symbol_v2, constant_symbol,
-    ptx_merge_required_marker,
+    CODEGEN_FINGERPRINT_ENV, DEVICE_CODEGEN_CRATE_ENV, DEVICE_EXTERN_PREFIX, DEVICE_PREFIX,
+    INSTANTIATE_PREFIX, KERNEL_PREFIX, KERNEL_SCOPE_LOCAL, MATERIALIZE_CUBIN_ENV,
+    MATERIALIZER_PROVENANCE_ENV, RESERVED_ROOT, artifact_anchor_symbol, artifact_anchor_symbol_v2,
+    constant_symbol, ptx_merge_required_marker,
 };
 use syn::{
     Expr, ExprCall, ExprMethodCall, ExprPath, FnArg, ForeignItem, GenericArgument, GenericParam,
@@ -119,6 +120,15 @@ use syn::{
     visit::{self, Visit},
     visit_mut::{self, VisitMut},
 };
+
+/// Record cuda-oxide's exact device-codegen identity in the consuming crate's
+/// dep-info. Cargo then rebuilds only crates that can own or instantiate device
+/// code when output mode, architecture, policy, or tool provenance changes.
+fn track_codegen_environment() {
+    let _ = proc_macro::tracked::env_var(CODEGEN_FINGERPRINT_ENV);
+    let _ = proc_macro::tracked::env_var(MATERIALIZE_CUBIN_ENV);
+    let _ = proc_macro::tracked::env_var(MATERIALIZER_PROVENANCE_ENV);
+}
 
 /// Build a private identifier that cannot capture, or be captured by, a name
 /// written in the user's kernel signature.
@@ -407,6 +417,7 @@ fn scope_parameter_collision(input: &ItemFn, scope: &Ident) -> Option<Ident> {
 /// when the source kernel itself is safe.
 #[proc_macro_attribute]
 pub fn cuda_module(attr: TokenStream, item: TokenStream) -> TokenStream {
+    track_codegen_environment();
     if !attr.is_empty() {
         return syn::Error::new(
             proc_macro2::Span::call_site(),
@@ -1398,7 +1409,7 @@ fn cuda_module_artifact_anchor_statements(
         return Ok(TokenStream2::new());
     };
 
-    let owner_filter = std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE").ok();
+    let owner_filter = proc_macro::tracked::env_var(DEVICE_CODEGEN_CRATE_ENV).ok();
     let owner_selection = device_codegen_owner_selection(owner_filter.as_deref(), &crate_name);
     if owner_selection == Some(false) {
         // The backend deliberately omits this crate's artifact. Omitting the
@@ -3350,6 +3361,7 @@ fn cuda_kernel_marker_name(fn_name: &Ident) -> Ident {
 /// and are not unrolled.
 #[proc_macro_attribute]
 pub fn kernel(attr: TokenStream, item: TokenStream) -> TokenStream {
+    track_codegen_environment();
     let args = parse_macro_input!(attr as KernelArgs);
     let mut input = parse_macro_input!(item as ItemFn);
 
@@ -3534,6 +3546,7 @@ impl Parse for ConstantArgs {
 /// ```
 #[proc_macro_attribute]
 pub fn constant(attr: TokenStream, item: TokenStream) -> TokenStream {
+    track_codegen_environment();
     let args = parse_macro_input!(attr as ConstantArgs);
     let input = parse_macro_input!(item as syn::ItemStatic);
 
@@ -5436,6 +5449,7 @@ pub fn cooperative_launch(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn device(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    track_codegen_environment();
     // Try parsing as a function definition first
     if let Ok(input) = syn::parse::<ItemFn>(item.clone()) {
         return generate_device_function(input);
@@ -6056,6 +6070,7 @@ impl Parse for CudaLaunchInput {
 /// `stream.synchronize()` to wait for completion.
 #[proc_macro]
 pub fn cuda_launch(input: TokenStream) -> TokenStream {
+    track_codegen_environment();
     let input = parse_macro_input!(input as CudaLaunchInput);
 
     let stream = &input.stream;
@@ -6470,6 +6485,7 @@ impl Parse for CudaLaunchAsyncInput {
 /// ```
 #[proc_macro]
 pub fn cuda_launch_async(input: TokenStream) -> TokenStream {
+    track_codegen_environment();
     let input = parse_macro_input!(input as CudaLaunchAsyncInput);
     expand_cuda_launch_async(input).into()
 }

--- a/crates/cuda-macros/tests/pass/kernel_launch_context_api.rs
+++ b/crates/cuda-macros/tests/pass/kernel_launch_context_api.rs
@@ -34,10 +34,11 @@ pub fn generated_storage_name_is_hygienic(cuda_oxide_kernel_scope_246e25db_stora
 }
 
 fn entry_abis_do_not_contain_the_launch_context() {
-    let _: fn(u32) = cuda_oxide_kernel_246e25db_simple;
-    let _: fn(u32) = cuda_oxide_kernel_246e25db_generic::<4>;
-    let _: fn(u32) = cuda_oxide_kernel_246e25db_explicit_u32;
-    let _: fn(u32) = cuda_oxide_kernel_246e25db_generated_storage_name_is_hygienic;
+    let _: fn(u32) = cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_simple;
+    let _: fn(u32) = cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_generic::<4>;
+    let _: fn(u32) = cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_explicit_u32;
+    let _: fn(u32) =
+        cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_generated_storage_name_is_hygienic;
 }
 
 fn main() {}

--- a/crates/libnvvm-sys/src/lib.rs
+++ b/crates/libnvvm-sys/src/lib.rs
@@ -43,6 +43,8 @@ use libloading::{Library, Symbol};
 use std::ffi::{CString, c_char, c_int, c_void};
 use std::fmt;
 use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::str::FromStr;
@@ -658,6 +660,7 @@ impl LibraryFileIdentity {
         Self::capture_file(file).as_ref() == Some(self)
     }
 
+    #[cfg(test)]
     fn matches_path(&self, path: &Path) -> bool {
         path.metadata()
             .ok()
@@ -718,12 +721,12 @@ fn open_library_path(path: &Path, retain_exact_file: bool) -> Option<OpenedLibra
         && file.metadata().is_ok_and(|metadata| metadata.is_file())
     {
         let identity = LibraryFileIdentity::capture_file(&file);
-        // Load the same absolute file we opened. Re-resolving a relative path
-        // could select another DSO if the process working directory changes.
-        if let Ok(lib) = unsafe { Library::new(canonical_path) } {
-            let identity = identity.filter(|identity| {
-                identity.matches_file(&file) && identity.matches_path(canonical_path)
-            });
+        // Load through the retained descriptor, not the pathname. A pathname
+        // can already be present in glibc's dlopen cache for an older inode;
+        // `/proc/self/fd/N` names the exact inode that we fingerprint below.
+        let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+        if let Ok(lib) = unsafe { Library::new(&descriptor_path) } {
+            let identity = identity.filter(|identity| identity.matches_file(&file));
             return Some(OpenedLibrary {
                 library: lib,
                 loaded_file: Some(file),
@@ -807,6 +810,68 @@ fn find_libdevice_with(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    fn compile_probe_library(source: &Path, output: &Path, value: i32) {
+        std::fs::write(
+            source,
+            format!("int cuda_oxide_probe(void) {{ return {value}; }}\n"),
+        )
+        .unwrap();
+        let status = std::process::Command::new("cc")
+            .args(["-shared", "-fPIC", "-Wl,-soname,libprobe.so"])
+            .arg(source)
+            .arg("-o")
+            .arg(output)
+            .status()
+            .expect("run C compiler for the dlopen identity regression test");
+        assert!(status.success(), "C compiler failed with {status}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cache_loader_uses_replacement_inode_even_when_path_is_already_loaded() {
+        let nonce = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory =
+            std::env::temp_dir().join(format!("libnvvm-sys-dlopen-{}-{nonce}", std::process::id()));
+        std::fs::create_dir(&directory).unwrap();
+        let library_path = directory.join("libprobe.so");
+        let replacement_path = directory.join("replacement.so");
+        let first_source = directory.join("first.c");
+        let second_source = directory.join("second.c");
+        compile_probe_library(&first_source, &library_path, 1);
+
+        let old_library = unsafe { Library::new(&library_path) }.unwrap();
+        let old_probe: Symbol<unsafe extern "C" fn() -> c_int> =
+            unsafe { old_library.get(b"cuda_oxide_probe") }.unwrap();
+        assert_eq!(unsafe { old_probe() }, 1);
+
+        compile_probe_library(&second_source, &replacement_path, 2);
+        let replacement_bytes = std::fs::read(&replacement_path).unwrap();
+        std::fs::rename(&replacement_path, &library_path).unwrap();
+
+        let opened = open_library_path(&library_path, true).expect("load retained replacement");
+        let replacement_probe: Symbol<unsafe extern "C" fn() -> c_int> =
+            unsafe { opened.library.get(b"cuda_oxide_probe") }.unwrap();
+        assert_eq!(unsafe { replacement_probe() }, 2);
+        assert_eq!(unsafe { old_probe() }, 1);
+        let retained = opened
+            .loaded_file
+            .as_ref()
+            .expect("exact cache load retains its descriptor");
+        let mut retained_bytes = Vec::new();
+        std::io::Read::read_to_end(&mut retained.try_clone().unwrap(), &mut retained_bytes)
+            .unwrap();
+        assert_eq!(retained_bytes, replacement_bytes);
+        assert!(opened.loaded_identity.is_some());
+
+        drop(opened);
+        drop(old_library);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn open_descriptor_remains_bound_to_replaced_inode() {

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -327,6 +327,7 @@ pub fn run_pipeline(
                 &config.output_dir,
                 &config.output_name,
                 config.allow_fma_contraction,
+                config.debug_kind,
             )?;
             // Publish the target last: its version marker is the completion record
             // that says the sibling options file is required.
@@ -393,16 +394,23 @@ fn write_nvvm_target_sidecar(
     })
 }
 
-/// Records the compile-wide options (currently the fma-contraction policy) that
-/// downstream LTOIR builds must preserve, next to the emitted `.ll`.
+/// Records the compile-wide FMA and debug policies that downstream libNVVM and
+/// nvJitLink stages must preserve, next to the emitted `.ll`.
 fn write_nvvm_compile_options_sidecar(
     output_dir: &Path,
     output_name: &str,
     allow_fma_contraction: bool,
+    debug_kind: DebugKind,
 ) -> Result<(), PipelineError> {
     let path = output_dir.join(format!("{output_name}.options"));
-    let options =
-        oxide_artifacts::ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction);
+    let debug_policy = match debug_kind {
+        DebugKind::Off => oxide_artifacts::ArtifactDebugPolicy::None,
+        DebugKind::LineTables => oxide_artifacts::ArtifactDebugPolicy::LineTables,
+        DebugKind::Full => oxide_artifacts::ArtifactDebugPolicy::Full,
+    };
+    let options = oxide_artifacts::ArtifactCompileOptions::new()
+        .with_fma_contraction(allow_fma_contraction)
+        .with_debug_policy(debug_policy);
     std::fs::write(&path, options.sidecar_text()).map_err(|error| {
         PipelineError::Export(format!(
             "failed to record NVVM compile options in {}: {error}",
@@ -555,6 +563,47 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("clean up temp output dir");
+    }
+
+    #[test]
+    fn nvvm_sidecar_preserves_deferred_debug_policy() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_nvvm_debug_options_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(&root).unwrap();
+
+        for (name, debug_kind, expected_debug) in [
+            (
+                "off",
+                DebugKind::Off,
+                oxide_artifacts::ArtifactDebugPolicy::None,
+            ),
+            (
+                "lines",
+                DebugKind::LineTables,
+                oxide_artifacts::ArtifactDebugPolicy::LineTables,
+            ),
+            (
+                "full",
+                DebugKind::Full,
+                oxide_artifacts::ArtifactDebugPolicy::Full,
+            ),
+        ] {
+            write_nvvm_compile_options_sidecar(&root, name, false, debug_kind).unwrap();
+            let text = fs::read_to_string(root.join(format!("{name}.options"))).unwrap();
+            let options =
+                oxide_artifacts::ArtifactCompileOptions::from_sidecar_text(&text).unwrap();
+            assert!(!options.fma_contraction_enabled());
+            assert_eq!(options.debug_policy(), expected_debug);
+        }
+
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/nvjitlink-sys/src/lib.rs
+++ b/crates/nvjitlink-sys/src/lib.rs
@@ -33,6 +33,8 @@
 use libloading::{Library, Symbol};
 use std::ffi::{CString, c_char, c_int, c_void};
 use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::time::SystemTime;
@@ -572,6 +574,7 @@ impl LibraryFileIdentity {
         Self::capture_file(file).as_ref() == Some(self)
     }
 
+    #[cfg(test)]
     fn matches_path(&self, path: &Path) -> bool {
         path.metadata()
             .ok()
@@ -636,12 +639,12 @@ fn open_library_path(path: &Path, retain_exact_file: bool) -> Option<OpenedLibra
         && file.metadata().is_ok_and(|metadata| metadata.is_file())
     {
         let identity = LibraryFileIdentity::capture_file(&file);
-        // Load the same absolute file we opened. Re-resolving a relative path
-        // could select another DSO if the process working directory changes.
-        if let Ok(lib) = unsafe { Library::new(canonical_path) } {
-            let identity = identity.filter(|identity| {
-                identity.matches_file(&file) && identity.matches_path(canonical_path)
-            });
+        // Load through the retained descriptor, not the pathname. A pathname
+        // can already be present in glibc's dlopen cache for an older inode;
+        // `/proc/self/fd/N` names the exact inode that we fingerprint below.
+        let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+        if let Ok(lib) = unsafe { Library::new(&descriptor_path) } {
+            let identity = identity.filter(|identity| identity.matches_file(&file));
             return Some(OpenedLibrary {
                 library: lib,
                 loaded_file: Some(file),
@@ -679,6 +682,70 @@ fn cuda_roots_from_env(mut get_env: impl FnMut(&str) -> Option<String>) -> Vec<P
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    fn compile_probe_library(source: &Path, output: &Path, value: i32) {
+        std::fs::write(
+            source,
+            format!("int cuda_oxide_probe(void) {{ return {value}; }}\n"),
+        )
+        .unwrap();
+        let status = std::process::Command::new("cc")
+            .args(["-shared", "-fPIC", "-Wl,-soname,libprobe.so"])
+            .arg(source)
+            .arg("-o")
+            .arg(output)
+            .status()
+            .expect("run C compiler for the dlopen identity regression test");
+        assert!(status.success(), "C compiler failed with {status}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cache_loader_uses_replacement_inode_even_when_path_is_already_loaded() {
+        let nonce = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "nvjitlink-sys-dlopen-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let library_path = directory.join("libprobe.so");
+        let replacement_path = directory.join("replacement.so");
+        let first_source = directory.join("first.c");
+        let second_source = directory.join("second.c");
+        compile_probe_library(&first_source, &library_path, 1);
+
+        let old_library = unsafe { Library::new(&library_path) }.unwrap();
+        let old_probe: Symbol<unsafe extern "C" fn() -> c_int> =
+            unsafe { old_library.get(b"cuda_oxide_probe") }.unwrap();
+        assert_eq!(unsafe { old_probe() }, 1);
+
+        compile_probe_library(&second_source, &replacement_path, 2);
+        let replacement_bytes = std::fs::read(&replacement_path).unwrap();
+        std::fs::rename(&replacement_path, &library_path).unwrap();
+
+        let opened = open_library_path(&library_path, true).expect("load retained replacement");
+        let replacement_probe: Symbol<unsafe extern "C" fn() -> c_int> =
+            unsafe { opened.library.get(b"cuda_oxide_probe") }.unwrap();
+        assert_eq!(unsafe { replacement_probe() }, 2);
+        assert_eq!(unsafe { old_probe() }, 1);
+        let retained = opened
+            .loaded_file
+            .as_ref()
+            .expect("exact cache load retains its descriptor");
+        let mut retained_bytes = Vec::new();
+        std::io::Read::read_to_end(&mut retained.try_clone().unwrap(), &mut retained_bytes)
+            .unwrap();
+        assert_eq!(retained_bytes, replacement_bytes);
+        assert!(opened.loaded_identity.is_some());
+
+        drop(opened);
+        drop(old_library);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn open_descriptor_remains_bound_to_replaced_inode() {

--- a/crates/oxide-artifacts/src/lib.rs
+++ b/crates/oxide-artifacts/src/lib.rs
@@ -23,16 +23,41 @@ const PAYLOAD_RECORD_BYTES: usize = 24;
 const ENTRY_RECORD_BYTES: usize = 24;
 
 const OPTION_NO_FMA_CONTRACTION: u64 = 1 << 0;
-const KNOWN_COMPILE_OPTIONS: u64 = OPTION_NO_FMA_CONTRACTION;
+const OPTION_DEBUG_LINE_TABLES: u64 = 1 << 1;
+const OPTION_DEBUG_FULL: u64 = 1 << 2;
+const OPTION_DEBUG_MASK: u64 = OPTION_DEBUG_LINE_TABLES | OPTION_DEBUG_FULL;
+const KNOWN_COMPILE_OPTIONS: u64 = OPTION_NO_FMA_CONTRACTION | OPTION_DEBUG_MASK;
 
 /// Marker written on the second line of a versioned NVVM/LTOIR `.target`
 /// sidecar. Its presence makes older one-line readers reject the artifact
-/// instead of silently ignoring required compile policy.
+/// instead of silently ignoring required compile policy. The marker versions
+/// the target/options handshake; the `.options` file carries its own v1/v2
+/// format header.
 pub const COMPILE_OPTIONS_TARGET_MARKER: &str = "compile-options=v1";
 
 const COMPILE_OPTIONS_SIDECAR_HEADER: &str = "cuda-oxide-compile-options-v1";
 const COMPILE_OPTIONS_FMA_ON: &str = "cuda-oxide-compile-options-v1\nfma-contraction=on\n";
 const COMPILE_OPTIONS_FMA_OFF: &str = "cuda-oxide-compile-options-v1\nfma-contraction=off\n";
+const COMPILE_OPTIONS_FMA_ON_LINE_TABLES: &str =
+    "cuda-oxide-compile-options-v2\nfma-contraction=on\ndebug=line-tables\n";
+const COMPILE_OPTIONS_FMA_OFF_LINE_TABLES: &str =
+    "cuda-oxide-compile-options-v2\nfma-contraction=off\ndebug=line-tables\n";
+const COMPILE_OPTIONS_FMA_ON_FULL_DEBUG: &str =
+    "cuda-oxide-compile-options-v2\nfma-contraction=on\ndebug=full\n";
+const COMPILE_OPTIONS_FMA_OFF_FULL_DEBUG: &str =
+    "cuda-oxide-compile-options-v2\nfma-contraction=off\ndebug=full\n";
+
+/// Debug information that later CUDA compilation/linking stages must retain.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ArtifactDebugPolicy {
+    /// No device debug output is requested.
+    #[default]
+    None,
+    /// Preserve source line mappings without disabling optimization.
+    LineTables,
+    /// Preserve full debug information; libNVVM finalization runs unoptimized.
+    Full,
+}
 
 /// Compilation policy that must remain attached to a device artifact until
 /// its final machine-code generation step.
@@ -64,8 +89,29 @@ impl ArtifactCompileOptions {
         self.0 & OPTION_NO_FMA_CONTRACTION == 0
     }
 
+    /// Record the debug policy that all remaining CUDA compiler stages must
+    /// use.
+    pub const fn with_debug_policy(mut self, policy: ArtifactDebugPolicy) -> Self {
+        self.0 &= !OPTION_DEBUG_MASK;
+        self.0 |= match policy {
+            ArtifactDebugPolicy::None => 0,
+            ArtifactDebugPolicy::LineTables => OPTION_DEBUG_LINE_TABLES,
+            ArtifactDebugPolicy::Full => OPTION_DEBUG_FULL,
+        };
+        self
+    }
+
+    /// Debug policy attached to this artifact.
+    pub const fn debug_policy(self) -> ArtifactDebugPolicy {
+        match self.0 & OPTION_DEBUG_MASK {
+            OPTION_DEBUG_LINE_TABLES => ArtifactDebugPolicy::LineTables,
+            OPTION_DEBUG_FULL => ArtifactDebugPolicy::Full,
+            _ => ArtifactDebugPolicy::None,
+        }
+    }
+
     fn from_bits(bits: u64) -> Result<Self, ArtifactError> {
-        if bits & !KNOWN_COMPILE_OPTIONS != 0 {
+        if bits & !KNOWN_COMPILE_OPTIONS != 0 || bits & OPTION_DEBUG_MASK == OPTION_DEBUG_MASK {
             return Err(ArtifactError::UnsupportedCompileOptions(bits));
         }
         Ok(Self(bits))
@@ -77,20 +123,36 @@ impl ArtifactCompileOptions {
 
     /// Encode this policy for a sibling `.options` file.
     pub const fn sidecar_text(self) -> &'static str {
-        if self.fma_contraction_enabled() {
-            COMPILE_OPTIONS_FMA_ON
-        } else {
-            COMPILE_OPTIONS_FMA_OFF
+        match (self.fma_contraction_enabled(), self.debug_policy()) {
+            (true, ArtifactDebugPolicy::None) => COMPILE_OPTIONS_FMA_ON,
+            (false, ArtifactDebugPolicy::None) => COMPILE_OPTIONS_FMA_OFF,
+            (true, ArtifactDebugPolicy::LineTables) => COMPILE_OPTIONS_FMA_ON_LINE_TABLES,
+            (false, ArtifactDebugPolicy::LineTables) => COMPILE_OPTIONS_FMA_OFF_LINE_TABLES,
+            (true, ArtifactDebugPolicy::Full) => COMPILE_OPTIONS_FMA_ON_FULL_DEBUG,
+            (false, ArtifactDebugPolicy::Full) => COMPILE_OPTIONS_FMA_OFF_FULL_DEBUG,
         }
     }
 
-    /// Parse a complete version-1 `.options` file.
+    /// Parse a complete `.options` file. Version 1 defaults to no debug policy;
+    /// version 2 records line-table or full-debug preservation explicitly.
     pub fn from_sidecar_text(value: &str) -> Result<Self, ArtifactError> {
         match value {
             COMPILE_OPTIONS_FMA_ON => Ok(Self::new()),
             COMPILE_OPTIONS_FMA_OFF => Ok(Self::new().with_fma_contraction(false)),
+            COMPILE_OPTIONS_FMA_ON_LINE_TABLES => {
+                Ok(Self::new().with_debug_policy(ArtifactDebugPolicy::LineTables))
+            }
+            COMPILE_OPTIONS_FMA_OFF_LINE_TABLES => Ok(Self::new()
+                .with_fma_contraction(false)
+                .with_debug_policy(ArtifactDebugPolicy::LineTables)),
+            COMPILE_OPTIONS_FMA_ON_FULL_DEBUG => {
+                Ok(Self::new().with_debug_policy(ArtifactDebugPolicy::Full))
+            }
+            COMPILE_OPTIONS_FMA_OFF_FULL_DEBUG => Ok(Self::new()
+                .with_fma_contraction(false)
+                .with_debug_policy(ArtifactDebugPolicy::Full)),
             _ => Err(ArtifactError::MalformedCompileOptions(format!(
-                "expected `{COMPILE_OPTIONS_SIDECAR_HEADER}` with exactly one `fma-contraction=on|off` setting"
+                "expected `{COMPILE_OPTIONS_SIDECAR_HEADER}` or `cuda-oxide-compile-options-v2` with canonical fma/debug settings"
             ))),
         }
     }
@@ -994,6 +1056,10 @@ mod tests {
 
         let bundle = parse_artifact_blob(&blob).unwrap();
         assert!(bundle.compile_options.fma_contraction_enabled());
+        assert_eq!(
+            bundle.compile_options.debug_policy(),
+            ArtifactDebugPolicy::None
+        );
     }
 
     #[test]
@@ -1009,15 +1075,59 @@ mod tests {
     }
 
     #[test]
-    fn compile_options_sidecar_round_trips_both_policies() {
+    fn compile_options_sidecar_round_trips_fma_and_debug_policies() {
         for allow_fma_contraction in [true, false] {
-            let expected =
-                ArtifactCompileOptions::new().with_fma_contraction(allow_fma_contraction);
-            let parsed =
-                ArtifactCompileOptions::from_sidecar_text(expected.sidecar_text()).unwrap();
-            assert_eq!(parsed, expected);
+            for debug in [
+                ArtifactDebugPolicy::None,
+                ArtifactDebugPolicy::LineTables,
+                ArtifactDebugPolicy::Full,
+            ] {
+                let expected = ArtifactCompileOptions::new()
+                    .with_fma_contraction(allow_fma_contraction)
+                    .with_debug_policy(debug);
+                let parsed =
+                    ArtifactCompileOptions::from_sidecar_text(expected.sidecar_text()).unwrap();
+                assert_eq!(parsed, expected);
+            }
         }
         assert!(ArtifactCompileOptions::from_sidecar_text("fma-contraction=off\n").is_err());
+    }
+
+    #[test]
+    fn artifact_blob_round_trips_each_debug_policy() {
+        for debug in [ArtifactDebugPolicy::LineTables, ArtifactDebugPolicy::Full] {
+            let expected = ArtifactCompileOptions::new()
+                .with_fma_contraction(false)
+                .with_debug_policy(debug);
+            let blob = build_artifact_blob(
+                &ArtifactBundleSpec::new("debug", "sm_90")
+                    .with_compile_options(expected)
+                    .with_payload(ArtifactPayloadSpec::new(
+                        ArtifactPayloadKind::NvvmIr,
+                        "debug.ll",
+                        b"nvvm ir",
+                    )),
+            )
+            .unwrap();
+
+            assert_eq!(read_u16(&blob, 8).unwrap(), ARTIFACT_VERSION);
+            assert_eq!(
+                parse_artifact_blob(&blob).unwrap().compile_options,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn version_2_rejects_conflicting_debug_bits() {
+        let mut blob = sample_blob();
+        write_u16(&mut blob, 8, ARTIFACT_VERSION);
+        write_u64(&mut blob, 24, OPTION_DEBUG_MASK);
+
+        assert!(matches!(
+            parse_artifact_blob(&blob),
+            Err(ArtifactError::UnsupportedCompileOptions(bits)) if bits == OPTION_DEBUG_MASK
+        ));
     }
 
     #[test]

--- a/crates/reserved-oxide-symbols/README.md
+++ b/crates/reserved-oxide-symbols/README.md
@@ -12,15 +12,15 @@ The `cuda_oxide_*` symbol namespace that `#[kernel]` and `#[device]`
 mangle user functions into, and that the codegen backend, MIR-lowering,
 and LLVM-export passes look for.
 
-Every prefix here ends with the magic suffix `246e25db_`, which is
+Every prefix here contains the magic component `246e25db_`, which is
 `sha256("cuda_oxide_ + rust")` truncated to 8 hex chars. The hash
 exists purely to make accidental collisions impossible — a user is
-never going to write `fn cuda_oxide_kernel_246e25db_foo()` by accident.
+never going to write `fn cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_foo()` by accident.
 
 | Constant                | Value                                  |
 |-------------------------|----------------------------------------|
-| `KERNEL_PREFIX`         | `cuda_oxide_kernel_246e25db_`          |
-| `DEVICE_PREFIX`         | `cuda_oxide_device_246e25db_`          |
+| `KERNEL_PREFIX`         | `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_` |
+| `DEVICE_PREFIX`         | `cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_` |
 | `DEVICE_EXTERN_PREFIX`  | `cuda_oxide_device_extern_246e25db_`   |
 | `INSTANTIATE_PREFIX`    | `cuda_oxide_instantiate_246e25db_`     |
 

--- a/crates/reserved-oxide-symbols/src/lib.rs
+++ b/crates/reserved-oxide-symbols/src/lib.rs
@@ -133,6 +133,17 @@ pub const KERNEL_SCOPE_LOCAL: &str = "cuda_oxide_kernel_scope_246e25db";
 /// linker to pull the artifact member out of the archive.
 pub const ARTIFACT_ANCHOR_PREFIX: &str = "cuda_oxide_artifact_anchor_246e25db_";
 
+/// Prefix of private statics emitted by `#[cuda_module]` for enabled generic
+/// kernels.
+///
+/// Generic kernel specializations can be emitted into a downstream crate's
+/// device artifact, so loading only the defining crate's artifact is not
+/// sufficient. The host API therefore merges PTX bundles for such modules.
+/// Ahead-of-time cubin materialization cannot preserve that behavior today;
+/// the codegen collector uses this marker to reject the unsupported case
+/// before loading libNVVM or nvJitLink.
+pub const PTX_MERGE_REQUIRED_PREFIX: &str = "cuda_oxide_ptx_merge_required_246e25db_";
+
 // ============================================================================
 // Layer 2 — builders (macro side)
 // ============================================================================
@@ -191,6 +202,13 @@ pub fn instantiate_symbol(base: &str) -> String {
 /// ```
 pub fn constant_symbol(base: &str) -> String {
     format!("{CONSTANT_PREFIX}{base}")
+}
+
+/// Build the compiler marker associated with one generic kernel.
+pub fn ptx_merge_required_marker(base: &str) -> String {
+    let mut symbol = String::from(PTX_MERGE_REQUIRED_PREFIX);
+    push_symbol_sanitized(&mut symbol, base);
+    symbol
 }
 
 /// Build the legacy artifact link-anchor symbol for a package and version.
@@ -296,6 +314,14 @@ pub fn is_device_symbol(name: &str) -> bool {
 /// ```
 pub fn is_device_extern_symbol(name: &str) -> bool {
     name.contains(DEVICE_EXTERN_PREFIX)
+}
+
+/// Returns `true` for a generic-kernel PTX-merge marker path.
+pub fn is_ptx_merge_required_marker(name: &str) -> bool {
+    name.rsplit("::")
+        .next()
+        .and_then(|component| component.strip_prefix(PTX_MERGE_REQUIRED_PREFIX))
+        .is_some_and(|base| !base.is_empty())
 }
 
 /// Returns `true` if `name` is a closure-monomorphization helper symbol.
@@ -465,6 +491,10 @@ mod tests {
         assert_eq!(DEVICE_EXTERN_PREFIX, "cuda_oxide_device_extern_246e25db_");
         assert_eq!(INSTANTIATE_PREFIX, "cuda_oxide_instantiate_246e25db_");
         assert_eq!(CONSTANT_PREFIX, "cuda_oxide_const_246e25db_");
+        assert_eq!(
+            PTX_MERGE_REQUIRED_PREFIX,
+            "cuda_oxide_ptx_merge_required_246e25db_"
+        );
     }
 
     /// Every prefix shares the reserved root. The macro guard checks
@@ -479,6 +509,7 @@ mod tests {
             DEVICE_EXTERN_PREFIX,
             INSTANTIATE_PREFIX,
             CONSTANT_PREFIX,
+            PTX_MERGE_REQUIRED_PREFIX,
         ] {
             assert!(
                 p.starts_with(RESERVED_ROOT),
@@ -496,6 +527,22 @@ mod tests {
         assert!(!DEVICE_EXTERN_PREFIX.contains(DEVICE_PREFIX));
         // ...and vice versa
         assert!(!DEVICE_PREFIX.contains(DEVICE_EXTERN_PREFIX));
+    }
+
+    #[test]
+    fn ptx_merge_markers_are_per_kernel_and_sanitized() {
+        let marker = ptx_merge_required_marker("nested::map-value");
+        assert_eq!(
+            marker,
+            "cuda_oxide_ptx_merge_required_246e25db_nested__map_value"
+        );
+        assert!(is_ptx_merge_required_marker(&marker));
+        assert!(is_ptx_merge_required_marker(&format!(
+            "crate::module::{marker}"
+        )));
+        assert!(!is_ptx_merge_required_marker(PTX_MERGE_REQUIRED_PREFIX));
+        assert!(!is_ptx_merge_required_marker(&format!("prefix_{marker}")));
+        assert!(!is_ptx_merge_required_marker(&format!("{marker}::child")));
     }
 
     /// `kernel_base_name(kernel_symbol(x)) == Some(x)` for any reasonable

--- a/crates/reserved-oxide-symbols/src/lib.rs
+++ b/crates/reserved-oxide-symbols/src/lib.rs
@@ -18,10 +18,10 @@
 //! ## What this crate owns
 //!
 //! The `cuda_oxide_*` namespace, reserved for cuda-oxide internal symbols.
-//! Every prefix below ends with `246e25db_`, which is
+//! Every prefix below contains the component `246e25db_`, which is
 //! `sha256("cuda_oxide_ + rust")` truncated to 8 hex chars. The hash
 //! makes accidental collisions effectively impossible — nobody writes
-//! `fn cuda_oxide_kernel_246e25db_foo()` by accident.
+//! `fn cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_foo()` by accident.
 //!
 //! ## Layered API
 //!
@@ -54,6 +54,21 @@ use alloc::string::String;
 // Layer 1 — raw constants
 // ============================================================================
 
+/// Cargo-visible identity for settings that can change device code or its
+/// embedded artifact. Device-owning procedural macros track this variable so
+/// Cargo invalidates those crates without invalidating unrelated host crates.
+pub const CODEGEN_FINGERPRINT_ENV: &str = "CUDA_OXIDE_INTERNAL_CODEGEN_FINGERPRINT";
+
+/// Internal cargo-oxide/backend opt-in for build-time cubin materialization.
+pub const MATERIALIZE_CUBIN_ENV: &str = "CUDA_OXIDE_MATERIALIZE_CUBIN";
+
+/// Exact CUDA compiler/linker provenance discovered by cargo-oxide and checked
+/// again by the codegen backend before materialization.
+pub const MATERIALIZER_PROVENANCE_ENV: &str = "CUDA_OXIDE_INTERNAL_MATERIALIZER_PROVENANCE";
+
+/// Optional comma-separated filter selecting crates that may own device code.
+pub const DEVICE_CODEGEN_CRATE_ENV: &str = "CUDA_OXIDE_DEVICE_CODEGEN_CRATE";
+
 /// Reserved root that prefixes every cuda-oxide internal symbol.
 ///
 /// User code must not define functions whose name starts with this.
@@ -62,8 +77,8 @@ use alloc::string::String;
 /// and emitting a compile error.
 pub const RESERVED_ROOT: &str = "cuda_oxide_";
 
-/// Magic suffix appended to every prefix to defend against accidental
-/// name collisions in user code.
+/// Magic component embedded in every prefix to defend against accidental name
+/// collisions in user code.
 ///
 /// `sha256("cuda_oxide_ + rust")` truncated to 8 hex chars. The exact
 /// value is irrelevant — what matters is that it's fixed forever and
@@ -72,17 +87,35 @@ pub const HASH_SUFFIX: &str = "246e25db";
 
 /// Prefix added to `#[kernel]` functions for collector detection.
 ///
-/// `#[kernel] fn vecadd(...)` becomes `fn cuda_oxide_kernel_246e25db_vecadd(...)`.
+/// `#[kernel] fn vecadd(...)` becomes
+/// `fn cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_vecadd(...)`.
 /// The collector finds these by name; the PTX entry name itself is the
 /// unprefixed base (e.g., `vecadd`).
-pub const KERNEL_PREFIX: &str = "cuda_oxide_kernel_246e25db_";
+///
+/// The `codegen_v1` component is a cache-protocol handshake. It lets a newer
+/// backend reject pre-tracked-env macro expansions instead of silently reusing
+/// device artifacts across output or architecture changes. The complete
+/// legacy prefix remains embedded after that tag so an explicitly configured
+/// older backend still recognizes and compiles a new root.
+pub const KERNEL_PREFIX: &str = "cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_";
+
+/// Kernel prefix emitted before the scoped Cargo cache protocol existed.
+///
+/// Consumers continue to recognize it so the backend can produce an explicit
+/// compatibility diagnostic. New macro expansions must never emit it.
+pub const LEGACY_KERNEL_PREFIX: &str = "cuda_oxide_kernel_246e25db_";
 
 /// Prefix added to `#[device]` functions for collector detection.
 ///
-/// `#[device] fn helper(...)` becomes `fn cuda_oxide_device_246e25db_helper(...)`.
+/// `#[device] fn helper(...)` becomes
+/// `fn cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_helper(...)`.
 /// The LLVM-export layer strips this prefix to produce clean device-side
-/// symbol names in the final PTX/LTOIR.
-pub const DEVICE_PREFIX: &str = "cuda_oxide_device_246e25db_";
+/// symbol names in the final PTX/LTOIR. As with [`KERNEL_PREFIX`], the complete
+/// legacy prefix remains embedded for older-backend compatibility.
+pub const DEVICE_PREFIX: &str = "cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_";
+
+/// Device-function prefix emitted before the scoped Cargo cache protocol.
+pub const LEGACY_DEVICE_PREFIX: &str = "cuda_oxide_device_246e25db_";
 
 /// Prefix added to functions inside `#[device] extern "C" { ... }` blocks.
 ///
@@ -152,7 +185,10 @@ pub const PTX_MERGE_REQUIRED_PREFIX: &str = "cuda_oxide_ptx_merge_required_246e2
 ///
 /// ```
 /// use reserved_oxide_symbols::kernel_symbol;
-/// assert_eq!(kernel_symbol("vecadd"), "cuda_oxide_kernel_246e25db_vecadd");
+/// assert_eq!(
+///     kernel_symbol("vecadd"),
+///     "cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_vecadd"
+/// );
 /// ```
 pub fn kernel_symbol(base: &str) -> String {
     format!("{KERNEL_PREFIX}{base}")
@@ -162,7 +198,10 @@ pub fn kernel_symbol(base: &str) -> String {
 ///
 /// ```
 /// use reserved_oxide_symbols::device_symbol;
-/// assert_eq!(device_symbol("helper"), "cuda_oxide_device_246e25db_helper");
+/// assert_eq!(
+///     device_symbol("helper"),
+///     "cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_helper"
+/// );
 /// ```
 pub fn device_symbol(base: &str) -> String {
     format!("{DEVICE_PREFIX}{base}")
@@ -280,7 +319,10 @@ fn push_symbol_sanitized(symbol: &mut String, raw: &str) {
 // ============================================================================
 
 /// Returns `true` if `name` is a kernel symbol (or contains one as a
-/// suffix of a longer FQDN like `crate::module::cuda_oxide_kernel_246e25db_foo`).
+/// suffix of a longer FQDN like
+/// `crate::module::cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_foo`). Legacy roots
+/// are recognized too so they can be rejected safely by a protocol-aware
+/// backend rather than disappearing as ordinary host functions.
 ///
 /// ```
 /// use reserved_oxide_symbols::{is_kernel_symbol, kernel_symbol};
@@ -288,7 +330,22 @@ fn push_symbol_sanitized(symbol: &mut String, raw: &str) {
 /// assert!(!is_kernel_symbol("vecadd"));
 /// ```
 pub fn is_kernel_symbol(name: &str) -> bool {
-    name.contains(KERNEL_PREFIX)
+    name.contains(KERNEL_PREFIX) || name.contains(LEGACY_KERNEL_PREFIX)
+}
+
+/// Returns `true` only for a kernel emitted by the scoped-cache protocol.
+pub fn is_current_kernel_symbol(name: &str) -> bool {
+    name.rsplit("::")
+        .next()
+        .is_some_and(|item| item.starts_with(KERNEL_PREFIX))
+}
+
+/// Returns `true` only for a kernel emitted before the scoped-cache protocol.
+pub fn is_legacy_kernel_symbol(name: &str) -> bool {
+    name.rsplit("::")
+        .next()
+        .is_some_and(|item| item.starts_with(LEGACY_KERNEL_PREFIX))
+        && !is_current_kernel_symbol(name)
 }
 
 /// Returns `true` if `name` is a device-function symbol (excluding extern).
@@ -303,7 +360,24 @@ pub fn is_kernel_symbol(name: &str) -> bool {
 /// assert!(!is_device_symbol(&device_extern_symbol("foo")));
 /// ```
 pub fn is_device_symbol(name: &str) -> bool {
-    name.contains(DEVICE_PREFIX)
+    name.contains(DEVICE_PREFIX) || name.contains(LEGACY_DEVICE_PREFIX)
+}
+
+/// Returns `true` only for a device function emitted by the scoped-cache
+/// protocol.
+pub fn is_current_device_symbol(name: &str) -> bool {
+    name.rsplit("::")
+        .next()
+        .is_some_and(|item| item.starts_with(DEVICE_PREFIX))
+}
+
+/// Returns `true` only for a device function emitted before the scoped-cache
+/// protocol.
+pub fn is_legacy_device_symbol(name: &str) -> bool {
+    name.rsplit("::")
+        .next()
+        .is_some_and(|item| item.starts_with(LEGACY_DEVICE_PREFIX))
+        && !is_current_device_symbol(name)
 }
 
 /// Returns `true` if `name` is a `#[device] extern` symbol.
@@ -358,7 +432,7 @@ pub fn is_constant_symbol(name: &str) -> bool {
 /// ```
 /// use reserved_oxide_symbols::kernel_base_name;
 /// assert_eq!(
-///     kernel_base_name("cuda_oxide_kernel_246e25db_vecadd"),
+///     kernel_base_name("cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_vecadd"),
 ///     Some("vecadd"),
 /// );
 /// assert_eq!(
@@ -370,6 +444,10 @@ pub fn is_constant_symbol(name: &str) -> bool {
 pub fn kernel_base_name(name: &str) -> Option<&str> {
     name.find(KERNEL_PREFIX)
         .map(|pos| &name[pos + KERNEL_PREFIX.len()..])
+        .or_else(|| {
+            name.find(LEGACY_KERNEL_PREFIX)
+                .map(|pos| &name[pos + LEGACY_KERNEL_PREFIX.len()..])
+        })
 }
 
 /// Strip the device prefix from a possibly-FQDN symbol name.
@@ -381,7 +459,7 @@ pub fn kernel_base_name(name: &str) -> Option<&str> {
 /// ```
 /// use reserved_oxide_symbols::device_base_name;
 /// assert_eq!(
-///     device_base_name("cuda_oxide_device_246e25db_helper"),
+///     device_base_name("cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_helper"),
 ///     Some("helper"),
 /// );
 /// assert_eq!(device_base_name("cuda_oxide_device_extern_246e25db_foo"), None);
@@ -389,6 +467,10 @@ pub fn kernel_base_name(name: &str) -> Option<&str> {
 pub fn device_base_name(name: &str) -> Option<&str> {
     name.find(DEVICE_PREFIX)
         .map(|pos| &name[pos + DEVICE_PREFIX.len()..])
+        .or_else(|| {
+            name.find(LEGACY_DEVICE_PREFIX)
+                .map(|pos| &name[pos + LEGACY_DEVICE_PREFIX.len()..])
+        })
 }
 
 /// Strip the device-extern prefix from a possibly-FQDN symbol name.
@@ -408,8 +490,8 @@ pub fn device_extern_base_name(name: &str) -> Option<&str> {
 
 /// Format a mangled symbol as a human-readable diagnostic label.
 ///
-/// `cuda_oxide_kernel_246e25db_vecadd` becomes `vecadd (kernel)`,
-/// `cuda_oxide_device_246e25db_helper` becomes `helper (device)`, and
+/// `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_vecadd` becomes `vecadd (kernel)`,
+/// `cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_helper` becomes `helper (device)`, and
 /// device-extern symbols become `<base> (device extern)`. Returns `None`
 /// for anything outside the reserved namespace.
 ///
@@ -419,7 +501,7 @@ pub fn device_extern_base_name(name: &str) -> Option<&str> {
 /// ```
 /// use reserved_oxide_symbols::display_name;
 /// assert_eq!(
-///     display_name("cuda_oxide_kernel_246e25db_vecadd").as_deref(),
+///     display_name("cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_vecadd").as_deref(),
 ///     Some("vecadd (kernel)"),
 /// );
 /// assert_eq!(display_name("std::vec::Vec::new"), None);
@@ -486,8 +568,16 @@ mod tests {
     #[test]
     fn hash_value_is_pinned() {
         assert_eq!(HASH_SUFFIX, "246e25db");
-        assert_eq!(KERNEL_PREFIX, "cuda_oxide_kernel_246e25db_");
-        assert_eq!(DEVICE_PREFIX, "cuda_oxide_device_246e25db_");
+        assert_eq!(
+            KERNEL_PREFIX,
+            "cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_"
+        );
+        assert_eq!(LEGACY_KERNEL_PREFIX, "cuda_oxide_kernel_246e25db_");
+        assert_eq!(
+            DEVICE_PREFIX,
+            "cuda_oxide_codegen_v1_cuda_oxide_device_246e25db_"
+        );
+        assert_eq!(LEGACY_DEVICE_PREFIX, "cuda_oxide_device_246e25db_");
         assert_eq!(DEVICE_EXTERN_PREFIX, "cuda_oxide_device_extern_246e25db_");
         assert_eq!(INSTANTIATE_PREFIX, "cuda_oxide_instantiate_246e25db_");
         assert_eq!(CONSTANT_PREFIX, "cuda_oxide_const_246e25db_");
@@ -505,7 +595,9 @@ mod tests {
     fn all_prefixes_share_reserved_root() {
         for p in [
             KERNEL_PREFIX,
+            LEGACY_KERNEL_PREFIX,
             DEVICE_PREFIX,
+            LEGACY_DEVICE_PREFIX,
             DEVICE_EXTERN_PREFIX,
             INSTANTIATE_PREFIX,
             CONSTANT_PREFIX,
@@ -559,6 +651,61 @@ mod tests {
             assert_eq!(instantiate_base_name(&instantiate_symbol(base)), Some(base),);
             assert_eq!(constant_base_name(&constant_symbol(base)), Some(base));
         }
+    }
+
+    #[test]
+    fn current_and_legacy_codegen_roots_are_distinguished_and_strip_identically() {
+        let current_kernel = kernel_symbol("map");
+        let legacy_kernel = format!("{LEGACY_KERNEL_PREFIX}map");
+        let current_device = device_symbol("helper");
+        let legacy_device = format!("{LEGACY_DEVICE_PREFIX}helper");
+
+        assert!(is_kernel_symbol(&current_kernel));
+        assert!(is_current_kernel_symbol(&current_kernel));
+        assert!(!is_legacy_kernel_symbol(&current_kernel));
+        assert!(is_kernel_symbol(&legacy_kernel));
+        assert!(!is_current_kernel_symbol(&legacy_kernel));
+        assert!(is_legacy_kernel_symbol(&legacy_kernel));
+        assert_eq!(kernel_base_name(&current_kernel), Some("map"));
+        assert_eq!(kernel_base_name(&legacy_kernel), Some("map"));
+        assert!(current_kernel.contains(LEGACY_KERNEL_PREFIX));
+        assert_eq!(
+            current_kernel
+                .find(LEGACY_KERNEL_PREFIX)
+                .map(|index| &current_kernel[index + LEGACY_KERNEL_PREFIX.len()..]),
+            Some("map"),
+            "an older backend must detect and strip the embedded legacy prefix"
+        );
+
+        assert!(is_device_symbol(&current_device));
+        assert!(is_current_device_symbol(&current_device));
+        assert!(!is_legacy_device_symbol(&current_device));
+        assert!(is_device_symbol(&legacy_device));
+        assert!(!is_current_device_symbol(&legacy_device));
+        assert!(is_legacy_device_symbol(&legacy_device));
+        assert_eq!(device_base_name(&current_device), Some("helper"));
+        assert_eq!(device_base_name(&legacy_device), Some("helper"));
+        assert!(current_device.contains(LEGACY_DEVICE_PREFIX));
+        assert_eq!(
+            current_device
+                .find(LEGACY_DEVICE_PREFIX)
+                .map(|index| &current_device[index + LEGACY_DEVICE_PREFIX.len()..]),
+            Some("helper"),
+            "an older backend must detect and strip the embedded legacy prefix"
+        );
+
+        // An old macro prefixes the user-written base verbatim. Its output
+        // must remain legacy even when that base begins with the protocol's
+        // spelling.
+        let old_collision = format!("{LEGACY_KERNEL_PREFIX}codegen_v1_map");
+        assert!(is_legacy_kernel_symbol(&old_collision));
+        assert!(!is_current_kernel_symbol(&old_collision));
+
+        // Protocol classification is about the root item, never an enclosing
+        // path component with a reserved-looking name.
+        let misleading_path = format!("crate::{KERNEL_PREFIX}module::{LEGACY_KERNEL_PREFIX}map");
+        assert!(is_legacy_kernel_symbol(&misleading_path));
+        assert!(!is_current_kernel_symbol(&misleading_path));
     }
 
     /// Cross-crate kernels carry path qualifiers like

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -395,6 +395,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvjitlink-sys"
+version = "0.2.1"
+dependencies = [
+ "libloading",
+ "thiserror",
+]
+
+[[package]]
 name = "nvvm-transforms"
 version = "0.2.1"
 dependencies = [
@@ -562,10 +570,12 @@ dependencies = [
  "combine",
  "dialect-mir",
  "dialect-nvvm",
+ "libnvvm-sys",
  "linkme",
  "llvm-export",
  "mir-importer",
  "mir-lower",
+ "nvjitlink-sys",
  "once_cell",
  "oxide-artifacts",
  "pliron",

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -105,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,12 +157,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
 ]
 
 [[package]]
@@ -197,6 +235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +273,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -273,6 +331,12 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.187"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libloading"
@@ -568,14 +632,13 @@ name = "rustc_codegen_cuda"
 version = "0.2.1"
 dependencies = [
  "combine",
+ "cuda-artifact-finalizer",
  "dialect-mir",
  "dialect-nvvm",
- "libnvvm-sys",
  "linkme",
  "llvm-export",
  "mir-importer",
  "mir-lower",
- "nvjitlink-sys",
  "once_cell",
  "oxide-artifacts",
  "pliron",
@@ -604,6 +667,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "slotmap"
@@ -668,6 +742,12 @@ checksum = "3a99051ec05383f70bcab71884d39083a455257795e71cb780048a4bc890f3b8"
 dependencies = [
  "recasting",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -24,6 +24,13 @@ dialect-mir = { path = "../dialect-mir" }
 dialect-nvvm = { path = "../dialect-nvvm" }
 reserved-oxide-symbols = { path = "../reserved-oxide-symbols" }
 oxide-artifacts = { path = "../oxide-artifacts", features = ["object-write"] }
+# Opt-in cubin materialization (CUDA_OXIDE_MATERIALIZE_CUBIN): both crates
+# load their libraries via dlopen at call time, so the backend dylib gains
+# no CUDA link-time or load-time dependency. Deliberately NOT cuda-host,
+# which would link the backend against the CUDA driver (libcuda.so.1) and
+# break building/loading it on machines without a GPU driver.
+libnvvm-sys = { path = "../libnvvm-sys" }
+nvjitlink-sys = { path = "../nvjitlink-sys" }
 
 # IMPORTANT: This crate is isolated from the main workspace, so we cannot use
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -24,13 +24,9 @@ dialect-mir = { path = "../dialect-mir" }
 dialect-nvvm = { path = "../dialect-nvvm" }
 reserved-oxide-symbols = { path = "../reserved-oxide-symbols" }
 oxide-artifacts = { path = "../oxide-artifacts", features = ["object-write"] }
-# Opt-in cubin materialization (CUDA_OXIDE_MATERIALIZE_CUBIN): both crates
-# load their libraries via dlopen at call time, so the backend dylib gains
-# no CUDA link-time or load-time dependency. Deliberately NOT cuda-host,
-# which would link the backend against the CUDA driver (libcuda.so.1) and
-# break building/loading it on machines without a GPU driver.
-libnvvm-sys = { path = "../libnvvm-sys" }
-nvjitlink-sys = { path = "../nvjitlink-sys" }
+# Shared driver-independent libNVVM + nvJitLink finalization policy. This
+# crate loads CUDA compiler libraries at run time and never links libcuda.
+cuda-artifact-finalizer = { path = "../cuda-artifact-finalizer" }
 
 # IMPORTANT: This crate is isolated from the main workspace, so we cannot use
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml

--- a/crates/rustc-codegen-cuda/examples/abi_hmm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/abi_hmm/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/array_constants/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/array_constants/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/array_index/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/array_index/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/array_init/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/array_init/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/asin_acos_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/asin_acos_smoke/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/async_mlp/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/async_mlp/Cargo.lock
@@ -125,6 +125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-async"
 version = "0.2.1"
 dependencies = [
@@ -165,12 +175,11 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-async",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/async_vecadd/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/async_vecadd/Cargo.lock
@@ -125,6 +125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-async"
 version = "0.2.1"
 dependencies = [
@@ -165,12 +175,11 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-async",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/atomic_f16/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/atomic_f16/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/atomics/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/atomics/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/barrier/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/barrier/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/bf16x2_arith/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/bf16x2_arith/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/bf16x2_fma/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/bf16x2_fma/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/bool_phi_cmp/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/bool_phi_cmp/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/carrying_mul_add/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/carrying_mul_add/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cast_tests/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cast_tests/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cbrt_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cbrt_smoke/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/checked_arith/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/checked_arith/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/clc/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/clc/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -151,11 +161,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cluster/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cluster/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -151,11 +161,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/compiler_features/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -151,11 +161,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/complex_mul/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/complex_mul/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/const_generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/const_generic/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/constant_memory/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/constant_memory/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/constant_memory_coeffs/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/constant_memory_coeffs/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/constant_memory_simple/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/constant_memory_simple/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/copy_nonoverlapping/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/copy_nonoverlapping/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cp_async_small/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cp_async_small/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cp_async_zfill/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cp_async_zfill/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -150,11 +160,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cpp_consumes_rust_device/Cargo.lock
@@ -121,6 +121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -149,11 +159,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cross_crate_embedded/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_embedded/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -151,11 +161,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -151,11 +161,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cuda_module_in_lib/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_in_lib/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cuda_module_nested/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_nested/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cutile_inter_kernel/simt/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cutile_inter_kernel/simt/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cvt_f16x2/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cvt_f16x2/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/cvt_packed/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cvt_packed/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/debug/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/debug/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/device_closures/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_closures/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/device_global/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/device_global/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/dotprod/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/dotprod/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/dynamic_smem/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/dynamic_smem/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/elect_leader/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/elect_leader/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/enum_array_match/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/enum_array_match/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_drop_glue/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_drop_glue/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_abi/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_abi/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_callable/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_callable/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_fn_pointer/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_fn_pointer/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_unknown_id/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_generated_intrinsic_unknown_id/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_heap_alloc/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_heap_alloc/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_missing_device_attr/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_missing_device_attr/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_set_discriminant_niche/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_set_discriminant_niche/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_set_discriminant_uninhabited/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_set_discriminant_uninhabited/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_static_initializer_provenance/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_static_initializer_provenance/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/error_wgmma_mma_unimplemented/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/error_wgmma_mma_unimplemented/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/export_name_policy/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/export_name_policy/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/extern_crate_closure/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/extern_crate_closure/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/extern_libdevice/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/extern_libdevice/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/f16_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/f16_stress/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/f16x2_arith/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/f16x2_arith/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/fcmp_ne_nan_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/fcmp_ne_nan_smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/field_array_assign/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/field_array_assign/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/fn_ptr_naming/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/fn_ptr_naming/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/function_item_call/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/function_item_call/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/future_apis/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/future_apis/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/gemm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/generated_intrinsics/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/generated_intrinsics/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/generated_intrinsics_blackwell/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/generated_intrinsics_blackwell/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/generated_ldmatrix/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/generated_ldmatrix/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/generic/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/hashmap/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/Cargo.lock
@@ -144,6 +144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -172,11 +182,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/Cargo.lock
@@ -144,6 +144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -172,11 +182,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/hello_constant/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/hello_constant/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/helper_fn/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/helper_fn/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/host_closure/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/host_closure/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-async"
 version = "0.2.1"
 dependencies = [
@@ -153,12 +163,11 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-async",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/index2d_const/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/index2d_const/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/inline_ptx/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/inline_ptx/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/lanemask_scan/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/lanemask_scan/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/legacy_nvvm_pointer_shapes/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/legacy_nvvm_pointer_shapes/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/libdevice_math/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/libdevice_math/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/libm_math/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/libm_math/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/manual_launch_generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/manual_launch_generic/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/manual_launch_libdevice/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/manual_launch_libdevice/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/math_atan/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/math_atan/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/math_hyperbolic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/math_hyperbolic/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/math_tan/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/math_tan/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mathdx_ffi_test/Cargo.lock
@@ -133,6 +133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -161,11 +171,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/mcast_barrier_test/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mcast_barrier_test/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/mem_swap/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/ne_bytes_transmute/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/ne_bytes_transmute/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/nested_index_assignment/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/nested_index_assignment/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/numeric_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/numeric_stress/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/option_ref_transmute/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/option_ref_transmute/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/ord_cmp/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/ord_cmp/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/packed_atomic_add/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/packed_atomic_add/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/place_read_fallbacks/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/place_read_fallbacks/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/policy_config/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/policy_config/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/primitive_stress/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/primitive_stress/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/printf/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/printf/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/projected_place_read/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/projected_place_read/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/ptr_offset_from/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/ptr_offset_from/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/redux_minmax/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/redux_minmax/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/redux_sum/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/redux_sum/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/ref_operand_mul/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/ref_operand_mul/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/repr_u32_enum_stride/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/repr_u32_enum_stride/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/rustlantis-smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/rustlantis-smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/set_discriminant/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/set_discriminant/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/shared_slice_unsize/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/shared_slice_unsize/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/sharedmem/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/sharedmem/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/shuffle_64/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/shuffle_64/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/slice_get_mut/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/slice_get_mut/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/slice_reslice/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/slice_reslice/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/step_by/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/step_by/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/struct_field_layout/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/struct_field_layout/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tcgen05/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tiled_gemm/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tiled_gemm/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tma_copy/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/toolchain_pairing_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/toolchain_pairing_smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/tuple_return/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/tuple_return/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/union_aggregate/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/union_aggregate/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/unroll_smoke/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/unroll_smoke/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/vecadd/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/vecadd/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/vectorization/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/vectorization/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/volatile_memory/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/volatile_memory/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/examples/wgmma/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/wgmma/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-artifact-finalizer"
+version = "0.2.1"
+dependencies = [
+ "libnvvm-sys",
+ "nvjitlink-sys",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "0.2.1"
 dependencies = [
@@ -141,11 +151,10 @@ dependencies = [
 name = "cuda-host"
 version = "0.2.1"
 dependencies = [
+ "cuda-artifact-finalizer",
  "cuda-core",
  "cuda-macros",
  "half",
- "libnvvm-sys",
- "nvjitlink-sys",
  "sha2",
  "thiserror",
 ]

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -152,14 +152,15 @@ enum CollectDecision {
 // single source of truth for the cuda_oxide_* naming contract; see its
 // crate-level docs for the layered API and the hash-suffix rationale.
 //
-// Each prefix ends with the magic suffix `246e25db_`, which makes a
+// Each prefix contains the magic component `246e25db_`, which makes a
 // substring like "cuda_oxide_kernel_" — without the hash — never falsely
 // match. The mutual-exclusion guarantee between `DEVICE_PREFIX` and
 // `DEVICE_EXTERN_PREFIX` means we no longer need the historical
 // "test extern first" ordering dance that lived here previously.
 use reserved_oxide_symbols::{
-    device_extern_base_name, is_device_extern_symbol, is_device_symbol, is_kernel_symbol,
-    is_ptx_merge_required_marker, kernel_base_name,
+    device_extern_base_name, is_current_device_symbol, is_current_kernel_symbol,
+    is_device_extern_symbol, is_device_symbol, is_kernel_symbol, is_ptx_merge_required_marker,
+    kernel_base_name,
 };
 
 /// Sanitize a symbol name for use as a PTX identifier.
@@ -349,17 +350,46 @@ pub fn count_device_fns_in_cgus<'tcx>(tcx: TyCtxt<'tcx>, cgus: &[CodegenUnit<'tc
     count
 }
 
+/// Find a device-code root emitted before the scoped Cargo cache protocol.
+///
+/// This deliberately inspects both local and external `DefId`s. A generic
+/// kernel defined by an older macro may have no monomorphized root in its
+/// defining crate; its first concrete `MonoItem` then appears only in a
+/// downstream consumer. Recognizing the legacy name there prevents that
+/// consumer from seeding a cache entry that would stay fresh across device
+/// output or architecture changes.
+pub fn unsupported_codegen_protocol_root_in_cgus<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    cgus: &[CodegenUnit<'tcx>],
+) -> Option<String> {
+    cgus.iter().find_map(|cgu| {
+        cgu.items().iter().find_map(|(item, _data)| {
+            let MonoItem::Fn(instance) = item else {
+                return None;
+            };
+            let def_id = instance.def_id();
+            let item_name = tcx.opt_item_name(def_id)?;
+            unsupported_codegen_protocol_root(item_name.as_str()).then(|| tcx.def_path_str(def_id))
+        })
+    })
+}
+
+fn unsupported_codegen_protocol_root(name: &str) -> bool {
+    (is_kernel_symbol(name) && !is_current_kernel_symbol(name))
+        || (is_device_symbol(name) && !is_current_device_symbol(name))
+}
+
 /// Checks if a function is a kernel entry point.
 ///
 /// Detection is based on the `KERNEL_PREFIX` substring (currently
-/// `cuda_oxide_kernel_246e25db_`) which the `#[kernel]` macro adds to
+/// `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_`) which the `#[kernel]` macro adds to
 /// renamed functions:
 ///
 /// ```text
 /// User writes:        Macro expands to:
 /// ┌─────────────────┐  ┌────────────────────────────────────────────────┐
 /// │ #[kernel]       │  │ #[no_mangle]                                   │
-/// │ fn add_one(...) │ ⇒│ pub fn cuda_oxide_kernel_246e25db_add_one(...) │
+/// │ fn add_one(...) │ ⇒│ pub fn cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_add_one(...) │
 /// └─────────────────┘  └────────────────────────────────────────────────┘
 /// ```
 pub fn is_kernel_function(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
@@ -2098,8 +2128,11 @@ pub fn dump_device_mir_info<'tcx>(tcx: TyCtxt<'tcx>, functions: &[CollectedFunct
 #[cfg(test)]
 mod tests {
     use reserved_oxide_symbols::{
+        DEVICE_PREFIX, KERNEL_PREFIX, LEGACY_DEVICE_PREFIX, LEGACY_KERNEL_PREFIX,
         PTX_MERGE_REQUIRED_PREFIX, is_ptx_merge_required_marker, ptx_merge_required_marker,
     };
+
+    use super::unsupported_codegen_protocol_root;
 
     #[test]
     fn ptx_merge_marker_matches_only_the_final_path_component() {
@@ -2113,5 +2146,33 @@ mod tests {
         )));
         assert!(!is_ptx_merge_required_marker(PTX_MERGE_REQUIRED_PREFIX));
         assert!(!is_ptx_merge_required_marker("crate_name::ordinary_static"));
+    }
+
+    #[test]
+    fn scoped_cache_protocol_rejects_legacy_local_and_external_roots() {
+        assert!(!unsupported_codegen_protocol_root(&format!(
+            "local::{KERNEL_PREFIX}map"
+        )));
+        assert!(!unsupported_codegen_protocol_root(&format!(
+            "local::{DEVICE_PREFIX}helper"
+        )));
+        assert!(unsupported_codegen_protocol_root(&format!(
+            "legacy::{LEGACY_KERNEL_PREFIX}map"
+        )));
+        assert!(unsupported_codegen_protocol_root(&format!(
+            "dependency::{LEGACY_KERNEL_PREFIX}generic_kernel"
+        )));
+        assert!(unsupported_codegen_protocol_root(&format!(
+            "legacy::{LEGACY_DEVICE_PREFIX}helper"
+        )));
+        assert!(unsupported_codegen_protocol_root(&format!(
+            "{LEGACY_KERNEL_PREFIX}codegen_v1_map"
+        )));
+        assert!(unsupported_codegen_protocol_root(&format!(
+            "crate::{KERNEL_PREFIX}module::{LEGACY_KERNEL_PREFIX}map"
+        )));
+        assert!(!unsupported_codegen_protocol_root(
+            "ordinary::host_function"
+        ));
     }
 }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -159,7 +159,7 @@ enum CollectDecision {
 // "test extern first" ordering dance that lived here previously.
 use reserved_oxide_symbols::{
     device_extern_base_name, is_device_extern_symbol, is_device_symbol, is_kernel_symbol,
-    kernel_base_name,
+    is_ptx_merge_required_marker, kernel_base_name,
 };
 
 /// Sanitize a symbol name for use as a PTX identifier.
@@ -298,6 +298,14 @@ pub struct CollectionResult<'tcx> {
 
     /// External device function declarations (no MIR, emit as `declare`).
     pub device_externs: Vec<DeviceExternDecl>,
+
+    /// Whether this crate needs the run-time loader to merge PTX bundles.
+    ///
+    /// This is true for a `#[cuda_module]` containing a generic kernel and
+    /// for a concrete specialization of a generic kernel imported from a
+    /// dependency. Cubin materialization must reject this case until it can
+    /// reproduce the same cross-crate linking semantics.
+    pub requires_ptx_bundle_merge: bool,
 }
 
 /// Counts kernel functions across all codegen units.
@@ -679,6 +687,12 @@ pub fn collect_device_functions<'tcx>(
     verbose: bool,
 ) -> CollectionResult<'tcx> {
     let mut collector = DeviceCollector::new(tcx, verbose);
+    let mut requires_ptx_bundle_merge = cgus.iter().any(|cgu| {
+        cgu.items().iter().any(|(item, _data)| match item {
+            MonoItem::Static(def_id) => is_ptx_merge_required_marker(&tcx.def_path_str(*def_id)),
+            _ => false,
+        })
+    });
 
     // Find all kernel entry points
     for cgu in cgus {
@@ -714,6 +728,15 @@ pub fn collect_device_functions<'tcx>(
                     }
                     continue;
                 }
+
+                // A downstream monomorphization of a generic kernel may be
+                // present even when the defining crate's private module
+                // marker is not. Such modules use the all-PTX-bundles loader,
+                // so strict ahead-of-time cubin materialization cannot safely
+                // compile only this crate's artifact.
+                requires_ptx_bundle_merge |= tcx
+                    .generics_of(instance.def_id())
+                    .requires_monomorphization(tcx);
 
                 let name = tcx.def_path_str(instance.def_id());
                 // Extract the kernel base name by stripping the reserved
@@ -780,7 +803,9 @@ pub fn collect_device_functions<'tcx>(
     }
 
     // Process the worklist to collect all reachable functions
-    collector.collect()
+    let mut result = collector.collect();
+    result.requires_ptx_bundle_merge = requires_ptx_bundle_merge;
+    result
 }
 
 /// Worklist-based collector for device-reachable functions.
@@ -936,6 +961,7 @@ impl<'tcx> DeviceCollector<'tcx> {
         CollectionResult {
             functions: self.result,
             device_externs: self.device_externs,
+            requires_ptx_bundle_merge: false,
         }
     }
 
@@ -2067,4 +2093,25 @@ pub fn dump_device_mir_info<'tcx>(tcx: TyCtxt<'tcx>, functions: &[CollectedFunct
         }
     }
     eprintln!("=================================\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use reserved_oxide_symbols::{
+        PTX_MERGE_REQUIRED_PREFIX, is_ptx_merge_required_marker, ptx_merge_required_marker,
+    };
+
+    #[test]
+    fn ptx_merge_marker_matches_only_the_final_path_component() {
+        let marker = ptx_merge_required_marker("map");
+        assert!(is_ptx_merge_required_marker(&marker));
+        assert!(is_ptx_merge_required_marker(&format!(
+            "crate_name::kernels::{marker}"
+        )));
+        assert!(!is_ptx_merge_required_marker(&format!(
+            "crate_name::prefix_{marker}"
+        )));
+        assert!(!is_ptx_merge_required_marker(PTX_MERGE_REQUIRED_PREFIX));
+        assert!(!is_ptx_merge_required_marker("crate_name::ordinary_static"));
+    }
 }

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -245,6 +245,10 @@ pub struct DeviceCodegenResult {
     /// Whether later compilation stages may contract ordinary floating-point
     /// multiply/add expressions.
     pub allow_fma_contraction: bool,
+    /// Debug policy used when exporting the NVVM IR. Later materialization
+    /// stages must preserve this policy instead of silently compiling with
+    /// their own defaults.
+    pub debug_kind: llvm_export::export::DebugKind,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -562,6 +566,7 @@ pub fn generate_device_code<'tcx>(
     let show_rustc_mir = config.dump_rustc_mir;
     let show_mir = config.dump_mir_dialect;
     let show_llvm = config.dump_llvm_dialect;
+    let debug_kind = device_debug_kind(tcx.sess.opts.debuginfo);
 
     // Print raw rustc MIR if requested (before conversion to stable_mir)
     if show_rustc_mir {
@@ -669,7 +674,6 @@ pub fn generate_device_code<'tcx>(
             }
         }
 
-        let debug_kind = device_debug_kind(tcx.sess.opts.debuginfo);
         let target_arch = std::env::var("CUDA_OXIDE_TARGET").ok();
         let device_arch_hint = std::env::var("CUDA_OXIDE_DEVICE_ARCH").ok();
         let allow_fma_contraction = std::env::var_os("CUDA_OXIDE_NO_FMA").is_none();
@@ -737,6 +741,7 @@ pub fn generate_device_code<'tcx>(
                     ptx_content,
                     artifact,
                     allow_fma_contraction: compilation_result.allow_fma_contraction,
+                    debug_kind,
                 })
             }
             Err(pipeline_err) => Err(DeviceCodegenError::PtxGeneration(format!(

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -568,6 +568,19 @@ impl CodegenBackend for CudaCodegenBackend {
 
             // Step 2: If device code exists, compile via cuda-oxide
             let _device_result = if has_device_code {
+                let wrapper_provenance = tcx.sess.psess.config.iter().find_map(|(name, value)| {
+                    if name.as_str() == materialize::WRAPPER_PROVENANCE_CFG {
+                        value.as_ref().map(|value| value.as_str())
+                    } else {
+                        None
+                    }
+                });
+                let materialization_request = materialize::request_from_env(wrapper_provenance)
+                    .unwrap_or_else(|error| {
+                        tcx.dcx().fatal(format!(
+                            "[rustc_codegen_cuda] Invalid cubin materialization request: {error}"
+                        ))
+                    });
                 if self.config.verbose {
                     eprintln!("[rustc_codegen_cuda] Compiling device code via cuda-oxide...");
                 }
@@ -578,6 +591,17 @@ impl CodegenBackend for CudaCodegenBackend {
                     mono_partitions.codegen_units,
                     self.config.verbose,
                 );
+
+                materialize::validate_collection(
+                    materialization_request,
+                    !collection_result.device_externs.is_empty(),
+                    collection_result.requires_ptx_bundle_merge,
+                )
+                .unwrap_or_else(|error| {
+                    tcx.dcx().fatal(format!(
+                        "[rustc_codegen_cuda] Cannot materialize this device artifact: {error}"
+                    ))
+                });
 
                 if self.config.verbose {
                     eprintln!(
@@ -691,6 +715,7 @@ impl CodegenBackend for CudaCodegenBackend {
                                 artifact,
                                 device_functions,
                                 self.config.device_codegen_crates.is_some(),
+                                materialization_request,
                             ) {
                                 Ok(path) => {
                                     if self.config.verbose {
@@ -782,6 +807,7 @@ impl CodegenBackend for CudaCodegenBackend {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_device_artifact_object(
     output_dir: &Path,
     output_name: &str,
@@ -790,16 +816,21 @@ fn write_device_artifact_object(
     artifact: &device_codegen::DeviceCodegenArtifact,
     functions: &[collector::CollectedFunction<'_>],
     use_target_specific_anchor: bool,
+    materialization_request: Option<materialize::MaterializationRequest>,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let bundle_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| output_name.to_string());
     let materialized_artifact;
-    let artifact = match materialize_artifact_for_embedding(&bundle_name, &result.target, artifact)?
-    {
+    let (artifact, was_materialized) = match materialize_artifact_for_embedding(
+        materialization_request,
+        &bundle_name,
+        result,
+        artifact,
+    )? {
         Some(cubin) => {
             materialized_artifact = cubin;
-            &materialized_artifact
+            (&materialized_artifact, true)
         }
-        None => artifact,
+        None => (artifact, false),
     };
     let payload_kind = match artifact.kind {
         device_codegen::DeviceCodegenArtifactKind::Ptx => oxide_artifacts::ArtifactPayloadKind::Ptx,
@@ -813,16 +844,20 @@ fn write_device_artifact_object(
             oxide_artifacts::ArtifactPayloadKind::Cubin
         }
     };
-    let compile_options = if matches!(
-        artifact.kind,
-        device_codegen::DeviceCodegenArtifactKind::NvvmIr
-            | device_codegen::DeviceCodegenArtifactKind::Ltoir
-    ) {
-        oxide_artifacts::ArtifactCompileOptions::new()
-            .with_fma_contraction(result.allow_fma_contraction)
-    } else {
-        oxide_artifacts::ArtifactCompileOptions::new()
-    };
+    // Preserve the actual policy even after IR has become a cubin. Consumers
+    // and diagnostics must not mistake `--no-fmad` materialization for a
+    // default-policy artifact merely because no compilation remains to do.
+    let carries_compile_policy = was_materialized
+        || matches!(
+            artifact.kind,
+            device_codegen::DeviceCodegenArtifactKind::NvvmIr
+                | device_codegen::DeviceCodegenArtifactKind::Ltoir
+        );
+    let compile_options = embedded_compile_options(
+        result.allow_fma_contraction,
+        result.debug_kind,
+        carries_compile_policy,
+    );
     let mut spec = oxide_artifacts::ArtifactBundleSpec::new(&bundle_name, &result.target)
         .with_compile_options(compile_options)
         .with_payload(oxide_artifacts::ArtifactPayloadSpec::new(
@@ -877,31 +912,79 @@ fn write_device_artifact_object(
     write_artifact_object(output_dir, output_name, host_target, &object, "embed")
 }
 
+fn embedded_compile_options(
+    allow_fma_contraction: bool,
+    debug_kind: llvm_export::export::DebugKind,
+    carries_compile_policy: bool,
+) -> oxide_artifacts::ArtifactCompileOptions {
+    if carries_compile_policy {
+        let debug_policy = match debug_kind {
+            llvm_export::export::DebugKind::Off => oxide_artifacts::ArtifactDebugPolicy::None,
+            llvm_export::export::DebugKind::LineTables => {
+                oxide_artifacts::ArtifactDebugPolicy::LineTables
+            }
+            llvm_export::export::DebugKind::Full => oxide_artifacts::ArtifactDebugPolicy::Full,
+        };
+        oxide_artifacts::ArtifactCompileOptions::new()
+            .with_fma_contraction(allow_fma_contraction)
+            .with_debug_policy(debug_policy)
+    } else {
+        // Preserve main's byte-level PTX/already-cubin default. These payloads
+        // never carried later-stage compile policy before materialization was
+        // added, including when the backend itself ran with --no-fmad.
+        oxide_artifacts::ArtifactCompileOptions::new()
+    }
+}
+
 /// Opt-in (`CUDA_OXIDE_MATERIALIZE_CUBIN`): compile NVVM IR / LTOIR
 /// artifacts down to a final cubin before embedding, so the consuming
 /// binary loads device code directly through the CUDA driver — no libNVVM
 /// or nvJitLink on the deployment host and no first-load compile hit. The
 /// cubin is pinned to the emitted architecture; the default (embed the IR,
 /// compile at load) keeps cuda-host's execution routing, including the PTX
-/// bridge to newer GPUs. PTX and cubin artifacts pass through untouched
-/// either way. See `materialize` for the trade-offs.
+/// bridge to newer GPUs. Once requested, this path fails closed unless codegen
+/// produced NVVM IR or LTOIR; accepting PTX or an already-built cubin would
+/// bypass the wrapper's provenance-checked finalization recipe. See
+/// `materialize` for the trade-offs.
 fn materialize_artifact_for_embedding(
+    request: Option<materialize::MaterializationRequest>,
     bundle_name: &str,
-    target: &str,
+    result: &device_codegen::DeviceCodegenResult,
     artifact: &device_codegen::DeviceCodegenArtifact,
 ) -> Result<Option<device_codegen::DeviceCodegenArtifact>, Box<dyn std::error::Error>> {
-    if !materialize::materialize_cubin_enabled() {
+    let Some(request) = request else {
         return Ok(None);
-    }
+    };
+    let debug_policy = match result.debug_kind {
+        llvm_export::export::DebugKind::Off => cuda_artifact_finalizer::DebugPolicy::None,
+        llvm_export::export::DebugKind::LineTables => {
+            cuda_artifact_finalizer::DebugPolicy::LineTables
+        }
+        llvm_export::export::DebugKind::Full => cuda_artifact_finalizer::DebugPolicy::Full,
+    };
     let cubin = match artifact.kind {
-        device_codegen::DeviceCodegenArtifactKind::NvvmIr => {
-            materialize::nvvm_ir_to_cubin(&artifact.bytes, bundle_name, target)?
+        device_codegen::DeviceCodegenArtifactKind::NvvmIr => materialize::nvvm_ir_to_cubin(
+            request,
+            &artifact.bytes,
+            bundle_name,
+            &result.target,
+            result.allow_fma_contraction,
+            debug_policy,
+        )?,
+        device_codegen::DeviceCodegenArtifactKind::Ltoir => materialize::ltoir_to_cubin(
+            request,
+            &artifact.bytes,
+            &artifact.name,
+            &result.target,
+            result.allow_fma_contraction,
+            debug_policy,
+        )?,
+        device_codegen::DeviceCodegenArtifactKind::Ptx => {
+            return Err(Box::new(materialize::MaterializeError::PtxInput));
         }
-        device_codegen::DeviceCodegenArtifactKind::Ltoir => {
-            materialize::ltoir_to_cubin(&artifact.bytes, &artifact.name, target)?
+        device_codegen::DeviceCodegenArtifactKind::Cubin => {
+            return Err(Box::new(materialize::MaterializeError::CubinInput));
         }
-        device_codegen::DeviceCodegenArtifactKind::Ptx
-        | device_codegen::DeviceCodegenArtifactKind::Cubin => return Ok(None),
     };
     Ok(Some(device_codegen::DeviceCodegenArtifact {
         kind: device_codegen::DeviceCodegenArtifactKind::Cubin,
@@ -1036,5 +1119,89 @@ mod tests {
             ..CudaCodegenConfig::default()
         };
         assert!(config.allows_device_codegen_for("gpu_kernels"));
+    }
+
+    #[test]
+    fn materialized_cubin_keeps_target_entries_and_no_fmad_policy() {
+        use oxide_artifacts::{
+            ArtifactBundleSpec, ArtifactEntryKind, ArtifactEntrySpec, ArtifactPayloadKind,
+            ArtifactPayloadSpec, build_artifact_blob, parse_artifact_blob,
+        };
+
+        let blob = build_artifact_blob(
+            &ArtifactBundleSpec::new("demo", "sm_90a")
+                .with_compile_options(embedded_compile_options(
+                    false,
+                    llvm_export::export::DebugKind::LineTables,
+                    true,
+                ))
+                .with_payload(ArtifactPayloadSpec::new(
+                    ArtifactPayloadKind::Cubin,
+                    "demo.cubin",
+                    b"final cubin",
+                ))
+                .with_entry(ArtifactEntrySpec::new(
+                    "kernel_a",
+                    ArtifactEntryKind::Kernel,
+                ))
+                .with_entry(ArtifactEntrySpec::new(
+                    "helper",
+                    ArtifactEntryKind::DeviceFunction,
+                )),
+        )
+        .unwrap();
+        let bundle = parse_artifact_blob(&blob).unwrap();
+
+        assert_eq!(bundle.name, "demo");
+        assert_eq!(bundle.target, "sm_90a");
+        assert_eq!(
+            bundle.payload(ArtifactPayloadKind::Cubin),
+            Some(&b"final cubin"[..])
+        );
+        assert!(!bundle.compile_options.fma_contraction_enabled());
+        assert_eq!(
+            bundle.compile_options.debug_policy(),
+            oxide_artifacts::ArtifactDebugPolicy::LineTables
+        );
+        assert_eq!(bundle.entries.len(), 2);
+        assert_eq!(
+            bundle.entry("kernel_a").map(|entry| entry.kind),
+            Some(ArtifactEntryKind::Kernel)
+        );
+        assert_eq!(
+            bundle.entry("helper").map(|entry| entry.kind),
+            Some(ArtifactEntryKind::DeviceFunction)
+        );
+    }
+
+    #[test]
+    fn ordinary_ptx_keeps_legacy_default_bundle_header() {
+        let blob = oxide_artifacts::build_artifact_blob(
+            &oxide_artifacts::ArtifactBundleSpec::new("demo", "sm_90")
+                .with_compile_options(embedded_compile_options(
+                    false,
+                    llvm_export::export::DebugKind::Full,
+                    false,
+                ))
+                .with_payload(oxide_artifacts::ArtifactPayloadSpec::new(
+                    oxide_artifacts::ArtifactPayloadKind::Ptx,
+                    "demo.ptx",
+                    b"ptx",
+                )),
+        )
+        .unwrap();
+
+        assert_eq!(&blob[..8], &oxide_artifacts::ARTIFACT_MAGIC);
+        assert_eq!(u16::from_le_bytes([blob[8], blob[9]]), 1);
+        let parsed = oxide_artifacts::parse_artifact_blob(&blob).unwrap();
+        assert!(parsed.compile_options.fma_contraction_enabled());
+        assert_eq!(
+            parsed.compile_options.debug_policy(),
+            oxide_artifacts::ArtifactDebugPolicy::None
+        );
+        assert_eq!(
+            parsed.payload(oxide_artifacts::ArtifactPayloadKind::Ptx),
+            Some(&b"ptx"[..])
+        );
     }
 }

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -406,7 +406,7 @@ impl CudaCodegenConfig {
                 .ok()
                 .map(std::path::PathBuf::from),
             device_codegen_crates: parse_device_codegen_crates(
-                std::env::var("CUDA_OXIDE_DEVICE_CODEGEN_CRATE")
+                std::env::var(reserved_oxide_symbols::DEVICE_CODEGEN_CRATE_ENV)
                     .ok()
                     .as_deref(),
             ),
@@ -441,6 +441,13 @@ fn should_codegen_device_crate(
     contains_device_code: bool,
 ) -> bool {
     contains_device_code && config.allows_device_codegen_for(crate_name)
+}
+
+fn reject_unsupported_codegen_protocol(
+    scoped_fingerprint_present: bool,
+    unsupported_root_present: bool,
+) -> bool {
+    scoped_fingerprint_present && unsupported_root_present
 }
 
 impl CodegenBackend for CudaCodegenBackend {
@@ -514,6 +521,19 @@ impl CodegenBackend for CudaCodegenBackend {
             let kernel_count = collector::count_kernels_in_cgus(tcx, mono_partitions.codegen_units);
             let device_fn_count =
                 collector::count_device_fns_in_cgus(tcx, mono_partitions.codegen_units);
+            let unsupported_protocol_root = collector::unsupported_codegen_protocol_root_in_cgus(
+                tcx,
+                mono_partitions.codegen_units,
+            );
+            if reject_unsupported_codegen_protocol(
+                std::env::var_os(reserved_oxide_symbols::CODEGEN_FINGERPRINT_ENV).is_some(),
+                unsupported_protocol_root.is_some(),
+            ) {
+                let root = unsupported_protocol_root.expect("presence checked above");
+                tcx.dcx().fatal(format!(
+                    "[rustc_codegen_cuda] Device-code root `{root}` was emitted by a cuda-macros version that predates the scoped Cargo cache protocol. Rebuild the source with cuda-macros from the same cuda-oxide revision; older macro expansions, including pre-expanded output from before this protocol, cannot be cached safely across output and architecture changes."
+                ));
+            }
             let crate_name = tcx.crate_name(rustc_hir::def_id::LOCAL_CRATE);
             let owner_selected = self.config.allows_device_codegen_for(crate_name.as_str());
             let contains_device_code = kernel_count > 0 || device_fn_count > 0;
@@ -568,15 +588,8 @@ impl CodegenBackend for CudaCodegenBackend {
 
             // Step 2: If device code exists, compile via cuda-oxide
             let _device_result = if has_device_code {
-                let wrapper_provenance = tcx.sess.psess.config.iter().find_map(|(name, value)| {
-                    if name.as_str() == materialize::WRAPPER_PROVENANCE_CFG {
-                        value.as_ref().map(|value| value.as_str())
-                    } else {
-                        None
-                    }
-                });
-                let materialization_request = materialize::request_from_env(wrapper_provenance)
-                    .unwrap_or_else(|error| {
+                let materialization_request =
+                    materialize::request_from_env().unwrap_or_else(|error| {
                         tcx.dcx().fatal(format!(
                             "[rustc_codegen_cuda] Invalid cubin materialization request: {error}"
                         ))
@@ -1119,6 +1132,23 @@ mod tests {
             ..CudaCodegenConfig::default()
         };
         assert!(config.allows_device_codegen_for("gpu_kernels"));
+    }
+
+    #[test]
+    fn scoped_cache_protocol_rejects_old_roots_even_when_codegen_would_be_filtered() {
+        assert!(reject_unsupported_codegen_protocol(true, true));
+        assert!(!reject_unsupported_codegen_protocol(false, true));
+        assert!(!reject_unsupported_codegen_protocol(true, false));
+
+        let config = CudaCodegenConfig {
+            device_codegen_crates: parse_device_codegen_crates(Some("some_other_crate")),
+            ..CudaCodegenConfig::default()
+        };
+        assert!(!config.allows_device_codegen_for("legacy_kernel_crate"));
+        // Protocol validation is intentionally independent of owner selection:
+        // filtered legacy output must not become fresh forever when the filter
+        // later selects the crate.
+        assert!(reject_unsupported_codegen_protocol(true, true));
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -320,6 +320,7 @@ extern crate rustc_codegen_llvm;
 mod collector;
 mod device_codegen;
 mod generated_intrinsics;
+mod materialize;
 
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CompiledModule, CompiledModules, CrateInfo, ModuleKind};
@@ -791,6 +792,15 @@ fn write_device_artifact_object(
     use_target_specific_anchor: bool,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let bundle_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| output_name.to_string());
+    let materialized_artifact;
+    let artifact = match materialize_artifact_for_embedding(&bundle_name, &result.target, artifact)?
+    {
+        Some(cubin) => {
+            materialized_artifact = cubin;
+            &materialized_artifact
+        }
+        None => artifact,
+    };
     let payload_kind = match artifact.kind {
         device_codegen::DeviceCodegenArtifactKind::Ptx => oxide_artifacts::ArtifactPayloadKind::Ptx,
         device_codegen::DeviceCodegenArtifactKind::NvvmIr => {
@@ -865,6 +875,39 @@ fn write_device_artifact_object(
         oxide_artifacts::build_host_object_for_target(&blob, host_target, Some(&legacy_anchor))?
     };
     write_artifact_object(output_dir, output_name, host_target, &object, "embed")
+}
+
+/// Opt-in (`CUDA_OXIDE_MATERIALIZE_CUBIN`): compile NVVM IR / LTOIR
+/// artifacts down to a final cubin before embedding, so the consuming
+/// binary loads device code directly through the CUDA driver — no libNVVM
+/// or nvJitLink on the deployment host and no first-load compile hit. The
+/// cubin is pinned to the emitted architecture; the default (embed the IR,
+/// compile at load) keeps cuda-host's execution routing, including the PTX
+/// bridge to newer GPUs. PTX and cubin artifacts pass through untouched
+/// either way. See `materialize` for the trade-offs.
+fn materialize_artifact_for_embedding(
+    bundle_name: &str,
+    target: &str,
+    artifact: &device_codegen::DeviceCodegenArtifact,
+) -> Result<Option<device_codegen::DeviceCodegenArtifact>, Box<dyn std::error::Error>> {
+    if !materialize::materialize_cubin_enabled() {
+        return Ok(None);
+    }
+    let cubin = match artifact.kind {
+        device_codegen::DeviceCodegenArtifactKind::NvvmIr => {
+            materialize::nvvm_ir_to_cubin(&artifact.bytes, bundle_name, target)?
+        }
+        device_codegen::DeviceCodegenArtifactKind::Ltoir => {
+            materialize::ltoir_to_cubin(&artifact.bytes, &artifact.name, target)?
+        }
+        device_codegen::DeviceCodegenArtifactKind::Ptx
+        | device_codegen::DeviceCodegenArtifactKind::Cubin => return Ok(None),
+    };
+    Ok(Some(device_codegen::DeviceCodegenArtifact {
+        kind: device_codegen::DeviceCodegenArtifactKind::Cubin,
+        name: format!("{bundle_name}.cubin"),
+        bytes: cubin,
+    }))
 }
 
 fn write_filtered_artifact_anchor_object(

--- a/crates/rustc-codegen-cuda/src/materialize.rs
+++ b/crates/rustc-codegen-cuda/src/materialize.rs
@@ -6,9 +6,9 @@
 //! Strict, opt-in build-time finalization of embedded device artifacts.
 //!
 //! `cargo oxide --materialize-cubin` discovers and fingerprints the exact
-//! libNVVM, nvJitLink, and libdevice inputs before invoking Cargo. The digest
-//! is part of Cargo's rustc fingerprint and is passed here through an internal
-//! environment variable. We rediscover the tools and compare their bytes
+//! libNVVM, nvJitLink, and libdevice inputs before invoking Cargo. Device
+//! macros record the complete codegen identity and exact provenance as Cargo
+//! environment dependencies. We rediscover the tools and compare their bytes
 //! before compiling. Setting the internal opt-in around raw Cargo is
 //! unsupported: Cargo can reuse an existing artifact without invoking this
 //! backend, and when the backend does run it rejects a missing handshake.
@@ -19,9 +19,10 @@ use cuda_artifact_finalizer::{
 };
 use thiserror::Error;
 
-pub(crate) const MATERIALIZE_ENV: &str = "CUDA_OXIDE_MATERIALIZE_CUBIN";
-pub(crate) const EXPECTED_PROVENANCE_ENV: &str = "CUDA_OXIDE_INTERNAL_MATERIALIZER_PROVENANCE";
-pub(crate) const WRAPPER_PROVENANCE_CFG: &str = "cuda_oxide_internal_materializer_provenance";
+pub(crate) const MATERIALIZE_ENV: &str = reserved_oxide_symbols::MATERIALIZE_CUBIN_ENV;
+pub(crate) const EXPECTED_PROVENANCE_ENV: &str =
+    reserved_oxide_symbols::MATERIALIZER_PROVENANCE_ENV;
+pub(crate) const CODEGEN_FINGERPRINT_ENV: &str = reserved_oxide_symbols::CODEGEN_FINGERPRINT_ENV;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct MaterializationRequest {
@@ -45,19 +46,14 @@ pub(crate) enum MaterializeError {
     MissingExpectedProvenance,
 
     #[error(
-        "{MATERIALIZE_ENV}=true is missing cargo-oxide's rustc fingerprint; use `cargo oxide build --materialize-cubin` instead of invoking raw Cargo"
+        "{MATERIALIZE_ENV}=true is missing cargo-oxide's tracked codegen fingerprint; use `cargo oxide build --materialize-cubin` instead of invoking raw Cargo"
     )]
     MissingCargoFingerprint,
 
     #[error(
-        "cargo-oxide's materializer provenance cfg must be exactly 64 lowercase hexadecimal characters, got {value:?}"
+        "cargo-oxide's tracked codegen fingerprint must be exactly 64 lowercase hexadecimal characters, got {value:?}"
     )]
-    InvalidCargoProvenance { value: String },
-
-    #[error(
-        "cargo-oxide's materializer provenance cfg does not match {EXPECTED_PROVENANCE_ENV}; refusing an unfingerprinted materialization build"
-    )]
-    CargoProvenanceMismatch,
+    InvalidCargoFingerprint { value: String },
 
     #[error(
         "{EXPECTED_PROVENANCE_ENV} must be exactly 64 lowercase hexadecimal characters, got {value:?}"
@@ -103,9 +99,7 @@ pub(crate) enum MaterializeError {
 
 /// Parse the strict opt-in and its wrapper-generated provenance handshake.
 /// No CUDA library is loaded here.
-pub(crate) fn request_from_env(
-    wrapper_provenance: Option<&str>,
-) -> Result<Option<MaterializationRequest>, MaterializeError> {
+pub(crate) fn request_from_env() -> Result<Option<MaterializationRequest>, MaterializeError> {
     let enabled = match std::env::var(MATERIALIZE_ENV) {
         Ok(value) => parse_bool(&value)?,
         Err(std::env::VarError::NotPresent) => false,
@@ -119,7 +113,7 @@ pub(crate) fn request_from_env(
     let value = std::env::var(EXPECTED_PROVENANCE_ENV)
         .map_err(|_| MaterializeError::MissingExpectedProvenance)?;
     let expected_provenance = parse_digest(&value)?;
-    validate_wrapper_provenance(wrapper_provenance, &expected_provenance)?;
+    validate_codegen_fingerprint()?;
     Ok(Some(MaterializationRequest {
         expected_provenance,
     }))
@@ -209,19 +203,18 @@ fn parse_bool(value: &str) -> Result<bool, MaterializeError> {
     }
 }
 
-fn validate_wrapper_provenance(
-    value: Option<&str>,
-    expected: &[u8; 32],
-) -> Result<(), MaterializeError> {
+fn validate_codegen_fingerprint() -> Result<(), MaterializeError> {
+    let value = std::env::var(CODEGEN_FINGERPRINT_ENV).ok();
+    validate_codegen_fingerprint_value(value.as_deref())
+}
+
+fn validate_codegen_fingerprint_value(value: Option<&str>) -> Result<(), MaterializeError> {
     let value = value.ok_or(MaterializeError::MissingCargoFingerprint)?;
-    let wrapper = parse_digest(value).map_err(|_| MaterializeError::InvalidCargoProvenance {
-        value: value.to_string(),
-    })?;
-    if &wrapper == expected {
-        Ok(())
-    } else {
-        Err(MaterializeError::CargoProvenanceMismatch)
-    }
+    parse_digest(value)
+        .map(|_| ())
+        .map_err(|_| MaterializeError::InvalidCargoFingerprint {
+            value: value.to_string(),
+        })
 }
 
 fn parse_digest(value: &str) -> Result<[u8; 32], MaterializeError> {
@@ -304,15 +297,14 @@ mod tests {
 
     #[test]
     fn backend_invocation_rejects_raw_cargo_materialization_without_fingerprint() {
-        let expected = [0; 32];
         assert!(matches!(
-            validate_wrapper_provenance(None, &expected),
+            validate_codegen_fingerprint_value(None),
             Err(MaterializeError::MissingCargoFingerprint)
         ));
-        assert!(validate_wrapper_provenance(Some(&"00".repeat(32)), &expected).is_ok());
+        assert!(validate_codegen_fingerprint_value(Some(&"00".repeat(32))).is_ok());
         assert!(matches!(
-            validate_wrapper_provenance(Some(&"11".repeat(32)), &expected),
-            Err(MaterializeError::CargoProvenanceMismatch)
+            validate_codegen_fingerprint_value(Some("not-a-digest")),
+            Err(MaterializeError::InvalidCargoFingerprint { .. })
         ));
     }
 }

--- a/crates/rustc-codegen-cuda/src/materialize.rs
+++ b/crates/rustc-codegen-cuda/src/materialize.rs
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Opt-in build-time compilation of NVVM IR / LTOIR device artifacts to a
+//! final cubin, so the *embedded* payload is directly loadable by the CUDA
+//! driver.
+//!
+//! By default the backend embeds NVVM IR and LTOIR artifacts as-is and
+//! `cuda-host` compiles them at first load, choosing between a native cubin
+//! and a forward-compatible PTX bridge based on the GPU actually present
+//! (see `cuda-host`'s `ExecutionRoute`). Setting
+//! `CUDA_OXIDE_MATERIALIZE_CUBIN` moves that compilation to host build time
+//! instead:
+//!
+//! - deployment hosts no longer need libNVVM or nvJitLink, and there is no
+//!   first-load compile hit;
+//! - the build host must have libNVVM and nvJitLink available;
+//! - the embedded cubin is pinned to the emitted architecture — the
+//!   load-time PTX bridge to newer GPUs no longer applies. Use the default
+//!   when one binary must serve multiple GPU architectures.
+//!
+//! This module talks to `libnvvm-sys` / `nvjitlink-sys` directly (both load
+//! their libraries at call time via `dlopen`) rather than going through
+//! `cuda-host`, which would link the backend dylib against the CUDA driver
+//! (`libcuda.so.1`) and break building or loading the backend on machines
+//! without a GPU driver. The compile sequence mirrors `cuda-host`'s
+//! `ltoir` module and `cargo-oxide`'s `emit-ltoir`: validate the libNVVM
+//! frontend, add `libdevice.10.bc`, compile with `-gen-lto`, then link the
+//! LTOIR to a cubin with nvJitLink.
+
+use libnvvm_sys::{CudaArch, CudaArchParseError, LibNvvm, NvvmError, Program};
+use nvjitlink_sys::{InputType, LibNvJitLink, Linker, NvJitLinkError};
+use thiserror::Error;
+
+/// Whether the user asked for build-time cubin materialization.
+///
+/// Presence-based, mirroring `CUDA_OXIDE_EMIT_NVVM_IR`.
+pub(crate) fn materialize_cubin_enabled() -> bool {
+    std::env::var("CUDA_OXIDE_MATERIALIZE_CUBIN").is_ok()
+}
+
+/// Failures while materializing an embedded artifact to a cubin.
+#[derive(Debug, Error)]
+pub(crate) enum MaterializeError {
+    /// The recorded artifact target was not a concrete CUDA architecture.
+    #[error(transparent)]
+    InvalidTarget(#[from] CudaArchParseError),
+
+    /// The installed toolkit does not accept the NVVM IR version cuda-oxide emits.
+    #[error("installed libNVVM accepts NVVM IR {major}.{minor}, but cuda-oxide emits NVVM IR 2.0")]
+    UnsupportedNvvmIrVersion { major: i32, minor: i32 },
+
+    /// Toolkit dialect discovery disagreed with cuda-oxide's target policy.
+    #[error(
+        "libNVVM reports LLVM {llvm_major} for {target}, which disagrees with cuda-oxide's expected {expected} dialect"
+    )]
+    DialectMismatch {
+        target: String,
+        llvm_major: i32,
+        expected: &'static str,
+    },
+
+    /// libNVVM failed (load, symbol resolution, or compile call).
+    #[error("libnvvm: {0}")]
+    Nvvm(#[from] NvvmError),
+
+    /// nvJitLink failed (load, symbol resolution, or link call).
+    #[error("nvJitLink: {0}")]
+    NvJitLink(#[from] NvJitLinkError),
+
+    /// `libdevice.10.bc` could not be located or read.
+    #[error("CUDA_OXIDE_MATERIALIZE_CUBIN requires libdevice.10.bc on the build host. {0}")]
+    Libdevice(#[from] libnvvm_sys::LibdeviceNotFound),
+
+    /// Reading `libdevice.10.bc` failed.
+    #[error("failed reading {path}: {source}")]
+    Io {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// Compile an NVVM IR payload to a cubin for the architecture it was
+/// emitted for.
+pub(crate) fn nvvm_ir_to_cubin(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    target: &str,
+) -> Result<Vec<u8>, MaterializeError> {
+    let arch: CudaArch = target.parse()?;
+    let ltoir = compile_nvvm_ir_to_ltoir(nvvm_ir, module_name, &arch)?;
+    link_ltoir(&ltoir, &format!("{module_name}.ltoir"), &arch)
+}
+
+/// Link an LTOIR payload to a cubin for the architecture it was emitted for.
+pub(crate) fn ltoir_to_cubin(
+    ltoir: &[u8],
+    module_name: &str,
+    target: &str,
+) -> Result<Vec<u8>, MaterializeError> {
+    let arch: CudaArch = target.parse()?;
+    link_ltoir(ltoir, module_name, &arch)
+}
+
+fn compile_nvvm_ir_to_ltoir(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+) -> Result<Vec<u8>, MaterializeError> {
+    let nvvm = LibNvvm::load()?;
+    validate_nvvm_frontend(&nvvm, arch)?;
+
+    let libdevice_path = libnvvm_sys::find_libdevice()?;
+    let libdevice = std::fs::read(&libdevice_path).map_err(|source| MaterializeError::Io {
+        path: libdevice_path,
+        source,
+    })?;
+
+    let mut prog = Program::new(&nvvm)?;
+    // Add libdevice first so the kernel module's __nv_* references are
+    // resolved at compile time, matching cuda-host's ltoir pipeline.
+    prog.add_module(&libdevice, "libdevice.10.bc")?;
+    prog.add_module(nvvm_ir, module_name)?;
+
+    let arch_opt = format!("-arch={}", arch.compute());
+    prog.verify(&[&arch_opt])?;
+    Ok(prog.compile(&[&arch_opt, "-gen-lto"])?)
+}
+
+/// Frontend validation identical to cuda-host's `ltoir` module: cuda-oxide
+/// emits NVVM IR 2.0, and the LLVM dialect libNVVM reports for the target
+/// must match the dialect the backend generated for it.
+fn validate_nvvm_frontend(nvvm: &LibNvvm, arch: &CudaArch) -> Result<(), MaterializeError> {
+    let ir_version = nvvm.ir_version()?;
+    if (ir_version.ir_major, ir_version.ir_minor) != (2, 0) {
+        return Err(MaterializeError::UnsupportedNvvmIrVersion {
+            major: ir_version.ir_major,
+            minor: ir_version.ir_minor,
+        });
+    }
+    if let Some(llvm_major) = nvvm.llvm_version(arch)? {
+        let mismatch = if arch.uses_legacy_llvm() {
+            llvm_major != 7
+        } else {
+            llvm_major == 7
+        };
+        if mismatch {
+            return Err(MaterializeError::DialectMismatch {
+                target: arch.compute(),
+                llvm_major,
+                expected: if arch.uses_legacy_llvm() {
+                    "legacy LLVM 7"
+                } else {
+                    "modern opaque-pointer"
+                },
+            });
+        }
+    }
+    Ok(())
+}
+
+fn link_ltoir(
+    ltoir: &[u8],
+    module_name: &str,
+    arch: &CudaArch,
+) -> Result<Vec<u8>, MaterializeError> {
+    let nvj = LibNvJitLink::load()?;
+    let arch_opt = format!("-arch={}", arch.sm());
+    let mut linker = Linker::new(&nvj, &[&arch_opt, "-lto"])?;
+    linker.add(InputType::Ltoir, ltoir, module_name)?;
+    Ok(linker.finish()?)
+}

--- a/crates/rustc-codegen-cuda/src/materialize.rs
+++ b/crates/rustc-codegen-cuda/src/materialize.rs
@@ -3,172 +3,316 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Opt-in build-time compilation of NVVM IR / LTOIR device artifacts to a
-//! final cubin, so the *embedded* payload is directly loadable by the CUDA
-//! driver.
+//! Strict, opt-in build-time finalization of embedded device artifacts.
 //!
-//! By default the backend embeds NVVM IR and LTOIR artifacts as-is and
-//! `cuda-host` compiles them at first load, choosing between a native cubin
-//! and a forward-compatible PTX bridge based on the GPU actually present
-//! (see `cuda-host`'s `ExecutionRoute`). Setting
-//! `CUDA_OXIDE_MATERIALIZE_CUBIN` moves that compilation to host build time
-//! instead:
-//!
-//! - deployment hosts no longer need libNVVM or nvJitLink, and there is no
-//!   first-load compile hit;
-//! - the build host must have libNVVM and nvJitLink available;
-//! - the embedded cubin is pinned to the emitted architecture — the
-//!   load-time PTX bridge to newer GPUs no longer applies. Use the default
-//!   when one binary must serve multiple GPU architectures.
-//!
-//! This module talks to `libnvvm-sys` / `nvjitlink-sys` directly (both load
-//! their libraries at call time via `dlopen`) rather than going through
-//! `cuda-host`, which would link the backend dylib against the CUDA driver
-//! (`libcuda.so.1`) and break building or loading the backend on machines
-//! without a GPU driver. The compile sequence mirrors `cuda-host`'s
-//! `ltoir` module and `cargo-oxide`'s `emit-ltoir`: validate the libNVVM
-//! frontend, add `libdevice.10.bc`, compile with `-gen-lto`, then link the
-//! LTOIR to a cubin with nvJitLink.
+//! `cargo oxide --materialize-cubin` discovers and fingerprints the exact
+//! libNVVM, nvJitLink, and libdevice inputs before invoking Cargo. The digest
+//! is part of Cargo's rustc fingerprint and is passed here through an internal
+//! environment variable. We rediscover the tools and compare their bytes
+//! before compiling. Setting the internal opt-in around raw Cargo is
+//! unsupported: Cargo can reuse an existing artifact without invoking this
+//! backend, and when the backend does run it rejects a missing handshake.
 
-use libnvvm_sys::{CudaArch, CudaArchParseError, LibNvvm, NvvmError, Program};
-use nvjitlink_sys::{InputType, LibNvJitLink, Linker, NvJitLinkError};
+use cuda_artifact_finalizer::{
+    CudaArch, CudaArchParseError, DebugPolicy, FinalizationOptions, Finalizer, FinalizerError,
+    FinalizerOutput, NamedInput,
+};
 use thiserror::Error;
 
-/// Whether the user asked for build-time cubin materialization.
-///
-/// Presence-based, mirroring `CUDA_OXIDE_EMIT_NVVM_IR`.
-pub(crate) fn materialize_cubin_enabled() -> bool {
-    std::env::var("CUDA_OXIDE_MATERIALIZE_CUBIN").is_ok()
+pub(crate) const MATERIALIZE_ENV: &str = "CUDA_OXIDE_MATERIALIZE_CUBIN";
+pub(crate) const EXPECTED_PROVENANCE_ENV: &str = "CUDA_OXIDE_INTERNAL_MATERIALIZER_PROVENANCE";
+pub(crate) const WRAPPER_PROVENANCE_CFG: &str = "cuda_oxide_internal_materializer_provenance";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MaterializationRequest {
+    expected_provenance: [u8; 32],
 }
 
-/// Failures while materializing an embedded artifact to a cubin.
+/// Failures in the wrapper/backend materialization contract.
 #[derive(Debug, Error)]
 pub(crate) enum MaterializeError {
-    /// The recorded artifact target was not a concrete CUDA architecture.
+    #[error(
+        "{MATERIALIZE_ENV} must be a boolean (accepted true values: 1, true, yes, on; false values: 0, false, no, off), got {value:?}"
+    )]
+    InvalidBoolean { value: String },
+
+    #[error("{MATERIALIZE_ENV} is not valid Unicode")]
+    NonUnicodeBoolean,
+
+    #[error(
+        "{MATERIALIZE_ENV}=true requires cargo-oxide's provenance handshake; use `cargo oxide build --materialize-cubin` instead of invoking raw Cargo"
+    )]
+    MissingExpectedProvenance,
+
+    #[error(
+        "{MATERIALIZE_ENV}=true is missing cargo-oxide's rustc fingerprint; use `cargo oxide build --materialize-cubin` instead of invoking raw Cargo"
+    )]
+    MissingCargoFingerprint,
+
+    #[error(
+        "cargo-oxide's materializer provenance cfg must be exactly 64 lowercase hexadecimal characters, got {value:?}"
+    )]
+    InvalidCargoProvenance { value: String },
+
+    #[error(
+        "cargo-oxide's materializer provenance cfg does not match {EXPECTED_PROVENANCE_ENV}; refusing an unfingerprinted materialization build"
+    )]
+    CargoProvenanceMismatch,
+
+    #[error(
+        "{EXPECTED_PROVENANCE_ENV} must be exactly 64 lowercase hexadecimal characters, got {value:?}"
+    )]
+    InvalidExpectedProvenance { value: String },
+
+    #[error(
+        "the loaded CUDA tools cannot be tied to exact files, so their provenance cannot be verified; refusing build-time cubin materialization"
+    )]
+    UnverifiableProvenance,
+
+    #[error(
+        "CUDA materializer provenance changed after Cargo fingerprinting (expected {expected}, loaded {actual}); rerun `cargo oxide build --materialize-cubin`"
+    )]
+    ProvenanceMismatch { expected: String, actual: String },
+
+    #[error(
+        "build-time cubin materialization does not yet support generic #[cuda_module] loading because it merges PTX bundles across crates at run time"
+    )]
+    RequiresPtxBundleMerge,
+
+    #[error(
+        "build-time cubin materialization does not yet support #[device] extern declarations because their ordered external link inputs are not available to the backend"
+    )]
+    HasDeviceExterns,
+
+    #[error(
+        "build-time cubin materialization requires an NVVM IR or LTOIR artifact, but codegen produced PTX; use cargo-oxide so materialization can force NVVM IR emission"
+    )]
+    PtxInput,
+
+    #[error(
+        "build-time cubin materialization expected compiler IR, but codegen already produced a cubin; refusing to bypass the provenance-checked finalization recipe"
+    )]
+    CubinInput,
+
     #[error(transparent)]
     InvalidTarget(#[from] CudaArchParseError),
 
-    /// The installed toolkit does not accept the NVVM IR version cuda-oxide emits.
-    #[error("installed libNVVM accepts NVVM IR {major}.{minor}, but cuda-oxide emits NVVM IR 2.0")]
-    UnsupportedNvvmIrVersion { major: i32, minor: i32 },
-
-    /// Toolkit dialect discovery disagreed with cuda-oxide's target policy.
-    #[error(
-        "libNVVM reports LLVM {llvm_major} for {target}, which disagrees with cuda-oxide's expected {expected} dialect"
-    )]
-    DialectMismatch {
-        target: String,
-        llvm_major: i32,
-        expected: &'static str,
-    },
-
-    /// libNVVM failed (load, symbol resolution, or compile call).
-    #[error("libnvvm: {0}")]
-    Nvvm(#[from] NvvmError),
-
-    /// nvJitLink failed (load, symbol resolution, or link call).
-    #[error("nvJitLink: {0}")]
-    NvJitLink(#[from] NvJitLinkError),
-
-    /// `libdevice.10.bc` could not be located or read.
-    #[error("CUDA_OXIDE_MATERIALIZE_CUBIN requires libdevice.10.bc on the build host. {0}")]
-    Libdevice(#[from] libnvvm_sys::LibdeviceNotFound),
-
-    /// Reading `libdevice.10.bc` failed.
-    #[error("failed reading {path}: {source}")]
-    Io {
-        path: std::path::PathBuf,
-        source: std::io::Error,
-    },
+    #[error(transparent)]
+    Finalizer(#[from] FinalizerError),
 }
 
-/// Compile an NVVM IR payload to a cubin for the architecture it was
-/// emitted for.
-pub(crate) fn nvvm_ir_to_cubin(
-    nvvm_ir: &[u8],
-    module_name: &str,
-    target: &str,
-) -> Result<Vec<u8>, MaterializeError> {
-    let arch: CudaArch = target.parse()?;
-    let ltoir = compile_nvvm_ir_to_ltoir(nvvm_ir, module_name, &arch)?;
-    link_ltoir(&ltoir, &format!("{module_name}.ltoir"), &arch)
-}
-
-/// Link an LTOIR payload to a cubin for the architecture it was emitted for.
-pub(crate) fn ltoir_to_cubin(
-    ltoir: &[u8],
-    module_name: &str,
-    target: &str,
-) -> Result<Vec<u8>, MaterializeError> {
-    let arch: CudaArch = target.parse()?;
-    link_ltoir(ltoir, module_name, &arch)
-}
-
-fn compile_nvvm_ir_to_ltoir(
-    nvvm_ir: &[u8],
-    module_name: &str,
-    arch: &CudaArch,
-) -> Result<Vec<u8>, MaterializeError> {
-    let nvvm = LibNvvm::load()?;
-    validate_nvvm_frontend(&nvvm, arch)?;
-
-    let libdevice_path = libnvvm_sys::find_libdevice()?;
-    let libdevice = std::fs::read(&libdevice_path).map_err(|source| MaterializeError::Io {
-        path: libdevice_path,
-        source,
-    })?;
-
-    let mut prog = Program::new(&nvvm)?;
-    // Add libdevice first so the kernel module's __nv_* references are
-    // resolved at compile time, matching cuda-host's ltoir pipeline.
-    prog.add_module(&libdevice, "libdevice.10.bc")?;
-    prog.add_module(nvvm_ir, module_name)?;
-
-    let arch_opt = format!("-arch={}", arch.compute());
-    prog.verify(&[&arch_opt])?;
-    Ok(prog.compile(&[&arch_opt, "-gen-lto"])?)
-}
-
-/// Frontend validation identical to cuda-host's `ltoir` module: cuda-oxide
-/// emits NVVM IR 2.0, and the LLVM dialect libNVVM reports for the target
-/// must match the dialect the backend generated for it.
-fn validate_nvvm_frontend(nvvm: &LibNvvm, arch: &CudaArch) -> Result<(), MaterializeError> {
-    let ir_version = nvvm.ir_version()?;
-    if (ir_version.ir_major, ir_version.ir_minor) != (2, 0) {
-        return Err(MaterializeError::UnsupportedNvvmIrVersion {
-            major: ir_version.ir_major,
-            minor: ir_version.ir_minor,
-        });
-    }
-    if let Some(llvm_major) = nvvm.llvm_version(arch)? {
-        let mismatch = if arch.uses_legacy_llvm() {
-            llvm_major != 7
-        } else {
-            llvm_major == 7
-        };
-        if mismatch {
-            return Err(MaterializeError::DialectMismatch {
-                target: arch.compute(),
-                llvm_major,
-                expected: if arch.uses_legacy_llvm() {
-                    "legacy LLVM 7"
-                } else {
-                    "modern opaque-pointer"
-                },
-            });
+/// Parse the strict opt-in and its wrapper-generated provenance handshake.
+/// No CUDA library is loaded here.
+pub(crate) fn request_from_env(
+    wrapper_provenance: Option<&str>,
+) -> Result<Option<MaterializationRequest>, MaterializeError> {
+    let enabled = match std::env::var(MATERIALIZE_ENV) {
+        Ok(value) => parse_bool(&value)?,
+        Err(std::env::VarError::NotPresent) => false,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(MaterializeError::NonUnicodeBoolean);
         }
+    };
+    if !enabled {
+        return Ok(None);
+    }
+    let value = std::env::var(EXPECTED_PROVENANCE_ENV)
+        .map_err(|_| MaterializeError::MissingExpectedProvenance)?;
+    let expected_provenance = parse_digest(&value)?;
+    validate_wrapper_provenance(wrapper_provenance, &expected_provenance)?;
+    Ok(Some(MaterializationRequest {
+        expected_provenance,
+    }))
+}
+
+/// Reject artifact-loading models the finalizer cannot reproduce, before any
+/// CUDA compiler library is discovered or loaded.
+pub(crate) fn validate_collection(
+    request: Option<MaterializationRequest>,
+    has_device_externs: bool,
+    requires_ptx_bundle_merge: bool,
+) -> Result<(), MaterializeError> {
+    if request.is_none() {
+        return Ok(());
+    }
+    if requires_ptx_bundle_merge {
+        return Err(MaterializeError::RequiresPtxBundleMerge);
+    }
+    if has_device_externs {
+        return Err(MaterializeError::HasDeviceExterns);
     }
     Ok(())
 }
 
-fn link_ltoir(
+pub(crate) fn nvvm_ir_to_cubin(
+    request: MaterializationRequest,
+    nvvm_ir: &[u8],
+    module_name: &str,
+    target: &str,
+    allow_fma_contraction: bool,
+    debug_policy: DebugPolicy,
+) -> Result<Vec<u8>, MaterializeError> {
+    let options = options(target, allow_fma_contraction, debug_policy)?;
+    let finalizer = checked_finalizer(request)?;
+    Ok(finalizer.materialize_nvvm_ir(module_name, nvvm_ir, &options)?)
+}
+
+pub(crate) fn ltoir_to_cubin(
+    request: MaterializationRequest,
     ltoir: &[u8],
     module_name: &str,
-    arch: &CudaArch,
+    target: &str,
+    allow_fma_contraction: bool,
+    debug_policy: DebugPolicy,
 ) -> Result<Vec<u8>, MaterializeError> {
-    let nvj = LibNvJitLink::load()?;
-    let arch_opt = format!("-arch={}", arch.sm());
-    let mut linker = Linker::new(&nvj, &[&arch_opt, "-lto"])?;
-    linker.add(InputType::Ltoir, ltoir, module_name)?;
-    Ok(linker.finish()?)
+    let options = options(target, allow_fma_contraction, debug_policy)?;
+    let finalizer = checked_finalizer(request)?;
+    Ok(finalizer.link_ltoir(
+        &[NamedInput::new(module_name, ltoir)],
+        &options,
+        FinalizerOutput::Cubin,
+    )?)
+}
+
+fn options(
+    target: &str,
+    allow_fma_contraction: bool,
+    debug_policy: DebugPolicy,
+) -> Result<FinalizationOptions, MaterializeError> {
+    let target: CudaArch = target.parse()?;
+    Ok(FinalizationOptions::new(target)
+        .with_fma_contraction(allow_fma_contraction)
+        .with_debug_policy(debug_policy))
+}
+
+fn checked_finalizer(request: MaterializationRequest) -> Result<Finalizer, MaterializeError> {
+    let finalizer = Finalizer::discover()?;
+    let actual = finalizer
+        .provenance_digest()
+        .ok_or(MaterializeError::UnverifiableProvenance)?;
+    if actual != request.expected_provenance {
+        return Err(MaterializeError::ProvenanceMismatch {
+            expected: digest_hex(&request.expected_provenance),
+            actual: digest_hex(&actual),
+        });
+    }
+    Ok(finalizer)
+}
+
+fn parse_bool(value: &str) -> Result<bool, MaterializeError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(MaterializeError::InvalidBoolean {
+            value: value.to_string(),
+        }),
+    }
+}
+
+fn validate_wrapper_provenance(
+    value: Option<&str>,
+    expected: &[u8; 32],
+) -> Result<(), MaterializeError> {
+    let value = value.ok_or(MaterializeError::MissingCargoFingerprint)?;
+    let wrapper = parse_digest(value).map_err(|_| MaterializeError::InvalidCargoProvenance {
+        value: value.to_string(),
+    })?;
+    if &wrapper == expected {
+        Ok(())
+    } else {
+        Err(MaterializeError::CargoProvenanceMismatch)
+    }
+}
+
+fn parse_digest(value: &str) -> Result<[u8; 32], MaterializeError> {
+    if value.len() != 64
+        || !value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(MaterializeError::InvalidExpectedProvenance {
+            value: value.to_string(),
+        });
+    }
+    let mut digest = [0_u8; 32];
+    for (index, byte) in digest.iter_mut().enumerate() {
+        let offset = index * 2;
+        *byte = u8::from_str_radix(&value[offset..offset + 2], 16).map_err(|_| {
+            MaterializeError::InvalidExpectedProvenance {
+                value: value.to_string(),
+            }
+        })?;
+    }
+    Ok(digest)
+}
+
+fn digest_hex(digest: &[u8; 32]) -> String {
+    use std::fmt::Write;
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_boolean_parser_accepts_only_documented_values() {
+        for value in ["1", " true ", "YES", "on"] {
+            assert!(parse_bool(value).unwrap());
+        }
+        for value in ["0", " false ", "NO", "off"] {
+            assert!(!parse_bool(value).unwrap());
+        }
+        for value in ["", "enabled", "2", "truthy"] {
+            assert!(matches!(
+                parse_bool(value),
+                Err(MaterializeError::InvalidBoolean { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn provenance_digest_requires_canonical_lower_hex() {
+        let value = "0123456789abcdef".repeat(4);
+        let digest = parse_digest(&value).unwrap();
+        assert_eq!(digest_hex(&digest), value);
+        assert!(parse_digest(&"A".repeat(64)).is_err());
+        assert!(parse_digest(&"0".repeat(63)).is_err());
+        assert!(parse_digest(&format!("{}g", "0".repeat(63))).is_err());
+    }
+
+    #[test]
+    fn unsupported_collection_models_fail_without_tools() {
+        let request = Some(MaterializationRequest {
+            expected_provenance: [0; 32],
+        });
+        assert!(matches!(
+            validate_collection(request, false, true),
+            Err(MaterializeError::RequiresPtxBundleMerge)
+        ));
+        assert!(matches!(
+            validate_collection(request, true, false),
+            Err(MaterializeError::HasDeviceExterns)
+        ));
+        assert!(validate_collection(None, true, true).is_ok());
+    }
+
+    #[test]
+    fn backend_invocation_rejects_raw_cargo_materialization_without_fingerprint() {
+        let expected = [0; 32];
+        assert!(matches!(
+            validate_wrapper_provenance(None, &expected),
+            Err(MaterializeError::MissingCargoFingerprint)
+        ));
+        assert!(validate_wrapper_provenance(Some(&"00".repeat(32)), &expected).is_ok());
+        assert!(matches!(
+            validate_wrapper_provenance(Some(&"11".repeat(32)), &expected),
+            Err(MaterializeError::CargoProvenanceMismatch)
+        ));
+    }
 }

--- a/cuda-oxide-book/compiler/rustc-codegen-cuda.md
+++ b/cuda-oxide-book/compiler/rustc-codegen-cuda.md
@@ -89,7 +89,7 @@ in a crowd. The exact prefix strings (and the helpers that match and strip
 them) live in the workspace-internal `reserved-oxide-symbols` crate; both the
 macro side and the collector side import from there so the contract stays in
 one place. The 8-hex-char `<hash>` makes accidental collisions effectively
-impossible: nobody writes `cuda_oxide_kernel_246e25db_foo` by accident.
+impossible: nobody writes `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_foo` by accident.
 
 ### Step 3: If Device Code Found, Build and Compile
 


### PR DESCRIPTION
## What this PR does

Some cuda-oxide deployments finish compiling embedded NVVM IR or LTOIR when
the program first loads. That adds startup work and can require libNVVM and
nvJitLink on the deployment machine.

This PR adds an explicit opt-in that finishes that compilation during the host
build and embeds native GPU code instead:

    cargo oxide build vecadd --materialize-cubin --arch sm_86
    NVVM IR + libdevice -> LTOIR -> nvJitLink -> embedded sm_86 cubin

Default artifact behavior is preserved: without `--materialize-cubin`, builds
continue to embed PTX.

## Why this is useful

For a deployment with a known GPU architecture, the program can load the cubin
directly through the CUDA driver. It does not need to run libNVVM or nvJitLink
at startup.

The trade-off is intentional: a cubin targets one real GPU architecture. It
does not provide the forward compatibility or multiple architectures of PTX
or a CUDA fatbinary.

## How it works

- Build-time and load-time CUDA finalization share one driver-independent
  implementation.
- The selected architecture, FMA policy (including `--no-fmad`), and debug
  policy are preserved through libNVVM and nvJitLink.
- Cache keys include the exact source artifact, ordered options, compiler and
  linker identities, toolkit inputs, and `libdevice`.
- The codegen backend still has no direct dependency on the CUDA driver or
  toolkit libraries.
- Missing architecture, incompatible output modes, multiple final artifacts,
  and unresolved late-link inputs fail with clear errors instead of producing
  an incomplete cubin.

## Cargo cache correctness and CI performance

The previous head was not a performance repair. It made target, output, and
materializer fingerprints global `CARGO_ENCODED_RUSTFLAGS`, so every mode or
architecture change invalidated Cargo's shared dependency cache.

Hosted comparison before this repair:

- `main` (`52accfa4`): compile-examples step 10m25s.
- Previous PR head (`7616282c`): 22m52s.
- `generated_intrinsics`: 3s -> 127s.
- `generated_intrinsics_blackwell`: 2s -> 122s.
- `tcgen05`: 4s -> 124s.

This repair splits the cache boundary according to ownership:

- The exact backend `.so` SHA-256 remains global because that backend compiles
  every crate.
- Architecture, output mode, FMA/debug policy, owner filter, and exact
  materializer provenance are a full SHA-256 environment dependency recorded
  by CUDA procedural macros only in crates that can own or instantiate device
  artifacts.
- Exact materializer provenance is tracked separately and is still rediscovered
  and byte-checked by the backend before cubin generation.

The workflow now checks Cargo compilation events rather than imposing a timing
threshold. PTX -> cubin -> PTX may rebuild `vecadd`, and an `sm_86` -> `sm_90`
cross-crate switch may rebuild `kernel-lib` plus its consumer, but either
transition fails CI if an unrelated shared dependency recompiles.

Local validation of the repaired candidate compiled all 145 examples in 181s.
The formerly regressed examples completed in 2s, 2s, and 3s respectively. A
focused retained-log run confirmed that each compiled only its owning example
crate. These local timings are supporting evidence; the authoritative hosted
comparison will be recorded after the repaired head runs in CI.

## Validation

- 86 `cargo-oxide` tests, including cold/warm/architecture/output/provenance
  Cargo JSON `fresh` assertions for an owner, downstream consumer, and plain
  shared dependency.
- 69 CUDA macro unit tests and the existing macro compile-test suite.
- 17 codegen-backend tests.
- Strict clippy for the affected root and backend crates.
- Full GPU-less compile sweep: 145/145 examples passed in 181s.
- Real PTX -> cubin -> PTX and `sm_86` -> `sm_90` cross-crate cache transitions.
- Extracted cubin inspection: CUDA ELF `sm=86` with exported `vecadd` entry.
- Current macros compiled successfully with the exact previous backend head,
  which recognized `vecadd` and embedded a non-empty PTX artifact.

No CUDA device was available, so this validation does not make a GPU-execution
claim.

## Issue relationship

Issues #378, #388, and #390 are related, but this PR does not close them.

## History

The contributor-authored, DCO-compliant commit is preserved. Separate signed
maintainer commits rebuild the feature around the shared finalizer and repair
the Cargo cache boundary.
