### PR TITLE
fix(collector): don't root items nested inside kernel bodies as kernels

### DIFF
--- a/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
@@ -70,6 +70,22 @@ mod kernels {
     /// an owned value.
     #[kernel]
     pub fn vecadd_with_helper(a: &[f32], b: &[f32], c: DisjointSlice<f32>) {
+        // A named generic helper nested inside a kernel carries the kernel's
+        // generated symbol in an earlier def-path segment. It must remain a
+        // normal device callee under its canonical mangled symbol, not become
+        // a second `_TID_` kernel entry.
+        #[inline(never)]
+        fn nested_identity<T: Copy>(value: T) -> T {
+            value
+        }
+
+        // Keep two concrete monomorphizations reachable without changing the
+        // example's result. `inline(never)` makes them visible to the device
+        // collector and this guard is always false at runtime.
+        if nested_identity::<f32>(0.0) != 0.0 || nested_identity::<u32>(0) != 0 {
+            return;
+        }
+
         // Call the device function by its original name
         vecadd_device(a, b, c);
     }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -396,6 +396,24 @@ pub fn is_kernel_function(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     is_kernel_symbol(&tcx.def_path_str(def_id))
 }
 
+/// Returns `true` when `def_path` names a kernel entry point *itself*, as
+/// opposed to an item nested inside a kernel body.
+///
+/// [`is_kernel_function`] matches by substring, so a closure or a named `fn`
+/// defined inside a `#[kernel]` also matches — its def path has the kernel's
+/// name as a path *prefix* (`...::cuda_oxide_kernel_<hash>_k::helper`). Only
+/// a def path whose *final* segment carries the kernel marker is the kernel:
+/// nested items are plain device functions, exported under their mangled
+/// symbol by the call-graph walk. Rooting them as kernels would give generic
+/// nested fns a `_TID_<hash>` export name that no call site references,
+/// failing module verification with "Symbol ... not found".
+pub(crate) fn is_kernel_entry_def_path(def_path: &str) -> bool {
+    if def_path.contains("{closure") || def_path.contains("::closure") {
+        return false;
+    }
+    def_path.rsplit("::").next().is_some_and(is_kernel_symbol)
+}
+
 /// Checks if a function is a standalone device function definition.
 ///
 /// Detection is based on the `DEVICE_PREFIX` substring added by the
@@ -730,14 +748,16 @@ pub fn collect_device_functions<'tcx>(
             if let MonoItem::Fn(instance) = item
                 && is_kernel_function(tcx, instance.def_id())
             {
-                // Skip closures inside kernels - they are device functions, not kernels.
-                // Closures have names like "cuda_oxide_kernel_<hash>_foo::{closure#0}" but
-                // only "cuda_oxide_kernel_<hash>_foo" is the actual kernel entry point.
+                // Items nested inside a kernel body (closures, named fns)
+                // match the substring check above but are device functions,
+                // not entry points; rooting a nested fn here would export it
+                // under a `_TID_` kernel name that no call site uses. They
+                // are collected transitively via the call-graph walk instead.
                 let name = tcx.def_path_str(instance.def_id());
-                if name.contains("{closure") || name.contains("::closure") {
+                if !is_kernel_entry_def_path(&name) {
                     if verbose {
                         eprintln!(
-                            "[collector] Skipping closure inside kernel (not an entry point): {}",
+                            "[collector] Skipping item nested inside kernel (not an entry point): {}",
                             name
                         );
                     }
@@ -2132,7 +2152,7 @@ mod tests {
         PTX_MERGE_REQUIRED_PREFIX, is_ptx_merge_required_marker, ptx_merge_required_marker,
     };
 
-    use super::unsupported_codegen_protocol_root;
+    use super::{is_kernel_entry_def_path, unsupported_codegen_protocol_root};
 
     #[test]
     fn ptx_merge_marker_matches_only_the_final_path_component() {
@@ -2174,5 +2194,44 @@ mod tests {
         assert!(!unsupported_codegen_protocol_root(
             "ordinary::host_function"
         ));
+    }
+
+        const K: &str = "cuda_oxide_kernel_246e25db_vecadd";
+
+    #[test]
+    fn kernel_def_paths_are_entry_points() {
+        // Bare and fully-qualified kernel names: the marker is the final segment.
+        assert!(is_kernel_entry_def_path(K));
+        assert!(is_kernel_entry_def_path(&format!("kernels::{K}")));
+        assert!(is_kernel_entry_def_path(&format!("my_crate::kernels::{K}")));
+    }
+
+    #[test]
+    fn items_nested_inside_kernel_bodies_are_not_entry_points() {
+        // A named fn defined inside a kernel body: the kernel name is a path
+        // prefix, not the final segment. Rooting it would mint a `_TID_`
+        // export name (generic case) that no call site references.
+        assert!(!is_kernel_entry_def_path(&format!(
+            "{K}::reduce_workspace_max"
+        )));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "my_crate::kernels::{K}::helper"
+        )));
+        // Deeper nesting (fn inside a block inside the kernel).
+        assert!(!is_kernel_entry_def_path(&format!("{K}::inner::helper")));
+    }
+
+    #[test]
+    fn closures_inside_kernel_bodies_are_not_entry_points() {
+        assert!(!is_kernel_entry_def_path(&format!("{K}::{{closure#0}}")));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "kernels::{K}::{{closure#1}}"
+        )));
+    }
+
+    #[test]
+    fn non_kernel_paths_are_not_entry_points() {
+        assert!(!is_kernel_entry_def_path("my_crate::helpers::sum_slice"));
+        assert!(!is_kernel_entry_def_path(""));
     }
 }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -159,8 +159,8 @@ enum CollectDecision {
 // "test extern first" ordering dance that lived here previously.
 use reserved_oxide_symbols::{
     device_extern_base_name, is_current_device_symbol, is_current_kernel_symbol,
-    is_device_extern_symbol, is_device_symbol, is_kernel_symbol, is_ptx_merge_required_marker,
-    kernel_base_name,
+    is_device_extern_symbol, is_device_symbol, is_kernel_symbol, is_legacy_kernel_symbol,
+    is_ptx_merge_required_marker, kernel_base_name,
 };
 
 /// Sanitize a symbol name for use as a PTX identifier.
@@ -381,9 +381,15 @@ fn unsupported_codegen_protocol_root(name: &str) -> bool {
 
 /// Checks if a function is a kernel entry point.
 ///
-/// Detection is based on the `KERNEL_PREFIX` substring (currently
-/// `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_`) which the `#[kernel]` macro adds to
-/// renamed functions:
+/// Detection is based on the generated namespace in the *final* def-path
+/// segment: it must start with `KERNEL_PREFIX` (currently
+/// `cuda_oxide_codegen_v1_cuda_oxide_kernel_246e25db_`) or, for roots emitted
+/// before the scoped Cargo cache protocol, `LEGACY_KERNEL_PREFIX`. Legacy
+/// roots stay classified so the protocol handshake can reject them with an
+/// explicit diagnostic instead of silently skipping device codegen. The
+/// final-segment check matters because a named item nested inside a kernel
+/// has the kernel symbol as an earlier path segment, but is a device helper
+/// rather than another entry point.
 ///
 /// ```text
 /// User writes:        Macro expands to:
@@ -393,25 +399,20 @@ fn unsupported_codegen_protocol_root(name: &str) -> bool {
 /// └─────────────────┘  └────────────────────────────────────────────────┘
 /// ```
 pub fn is_kernel_function(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    is_kernel_symbol(&tcx.def_path_str(def_id))
+    is_kernel_entry_def_path(&tcx.def_path_str(def_id))
 }
 
 /// Returns `true` when `def_path` names a kernel entry point *itself*, as
 /// opposed to an item nested inside a kernel body.
 ///
-/// [`is_kernel_function`] matches by substring, so a closure or a named `fn`
-/// defined inside a `#[kernel]` also matches — its def path has the kernel's
-/// name as a path *prefix* (`...::cuda_oxide_kernel_<hash>_k::helper`). Only
-/// a def path whose *final* segment carries the kernel marker is the kernel:
-/// nested items are plain device functions, exported under their mangled
-/// symbol by the call-graph walk. Rooting them as kernels would give generic
-/// nested fns a `_TID_<hash>` export name that no call site references,
+/// A closure or named `fn` defined inside a `#[kernel]` has the kernel's name
+/// as an earlier path segment (`...::cuda_oxide_kernel_<hash>_k::helper`).
+/// Nested items are plain device functions, exported under their canonical
+/// mangled symbol by the call-graph walk. Rooting them as kernels would give
+/// generic nested fns a `_TID_<hash>` export name that no call site references,
 /// failing module verification with "Symbol ... not found".
 pub(crate) fn is_kernel_entry_def_path(def_path: &str) -> bool {
-    if def_path.contains("{closure") || def_path.contains("::closure") {
-        return false;
-    }
-    def_path.rsplit("::").next().is_some_and(is_kernel_symbol)
+    is_current_kernel_symbol(def_path) || is_legacy_kernel_symbol(def_path)
 }
 
 /// Checks if a function is a standalone device function definition.
@@ -748,22 +749,6 @@ pub fn collect_device_functions<'tcx>(
             if let MonoItem::Fn(instance) = item
                 && is_kernel_function(tcx, instance.def_id())
             {
-                // Items nested inside a kernel body (closures, named fns)
-                // match the substring check above but are device functions,
-                // not entry points; rooting a nested fn here would export it
-                // under a `_TID_` kernel name that no call site uses. They
-                // are collected transitively via the call-graph walk instead.
-                let name = tcx.def_path_str(instance.def_id());
-                if !is_kernel_entry_def_path(&name) {
-                    if verbose {
-                        eprintln!(
-                            "[collector] Skipping item nested inside kernel (not an entry point): {}",
-                            name
-                        );
-                    }
-                    continue;
-                }
-
                 // Skip generic (non-monomorphized) instances.
                 // For generic kernels like scale<T>, the CGU contains both:
                 // - The generic definition (scale<T>) - skip this
@@ -2196,14 +2181,24 @@ mod tests {
         ));
     }
 
-        const K: &str = "cuda_oxide_kernel_246e25db_vecadd";
-
     #[test]
     fn kernel_def_paths_are_entry_points() {
         // Bare and fully-qualified kernel names: the marker is the final segment.
-        assert!(is_kernel_entry_def_path(K));
-        assert!(is_kernel_entry_def_path(&format!("kernels::{K}")));
-        assert!(is_kernel_entry_def_path(&format!("my_crate::kernels::{K}")));
+        assert!(is_kernel_entry_def_path(&format!("{KERNEL_PREFIX}vecadd")));
+        assert!(is_kernel_entry_def_path(&format!(
+            "kernels::{KERNEL_PREFIX}vecadd"
+        )));
+        assert!(is_kernel_entry_def_path(&format!(
+            "my_crate::kernels::{KERNEL_PREFIX}vecadd"
+        )));
+        // Legacy roots still classify as entry points. They must not vanish
+        // as ordinary host functions: the scoped-cache handshake rejects
+        // them with an explicit diagnostic (see
+        // `unsupported_codegen_protocol_root`), and builds outside the
+        // protocol continue to compile them.
+        assert!(is_kernel_entry_def_path(&format!(
+            "legacy::{LEGACY_KERNEL_PREFIX}vecadd"
+        )));
     }
 
     #[test]
@@ -2212,26 +2207,41 @@ mod tests {
         // prefix, not the final segment. Rooting it would mint a `_TID_`
         // export name (generic case) that no call site references.
         assert!(!is_kernel_entry_def_path(&format!(
-            "{K}::reduce_workspace_max"
+            "{KERNEL_PREFIX}softmax::reduce_workspace_max"
         )));
         assert!(!is_kernel_entry_def_path(&format!(
-            "my_crate::kernels::{K}::helper"
+            "my_crate::kernels::{KERNEL_PREFIX}softmax::helper"
         )));
         // Deeper nesting (fn inside a block inside the kernel).
-        assert!(!is_kernel_entry_def_path(&format!("{K}::inner::helper")));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "{KERNEL_PREFIX}softmax::inner::helper"
+        )));
     }
 
     #[test]
     fn closures_inside_kernel_bodies_are_not_entry_points() {
-        assert!(!is_kernel_entry_def_path(&format!("{K}::{{closure#0}}")));
         assert!(!is_kernel_entry_def_path(&format!(
-            "kernels::{K}::{{closure#1}}"
+            "{KERNEL_PREFIX}map::{{closure#0}}"
+        )));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "kernels::{KERNEL_PREFIX}map::{{closure#1}}"
         )));
     }
 
     #[test]
     fn non_kernel_paths_are_not_entry_points() {
         assert!(!is_kernel_entry_def_path("my_crate::helpers::sum_slice"));
+        // The marker must begin the final segment. A substring match here
+        // would let ordinary near-miss names masquerade as kernel entries.
+        assert!(!is_kernel_entry_def_path(&format!(
+            "my_crate::helpers::not_{KERNEL_PREFIX}vecadd"
+        )));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "my_crate::helpers::not_{LEGACY_KERNEL_PREFIX}vecadd"
+        )));
+        assert!(!is_kernel_entry_def_path(&format!(
+            "my_crate::helpers::prefix{KERNEL_PREFIX}vecadd"
+        )));
         assert!(!is_kernel_entry_def_path(""));
     }
 }

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -1226,6 +1226,18 @@ run_cargo() {
         cargo oxide "${args[@]}" >"${log}" 2>&1
         CARGO_EC=$?
     fi
+    if [[ ${CARGO_EC} -eq 0 && ${COMPILE_ONLY} -eq 1 && "${ex}" == "helper_fn" ]]; then
+        local ptx="crates/rustc-codegen-cuda/examples/${ex}/${ex}.ptx"
+        local nested_defs entry_count
+        nested_defs="$(grep -cE '^\.visible \.func .*_RI.*nested_identity' "${ptx}" 2>/dev/null)"
+        entry_count="$(grep -cE '^\.visible \.entry ' "${ptx}" 2>/dev/null)"
+        if [[ ! -s "${ptx}" || ${nested_defs} -ne 2 || ${entry_count} -ne 1 ]] \
+            || ! grep -qF '.visible .entry vecadd_with_helper(' "${ptx}" \
+            || grep -qE '(nested_identity.*_TID_|_TID_.*nested_identity)' "${ptx}"; then
+            printf 'helper_fn expected one kernel entry and two canonically mangled nested_identity device functions, with no helper _TID_ exports\n' >>"${log}"
+            CARGO_EC=1
+        fi
+    fi
     if [[ ${CARGO_EC} -eq 0 && ${COMPILE_ONLY} -eq 1 && "${ex}" == "standalone_device_fn" ]]; then
         local ptx="crates/rustc-codegen-cuda/examples/${ex}/${ex}.ptx"
         local tf32_count


### PR DESCRIPTION
## Summary

`is_kernel_function` matches the kernel marker by substring, so a named `fn` defined *inside* a `#[kernel]` body also matches — its def path carries the kernel's name as a path prefix (`...::cuda_oxide_kernel_<hash>_k::helper`). The collector's root scan then treats the nested fn as a kernel entry point: a generic monomorphization gets exported under a `<kernel>__<fn>_TID_<hash>` name (and tagged `gpu_kernel`) while its call sites reference the canonical mangled symbol, so the module fails verification with *"Symbol ... not found"*.

Repro shape (verified against current `main`):

```rust
#[kernel]
pub fn nested_helper(a: &[f32], b: &[u32], mut out: DisjointSlice<f32>) {
    #[inline(never)]
    fn pick<T: Copy>(xs: &[T], i: usize) -> T { xs[i % xs.len()] }
    // ...
    *slot = pick::<f32>(a, i) + pick::<u32>(b, i) as f32;  // Symbol ..pick.. not found
}
```

The existing closure skip already handled the anonymous flavor of exactly this problem; this PR folds both into one shared predicate.

## Changes

- New `is_kernel_entry_def_path` predicate: a def path is a kernel entry point only when its **final** segment carries the kernel marker; closures and named fns nested inside kernel bodies are rejected and left to the call-graph walk, which collects them under their mangled symbols as before.
- The root scan's inline closure check is replaced by the predicate (one skip path instead of two).
- Four unit tests in `collector.rs` covering: bare/qualified kernel paths, nested named fns (single and deep nesting), closures, and non-kernel paths.

## Testing

- `cargo test` in `crates/rustc-codegen-cuda` — 12 passed (4 new).
- Repro kernel above: fails device codegen on `main` with `Symbol ..._pick... not found` (the def exported as `nested_helper__pick_TID_<hash>`); with the fix it builds and runs correctly on an RTX 5080 (sm_120).
- Downstream validation: a shader stack whose reduction kernels define generic tree-reduce helpers inside kernel bodies compiles and runs bit-identically with this fix.

- [x] `cargo test --workspace` passes (crate-local suite; see above)
- [ ] New example added — not needed: covered by unit tests on the predicate (repro kernel included above for reference)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Maintainer note (2026-07-22):** Follow-up commits extended this PR beyond the original description: `is_kernel_function` now delegates to the exact final-segment classifier directly (the root scan's manual skip path is gone entirely), near-miss negative tests were added, the `helper_fn` example gained a nested generic helper with two monomorphizations, and the smoketest gained a compile-only PTX assertion pinning the expected shape, so the "new example" item above is now covered after all. The branch was also rebased across #340's scoped-cache protocol: the classifier accepts the current or legacy kernel prefix on the final def-path segment (`is_current_kernel_symbol` / `is_legacy_kernel_symbol`), keeping legacy roots on the explicit protocol diagnostic path instead of silently dropping them.
