### PR TITLE
fix(cuda-host): use same-major cubin compatibility

### DIFF
--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -1257,6 +1257,12 @@ pub(crate) fn execution_route(
             "an artifact built for a newer GPU cannot run on an older GPU",
         ));
     }
+    // NVIDIA guarantees cubin binary compatibility within one compute
+    // capability major version when the execution minor is at least the
+    // emitted minor. The backward case was rejected immediately above.
+    if emitted.capability() / 10 == execution.capability() / 10 {
+        return Ok(ExecutionRoute::Cubin);
+    }
     if emitted.uses_legacy_llvm() && execution.capability() >= 100 {
         return Ok(ExecutionRoute::PtxBridge);
     }
@@ -1494,6 +1500,21 @@ mod tests {
     }
 
     #[test]
+    fn same_major_forward_minor_uses_binary_compatible_cubin() {
+        for (emitted, execution) in [
+            ("sm_80", "sm_86"),
+            ("compute_86", "sm_89"),
+            ("sm_120", "sm_121"),
+        ] {
+            assert_eq!(
+                execution_route(&emitted.parse().unwrap(), &execution.parse().unwrap()).unwrap(),
+                ExecutionRoute::Cubin,
+                "{emitted} on {execution}"
+            );
+        }
+    }
+
+    #[test]
     fn standard_legacy_target_bridges_forward_to_blackwell_as_ptx() {
         for (emitted, execution) in [
             ("sm_75", "sm_100"),
@@ -1527,20 +1548,25 @@ mod tests {
 
     #[test]
     fn execution_route_rejects_backward_targets() {
-        let error = execution_route(&"sm_120".parse().unwrap(), &"sm_86".parse().unwrap())
+        for (emitted_target, execution_target) in [("sm_89", "sm_86"), ("sm_120", "sm_86")] {
+            let error = execution_route(
+                &emitted_target.parse().unwrap(),
+                &execution_target.parse().unwrap(),
+            )
             .expect_err("a newer artifact cannot run on an older GPU");
 
-        let LtoirError::IncompatibleExecutionTarget {
-            emitted,
-            execution,
-            reason,
-        } = error
-        else {
-            panic!("unexpected error: {error}");
-        };
-        assert_eq!(emitted, "sm_120");
-        assert_eq!(execution, "sm_86");
-        assert!(reason.contains("newer GPU"));
+            let LtoirError::IncompatibleExecutionTarget {
+                emitted,
+                execution,
+                reason,
+            } = error
+            else {
+                panic!("unexpected error: {error}");
+            };
+            assert_eq!(emitted, emitted_target);
+            assert_eq!(execution, execution_target);
+            assert!(reason.contains("newer GPU"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #378.

## Summary

Allow cuda-host to use cubins on newer GPUs within the same compute-capability major version, following NVIDIA's binary compatibility contract. Preserve existing rejection for backward, architecture-suffixed, and unsupported cross-major forwarding.

```text
Before: sm_80 artifact on sm_86 -> IncompatibleExecutionTarget
After:  sm_80 artifact on sm_86 -> Cubin route and successful execution
```

## What changed

### Binary-compatible route selection

- Compare parsed numeric compute-capability major versions after exact-match, suffix, and backward-target checks.
- Select `ExecutionRoute::Cubin` when execution has the same major capability and a greater minor capability.
- Cover both `sm_XX` and `compute_XX` input spellings through the shared parser.

### Correctness boundaries

- Preserve newer-to-older rejection, including same-major `sm_89 -> sm_86`.
- Preserve architecture-suffix restrictions and the existing cross-major PTX bridge.
- Pin two-digit (`sm_80 -> sm_86`) and three-digit (`sm_120 -> sm_121`) capability encoding.

## Known separate limitations

- This does not add cross-major cubin compatibility.
- Architecture- and family-suffixed targets retain their existing forwarding policy.
- PTX bridging from legacy LLVM IR to Blackwell remains unchanged.

## Testing

- `cargo oxide fmt --check`
- `cargo test -p cuda-host`: 61 passed, 1 ignored unit test; 9 `cuda_module_api`; 13 `kernel_family`; 6 doctests passed and 8 ignored
- `cargo clippy -p cuda-host --all-targets -- -D warnings`
- `cargo oxide run vecadd --emit-nvvm-ir --arch sm_80` on RTX 3080 (`sm_86`): 1,024/1,024 elements correct
- `CUDA_OXIDE_NO_OPT=1 cargo oxide run vecadd --emit-nvvm-ir --arch sm_80`: 1,024/1,024 elements correct
- Artifact evidence: target sidecar `sm_80`; executable `.oxart` section contained `OXIDEART`, `vecadd`, `sm_80`, and `vecadd.ll`

Reference: https://docs.nvidia.com/cuda/archive/13.2.1/cuda-programming-guide/01-introduction/cuda-platform.html#binary-compatibility

## Checklist

- [x] Branch based directly on current `upstream/main`
- [x] Correctness claim covered by focused route tests
- [x] Unsupported cases fail clearly
- [x] Optimized and unoptimized GPU behavior verified
- [x] All commits signed off (`git commit -s`)
- [x] Diff contains no fork-only scaffolding

<!-- impulse-cuda-upstream:same-major-cubin-compat:pr -->