### PR TITLE
fix(mir): accept empty enum types

### DIFF
--- a/crates/dialect-mir/src/ops/enum_ops.rs
+++ b/crates/dialect-mir/src/ops/enum_ops.rs
@@ -211,6 +211,13 @@ impl Verify for MirGetDiscriminantOp {
             }
         };
 
+        if enum_ty.variant_count() == 0 {
+            return verify_err!(
+                op.loc(),
+                "MirGetDiscriminantOp cannot inspect an enum with no variants"
+            );
+        }
+
         // Result must match the enum's discriminant type
         let result = op.get_result(0);
         let result_ty = result.get_type(ctx);
@@ -289,6 +296,12 @@ impl Verify for MirSetDiscriminantOp {
                 let pointee = ptr_type.pointee.deref(ctx);
                 match pointee.downcast_ref::<MirEnumType>() {
                     Some(enum_ty) => {
+                        if enum_ty.variant_count() == 0 {
+                            return verify_err!(
+                                op.loc(),
+                                "MirSetDiscriminantOp cannot mutate an enum with no variants"
+                            );
+                        }
                         let expected_discr_ty = enum_ty.discriminant_type();
                         if discr_ty != expected_discr_ty {
                             return verify_err!(

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -735,8 +735,8 @@ impl EnumVariant {
 /// `variant_field_counts` to split the `all_*` vectors per variant.
 ///
 /// # Verification
-/// * Must have at least one variant.
-/// * Discriminant type must be an integer type.
+/// * Zero variants are valid and represent an uninhabited Rust type.
+/// * The parallel variant metadata vectors must have consistent lengths.
 #[pliron_type(
     name = "mir.enum",
     format = "`<` $name `,` $discriminant_ty `,` `[` vec($variant_names, CharSpace(`,`)) `]` `,` `[` vec($variant_discriminants, CharSpace(`,`)) `]` `,` `[` vec($variant_field_counts, CharSpace(`,`)) `]` `,` `[` vec($all_field_types, CharSpace(`,`)) `]` `,` `[` vec($all_field_offsets, CharSpace(`,`)) `]` `,` $tag_offset `,` $total_size `,` $abi_align `>`"
@@ -950,13 +950,9 @@ impl MirEnumType {
 
 impl Verify for MirEnumType {
     fn verify(&self, _ctx: &Context) -> Result<(), Error> {
-        // Enum types must have at least one variant
-        if self.variant_names.is_empty() {
-            return verify_err!(
-                Location::Unknown,
-                "MirEnumType must have at least one variant"
-            );
-        }
+        // Rust permits uninhabited enums with no variants. Enum operations
+        // reject attempts to construct, inspect, or mutate values of these
+        // types.
         if self.variant_names.len() != self.variant_discriminants.len() {
             return verify_err!(
                 Location::Unknown,

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -6,6 +6,7 @@
 //! MIR dialect types.
 
 use pliron::builtin::type_interfaces::FloatTypeInterface;
+use pliron::builtin::types::IntegerType;
 use pliron::context::Context;
 use pliron::derive::{pliron_type, type_interface_impl};
 use pliron::location::Location;
@@ -736,6 +737,7 @@ impl EnumVariant {
 ///
 /// # Verification
 /// * Zero variants are valid and represent an uninhabited Rust type.
+/// * The discriminant type must be an integer type.
 /// * The parallel variant metadata vectors must have consistent lengths.
 #[pliron_type(
     name = "mir.enum",
@@ -949,10 +951,21 @@ impl MirEnumType {
 }
 
 impl Verify for MirEnumType {
-    fn verify(&self, _ctx: &Context) -> Result<(), Error> {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
         // Rust permits uninhabited enums with no variants. Enum operations
         // reject attempts to construct, inspect, or mutate values of these
         // types.
+        if self
+            .discriminant_ty
+            .deref(ctx)
+            .downcast_ref::<IntegerType>()
+            .is_none()
+        {
+            return verify_err!(
+                Location::Unknown,
+                "MirEnumType discriminant type must be an integer type"
+            );
+        }
         if self.variant_names.len() != self.variant_discriminants.len() {
             return verify_err!(
                 Location::Unknown,
@@ -963,6 +976,32 @@ impl Verify for MirEnumType {
             return verify_err!(
                 Location::Unknown,
                 "MirEnumType variant field count must match variant count"
+            );
+        }
+        let Some(recorded_field_count) = self
+            .variant_field_counts
+            .iter()
+            .try_fold(0usize, |sum, &count| sum.checked_add(count as usize))
+        else {
+            return verify_err!(
+                Location::Unknown,
+                "MirEnumType total variant field count overflows usize"
+            );
+        };
+        if recorded_field_count != self.all_field_types.len() {
+            return verify_err!(
+                Location::Unknown,
+                "MirEnumType variant field counts describe {} fields but {} field type entries were recorded",
+                recorded_field_count,
+                self.all_field_types.len()
+            );
+        }
+        if !self.all_field_offsets.is_empty()
+            && self.all_field_offsets.len() != self.all_field_types.len()
+        {
+            return verify_err!(
+                Location::Unknown,
+                "MirEnumType field offset count must be empty or match the field type count"
             );
         }
         if self.total_size > 0 {

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -124,6 +124,71 @@ fn empty_enum_types_are_valid_but_reject_value_operations() {
 }
 
 #[test]
+fn enum_type_verifier_rejects_malformed_flattened_metadata() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    let discr = IntegerType::get(&ctx, 8, Signedness::Signless);
+    let f32_ty = FP32Type::get(&ctx);
+
+    let non_integer_discriminant = MirEnumType {
+        name: "NonIntegerDiscriminant".to_string(),
+        discriminant_ty: f32_ty.into(),
+        variant_names: vec!["Only".to_string()],
+        variant_discriminants: vec![0],
+        variant_field_counts: vec![0],
+        all_field_types: vec![],
+        all_field_offsets: vec![],
+        tag_offset: 0,
+        total_size: 0,
+        abi_align: 0,
+    };
+    let error = non_integer_discriminant
+        .verify(&ctx)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("discriminant type must be an integer type"),
+        "unexpected non-integer discriminant diagnostic: {error}"
+    );
+
+    let malformed_field_count = MirEnumType {
+        name: "MalformedFieldCount".to_string(),
+        discriminant_ty: discr.into(),
+        variant_names: vec!["Only".to_string()],
+        variant_discriminants: vec![0],
+        variant_field_counts: vec![2],
+        all_field_types: vec![discr.into()],
+        all_field_offsets: vec![],
+        tag_offset: 0,
+        total_size: 0,
+        abi_align: 0,
+    };
+    let error = malformed_field_count.verify(&ctx).unwrap_err().to_string();
+    assert!(
+        error.contains("describe 2 fields but 1 field type entries were recorded"),
+        "unexpected field-count diagnostic: {error}"
+    );
+
+    let malformed_offsets = MirEnumType {
+        name: "MalformedOffsets".to_string(),
+        discriminant_ty: discr.into(),
+        variant_names: vec!["Only".to_string()],
+        variant_discriminants: vec![0],
+        variant_field_counts: vec![2],
+        all_field_types: vec![discr.into(), discr.into()],
+        all_field_offsets: vec![0],
+        tag_offset: 0,
+        total_size: 0,
+        abi_align: 0,
+    };
+    let error = malformed_offsets.verify(&ctx).unwrap_err().to_string();
+    assert!(
+        error.contains("field offset count must be empty or match"),
+        "unexpected field-offset diagnostic: {error}"
+    );
+}
+
+#[test]
 fn test_mir_control_flow_verify() {
     let mut ctx = Context::new();
     dialect_mir::register(&mut ctx);

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -4,13 +4,14 @@
  */
 
 use dialect_mir::{
-    attributes::MirCastKindAttr,
+    attributes::{FieldIndexAttr, MirCastKindAttr, VariantIndexAttr},
     ops::{
         MirAddOp, MirAssertOp, MirAssignOp, MirCallOp, MirCastOp, MirCheckedAddOp, MirCmpOp,
-        MirCondBranchOp, MirConstantOp, MirConstructSliceOp, MirDivOp, MirEqOp, MirExtractFieldOp,
-        MirFuncOp, MirGeOp, MirGlobalAllocOp, MirGotoOp, MirGtOp, MirLeOp, MirLoadOp, MirLtOp,
-        MirMulOp, MirNeOp, MirNegOp, MirNotOp, MirPtrOffsetOp, MirRemOp, MirReturnOp,
-        MirSetDiscriminantOp, MirStoreOp, MirSubOp,
+        MirCondBranchOp, MirConstantOp, MirConstructEnumOp, MirConstructSliceOp, MirDivOp,
+        MirEnumPayloadOp, MirEqOp, MirExtractFieldOp, MirFuncOp, MirGeOp, MirGetDiscriminantOp,
+        MirGlobalAllocOp, MirGotoOp, MirGtOp, MirLeOp, MirLoadOp, MirLtOp, MirMulOp, MirNeOp,
+        MirNegOp, MirNotOp, MirPtrOffsetOp, MirRemOp, MirReturnOp, MirSetDiscriminantOp,
+        MirStoreOp, MirSubOp,
     },
     types::{EnumVariant, MirEnumType, MirPtrType, MirSliceType, MirTupleType, MirUnionType},
 };
@@ -29,6 +30,98 @@ use pliron::{
     utils::apint::APInt,
 };
 use std::num::NonZeroUsize;
+
+#[test]
+fn empty_enum_types_are_valid_but_reject_value_operations() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    let discr = IntegerType::get(&ctx, 8, Signedness::Signless);
+    let empty = MirEnumType::get(
+        &mut ctx,
+        "Infallible".to_string(),
+        discr.into(),
+        vec![],
+        vec![],
+    );
+
+    assert!(empty.deref(&ctx).verify(&ctx).is_ok());
+    assert_eq!(empty.deref(&ctx).variant_count(), 0);
+    assert!(empty.deref(&ctx).get_variant(0).is_none());
+
+    let value_block = BasicBlock::new(&mut ctx, None, vec![empty.into()]);
+    let empty_value = value_block.deref(&ctx).get_argument(0);
+
+    let construct = Operation::new(
+        &mut ctx,
+        MirConstructEnumOp::get_concrete_op_info(),
+        vec![empty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    let construct = MirConstructEnumOp::new(construct);
+    construct.set_attr_construct_enum_variant_index(&ctx, VariantIndexAttr(0));
+    let error = construct.verify(&ctx).unwrap_err().to_string();
+    assert!(
+        error.contains("variant_index 0 out of bounds") && error.contains("with 0 variants"),
+        "unexpected construct diagnostic: {error}"
+    );
+
+    let payload = Operation::new(
+        &mut ctx,
+        MirEnumPayloadOp::get_concrete_op_info(),
+        vec![discr.into()],
+        vec![empty_value],
+        vec![],
+        0,
+    );
+    let payload = MirEnumPayloadOp::new(payload);
+    payload.set_attr_payload_variant_index(&ctx, VariantIndexAttr(0));
+    payload.set_attr_payload_field_index(&ctx, FieldIndexAttr(0));
+    let error = payload.verify(&ctx).unwrap_err().to_string();
+    assert!(
+        error.contains("variant_index 0 out of bounds") && error.contains("with 0 variants"),
+        "unexpected payload diagnostic: {error}"
+    );
+
+    let get_discriminant = Operation::new(
+        &mut ctx,
+        MirGetDiscriminantOp::get_concrete_op_info(),
+        vec![discr.into()],
+        vec![empty_value],
+        vec![],
+        0,
+    );
+    let error = MirGetDiscriminantOp::new(get_discriminant)
+        .verify(&ctx)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("cannot inspect an enum with no variants"),
+        "unexpected get-discriminant diagnostic: {error}"
+    );
+
+    let empty_ptr = MirPtrType::get_generic(&mut ctx, empty.into(), true);
+    let set_block = BasicBlock::new(&mut ctx, None, vec![empty_ptr.into(), discr.into()]);
+    let empty_ptr_value = set_block.deref(&ctx).get_argument(0);
+    let discr_value = set_block.deref(&ctx).get_argument(1);
+    let set_discriminant = Operation::new(
+        &mut ctx,
+        MirSetDiscriminantOp::get_concrete_op_info(),
+        vec![],
+        vec![empty_ptr_value, discr_value],
+        vec![],
+        0,
+    );
+    let error = MirSetDiscriminantOp::new(set_discriminant)
+        .verify(&ctx)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("cannot mutate an enum with no variants"),
+        "unexpected set-discriminant diagnostic: {error}"
+    );
+}
 
 #[test]
 fn test_mir_control_flow_verify() {

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/README.md
@@ -22,14 +22,15 @@ Rust device libraries that are consumed by CUDA C++ via LTOIR linking.
 | 8 | `mma_m16n8k8_f32_tf32_raw_stub` | The raw TF32 MMA stub reaches the device pipeline |
 | 9 | `mma_m16n8k8_f32_tf32_from_f32_stub` | The f32-to-TF32 conversion path compiles |
 | 10 | `int8_mma_registers` | The signed INT8 MMA stub reaches the device pipeline |
-| 11 | Exact F16 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` |
-| 12 | Exact TF32 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32` |
-| 13 | Six TF32 conversions | PTX contains six `cvt.rna.tf32.f32` instructions feeding the MMA |
-| 14 | Exact INT8 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32` |
-| 15 | PTX 7.0 floor | PTX selects version 7.0 or newer for the Ampere MMA forms |
-| 16 | `sm_80` floor | PTX targets `sm_80` or newer |
-| 17 | `lerp` absent | An uninstantiated generic is not compiled |
-| 18 | No `.entry` directives | Every emitted symbol is a device `.func`, not a kernel |
+| 11 | `empty_enum_argument` | A zero-variant enum type survives import in statically unreachable device code |
+| 12 | Exact F16 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` |
+| 13 | Exact TF32 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32` |
+| 14 | Six TF32 conversions | PTX contains six `cvt.rna.tf32.f32` instructions feeding the MMA |
+| 15 | Exact INT8 MMA mnemonic | PTX contains `mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32` |
+| 16 | PTX 7.0 floor | PTX selects version 7.0 or newer for the Ampere MMA forms |
+| 17 | `sm_80` floor | PTX targets `sm_80` or newer |
+| 18 | `lerp` absent | An uninstantiated generic is not compiled |
+| 19 | No `.entry` directives | Every emitted symbol is a device `.func`, not a kernel |
 
 ## How to Run
 
@@ -54,6 +55,7 @@ PTX file: standalone_device_fn.ptx (... bytes)
   PASS  mma_m16n8k8_f32_tf32_raw_stub — Test 5: raw TF32 warp-MMA stub
   PASS  mma_m16n8k8_f32_tf32_from_f32_stub — Test 5: f32-to-TF32 conversion path
   PASS  int8_mma_registers — Test 5: signed INT8 warp-MMA stub
+  PASS  empty_enum_argument — Test 6: zero-variant enum in unreachable device code
   PASS  exact F16 warp-MMA instruction emitted
   PASS  exact TF32 warp-MMA instruction emitted
   PASS  six f32-to-TF32 register conversions emitted
@@ -63,7 +65,7 @@ PTX file: standalone_device_fn.ptx (... bytes)
   PASS  INT8 MMA selected PTX 7.0 or newer
   PASS  INT8 MMA selected sm_80 or newer
 
-SUCCESS: 18/18 tests passed — all device functions compiled to PTX!
+SUCCESS: 19/19 tests passed — all device functions compiled to PTX!
 ```
 
 ## How It Works

--- a/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/standalone_device_fn/src/main.rs
@@ -19,10 +19,21 @@
 //! 3. Generic logic via concrete wrappers, including multiple monomorphizations
 //! 4. Device function using GPU intrinsics (thread indexing)
 //! 5. F16, TF32, and INT8 warp-MMA lowering through the complete PTX pipeline
+//! 6. A zero-variant enum type in statically unreachable device code
 
 use cuda_device::thread;
 use cuda_device::wmma::{mma_m16n8k8_f32_tf32, mma_m16n8k16_f32_f16, mma_m16n8k32_s32_s8};
 use cuda_device::{device, ptx_asm};
+
+/// Uninhabited argument used to exercise zero-variant enum type import.
+pub enum StandaloneNever {}
+
+/// The type must survive MIR verification, while the empty match lowers
+/// directly to unreachable code without constructing or inspecting a value.
+#[device]
+pub fn empty_enum_argument(value: StandaloneNever) -> u32 {
+    match value {}
+}
 
 // =============================================================================
 // TEST 1: Simple standalone device functions
@@ -253,6 +264,10 @@ fn main() {
             "Test 5: f32-to-TF32 conversion path",
         ),
         ("int8_mma_registers", "Test 5: signed INT8 warp-MMA stub"),
+        (
+            "empty_enum_argument",
+            "Test 6: zero-variant enum in unreachable device code",
+        ),
     ];
 
     let mut passed = 0;


### PR DESCRIPTION
## Summary

Closes #376.

Permit zero-variant Rust enum types in the MIR dialect while keeping every enum-specific value and discriminant operation fail-closed.

```text
Before: a zero-variant MirEnumType fails type verification
After:  the type verifies; construct, payload, get-discriminant, and
        set-discriminant operations reject it explicitly
```

## What changed

### Empty enum type verification

- Treat zero variants as a valid uninhabited Rust type.
- Retain the existing consistency checks for variant metadata and recorded layout.
- Update the type documentation to state the zero-variant contract.

### Fail-closed operation verification

- Keep construction and payload extraction rejected by the shared variant bounds.
- Explicitly reject discriminant reads and writes because an empty enum has no valid discriminant.
- Assert the precise diagnostics for all four enum-specific operation kinds.

## Known separate limitations

- This does not change niche-encoded or single-live-variant enum ABI modeling.
- It does not make values of a zero-variant enum constructible.
- No end-to-end compiler failure caused by the old verifier has been identified; the regression is the dialect invariant itself.

## Testing

- `cargo oxide fmt --check`
- `cargo test -p dialect-mir`: 5 const-fold tests and 17 operation tests passed
- `cargo clippy -p dialect-mir --all-targets -- -D warnings`

## Checklist

- [x] Branch based directly on current `upstream/main`
- [x] Correctness claim covered by a focused regression
- [x] Unsupported operations fail clearly
- [x] All commits signed off (`git commit -s`)
- [x] Diff contains no fork-only scaffolding