### PR TITLE
Document descriptor offset output

### DIFF
--- a/crates/rustc-codegen-cuda/examples/wgmma/README.md
+++ b/crates/rustc-codegen-cuda/examples/wgmma/README.md
@@ -78,8 +78,8 @@ Loading PTX from: wgmma.ptx
 Launching wgmma_sync_test kernel...
 SMEM descriptor: 0xC000000000000xxx
 ✓ Swizzle mode correct (128B)
-  Leading dimension offset: xxx (raw bits)
-  Stride offset: xxx (raw bits)
+  Leading dimension offset: 8 (raw bits)
+  Stride offset: 8 (raw bits)
 
 === WGMMA Test Complete ===
 ```

--- a/crates/rustc-codegen-cuda/examples/wgmma/README.md
+++ b/crates/rustc-codegen-cuda/examples/wgmma/README.md
@@ -76,13 +76,16 @@ Loading PTX from: wgmma.ptx
 --- Test: WGMMA Sync Primitives ---
 
 Launching wgmma_sync_test kernel...
-SMEM descriptor: 0xC000000000000xxx
+SMEM descriptor: 0xC00000080008xxxx
 ✓ Swizzle mode correct (128B)
   Leading dimension offset: 8 (raw bits)
   Stride offset: 8 (raw bits)
 
 === WGMMA Test Complete ===
 ```
+
+`xxxx` is the descriptor's variable 14-bit shared-memory address field. The
+fixed `0008` fields decode to raw leading-dimension and stride offsets of `8`.
 
 ### On Pre-Hopper or Blackwell:
 


### PR DESCRIPTION
Closes #371 

## Summary

- Replace placeholder WGMMA descriptor offset values in the README expected output.
- Document the current raw leading-dimension and stride offsets as `8`.

## Details

The WGMMA lowering builds the descriptor with `0xC000000800080000`, and the example prints:

- `(desc >> 16) & 0x3FFF`
- `(desc >> 32) & 0x3FFF`

Both fields resolve to `8`, so the README output should not keep `xxx` placeholders.

## Validation

Docs-only change. No runtime validation required.