### PR TITLE
Fix difftest Clippy warnings under -D warnings

### DIFF
--- a/crates/fuzzer/rustlantis/difftest/src/backends.rs
+++ b/crates/fuzzer/rustlantis/difftest/src/backends.rs
@@ -80,7 +80,7 @@ pub fn from_config(config: Config) -> HashMap<String, Box<dyn Backend>> {
             BackendConfig::MiriRepo { path, flags } => {
                 Box::new(Miri::from_repo(path, flags).unwrap())
             }
-            BackendConfig::LLVM { toolchain, flags } => Box::new(LLVM::new(toolchain, flags)),
+            BackendConfig::LLVM { toolchain, flags } => Box::new(Llvm::new(toolchain, flags)),
             BackendConfig::Cranelift { toolchain, flags } => {
                 Box::new(Cranelift::from_rustup(toolchain, flags))
             }
@@ -91,7 +91,7 @@ pub fn from_config(config: Config) -> HashMap<String, Box<dyn Backend>> {
                 Box::new(Cranelift::from_binary(path, flags))
             }
             BackendConfig::GCC { path, flags } => {
-                Box::new(GCC::from_built_repo(path, flags).unwrap())
+                Box::new(Gcc::from_built_repo(path, flags).unwrap())
             }
         };
         backends.insert(name, backend);
@@ -154,25 +154,23 @@ fn run_compile_command(mut command: Command, source: &Source) -> process::Output
         }
     };
 
-    let compile_out = compiler
+    compiler
         .wait_with_output()
-        .expect("can execute rustc and get output");
-
-    compile_out
+        .expect("can execute rustc and get output")
 }
 
-struct LLVM {
+struct Llvm {
     toolchain: String,
     flags: Vec<String>,
 }
 
-impl LLVM {
+impl Llvm {
     fn new(toolchain: String, flags: Vec<String>) -> Self {
         Self { toolchain, flags }
     }
 }
 
-impl Backend for LLVM {
+impl Backend for Llvm {
     fn compile(&self, source: &Source, target: &Path) -> ProcessOutput {
         let mut command = Command::new("rustc");
 
@@ -312,7 +310,7 @@ impl Backend for Miri {
             BackendSource::Path(binary) => Command::new(binary),
             BackendSource::Rustup(toolchain) => {
                 let mut cmd = Command::new("rustup");
-                cmd.args(["run", &toolchain, "miri"]);
+                cmd.args(["run", toolchain, "miri"]);
                 cmd
             }
         };
@@ -413,14 +411,14 @@ impl Backend for Cranelift {
     }
 }
 
-struct GCC {
+struct Gcc {
     library: PathBuf,
     sysroot: PathBuf,
     repo: PathBuf,
     flags: Vec<String>,
 }
 
-impl GCC {
+impl Gcc {
     fn from_built_repo<P: AsRef<Path>>(
         cg_gcc: P,
         flags: Vec<String>,
@@ -452,7 +450,7 @@ impl GCC {
     }
 }
 
-impl Backend for GCC {
+impl Backend for Gcc {
     fn compile(&self, source: &Source, target: &Path) -> ProcessOutput {
         let mut command = Command::new("rustc");
         command

--- a/crates/fuzzer/rustlantis/difftest/src/lib.rs
+++ b/crates/fuzzer/rustlantis/difftest/src/lib.rs
@@ -35,7 +35,7 @@ pub struct ExecResults {
 }
 
 impl ExecResults {
-    fn from_exec_results<'a>(map: impl Iterator<Item = (String, ExecResult)>) -> Self {
+    fn from_exec_results(map: impl Iterator<Item = (String, ExecResult)>) -> Self {
         //TODO: optimisation here to check if all results are equal directly, since most should be
 
         // Split execution results into equivalent classes


### PR DESCRIPTION
Closes #367 

This fixes existing Clippy warnings in `crates/fuzzer/rustlantis/difftest/src/backends.rs` so the crate can pass strict Clippy validation with warnings denied.

Changes:

* Return the `wait_with_output().expect(...)` expression directly instead of binding and returning it.
* Rename private implementation structs `LLVM` and `GCC` to `Llvm` and `Gcc`.
* Remove an unnecessary borrow in the Miri `rustup run ... miri` command.

These are mechanical cleanup changes only. The affected structs are private, so this should not change the public API or runtime behavior.

Validation:

```bash
cargo fmt
RUST_TEST_THREADS=1 cargo test
cargo clippy --all-targets -- -D warnings
```
