### PR TITLE
fix(mir-lower): keep scalar float math on the LLVM-to-PTX path

### DIFF
--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -460,9 +460,10 @@ pub fn compile_translated_module(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct PreLoweringBackendSelection {
     /// Whether the lowered module will contain CUDA libdevice (`__nv_*`)
-    /// calls under the selected intrinsic backend. Rounding placeholders
-    /// count only when the LibNvvm backend is selected; on the NVPTX path
-    /// they lower to native LLVM intrinsics instead.
+    /// calls under the selected intrinsic backend. Rounding and sign
+    /// (`fabs`/`copysign`) placeholders count only when the LibNvvm backend
+    /// is selected; on the NVPTX path they lower to native LLVM intrinsics
+    /// instead.
     needs_libdevice: bool,
     /// Whether the pipeline must stop at NVVM IR instead of invoking `llc`.
     emit_nvvm_ir: bool,
@@ -484,14 +485,18 @@ fn select_pre_lowering_backend(
     //
     // * strict: calls that lower to `__nv_*` under every intrinsic backend
     //   (direct `__nv_*` externs and the transcendental-family placeholders);
-    // * backend-dependent: the rounding placeholders, which lower to native
-    //   LLVM intrinsics on the NVPTX path and fall back to libdevice only
-    //   when the module is emitted as NVVM IR (the legacy LLVM 7 dialect has
-    //   no `llvm.roundeven.*`).
+    // * backend-dependent: the rounding and sign (`fabs`/`copysign`)
+    //   placeholders, which lower to native LLVM intrinsics on the NVPTX
+    //   path and fall back to libdevice only when the module is emitted as
+    //   NVVM IR (the legacy LLVM 7 dialect has no `llvm.roundeven.*`).
+    //
+    // The float `max`/`min` placeholders are in neither flavor: they expand
+    // to an ordered compare/select under every backend and never produce a
+    // `__nv_*` call.
     //
     // Only strict use participates in the emit-NVVM-IR decision; otherwise a
-    // rounding-only kernel would drag in the libNVVM dependency it no longer
-    // needs.
+    // kernel using only rounding or sign ops would drag in the libNVVM
+    // dependency it no longer needs.
     let uses_strict_libdevice =
         typed_mir_uses_libdevice(ctx, module) || module_uses_libdevice(ctx, module);
     let uses_backend_dependent_libdevice = typed_mir_calls_match(
@@ -507,9 +512,9 @@ fn select_pre_lowering_backend(
         mir_lower::IntrinsicBackend::LlvmNvptx
     };
     // Predict the `__nv_*` symbols the lowered module will actually contain,
-    // for the post-lowering consistency check: rounding placeholders lower to
-    // `__nv_*` precisely when the LibNvvm backend was chosen (and LibNvvm is
-    // chosen exactly when NVVM IR is emitted).
+    // for the post-lowering consistency check: rounding and sign placeholders
+    // lower to `__nv_*` precisely when the LibNvvm backend was chosen (and
+    // LibNvvm is chosen exactly when NVVM IR is emitted).
     let needs_libdevice =
         uses_strict_libdevice || (emit_nvvm_ir && uses_backend_dependent_libdevice);
 
@@ -569,9 +574,10 @@ fn typed_mir_calls_match(
 /// pre-Blackwell targets.
 ///
 /// Only strict libdevice use (transcendentals and direct `__nv_*` calls) is
-/// consulted. Rounding intrinsics never force the NVVM fallback: on the PTX
-/// path they lower to native LLVM intrinsics with no libdevice involvement,
-/// and they use libdevice only when NVVM IR is emitted for another reason.
+/// consulted. Rounding and sign intrinsics never force the NVVM fallback: on
+/// the PTX path they lower to native LLVM intrinsics with no libdevice
+/// involvement, and they use libdevice only when NVVM IR is emitted for
+/// another reason. Float `max`/`min` never involve libdevice at all.
 fn should_emit_nvvm_ir(
     policy: OutputPolicy,
     uses_strict_libdevice: bool,
@@ -808,6 +814,71 @@ mod tests {
         assert!(selection.emit_nvvm_ir);
         assert_eq!(
             selection.intrinsic_backend,
+            mir_lower::IntrinsicBackend::LibNvvm
+        );
+    }
+
+    /// The sign placeholders (`fabs`/`copysign`) are backend-dependent like
+    /// rounding, and the float `max`/`min` placeholders never use libdevice
+    /// at all: a module using only these ops must stay on the
+    /// self-sufficient PTX path with no libdevice prediction.
+    #[test]
+    fn sign_and_minmax_only_module_stays_on_self_sufficient_ptx_path() {
+        let mut ctx = Context::new();
+        let module = typed_mir_test_module(
+            &mut ctx,
+            &[
+                dialect_mir::rust_intrinsics::CALLEE_FABS,
+                dialect_mir::rust_intrinsics::CALLEE_COPYSIGN_F32,
+                dialect_mir::rust_intrinsics::CALLEE_MAXNUM_NSZ_F32,
+                dialect_mir::rust_intrinsics::CALLEE_MINNUM_NSZ_F64,
+            ],
+        );
+        for can_ir_link_libdevice in [false, true] {
+            let selection = select_pre_lowering_backend(
+                &ctx,
+                module,
+                OutputPolicy::ExternalLinkAllowed {
+                    request_nvvm_ir: false,
+                },
+                can_ir_link_libdevice,
+            );
+            assert!(!selection.needs_libdevice);
+            assert!(!selection.emit_nvvm_ir);
+            assert_eq!(
+                selection.intrinsic_backend,
+                mir_lower::IntrinsicBackend::LlvmNvptx
+            );
+        }
+    }
+
+    /// Under an explicit NVVM IR request the sign placeholders fall back to
+    /// `__nv_fabsf`/`__nv_copysignf` (so libdevice must be predicted), while
+    /// `max`/`min` expand to compare/select under every backend and
+    /// contribute nothing to the prediction.
+    #[test]
+    fn sign_module_needs_libdevice_under_nvvm_ir_but_minmax_never_does() {
+        let mut ctx = Context::new();
+        let nvvm_requested = OutputPolicy::ExternalLinkAllowed {
+            request_nvvm_ir: true,
+        };
+
+        let sign_module =
+            typed_mir_test_module(&mut ctx, &[dialect_mir::rust_intrinsics::CALLEE_FABS]);
+        let sign = select_pre_lowering_backend(&ctx, sign_module, nvvm_requested, false);
+        assert!(sign.needs_libdevice);
+        assert!(sign.emit_nvvm_ir);
+        assert_eq!(sign.intrinsic_backend, mir_lower::IntrinsicBackend::LibNvvm);
+
+        let minmax_module = typed_mir_test_module(
+            &mut ctx,
+            &[dialect_mir::rust_intrinsics::CALLEE_MAXNUM_NSZ_F32],
+        );
+        let minmax = select_pre_lowering_backend(&ctx, minmax_module, nvvm_requested, false);
+        assert!(!minmax.needs_libdevice);
+        assert!(minmax.emit_nvvm_ir);
+        assert_eq!(
+            minmax.intrinsic_backend,
             mir_lower::IntrinsicBackend::LibNvvm
         );
     }

--- a/crates/dialect-mir/src/rust_intrinsics.rs
+++ b/crates/dialect-mir/src/rust_intrinsics.rs
@@ -228,11 +228,20 @@ pub const CALLEE_SELECT_UNPREDICTABLE: &str = placeholder!("select_unpredictable
 /// `f*_fast` intrinsics, so matching the common placeholder prefix would select
 /// the libNVVM backend for modules that do not need it.
 ///
-/// The rounding placeholders (`floor`/`ceil`/`trunc`/`round`/`roundeven`) are
-/// intentionally NOT in this list: on the LLVM NVPTX path they lower to the
-/// native `llvm.floor.*`-family intrinsics and need no libdevice at all. They
-/// fall back to libdevice only when the pipeline emits NVVM IR; see
+/// The rounding placeholders (`floor`/`ceil`/`trunc`/`round`/`roundeven`)
+/// and the sign placeholders (`fabs`/`copysign`) are intentionally NOT in
+/// this list: on the LLVM NVPTX path they lower to the native
+/// `llvm.floor.*`-family / `llvm.fabs.*` / `llvm.copysign.*` intrinsics and
+/// need no libdevice at all. They fall back to libdevice only when the
+/// pipeline emits NVVM IR; see
 /// [`is_backend_dependent_libdevice_placeholder`].
+///
+/// The `max`/`min` placeholders (`maximum_number_nsz_*` /
+/// `minimum_number_nsz_*`) are in NEITHER list: they lower to an ordered
+/// compare/select expansion under every intrinsic backend, so they never
+/// produce a `__nv_*` call. (`llvm.maxnum`/`llvm.minnum` are unusable
+/// because under LLVM 21 they propagate signaling NaNs, contradicting
+/// Rust's ignore-any-NaN contract; see #390.)
 pub fn is_libdevice_backed_placeholder(callee: &str) -> bool {
     matches!(
         callee,
@@ -262,13 +271,6 @@ pub fn is_libdevice_backed_placeholder(callee: &str) -> bool {
             | CALLEE_FMA_F64
             | CALLEE_FMULADD_F32
             | CALLEE_FMULADD_F64
-            | CALLEE_FABS
-            | CALLEE_COPYSIGN_F32
-            | CALLEE_COPYSIGN_F64
-            | CALLEE_MAXNUM_NSZ_F32
-            | CALLEE_MAXNUM_NSZ_F64
-            | CALLEE_MINNUM_NSZ_F32
-            | CALLEE_MINNUM_NSZ_F64
             | CALLEE_ASIN_F32
             | CALLEE_ASIN_F64
             | CALLEE_ACOS_F32
@@ -300,9 +302,12 @@ pub fn is_libdevice_backed_placeholder(callee: &str) -> bool {
 /// The rounding placeholders lower to the native LLVM intrinsics
 /// (`llvm.floor.*`, `llvm.ceil.*`, `llvm.trunc.*`, `llvm.round.*`,
 /// `llvm.roundeven.*`) when the module is headed to LLVM's NVPTX backend, so
-/// on that path they need no libdevice at all. When the pipeline emits NVVM
-/// IR instead, the same placeholders fall back to `__nv_floorf`/... libdevice
-/// calls, because the legacy LLVM 7-based NVVM IR dialect predates
+/// on that path they need no libdevice at all. The sign placeholders
+/// (`fabs`/`copysign`) take the same route via `llvm.fabs.*` /
+/// `llvm.copysign.*`, which the NVPTX backend selects to single PTX
+/// `abs`/`copysign` instructions. When the pipeline emits NVVM IR instead,
+/// the same placeholders fall back to `__nv_floorf`/`__nv_fabsf`/...
+/// libdevice calls, because the legacy LLVM 7-based NVVM IR dialect predates
 /// `llvm.roundeven.*` (added in LLVM 11) and admits only a small intrinsic
 /// allow-list.
 ///
@@ -323,6 +328,9 @@ pub fn is_backend_dependent_libdevice_placeholder(callee: &str) -> bool {
             | CALLEE_ROUND_F64
             | CALLEE_ROUNDEVEN_F32
             | CALLEE_ROUNDEVEN_F64
+            | CALLEE_FABS
+            | CALLEE_COPYSIGN_F32
+            | CALLEE_COPYSIGN_F64
     )
 }
 
@@ -331,7 +339,7 @@ mod tests {
     use super::*;
 
     /// Every placeholder that must be classified as libdevice-backed under
-    /// every intrinsic backend (transcendentals, fma, sign ops, max/min).
+    /// every intrinsic backend (transcendentals and fma).
     const ALWAYS_LIBDEVICE: &[&str] = &[
         CALLEE_SQRT_F32,
         CALLEE_SQRT_F64,
@@ -359,13 +367,6 @@ mod tests {
         CALLEE_FMA_F64,
         CALLEE_FMULADD_F32,
         CALLEE_FMULADD_F64,
-        CALLEE_FABS,
-        CALLEE_COPYSIGN_F32,
-        CALLEE_COPYSIGN_F64,
-        CALLEE_MAXNUM_NSZ_F32,
-        CALLEE_MAXNUM_NSZ_F64,
-        CALLEE_MINNUM_NSZ_F32,
-        CALLEE_MINNUM_NSZ_F64,
         CALLEE_ASIN_F32,
         CALLEE_ASIN_F64,
         CALLEE_ACOS_F32,
@@ -391,7 +392,7 @@ mod tests {
     ];
 
     /// Every placeholder that is libdevice-backed only under the libNVVM
-    /// intrinsic backend (exactly the ten rounding ops).
+    /// intrinsic backend (the ten rounding ops plus the three sign ops).
     const LIBNVVM_ONLY_LIBDEVICE: &[&str] = &[
         CALLEE_FLOOR_F32,
         CALLEE_FLOOR_F64,
@@ -403,10 +404,19 @@ mod tests {
         CALLEE_ROUND_F64,
         CALLEE_ROUNDEVEN_F32,
         CALLEE_ROUNDEVEN_F64,
+        CALLEE_FABS,
+        CALLEE_COPYSIGN_F32,
+        CALLEE_COPYSIGN_F64,
     ];
 
-    /// Callees that never lower to libdevice under any backend.
+    /// Callees that never lower to libdevice under any backend. `max`/`min`
+    /// sit here because they expand to an ordered compare/select under every
+    /// intrinsic backend (see #390).
     const NEVER_LIBDEVICE: &[&str] = &[
+        CALLEE_MAXNUM_NSZ_F32,
+        CALLEE_MAXNUM_NSZ_F64,
+        CALLEE_MINNUM_NSZ_F32,
+        CALLEE_MINNUM_NSZ_F64,
         CALLEE_ROTATE_LEFT,
         CALLEE_ROTATE_RIGHT,
         CALLEE_CTPOP,

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -69,7 +69,9 @@ use crate::helpers;
 use dialect_mir::ops::{MirCallOp, MirFuncOp};
 use dialect_mir::rust_intrinsics;
 use dialect_mir::types::{MirDisjointSliceType, MirSliceType, MirStructType, MirTupleType};
-use llvm_export::attributes::{FastmathFlags, FastmathFlagsAttr, IntegerOverflowFlagsAttr};
+use llvm_export::attributes::{
+    FCmpPredicateAttr, FastmathFlags, FastmathFlagsAttr, IntegerOverflowFlagsAttr,
+};
 use llvm_export::op_interfaces::{
     BinArithOp, CastOpInterface, CastOpWithNNegInterface, FloatBinArithOpWithFastMathFlags,
     IntBinArithOpWithOverflowFlag,
@@ -338,6 +340,15 @@ impl RustFloatMathIntrinsic {
         }
     }
 
+    /// Whether this is Rust's NaN-ignoring scalar maximum/minimum operation.
+    fn minmax_nsz_predicate(self) -> Option<FCmpPredicateAttr> {
+        match self {
+            Self::MaxNumNszF32 | Self::MaxNumNszF64 => Some(FCmpPredicateAttr::OGE),
+            Self::MinNumNszF32 | Self::MinNumNszF64 => Some(FCmpPredicateAttr::OLE),
+            _ => None,
+        }
+    }
+
     /// CUDA libdevice function name for this Rust math intrinsic.
     fn libdevice_name(
         self,
@@ -457,8 +468,8 @@ impl RustFloatMathIntrinsic {
         }
     }
 
-    /// Return the LLVM intrinsic name for rounding operations, which can bypass
-    /// libdevice.
+    /// Return the LLVM intrinsic name for operations that can bypass
+    /// libdevice: the rounding family plus `fabs` and `copysign`.
     ///
     /// The NVPTX backend selects these without a libdevice call. Measured with
     /// LLVM 21.1 `llc -march=nvptx64 -mcpu=sm_80`, counting only the body:
@@ -470,6 +481,8 @@ impl RustFloatMathIntrinsic {
     /// | `trunc` | `cvt.rzi` | 1 |
     /// | `roundeven` | `cvt.rni` | 1 |
     /// | `round` | expanded sequence | 11 (f32), 8 (f64) |
+    /// | `fabs` | `abs` | 1 |
+    /// | `copysign` | `copysign` | 1 |
     ///
     /// `round` is the one exception, and deliberately so. It rounds halfway
     /// cases away from zero, which is not one of the four hardware `cvt` modes
@@ -481,32 +494,43 @@ impl RustFloatMathIntrinsic {
     /// Using LLVM intrinsics avoids a libdevice function call and removes the
     /// libNVVM dependency for kernels that only use these operations.
     ///
-    /// Scope: this covers rounding only. `fabs` and `copysign` take the same
-    /// route but are left to #391, which moves them off libdevice as part of a
-    /// broader change that also handles `max`/`min`. `max`/`min` cannot use
+    /// Scope: `max`/`min` deliberately return `None` here. They cannot use
     /// `llvm.maxnum`/`llvm.minnum` at all, because under LLVM 21 those
-    /// propagate signaling NaNs and so contradict Rust's contract; #391 lowers
-    /// them as an ordered compare/select instead (see #390).
+    /// propagate signaling NaNs and so contradict Rust's contract; they lower
+    /// as an ordered compare/select instead (`lower_float_minmax_nsz`, see
+    /// #390) and never reach this table.
     ///
     /// Naming: pliron identifiers cannot contain dots, so intrinsic symbols
     /// use the underscore encoding (`llvm_floor_f32`) that the textual `.ll`
     /// exporter decodes back to the dotted LLVM name (`llvm.floor.f32`),
     /// exactly like the `llvm_ctpop_i*` bit-intrinsic family above.
-    fn llvm_intrinsic_name(self) -> Option<&'static str> {
+    fn llvm_intrinsic_name(
+        self,
+        ctx: &Context,
+        result_ty: TypeHandle,
+        loc: pliron::location::Location,
+    ) -> Result<Option<&'static str>> {
         match self {
             // Rounding: each maps to a single PTX `cvt` instruction, except
             // `round`; see the note above.
-            Self::FloorF32 => Some("llvm_floor_f32"),
-            Self::FloorF64 => Some("llvm_floor_f64"),
-            Self::CeilF32 => Some("llvm_ceil_f32"),
-            Self::CeilF64 => Some("llvm_ceil_f64"),
-            Self::TruncF32 => Some("llvm_trunc_f32"),
-            Self::TruncF64 => Some("llvm_trunc_f64"),
-            Self::RoundF32 => Some("llvm_round_f32"),
-            Self::RoundF64 => Some("llvm_round_f64"),
-            Self::RoundevenF32 => Some("llvm_roundeven_f32"),
-            Self::RoundevenF64 => Some("llvm_roundeven_f64"),
-            _ => None,
+            Self::FloorF32 => Ok(Some("llvm_floor_f32")),
+            Self::FloorF64 => Ok(Some("llvm_floor_f64")),
+            Self::CeilF32 => Ok(Some("llvm_ceil_f32")),
+            Self::CeilF64 => Ok(Some("llvm_ceil_f64")),
+            Self::TruncF32 => Ok(Some("llvm_trunc_f32")),
+            Self::TruncF64 => Ok(Some("llvm_trunc_f64")),
+            Self::RoundF32 => Ok(Some("llvm_round_f32")),
+            Self::RoundF64 => Ok(Some("llvm_round_f64")),
+            Self::RoundevenF32 => Ok(Some("llvm_roundeven_f32")),
+            Self::RoundevenF64 => Ok(Some("llvm_roundeven_f64")),
+            // Sign operations: `llvm.fabs.*` / `llvm.copysign.*` select to
+            // single PTX `abs` / `copysign` instructions. `fabs` is the one
+            // placeholder that is generic over the float width, so its name
+            // dispatches on the result type.
+            Self::Fabs => fabs_llvm_intrinsic_name(ctx, result_ty, loc).map(Some),
+            Self::CopysignF32 => Ok(Some("llvm_copysign_f32")),
+            Self::CopysignF64 => Ok(Some("llvm_copysign_f64")),
+            _ => Ok(None),
         }
     }
 
@@ -1147,7 +1171,11 @@ fn convert_rust_carrying_mul_add(
     Ok(())
 }
 
-/// Lower placeholder calls for rustc's `f32` / `f64` math intrinsics to libdevice.
+/// Lower placeholder calls for rustc's `f32` / `f64` math intrinsics.
+///
+/// Simple scalar operations go to LLVM intrinsics so the ordinary llc -> PTX
+/// path can lower them directly. Transcendentals and other libdevice-owned
+/// operations still lower to `__nv_*` calls and therefore force NVVM IR mode.
 fn convert_rust_float_math_intrinsic(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -1176,12 +1204,16 @@ fn convert_rust_float_math_intrinsic(
         return lower_fast_binop(ctx, rewriter, op, &args, binop, loc);
     }
 
+    if let Some(predicate) = intrinsic.minmax_nsz_predicate() {
+        return lower_float_minmax_nsz(ctx, rewriter, op, &args, predicate);
+    }
+
     let result_mir_ty = op.deref(ctx).get_result(0).get_type(ctx);
     let result_ty = convert_type(ctx, result_mir_ty).map_err(anyhow_to_pliron)?;
 
-    // The rounding intrinsics have direct LLVM equivalents that the NVPTX
-    // backend selects without a libdevice call; everything else (and every op
-    // under the libNVVM backend) stays on libdevice. See
+    // The rounding and sign intrinsics have direct LLVM equivalents that the
+    // NVPTX backend selects without a libdevice call; everything else (and
+    // every op under the libNVVM backend) stays on libdevice. See
     // `float_math_intrinsic_symbol` for the dispatch and
     // `llvm_intrinsic_name` for the per-op PTX mapping and instruction counts.
     let intrinsic_name = float_math_intrinsic_symbol(ctx, intrinsic, result_ty, loc.clone())?;
@@ -1211,7 +1243,7 @@ fn convert_rust_float_math_intrinsic(
 /// active intrinsic backend.
 ///
 /// * [`IntrinsicBackend::LlvmNvptx`](crate::IntrinsicBackend::LlvmNvptx):
-///   rounding ops use the native LLVM intrinsics (see
+///   rounding and sign ops use the native LLVM intrinsics (see
 ///   [`RustFloatMathIntrinsic::llvm_intrinsic_name`]); everything else uses
 ///   libdevice.
 /// * [`IntrinsicBackend::LibNvvm`](crate::IntrinsicBackend::LibNvvm): every
@@ -1223,8 +1255,8 @@ fn convert_rust_float_math_intrinsic(
 /// This dispatch mirrors the pre-lowering libdevice prediction in the
 /// pipeline (`is_libdevice_backed_placeholder` vs
 /// `is_backend_dependent_libdevice_placeholder` in
-/// `dialect_mir::rust_intrinsics`): a rounding op emits a `__nv_*` symbol
-/// precisely when the LibNvvm backend was selected.
+/// `dialect_mir::rust_intrinsics`): a rounding or sign op emits a `__nv_*`
+/// symbol precisely when the LibNvvm backend was selected.
 fn float_math_intrinsic_symbol(
     ctx: &Context,
     intrinsic: RustFloatMathIntrinsic,
@@ -1232,12 +1264,69 @@ fn float_math_intrinsic_symbol(
     loc: pliron::location::Location,
 ) -> Result<&'static str> {
     match crate::context::lowering_options(ctx).intrinsic_backend {
-        crate::IntrinsicBackend::LlvmNvptx => match intrinsic.llvm_intrinsic_name() {
-            Some(llvm_name) => Ok(llvm_name),
-            None => intrinsic.libdevice_name(ctx, result_ty, loc),
-        },
+        crate::IntrinsicBackend::LlvmNvptx => {
+            match intrinsic.llvm_intrinsic_name(ctx, result_ty, loc.clone())? {
+                Some(llvm_name) => Ok(llvm_name),
+                None => intrinsic.libdevice_name(ctx, result_ty, loc),
+            }
+        }
         crate::IntrinsicBackend::LibNvvm => intrinsic.libdevice_name(ctx, result_ty, loc),
     }
+}
+
+/// Lower Rust's NaN-ignoring `min` and `max` contract without libdevice.
+///
+/// LLVM 21's legacy `llvm.maxnum` / `llvm.minnum` intrinsics propagate a
+/// signaling NaN, whereas Rust requires either kind of NaN to be ignored when
+/// paired with a number. Mirror the definition in `core::intrinsics` exactly:
+/// select `y` when `x` is NaN or `y` compares at least/as-most `x`, otherwise
+/// select `x`. An unordered `y` comparison is false, so a NaN in `y` selects
+/// the numeric `x`.
+fn lower_float_minmax_nsz(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    args: &[Value],
+    ordered_predicate: FCmpPredicateAttr,
+) -> Result<()> {
+    let [x, y] = args else {
+        return pliron::input_err!(
+            op.deref(ctx).loc(),
+            "Rust float min/max intrinsic requires two operands"
+        );
+    };
+
+    let x_is_nan = llvm::FCmpOp::new(ctx, FCmpPredicateAttr::UNO, *x, *x).get_operation();
+    set_empty_fastmath_flags(ctx, x_is_nan);
+    rewriter.insert_operation(ctx, x_is_nan);
+
+    let y_ordered_against_x = llvm::FCmpOp::new(ctx, ordered_predicate, *y, *x).get_operation();
+    set_empty_fastmath_flags(ctx, y_ordered_against_x);
+    rewriter.insert_operation(ctx, y_ordered_against_x);
+
+    let y_is_ordered_choice = y_ordered_against_x.deref(ctx).get_result(0);
+    let ordered_result = llvm::SelectOp::new(ctx, y_is_ordered_choice, *y, *x).get_operation();
+    rewriter.insert_operation(ctx, ordered_result);
+
+    let x_is_nan_value = x_is_nan.deref(ctx).get_result(0);
+    let ordered_result_value = ordered_result.deref(ctx).get_result(0);
+    let result = llvm::SelectOp::new(ctx, x_is_nan_value, *y, ordered_result_value).get_operation();
+    rewriter.insert_operation(ctx, result);
+    rewriter.replace_operation(ctx, op, result);
+    Ok(())
+}
+
+/// Attach empty fast-math flags to a float op.
+///
+/// Upstream `FCmpOp` carries the FastMathFlags interface, whose verifier
+/// requires the `llvm_fast_math_flags` attribute to be present (it is not
+/// set by `FCmpOp::new`). The min/max expansion must stay exactly IEEE
+/// ordered/unordered, so no relaxation flag is ever appropriate here.
+fn set_empty_fastmath_flags(ctx: &mut Context, op: Ptr<Operation>) {
+    let key: pliron::identifier::Identifier = "llvm_fast_math_flags".try_into().unwrap();
+    op.deref_mut(ctx)
+        .attributes
+        .set(key, FastmathFlagsAttr::default());
 }
 
 /// Lower a `core::intrinsics::f*_fast` placeholder call to the matching
@@ -1311,6 +1400,25 @@ fn integer_bit_width(
         return pliron::input_err!(loc, "expected integer type for Rust bit intrinsic");
     };
     Ok(int_ty.width())
+}
+
+/// Return the LLVM `fabs` intrinsic for the concrete float type.
+fn fabs_llvm_intrinsic_name(
+    ctx: &Context,
+    ty: TypeHandle,
+    loc: pliron::location::Location,
+) -> Result<&'static str> {
+    let ty_ref = ty.deref(ctx);
+    if ty_ref.is::<FP32Type>() {
+        Ok("llvm_fabs_f32")
+    } else if ty_ref.is::<FP64Type>() {
+        Ok("llvm_fabs_f64")
+    } else {
+        pliron::input_err!(
+            loc,
+            "expected f32 or f64 type for Rust float math intrinsic"
+        )
+    }
 }
 
 /// Return the libdevice `fabs` entry point for the concrete float type.
@@ -1892,50 +2000,62 @@ mod tests {
         assert_eq!(RustFloatMathIntrinsic::MinNumNszF64.arg_count(), 2);
     }
 
-    /// `f32::max`/`f64::max` and their `min` siblings lower to the `_nsz`
-    /// flavor of the rustc maxNum/minNum intrinsics, which we route through
-    /// libdevice `__nv_fmax{f}`/`__nv_fmin{f}`. Spot-check the table so a
-    /// future rename in `dialect-mir::rust_intrinsics` cannot drift the
-    /// placeholder name silently away from its libdevice symbol.
+    /// The LLVM 21 `maxnum`/`minnum` intrinsics do not match Rust's signaling
+    /// NaN behavior, so these variants use explicit compare/select lowering.
     #[test]
-    fn test_float_math_maxnum_minnum_nsz_libdevice_symbols() {
+    fn test_float_math_minmax_nsz_predicates() {
+        assert_eq!(
+            RustFloatMathIntrinsic::MaxNumNszF32.minmax_nsz_predicate(),
+            Some(FCmpPredicateAttr::OGE)
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::MaxNumNszF64.minmax_nsz_predicate(),
+            Some(FCmpPredicateAttr::OGE)
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::MinNumNszF32.minmax_nsz_predicate(),
+            Some(FCmpPredicateAttr::OLE)
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::MinNumNszF64.minmax_nsz_predicate(),
+            Some(FCmpPredicateAttr::OLE)
+        );
+        assert_eq!(RustFloatMathIntrinsic::Fabs.minmax_nsz_predicate(), None);
+    }
+
+    #[test]
+    fn test_float_math_copysign_uses_llvm_and_transcendentals_use_libdevice() {
         let ctx = Context::new();
         let f32_ty = FP32Type::get(&ctx).into();
         let f64_ty = FP64Type::get(&ctx).into();
         let loc = pliron::location::Location::Unknown;
 
         assert_eq!(
-            RustFloatMathIntrinsic::MaxNumNszF32
-                .libdevice_name(&ctx, f32_ty, loc.clone())
+            RustFloatMathIntrinsic::CopysignF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
                 .unwrap(),
-            "__nv_fmaxf"
+            Some("llvm_copysign_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::MaxNumNszF64
-                .libdevice_name(&ctx, f64_ty, loc.clone())
+            RustFloatMathIntrinsic::CopysignF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
                 .unwrap(),
-            "__nv_fmax"
+            Some("llvm_copysign_f64")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::MinNumNszF32
-                .libdevice_name(&ctx, f32_ty, loc.clone())
+            RustFloatMathIntrinsic::SinF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc)
                 .unwrap(),
-            "__nv_fminf"
-        );
-        assert_eq!(
-            RustFloatMathIntrinsic::MinNumNszF64
-                .libdevice_name(&ctx, f64_ty, loc)
-                .unwrap(),
-            "__nv_fmin"
+            None
         );
     }
 
-    /// `Fabs` is the only float-math intrinsic whose libdevice name depends on
+    /// `Fabs` is the only float-math intrinsic whose LLVM name depends on
     /// the result type (the others are width-suffixed in the enum itself).
     /// Ensure both float widths are dispatched correctly and that anything
     /// else is rejected.
     #[test]
-    fn test_fabs_libdevice_name_dispatches_on_float_width() {
+    fn test_fabs_llvm_intrinsic_name_dispatches_on_float_width() {
         let ctx = Context::new();
         let f32_ty = FP32Type::get(&ctx).into();
         let f64_ty = FP64Type::get(&ctx).into();
@@ -1943,87 +2063,139 @@ mod tests {
         let loc = pliron::location::Location::Unknown;
 
         assert_eq!(
-            fabs_libdevice_name(&ctx, f32_ty, loc.clone()).unwrap(),
-            "__nv_fabsf"
+            fabs_llvm_intrinsic_name(&ctx, f32_ty, loc.clone()).unwrap(),
+            "llvm_fabs_f32"
         );
         assert_eq!(
-            fabs_libdevice_name(&ctx, f64_ty, loc.clone()).unwrap(),
-            "__nv_fabs"
+            fabs_llvm_intrinsic_name(&ctx, f64_ty, loc.clone()).unwrap(),
+            "llvm_fabs_f64"
         );
-        assert!(fabs_libdevice_name(&ctx, i32_ty, loc).is_err());
+        assert!(fabs_llvm_intrinsic_name(&ctx, i32_ty, loc).is_err());
     }
 
     /// `llvm_intrinsic_name` returns direct LLVM intrinsic names for the
-    /// rounding operations, which bypass libdevice. Everything else, including
-    /// the transcendentals, still returns `None`.
+    /// rounding and sign operations, which bypass libdevice. Everything else,
+    /// including the transcendentals, still returns `None`.
     #[test]
     fn test_llvm_intrinsic_name_routing() {
-        // fabs and copysign stay on the libdevice path here; #391 moves them
-        // off it as part of a broader change that also covers max/min.
-        assert_eq!(RustFloatMathIntrinsic::Fabs.llvm_intrinsic_name(), None);
+        let ctx = Context::new();
+        let f32_ty = FP32Type::get(&ctx).into();
+        let f64_ty = FP64Type::get(&ctx).into();
+        let loc = pliron::location::Location::Unknown;
+
+        // fabs and copysign -> llvm.fabs.*/llvm.copysign.*, which the NVPTX
+        // backend selects to single `abs`/`copysign` PTX instructions.
         assert_eq!(
-            RustFloatMathIntrinsic::CopysignF32.llvm_intrinsic_name(),
-            None
+            RustFloatMathIntrinsic::Fabs
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
+            Some("llvm_fabs_f32")
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::Fabs
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
+            Some("llvm_fabs_f64")
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::CopysignF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
+            Some("llvm_copysign_f32")
         );
 
         // Rounding -> llvm.floor/ceil/trunc/round/roundeven.* in pliron's
         // underscore encoding (the exporter prints the dotted LLVM name).
         assert_eq!(
-            RustFloatMathIntrinsic::FloorF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::FloorF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             Some("llvm_floor_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::FloorF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::FloorF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             Some("llvm_floor_f64")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::CeilF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::CeilF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             Some("llvm_ceil_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::CeilF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::CeilF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             Some("llvm_ceil_f64")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::TruncF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::TruncF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             Some("llvm_trunc_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::TruncF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::TruncF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             Some("llvm_trunc_f64")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::RoundF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::RoundF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             Some("llvm_round_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::RoundF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::RoundF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             Some("llvm_round_f64")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::RoundevenF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::RoundevenF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             Some("llvm_roundeven_f32")
         );
         assert_eq!(
-            RustFloatMathIntrinsic::RoundevenF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::RoundevenF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             Some("llvm_roundeven_f64")
         );
 
         // max/min return None: LLVM 21's maxnum/minnum propagate signaling
-        // NaNs, which contradicts Rust's contract. These need compare/select
-        // lowering instead (see #390).
+        // NaNs, which contradicts Rust's contract. These use compare/select
+        // lowering instead and never reach the intrinsic tables (see #390).
         assert_eq!(
-            RustFloatMathIntrinsic::MaxNumNszF32.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::MaxNumNszF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
             None
         );
         assert_eq!(
-            RustFloatMathIntrinsic::MinNumNszF64.llvm_intrinsic_name(),
+            RustFloatMathIntrinsic::MinNumNszF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc.clone())
+                .unwrap(),
             None
         );
 
         // Transcendentals still return None (they need libdevice).
-        assert_eq!(RustFloatMathIntrinsic::SinF32.llvm_intrinsic_name(), None);
-        assert_eq!(RustFloatMathIntrinsic::SqrtF64.llvm_intrinsic_name(), None);
+        assert_eq!(
+            RustFloatMathIntrinsic::SinF32
+                .llvm_intrinsic_name(&ctx, f32_ty, loc.clone())
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            RustFloatMathIntrinsic::SqrtF64
+                .llvm_intrinsic_name(&ctx, f64_ty, loc)
+                .unwrap(),
+            None
+        );
     }
 
     /// The resolved callee symbol follows the active intrinsic backend:

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -394,17 +394,19 @@ impl RustFloatMathIntrinsic {
             Self::Fabs => fabs_libdevice_name(ctx, result_ty, loc),
             Self::CopysignF32 => Ok("__nv_copysignf"),
             Self::CopysignF64 => Ok("__nv_copysign"),
-            // `f32::max` / `f32::min` (and the f64 forms) call the
-            // `_nsz` intrinsics, i.e. IEEE-754 maxNum/minNum with the
-            // "no signed zero" relaxation: when one operand is NaN the
-            // non-NaN operand is returned, and -0.0 / +0.0 may be
-            // treated as equivalent. libdevice `__nv_fmaxf`/`__nv_fminf`
-            // implement the same maxNum/minNum NaN rule (the -0/+0 nsz
-            // relaxation is a permitted slack, not a required behavior).
-            Self::MaxNumNszF32 => Ok("__nv_fmaxf"),
-            Self::MaxNumNszF64 => Ok("__nv_fmax"),
-            Self::MinNumNszF32 => Ok("__nv_fminf"),
-            Self::MinNumNszF64 => Ok("__nv_fmin"),
+            // `f32::max` / `f32::min` (and the f64 forms) call the `_nsz`
+            // intrinsics, i.e. IEEE-754 maxNum/minNum with the "no signed
+            // zero" relaxation. They expand to an ordered compare/select
+            // sequence under every intrinsic backend (the caller routes them
+            // through `lower_float_minmax_nsz` before any symbol lookup), so
+            // they must never reach a libdevice name.
+            Self::MaxNumNszF32 | Self::MaxNumNszF64 | Self::MinNumNszF32 | Self::MinNumNszF64 => {
+                pliron::input_err!(
+                    loc,
+                    "float max/min intrinsics lower to a compare/select \
+                     expansion, never to libdevice"
+                )
+            }
             Self::AsinF32 => Ok("__nv_asinf"),
             Self::AsinF64 => Ok("__nv_asin"),
             Self::AcosF32 => Ok("__nv_acosf"),
@@ -1174,8 +1176,10 @@ fn convert_rust_carrying_mul_add(
 /// Lower placeholder calls for rustc's `f32` / `f64` math intrinsics.
 ///
 /// Simple scalar operations go to LLVM intrinsics so the ordinary llc -> PTX
-/// path can lower them directly. Transcendentals and other libdevice-owned
-/// operations still lower to `__nv_*` calls and therefore force NVVM IR mode.
+/// path can lower them directly, and float `max`/`min` expand to an ordered
+/// compare/select. Transcendentals and other libdevice-owned operations still
+/// lower to `__nv_*` calls, which need libdevice linked at the IR level or
+/// the NVVM IR route.
 fn convert_rust_float_math_intrinsic(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -2199,9 +2203,10 @@ mod tests {
     }
 
     /// The resolved callee symbol follows the active intrinsic backend:
-    /// rounding uses the native LLVM intrinsics under `LlvmNvptx` but stays
-    /// on libdevice under `LibNvvm` (whose legacy LLVM 7 dialect predates
-    /// `llvm.roundeven.*`); transcendentals use libdevice under both.
+    /// rounding and sign ops use the native LLVM intrinsics under
+    /// `LlvmNvptx` but stay on libdevice under `LibNvvm` (whose legacy
+    /// LLVM 7 dialect predates `llvm.roundeven.*`); transcendentals use
+    /// libdevice under both.
     #[test]
     fn float_math_symbol_dispatches_on_intrinsic_backend() {
         let mut ctx = Context::new();
@@ -2236,6 +2241,21 @@ mod tests {
             "llvm_roundeven_f32"
         );
         assert_eq!(
+            float_math_intrinsic_symbol(&ctx, RustFloatMathIntrinsic::Fabs, f32_ty, loc.clone())
+                .unwrap(),
+            "llvm_fabs_f32"
+        );
+        assert_eq!(
+            float_math_intrinsic_symbol(
+                &ctx,
+                RustFloatMathIntrinsic::CopysignF32,
+                f32_ty,
+                loc.clone()
+            )
+            .unwrap(),
+            "llvm_copysign_f32"
+        );
+        assert_eq!(
             float_math_intrinsic_symbol(&ctx, RustFloatMathIntrinsic::SinF32, f32_ty, loc.clone())
                 .unwrap(),
             "__nv_sinf"
@@ -2267,6 +2287,21 @@ mod tests {
             )
             .unwrap(),
             "__nv_rintf"
+        );
+        assert_eq!(
+            float_math_intrinsic_symbol(&ctx, RustFloatMathIntrinsic::Fabs, f32_ty, loc.clone())
+                .unwrap(),
+            "__nv_fabsf"
+        );
+        assert_eq!(
+            float_math_intrinsic_symbol(
+                &ctx,
+                RustFloatMathIntrinsic::CopysignF32,
+                f32_ty,
+                loc.clone()
+            )
+            .unwrap(),
+            "__nv_copysignf"
         );
         assert_eq!(
             float_math_intrinsic_symbol(&ctx, RustFloatMathIntrinsic::SinF32, f32_ty, loc).unwrap(),

--- a/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/README.md
+++ b/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/README.md
@@ -1,17 +1,20 @@
 # fmaxmin_smoke
 
-Smoke test for `f32::max` / `f32::min` (and the f64 forms) lowering to
-CUDA libdevice.
+Smoke test for direct LLVM lowering of `max`, `min`, `abs`, and `copysign` on
+`f32` and `f64`, followed by PTX generation.
 
-Both methods lower to the `_nsz` flavor of the rustc maxNum / minNum
+The max/min methods lower to the `_nsz` flavor of the rustc maxNum / minNum
 intrinsics in MIR:
 
-| Public API | MIR intrinsic | libdevice symbol |
+| Public API | MIR intrinsic | Direct LLVM lowering |
 | ---------- | ------------- | ---------------- |
-| `f32::max` | `core::intrinsics::maximum_number_nsz_f32` | `__nv_fmaxf` |
-| `f64::max` | `core::intrinsics::maximum_number_nsz_f64` | `__nv_fmax`  |
-| `f32::min` | `core::intrinsics::minimum_number_nsz_f32` | `__nv_fminf` |
-| `f64::min` | `core::intrinsics::minimum_number_nsz_f64` | `__nv_fmin`  |
+| `f32::max` | `core::intrinsics::maximum_number_nsz_f32` | `fcmp` + `select` |
+| `f64::max` | `core::intrinsics::maximum_number_nsz_f64` | `fcmp` + `select` |
+| `f32::min` | `core::intrinsics::minimum_number_nsz_f32` | `fcmp` + `select` |
+| `f64::min` | `core::intrinsics::minimum_number_nsz_f64` | `fcmp` + `select` |
+
+The same kernel also covers the width-specific `llvm.fabs` and
+`llvm.copysign` intrinsics.
 
 This example exists as a regression test for that lowering chain. Before
 the corresponding entries existed in `dialect-mir::rust_intrinsics`,
@@ -26,23 +29,22 @@ cargo oxide run fmaxmin_smoke
 
 ## How code reaches the GPU
 
-The kernels in this example call into libdevice (`__nv_fmaxf` etc.), so
-cuda-oxide auto-detects the `__nv_*` symbols and emits NVVM IR
-(`fmaxmin_smoke.ll`) instead of `.ptx`.
-[`cuda_host::ltoir::load_kernel_module`] then transparently runs the
-libNVVM (with libdevice) + nvJitLink pipeline and loads the resulting
-cubin — exactly the same path as the larger `primitive_stress` example,
-just focused on the max / min intrinsic lowering.
+The kernels in this example use LLVM comparisons/selects, `fabs`, and
+`copysign`, so cuda-oxide emits ordinary PTX.
+[`cuda_host::ltoir::load_kernel_module`] loads that PTX directly; it only
+falls back to libNVVM + nvJitLink for modules that actually emit NVVM IR.
 
 ## What the smoke checks
 
 For both `f32` and `f64`:
 
 1. The finite case — `(1.5_f32).max(-2.5_f32) == 1.5_f32` and the matching
-   `.min` — confirms the libdevice symbol is reached and the result is
+   `.min` — confirms the direct LLVM lowering is reached and the result is
    bit-exact.
-2. The NaN case — `f32::NAN.max(b) == b` and `f32::NAN.min(b) == b` —
-   confirms the maxNum / minNum NaN-suppression rule is honored. The
-   NaN payload is passed in as a kernel argument from the host so that
-   the example does not double up with how cuda-oxide renders NaN
-   constants in LLVM IR.
+2. Quiet and signaling NaNs in either operand position are ignored when paired
+   with a number; two NaNs still produce a NaN.
+3. Both signed-zero orders produce a valid zero result.
+4. `abs` produces exact finite/zero results and clears the sign of a NaN; its
+   NaN payload is not constrained.
+5. `copysign` changes only the sign bit, including for NaN magnitudes, whose
+   payload is checked exactly.

--- a/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fmaxmin_smoke/src/main.rs
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Smoke test for `f32::max` / `f32::min` (and the f64 forms).
+//! Smoke test for scalar `max`, `min`, `abs`, and `copysign` operations that
+//! lower directly through LLVM for both float widths.
 //!
 //! These lower to `core::intrinsics::maximum_number_nsz_f32` /
 //! `minimum_number_nsz_f32` / ... in MIR. Before this example was added,
@@ -16,10 +17,9 @@
 //! * `mir-importer::translator::terminator::intrinsics::float_math`
 //! * `mir-lower::convert::ops::call`
 //!
-//! the calls lower to libdevice `__nv_fmaxf` / `__nv_fmax` / `__nv_fminf`
-//! / `__nv_fmin`, which the auto-detected libNVVM + nvJitLink pipeline
-//! resolves transparently. This smoke check validates the full chain on a
-//! real GPU.
+//! max/min lower to ordered comparisons and selects, while abs/copysign use
+//! their LLVM intrinsics. llc lowers all four directly to PTX. This smoke check
+//! validates the full chain on a real GPU.
 //!
 //! NaN inputs are passed in from the host rather than being embedded as
 //! `f32::NAN` literals in the kernel so the example stays focused on the
@@ -41,31 +41,65 @@ use cuda_host::{cuda_module, ltoir};
 mod kernels {
     use super::*;
 
-    /// Writes `f32::max(a, b)` and `f32::min(a, b)` to `out[0..2]`, and then
-    /// `f32::max(nan_arg, b)` and `f32::min(nan_arg, b)` to `out[2..4]` so the
-    /// host can exercise the maxNum / minNum NaN-suppression rule by passing
-    /// a NaN through `nan_arg`.
+    /// Exercise finite, quiet/signaling NaN, signed-zero, sign, and payload
+    /// behavior for the four LLVM-only scalar operations.
     #[kernel]
-    pub fn fmaxmin_f32_kernel(a: f32, b: f32, nan_arg: f32, mut out: DisjointSlice<u32>) {
+    pub fn fmaxmin_f32_kernel(a: f32, b: f32, qnan: f32, snan: f32, mut out: DisjointSlice<u32>) {
         if thread::index_1d().get() == 0 {
             unsafe {
                 *out.get_unchecked_mut(0) = a.max(b).to_bits();
                 *out.get_unchecked_mut(1) = a.min(b).to_bits();
-                *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
-                *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+                *out.get_unchecked_mut(2) = qnan.max(b).to_bits();
+                *out.get_unchecked_mut(3) = b.max(qnan).to_bits();
+                *out.get_unchecked_mut(4) = snan.max(b).to_bits();
+                *out.get_unchecked_mut(5) = b.max(snan).to_bits();
+                *out.get_unchecked_mut(6) = qnan.min(b).to_bits();
+                *out.get_unchecked_mut(7) = b.min(qnan).to_bits();
+                *out.get_unchecked_mut(8) = snan.min(b).to_bits();
+                *out.get_unchecked_mut(9) = b.min(snan).to_bits();
+                *out.get_unchecked_mut(10) = qnan.max(snan).to_bits();
+                *out.get_unchecked_mut(11) = (-0.0_f32).max(0.0).to_bits();
+                *out.get_unchecked_mut(12) = b.abs().to_bits();
+                *out.get_unchecked_mut(13) = a.copysign(b).to_bits();
+                *out.get_unchecked_mut(14) = (-0.0_f32).abs().to_bits();
+                *out.get_unchecked_mut(15) = (-qnan).abs().to_bits();
+                *out.get_unchecked_mut(16) = a.copysign(-b).to_bits();
+                *out.get_unchecked_mut(17) = qnan.copysign(b).to_bits();
+                *out.get_unchecked_mut(18) = (-qnan).copysign(a).to_bits();
+                *out.get_unchecked_mut(19) = 0.0_f32.max(-0.0).to_bits();
+                *out.get_unchecked_mut(20) = (-0.0_f32).min(0.0).to_bits();
+                *out.get_unchecked_mut(21) = 0.0_f32.min(-0.0).to_bits();
             }
         }
     }
 
     /// Same as `fmaxmin_f32_kernel` for `f64::max` / `f64::min`.
     #[kernel]
-    pub fn fmaxmin_f64_kernel(a: f64, b: f64, nan_arg: f64, mut out: DisjointSlice<u64>) {
+    pub fn fmaxmin_f64_kernel(a: f64, b: f64, qnan: f64, snan: f64, mut out: DisjointSlice<u64>) {
         if thread::index_1d().get() == 0 {
             unsafe {
                 *out.get_unchecked_mut(0) = a.max(b).to_bits();
                 *out.get_unchecked_mut(1) = a.min(b).to_bits();
-                *out.get_unchecked_mut(2) = nan_arg.max(b).to_bits();
-                *out.get_unchecked_mut(3) = nan_arg.min(b).to_bits();
+                *out.get_unchecked_mut(2) = qnan.max(b).to_bits();
+                *out.get_unchecked_mut(3) = b.max(qnan).to_bits();
+                *out.get_unchecked_mut(4) = snan.max(b).to_bits();
+                *out.get_unchecked_mut(5) = b.max(snan).to_bits();
+                *out.get_unchecked_mut(6) = qnan.min(b).to_bits();
+                *out.get_unchecked_mut(7) = b.min(qnan).to_bits();
+                *out.get_unchecked_mut(8) = snan.min(b).to_bits();
+                *out.get_unchecked_mut(9) = b.min(snan).to_bits();
+                *out.get_unchecked_mut(10) = qnan.max(snan).to_bits();
+                *out.get_unchecked_mut(11) = (-0.0_f64).max(0.0).to_bits();
+                *out.get_unchecked_mut(12) = b.abs().to_bits();
+                *out.get_unchecked_mut(13) = a.copysign(b).to_bits();
+                *out.get_unchecked_mut(14) = (-0.0_f64).abs().to_bits();
+                *out.get_unchecked_mut(15) = (-qnan).abs().to_bits();
+                *out.get_unchecked_mut(16) = a.copysign(-b).to_bits();
+                *out.get_unchecked_mut(17) = qnan.copysign(b).to_bits();
+                *out.get_unchecked_mut(18) = (-qnan).copysign(a).to_bits();
+                *out.get_unchecked_mut(19) = 0.0_f64.max(-0.0).to_bits();
+                *out.get_unchecked_mut(20) = (-0.0_f64).min(0.0).to_bits();
+                *out.get_unchecked_mut(21) = 0.0_f64.min(-0.0).to_bits();
             }
         }
     }
@@ -81,9 +115,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    // The kernels use libdevice (`__nv_fmaxf` etc.), so cuda-oxide emits NVVM
-    // IR rather than PTX and `ltoir::load_kernel_module` finishes the build
-    // through libNVVM + nvJitLink, just like `primitive_stress`.
+    // `load_kernel_module` loads the PTX produced by llc directly here. The
+    // same helper also handles NVVM IR for examples that genuinely need
+    // libdevice.
     let module = ltoir::load_kernel_module(&ctx, "fmaxmin_smoke")?;
     let module = kernels::from_module(module)?;
     let cfg = LaunchConfig::for_num_elems(1);
@@ -95,17 +129,51 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let a = 1.5_f32;
         let b = -2.5_f32;
-        let nan_arg = f32::NAN;
-        let mut out = DeviceBuffer::<u32>::zeroed(&stream, 4)?;
+        let qnan = f32::from_bits(0x7fc1_2345);
+        let snan = f32::from_bits(0x7f81_2345);
+        let mut out = DeviceBuffer::<u32>::zeroed(&stream, 22)?;
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
-        unsafe { module.fmaxmin_f32_kernel(&stream, cfg, a, b, nan_arg, &mut out) }?;
-        let result = out.to_host_vec(&stream)?;
-        let expected: [u32; 4] = [
+        unsafe { module.fmaxmin_f32_kernel(&stream, cfg, a, b, qnan, snan, &mut out) }?;
+        let mut result = out.to_host_vec(&stream)?;
+        let expected: [u32; 22] = [
             a.max(b).to_bits(), // f32::max finite
             a.min(b).to_bits(), // f32::min finite
-            b.to_bits(),        // f32::max(NaN, b) == b  (maxNum rule)
-            b.to_bits(),        // f32::min(NaN, b) == b  (minNum rule)
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            qnan.to_bits(),    // normalized below: both-NaN payload is unspecified
+            0.0_f32.to_bits(), // normalized below: either signed zero is valid
+            b.abs().to_bits(),
+            a.copysign(b).to_bits(),
+            0.0_f32.to_bits(),
+            qnan.to_bits(),
+            a.to_bits(),
+            (-qnan).to_bits(),
+            qnan.to_bits(),
+            0.0_f32.to_bits(),
+            0.0_f32.to_bits(),
+            0.0_f32.to_bits(),
         ];
+        assert!(f32::from_bits(result[10]).is_nan());
+        assert_eq!(f32::from_bits(result[11]), 0.0);
+        assert!(f32::from_bits(result[15]).is_nan());
+        assert_eq!(result[15] >> 31, 0);
+        assert!(f32::from_bits(result[17]).is_nan());
+        assert_eq!(result[17] >> 31, 1);
+        assert!(f32::from_bits(result[18]).is_nan());
+        assert_eq!(result[18] >> 31, 0);
+        for bits in &result[19..22] {
+            assert_eq!(f32::from_bits(*bits), 0.0);
+        }
+        result[10] = expected[10];
+        result[11] = expected[11];
+        result[15] = expected[15];
+        result[19..22].copy_from_slice(&expected[19..22]);
         check_f32(
             "f32::max / f32::min",
             &result,
@@ -119,17 +187,51 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let a = 1.5e10_f64;
         let b = -2.5e10_f64;
-        let nan_arg = f64::NAN;
-        let mut out = DeviceBuffer::<u64>::zeroed(&stream, 4)?;
+        let qnan = f64::from_bits(0x7ff8_0000_0001_2345);
+        let snan = f64::from_bits(0x7ff0_0000_0001_2345);
+        let mut out = DeviceBuffer::<u64>::zeroed(&stream, 22)?;
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
-        unsafe { module.fmaxmin_f64_kernel(&stream, cfg, a, b, nan_arg, &mut out) }?;
-        let result = out.to_host_vec(&stream)?;
-        let expected: [u64; 4] = [
+        unsafe { module.fmaxmin_f64_kernel(&stream, cfg, a, b, qnan, snan, &mut out) }?;
+        let mut result = out.to_host_vec(&stream)?;
+        let expected: [u64; 22] = [
             a.max(b).to_bits(),
             a.min(b).to_bits(),
             b.to_bits(),
             b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            b.to_bits(),
+            qnan.to_bits(),
+            0.0_f64.to_bits(),
+            b.abs().to_bits(),
+            a.copysign(b).to_bits(),
+            0.0_f64.to_bits(),
+            qnan.to_bits(),
+            a.to_bits(),
+            (-qnan).to_bits(),
+            qnan.to_bits(),
+            0.0_f64.to_bits(),
+            0.0_f64.to_bits(),
+            0.0_f64.to_bits(),
         ];
+        assert!(f64::from_bits(result[10]).is_nan());
+        assert_eq!(f64::from_bits(result[11]), 0.0);
+        assert!(f64::from_bits(result[15]).is_nan());
+        assert_eq!(result[15] >> 63, 0);
+        assert!(f64::from_bits(result[17]).is_nan());
+        assert_eq!(result[17] >> 63, 1);
+        assert!(f64::from_bits(result[18]).is_nan());
+        assert_eq!(result[18] >> 63, 0);
+        for bits in &result[19..22] {
+            assert_eq!(f64::from_bits(*bits), 0.0);
+        }
+        result[10] = expected[10];
+        result[11] = expected[11];
+        result[15] = expected[15];
+        result[19..22].copy_from_slice(&expected[19..22]);
         check_f64(
             "f64::max / f64::min",
             &result,
@@ -158,7 +260,7 @@ fn check_f32(name: &str, got: &[u32], expected: &[u32], passed: &mut u32, failed
         *passed += 1;
     } else {
         println!(
-            "FAIL {name}: got {:?} expected {:?}",
+            "FAIL {name}: got {:?} expected {:?}\ngot bits: {got:x?}\nexpected bits: {expected:x?}",
             got.iter().map(|b| f32::from_bits(*b)).collect::<Vec<_>>(),
             expected
                 .iter()
@@ -178,7 +280,7 @@ fn check_f64(name: &str, got: &[u64], expected: &[u64], passed: &mut u32, failed
         *passed += 1;
     } else {
         println!(
-            "FAIL {name}: got {:?} expected {:?}",
+            "FAIL {name}: got {:?} expected {:?}\ngot bits: {got:x?}\nexpected bits: {expected:x?}",
             got.iter().map(|b| f64::from_bits(*b)).collect::<Vec<_>>(),
             expected
                 .iter()


### PR DESCRIPTION
Closes #390.

## Summary

Simple scalar `abs`, `copysign`, `max`, and `min` operations were routed
through libdevice even though LLVM and NVPTX can lower them directly. This
keeps those operations on the ordinary LLVM-to-PTX path while preserving
Rust's NaN and signed-zero semantics for both `f32` and `f64`.

Before: these operations forced NVVM IR emission and CUDA Toolkit runtime
linking. After: focused kernels containing only these operations emit PTX
directly.

## What changed

### Direct scalar lowering

- `abs` and `copysign` select the width-correct `llvm.fabs` and
  `llvm.copysign` intrinsics.
- Rust's `_nsz` `max` and `min` use the ordered compare/select definition from
  `core::intrinsics` instead of libdevice.
- The existing libdevice table remains the fallback for operations without a
  correct LLVM-only route.

### Rust semantics and sibling paths

- The explicit max/min sequence avoids LLVM 21's legacy `maxnum`/`minnum`
  behavior, which propagates signaling NaNs contrary to Rust's contract.
- Every `RustFloatMathIntrinsic` variant was audited. Transcendentals, rounding
  operations, FMA, and remaining functions retain their `__nv_*` lowering.
- Rust methods and libm/cmath spellings that share these importer placeholders
  intentionally receive the same direct lowering; unrelated external math
  calls and the fast-arithmetic path are unchanged.

## Known separate limitations

- This does not move transcendental, rounding, FMA, or other libdevice-owned
  operations onto the direct PTX path.
- Max/min deliberately retain an explicit compare/select sequence until the
  available LLVM intrinsic semantics match Rust's signaling-NaN contract.
- All-target clippy still exposes ten pre-existing `unnecessary_mut_passed`
  warnings in unchanged `tests/lowering_test.rs`; library and focused-example
  clippy are clean.

## Testing

- Added unit coverage for width-specific LLVM names, min/max predicates, and
  the libdevice fallback.
- Expanded `fmaxmin_smoke` across both widths, quiet/signaling NaNs in either
  operand, both-NaN results, both signed-zero orders, finite values, `abs` sign
  behavior, and exact `copysign` NaN-payload preservation.
- Verified generated LLVM IR contains the expected compare/select sequences
  and width-specific `fabs`/`copysign` declarations, without legacy
  `maxnum`/`minnum` or matching `__nv_*` references.
- On upstream `main`, the example emitted LTOIR with
  `__nv_fmax{f}`/`__nv_fmin{f}` calls; this branch emits PTX directly.
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path crates/rustc-codegen-cuda/examples/fmaxmin_smoke/Cargo.toml -- --check`
- `LIBRARY_PATH=/tmp/cuda-oxide-libffi-link cargo test -p mir-lower --all-targets`
- `LIBRARY_PATH=/tmp/cuda-oxide-libffi-link cargo clippy -p mir-lower --lib -- -D warnings`
- `cargo clippy --manifest-path crates/rustc-codegen-cuda/examples/fmaxmin_smoke/Cargo.toml --all-targets -- -D warnings`
- Optimized and `CUDA_OXIDE_NO_OPT=1` GPU executions passed on an NVIDIA RTX
  3080 (`sm_86`).

## Checklist

- [x] The branch is based on current upstream `main`.
- [x] The routing regression fails on upstream `main` and passes on this branch.
- [x] Both widths, NaN classes, signed zeros, and exact sign/payload behavior are covered.
- [x] Unrelated libdevice and fast-arithmetic paths remain unchanged.
- [x] Formatting, focused tests, library clippy, example clippy, and GPU runs pass.
- [x] Commits include DCO signoff and new example files have required headers.
