### PR TITLE
Add mma.sync.aligned.m16n8k32 u8 tensor core intrinsic

### DIFF
--- a/crates/cuda-device/src/wmma.rs
+++ b/crates/cuda-device/src/wmma.rs
@@ -443,3 +443,59 @@ pub unsafe fn mma_m16n8k32_s32_s8(c: [i32; 4], a: [u32; 4], b: [u32; 2]) -> [i32
     let _ = (c, a, b);
     unreachable!("mma_m16n8k32_s32_s8 called outside CUDA kernel context")
 }
+
+/// Multiply one warp-distributed unsigned INT8 tile and add an i32 accumulator.
+///
+/// Together, the 32 lanes compute `D = A × B + C` for row-major `A` with
+/// shape 16×32, column-major `B` with shape 32×8, and `C`/`D` with shape
+/// 16×8. Each lane supplies its fragments in registers and receives four i32
+/// result registers. The call itself does not access memory or act as a fence.
+///
+/// Each `a` and `b` register packs four unsigned `u8` values from low byte to
+/// high byte. In other words, logical element `i` is stored in bits
+/// `(i % 4) * 8..(i % 4 + 1) * 8` of register `[i / 4]`.
+///
+/// For lane `lane`, let `group = lane / 4` and `thread = lane % 4`:
+///
+/// ```text
+/// A element i=0,...,15:
+///   row = group       for 0 <= i < 4 or 8 <= i < 12; otherwise group + 8
+///   col = thread*4 + (i&3) + (if i >= 8 { 16 } else { 0 })
+///
+/// B element i=0,...,7:
+///   row = thread*4 + (i&3) + (if i >= 4 { 16 } else { 0 })
+///   col = group
+///
+/// C/D register i=0,...,3:
+///   row = group + (if i >= 2 { 8 } else { 0 })
+///   col = thread*2 + (i&1)
+/// ```
+///
+/// This is the non-`.satfinite` form. The i32 accumulator is signed, so
+/// accumulator overflow wraps rather than clamping to `i32::MIN` or `i32::MAX`.
+///
+/// # PTX
+///
+/// ```ptx
+/// mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32
+///     {%d0, %d1, %d2, %d3},
+///     {%a0, %a1, %a2, %a3},
+///     {%b0, %b1},
+///     {%c0, %c1, %c2, %c3};
+/// ```
+///
+/// # Safety
+///
+/// - All 32 lanes must execute the same instruction with the same qualifiers.
+///   Calling from divergent control flow, or after any lane has exited, is
+///   undefined behavior.
+/// - `c`, `a`, and `b` must contain the calling lane's fragments in the layout
+///   above. A different layout computes a different matrix operation.
+/// - Requires `sm_80+` and PTX ISA 7.0+. cuda-oxide selects both floors
+///   automatically and rejects an explicit lower target.
+#[inline(never)]
+#[must_use]
+pub unsafe fn mma_m16n8k32_s32_u8(c: [i32; 4], a: [u32; 4], b: [u32; 2]) -> [i32; 4] {
+    let _ = (c, a, b);
+    unreachable!("mma_m16n8k32_s32_u8 called outside CUDA kernel context")
+}

--- a/crates/cuda-oxide-codegen/src/target.rs
+++ b/crates/cuda-oxide-codegen/src/target.rs
@@ -178,6 +178,20 @@ fn contains_mma_m16n8k32_s32_s8_features(contents: &str) -> bool {
     .any(|mnemonic| contains_instruction_mnemonic(contents, mnemonic))
 }
 
+/// Checks for the Ampere unsigned INT8 MMA operation (PTX 7.0, sm_80+).
+///
+/// PTX permits both wrapping and `.satfinite` accumulator-overflow behavior.
+/// Match each complete legal mnemonic so a qualifier near-miss cannot raise
+/// the module target accidentally.
+fn contains_mma_m16n8k32_s32_u8_features(contents: &str) -> bool {
+    [
+        "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32",
+        "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32",
+    ]
+    .into_iter()
+    .any(|mnemonic| contains_instruction_mnemonic(contents, mnemonic))
+}
+
 /// Checks for the Ampere FP64 tensor-core MMA operation (PTX 7.0, sm_80+).
 fn contains_mma_m8n8k4_f64_features(contents: &str) -> bool {
     contains_instruction_mnemonic(contents, "mma.sync.aligned.m8n8k4.row.col.f64.f64.f64.f64")
@@ -286,6 +300,7 @@ fn contains_sm80_features(contents: &str) -> bool {
         || contains_mma_m16n8k16_f32_f16_features(contents)
         || contains_mma_m16n8k8_f32_tf32_features(contents)
         || contains_mma_m16n8k32_s32_s8_features(contents)
+        || contains_mma_m16n8k32_s32_u8_features(contents)
 }
 
 /// Checks for TMA/mbarrier instructions (Hopper+ compatible with Blackwell).
@@ -723,6 +738,7 @@ fn detect_module_requirements_in_llvm_text(contents: &str) -> ModuleRequirements
         || contains_mma_m16n8k16_f32_f16_features(contents)
         || contains_mma_m16n8k8_f32_tf32_features(contents)
         || contains_mma_m16n8k32_s32_s8_features(contents)
+        || contains_mma_m16n8k32_s32_u8_features(contents)
         || contains_mma_m8n8k4_f64_features(contents)
     {
         ptx_isa = ptx_isa.max(PtxIsaRequirement::Ptx70);
@@ -1684,6 +1700,107 @@ mod tests {
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
         let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
             .expect_err("sm_75 must not accept INT8 tensor-core MMA")
+            .to_string();
+        assert!(
+            error.contains("cannot lower detected feature Sm80"),
+            "{error}"
+        );
+
+        let combined = format!("{mnemonic}\nmovmatrix.sync.aligned.m8n8.trans.b16 $0, $1;");
+        assert_eq!(
+            detect_module_requirements_in_llvm_text(&combined),
+            ModuleRequirements {
+                features: DetectedFeatures::Sm80 | DetectedFeatures::Movmatrix,
+                ptx_isa: PtxIsaRequirement::Ptx78,
+            }
+        );
+    }
+
+    #[test]
+    fn unsigned_int8_mma_detection_applies_exact_sm80_and_ptx70_floors() {
+        let mnemonic = concat!(
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 ",
+            "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};"
+        );
+        let satfinite_mnemonic = concat!(
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32 ",
+            "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};"
+        );
+        for spelling in [
+            mnemonic,
+            satfinite_mnemonic,
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32\t{$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32\\09{$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32\t{$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32\\09{$0}, {$1}, {$2}, {$3};",
+            ";mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            ";mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "prefix\\0Amma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "\"mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "{mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "$L:mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "/* comment */mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "@p mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "@!%p\\09mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "@p mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+        ] {
+            assert!(
+                contains_mma_m16n8k32_s32_u8_features(spelling),
+                "missed {spelling:?}"
+            );
+        }
+
+        for spelling in [mnemonic, satfinite_mnemonic] {
+            let requirements = detect_module_requirements_in_llvm_text(spelling);
+            assert_eq!(requirements.features, DetectedFeatures::Sm80, "{spelling}");
+            assert_eq!(requirements.ptx_isa, PtxIsaRequirement::Ptx70, "{spelling}");
+        }
+        let requirements = detect_module_requirements_in_llvm_text(mnemonic);
+        let (target, _) =
+            resolve_ptx_target(None, None, requirements.features).expect("auto-resolve");
+        assert_eq!(target, "sm_80");
+
+        for near_miss in [
+            // Signed and mixed-signedness forms are distinct instructions; the
+            // unsigned detector must not raise the target for any of them.
+            "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.s32.s8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.s8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k16.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.col.row.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sp.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32x {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32.satfinite {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfiniteX.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32x {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.u32 {$0}, {$1}, {$2}, {$3};",
+            "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "not_mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "$mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "$mma.sync.aligned.m16n8k32.row.col.satfinite.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "%mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "@mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "!mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "@!mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "not$mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            "/mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+            ")mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 {$0}, {$1}, {$2}, {$3};",
+        ] {
+            assert!(
+                !contains_mma_m16n8k32_s32_u8_features(near_miss),
+                "matched {near_miss:?}"
+            );
+        }
+
+        // The signed detector must likewise reject the unsigned form.
+        assert!(!contains_mma_m16n8k32_s32_s8_features(mnemonic));
+
+        let sm_75: CudaArch = "sm_75".parse().unwrap();
+        let sm_80: CudaArch = "sm_80".parse().unwrap();
+        assert!(validate_target_features(&sm_75, requirements.features).is_err());
+        assert!(validate_target_features(&sm_80, requirements.features).is_ok());
+        let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
+            .expect_err("sm_75 must not accept unsigned INT8 tensor-core MMA")
             .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm80"),

--- a/crates/dialect-nvvm/src/ops/wmma.rs
+++ b/crates/dialect-nvvm/src/ops/wmma.rs
@@ -419,6 +419,90 @@ impl MmaM16N8K32S32S8Op {
     }
 }
 
+/// Register-only warp MMA: m16n8k32 with i32 accumulator and u8 inputs.
+///
+/// # Operands
+///
+/// - operands 0-3: four i32 C accumulator registers
+/// - operands 4-7: four i32 A fragment registers, each packing four u8 values
+/// - operands 8-9: two i32 B fragment registers, each packing four u8 values
+///
+/// # Results
+///
+/// - results 0-3: four i32 D accumulator registers
+#[pliron_op(
+    name = "nvvm.mma_m16n8k32_s32_u8",
+    format,
+    interfaces = [NOpdsInterface<10>, NResultsInterface<4>],
+)]
+pub struct MmaM16N8K32S32U8Op;
+
+impl Verify for MmaM16N8K32S32U8Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let operands: Vec<_> = op.operands().collect();
+
+        if operands.len() != 10 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.mma_m16n8k32_s32_u8 requires 10 register operands, got {}",
+                operands.len()
+            );
+        }
+
+        for (index, operand) in operands.iter().enumerate() {
+            let ty = operand.get_type(ctx);
+            let ty = ty.deref(ctx);
+            let Some(integer) = ty.downcast_ref::<IntegerType>() else {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k32_s32_u8 operand {} must be i32",
+                    index
+                );
+            };
+            if integer.width() != 32 {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k32_s32_u8 operand {} must be i32",
+                    index
+                );
+            }
+        }
+
+        if op.get_num_results() != 4 {
+            return verify_err!(op.loc(), "nvvm.mma_m16n8k32_s32_u8 requires 4 i32 results");
+        }
+
+        for index in 0..4 {
+            let ty = op.get_result(index).get_type(ctx);
+            let ty = ty.deref(ctx);
+            let Some(integer) = ty.downcast_ref::<IntegerType>() else {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k32_s32_u8 result {} must be i32",
+                    index
+                );
+            };
+            if integer.width() != 32 {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.mma_m16n8k32_s32_u8 result {} must be i32",
+                    index
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl MmaM16N8K32S32U8Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        MmaM16N8K32S32U8Op { op }
+    }
+}
+
 /// Warp MMA: m8n8k4 with f64 accumulator and f64 inputs.
 ///
 /// # Operands
@@ -489,5 +573,6 @@ pub(super) fn register(ctx: &mut Context) {
     MmaM16N8K16F32F16Op::register(ctx);
     MmaM16N8K8F32Tf32Op::register(ctx);
     MmaM16N8K32S32S8Op::register(ctx);
+    MmaM16N8K32S32U8Op::register(ctx);
     MmaM8N8K4F64Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -6,14 +6,15 @@
 use dialect_mir::types::MirPtrType;
 use dialect_nvvm::ops::{
     Barrier0Op, ElectSyncOp, FmaBf16x2Op, LdmatrixX2Op, MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op,
-    MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MmaM16N8K32S32S8Op, MovmatrixTransB16Op,
-    NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, ReadPtxSregDynamicSmemSizeOp, ReadPtxSregGridIdOp,
-    ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp, ReadPtxSregLanemaskGtOp,
-    ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp, ReadPtxSregNwarpIdOp,
-    ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp, ReadPtxSregWarpIdOp,
-    ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp, ReduxSyncOrOp, ReduxSyncUmaxOp,
-    ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op, ShflSyncDownI64Op, ShflSyncIdxI64Op,
-    ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp, ThreadfenceOp, ThreadfenceSystemOp,
+    MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MmaM16N8K32S32S8Op, MmaM16N8K32S32U8Op,
+    MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, ReadPtxSregDynamicSmemSizeOp,
+    ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp,
+    ReadPtxSregLanemaskGtOp, ReadPtxSregLanemaskLeOp, ReadPtxSregLanemaskLtOp, ReadPtxSregNsmIdOp,
+    ReadPtxSregNwarpIdOp, ReadPtxSregSmIdOp, ReadPtxSregTidXOp, ReadPtxSregTotalSmemSizeOp,
+    ReadPtxSregWarpIdOp, ReduxSyncAddOp, ReduxSyncAndOp, ReduxSyncMaxOp, ReduxSyncMinOp,
+    ReduxSyncOrOp, ReduxSyncUmaxOp, ReduxSyncUminOp, ReduxSyncXorOp, ShflSyncBflyI64Op,
+    ShflSyncDownI64Op, ShflSyncIdxI64Op, ShflSyncUpI64Op, StmatrixM8n8X4Op, ThreadfenceBlockOp,
+    ThreadfenceOp, ThreadfenceSystemOp,
 };
 use pliron::{
     basic_block::BasicBlock,
@@ -477,6 +478,81 @@ fn test_mma_m16n8k32_s8_verifies_exact_register_signature() {
         0,
     );
     assert!(verify_op(&MmaM16N8K32S32S8Op::new(invalid_arity), &ctx).is_err());
+}
+
+#[test]
+fn test_mma_m16n8k32_u8_verifies_exact_register_signature() {
+    let mut ctx = Context::new();
+    dialect_nvvm::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let f32_ty = FP32Type::get(&ctx);
+    let block = BasicBlock::new(
+        &mut ctx,
+        None,
+        vec![i32_ty.into(), i64_ty.into(), f32_ty.into()],
+    );
+    let i32_value = block.deref(&ctx).get_argument(0);
+    let i64_value = block.deref(&ctx).get_argument(1);
+    let f32_value = block.deref(&ctx).get_argument(2);
+    let valid_operands = vec![i32_value; 10];
+
+    let valid = Operation::new(
+        &mut ctx,
+        MmaM16N8K32S32U8Op::get_concrete_op_info(),
+        vec![i32_ty.into(); 4],
+        valid_operands.clone(),
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K32S32U8Op::new(valid), &ctx).is_ok());
+
+    for bad_value in [i64_value, f32_value] {
+        let mut bad_operands = valid_operands.clone();
+        bad_operands[4] = bad_value;
+        let invalid = Operation::new(
+            &mut ctx,
+            MmaM16N8K32S32U8Op::get_concrete_op_info(),
+            vec![i32_ty.into(); 4],
+            bad_operands,
+            vec![],
+            0,
+        );
+        assert!(
+            verify_op(&MmaM16N8K32S32U8Op::new(invalid), &ctx).is_err(),
+            "MMA must reject non-i32 register operands"
+        );
+    }
+
+    for bad_results in [
+        vec![i32_ty.into(), i32_ty.into(), i32_ty.into(), i64_ty.into()],
+        vec![i32_ty.into(), i32_ty.into(), i32_ty.into(), f32_ty.into()],
+        vec![i32_ty.into(); 3],
+    ] {
+        let invalid = Operation::new(
+            &mut ctx,
+            MmaM16N8K32S32U8Op::get_concrete_op_info(),
+            bad_results,
+            valid_operands.clone(),
+            vec![],
+            0,
+        );
+        assert!(
+            verify_op(&MmaM16N8K32S32U8Op::new(invalid), &ctx).is_err(),
+            "MMA must reject the wrong result register signature"
+        );
+    }
+
+    let invalid_arity = Operation::new(
+        &mut ctx,
+        MmaM16N8K32S32U8Op::get_concrete_op_info(),
+        vec![i32_ty.into(); 4],
+        vec![i32_value; 9],
+        vec![],
+        0,
+    );
+    assert!(verify_op(&MmaM16N8K32S32U8Op::new(invalid_arity), &ctx).is_err());
 }
 
 /// The `(constructor, TypeId)` pair returned by `get_concrete_op_info()`.

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wmma.rs
@@ -16,7 +16,7 @@ use dialect_mir::{
 };
 use dialect_nvvm::ops::{
     MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op,
-    MmaM16N8K32S32S8Op, MovmatrixTransB16Op,
+    MmaM16N8K32S32S8Op, MmaM16N8K32S32U8Op, MovmatrixTransB16Op,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
@@ -708,6 +708,144 @@ pub fn emit_mma_m16n8k32_s32_s8(
     )
 }
 
+/// Emit `mma_m16n8k32_s32_u8` as a register-producing dialect operation.
+///
+/// Args:
+/// - `args[0]`: `[i32; 4]` C accumulator registers
+/// - `args[1]`: `[u32; 4]` packed A fragment registers
+/// - `args[2]`: `[u32; 2]` packed B fragment registers
+///
+/// Returns: `[i32; 4]` D accumulator registers.
+pub fn emit_mma_m16n8k32_s32_u8(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    if args.len() != 3 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "mma_m16n8k32_s32_u8 expects 3 arguments (acc, a, b), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signed);
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+
+    let (c_array, last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let (c_registers, last_op) = extract_array_registers(
+        ctx,
+        c_array,
+        i32_ty.into(),
+        4,
+        block_ptr,
+        last_op,
+        loc.clone(),
+        "C",
+    )?;
+
+    let (a_array, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        Some(last_op),
+        loc.clone(),
+    )?;
+    let (a_registers, last_op) = extract_array_registers(
+        ctx,
+        a_array,
+        u32_ty.into(),
+        4,
+        block_ptr,
+        last_op_after,
+        loc.clone(),
+        "A",
+    )?;
+
+    let (b_array, last_op_after) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[2],
+        value_map,
+        block_ptr,
+        Some(last_op),
+        loc.clone(),
+    )?;
+    let (b_registers, last_op) = extract_array_registers(
+        ctx,
+        b_array,
+        u32_ty.into(),
+        2,
+        block_ptr,
+        last_op_after,
+        loc.clone(),
+        "B",
+    )?;
+
+    let mut operands = c_registers;
+    operands.extend(a_registers);
+    operands.extend(b_registers);
+
+    let mma_op = Operation::new(
+        ctx,
+        MmaM16N8K32S32U8Op::get_concrete_op_info(),
+        vec![i32_ty.into(); 4],
+        operands,
+        vec![],
+        0,
+    );
+    mma_op.deref_mut(ctx).set_loc(loc.clone());
+    mma_op.insert_after(ctx, last_op);
+
+    let d_registers = (0..4)
+        .map(|index| mma_op.deref(ctx).get_result(index))
+        .collect();
+    let array_ty = MirArrayType::get(ctx, i32_ty.into(), 4);
+    let d_array = Operation::new(
+        ctx,
+        MirConstructArrayOp::get_concrete_op_info(),
+        vec![array_ty.into()],
+        d_registers,
+        vec![],
+        0,
+    );
+    d_array.deref_mut(ctx).set_loc(loc.clone());
+    d_array.insert_after(ctx, mma_op);
+    let result = d_array.deref(ctx).get_result(0);
+
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        d_array,
+        value_map,
+        block_map,
+        loc,
+        "mma_m16n8k32_s32_u8 call without target block",
+    )
+}
+
 /// Emit `mma_m8n8k4_f64`: Warp MMA with f64 accumulator and f64 inputs.
 ///
 /// Args:
@@ -944,7 +1082,8 @@ mod tests {
             !message.contains("bf16")
                 && !message.contains("tf32")
                 && !message.contains("f16")
-                && !message.contains("s8"),
+                && !message.contains("s8")
+                && !message.contains("u8"),
             "shared fragment diagnostics must not name a different MMA operation: {message}"
         );
     }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3749,6 +3749,20 @@ fn try_dispatch_intrinsic(
                 loc,
             )?))
         }
+        "cuda_device::wmma::mma_m16n8k32_s32_u8" => {
+            Ok(Some(intrinsics::wmma::emit_mma_m16n8k32_s32_u8(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
         "cuda_device::wmma::mma_m8n8k4_f64" => Ok(Some(intrinsics::wmma::emit_mma_m8n8k4_f64(
             ctx,
             body,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -60,8 +60,8 @@ use dialect_nvvm::ops::{
     MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
     MbarrierTryWaitParityClusterOp, MbarrierTryWaitParitySharedOp, MbarrierTryWaitSharedOp,
     MinBf16x2Op, MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op,
-    MmaM16N8K32S32S8Op, MovmatrixTransB16Op, MulBf16x2Op, NanosleepOp, NegBf16x2Op,
-    NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
+    MmaM16N8K32S32S8Op, MmaM16N8K32S32U8Op, MovmatrixTransB16Op, MulBf16x2Op, NanosleepOp,
+    NegBf16x2Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
     NvvmAtomicRmwOp, NvvmAtomicStoreOp, PmEventOp, ReadPtxSregClock64Op, ReadPtxSregClockOp,
     ReadPtxSregClusterCtaidXOp, ReadPtxSregClusterCtaidYOp, ReadPtxSregClusterCtaidZOp,
     ReadPtxSregClusterIdxOp, ReadPtxSregClusterNctaidXOp, ReadPtxSregClusterNctaidYOp,
@@ -2785,6 +2785,23 @@ impl MirToLlvmConversion for MmaM16N8K32S32S8Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wmma::convert_mma_m16n8k32_s32_s8(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MmaM16N8K32S32U8Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wmma::convert_mma_m16n8k32_s32_u8(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wmma.rs
@@ -255,6 +255,56 @@ pub(crate) fn convert_mma_m16n8k32_s32_s8(
     Ok(())
 }
 
+/// Convert `mma_m16n8k32_s32_u8` to one register-only inline PTX operation.
+///
+/// Operand order is C[0..4], A[0..4], B[0..2]. The four D registers are
+/// returned as an LLVM struct and then split back into the dialect op's four
+/// SSA results. All operands and results use the `r` (integer) constraint.
+pub(crate) fn convert_mma_m16n8k32_s32_u8(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 10 {
+        return pliron::input_err_noloc!(
+            "mma_m16n8k32_s32_u8 requires 10 register operands, got {}",
+            operands.len()
+        );
+    }
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+    let result_ty = llvm_types::StructType::get_unnamed(ctx, vec![i32_ty.into(); 4]);
+    let template = concat!(
+        "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 ",
+        "{$0, $1, $2, $3}, ",
+        "{$8, $9, $10, $11}, ",
+        "{$12, $13}, ",
+        "{$4, $5, $6, $7};"
+    );
+    let constraints = "=r,=r,=r,=r,r,r,r,r,r,r,r,r,r,r";
+    let inline_asm = inline_asm_convergent(
+        ctx,
+        rewriter,
+        result_ty.into(),
+        operands,
+        template,
+        constraints,
+    );
+
+    let aggregate = inline_asm.deref(ctx).get_result(0);
+    let mut results = Vec::with_capacity(4);
+    for index in 0..4 {
+        let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![index as u32])
+            .map_err(|error| pliron::input_error_noloc!("{}", error))?;
+        rewriter.insert_operation(ctx, extract.get_operation());
+        results.push(extract.get_operation().deref(ctx).get_result(0));
+    }
+    rewriter.replace_operation_with_values(ctx, op, results);
+    Ok(())
+}
+
 /// Convert `mma_m8n8k4_f64` to inline PTX assembly.
 ///
 /// The operation consumes the two C registers plus A and B directly, and

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -3704,6 +3704,106 @@ fn test_mma_m8n8k4_f64_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn test_mma_m16n8k32_s32_u8_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let i32_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        32,
+        pliron::builtin::types::Signedness::Signless,
+    );
+    let argument_types = (0..10).map(|_| i32_ty.into()).collect();
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, argument_types);
+    let operands = (0..10)
+        .map(|index| entry.deref(&ctx).get_argument(index))
+        .collect();
+
+    let op = Operation::new(
+        &mut ctx,
+        nvvm::MmaM16N8K32S32U8Op::get_concrete_op_info(),
+        vec![i32_ty.into(); 4],
+        operands,
+        vec![],
+        0,
+    );
+    op.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let mut found = 0;
+    let module_region = module_ptr.deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    for module_op in module_block.deref(&ctx).iter(&ctx) {
+        let Some(function) = Operation::get_op::<llvm::FuncOp>(module_op, &ctx) else {
+            continue;
+        };
+        if function.get_symbol_name(&ctx).to_string() != "kernel_func" {
+            continue;
+        }
+        let body = function.get_operation().deref(&ctx).get_region(0);
+        for block in body.deref(&ctx).iter(&ctx) {
+            for body_op in block.deref(&ctx).iter(&ctx) {
+                let Some(asm) = Operation::get_op::<llvm::InlineAsmOp>(body_op, &ctx) else {
+                    continue;
+                };
+                let template = asm
+                    .get_attr_inline_asm_template(&ctx)
+                    .map(|value| String::from((*value).clone()));
+                let constraints = asm
+                    .get_attr_inline_asm_constraints(&ctx)
+                    .map(|value| String::from((*value).clone()));
+                if !template
+                    .as_deref()
+                    .is_some_and(|t| t.contains("mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32"))
+                {
+                    continue;
+                }
+                found += 1;
+                let template = template.expect("MMA inline asm must have a template");
+                assert_eq!(
+                    template,
+                    concat!(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32 ",
+                        "{$0, $1, $2, $3}, ",
+                        "{$8, $9, $10, $11}, ",
+                        "{$12, $13}, ",
+                        "{$4, $5, $6, $7};"
+                    )
+                );
+                for forbidden in [".reg", "ld.", "st.", "["] {
+                    assert!(
+                        !template.contains(forbidden),
+                        "register-only MMA must not contain {forbidden:?}: {template}"
+                    );
+                }
+                assert_eq!(
+                    constraints.as_deref(),
+                    Some("=r,=r,=r,=r,r,r,r,r,r,r,r,r,r,r")
+                );
+                assert_eq!(
+                    llvm::asm_kind_opt(&ctx, &asm),
+                    Some(llvm::AsmKind::Convergent)
+                );
+                assert_eq!(
+                    body_op.deref(&ctx).get_num_operands(),
+                    10,
+                    "expected C, A, and B scalar register operands"
+                );
+                assert_eq!(
+                    body_op.deref(&ctx).get_num_results(),
+                    1,
+                    "LLVM inline asm returns the four D registers as one struct"
+                );
+            }
+        }
+    }
+
+    assert_eq!(found, 1, "expected one mma.sync inline-asm operation");
+    Ok(())
+}
+
+#[test]
 fn test_mma_m16n8k32_s32_s8_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     let mut ctx = make_test_ctx();
     let i32_ty = pliron::builtin::types::IntegerType::get(

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
@@ -22,14 +22,16 @@ Rust device libraries that are consumed by CUDA C++ via LTOIR linking.
 | 8 | `mma_m16n8k8_f32_tf32_raw_stub` | The raw TF32 MMA stub reaches the device pipeline |
 | 9 | `mma_m16n8k8_f32_tf32_from_f32_stub` | The f32-to-TF32 conversion path compiles |
 | 10 | `int8_mma_registers` | The signed INT8 MMA stub reaches the device pipeline |
-| 11 | Exact F16 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` |
-| 12 | Exact TF32 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32` |
-| 13 | Six TF32 conversions | PTX contains six `cvt.rna.tf32.f32` instructions feeding the MMA |
-| 14 | Exact INT8 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32` |
-| 15 | PTX 7.0 floor | PTX selects version 7.0 or newer for the Ampere MMA forms |
-| 16 | `sm_80` floor | PTX targets `sm_80` or newer |
-| 17 | `lerp` absent | An uninstantiated generic is not compiled |
-| 18 | No `.entry` directives | Every emitted symbol is a device `.func`, not a kernel |
+| 11 | `uint8_mma_registers` | The unsigned INT8 MMA stub reaches the device pipeline |
+| 12 | Exact F16 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` |
+| 13 | Exact TF32 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32` |
+| 14 | Six TF32 conversions | PTX contains six `cvt.rna.tf32.f32` instructions feeding the MMA |
+| 15 | Exact INT8 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32` |
+| 16 | Exact unsigned INT8 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32` |
+| 17 | PTX 7.0 floor | PTX selects version 7.0 or newer for the Ampere MMA forms |
+| 18 | `sm_80` floor | PTX targets `sm_80` or newer |
+| 19 | `lerp` absent | An uninstantiated generic is not compiled |
+| 20 | No `.entry` directives | Every emitted symbol is a device `.func`, not a kernel |
 
 ## How to Run
 
@@ -54,16 +56,18 @@ PTX file: standalone_device_fn.ptx (... bytes)
   PASS  mma_m16n8k8_f32_tf32_raw_stub — Test 5: raw TF32 warp-MMA stub
   PASS  mma_m16n8k8_f32_tf32_from_f32_stub — Test 5: f32-to-TF32 conversion path
   PASS  int8_mma_registers — Test 5: signed INT8 warp-MMA stub
+  PASS  uint8_mma_registers — Test 5: unsigned INT8 warp-MMA stub
   PASS  exact F16 warp-MMA instruction emitted
   PASS  exact TF32 warp-MMA instruction emitted
   PASS  six f32-to-TF32 register conversions emitted
   PASS  lerp absent — Test 3b: uninstantiated generic not compiled
   PASS  No .entry directives (all are .func)
   PASS  INT8 MMA lowered to the exact PTX instruction
+  PASS  Unsigned INT8 MMA lowered to the exact PTX instruction
   PASS  INT8 MMA selected PTX 7.0 or newer
   PASS  INT8 MMA selected sm_80 or newer
 
-SUCCESS: 18/18 tests passed — all device functions compiled to PTX!
+SUCCESS: 20/20 tests passed — all device functions compiled to PTX!
 ```
 
 ## How It Works

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
@@ -21,7 +21,9 @@
 //! 5. F16, TF32, and INT8 warp-MMA lowering through the complete PTX pipeline
 
 use cuda_device::thread;
-use cuda_device::wmma::{mma_m16n8k8_f32_tf32, mma_m16n8k16_f32_f16, mma_m16n8k32_s32_s8};
+use cuda_device::wmma::{
+    mma_m16n8k8_f32_tf32, mma_m16n8k16_f32_f16, mma_m16n8k32_s32_s8, mma_m16n8k32_s32_u8,
+};
 use cuda_device::{device, ptx_asm};
 
 // =============================================================================
@@ -211,6 +213,17 @@ pub unsafe fn int8_mma_registers(c: [i32; 4], a: [u32; 4], b: [u32; 2]) -> [i32;
     unsafe { mma_m16n8k32_s32_s8(c, a, b) }
 }
 
+/// Emits one register-only unsigned INT8 tensor-core MMA instruction.
+///
+/// # Safety
+///
+/// The caller must satisfy [`mma_m16n8k32_s32_u8`]'s warp participation and
+/// per-lane fragment-layout contract.
+#[device]
+pub unsafe fn uint8_mma_registers(c: [i32; 4], a: [u32; 4], b: [u32; 2]) -> [i32; 4] {
+    unsafe { mma_m16n8k32_s32_u8(c, a, b) }
+}
+
 // =============================================================================
 // HOST CODE - Verifies PTX was generated correctly
 // =============================================================================
@@ -253,6 +266,7 @@ fn main() {
             "Test 5: f32-to-TF32 conversion path",
         ),
         ("int8_mma_registers", "Test 5: signed INT8 warp-MMA stub"),
+        ("uint8_mma_registers", "Test 5: unsigned INT8 warp-MMA stub"),
     ];
 
     let mut passed = 0;
@@ -325,6 +339,15 @@ fn main() {
         failed += 1;
     }
 
+    let uint8_mma = "mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32";
+    if ptx_content.contains(uint8_mma) {
+        println!("  PASS  Unsigned INT8 MMA lowered to the exact PTX instruction");
+        passed += 1;
+    } else {
+        println!("  FAIL  Missing exact unsigned INT8 MMA PTX instruction");
+        failed += 1;
+    }
+
     let ptx_version = ptx_content
         .lines()
         .find_map(|line| line.trim().strip_prefix(".version "))
@@ -358,7 +381,7 @@ fn main() {
 
     println!();
     if failed == 0 {
-        let total = tests.len() + 8;
+        let total = tests.len() + 9;
         println!(
             "SUCCESS: {}/{} tests passed — all device functions compiled to PTX!",
             passed, total


### PR DESCRIPTION
> I am still getting used to the repo. So I purposely followed the structure and style  #329, for the description. Felt that this also allows the two `m16n8k32` INT8 intrinsics to read the same way and hence, are easy to compare side by side.

## Summary

Adds the raw Ampere unsigned-INT8 warp-level matrix multiply-accumulate operation:

```ptx
mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32
    {%d0, %d1, %d2, %d3},
    {%a0, %a1, %a2, %a3},
    {%b0, %b1},
    {%c0, %c1, %c2, %c3};
```

It is the unsigned twin of the signed `s8` form (#329). The per-lane register layout is identical, and the `sm_80` / PTX 7.0 floors are the same. Only the `.u8.u8` operand types differ. This is the low-level, unsafe register atom used to build typed quantized matrix and tile APIs. It partially addresses tracking issue #274 (item "INT8 u8 m16n8k32"). It does not close the issue.

## What changed

- Added the `cuda-device` stub `mma_m16n8k32_s32_u8`.
- Added the dialect-nvvm operation, MIR importer handling, and register-only convergent lowering.
- Documented the exact per-lane A/B/C/D coordinates and the low-byte-to-high-byte packing of four unsigned 8-bit values in each `u32` carrier.
- Documented that this non-`.satfinite` form wraps signed accumulator overflow.
- Extended target detection to recognize both the plain and `.satfinite` spellings. It rejects near-misses, and it also rejects the signed and mixed-signedness (`s8.u8` / `u8.s8`) forms, so neither detector cross-matches the other.
- Extended the shared MMA fragment diagnostic guard and added verifier boundary tests.
- Added a checked-in device-stub to MIR importer to lowering to PTX regression.
- Kept the BF16, F16, TF32, INT8 (signed and unsigned), and FP64 paths separate.

## Safety and integer contract

```text
each lane: C[s32 x4] + A[b32 x4] * B[b32 x2]
             wrapping    four u8 values per b32
                              |
                              v
                          D[s32 x4]
```

All 32 lanes must execute the same instruction with the same qualifiers, and no lane may have exited. `A` and `B` must use the documented per-lane layout and byte order. The instruction requires PTX ISA 7.0 and `sm_80` or newer. cuda-oxide selects both floors automatically and rejects a lower explicit target.

## Testing

- [x] `cargo test -p dialect-nvvm -p cuda-oxide-codegen -p mir-lower -p mir-importer`
- [x] `cargo clippy` on the changed crates, clean
- [x] Root and example workspace pass `cargo fmt -- --check`
- [x] `cargo oxide run standalone_device_fn --arch sm_86` passes 20/20
- [x] The unsigned INT8 MMA selects the PTX 7.0 and `sm_80` floors. `sm_75` is rejected with the required `sm_80` floor (target-detection tests).
- [x] Plain and `.satfinite` detector boundary tests, plus cross-guards that reject the signed and mixed-signedness forms.
- [x] **Full-warp numerical comparison on an `sm_86` GPU against a CPU-reference matmul.** One warp computed `D = A x B` for `A` (16x32) and `B` (32x8) into `s32`. All 16x8 = 128 outputs matched the reference exactly. Sample values: `A[0][0..4] = [11, 48, 85, 122]`, `B[0..4][0] = [7, 175, 87, 255]`, `D[0][0] = 527216` (gpu == ref). The inputs deliberately include bytes above 127 (`175`, `255`). Under a signed lowering those decode as `-81` and `-1`, which would change the result. The exact match is therefore positive evidence of unsigned operand lowering. This was verified locally. The numerical example is not shipped, matching the MMA-family PTX-check convention set by #327, #321, #328, #323, and #329.

## Notes

This may need a small rebase if #334 (mixed-signedness INT8) lands first. That PR touches the same `m16n8k32` detection and emit paths. The overlap is additive.

## Checklist

- [x] All commits carry the DCO `Signed-off-by` trailer
- [x] No `crates/cuda-bindings/` changes relative to `main`
- [x] Public unsafe contract and compiler regression coverage included
