### PR TITLE
fix(mir-importer): dispatch sync_threads via its canonical thread:: path

### DIFF
--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2644,9 +2644,14 @@ fn try_dispatch_intrinsic(
         // =================================================================
         // Synchronization (from intrinsics::sync)
         // =================================================================
-        "cuda_device::sync_threads" => Ok(Some(intrinsics::sync::emit_sync_threads(
-            ctx, target, block_ptr, prev_op, block_map, loc,
-        )?)),
+        // Match the canonical `thread::` path too, like every sreg accessor
+        // above: `sync_threads` lives in `cuda_device::thread`, and a call
+        // resolved via that path (rather than the crate-root re-export)
+        // otherwise falls through to a plain call against a symbol no
+        // definition provides.
+        "cuda_device::sync_threads" | "cuda_device::thread::sync_threads" => Ok(Some(
+            intrinsics::sync::emit_sync_threads(ctx, target, block_ptr, prev_op, block_map, loc)?,
+        )),
         "cuda_device::threadfence_block" | "cuda_device::fence::threadfence_block" => {
             Ok(Some(intrinsics::sync::emit_threadfence_block(
                 ctx, target, block_ptr, prev_op, block_map, loc,


### PR DESCRIPTION
## Summary

Every sreg accessor arm in `try_dispatch_intrinsic` matches both the crate-root re-export path and the canonical module path (`"cuda_device::threadIdx_x" | "cuda_device::thread::threadIdx_x"`), but the barrier arm only matches `"cuda_device::sync_threads"`. A call that resolves through the canonical `cuda_device::thread::sync_threads` path — e.g. a dependency crate calling the API by full path — misses intrinsic dispatch and falls through to a plain function call against a symbol no definition provides, failing module verification with *"Symbol cuda_device__thread__sync_threads not found"*. (Found while porting a multi-crate shader codebase whose support crate calls `cuda_device::thread::sync_threads()` directly; mentioned in #359.)

## Changes

- Add the missing `"cuda_device::thread::sync_threads"` alias to the barrier dispatch arm, matching the sreg arms' pattern.
- Swept the other dispatch arms against the `cuda_device` module tree: `sync_threads` was the only function with a root-path arm but no canonical-path alias.

## Testing

- `cargo test -p mir-importer` — all green.
- Downstream validation: a support crate calling `cuda_device::thread::sync_threads()` by full path fails module verification without this change and compiles + runs correctly (barrier lowers to `bar.sync`) with it.

- [x] `cargo test` passes
- [ ] New example — not applicable (one-line dispatch alias)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)