### PR TITLE
Ignore JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ target/
 .DS_Store
 *.tar.gz
 .cursor/
+.idea/
+*.iml
 .vscode/
 .claude/
 .codex/


### PR DESCRIPTION
## Summary

Adds JetBrains-generated project metadata to the existing editor/tooling ignore
group:

- `.idea/`
- `*.iml`

## Maintainer verification

- Root and nested `.idea/` paths and `*.iml` files are ignored.
- Similar source names such as `.idea.rs`, `iml_parser.rs`, and
  `workspace.iml.toml` remain visible.
- `git diff --check` and an independent post-repair audit passed.

The original sole commit lacked DCO. This trivial change was independently
reimplemented from current `main` as a maintainer-authored, signed-off commit;
no sign-off was added on the contributor's behalf.
