### PR TITLE
fix(ptx): internalize non-root device helpers

### DIFF
--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -192,8 +192,8 @@ pub fn export_llvm_ir(
     emit_nvvm_ir: bool,
     nvvm_dialect: Option<NvvmIrDialect>,
     debug_kind: DebugKind,
-) -> Result<String, PipelineError> {
-    let llvm_ir = render_llvm_ir(
+) -> Result<llvm_export::export::ExportedModule, PipelineError> {
+    let exported = render_exported_llvm_ir(
         ctx,
         module_op_ptr,
         device_externs,
@@ -202,9 +202,9 @@ pub fn export_llvm_ir(
         debug_kind,
     )?;
 
-    std::fs::write(path, &llvm_ir).map_err(|e| PipelineError::Export(e.to_string()))?;
+    std::fs::write(path, &exported.llvm_ir).map_err(|e| PipelineError::Export(e.to_string()))?;
 
-    Ok(llvm_ir)
+    Ok(exported)
 }
 
 /// Render LLVM text without publishing an artifact.
@@ -222,10 +222,29 @@ pub fn render_llvm_ir(
     nvvm_dialect: Option<NvvmIrDialect>,
     debug_kind: DebugKind,
 ) -> Result<String, PipelineError> {
+    render_exported_llvm_ir(
+        ctx,
+        module_op_ptr,
+        device_externs,
+        emit_nvvm_ir,
+        nvvm_dialect,
+        debug_kind,
+    )
+    .map(|exported| exported.llvm_ir)
+}
+
+fn render_exported_llvm_ir(
+    ctx: &Context,
+    module_op_ptr: Ptr<Operation>,
+    device_externs: &[DeviceExternDecl],
+    emit_nvvm_ir: bool,
+    nvvm_dialect: Option<NvvmIrDialect>,
+    debug_kind: DebugKind,
+) -> Result<llvm_export::export::ExportedModule, PipelineError> {
     let module_op = Operation::get_op::<pliron::builtin::ops::ModuleOp>(module_op_ptr, ctx)
         .ok_or_else(|| PipelineError::Export("Not a module op".to_string()))?;
 
-    let llvm_ir = if emit_nvvm_ir {
+    let exported = if emit_nvvm_ir {
         let dialect = nvvm_dialect.ok_or_else(|| {
             PipelineError::Export("NVVM export reached without a selected IR dialect".to_string())
         })?;
@@ -233,18 +252,28 @@ pub fn render_llvm_ir(
             inner: llvm_export::export::NvvmExportConfig::new(dialect),
             debug_kind,
         };
-        llvm_export::export::export_module_with_externs(ctx, &module_op, device_externs, &config)
-            .map_err(PipelineError::Export)?
+        llvm_export::export::export_module_with_externs_and_roots(
+            ctx,
+            &module_op,
+            device_externs,
+            &config,
+        )
+        .map_err(PipelineError::Export)?
     } else {
         let config = PipelineExportConfig {
             inner: llvm_export::export::PtxExportConfig,
             debug_kind,
         };
-        llvm_export::export::export_module_with_externs(ctx, &module_op, device_externs, &config)
-            .map_err(PipelineError::Export)?
+        llvm_export::export::export_module_with_externs_and_roots(
+            ctx,
+            &module_op,
+            device_externs,
+            &config,
+        )
+        .map_err(PipelineError::Export)?
     };
 
-    Ok(llvm_ir)
+    Ok(exported)
 }
 
 struct PipelineExportConfig<C> {

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -22,7 +22,7 @@ use crate::llvm_tools::LlvmToolchain;
 use crate::lower::{add_device_extern_declarations, lower_to_llvm};
 use crate::options::BackendOptions;
 use crate::prep::{MirPreparation, prepare_mir_module};
-use crate::ptx::{generate_ptx, generate_ptx_with_toolchain};
+use crate::ptx::{PtxModule, generate_ptx, generate_ptx_with_toolchain};
 use crate::target::detect_features_in_llvm_text;
 use crate::verify::verify_operation;
 use llvm_export::export::{DebugKind, NvvmIrDialect};
@@ -415,11 +415,14 @@ pub fn compile_translated_module(
     } else {
         None
     };
+    let ptx_module = PtxModule {
+        llvm_ir: request.files.llvm_ir,
+        output: request.files.ptx,
+        public_symbols: &exported.public_symbols,
+    };
     let generated = match request.toolchain {
         ToolchainPolicy::Discover => generate_ptx(
-            request.files.llvm_ir,
-            request.files.ptx,
-            &exported.public_symbols,
+            ptx_module,
             request.debug_kind,
             request.backend,
             request.trace.sink,
@@ -427,9 +430,7 @@ pub fn compile_translated_module(
             ptx_libdevice,
         )?,
         ToolchainPolicy::Explicit(toolchain) => generate_ptx_with_toolchain(
-            request.files.llvm_ir,
-            request.files.ptx,
-            &exported.public_symbols,
+            ptx_module,
             request.debug_kind,
             request.backend,
             toolchain,

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -371,7 +371,7 @@ pub fn compile_translated_module(
             .emit(format!("\n=== Exporting to LLVM IR ({mode} mode) ==="));
     }
     remove_stale_files(request.files.stale_before_export)?;
-    export_llvm_ir(
+    let exported = export_llvm_ir(
         ctx,
         module,
         request.device_externs,
@@ -419,6 +419,7 @@ pub fn compile_translated_module(
         ToolchainPolicy::Discover => generate_ptx(
             request.files.llvm_ir,
             request.files.ptx,
+            &exported.public_symbols,
             request.debug_kind,
             request.backend,
             request.trace.sink,
@@ -428,6 +429,7 @@ pub fn compile_translated_module(
         ToolchainPolicy::Explicit(toolchain) => generate_ptx_with_toolchain(
             request.files.llvm_ir,
             request.files.ptx,
+            &exported.public_symbols,
             request.debug_kind,
             request.backend,
             toolchain,

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -92,7 +92,12 @@ fn link_libdevice(
     }
 }
 
-/// Runs LLVM's middle-end (`opt -O2`) on the emitted IR before `llc`.
+/// Runs LLVM's middle-end on the emitted IR before `llc`.
+///
+/// Modules with explicit `@llvm.used` roots internalize every other definition
+/// before the default O2 pipeline so fully inlined helpers are eligible for
+/// global dead-code elimination. Modules without an explicit root set retain
+/// the historical `opt -O2` path.
 ///
 /// This is what consumes the per-op ABI alignment we emit: the
 /// LoadStoreVectorizer fuses aligned aggregate/element accesses, SROA
@@ -109,6 +114,7 @@ fn link_libdevice(
 /// is strict; the legacy rustc path retains its warn-and-continue behavior.
 fn optimize_ll(
     ll_path: &Path,
+    public_symbols: &[String],
     toolchain: &LlvmToolchain,
     opts: &BackendOptions,
     strict: bool,
@@ -127,9 +133,11 @@ fn optimize_ll(
         return Ok((None, Vec::new()));
     };
 
+    let optimization_args = optimization_args(public_symbols)?;
+
     let opt_ll = ll_path.with_extension("opt.ll");
     match std::process::Command::new(&opt.path)
-        .arg("-O2")
+        .args(&optimization_args)
         .arg(ll_path)
         .arg("-S")
         .arg("-o")
@@ -139,7 +147,14 @@ fn optimize_ll(
         Ok(output) if output.status.success() => {
             let diagnostics = opts
                 .verbose
-                .then(|| format!("opt -O2 via {}: {}", opt.path, opt_ll.display()))
+                .then(|| {
+                    format!(
+                        "opt {} via {}: {}",
+                        optimization_args.join(" "),
+                        opt.path,
+                        opt_ll.display()
+                    )
+                })
                 .into_iter()
                 .collect();
             Ok((Some(opt_ll), diagnostics))
@@ -178,6 +193,32 @@ fn optimize_ll(
     }
 }
 
+/// Build the middle-end arguments for a self-contained PTX module.
+///
+/// The LLVM exporter returns the module's externally consumed definitions as
+/// typed export metadata: entry kernels (or standalone device functions) plus
+/// host-visible globals. Passing that root set directly avoids inferring
+/// visibility from symbol spelling or rendered LLVM text.
+/// Once ordinary inlining has copied a non-root helper into every caller,
+/// internalization lets GlobalDCE remove it instead of asking `llc` to emit an
+/// unreachable `.visible .func` body.
+fn optimization_args(public_symbols: &[String]) -> Result<Vec<String>, PipelineError> {
+    if public_symbols.is_empty() {
+        return Ok(vec!["-O2".to_string()]);
+    }
+
+    if let Some(symbol) = public_symbols.iter().find(|symbol| symbol.contains(',')) {
+        return Err(PipelineError::Optimization(format!(
+            "external symbol `{symbol}` cannot be represented in LLVM's comma-separated internalization API list"
+        )));
+    }
+
+    Ok(vec![
+        "-passes=internalize,default<O2>".to_string(),
+        format!("-internalize-public-api-list={}", public_symbols.join(",")),
+    ])
+}
+
 /// Legacy rustc-pipeline result, including messages the CLI should print.
 #[doc(hidden)]
 #[allow(missing_docs)]
@@ -191,6 +232,12 @@ struct PtxBackend<'a> {
     options: &'a BackendOptions,
     toolchain: &'a LlvmToolchain,
     generated: &'a GeneratedModuleRequirements,
+}
+
+struct PtxModule<'a> {
+    llvm_ir: &'a Path,
+    output: &'a Path,
+    public_symbols: &'a [String],
 }
 
 /// Generates PTX from LLVM IR using `llc`.
@@ -215,6 +262,7 @@ struct PtxBackend<'a> {
 pub fn generate_ptx(
     ll_path: &Path,
     ptx_path: &Path,
+    public_symbols: &[String],
     debug_kind: DebugKind,
     opts: &BackendOptions,
     diagnostic_sink: Option<fn(&str)>,
@@ -256,8 +304,11 @@ pub fn generate_ptx(
     }
     emit_diagnostics(diagnostic_sink, &diagnostics);
     let mut generated = generate_ptx_impl(
-        ll_path,
-        ptx_path,
+        PtxModule {
+            llvm_ir: ll_path,
+            output: ptx_path,
+            public_symbols,
+        },
         debug_kind,
         PtxBackend {
             options: opts,
@@ -280,6 +331,7 @@ pub fn generate_ptx(
 pub(crate) fn generate_ptx_with_toolchain(
     ll_path: &Path,
     ptx_path: &Path,
+    public_symbols: &[String],
     debug_kind: DebugKind,
     opts: &BackendOptions,
     toolchain: &LlvmToolchain,
@@ -287,8 +339,11 @@ pub(crate) fn generate_ptx_with_toolchain(
     libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
     generate_ptx_impl(
-        ll_path,
-        ptx_path,
+        PtxModule {
+            llvm_ir: ll_path,
+            output: ptx_path,
+            public_symbols,
+        },
         debug_kind,
         PtxBackend {
             options: opts,
@@ -302,8 +357,7 @@ pub(crate) fn generate_ptx_with_toolchain(
 }
 
 fn generate_ptx_impl(
-    ll_path: &Path,
-    ptx_path: &Path,
+    module: PtxModule<'_>,
     debug_kind: DebugKind,
     backend: PtxBackend<'_>,
     strict_optimization: bool,
@@ -322,7 +376,7 @@ fn generate_ptx_impl(
     let device_hint = opts.device_arch_hint.clone();
 
     let requirements = merge_generated_module_requirements(
-        detect_module_requirements_in_llvm_file(ll_path)?,
+        detect_module_requirements_in_llvm_file(module.llvm_ir)?,
         generated,
     )
     .map_err(PipelineError::PtxGeneration)?;
@@ -365,7 +419,7 @@ fn generate_ptx_impl(
     // the legacy NVVM IR path, which cannot represent f16 on pre-Blackwell.
     let linked = match libdevice_path {
         Some(lp) => Some(link_libdevice(
-            ll_path,
+            module.llvm_ir,
             lp,
             toolchain,
             diagnostic_sink,
@@ -374,7 +428,7 @@ fn generate_ptx_impl(
         )?),
         None => None,
     };
-    let post_link_input: &Path = linked.as_deref().unwrap_or(ll_path);
+    let post_link_input: &Path = linked.as_deref().unwrap_or(module.llvm_ir);
 
     // Run the LLVM middle-end (opt -O2) before llc. Feature detection above
     // intentionally reads the original (pre-opt) IR so the target is determined
@@ -396,8 +450,13 @@ fn generate_ptx_impl(
         }
         None
     } else {
-        let (optimized, mut opt_diagnostics) =
-            optimize_ll(post_link_input, toolchain, opts, strict_optimization)?;
+        let (optimized, mut opt_diagnostics) = optimize_ll(
+            post_link_input,
+            module.public_symbols,
+            toolchain,
+            opts,
+            strict_optimization,
+        )?;
         for diagnostic in opt_diagnostics.drain(..) {
             record_diagnostic(&mut diagnostics, diagnostic_sink, diagnostic);
         }
@@ -447,12 +506,12 @@ fn generate_ptx_impl(
     if !opts.no_fma {
         llc_cmd.arg("-fp-contract=fast");
     }
-    let result = llc_cmd.arg(llc_input).arg("-o").arg(ptx_path).output();
+    let result = llc_cmd.arg(llc_input).arg("-o").arg(module.output).output();
 
     match result {
         Ok(output) if output.status.success() => {
             if matches!(debug_kind, DebugKind::LineTables) {
-                strip_target_debug_from_ptx(ptx_path)?;
+                strip_target_debug_from_ptx(module.output)?;
                 if opts.verbose {
                     record_diagnostic(
                         &mut diagnostics,
@@ -587,13 +646,37 @@ mod tests {
         let opts = BackendOptions::default();
         let input = Path::new("unused.ll");
 
-        let (optimized, diagnostics) = optimize_ll(input, &toolchain, &opts, false).unwrap();
+        let (optimized, diagnostics) = optimize_ll(input, &[], &toolchain, &opts, false).unwrap();
         assert!(optimized.is_none());
         assert!(diagnostics[0].contains("continuing with unoptimized IR"));
 
-        let error = optimize_ll(input, &toolchain, &opts, true).unwrap_err();
+        let error = optimize_ll(input, &[], &toolchain, &opts, true).unwrap_err();
         assert!(matches!(&error, PipelineError::Optimization(_)));
         assert!(error.to_string().contains("opt (/bin/false) failed"));
+    }
+
+    #[test]
+    fn ptx_optimization_internalizes_helpers_but_preserves_public_roots() {
+        let symbols = vec!["constant_data".into(), "first_kernel".into()];
+        assert_eq!(
+            optimization_args(&symbols).unwrap(),
+            [
+                "-passes=internalize,default<O2>",
+                "-internalize-public-api-list=constant_data,first_kernel",
+            ]
+        );
+    }
+
+    #[test]
+    fn modules_without_public_roots_keep_the_existing_optimization_pipeline() {
+        assert_eq!(optimization_args(&[]).unwrap(), ["-O2"]);
+    }
+
+    #[test]
+    fn unrepresentable_public_root_is_rejected() {
+        let error = optimization_args(&["invalid,root".into()]).unwrap_err();
+        assert!(matches!(error, PipelineError::Optimization(_)));
+        assert!(error.to_string().contains("invalid,root"));
     }
 
     #[test]
@@ -631,6 +714,7 @@ mod tests {
         let error = generate_ptx(
             &ll_path,
             &ptx_path,
+            &[],
             DebugKind::Off,
             &opts,
             Some(collect_legacy_diagnostic),

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -234,10 +234,16 @@ struct PtxBackend<'a> {
     generated: &'a GeneratedModuleRequirements,
 }
 
-struct PtxModule<'a> {
-    llvm_ir: &'a Path,
-    output: &'a Path,
-    public_symbols: &'a [String],
+/// One module's artifact paths plus its externally consumed symbol roots.
+// mir-importer pipeline plumbing; not part of the frontend contract.
+#[doc(hidden)]
+pub struct PtxModule<'a> {
+    /// Textual LLVM IR input.
+    pub llvm_ir: &'a Path,
+    /// PTX output path.
+    pub output: &'a Path,
+    /// Symbols the internalization pass must keep external.
+    pub public_symbols: &'a [String],
 }
 
 /// Generates PTX from LLVM IR using `llc`.
@@ -260,9 +266,7 @@ struct PtxModule<'a> {
 // mir-importer pipeline plumbing; not part of the frontend contract.
 #[doc(hidden)]
 pub fn generate_ptx(
-    ll_path: &Path,
-    ptx_path: &Path,
-    public_symbols: &[String],
+    module: PtxModule<'_>,
     debug_kind: DebugKind,
     opts: &BackendOptions,
     diagnostic_sink: Option<fn(&str)>,
@@ -304,11 +308,7 @@ pub fn generate_ptx(
     }
     emit_diagnostics(diagnostic_sink, &diagnostics);
     let mut generated = generate_ptx_impl(
-        PtxModule {
-            llvm_ir: ll_path,
-            output: ptx_path,
-            public_symbols,
-        },
+        module,
         debug_kind,
         PtxBackend {
             options: opts,
@@ -329,9 +329,7 @@ pub fn generate_ptx(
 /// The experimental compiler uses this entry point so discovery is explicit
 /// and one [`LlvmToolchain`] can be reused across compilations.
 pub(crate) fn generate_ptx_with_toolchain(
-    ll_path: &Path,
-    ptx_path: &Path,
-    public_symbols: &[String],
+    module: PtxModule<'_>,
     debug_kind: DebugKind,
     opts: &BackendOptions,
     toolchain: &LlvmToolchain,
@@ -339,11 +337,7 @@ pub(crate) fn generate_ptx_with_toolchain(
     libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
     generate_ptx_impl(
-        PtxModule {
-            llvm_ir: ll_path,
-            output: ptx_path,
-            public_symbols,
-        },
+        module,
         debug_kind,
         PtxBackend {
             options: opts,
@@ -712,9 +706,11 @@ mod tests {
             ..BackendOptions::default()
         };
         let error = generate_ptx(
-            &ll_path,
-            &ptx_path,
-            &[],
+            PtxModule {
+                llvm_ir: &ll_path,
+                output: &ptx_path,
+                public_symbols: &[],
+            },
             DebugKind::Off,
             &opts,
             Some(collect_legacy_diagnostic),
@@ -922,9 +918,11 @@ mod tests {
         .unwrap();
 
         let target = generate_ptx_with_toolchain(
-            &ll_path,
-            &ptx_path,
-            &["kernel".to_string()],
+            PtxModule {
+                llvm_ir: &ll_path,
+                output: &ptx_path,
+                public_symbols: &["kernel".to_string()],
+            },
             DebugKind::Off,
             &opts,
             &toolchain,

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -924,6 +924,7 @@ mod tests {
         let target = generate_ptx_with_toolchain(
             &ll_path,
             &ptx_path,
+            &["kernel".to_string()],
             DebugKind::Off,
             &opts,
             &toolchain,

--- a/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
@@ -76,7 +76,17 @@ if [ "${1:-}" = "--version" ]; then
   echo "LLVM version 21.0.0"
   exit 0
 fi
-cp "$2" "$5"
+input=""
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; out="$1" ;;
+    -*) ;;
+    *) input="$1" ;;
+  esac
+  shift
+done
+cp "$input" "$out"
 "#,
             )
         });

--- a/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
@@ -31,7 +31,9 @@
 //!
 //! The owned module's `mark_kernel_entry` method owns this internal marker spelling.
 
-use cuda_oxide_codegen::experimental::{CodegenModule, CompileOptions, Compiler, Target};
+use cuda_oxide_codegen::experimental::{
+    CodegenModule, CompileOptions, Compiler, Optimization, Target,
+};
 
 use dialect_mir::ops::{
     MirAddOp, MirFuncOp, MirLoadOp, MirMulOp, MirPtrOffsetOp, MirReturnOp, MirStoreOp,
@@ -235,10 +237,45 @@ fn build_add_kernel(module: &mut CodegenModule) {
     module.mark_kernel_entry("add_kernel").unwrap();
 }
 
+fn build_unused_helper(module: &mut CodegenModule) {
+    module.edit(|ctx, module| {
+        let module_region = module.get_operation().deref(ctx).get_region(0);
+        let module_block = module_region
+            .deref(ctx)
+            .iter(ctx)
+            .next()
+            .expect("kernel builder created the module block");
+        let func_type = FunctionType::get(ctx, vec![], vec![]);
+        let op = Operation::new(
+            ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let helper = MirFuncOp::new(ctx, op, TypeAttr::new(func_type.into()));
+        helper.set_symbol_name(ctx, "unused_helper".try_into().unwrap());
+        let entry = BasicBlock::new(ctx, None, vec![]);
+        entry.insert_at_back(op.deref(ctx).get_region(0), ctx);
+        Operation::new(
+            ctx,
+            MirReturnOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        )
+        .insert_at_back(entry, ctx);
+        helper.get_operation().insert_at_back(module_block, ctx);
+    });
+}
+
 #[test]
 fn spine_add_kernel_emits_entry_and_validates() {
     let mut module = CodegenModule::new("spine_module").unwrap();
     build_add_kernel(&mut module);
+    build_unused_helper(&mut module);
     let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
     let options = CompileOptions::new(Target::parse("sm_120").unwrap());
     let ptx = compiler
@@ -254,6 +291,25 @@ fn spine_add_kernel_emits_entry_and_validates() {
     assert!(
         text.contains(".target sm_120"),
         "PTX targets sm_120:\n{text}"
+    );
+    assert!(text.contains("add_kernel"), "kernel root survives:\n{text}");
+    assert!(
+        !text.contains("unused_helper"),
+        "optimized PTX removes the non-root helper:\n{text}"
+    );
+
+    let no_opt = compiler
+        .compile(
+            &mut module,
+            &CompileOptions::new(Target::parse("sm_120").unwrap())
+                .with_optimization(Optimization::None),
+        )
+        .expect("compiles unoptimized PTX")
+        .into_ptx();
+    let no_opt = String::from_utf8(no_opt).expect("PTX is utf-8");
+    assert!(
+        no_opt.contains("unused_helper"),
+        "no-opt PTX demonstrates that helper removal comes from the optimizer:\n{no_opt}"
     );
 
     // ptxas must accept it for the real target.

--- a/crates/llvm-export/src/export/config.rs
+++ b/crates/llvm-export/src/export/config.rs
@@ -110,7 +110,7 @@ impl ExportBackendConfig for PtxExportConfig {
     }
 
     fn emit_llvm_used(&self) -> bool {
-        false
+        true
     }
 
     fn emit_nvvmir_version(&self) -> bool {

--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -788,7 +788,6 @@ mod tests {
         };
         let state = ModuleExportState::new(
             &ctx,
-            false,
             true,
             super::super::config::DebugKind::LineTables,
             None,

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -105,7 +105,9 @@ impl<'a> ModuleExportState<'a> {
             self.export_type(ty, output)?;
             writeln!(output, ", align {alignment}").unwrap();
         } else {
-            // Internal linkage: static storage in the global's address space.
+            self.public_globals.push(name.to_string());
+            // Defined static storage in the global's address space. The LLVM
+            // definition retains external linkage for host-side symbol lookup.
             write!(output, "@{name} = addrspace({address_space}) global ").unwrap();
             self.export_type(ty, output)?;
             if let Some(hex) = global.initializer_hex(self.ctx) {
@@ -244,8 +246,9 @@ impl<'a> ModuleExportState<'a> {
 
         self.function_types.insert(fixed_func_name.clone(), ft);
 
-        // Track ALL kernels if backend requires annotations for every kernel.
-        if is_kernel && self.track_all_kernels {
+        // Track every kernel as an external root. Backends independently decide
+        // whether to emit annotations for all of them.
+        if is_kernel {
             self.all_kernels.push(KernelInfo {
                 name: fixed_func_name.clone(),
             });

--- a/crates/llvm-export/src/export/metadata.rs
+++ b/crates/llvm-export/src/export/metadata.rs
@@ -154,7 +154,7 @@ mod tests {
     use pliron::context::Context;
 
     fn test_state<'a>(ctx: &'a Context) -> ModuleExportState<'a> {
-        ModuleExportState::new(ctx, true, false, DebugKind::Off, None)
+        ModuleExportState::new(ctx, false, DebugKind::Off, None)
     }
 
     #[test]

--- a/crates/llvm-export/src/export/mod.rs
+++ b/crates/llvm-export/src/export/mod.rs
@@ -55,6 +55,18 @@ pub use externs::{AsDeviceExtern, DeviceExternAttrs, DeviceExternDecl, DeviceExt
 
 use pliron::{builtin::ops::ModuleOp, context::Context};
 
+/// Textual LLVM IR plus the exporter-derived symbols consumed outside the
+/// module. The optimizer uses this semantic root set instead of reparsing the
+/// rendered LLVM syntax.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExportedModule {
+    /// Rendered LLVM IR.
+    pub llvm_ir: String,
+    /// Kernel entries, standalone device exports, and defined globals whose
+    /// external linkage must survive optimization.
+    pub public_symbols: Vec<String>,
+}
+
 /// Export a module op to a String containing LLVM IR.
 ///
 /// Uses default PTX export mode. For alternate backends, use [`export_module_to_string_with_config`].
@@ -76,6 +88,17 @@ pub fn export_module_with_externs<T: AsDeviceExtern>(
     device_externs: &[T],
     config: &dyn ExportBackendConfig,
 ) -> Result<String, String> {
+    export_module_with_externs_and_roots(ctx, module, device_externs, config)
+        .map(|exported| exported.llvm_ir)
+}
+
+/// Export a module together with its semantic external-root set.
+pub fn export_module_with_externs_and_roots<T: AsDeviceExtern>(
+    ctx: &Context,
+    module: &ModuleOp,
+    device_externs: &[T],
+    config: &dyn ExportBackendConfig,
+) -> Result<ExportedModule, String> {
     let externs: Vec<DeviceExternDecl> = device_externs
         .iter()
         .map(|e| e.as_device_extern())

--- a/crates/llvm-export/src/export/module.rs
+++ b/crates/llvm-export/src/export/module.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 use super::{
+    ExportedModule,
     config::{DebugKind, ExportBackendConfig, NvvmIrDialect},
     externs::{DeviceExternDecl, DeviceExternType},
     metadata::{emit_nvvm_annotations, emit_nvvmir_version, needs_nvvm_annotations},
@@ -371,14 +372,13 @@ pub(super) fn export_module_with_externs_impl(
     module: &ModuleOp,
     device_externs: &[DeviceExternDecl],
     config: &dyn ExportBackendConfig,
-) -> Result<String, String> {
+) -> Result<ExportedModule, String> {
     validate_export_config(config)?;
     let mut output = String::new();
     let emit_all_annotations = config.emit_all_kernel_annotations();
     let emit_ptx_kernel_keyword = config.emit_ptx_kernel_keyword();
     let mut state = ModuleExportState::new(
         ctx,
-        emit_all_annotations,
         emit_ptx_kernel_keyword,
         config.debug_kind(),
         config.nvvm_ir_dialect(),
@@ -536,7 +536,26 @@ pub(super) fn export_module_with_externs_impl(
     }
 
     verify_legacy_text(&output, &state)?;
-    Ok(output)
+    Ok(ExportedModule {
+        llvm_ir: output,
+        public_symbols: public_symbols(&state),
+    })
+}
+
+fn public_symbols(state: &ModuleExportState<'_>) -> Vec<String> {
+    let mut symbols = if state.all_kernels.is_empty() {
+        state.device_functions.clone()
+    } else {
+        state
+            .all_kernels
+            .iter()
+            .map(|kernel| kernel.name.clone())
+            .collect()
+    };
+    symbols.extend(state.public_globals.iter().cloned());
+    symbols.sort_unstable();
+    symbols.dedup();
+    symbols
 }
 
 /// Export a module op to a String containing LLVM IR with custom backend configuration.
@@ -554,7 +573,6 @@ pub(super) fn export_module_to_string_with_config(
     let emit_ptx_kernel_keyword = config.emit_ptx_kernel_keyword();
     let mut state = ModuleExportState::new(
         ctx,
-        emit_all_annotations,
         emit_ptx_kernel_keyword,
         config.debug_kind(),
         config.nvvm_ir_dialect(),

--- a/crates/llvm-export/src/export/module.rs
+++ b/crates/llvm-export/src/export/module.rs
@@ -166,16 +166,26 @@ fn validate_device_extern_function_shape(
     Ok(())
 }
 
+/// Names of the module's externally consumed function definitions: kernel
+/// entries plus `#[device]` exports. One shared list feeds both `@llvm.used`
+/// emission and the internalization public-API list so the two root sets can
+/// never drift apart. The union (rather than kernels-else-device-functions)
+/// keeps a `#[device]` export visible even when the module also has kernels;
+/// anonymous helpers carry neither marker and stay internalizable.
+fn root_function_names<'a>(state: &'a ModuleExportState<'_>) -> Vec<&'a str> {
+    let mut names: Vec<&str> = state
+        .all_kernels
+        .iter()
+        .map(|kernel| kernel.name.as_str())
+        .chain(state.device_functions.iter().map(String::as_str))
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
 fn emit_llvm_used(output: &mut String, state: &ModuleExportState<'_>) -> Result<(), String> {
-    let names: Vec<&str> = if !state.all_kernels.is_empty() {
-        state
-            .all_kernels
-            .iter()
-            .map(|kernel| kernel.name.as_str())
-            .collect()
-    } else {
-        state.device_functions.iter().map(String::as_str).collect()
-    };
+    let names = root_function_names(state);
     if names.is_empty() {
         return Ok(());
     }
@@ -543,15 +553,10 @@ pub(super) fn export_module_with_externs_impl(
 }
 
 fn public_symbols(state: &ModuleExportState<'_>) -> Vec<String> {
-    let mut symbols = if state.all_kernels.is_empty() {
-        state.device_functions.clone()
-    } else {
-        state
-            .all_kernels
-            .iter()
-            .map(|kernel| kernel.name.clone())
-            .collect()
-    };
+    let mut symbols: Vec<String> = root_function_names(state)
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
     symbols.extend(state.public_globals.iter().cloned());
     symbols.sort_unstable();
     symbols.dedup();

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -57,12 +57,13 @@ pub(super) struct ModuleExportState<'a> {
     pub(super) launch_bounds_kernels: Vec<KernelLaunchBounds>,
     /// Track ALL kernels (for backends that require annotations for every kernel)
     pub(super) all_kernels: Vec<KernelInfo>,
-    /// Whether to track all kernels (set by backend config)
-    pub(super) track_all_kernels: bool,
     /// Whether to print `ptx_kernel` on kernel definitions.
     pub(super) emit_ptx_kernel_keyword: bool,
     /// Track device function names for @llvm.used (standalone device fn compilation)
     pub(super) device_functions: Vec<String>,
+    /// Defined globals retain external linkage because CUDA host code can
+    /// resolve them by name (for example through `cuModuleGetGlobal`).
+    pub(super) public_globals: Vec<String>,
     /// Emitted function signatures keyed by their final, prefix-stripped name.
     pub(super) function_types: FxHashMap<String, TypeHandle>,
     /// Original pliron symbol spelling for each final exported function name.
@@ -133,7 +134,6 @@ pub(super) struct ResolvedDebugScope {
 impl<'a> ModuleExportState<'a> {
     pub(super) fn new(
         ctx: &'a pliron::context::Context,
-        track_all_kernels: bool,
         emit_ptx_kernel_keyword: bool,
         debug_kind: DebugKind,
         nvvm_ir_dialect: Option<NvvmIrDialect>,
@@ -144,9 +144,9 @@ impl<'a> ModuleExportState<'a> {
             cluster_kernels: Vec::new(),
             launch_bounds_kernels: Vec::new(),
             all_kernels: Vec::new(),
-            track_all_kernels,
             emit_ptx_kernel_keyword,
             device_functions: Vec::new(),
+            public_globals: Vec::new(),
             function_types: FxHashMap::default(),
             function_source_names: FxHashMap::default(),
             function_definitions: HashSet::new(),

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -9,6 +9,7 @@ use llvm_export::{
         DebugKind, DeviceExternAttrs, DeviceExternDecl, DeviceExternType, ExportBackendConfig,
         NvvmExportConfig, NvvmIrDialect, PtxExportConfig, export_module_to_string,
         export_module_to_string_with_config, export_module_with_externs,
+        export_module_with_externs_and_roots,
     },
     op_interfaces::CastOpInterface,
     ops::{
@@ -1230,6 +1231,80 @@ fn legacy_kernel_metadata_uses_typed_function_references() {
     assert!(
         ir.contains("!{void (i8*)* @metadata_kernel, !\"kernel\", i32 1}"),
         "{ir}"
+    );
+}
+
+#[test]
+fn ptx_export_records_kernel_roots_for_internalization() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "ptx_roots".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let global = GlobalOp::new(&mut ctx, "COEFFS".try_into().unwrap(), i32_ty.into());
+    global.set_address_space(&mut ctx, 4);
+    global.get_operation().insert_at_back(module_block, &ctx);
+    let func_ty = FuncType::get(&ctx, VoidType::get(&ctx).into(), vec![], false);
+    let func = FuncOp::new(&mut ctx, "entry_kernel".try_into().unwrap(), func_ty);
+    func.get_operation().deref_mut(&ctx).attributes.set(
+        "gpu_kernel".try_into().unwrap(),
+        StringAttr::new("true".into()),
+    );
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let exported = export_module_with_externs_and_roots::<DeviceExternDecl>(
+        &ctx,
+        &module,
+        &[],
+        &PtxExportConfig,
+    )
+    .expect("PTX export succeeds");
+    let ir = exported.llvm_ir;
+    assert!(
+        ir.contains(
+            "@llvm.used = appending global [1 x ptr] [ptr @entry_kernel], section \"llvm.metadata\""
+        ),
+        "{ir}"
+    );
+    assert_eq!(exported.public_symbols, ["COEFFS", "entry_kernel"]);
+}
+
+#[test]
+fn ptx_export_records_standalone_device_function_roots_for_internalization() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "ptx_device_root".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+    let func_ty = FuncType::get(&ctx, VoidType::get(&ctx).into(), vec![], false);
+    let func = FuncOp::new(
+        &mut ctx,
+        "cuda_oxide_device_246e25db_standalone_export"
+            .try_into()
+            .unwrap(),
+        func_ty,
+    );
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let exported = export_module_with_externs_and_roots::<DeviceExternDecl>(
+        &ctx,
+        &module,
+        &[],
+        &PtxExportConfig,
+    )
+    .expect("standalone PTX export succeeds");
+    assert_eq!(exported.public_symbols, ["standalone_export"]);
+    assert!(
+        exported.llvm_ir.contains(
+            "@llvm.used = appending global [1 x ptr] [ptr @standalone_export], section \"llvm.metadata\""
+        ),
+        "{}",
+        exported.llvm_ir
     );
 }
 

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -1282,13 +1282,19 @@ run_cargo() {
     fi
     if [[ ${CARGO_EC} -eq 0 && ${COMPILE_ONLY} -eq 1 && "${ex}" == "helper_fn" ]]; then
         local ptx="crates/rustc-codegen-cuda/examples/${ex}/${ex}.ptx"
+        local llvm="crates/rustc-codegen-cuda/examples/${ex}/${ex}.ll"
         local nested_defs entry_count
-        nested_defs="$(grep -cE '^\.visible \.func .*_RI.*nested_identity' "${ptx}" 2>/dev/null)"
+        # The nested helpers are private, so the middle-end internalizes,
+        # inlines, and deletes them from the optimized PTX. Their canonical
+        # mangling and non-kernel classification (the #358 regression) are
+        # pinned in the pre-opt LLVM IR; the PTX pins the single kernel entry.
+        nested_defs="$(grep -cE '^define .*_RI.*nested_identity' "${llvm}" 2>/dev/null)"
         entry_count="$(grep -cE '^\.visible \.entry ' "${ptx}" 2>/dev/null)"
-        if [[ ! -s "${ptx}" || ${nested_defs} -ne 2 || ${entry_count} -ne 1 ]] \
+        if [[ ! -s "${ptx}" || ! -s "${llvm}" || ${nested_defs} -ne 2 || ${entry_count} -ne 1 ]] \
             || ! grep -qF '.visible .entry vecadd_with_helper(' "${ptx}" \
+            || grep -qE '(nested_identity.*_TID_|_TID_.*nested_identity)' "${llvm}" \
             || grep -qE '(nested_identity.*_TID_|_TID_.*nested_identity)' "${ptx}"; then
-            printf 'helper_fn expected one kernel entry and two canonically mangled nested_identity device functions, with no helper _TID_ exports\n' >>"${log}"
+            printf 'helper_fn expected one kernel entry, two canonically mangled nested_identity helpers in the pre-opt LLVM IR, and no _TID_ helper symbols\n' >>"${log}"
             CARGO_EC=1
         fi
     fi


### PR DESCRIPTION
Closes #386.

## Summary

Make LLVM's optimized PTX pipeline internalize compiler-private device helpers so ordinary inlining and GlobalDCE can remove their unused definitions. Preserve the module's exporter-derived public ABI, including kernel entries, standalone device-function roots, and defined globals.

```text
Before: fully inlined helpers can remain as `.visible .func` definitions in optimized PTX
After:  private helper definitions are removed while public functions and globals remain visible
```

## What changed

### Semantic public roots

- Return rendered LLVM and its public-symbol set together as a typed `ExportedModule`.
- Derive roots from exporter state: kernel entries or standalone device-function roots, plus every defined global.
- Sort and deduplicate the root list before carrying it through the compilation pipeline; rendered LLVM text is never reparsed to recover visibility.

### PTX optimization

- Run `internalize,default<O2>` with the explicit public API list when roots are available.
- Retain the existing `-O2` path for modules without roots and leave no-opt compilation unchanged.
- Reject a symbol that cannot be represented in LLVM's comma-separated API-list argument rather than silently optimizing with an incomplete root set.

### Correctness hardening

- Preserve host-resolved constants and other defined globals at their historical external linkage.
- Add a real optimizer/llc regression proving that a non-root helper is removed only in the optimized artifact while the kernel survives.
- Exercise constant-memory lookup and execution on the GPU after optimization.

## Known separate limitations

- This change does not add new inlining or loop-unrolling policy; it only permits LLVM to delete private definitions after existing optimization makes them unreachable.
- The current IR does not distinguish host-exported globals from compiler-private globals, so all defined globals are conservatively retained.

## Testing

- `cargo oxide fmt --check`
- `cargo test -p llvm-export` — 26 unit tests, 46 export integration tests, and 3 operation tests passed
- `cargo test -p cuda-oxide-codegen` — 59 unit tests, 10 `compile_to_ptx` tests, concurrent and spine integrations, and 1 doctest passed
- `cargo clippy -p llvm-export -p cuda-oxide-codegen --all-targets -- -D warnings`
- Real `opt`/`llc` artifact regression: optimized PTX retains `add_kernel` and removes `unused_helper`; no-opt PTX retains the helper
- RTX 3080 (`sm_86`): optimized `constant_memory` successfully looked up, populated, and read its host-visible constant across two launches
- RTX 3080 (`sm_86`): optimized and no-opt `array_for_loop` runs passed during branch preparation

## Checklist

- [x] Branch rebased onto current `upstream/main`
- [x] Correctness claim covered by focused regressions
- [x] Unsupported root serialization fails clearly
- [x] Optimized and unoptimized behavior verified
- [x] Host-visible global behavior verified on GPU

<!-- impulse-cuda-upstream:internalize-ptx-helpers:pr -->