### PR TITLE
feat: device-only crate builds (auto-detected) + llvm.* link-name intrinsic dispatch

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -1213,11 +1213,29 @@ fn run_compute_sanitizer(
 /// Same as [`codegen_run`] but uses `cargo build --release` instead of
 /// `cargo run`. Useful for cross-compilation or when the target hardware
 /// (e.g., Blackwell tensor cores) isn't available on the build machine.
+/// Detect a device-only crate: a library with no binary target and no
+/// dependency on the host-side crates (`cuda-host` / `cuda-core`).
+///
+/// Such a crate cannot be a unified host+device build — there is nothing to
+/// produce for the host — so `build` selects the `--device` path (real
+/// `nvptx64-nvidia-cuda` target) automatically. The explicit `--device` flag
+/// remains as an override for crates the heuristic cannot see through
+/// (e.g. a lib that optionally depends on host crates behind a feature).
+fn is_device_only_crate(crate_dir: &Path) -> bool {
+    let Ok(manifest) = std::fs::read_to_string(crate_dir.join("Cargo.toml")) else {
+        return false;
+    };
+    let has_bin_target = crate_dir.join("src/main.rs").is_file() || manifest.contains("[[bin]]");
+    let depends_on_host = manifest.contains("cuda-host") || manifest.contains("cuda-core");
+    !has_bin_target && !depends_on_host
+}
+
 pub fn codegen_build(
     ctx: &Context,
     example: &str,
     verbose: bool,
     emit_nvvm_ir: bool,
+    device: bool,
     arch: Option<&str>,
     features: Option<&str>,
     no_fmad: bool,
@@ -1257,6 +1275,27 @@ pub fn codegen_build(
 
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release"]).current_dir(&example_dir);
+
+    let device = device || {
+        let auto = is_device_only_crate(&example_dir);
+        if auto {
+            println!(
+                "Device-only crate detected (library without cuda-host); \
+                 building for nvptx64-nvidia-cuda"
+            );
+        }
+        auto
+    };
+    if device {
+        // Device-only crate: compile the front-end for the real nvptx64 target
+        // so `cfg(target_arch = "nvptx64")` is active (no host-target SIMD /
+        // barrier fallbacks). `core` is cross-compiled via build-std since the
+        // nvptx target ships no precompiled std. The backend writes the
+        // standalone `<crate>.ptx`; point it at the crate dir and skip the
+        // host-object embed (handled in the backend for nvptx targets).
+        cmd.args(["--target", "nvptx64-nvidia-cuda", "-Z", "build-std=core"]);
+        cmd.env("CUDA_OXIDE_PTX_DIR", &example_dir);
+    }
 
     if let Some(features) = features {
         cmd.args(["--features", features]);
@@ -1331,6 +1370,7 @@ pub fn emit_ltoir(
         example,
         verbose,
         true,
+        false,
         Some(&sm_arch),
         features,
         no_fmad,

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -115,6 +115,18 @@ enum Commands {
         /// Generate NVVM IR (use with libNVVM -gen-lto)
         #[arg(long)]
         emit_nvvm_ir: bool,
+        /// Compile as a device-only crate for the real `nvptx64-nvidia-cuda`
+        /// target (adds `--target nvptx64-nvidia-cuda -Z build-std=core`).
+        ///
+        /// In this mode `cfg(target_arch = "nvptx64")` is active, so crates
+        /// written for multiple GPU targets select their device code paths
+        /// (real barriers, scalar math, `link_llvm_intrinsics` externs) with
+        /// no host-target workarounds. The crate must be a pure device crate
+        /// (no `cuda_host` / `main` host glue); the emitted `<crate>.ptx` is
+        /// the deliverable. Library crates without a cuda-host dependency
+        /// select this mode automatically; the flag forces it.
+        #[arg(long)]
+        device: bool,
         /// Target architecture (e.g., sm_90, sm_100, sm_120)
         #[arg(long)]
         arch: Option<String>,
@@ -361,6 +373,7 @@ fn main() {
         Commands::Build {
             example,
             emit_nvvm_ir,
+            device,
             arch,
             features,
             verbose,
@@ -386,6 +399,7 @@ fn main() {
                     &example,
                     verbose,
                     emit_nvvm_ir,
+                    device,
                     arch.as_deref(),
                     features.as_deref(),
                     no_fmad,

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -4050,10 +4050,18 @@ fn generate_cuda_kernel_impl(fn_name: &Ident, ptx_name: &str, _func: &ItemFn) ->
     quote! {
         /// Marker type for the kernel, implements CudaKernel trait.
         /// This enables cuda_launch! to look up the PTX entry point name.
+        ///
+        /// Host-only: a device-only crate compiled for `nvptx64-nvidia-cuda`
+        /// has no `cuda_host` in scope, and the marker is meaningless on the
+        /// device anyway, so it is gated out for that target. This lets the
+        /// same `#[kernel]` source compile both as a unified host+device crate
+        /// (host target) and as a pure device crate (`--target nvptx64`).
+        #[cfg(not(target_arch = "nvptx64"))]
         #[doc(hidden)]
         #[allow(non_camel_case_types)]
         pub struct #marker_name;
 
+        #[cfg(not(target_arch = "nvptx64"))]
         impl cuda_host::CudaKernel for #marker_name {
             const PTX_NAME: &'static str = #ptx_name;
         }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1189,8 +1189,17 @@ fn translate_call(
         );
     }
 
-    // Try to dispatch as intrinsic
-    if let Some(ref name) = pattern_name
+    // Try to dispatch as intrinsic. Foreign `extern "C"` items declared with
+    // `#[link_name = "llvm.*"]` (the `link_llvm_intrinsics` pattern for sreg
+    // reads and barriers) dispatch on the link symbol, which is what the
+    // `llvm.*` match arms in `try_dispatch_intrinsic` expect; the Rust path
+    // (`pattern_name`) of such wrappers is an arbitrary user-crate path. All
+    // other calls dispatch on the Rust path as before.
+    let dispatch_name = match &call_name {
+        Some(link) if link.starts_with("llvm.") => Some(link.clone()),
+        _ => pattern_name.clone(),
+    };
+    if let Some(ref name) = dispatch_name
         && let Some(result) = try_dispatch_intrinsic(
             ctx,
             body,
@@ -2337,162 +2346,162 @@ fn try_dispatch_intrinsic(
         // Thread/Block Position Intrinsics
         // Support both re-exported (cuda_device::) and full paths (cuda_device::thread::)
         // =================================================================
-        "cuda_device::threadIdx_x" | "cuda_device::thread::threadIdx_x" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregTidXOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::threadIdx_y" | "cuda_device::thread::threadIdx_y" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregTidYOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockIdx_x" | "cuda_device::thread::blockIdx_x" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregCtaidXOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockIdx_y" | "cuda_device::thread::blockIdx_y" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregCtaidYOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockDim_x" | "cuda_device::thread::blockDim_x" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregNtidXOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockDim_y" | "cuda_device::thread::blockDim_y" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                ReadPtxSregNtidYOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::threadIdx_z" | "cuda_device::thread::threadIdx_z" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregTidZOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockIdx_z" | "cuda_device::thread::blockIdx_z" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregCtaidZOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::blockDim_z" | "cuda_device::thread::blockDim_z" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregNtidZOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::gridDim_x" | "cuda_device::thread::gridDim_x" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregNctaidXOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::gridDim_y" | "cuda_device::thread::gridDim_y" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregNctaidYOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        "cuda_device::gridDim_z" | "cuda_device::thread::gridDim_z" => {
-            Ok(Some(helpers::emit_nvvm_intrinsic(
-                ctx,
-                dialect_nvvm::ops::ReadPtxSregNctaidZOp::get_concrete_op_info(),
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
+        "cuda_device::threadIdx_x"
+        | "cuda_device::thread::threadIdx_x"
+        | "llvm.nvvm.read.ptx.sreg.tid.x" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregTidXOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::threadIdx_y"
+        | "cuda_device::thread::threadIdx_y"
+        | "llvm.nvvm.read.ptx.sreg.tid.y" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregTidYOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockIdx_x"
+        | "cuda_device::thread::blockIdx_x"
+        | "llvm.nvvm.read.ptx.sreg.ctaid.x" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregCtaidXOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockIdx_y"
+        | "cuda_device::thread::blockIdx_y"
+        | "llvm.nvvm.read.ptx.sreg.ctaid.y" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregCtaidYOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockDim_x"
+        | "cuda_device::thread::blockDim_x"
+        | "llvm.nvvm.read.ptx.sreg.ntid.x" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregNtidXOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockDim_y"
+        | "cuda_device::thread::blockDim_y"
+        | "llvm.nvvm.read.ptx.sreg.ntid.y" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            ReadPtxSregNtidYOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::threadIdx_z"
+        | "cuda_device::thread::threadIdx_z"
+        | "llvm.nvvm.read.ptx.sreg.tid.z" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregTidZOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockIdx_z"
+        | "cuda_device::thread::blockIdx_z"
+        | "llvm.nvvm.read.ptx.sreg.ctaid.z" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregCtaidZOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::blockDim_z"
+        | "cuda_device::thread::blockDim_z"
+        | "llvm.nvvm.read.ptx.sreg.ntid.z" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregNtidZOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::gridDim_x"
+        | "cuda_device::thread::gridDim_x"
+        | "llvm.nvvm.read.ptx.sreg.nctaid.x" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregNctaidXOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::gridDim_y"
+        | "cuda_device::thread::gridDim_y"
+        | "llvm.nvvm.read.ptx.sreg.nctaid.y" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregNctaidYOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
+        "cuda_device::gridDim_z"
+        | "cuda_device::thread::gridDim_z"
+        | "llvm.nvvm.read.ptx.sreg.nctaid.z" => Ok(Some(helpers::emit_nvvm_intrinsic(
+            ctx,
+            dialect_nvvm::ops::ReadPtxSregNctaidZOp::get_concrete_op_info(),
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
         // SM and grid identification
         "cuda_device::smid" | "cuda_device::thread::smid" => {
             Ok(Some(helpers::emit_nvvm_intrinsic(
@@ -2644,9 +2653,13 @@ fn try_dispatch_intrinsic(
         // =================================================================
         // Synchronization (from intrinsics::sync)
         // =================================================================
-        "cuda_device::sync_threads" => Ok(Some(intrinsics::sync::emit_sync_threads(
-            ctx, target, block_ptr, prev_op, block_map, loc,
-        )?)),
+        // A `#[link_name = "llvm.nvvm.barrier0"]` extern (the
+        // `link_llvm_intrinsics` pattern). Surfaced as its link name by
+        // `extract_func_info`; lowers to the same NVVM `Barrier0Op`
+        // (`bar.sync`) as `cuda_device::sync_threads`.
+        "cuda_device::sync_threads" | "llvm.nvvm.barrier0" => Ok(Some(
+            intrinsics::sync::emit_sync_threads(ctx, target, block_ptr, prev_op, block_map, loc)?,
+        )),
         "cuda_device::threadfence_block" | "cuda_device::fence::threadfence_block" => {
             Ok(Some(intrinsics::sync::emit_threadfence_block(
                 ctx, target, block_ptr, prev_op, block_map, loc,

--- a/crates/rustc-codegen-cuda/examples/llvmlink_device/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/llvmlink_device/Cargo.toml
@@ -1,0 +1,14 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[package]
+name = "llvmlink_device"
+version = "0.1.0"
+edition = "2024"
+[workspace]
+[lib]
+crate-type = ["lib"]
+[dependencies]
+cuda-device = { path = "../../../cuda-device" }

--- a/crates/rustc-codegen-cuda/examples/llvmlink_device/src/lib.rs
+++ b/crates/rustc-codegen-cuda/examples/llvmlink_device/src/lib.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Device-only crate exercising `#[link_name = "llvm.*"]` intrinsic externs
+//! (the `link_llvm_intrinsics` pattern: declaring an LLVM intrinsic directly
+//! as a foreign item instead of going through a wrapper API).
+#![no_std]
+#![feature(link_llvm_intrinsics)]
+#![allow(internal_features)]
+
+use cuda_device::kernel;
+
+// The Rust-side names are arbitrary — dispatch keys on the link symbol, so
+// the wrappers can use familiar CUDA names.
+unsafe extern "C" {
+    #[link_name = "llvm.nvvm.read.ptx.sreg.tid.x"]
+    fn thread_idx_x() -> u32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]
+    fn block_dim_x() -> u32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.x"]
+    fn block_idx_x() -> u32;
+    #[link_name = "llvm.nvvm.barrier0"]
+    fn sync_threads();
+}
+
+#[kernel]
+pub fn linkname_ids(out: &mut [u32]) {
+    let i = unsafe { (block_idx_x() * block_dim_x() + thread_idx_x()) as usize };
+    unsafe { sync_threads() };
+    if i < out.len() {
+        out[i] = i as u32 * 3 + 1;
+    }
+}

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -680,7 +680,22 @@ impl CodegenBackend for CudaCodegenBackend {
                                 artifact.name, artifact.kind, result.target
                             );
                         }
-                        if let Some(artifact) = result.artifact.as_ref() {
+                        // Device-only crates (compiled with
+                        // `--target nvptx64-nvidia-cuda`) have no host object to
+                        // embed the device blob into; the standalone .ptx/.ll
+                        // already written to the PTX output dir is the
+                        // deliverable, and the host-object writer does not
+                        // support an nvptx host target. Skip the embed step.
+                        let device_only_target =
+                            tcx.sess.target.llvm_target.as_ref().starts_with("nvptx64");
+                        if device_only_target {
+                            if self.config.verbose {
+                                eprintln!(
+                                    "[rustc_codegen_cuda] Device-only target; \
+                                     skipping host-object embed (PTX written to output dir)"
+                                );
+                            }
+                        } else if let Some(artifact) = result.artifact.as_ref() {
                             match write_device_artifact_object(
                                 &device_config.output_dir,
                                 &device_config.output_name,


### PR DESCRIPTION
## Summary

Two coupled features that together let cuda-oxide compile *device-only* Rust crates — GPU libraries written once against `cfg(target_arch)` for multiple device targets — wholesale to PTX:

1. **Device-only crate builds**: compile the crate front-end for the real `nvptx64-nvidia-cuda` target (`-Z build-std=core`). `cfg(target_arch = "nvptx64")` is then *true*, so shader-style crates pick their GPU code paths (real barriers, scalar math) with no host-target workarounds; the emitted standalone `<crate>.ptx` is the deliverable. Device-only crates are auto-detected (a library with no binary target and no cuda-host dependency cannot be a unified build), with `--device` as an explicit override. Three small pieces: the cargo-oxide build-mode selection, gating the host-side `CudaKernel` marker out of `#[kernel]` expansion on nvptx64, and skipping the host-object embed step for an nvptx `llvm_target`.

2. **Dispatch `#[link_name = "llvm.*"]` externs as intrinsics**: foreign items declared via the `link_llvm_intrinsics` pattern (sreg reads, `llvm.nvvm.barrier0`) dispatch on their link symbol instead of the wrapper's arbitrary Rust path, and the sreg/barrier match arms gain their `llvm.nvvm.*` aliases. Previously such calls fell through to a plain call against a symbol no definition provides, failing module verification with *"Symbol llvm_nvvm_read_ptx_sreg_tid_x not found"*.

They ship together because (2) is only reachable through (1): on the host target these externs cannot exist (x86 ISel rejects nvvm intrinsics — a unified crate carrying them dies with `Cannot select: intrinsic %llvm.nvvm.barrier...`), and (1) without (2) fails on the first sreg read any real shader crate performs.

Motivation: with these two changes (plus #350/#358) we compile an existing multi-crate physics/RL shader codebase (dimforge nexus + vortx) to sm_120 cubins *verbatim* and train on it — simulation results match the WebGPU reference backend on the scenes we test.

## Changes

- `cargo-oxide`: `build` auto-detects device-only crates (a library with no binary target and no cuda-host/cuda-core dependency cannot be a unified build) and selects the nvptx64 path; `--device` remains as an explicit override (adds `--target nvptx64-nvidia-cuda -Z build-std=core`, points `CUDA_OXIDE_PTX_DIR` at the crate dir).
- `cuda-macros`: `#[cfg(not(target_arch = "nvptx64"))]` on the host-side `CudaKernel` marker so the same `#[kernel]` source compiles as unified *and* as pure device crate.
- `rustc-codegen-cuda`: skip host-object embed for nvptx `llvm_target`.
- `mir-importer`: `translate_call` dispatches `llvm.*` callees on the link symbol; 12 sreg arms + the barrier arm gain `llvm.nvvm.*` aliases.
- New example `examples/llvmlink_device`: minimal device-only crate using the extern pattern.

## Testing

- `cargo oxide build llvmlink_device` (device mode auto-detected; same with explicit `--device`) emits PTX with real `%tid.x`/`%ntid.x`/`%ctaid.x` reads and `bar.sync`; assembles clean with `ptxas -arch=sm_120`. Without the dispatch commit it fails verification with `Symbol llvm_nvvm_read_ptx_sreg_ctaid_x not found`.
- Unified path regression: `cargo oxide build vecadd` builds and runs correctly on an RTX 5080 (all 1024 elements verified).
- `cargo test -p mir-importer` and the `rustc-codegen-cuda` suite — all green.
- Downstream validation: the dimforge nexus (265 device fns) + vortx shader crates build through `--device`-style invocations and run a full physics + PPO training loop on sm_120.

- [x] `cargo oxide run vecadd` passes (unified regression)
- [x] `cargo test` passes on touched crates
- [x] New example added (`llvmlink_device`)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)