### PR TITLE
fix(mir): keep small runtime-indexed arrays in SSA

### DIFF
--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -92,7 +92,7 @@ fn link_libdevice(
     }
 }
 
-/// Runs LLVM's middle-end (`opt -O2`) on the emitted IR before `llc`.
+/// Runs LLVM's middle-end on the emitted IR before `llc`.
 ///
 /// This is what consumes the per-op ABI alignment we emit: the
 /// LoadStoreVectorizer fuses aligned aggregate/element accesses, SROA
@@ -128,8 +128,12 @@ fn optimize_ll(
     };
 
     let opt_ll = ll_path.with_extension("opt.ll");
+    let optimization_args = [
+        "-passes=default<O2>,function(loop-unroll<O3;full-unroll-max=16;no-partial;no-peeling;no-runtime>),default<O2>",
+        "-unroll-threshold=512",
+    ];
     match std::process::Command::new(&opt.path)
-        .arg("-O2")
+        .args(optimization_args)
         .arg(ll_path)
         .arg("-S")
         .arg("-o")
@@ -139,7 +143,14 @@ fn optimize_ll(
         Ok(output) if output.status.success() => {
             let diagnostics = opts
                 .verbose
-                .then(|| format!("opt -O2 via {}: {}", opt.path, opt_ll.display()))
+                .then(|| {
+                    format!(
+                        "opt {} via {}: {}",
+                        optimization_args.join(" "),
+                        opt.path,
+                        opt_ll.display()
+                    )
+                })
                 .into_iter()
                 .collect();
             Ok((Some(opt_ll), diagnostics))

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -128,9 +128,14 @@ fn optimize_ll(
     };
 
     let opt_ll = ll_path.with_extension("opt.ll");
+    // The post-inline `loop-unroll` run is bounded per-pass (O3 cost model,
+    // full unrolls only, trip count <= 16). It carries NO global
+    // `-unroll-threshold` override: that cl::opt would leak into the
+    // unrollers inside every `default<O2>` run as well, and `loop-unroll`
+    // has no `threshold=` per-pass parameter in LLVM 21/22
+    // (`opt -print-passes`), so the default threshold applies.
     let optimization_args = [
         "-passes=default<O2>,function(loop-unroll<O3;full-unroll-max=16;no-partial;no-peeling;no-runtime>),default<O2>",
-        "-unroll-threshold=512",
     ];
     match std::process::Command::new(&opt.path)
         .args(optimization_args)

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -134,6 +134,16 @@ fn optimize_ll(
     // unrollers inside every `default<O2>` run as well, and `loop-unroll`
     // has no `threshold=` per-pass parameter in LLVM 21/22
     // (`opt -print-passes`), so the default threshold applies.
+    //
+    // The trailing `default<O2>` cleans up after the unroll (folds the now
+    // constant-index select chains, lets SROA scalarize the arrays). It is
+    // deliberately a full O2 rather than a minimal
+    // `sroa,early-cse,instcombine,simplifycfg` set: standalone `instcombine`
+    // in a `-passes` string enforces single-iteration fixpoint verification
+    // and hard-errors on real kernels (observed on gemm_sol with LLVM 21/22)
+    // unless verification is suppressed, while the measured cost of the full
+    // second run is ~0.05 s on the heaviest example -- under 0.5% of its
+    // end-to-end compile.
     let optimization_args = [
         "-passes=default<O2>,function(loop-unroll<O3;full-unroll-max=16;no-partial;no-peeling;no-runtime>),default<O2>",
     ];

--- a/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
@@ -76,7 +76,17 @@ if [ "${1:-}" = "--version" ]; then
   echo "LLVM version 21.0.0"
   exit 0
 fi
-cp "$2" "$5"
+input=""
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; output="$1" ;;
+    -*) ;;
+    *) input="$1" ;;
+  esac
+  shift
+done
+cp "$input" "$output"
 "#,
             )
         });

--- a/crates/dialect-mir/src/ops/aggregate.rs
+++ b/crates/dialect-mir/src/ops/aggregate.rs
@@ -884,8 +884,9 @@ impl Verify for MirConstructArrayOp {
 /// ```
 ///
 /// When Rust code indexes an array with a runtime value (e.g., `arr[tid % 4]`),
-/// we need this op to represent that access before lowering to the
-/// alloca→store→GEP→load pattern that LLVM requires.
+/// we need this op to represent that access before lowering. Small fixed arrays
+/// become constant `extractvalue` operations plus an SSA select chain; larger
+/// arrays use an alloca→store→GEP→load sequence to bound code growth.
 ///
 /// # Example
 ///
@@ -915,8 +916,8 @@ impl Verify for MirConstructArrayOp {
 ///
 /// # LLVM Lowering
 ///
-/// Since LLVM's `extractvalue` only supports constant indices, this op
-/// is lowered to:
+/// Since LLVM's `extractvalue` only supports constant indices, larger arrays
+/// are lowered to:
 /// ```text
 /// %ptr      = llvm.alloca [4 x float]       ; 1. Stack allocate
 /// llvm.store %arr, %ptr                     ; 2. Store array to memory
@@ -1157,7 +1158,7 @@ impl Verify for MirFieldAddrOp {
 ///   %x = mir.load %elem_ptr        // for reads
 /// ```
 ///
-/// This enables O(1) element access without copying the entire array.
+/// This preserves pointer semantics without copying the entire array.
 ///
 /// # Operands
 ///
@@ -1178,10 +1179,13 @@ impl Verify for MirFieldAddrOp {
 ///
 /// # LLVM Lowering
 ///
-/// Lowers to a single LLVM GEP instruction:
+/// Larger arrays lower to a single LLVM GEP instruction:
 /// ```llvm
 /// %elem_ptr = getelementptr [N x T], ptr %arr_ptr, i64 0, i64 %index
 /// ```
+/// Small fixed arrays lower to constant GEPs and an `icmp`/`select` pointer
+/// chain. The constant addresses let LLVM scalarize compiler-owned local arrays
+/// while still accessing exactly one element through user-visible pointers.
 #[pliron_op(
     name = "mir.array_element_addr",
     format,

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -1333,3 +1333,89 @@ fn test_mir_enum_payload_rejects_uninhabited_variant() {
     payload.set_attr_payload_field_index(&ctx, FieldIndexAttr(0));
     assert!(payload.verify(&ctx).is_err());
 }
+
+/// Reachable-but-dead MIR (e.g. the residual arms of `array::try_from_fn`)
+/// can name uninhabited variants. The importer must lower such reads and
+/// constructions to typed undefs; if it ever emits the real ops again, these
+/// verifiers are the loud stop.
+#[test]
+fn test_uninhabited_enum_construct_and_discriminant_fail_verification() {
+    use dialect_mir::types::{EnumCarrierKind, EnumEncoding, EnumLayoutKind};
+
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    let i8_ty = IntegerType::get(&ctx, 8, Signedness::Unsigned);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Unsigned);
+
+    // Constructing an uninhabited variant must fail verification.
+    let partial = MirEnumType::get_with_encoding(
+        &mut ctx,
+        "HasImpossibleVariant".into(),
+        i8_ty.into(),
+        vec![0, 1],
+        vec![
+            EnumVariant::unit("Live".into()),
+            EnumVariant::new_with_layout(
+                "Impossible".into(),
+                vec![i32_ty.into()],
+                vec![0],
+                vec![4],
+            ),
+        ],
+        EnumEncoding {
+            tag_offset: 0,
+            total_size: 8,
+            abi_align: 4,
+            layout_kind: EnumLayoutKind::Direct,
+            carrier_kind: EnumCarrierKind::Integer,
+            carrier_width: 8,
+            variant_inhabited: vec![1, 0],
+            ..EnumEncoding::default()
+        },
+    );
+    let block = BasicBlock::new(&mut ctx, None, vec![i32_ty.into()]);
+    let field = block.deref(&ctx).get_argument(0);
+    let construct = Operation::new(
+        &mut ctx,
+        MirConstructEnumOp::get_concrete_op_info(),
+        vec![partial.into()],
+        vec![field],
+        vec![],
+        0,
+    );
+    let construct = MirConstructEnumOp::new(construct);
+    construct.set_attr_construct_enum_variant_index(&ctx, VariantIndexAttr(1));
+    assert!(construct.verify(&ctx).is_err());
+
+    // Reading the discriminant of a fully uninhabited enum must fail
+    // verification.
+    let never = MirEnumType::get_with_encoding(
+        &mut ctx,
+        "Never".into(),
+        i8_ty.into(),
+        vec![],
+        vec![],
+        EnumEncoding {
+            tag_offset: 0,
+            total_size: 0,
+            abi_align: 1,
+            layout_kind: EnumLayoutKind::Empty,
+            carrier_kind: EnumCarrierKind::None,
+            variant_inhabited: vec![],
+            ..EnumEncoding::default()
+        },
+    );
+    assert!(never.verify(&ctx).is_ok());
+    let never_block = BasicBlock::new(&mut ctx, None, vec![never.into()]);
+    let never_value = never_block.deref(&ctx).get_argument(0);
+    let get_discriminant = Operation::new(
+        &mut ctx,
+        MirGetDiscriminantOp::get_concrete_op_info(),
+        vec![i8_ty.into()],
+        vec![never_value],
+        vec![],
+        0,
+    );
+    let get_discriminant = MirGetDiscriminantOp::new(get_discriminant);
+    assert!(get_discriminant.verify(&ctx).is_err());
+}

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -416,9 +416,14 @@ impl<'a> ModuleExportState<'a> {
                     let op_obj = Operation::get_op_dyn(op, self.ctx);
                     let op_dyn = op_obj.as_ref();
 
-                    // Skip ops that don't produce named results (UndefOp is handled specially)
+                    // UndefOp is virtual in textual LLVM IR: uses print the
+                    // literal `undef`. Pre-register the name here so CFG
+                    // order cannot break a use in an earlier-printed block
+                    // (e.g. a PHI incoming) when the defining block prints
+                    // later.
                     if op_dyn.downcast_ref::<ops::UndefOp>().is_some() {
-                        // UndefOp result will be named "undef"
+                        let res = op_ref.get_result(0);
+                        value_names.insert(res, "undef".to_string());
                         continue;
                     }
 

--- a/crates/mir-importer/src/lib.rs
+++ b/crates/mir-importer/src/lib.rs
@@ -87,4 +87,5 @@ pub use pipeline::{
     CollectedFunction, CompilationArtifactKind, CompilationResult, DeviceExternAttrs,
     DeviceExternDecl, DeviceExternType, PipelineConfig, PipelineError, run_pipeline,
 };
+pub use translator::DEVICE_RUNTIME_CHECKS;
 pub use translator::terminator::drop_glue::{drop_glue_is_noop, drop_instance_is_noop};

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -326,7 +326,7 @@ fn constant_operand_bits(operand: &mir::Operand) -> Option<u128> {
             };
             alloc.read_uint().ok()
         }
-        mir::Operand::RuntimeChecks(_) => Some(0),
+        mir::Operand::RuntimeChecks(_) => Some(super::DEVICE_RUNTIME_CHECKS as u128),
         _ => None,
     }
 }
@@ -1177,6 +1177,28 @@ mod tests {
         op::Op,
         operation::Operation,
     };
+
+    /// The reachability fold and the collector's dead-edge pruning both key
+    /// off [`DEVICE_RUNTIME_CHECKS`]; a fold that stopped consulting it (or a
+    /// device value that silently became session-dependent) would let the
+    /// collector and importer choose different `SwitchInt` edges.
+    #[test]
+    fn runtime_checks_fold_to_the_shared_device_value() {
+        for check in [
+            mir::RuntimeChecks::UbChecks,
+            mir::RuntimeChecks::ContractChecks,
+            mir::RuntimeChecks::OverflowChecks,
+        ] {
+            assert_eq!(
+                constant_operand_bits(&mir::Operand::RuntimeChecks(check)),
+                Some(crate::translator::DEVICE_RUNTIME_CHECKS as u128),
+            );
+        }
+        assert!(
+            !crate::translator::DEVICE_RUNTIME_CHECKS,
+            "device PTX never enables runtime safety checks",
+        );
+    }
 
     #[test]
     fn inline_always_flag_reaches_llvm_func_attr_before_export() {

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -1182,6 +1182,9 @@ mod tests {
     /// off [`DEVICE_RUNTIME_CHECKS`]; a fold that stopped consulting it (or a
     /// device value that silently became session-dependent) would let the
     /// collector and importer choose different `SwitchInt` edges.
+    /// Compile-time pin: device PTX never enables runtime safety checks.
+    const _: () = assert!(!crate::translator::DEVICE_RUNTIME_CHECKS);
+
     #[test]
     fn runtime_checks_fold_to_the_shared_device_value() {
         for check in [
@@ -1194,10 +1197,6 @@ mod tests {
                 Some(crate::translator::DEVICE_RUNTIME_CHECKS as u128),
             );
         }
-        assert!(
-            !crate::translator::DEVICE_RUNTIME_CHECKS,
-            "device PTX never enables runtime safety checks",
-        );
     }
 
     #[test]

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -256,11 +256,23 @@ fn detect_dynamic_shared_alignment(body: &mir::Body) -> Option<DynamicSharedAlig
 /// unwinding (hardware could, but `nvcc`/`ptxas` never wire it up), so the
 /// translator treats unwind cleanups as dead code. This helper strips them
 /// out so the worklist only visits blocks that matter on GPU.
-fn non_unwind_successors(kind: &mir::TerminatorKind) -> Vec<usize> {
+fn non_unwind_successors(body: &mir::Body, block_idx: usize) -> Vec<usize> {
+    let kind = &body.blocks[block_idx].terminator.kind;
     use mir::TerminatorKind::*;
     match kind {
         Goto { target } => vec![*target],
-        SwitchInt { targets, .. } => targets.all_targets(),
+        SwitchInt { discr, targets } => {
+            if let Some(value) = constant_operand_bits_in_block(body, block_idx, discr) {
+                let target = targets
+                    .branches()
+                    .find(|(branch_value, _)| *branch_value == value)
+                    .map(|(_, target)| target)
+                    .unwrap_or_else(|| targets.otherwise());
+                vec![target]
+            } else {
+                targets.all_targets()
+            }
+        }
         Return | Resume | Abort | Unreachable => vec![],
         Drop { target, .. } | Assert { target, .. } => vec![*target],
         Call { target, .. } => target.map(|t| vec![t]).unwrap_or_default(),
@@ -268,7 +280,58 @@ fn non_unwind_successors(kind: &mir::TerminatorKind) -> Vec<usize> {
     }
 }
 
-/// BFS from the entry block (index 0) following non-unwind successors.
+fn constant_operand_bits_in_block(
+    body: &mir::Body,
+    block_idx: usize,
+    operand: &mir::Operand,
+) -> Option<u128> {
+    if let Some(bits) = constant_operand_bits(operand) {
+        return Some(bits);
+    }
+    let place = match operand {
+        mir::Operand::Copy(place) | mir::Operand::Move(place) if place.projection.is_empty() => {
+            place
+        }
+        _ => return None,
+    };
+    let statement = body.blocks[block_idx]
+        .statements
+        .iter()
+        .rev()
+        .find(|statement| {
+            !matches!(
+                statement.kind,
+                mir::StatementKind::StorageLive(_) | mir::StatementKind::StorageDead(_)
+            )
+        })?;
+    let mir::StatementKind::Assign(destination, mir::Rvalue::Use(source)) = &statement.kind else {
+        return None;
+    };
+    (destination.local == place.local && destination.projection.is_empty())
+        .then(|| constant_operand_bits(source))
+        .flatten()
+}
+
+/// Extract a fully evaluated scalar used directly by `switchInt`.
+///
+/// Monomorphized core code frequently leaves type-property branches such as
+/// `T::IS_ZST` in MIR even though their discriminant is a constant. Following
+/// only the selected edge keeps dead panic helpers and unsupported ZST-only
+/// code out of the device translation.
+fn constant_operand_bits(operand: &mir::Operand) -> Option<u128> {
+    match operand {
+        mir::Operand::Constant(const_op) => {
+            let rustc_public::ty::ConstantKind::Allocated(alloc) = const_op.const_.kind() else {
+                return None;
+            };
+            alloc.read_uint().ok()
+        }
+        mir::Operand::RuntimeChecks(_) => Some(0),
+        _ => None,
+    }
+}
+
+/// BFS from the entry block (index 0) following feasible non-unwind successors.
 ///
 /// The result is a sorted set of reachable-on-GPU block indices; unwind-only
 /// cleanup blocks end up outside this set and are filled in with
@@ -279,7 +342,7 @@ fn compute_reachable_blocks(body: &mir::Body) -> std::collections::BTreeSet<usiz
     let mut frontier: Vec<usize> = vec![0];
     reachable.insert(0);
     while let Some(idx) = frontier.pop() {
-        let successors = non_unwind_successors(&body.blocks[idx].terminator.kind);
+        let successors = non_unwind_successors(body, idx);
         for succ in successors {
             if reachable.insert(succ) {
                 frontier.push(succ);

--- a/crates/mir-importer/src/translator/mod.rs
+++ b/crates/mir-importer/src/translator/mod.rs
@@ -64,6 +64,21 @@ use pliron::operation::Operation;
 use rustc_public::mir;
 use rustc_public::mir::mono;
 
+/// Device-side value of every `Operand::RuntimeChecks` flag (`UbChecks`,
+/// `OverflowChecks`, `ContractChecks`).
+///
+/// Runtime safety checks are never enabled in device PTX, regardless of the
+/// host session's `-C debug-assertions` setting: the operand translator
+/// lowers the flag to this constant, and the reachability walks fold
+/// `switchInt` edges with it. Every consumer that models the device value of
+/// a `RuntimeChecks` operand MUST read this one constant. In particular, the
+/// rustc-codegen-cuda collector's dead-edge pruning must never consult the
+/// session value (`RuntimeChecks::value(sess)`): a dev-profile device build
+/// keeps debug assertions on, so a session-value collector would prune a
+/// different `SwitchInt` edge than the importer translates, leaving calls to
+/// functions that were never collected.
+pub const DEVICE_RUNTIME_CHECKS: bool = false;
+
 /// Registers all dialects needed for translation.
 ///
 /// Registers `dialect-mir` (our MIR modelling dialect), `dialect-nvvm`

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1018,6 +1018,26 @@ pub fn translate_rvalue(
                             // (e.g., enum Foo { A = 0, B = 2, C = 6 } has indices 0,1,2 but discriminants 0,2,6)
                             let variant_index_val: usize = variant_idx.to_index();
 
+                            // A value inhabiting this variant cannot exist,
+                            // so this construction sits on a dynamically dead
+                            // path rustc keeps in MIR (e.g. building
+                            // `ControlFlow::Break(NeverShortCircuitResidual)`
+                            // inside `array::try_from_fn`).
+                            // `mir.construct_enum` refuses uninhabited
+                            // variants by verification, so keep the dead path
+                            // representable with a typed undef instead.
+                            let variant_is_uninhabited = adt_ty
+                                .deref(ctx)
+                                .downcast_ref::<dialect_mir::types::MirEnumType>()
+                                .and_then(|enum_ty| enum_ty.variant_is_inhabited(variant_index_val))
+                                .is_some_and(|inhabited| !inhabited);
+                            if variant_is_uninhabited {
+                                let undef = MirUndefOp::new(ctx, adt_ty).get_operation();
+                                undef.deref_mut(ctx).set_loc(loc);
+                                let result = undef.deref(ctx).get_result(0);
+                                return Ok((Some(undef), result, current_prev_op));
+                            }
+
                             // Cast field values to expected types (address space normalization)
                             // This handles cases where field values have specific address spaces
                             // (e.g., addrspace:3 for shared memory) but the enum type expects
@@ -1457,10 +1477,14 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let enum_ty = enum_val.get_type(ctx);
-            let native_tag_ty = {
+            let (native_tag_ty, enum_is_uninhabited) = {
                 let enum_ty_obj = enum_ty.deref(ctx);
                 if let Some(enum_type) = enum_ty_obj.downcast_ref::<MirEnumType>() {
-                    enum_type.discriminant_type()
+                    let uninhabited = !enum_type
+                        .variant_inhabited
+                        .iter()
+                        .any(|inhabited| *inhabited != 0);
+                    (enum_type.discriminant_type(), uninhabited)
                 } else {
                     return input_err!(
                         loc,
@@ -1471,6 +1495,28 @@ pub fn translate_rvalue(
                     );
                 }
             };
+
+            // No value of an uninhabited enum can exist, so this read sits
+            // on a dynamically dead path rustc keeps in MIR (e.g. matching
+            // the residual `ControlFlow<Infallible, NeverShortCircuitResidual>`
+            // inside `array::try_from_fn`). `mir.get_discriminant` refuses
+            // uninhabited enums by verification, so keep the dead path
+            // representable with a typed undef of the declared discriminant
+            // type instead.
+            if enum_is_uninhabited {
+                let declared_discr_ty = place
+                    .ty(body.locals())
+                    .ok()
+                    .and_then(|place_ty| place_ty.kind().discriminant_ty());
+                let undef_ty = match declared_discr_ty {
+                    Some(ty) => super::types::translate_type(ctx, &ty)?,
+                    None => native_tag_ty,
+                };
+                let undef = MirUndefOp::new(ctx, undef_ty).get_operation();
+                undef.deref_mut(ctx).set_loc(loc);
+                let result = undef.deref(ctx).get_result(0);
+                return Ok((Some(undef), result, prev_op_after));
+            }
 
             let get_disc_op = Operation::new(
                 ctx,
@@ -3617,6 +3663,48 @@ fn apply_enum_field_projection(
 
     let field_type = types::translate_type(ctx, field_ty)?;
 
+    // Get the variant index
+    // NOTE: variant_idx IS the index (0, 1, 2, ...), NOT the discriminant!
+    // We just need to validate it's an ADT type, then use the index directly.
+    let variant_idx_val: usize = match enum_rust_ty.kind() {
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(_adt_def, _)) => {
+            variant_idx.to_index()
+        }
+        _ => {
+            return input_err!(
+                loc.clone(),
+                TranslationErr::unsupported(format!(
+                    "Downcast on non-ADT type: {:?}",
+                    enum_rust_ty
+                ))
+            );
+        }
+    };
+
+    // A value inhabiting this variant cannot exist, so the read sits on a
+    // dynamically dead path that rustc nevertheless keeps in MIR (e.g. the
+    // `ControlFlow::Break(NeverShortCircuitResidual)` arm inside
+    // `array::try_from_fn`). `mir.enum_payload` refuses uninhabited
+    // variants by verification, so keep the dead path representable with a
+    // typed undef instead — the same treatment `[T; 0]` extraction gets.
+    let variant_is_uninhabited = {
+        let enum_ty = enum_value.get_type(ctx);
+        enum_ty
+            .deref(ctx)
+            .downcast_ref::<dialect_mir::types::MirEnumType>()
+            .and_then(|enum_ty| enum_ty.variant_is_inhabited(variant_idx_val))
+            .is_some_and(|inhabited| !inhabited)
+    };
+    if variant_is_uninhabited {
+        let undef = MirUndefOp::new(ctx, field_type).get_operation();
+        undef.deref_mut(ctx).set_loc(loc);
+        match prev_op {
+            Some(prev) => undef.insert_after(ctx, prev),
+            None => undef.insert_at_front(block_ptr, ctx),
+        }
+        return Ok((undef.deref(ctx).get_result(0), Some(undef)));
+    }
+
     let op = Operation::new(
         ctx,
         MirEnumPayloadOp::get_concrete_op_info(),
@@ -3628,24 +3716,6 @@ fn apply_enum_field_projection(
     op.deref_mut(ctx).set_loc(loc.clone());
 
     let payload_op = MirEnumPayloadOp::new(op);
-
-    // Get the variant index
-    // NOTE: variant_idx IS the index (0, 1, 2, ...), NOT the discriminant!
-    // We just need to validate it's an ADT type, then use the index directly.
-    let variant_idx_val: usize = match enum_rust_ty.kind() {
-        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(_adt_def, _)) => {
-            variant_idx.to_index()
-        }
-        _ => {
-            return input_err!(
-                loc,
-                TranslationErr::unsupported(format!(
-                    "Downcast on non-ADT type: {:?}",
-                    enum_rust_ty
-                ))
-            );
-        }
-    };
 
     payload_op.set_attr_payload_variant_index(
         ctx,

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1828,6 +1828,9 @@ pub fn translate_operand(
             let is_enum = const_ty_ptr
                 .deref(ctx)
                 .is::<dialect_mir::types::MirEnumType>();
+            let is_union = const_ty_ptr
+                .deref(ctx)
+                .is::<dialect_mir::types::MirUnionType>();
 
             // Check if this is a pointer to an array (byte strings, or typed arrays like [f64; 3])
             let is_ptr_to_array = const_ty_ptr
@@ -1902,6 +1905,15 @@ pub fn translate_operand(
                     ctx,
                     constant,
                     &rust_ty,
+                    const_ty_ptr,
+                    block_ptr,
+                    prev_op,
+                    loc,
+                )
+            } else if is_union {
+                translate_uninitialized_union_constant(
+                    ctx,
+                    constant,
                     const_ty_ptr,
                     block_ptr,
                     prev_op,
@@ -2516,6 +2528,56 @@ pub fn translate_operand(
             Ok((val, Some(const_op.get_operation())))
         }
     }
+}
+
+/// Materialize a union constant whose allocation is entirely uninitialized.
+///
+/// `core::array::map` initializes its output buffer from
+/// `[MaybeUninit::uninit(); N]`. rustc represents each repeated element as an
+/// allocated union constant containing only uninitialized bytes, which maps
+/// exactly to a typed `mir.undef`. Initialized union constants need an active
+/// byte-preserving field view and remain a loud error until that representation
+/// is available.
+fn translate_uninitialized_union_constant(
+    ctx: &mut Context,
+    constant: &mir::ConstOperand,
+    union_ty: TypeHandle,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
+    use rustc_public::ty::TyConstKind;
+
+    let allocation = match constant.const_.kind() {
+        ConstantKind::Allocated(allocation) => Some(allocation),
+        ConstantKind::Ty(ty_const) => match ty_const.kind() {
+            TyConstKind::Value(_, allocation) => Some(allocation),
+            _ => None,
+        },
+        _ => None,
+    };
+    let Some(allocation) = allocation else {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported("Non-ZST union constant is not backed by an allocation")
+        );
+    };
+    if allocation.bytes.iter().any(Option::is_some) || !allocation.provenance.ptrs.is_empty() {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(
+                "Union constants with initialized bytes are not yet supported"
+            )
+        );
+    }
+
+    let undef = MirUndefOp::new(ctx, union_ty).get_operation();
+    undef.deref_mut(ctx).set_loc(loc);
+    match prev_op {
+        Some(prev) => undef.insert_after(ctx, prev),
+        None => undef.insert_at_front(block_ptr, ctx),
+    }
+    Ok((undef.deref(ctx).get_result(0), Some(undef)))
 }
 
 /// Translate MIR [`Place`](mir::Place) reads to pliron IR SSA [`Value`]s.

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -2490,7 +2490,10 @@ pub fn translate_operand(
         }
         mir::Operand::RuntimeChecks(_) => {
             // RuntimeChecks variants (UbChecks, ContractChecks, OverflowChecks)
-            // evaluate to `false` on GPU -- runtime safety checks are disabled.
+            // evaluate to the shared device value on GPU -- runtime safety
+            // checks are disabled. The reachability walks fold `switchInt`
+            // edges with the same constant, so translation and edge pruning
+            // can never disagree about which branch is live.
             //
             // Emits a `mir.constant false : i1` and inserts it into the current
             // block. The op *must* be linked before returning; callers use the
@@ -2501,7 +2504,10 @@ pub fn translate_operand(
             use pliron::utils::apint::APInt;
 
             let bool_ty: TypeHandle = IntegerType::get(ctx, 1, Signedness::Signless).into();
-            let false_val = APInt::from_u64(0, std::num::NonZeroUsize::new(1).unwrap());
+            let false_val = APInt::from_u64(
+                crate::translator::DEVICE_RUNTIME_CHECKS as u64,
+                std::num::NonZeroUsize::new(1).unwrap(),
+            );
             let const_attr =
                 IntegerAttr::new(IntegerType::get(ctx, 1, Signedness::Signless), false_val);
 

--- a/crates/mir-importer/src/translator/terminator/drop_glue.rs
+++ b/crates/mir-importer/src/translator/terminator/drop_glue.rs
@@ -489,12 +489,11 @@ fn const_operand_bits(operand: &mir::Operand) -> Option<u128> {
             };
             alloc.read_uint().ok()
         }
-        // Runtime check flags (`UbChecks` and friends). Device code is
-        // built with `-C debug-assertions=off`, so these evaluate to
-        // false; the statement translator lowers them to a constant
-        // false for the same reason. Folding them here lets the proof
-        // skip check-only branches instead of having to prove them.
-        mir::Operand::RuntimeChecks(_) => Some(0),
+        // Runtime check flags (`UbChecks` and friends) fold to the shared
+        // device value; the operand translator lowers them to the same
+        // constant. Folding them here lets the proof skip check-only
+        // branches instead of having to prove them.
+        mir::Operand::RuntimeChecks(_) => Some(crate::translator::DEVICE_RUNTIME_CHECKS as u128),
         _ => None,
     }
 }

--- a/crates/mir-importer/src/translator/terminator/drop_glue.rs
+++ b/crates/mir-importer/src/translator/terminator/drop_glue.rs
@@ -28,7 +28,9 @@
 //! drop shim and the whole chain does nothing at runtime: it only
 //! shuffles index values between local variables on the way to the
 //! empty shim. The same holds for any element type without drop glue,
-//! including plain `Copy` structs.
+//! including plain `Copy` structs. `array::map` uses a related
+//! `core::array::drain::Drain<T, N, F>` guard. Its cleanup only drops
+//! the unconsumed `T` values, so it is harmless under the same condition.
 //!
 //! What counts as "nothing observable":
 //!
@@ -75,9 +77,10 @@ use pliron::input_error;
 use pliron::location::{Located, Location};
 use pliron::op::Op;
 use pliron::operation::Operation;
+use rustc_public::CrateDef;
 use rustc_public::mir;
 use rustc_public::mir::mono::Instance;
-use rustc_public::ty::{RigidTy, Ty, TyKind};
+use rustc_public::ty::{GenericArgKind, RigidTy, Ty, TyKind};
 
 /// Cap on the call-chain depth the proof is willing to follow. Real
 /// no-op drop glue is shallow (the `IntoIter` case above is two levels:
@@ -94,9 +97,37 @@ const MAX_PROOF_DEPTH: usize = 16;
 ///
 /// This is a thin wrapper over [`drop_instance_is_noop`], the single
 /// no-op predicate shared by every site that must agree on whether a
-/// drop is observable.
+/// drop is observable, with one type-level reduction applied first:
+/// core's private `array::Drain` guard drops only unconsumed input
+/// elements, so proving the element type's drop glue harmless is both
+/// sufficient and tighter than interpreting the guard's
+/// pointer-distance calculation and unreachable invariant panic.
 pub fn drop_glue_is_noop(dropped_ty: Ty) -> bool {
+    if let Some(element_ty) = array_drain_element_type(dropped_ty) {
+        return drop_instance_is_noop(&Instance::resolve_drop_in_place(element_ty));
+    }
     drop_instance_is_noop(&Instance::resolve_drop_in_place(dropped_ty))
+}
+
+/// Return the consumed element type for core's private `array::Drain` guard.
+fn array_drain_element_type(ty: Ty) -> Option<Ty> {
+    let TyKind::RigidTy(RigidTy::Adt(def, args)) = ty.kind() else {
+        return None;
+    };
+    let name = def.name();
+    if name.as_str() != "core::array::drain::Drain" && name.as_str() != "std::array::drain::Drain" {
+        return None;
+    }
+    match args.0.as_slice() {
+        [
+            GenericArgKind::Lifetime(_),
+            GenericArgKind::Lifetime(_),
+            GenericArgKind::Type(element_ty),
+            GenericArgKind::Const(_),
+            GenericArgKind::Type(_),
+        ] => Some(*element_ty),
+        _ => None,
+    }
 }
 
 /// Returns true when the given `drop_in_place` instance is provably a

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -1668,10 +1668,11 @@ fn convert_small_array_element_addr(
         let marker_key: pliron::identifier::Identifier = SMALL_ARRAY_ADDRESS_SELECT_ATTR
             .try_into()
             .expect("valid small-array marker attribute name");
-        select.get_operation().deref_mut(ctx).attributes.set(
-            marker_key,
-            pliron::builtin::attributes::UnitAttr::new(),
-        );
+        select
+            .get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(marker_key, pliron::builtin::attributes::UnitAttr::new());
         rewriter.insert_operation(ctx, select.get_operation());
         selected = select.get_operation().deref(ctx).get_result(0);
     }
@@ -1795,6 +1796,40 @@ mod tests {
         module_ptr
     }
 
+    fn build_array_element_addr_write(ctx: &mut Context, array_size: u64) -> Ptr<Operation> {
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(ctx, i32_ty, array_size).into();
+        let array_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, array_ty, true).into();
+        let element_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, i32_ty, true).into();
+
+        let (module_ptr, block) = build_kernel(ctx, vec![array_ptr_ty, usize_ty, i32_ty], vec![]);
+        let array_ptr = block.deref(ctx).get_argument(0);
+        let index = block.deref(ctx).get_argument(1);
+        let value = block.deref(ctx).get_argument(2);
+        let address = Operation::new(
+            ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty],
+            vec![array_ptr, index],
+            vec![],
+            0,
+        );
+        address.insert_at_back(block, ctx);
+        let element_ptr = address.deref(ctx).get_result(0);
+        let store = Operation::new(
+            ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![element_ptr, value],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, ctx);
+        append_mir_return(ctx, block, vec![]);
+        module_ptr
+    }
+
     #[test]
     fn small_runtime_array_extract_stays_in_ssa() {
         let mut ctx = make_ctx();
@@ -1839,6 +1874,20 @@ mod tests {
         assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
         assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 4);
         assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 3);
+    }
+
+    #[test]
+    fn small_runtime_array_store_updates_constant_pointer_candidates() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_array_element_addr_write(&mut ctx, 3);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 3);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 3);
+        assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 3);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -653,6 +653,22 @@ pub(crate) fn is_small_array_address_select(ctx: &Context, op: Ptr<Operation>) -
         .is_some()
 }
 
+fn is_local_array_address(ctx: &Context, ptr: Value) -> bool {
+    let Some(defining_op) = ptr.defining_op() else {
+        return false;
+    };
+    if Operation::get_op::<llvm::AllocaOp>(defining_op, ctx).is_some() {
+        return true;
+    }
+    if is_small_array_address_select(ctx, defining_op) {
+        return is_local_array_address(ctx, defining_op.deref(ctx).get_operand(1))
+            && is_local_array_address(ctx, defining_op.deref(ctx).get_operand(2));
+    }
+    Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx).is_some_and(|gep| {
+        is_local_array_address(ctx, gep.get_operation().deref(ctx).get_operand(0))
+    })
+}
+
 /// Convert `mir.extract_array_element` to LLVM SSA operations for small arrays.
 ///
 /// LLVM's `extractvalue` only accepts constant indices, so a runtime index is
@@ -1564,7 +1580,8 @@ pub(crate) fn convert_field_addr(
 // MirArrayElementAddrOp Conversion
 // ============================================================================
 
-/// Convert `mir.array_element_addr` to `llvm.getelementptr`.
+/// Convert `mir.array_element_addr` to constant-address selection for small
+/// local arrays or to `llvm.getelementptr` otherwise.
 ///
 /// This computes the address of an array element using a runtime index.
 /// The operation is: `&arr[i]` → `getelementptr [N x T], ptr %arr_ptr, i64 0, i64 %i`
@@ -1600,7 +1617,7 @@ pub(crate) fn convert_array_element_addr(
 
     let llvm_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
 
-    if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size) {
+    if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size) && is_local_array_address(ctx, arr_ptr) {
         return convert_small_array_element_addr(
             ctx,
             rewriter,
@@ -1796,17 +1813,35 @@ mod tests {
         module_ptr
     }
 
-    fn build_array_element_addr_write(ctx: &mut Context, array_size: u64) -> Ptr<Operation> {
+    fn build_local_array_element_addr_access(
+        ctx: &mut Context,
+        array_size: u64,
+        write: bool,
+    ) -> Ptr<Operation> {
         let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
         let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
         let array_ty: TypeHandle = MirArrayType::get(ctx, i32_ty, array_size).into();
         let array_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, array_ty, true).into();
         let element_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, i32_ty, true).into();
 
-        let (module_ptr, block) = build_kernel(ctx, vec![array_ptr_ty, usize_ty, i32_ty], vec![]);
-        let array_ptr = block.deref(ctx).get_argument(0);
-        let index = block.deref(ctx).get_argument(1);
-        let value = block.deref(ctx).get_argument(2);
+        let arg_tys = if write {
+            vec![usize_ty, i32_ty]
+        } else {
+            vec![usize_ty]
+        };
+        let result_tys = if write { vec![] } else { vec![i32_ty] };
+        let (module_ptr, block) = build_kernel(ctx, arg_tys, result_tys);
+        let index = block.deref(ctx).get_argument(0);
+        let alloca = Operation::new(
+            ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![array_ptr_ty],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca.insert_at_back(block, ctx);
+        let array_ptr = alloca.deref(ctx).get_result(0);
         let address = Operation::new(
             ctx,
             mir::MirArrayElementAddrOp::get_concrete_op_info(),
@@ -1817,16 +1852,32 @@ mod tests {
         );
         address.insert_at_back(block, ctx);
         let element_ptr = address.deref(ctx).get_result(0);
-        let store = Operation::new(
-            ctx,
-            mir::MirStoreOp::get_concrete_op_info(),
-            vec![],
-            vec![element_ptr, value],
-            vec![],
-            0,
-        );
-        store.insert_at_back(block, ctx);
-        append_mir_return(ctx, block, vec![]);
+
+        if write {
+            let value = block.deref(ctx).get_argument(1);
+            let store = Operation::new(
+                ctx,
+                mir::MirStoreOp::get_concrete_op_info(),
+                vec![],
+                vec![element_ptr, value],
+                vec![],
+                0,
+            );
+            store.insert_at_back(block, ctx);
+            append_mir_return(ctx, block, vec![]);
+        } else {
+            let load = Operation::new(
+                ctx,
+                mir::MirLoadOp::get_concrete_op_info(),
+                vec![i32_ty],
+                vec![element_ptr],
+                vec![],
+                0,
+            );
+            load.insert_at_back(block, ctx);
+            let loaded = load.deref(ctx).get_result(0);
+            append_mir_return(ctx, block, vec![loaded]);
+        }
         module_ptr
     }
 
@@ -1865,7 +1916,7 @@ mod tests {
     #[test]
     fn small_runtime_array_address_uses_constant_pointer_selection() {
         let mut ctx = make_ctx();
-        let module_ptr = build_array_element_addr_read(&mut ctx, 3);
+        let module_ptr = build_local_array_element_addr_access(&mut ctx, 3, false);
 
         crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
         let body = kernel_blocks(&ctx, module_ptr);
@@ -1879,7 +1930,7 @@ mod tests {
     #[test]
     fn small_runtime_array_store_updates_constant_pointer_candidates() {
         let mut ctx = make_ctx();
-        let module_ptr = build_array_element_addr_write(&mut ctx, 3);
+        let module_ptr = build_local_array_element_addr_access(&mut ctx, 3, true);
 
         crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
         let body = kernel_blocks(&ctx, module_ptr);
@@ -1888,6 +1939,20 @@ mod tests {
         assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
         assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 3);
         assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 3);
+    }
+
+    #[test]
+    fn small_external_array_address_keeps_single_dynamic_gep() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_array_element_addr_read(&mut ctx, 3);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -669,6 +669,35 @@ fn is_local_array_address(ctx: &Context, ptr: Value) -> bool {
     })
 }
 
+/// Whether `ptr` is a read-only array field projected from an aggregate.
+///
+/// Small runtime indexing through a shared aggregate reference is safe to
+/// express as constant-address candidate loads: Rust guarantees every array
+/// element behind the shared reference is initialized and cannot be mutated
+/// concurrently outside interior mutability. Exposing those constant field
+/// addresses also lets SROA eliminate caller-owned aggregate copies after an
+/// `#[inline(always)]` helper is inlined. Keep direct external arrays and all
+/// mutable projections as a single dynamic GEP so ordinary global-memory
+/// access does not fan out into speculative loads.
+fn is_readonly_aggregate_array_address(
+    ctx: &Context,
+    ptr: Value,
+    pointer_is_mutable: bool,
+) -> bool {
+    if pointer_is_mutable {
+        return false;
+    }
+
+    let Some(defining_op) = ptr.defining_op() else {
+        return false;
+    };
+    Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx).is_some_and(|gep| {
+        gep.src_elem_type(ctx)
+            .deref(ctx)
+            .is::<llvm_export::types::StructType>()
+    })
+}
+
 /// Convert `mir.extract_array_element` to LLVM SSA operations for small arrays.
 ///
 /// LLVM's `extractvalue` only accepts constant indices, so a runtime index is
@@ -1594,16 +1623,16 @@ pub(crate) fn convert_array_element_addr(
     let arr_ptr = op.deref(ctx).get_operand(0);
     let index = op.deref(ctx).get_operand(1);
 
-    let (pointee_ty, array_size) = {
-        let mir_ptr_pointee =
-            match operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, arr_ptr) {
-                Some(r) => r.pointee,
-                None => {
-                    return pliron::input_err_noloc!(
-                        "MirArrayElementAddrOp operand must be pointer type"
-                    );
-                }
-            };
+    let (pointee_ty, array_size, pointer_is_mutable) = {
+        let mir_ptr = match operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, arr_ptr) {
+            Some(r) => r,
+            None => {
+                return pliron::input_err_noloc!(
+                    "MirArrayElementAddrOp operand must be pointer type"
+                );
+            }
+        };
+        let mir_ptr_pointee = mir_ptr.pointee;
 
         let pointee_ref = mir_ptr_pointee.deref(ctx);
         let array_size = pointee_ref
@@ -1612,12 +1641,15 @@ pub(crate) fn convert_array_element_addr(
                 pliron::input_error_noloc!("MirArrayElementAddrOp pointer must point to array type")
             })?
             .size();
-        (mir_ptr_pointee, array_size)
+        (mir_ptr_pointee, array_size, mir_ptr.is_mutable())
     };
 
     let llvm_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
 
-    if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size) && is_local_array_address(ctx, arr_ptr) {
+    if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size)
+        && (is_local_array_address(ctx, arr_ptr)
+            || is_readonly_aggregate_array_address(ctx, arr_ptr, pointer_is_mutable))
+    {
         return convert_small_array_element_addr(
             ctx,
             rewriter,
@@ -1813,6 +1845,66 @@ mod tests {
         module_ptr
     }
 
+    fn build_aggregate_array_element_addr_read(
+        ctx: &mut Context,
+        array_size: u64,
+        mutable: bool,
+    ) -> Ptr<Operation> {
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(ctx, i32_ty, array_size).into();
+        let aggregate_ty: TypeHandle = MirStructType::get(
+            ctx,
+            "ArrayOwner".to_string(),
+            vec!["values".to_string()],
+            vec![array_ty],
+        )
+        .into();
+        let aggregate_ptr_ty: TypeHandle =
+            MirPtrType::get_generic(ctx, aggregate_ty, mutable).into();
+        let array_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, array_ty, mutable).into();
+        let element_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, i32_ty, mutable).into();
+
+        let (module_ptr, block) = build_kernel(ctx, vec![aggregate_ptr_ty, usize_ty], vec![i32_ty]);
+        let aggregate_ptr = block.deref(ctx).get_argument(0);
+        let index = block.deref(ctx).get_argument(1);
+
+        let field_address = Operation::new(
+            ctx,
+            MirFieldAddrOp::get_concrete_op_info(),
+            vec![array_ptr_ty],
+            vec![aggregate_ptr],
+            vec![],
+            0,
+        );
+        MirFieldAddrOp::new(field_address).set_attr_field_index(ctx, FieldIndexAttr(0));
+        field_address.insert_at_back(block, ctx);
+        let array_ptr = field_address.deref(ctx).get_result(0);
+
+        let address = Operation::new(
+            ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty],
+            vec![array_ptr, index],
+            vec![],
+            0,
+        );
+        address.insert_at_back(block, ctx);
+        let element_ptr = address.deref(ctx).get_result(0);
+        let load = Operation::new(
+            ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![i32_ty],
+            vec![element_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, ctx);
+        let value = load.deref(ctx).get_result(0);
+        append_mir_return(ctx, block, vec![value]);
+        module_ptr
+    }
+
     fn build_local_array_element_addr_access(
         ctx: &mut Context,
         array_size: u64,
@@ -1950,6 +2042,34 @@ mod tests {
         let body = kernel_blocks(&ctx, module_ptr);
 
         assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
+    }
+
+    #[test]
+    fn small_readonly_aggregate_array_address_uses_constant_pointer_selection() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, false);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 4);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 4);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 3);
+    }
+
+    #[test]
+    fn small_mutable_aggregate_array_address_keeps_single_dynamic_gep() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, true);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 2);
         assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
         assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
         assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -641,6 +641,18 @@ pub(crate) fn convert_construct_array(
 /// retain the compact memory-based lowering.
 const MAX_SSA_ARRAY_ELEMENTS: u64 = 16;
 
+const SMALL_ARRAY_ADDRESS_SELECT_ATTR: &str = "small_array_address_select";
+
+pub(crate) fn is_small_array_address_select(ctx: &Context, op: Ptr<Operation>) -> bool {
+    let key: pliron::identifier::Identifier = SMALL_ARRAY_ADDRESS_SELECT_ATTR
+        .try_into()
+        .expect("valid small-array marker attribute name");
+    op.deref(ctx)
+        .attributes
+        .get::<pliron::builtin::attributes::UnitAttr>(&key)
+        .is_some()
+}
+
 /// Convert `mir.extract_array_element` to LLVM SSA operations for small arrays.
 ///
 /// LLVM's `extractvalue` only accepts constant indices, so a runtime index is
@@ -1653,6 +1665,13 @@ fn convert_small_array_element_addr(
         let condition = matches.get_operation().deref(ctx).get_result(0);
 
         let select = llvm::SelectOp::new(ctx, condition, pointer, selected);
+        let marker_key: pliron::identifier::Identifier = SMALL_ARRAY_ADDRESS_SELECT_ATTR
+            .try_into()
+            .expect("valid small-array marker attribute name");
+        select.get_operation().deref_mut(ctx).attributes.set(
+            marker_key,
+            pliron::builtin::attributes::UnitAttr::new(),
+        );
         rewriter.insert_operation(ctx, select.get_operation());
         selected = select.get_operation().deref(ctx).get_result(0);
     }
@@ -1818,8 +1837,8 @@ mod tests {
 
         assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 3);
         assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
-        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 2);
-        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 4);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 3);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -72,6 +72,22 @@ fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
     pliron::input_error_noloc!("{e}")
 }
 
+fn integer_constant(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    width: u32,
+    value: u64,
+) -> Value {
+    let bit_width = NonZeroUsize::new(width as usize).expect("integer width is non-zero");
+    let attr = pliron::builtin::attributes::IntegerAttr::new(
+        IntegerType::get(ctx, width, Signedness::Signless),
+        APInt::from_u64(value, bit_width),
+    );
+    let constant = llvm::ConstantOp::new(ctx, attr.into());
+    rewriter.insert_operation(ctx, constant.get_operation());
+    constant.get_operation().deref(ctx).get_result(0)
+}
+
 /// How the MIR-level field indices of an aggregate operand map onto the
 /// lowered LLVM aggregate.
 enum AggregateSlots {
@@ -616,13 +632,24 @@ pub(crate) fn convert_construct_array(
     Ok(())
 }
 
-/// Convert `mir.extract_array_element` to LLVM alloca+store+GEP+load sequence.
+/// Largest fixed array lowered as an SSA selection chain.
 ///
-/// Since LLVM's `extractvalue` only supports constant indices, we need to:
-/// 1. Allocate stack space for the array
-/// 2. Store the array value to the stack
-/// 3. GEP to compute the element address
-/// 4. Load the element
+/// Device code commonly indexes three-axis and four-coefficient arrays inside
+/// small loops. Spilling those values to an alloca solely because LLVM's
+/// `extractvalue` requires a constant index creates avoidable per-thread local
+/// memory. Keep the limit deliberately small so genuinely large lookup tables
+/// retain the compact memory-based lowering.
+const MAX_SSA_ARRAY_ELEMENTS: u64 = 16;
+
+/// Convert `mir.extract_array_element` to LLVM SSA operations for small arrays.
+///
+/// LLVM's `extractvalue` only accepts constant indices, so a runtime index is
+/// represented as one constant `extractvalue` per element and an `icmp`/`select`
+/// chain. Rust emits a bounds check before an array projection, which guarantees
+/// that one of those indices matches whenever this operation executes.
+///
+/// Arrays above [`MAX_SSA_ARRAY_ELEMENTS`] retain the alloca+store+GEP+load
+/// lowering to bound code growth.
 pub(crate) fn convert_extract_array_element(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -640,6 +667,18 @@ pub(crate) fn convert_extract_array_element(
     };
 
     let llvm_element_ty = convert_type(ctx, element_ty).map_err(anyhow_to_pliron)?;
+    if array_size <= MAX_SSA_ARRAY_ELEMENTS {
+        return convert_small_array_extract(
+            ctx,
+            rewriter,
+            op,
+            array_val,
+            index_val,
+            llvm_element_ty,
+            array_size,
+        );
+    }
+
     let llvm_array_ty = llvm_export::types::ArrayType::get(ctx, llvm_element_ty, array_size);
 
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
@@ -668,6 +707,59 @@ pub(crate) fn convert_extract_array_element(
     rewriter.insert_operation(ctx, load_op.get_operation());
     rewriter.replace_operation(ctx, op, load_op.get_operation());
 
+    Ok(())
+}
+
+fn convert_small_array_extract(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    array_val: Value,
+    index_val: Value,
+    llvm_element_ty: TypeHandle,
+    array_size: u64,
+) -> Result<()> {
+    if array_size == 0 {
+        // A Rust bounds check makes extraction from `[T; 0]` unreachable. Undef
+        // keeps that dead path representable without inventing a stack slot.
+        let undef = llvm::UndefOp::new(ctx, llvm_element_ty);
+        rewriter.insert_operation(ctx, undef.get_operation());
+        rewriter.replace_operation(ctx, op, undef.get_operation());
+        return Ok(());
+    }
+
+    let index_width = index_val
+        .get_type(ctx)
+        .deref(ctx)
+        .downcast_ref::<IntegerType>()
+        .ok_or_else(|| pliron::input_error_noloc!("array index must lower to an integer"))?
+        .width();
+
+    let last_index = u32::try_from(array_size - 1)
+        .map_err(|_| pliron::input_error_noloc!("small array index does not fit u32"))?;
+    let last_extract = llvm::ExtractValueOp::new(ctx, array_val, vec![last_index])?;
+    rewriter.insert_operation(ctx, last_extract.get_operation());
+    let mut selected = last_extract.get_operation().deref(ctx).get_result(0);
+
+    // The final element is the default, so a valid index needs N-1 compares.
+    for index in (0..array_size - 1).rev() {
+        let llvm_index = u32::try_from(index)
+            .map_err(|_| pliron::input_error_noloc!("small array index does not fit u32"))?;
+        let extract = llvm::ExtractValueOp::new(ctx, array_val, vec![llvm_index])?;
+        rewriter.insert_operation(ctx, extract.get_operation());
+        let element = extract.get_operation().deref(ctx).get_result(0);
+
+        let index_constant = integer_constant(ctx, rewriter, index_width, index);
+        let matches = llvm::ICmpOp::new(ctx, ICmpPredicateAttr::EQ, index_val, index_constant);
+        rewriter.insert_operation(ctx, matches.get_operation());
+        let condition = matches.get_operation().deref(ctx).get_result(0);
+
+        let select = llvm::SelectOp::new(ctx, condition, element, selected);
+        rewriter.insert_operation(ctx, select.get_operation());
+        selected = select.get_operation().deref(ctx).get_result(0);
+    }
+
+    rewriter.replace_operation_with_values(ctx, op, vec![selected]);
     Ok(())
 }
 
@@ -1473,7 +1565,7 @@ pub(crate) fn convert_array_element_addr(
     let arr_ptr = op.deref(ctx).get_operand(0);
     let index = op.deref(ctx).get_operand(1);
 
-    let pointee_ty = {
+    let (pointee_ty, array_size) = {
         let mir_ptr_pointee =
             match operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, arr_ptr) {
                 Some(r) => r.pointee,
@@ -1485,15 +1577,28 @@ pub(crate) fn convert_array_element_addr(
             };
 
         let pointee_ref = mir_ptr_pointee.deref(ctx);
-        if pointee_ref.downcast_ref::<MirArrayType>().is_none() {
-            return pliron::input_err_noloc!(
-                "MirArrayElementAddrOp pointer must point to array type"
-            );
-        }
-        mir_ptr_pointee
+        let array_size = pointee_ref
+            .downcast_ref::<MirArrayType>()
+            .ok_or_else(|| {
+                pliron::input_error_noloc!("MirArrayElementAddrOp pointer must point to array type")
+            })?
+            .size();
+        (mir_ptr_pointee, array_size)
     };
 
     let llvm_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
+
+    if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size) {
+        return convert_small_array_element_addr(
+            ctx,
+            rewriter,
+            op,
+            arr_ptr,
+            index,
+            llvm_array_ty,
+            array_size,
+        );
+    }
 
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Value(index)];
@@ -1502,6 +1607,57 @@ pub(crate) fn convert_array_element_addr(
     rewriter.insert_operation(ctx, gep_op.get_operation());
     rewriter.replace_operation(ctx, op, gep_op.get_operation());
 
+    Ok(())
+}
+
+fn convert_small_array_element_addr(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    arr_ptr: Value,
+    index: Value,
+    llvm_array_ty: TypeHandle,
+    array_size: u64,
+) -> Result<()> {
+    use llvm_export::ops::GepIndex;
+
+    let index_width = index
+        .get_type(ctx)
+        .deref(ctx)
+        .downcast_ref::<IntegerType>()
+        .ok_or_else(|| pliron::input_error_noloc!("array index must lower to an integer"))?
+        .width();
+
+    let element_ptr = |ctx: &mut Context,
+                       rewriter: &mut DialectConversionRewriter,
+                       element_index: u64|
+     -> Result<Value> {
+        let llvm_index = u32::try_from(element_index)
+            .map_err(|_| pliron::input_error_noloc!("small array index does not fit u32"))?;
+        let gep = llvm::GetElementPtrOp::new(
+            ctx,
+            arr_ptr,
+            vec![GepIndex::Constant(0), GepIndex::Constant(llvm_index)],
+            llvm_array_ty,
+        );
+        rewriter.insert_operation(ctx, gep.get_operation());
+        Ok(gep.get_operation().deref(ctx).get_result(0))
+    };
+
+    let mut selected = element_ptr(ctx, rewriter, array_size - 1)?;
+    for element_index in (0..array_size - 1).rev() {
+        let pointer = element_ptr(ctx, rewriter, element_index)?;
+        let index_constant = integer_constant(ctx, rewriter, index_width, element_index);
+        let matches = llvm::ICmpOp::new(ctx, ICmpPredicateAttr::EQ, index, index_constant);
+        rewriter.insert_operation(ctx, matches.get_operation());
+        let condition = matches.get_operation().deref(ctx).get_result(0);
+
+        let select = llvm::SelectOp::new(ctx, condition, pointer, selected);
+        rewriter.insert_operation(ctx, select.get_operation());
+        selected = select.get_operation().deref(ctx).get_result(0);
+    }
+
+    rewriter.replace_operation_with_values(ctx, op, vec![selected]);
     Ok(())
 }
 
@@ -1543,6 +1699,141 @@ mod tests {
         );
 
         (struct_ty.into(), zst_ty)
+    }
+
+    fn build_array_extract(
+        ctx: &mut Context,
+        array_size: u64,
+    ) -> (Ptr<Operation>, Ptr<pliron::basic_block::BasicBlock>) {
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(ctx, i32_ty, array_size).into();
+        let mut arg_tys = vec![i32_ty; array_size as usize];
+        arg_tys.push(usize_ty);
+
+        let (module_ptr, block) = build_kernel(ctx, arg_tys, vec![i32_ty]);
+        let values: Vec<Value> = (0..array_size as usize)
+            .map(|index| block.deref(ctx).get_argument(index))
+            .collect();
+        let index = block.deref(ctx).get_argument(array_size as usize);
+
+        let construct = Operation::new(
+            ctx,
+            mir::MirConstructArrayOp::get_concrete_op_info(),
+            vec![array_ty],
+            values,
+            vec![],
+            0,
+        );
+        construct.insert_at_back(block, ctx);
+        let array = construct.deref(ctx).get_result(0);
+
+        let extract = Operation::new(
+            ctx,
+            mir::MirExtractArrayElementOp::get_concrete_op_info(),
+            vec![i32_ty],
+            vec![array, index],
+            vec![],
+            0,
+        );
+        extract.insert_at_back(block, ctx);
+        let extracted = extract.deref(ctx).get_result(0);
+        append_mir_return(ctx, block, vec![extracted]);
+        (module_ptr, block)
+    }
+
+    fn build_array_element_addr_read(ctx: &mut Context, array_size: u64) -> Ptr<Operation> {
+        let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(ctx, i32_ty, array_size).into();
+        let array_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, array_ty, false).into();
+        let element_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, i32_ty, false).into();
+
+        let (module_ptr, block) = build_kernel(ctx, vec![array_ptr_ty, usize_ty], vec![i32_ty]);
+        let array_ptr = block.deref(ctx).get_argument(0);
+        let index = block.deref(ctx).get_argument(1);
+        let address = Operation::new(
+            ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty],
+            vec![array_ptr, index],
+            vec![],
+            0,
+        );
+        address.insert_at_back(block, ctx);
+        let element_ptr = address.deref(ctx).get_result(0);
+        let load = Operation::new(
+            ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![i32_ty],
+            vec![element_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, ctx);
+        let value = load.deref(ctx).get_result(0);
+        append_mir_return(ctx, block, vec![value]);
+        module_ptr
+    }
+
+    #[test]
+    fn small_runtime_array_extract_stays_in_ssa() {
+        let mut ctx = make_ctx();
+        let (module_ptr, _block) = build_array_extract(&mut ctx, 3);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::ExtractValueOp>(&ctx, &body), 3);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::AllocaOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 0);
+    }
+
+    #[test]
+    fn large_runtime_array_extract_uses_bounded_memory_lowering() {
+        let mut ctx = make_ctx();
+        let (module_ptr, _block) = build_array_extract(&mut ctx, MAX_SSA_ARRAY_ELEMENTS + 1);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::AllocaOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+    }
+
+    #[test]
+    fn small_runtime_array_address_uses_constant_pointer_selection() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_array_element_addr_read(&mut ctx, 3);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 3);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
+    }
+
+    #[test]
+    fn large_runtime_array_address_keeps_single_dynamic_gep() {
+        let mut ctx = make_ctx();
+        let module_ptr = build_array_element_addr_read(&mut ctx, MAX_SSA_ARRAY_ELEMENTS + 1);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
     }
 
     fn append_empty_struct_value(

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -669,16 +669,22 @@ fn is_local_array_address(ctx: &Context, ptr: Value) -> bool {
     })
 }
 
-/// Whether `ptr` is a read-only array field projected from an aggregate.
+/// Whether `ptr` is a read-only array field projected from a stack-resident
+/// aggregate.
 ///
 /// Small runtime indexing through a shared aggregate reference is safe to
 /// express as constant-address candidate loads: Rust guarantees every array
 /// element behind the shared reference is initialized and cannot be mutated
 /// concurrently outside interior mutability. Exposing those constant field
 /// addresses also lets SROA eliminate caller-owned aggregate copies after an
-/// `#[inline(always)]` helper is inlined. Keep direct external arrays and all
-/// mutable projections as a single dynamic GEP so ordinary global-memory
-/// access does not fan out into speculative loads.
+/// `#[inline(always)]` helper is inlined.
+///
+/// The base must be alloca-rooted: for an aggregate genuinely resident in
+/// global memory (a `&BigStruct` kernel param), turning one dynamic load
+/// into up to [`MAX_SSA_ARRAY_ELEMENTS`] speculative global loads plus
+/// selects is a fan-out SROA can never delete. Function-local aggregates
+/// are the only bases where the candidate loads collapse back into
+/// registers. Mutable projections likewise keep the single dynamic GEP.
 fn is_readonly_aggregate_array_address(
     ctx: &Context,
     ptr: Value,
@@ -695,6 +701,7 @@ fn is_readonly_aggregate_array_address(
         gep.src_elem_type(ctx)
             .deref(ctx)
             .is::<llvm_export::types::StructType>()
+            && is_local_array_address(ctx, gep.get_operation().deref(ctx).get_operand(0))
     })
 }
 
@@ -1849,6 +1856,7 @@ mod tests {
         ctx: &mut Context,
         array_size: u64,
         mutable: bool,
+        local: bool,
     ) -> Ptr<Operation> {
         let i32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
         let usize_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
@@ -1865,9 +1873,32 @@ mod tests {
         let array_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, array_ty, mutable).into();
         let element_ptr_ty: TypeHandle = MirPtrType::get_generic(ctx, i32_ty, mutable).into();
 
-        let (module_ptr, block) = build_kernel(ctx, vec![aggregate_ptr_ty, usize_ty], vec![i32_ty]);
-        let aggregate_ptr = block.deref(ctx).get_argument(0);
-        let index = block.deref(ctx).get_argument(1);
+        let arg_tys = if local {
+            vec![usize_ty]
+        } else {
+            vec![aggregate_ptr_ty, usize_ty]
+        };
+        let (module_ptr, block) = build_kernel(ctx, arg_tys, vec![i32_ty]);
+        let (aggregate_ptr, index) = if local {
+            let alloca = Operation::new(
+                ctx,
+                mir::MirAllocaOp::get_concrete_op_info(),
+                vec![aggregate_ptr_ty],
+                vec![],
+                vec![],
+                0,
+            );
+            alloca.insert_at_back(block, ctx);
+            (
+                alloca.deref(ctx).get_result(0),
+                block.deref(ctx).get_argument(0),
+            )
+        } else {
+            (
+                block.deref(ctx).get_argument(0),
+                block.deref(ctx).get_argument(1),
+            )
+        };
 
         let field_address = Operation::new(
             ctx,
@@ -2048,9 +2079,9 @@ mod tests {
     }
 
     #[test]
-    fn small_readonly_aggregate_array_address_uses_constant_pointer_selection() {
+    fn small_readonly_local_aggregate_array_address_uses_constant_pointer_selection() {
         let mut ctx = make_ctx();
-        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, false);
+        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, false, true);
 
         crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
         let body = kernel_blocks(&ctx, module_ptr);
@@ -2062,9 +2093,26 @@ mod tests {
     }
 
     #[test]
+    fn small_readonly_external_aggregate_array_address_keeps_single_dynamic_gep() {
+        // A shared aggregate reference whose base is NOT alloca-rooted (a
+        // kernel param living in global memory) must not fan one dynamic
+        // load out into speculative candidate loads.
+        let mut ctx = make_ctx();
+        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, false, false);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 2);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
+    }
+
+    #[test]
     fn small_mutable_aggregate_array_address_keeps_single_dynamic_gep() {
         let mut ctx = make_ctx();
-        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, true);
+        let module_ptr = build_aggregate_array_element_addr_read(&mut ctx, 3, true, false);
 
         crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
         let body = kernel_blocks(&ctx, module_ptr);

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -1854,7 +1854,7 @@ mod tests {
     fn oversized_small_array_extract_uses_bounded_memory_lowering() {
         let mut ctx = make_ctx();
         let element_ty = wide_element_ty(&mut ctx);
-        let usize_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Unsigned).into();
         let array_ty: TypeHandle = MirArrayType::get(&mut ctx, element_ty, 8).into();
         let mut arg_tys = vec![element_ty; 8];
         arg_tys.push(usize_ty);
@@ -1898,7 +1898,7 @@ mod tests {
     fn oversized_small_array_address_keeps_single_dynamic_gep() {
         let mut ctx = make_ctx();
         let element_ty = wide_element_ty(&mut ctx);
-        let usize_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let usize_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Unsigned).into();
         let array_ty: TypeHandle = MirArrayType::get(&mut ctx, element_ty, 8).into();
         let array_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, array_ty, true).into();
         let element_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, element_ty, true).into();

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -641,6 +641,22 @@ pub(crate) fn convert_construct_array(
 /// retain the compact memory-based lowering.
 const MAX_SSA_ARRAY_ELEMENTS: u64 = 16;
 
+/// Total byte budget for the SSA selection-chain lowering.
+///
+/// [`MAX_SSA_ARRAY_ELEMENTS`] alone counts elements: `[BigStruct; 16]` would
+/// flow sixteen whole-aggregate extractvalues plus fifteen aggregate selects
+/// through registers. Cap the array's total size at 128 bytes -- the budget
+/// the element cap already implies for word-sized elements (16 x u64) -- so
+/// oversized aggregates keep the compact memory-based lowering.
+const MAX_SSA_ARRAY_BYTES: u64 = 128;
+
+/// Whether the lowered array type fits [`MAX_SSA_ARRAY_BYTES`]. Unsizeable
+/// layouts conservatively fall back to the memory lowering.
+fn fits_ssa_array_byte_budget(ctx: &Context, llvm_array_ty: TypeHandle) -> bool {
+    crate::convert::types::llvm_type_size_align(ctx, llvm_array_ty)
+        .is_some_and(|(size, _)| size <= MAX_SSA_ARRAY_BYTES)
+}
+
 const SMALL_ARRAY_ADDRESS_SELECT_ATTR: &str = "small_array_address_select";
 
 pub(crate) fn is_small_array_address_select(ctx: &Context, op: Ptr<Operation>) -> bool {
@@ -731,7 +747,9 @@ pub(crate) fn convert_extract_array_element(
     };
 
     let llvm_element_ty = convert_type(ctx, element_ty).map_err(anyhow_to_pliron)?;
-    if array_size <= MAX_SSA_ARRAY_ELEMENTS {
+    let llvm_array_ty = llvm_export::types::ArrayType::get(ctx, llvm_element_ty, array_size);
+    if array_size <= MAX_SSA_ARRAY_ELEMENTS && fits_ssa_array_byte_budget(ctx, llvm_array_ty.into())
+    {
         return convert_small_array_extract(
             ctx,
             rewriter,
@@ -742,8 +760,6 @@ pub(crate) fn convert_extract_array_element(
             array_size,
         );
     }
-
-    let llvm_array_ty = llvm_export::types::ArrayType::get(ctx, llvm_element_ty, array_size);
 
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
     let one_val = {
@@ -806,6 +822,10 @@ fn convert_small_array_extract(
     let mut selected = last_extract.get_operation().deref(ctx).get_result(0);
 
     // The final element is the default, so a valid index needs N-1 compares.
+    // This clamps an out-of-bounds UNCHECKED index to the last element
+    // instead of touching wild memory. Both are UB in Rust, but the alloca
+    // lowering faulted loudly where this reads a stale-but-valid value; the
+    // failure mode becomes silent.
     for index in (0..array_size - 1).rev() {
         let llvm_index = u32::try_from(index)
             .map_err(|_| pliron::input_error_noloc!("small array index does not fit u32"))?;
@@ -1654,6 +1674,7 @@ pub(crate) fn convert_array_element_addr(
     let llvm_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
 
     if (1..=MAX_SSA_ARRAY_ELEMENTS).contains(&array_size)
+        && fits_ssa_array_byte_budget(ctx, llvm_array_ty)
         && (is_local_array_address(ctx, arr_ptr)
             || is_readonly_aggregate_array_address(ctx, arr_ptr, pointer_is_mutable))
     {
@@ -1712,6 +1733,10 @@ fn convert_small_array_element_addr(
         Ok(gep.get_operation().deref(ctx).get_result(0))
     };
 
+    // The last element's address is the selection default: an out-of-bounds
+    // UNCHECKED index clamps to it instead of computing a wild address. Both
+    // are UB in Rust, but the dynamic-GEP lowering faulted loudly where this
+    // accesses a stale-but-valid slot; the failure mode becomes silent.
     let mut selected = element_ptr(ctx, rewriter, array_size - 1)?;
     for element_index in (0..array_size - 1).rev() {
         let pointer = element_ptr(ctx, rewriter, element_index)?;
@@ -1816,6 +1841,111 @@ mod tests {
         let extracted = extract.deref(ctx).get_result(0);
         append_mir_return(ctx, block, vec![extracted]);
         (module_ptr, block)
+    }
+
+    /// A 32-byte element: `[4 x i64]`. Eight of them stay under the element
+    /// cap while overflowing [`MAX_SSA_ARRAY_BYTES`].
+    fn wide_element_ty(ctx: &mut Context) -> TypeHandle {
+        let i64_ty: TypeHandle = IntegerType::get(ctx, 64, Signedness::Unsigned).into();
+        MirArrayType::get(ctx, i64_ty, 4).into()
+    }
+
+    #[test]
+    fn oversized_small_array_extract_uses_bounded_memory_lowering() {
+        let mut ctx = make_ctx();
+        let element_ty = wide_element_ty(&mut ctx);
+        let usize_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(&mut ctx, element_ty, 8).into();
+        let mut arg_tys = vec![element_ty; 8];
+        arg_tys.push(usize_ty);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, arg_tys, vec![element_ty]);
+        let values: Vec<Value> = (0..8).map(|i| block.deref(&ctx).get_argument(i)).collect();
+        let index = block.deref(&ctx).get_argument(8);
+        let construct = Operation::new(
+            &mut ctx,
+            mir::MirConstructArrayOp::get_concrete_op_info(),
+            vec![array_ty],
+            values,
+            vec![],
+            0,
+        );
+        construct.insert_at_back(block, &ctx);
+        let array = construct.deref(&ctx).get_result(0);
+        let extract = Operation::new(
+            &mut ctx,
+            mir::MirExtractArrayElementOp::get_concrete_op_info(),
+            vec![element_ty],
+            vec![array, index],
+            vec![],
+            0,
+        );
+        extract.insert_at_back(block, &ctx);
+        let extracted = extract.deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, block, vec![extracted]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        // 8 elements <= MAX_SSA_ARRAY_ELEMENTS, but 8 x 32 = 256 bytes blows
+        // MAX_SSA_ARRAY_BYTES: the whole-aggregate select chain must not fire.
+        assert_eq!(count_ops::<llvm::AllocaOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+    }
+
+    #[test]
+    fn oversized_small_array_address_keeps_single_dynamic_gep() {
+        let mut ctx = make_ctx();
+        let element_ty = wide_element_ty(&mut ctx);
+        let usize_ty: TypeHandle = IntegerType::get(&mut ctx, 64, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(&mut ctx, element_ty, 8).into();
+        let array_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, array_ty, true).into();
+        let element_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, element_ty, true).into();
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![usize_ty], vec![element_ty]);
+        let index = block.deref(&ctx).get_argument(0);
+        let alloca = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![array_ptr_ty],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca.insert_at_back(block, &ctx);
+        let array_ptr = alloca.deref(&ctx).get_result(0);
+        let address = Operation::new(
+            &mut ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty],
+            vec![array_ptr, index],
+            vec![],
+            0,
+        );
+        address.insert_at_back(block, &ctx);
+        let element_ptr = address.deref(&ctx).get_result(0);
+        let load = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![element_ty],
+            vec![element_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, &ctx);
+        let value = load.deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, block, vec![value]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module_ptr);
+
+        // Alloca-rooted and under the element cap, but over the byte budget:
+        // constant-address candidate selection must not fire.
+        assert_eq!(count_ops::<llvm::GetElementPtrOp>(&ctx, &body), 1);
+        assert_eq!(count_ops::<llvm::ICmpOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::SelectOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 1);
     }
 
     fn build_array_element_addr_read(ctx: &mut Context, array_size: u64) -> Ptr<Operation> {

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -297,8 +297,18 @@ pub(crate) fn convert_load(
     let result_ty = op.deref(ctx).get_result(0).get_type(ctx);
     let llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
 
+    let mir_load = dialect_mir::ops::MirLoadOp::new(op);
+    if !mir_load.is_volatile(ctx)
+        && matches!(small_array_pointer_candidate_count(ctx, ptr), Some(1..=64))
+    {
+        let loaded =
+            load_through_small_array_pointer_selection(ctx, rewriter, ptr, llvm_ty, op, &[])?;
+        rewriter.replace_operation_with_values(ctx, op, vec![loaded]);
+        return Ok(());
+    }
+
     let llvm_load = llvm::LoadOp::new(ctx, ptr, llvm_ty);
-    if dialect_mir::ops::MirLoadOp::new(op).is_volatile(ctx) {
+    if mir_load.is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_load.get_operation(), true);
     }
     copy_alignment(ctx, op, llvm_load.get_operation());
@@ -306,6 +316,105 @@ pub(crate) fn convert_load(
     rewriter.replace_operation(ctx, op, llvm_load.get_operation());
 
     Ok(())
+}
+
+#[derive(Clone)]
+struct DeferredGep {
+    indices: Vec<llvm::GepIndex>,
+    source_element_type: TypeHandle,
+}
+
+/// Count the constant-address leaves represented by a small-array pointer
+/// selection. `None` means the expression has no marked selection and should
+/// retain ordinary load lowering.
+fn small_array_pointer_candidate_count(ctx: &Context, ptr: pliron::value::Value) -> Option<u64> {
+    let defining_op = ptr.defining_op()?;
+    if crate::convert::ops::aggregate::is_small_array_address_select(ctx, defining_op) {
+        let true_ptr = defining_op.deref(ctx).get_operand(1);
+        let false_ptr = defining_op.deref(ctx).get_operand(2);
+        let true_count = small_array_pointer_candidate_count(ctx, true_ptr).unwrap_or(1);
+        let false_count = small_array_pointer_candidate_count(ctx, false_ptr).unwrap_or(1);
+        return true_count.checked_add(false_count);
+    }
+    let gep = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx)?;
+    small_array_pointer_candidate_count(ctx, gep.get_operation().deref(ctx).get_operand(0))
+}
+
+/// Load through a tree of marked pointer selections by loading every constant
+/// candidate and selecting values instead of pointers.
+///
+/// LLVM otherwise canonicalizes `select (gep 0), (gep 1)` back into one dynamic
+/// GEP, which prevents SROA from promoting a fixed local array. Nested array
+/// indexing can wrap a marked selection in constant GEPs, so those GEPs are
+/// deferred and cloned onto each constant pointer leaf before the load.
+fn load_through_small_array_pointer_selection(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    ptr: pliron::value::Value,
+    result_ty: TypeHandle,
+    mir_load: Ptr<Operation>,
+    deferred_geps: &[DeferredGep],
+) -> Result<pliron::value::Value> {
+    if let Some(defining_op) = ptr.defining_op() {
+        if crate::convert::ops::aggregate::is_small_array_address_select(ctx, defining_op) {
+            let condition = defining_op.deref(ctx).get_operand(0);
+            let true_ptr = defining_op.deref(ctx).get_operand(1);
+            let false_ptr = defining_op.deref(ctx).get_operand(2);
+            let true_value = load_through_small_array_pointer_selection(
+                ctx,
+                rewriter,
+                true_ptr,
+                result_ty,
+                mir_load,
+                deferred_geps,
+            )?;
+            let false_value = load_through_small_array_pointer_selection(
+                ctx,
+                rewriter,
+                false_ptr,
+                result_ty,
+                mir_load,
+                deferred_geps,
+            )?;
+            let select = llvm::SelectOp::new(ctx, condition, true_value, false_value);
+            rewriter.insert_operation(ctx, select.get_operation());
+            return Ok(select.get_operation().deref(ctx).get_result(0));
+        }
+        if let Some(gep) = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx) {
+            let base = gep.get_operation().deref(ctx).get_operand(0);
+            if small_array_pointer_candidate_count(ctx, base).is_some() {
+                let mut nested_geps = deferred_geps.to_vec();
+                nested_geps.push(DeferredGep {
+                    indices: gep.indices(ctx),
+                    source_element_type: gep.src_elem_type(ctx),
+                });
+                return load_through_small_array_pointer_selection(
+                    ctx,
+                    rewriter,
+                    base,
+                    result_ty,
+                    mir_load,
+                    &nested_geps,
+                );
+            }
+        }
+    }
+
+    let mut candidate_ptr = ptr;
+    for gep in deferred_geps.iter().rev() {
+        let cloned = llvm::GetElementPtrOp::new(
+            ctx,
+            candidate_ptr,
+            gep.indices.clone(),
+            gep.source_element_type,
+        );
+        rewriter.insert_operation(ctx, cloned.get_operation());
+        candidate_ptr = cloned.get_operation().deref(ctx).get_result(0);
+    }
+    let load = llvm::LoadOp::new(ctx, candidate_ptr, result_ty);
+    copy_alignment(ctx, mir_load, load.get_operation());
+    rewriter.insert_operation(ctx, load.get_operation());
+    Ok(load.get_operation().deref(ctx).get_result(0))
 }
 
 /// Convert `mir.dbg_value` to the LLVM-export debug marker.

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -115,8 +115,10 @@ pub(crate) fn convert_store(
             val,
             op,
             &[],
-            true_value,
-            false_value,
+            StorePredicate {
+                enabled: true_value,
+                false_value,
+            },
         )?;
         rewriter.erase_operation(ctx, op);
         return Ok(());
@@ -344,6 +346,12 @@ struct DeferredGep {
     source_element_type: TypeHandle,
 }
 
+#[derive(Clone, Copy)]
+struct StorePredicate {
+    enabled: pliron::value::Value,
+    false_value: pliron::value::Value,
+}
+
 fn integer_constant(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -464,8 +472,7 @@ fn store_through_small_array_pointer_selection(
     value: pliron::value::Value,
     mir_store: Ptr<Operation>,
     deferred_geps: &[DeferredGep],
-    enabled: pliron::value::Value,
-    false_value: pliron::value::Value,
+    predicate: StorePredicate,
 ) -> Result<()> {
     if let Some(defining_op) = ptr.defining_op() {
         if crate::convert::ops::aggregate::is_small_array_address_select(ctx, defining_op) {
@@ -473,11 +480,13 @@ fn store_through_small_array_pointer_selection(
             let true_ptr = defining_op.deref(ctx).get_operand(1);
             let false_ptr = defining_op.deref(ctx).get_operand(2);
 
-            let true_enabled = llvm::SelectOp::new(ctx, condition, enabled, false_value);
+            let true_enabled =
+                llvm::SelectOp::new(ctx, condition, predicate.enabled, predicate.false_value);
             rewriter.insert_operation(ctx, true_enabled.get_operation());
             let true_enabled = true_enabled.get_operation().deref(ctx).get_result(0);
 
-            let false_enabled = llvm::SelectOp::new(ctx, condition, false_value, enabled);
+            let false_enabled =
+                llvm::SelectOp::new(ctx, condition, predicate.false_value, predicate.enabled);
             rewriter.insert_operation(ctx, false_enabled.get_operation());
             let false_enabled = false_enabled.get_operation().deref(ctx).get_result(0);
 
@@ -488,8 +497,10 @@ fn store_through_small_array_pointer_selection(
                 value,
                 mir_store,
                 deferred_geps,
-                true_enabled,
-                false_value,
+                StorePredicate {
+                    enabled: true_enabled,
+                    ..predicate
+                },
             )?;
             store_through_small_array_pointer_selection(
                 ctx,
@@ -498,8 +509,10 @@ fn store_through_small_array_pointer_selection(
                 value,
                 mir_store,
                 deferred_geps,
-                false_enabled,
-                false_value,
+                StorePredicate {
+                    enabled: false_enabled,
+                    ..predicate
+                },
             )?;
             return Ok(());
         }
@@ -518,8 +531,7 @@ fn store_through_small_array_pointer_selection(
                     value,
                     mir_store,
                     &nested_geps,
-                    enabled,
-                    false_value,
+                    predicate,
                 );
             }
         }
@@ -543,7 +555,7 @@ fn store_through_small_array_pointer_selection(
     rewriter.insert_operation(ctx, old_value.get_operation());
     let old_value = old_value.get_operation().deref(ctx).get_result(0);
 
-    let selected = llvm::SelectOp::new(ctx, enabled, value, old_value);
+    let selected = llvm::SelectOp::new(ctx, predicate.enabled, value, old_value);
     rewriter.insert_operation(ctx, selected.get_operation());
     let selected = selected.get_operation().deref(ctx).get_result(0);
 

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -102,8 +102,28 @@ pub(crate) fn convert_store(
         }
     };
 
+    let mir_store = dialect_mir::ops::MirStoreOp::new(op);
+    if !mir_store.is_volatile(ctx)
+        && matches!(small_array_pointer_candidate_count(ctx, ptr), Some(1..=64))
+    {
+        let false_value = integer_constant(ctx, rewriter, 1, 0);
+        let true_value = integer_constant(ctx, rewriter, 1, 1);
+        store_through_small_array_pointer_selection(
+            ctx,
+            rewriter,
+            ptr,
+            val,
+            op,
+            &[],
+            true_value,
+            false_value,
+        )?;
+        rewriter.erase_operation(ctx, op);
+        return Ok(());
+    }
+
     let llvm_store = llvm::StoreOp::new(ctx, val, ptr);
-    if dialect_mir::ops::MirStoreOp::new(op).is_volatile(ctx) {
+    if mir_store.is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_store.get_operation(), true);
     }
     copy_alignment(ctx, op, llvm_store.get_operation());
@@ -324,6 +344,20 @@ struct DeferredGep {
     source_element_type: TypeHandle,
 }
 
+fn integer_constant(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    width: u32,
+    value: u64,
+) -> pliron::value::Value {
+    let ty = IntegerType::get(ctx, width, Signedness::Signless);
+    let width = std::num::NonZeroUsize::new(width as usize).expect("integer width is nonzero");
+    let attr: AttrObj = IntegerAttr::new(ty, APInt::from_u64(value, width)).into();
+    let constant = llvm::ConstantOp::new(ctx, attr);
+    rewriter.insert_operation(ctx, constant.get_operation());
+    constant.get_operation().deref(ctx).get_result(0)
+}
+
 /// Count the constant-address leaves represented by a small-array pointer
 /// selection. `None` means the expression has no marked selection and should
 /// retain ordinary load lowering.
@@ -415,6 +449,108 @@ fn load_through_small_array_pointer_selection(
     copy_alignment(ctx, mir_load, load.get_operation());
     rewriter.insert_operation(ctx, load.get_operation());
     Ok(load.get_operation().deref(ctx).get_result(0))
+}
+
+/// Store through a tree of marked pointer selections by updating every
+/// constant candidate under a mutually exclusive predicate.
+///
+/// Keeping the candidate addresses constant lets SROA promote fixed local
+/// arrays after a small indexing loop is unrolled. Each unselected candidate
+/// is written back unchanged, preserving the semantics of one dynamic store.
+fn store_through_small_array_pointer_selection(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    ptr: pliron::value::Value,
+    value: pliron::value::Value,
+    mir_store: Ptr<Operation>,
+    deferred_geps: &[DeferredGep],
+    enabled: pliron::value::Value,
+    false_value: pliron::value::Value,
+) -> Result<()> {
+    if let Some(defining_op) = ptr.defining_op() {
+        if crate::convert::ops::aggregate::is_small_array_address_select(ctx, defining_op) {
+            let condition = defining_op.deref(ctx).get_operand(0);
+            let true_ptr = defining_op.deref(ctx).get_operand(1);
+            let false_ptr = defining_op.deref(ctx).get_operand(2);
+
+            let true_enabled = llvm::SelectOp::new(ctx, condition, enabled, false_value);
+            rewriter.insert_operation(ctx, true_enabled.get_operation());
+            let true_enabled = true_enabled.get_operation().deref(ctx).get_result(0);
+
+            let false_enabled = llvm::SelectOp::new(ctx, condition, false_value, enabled);
+            rewriter.insert_operation(ctx, false_enabled.get_operation());
+            let false_enabled = false_enabled.get_operation().deref(ctx).get_result(0);
+
+            store_through_small_array_pointer_selection(
+                ctx,
+                rewriter,
+                true_ptr,
+                value,
+                mir_store,
+                deferred_geps,
+                true_enabled,
+                false_value,
+            )?;
+            store_through_small_array_pointer_selection(
+                ctx,
+                rewriter,
+                false_ptr,
+                value,
+                mir_store,
+                deferred_geps,
+                false_enabled,
+                false_value,
+            )?;
+            return Ok(());
+        }
+        if let Some(gep) = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx) {
+            let base = gep.get_operation().deref(ctx).get_operand(0);
+            if small_array_pointer_candidate_count(ctx, base).is_some() {
+                let mut nested_geps = deferred_geps.to_vec();
+                nested_geps.push(DeferredGep {
+                    indices: gep.indices(ctx),
+                    source_element_type: gep.src_elem_type(ctx),
+                });
+                return store_through_small_array_pointer_selection(
+                    ctx,
+                    rewriter,
+                    base,
+                    value,
+                    mir_store,
+                    &nested_geps,
+                    enabled,
+                    false_value,
+                );
+            }
+        }
+    }
+
+    let mut candidate_ptr = ptr;
+    for gep in deferred_geps.iter().rev() {
+        let cloned = llvm::GetElementPtrOp::new(
+            ctx,
+            candidate_ptr,
+            gep.indices.clone(),
+            gep.source_element_type,
+        );
+        rewriter.insert_operation(ctx, cloned.get_operation());
+        candidate_ptr = cloned.get_operation().deref(ctx).get_result(0);
+    }
+
+    let value_ty = value.get_type(ctx);
+    let old_value = llvm::LoadOp::new(ctx, candidate_ptr, value_ty);
+    copy_alignment(ctx, mir_store, old_value.get_operation());
+    rewriter.insert_operation(ctx, old_value.get_operation());
+    let old_value = old_value.get_operation().deref(ctx).get_result(0);
+
+    let selected = llvm::SelectOp::new(ctx, enabled, value, old_value);
+    rewriter.insert_operation(ctx, selected.get_operation());
+    let selected = selected.get_operation().deref(ctx).get_result(0);
+
+    let store = llvm::StoreOp::new(ctx, selected, candidate_ptr);
+    copy_alignment(ctx, mir_store, store.get_operation());
+    rewriter.insert_operation(ctx, store.get_operation());
+    Ok(())
 }
 
 /// Convert `mir.dbg_value` to the LLVM-export debug marker.

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -581,9 +581,10 @@ fn make_padding_type(ctx: &mut Context, size: u64) -> TypeHandle {
 /// alignment without consuming storage. Pointer-bearing fields are preferred
 /// so an ordinary union copy keeps LLVM pointer provenance.
 ///
-/// NVPTX gives scalar integers natural alignments up to 16 bytes. Reject a
-/// more strongly aligned union instead of silently emitting a by-value type
-/// with a weaker ABI alignment.
+/// NVPTX gives scalar integers natural alignments up to 16 bytes. Stronger
+/// Rust alignment is carried explicitly on memory operations because LLVM
+/// aggregate types cannot encode over-alignment; the storage type still keeps
+/// the union's exact size and therefore its array stride.
 pub(crate) fn build_union_storage_type(
     ctx: &mut Context,
     union_ty: &MirUnionType,
@@ -593,13 +594,6 @@ pub(crate) fn build_union_storage_type(
     if align == 0 || !align.is_power_of_two() {
         return Err(anyhow::anyhow!(
             "union `{}` has invalid ABI alignment {}",
-            union_ty.name(),
-            align
-        ));
-    }
-    if align > 16 {
-        return Err(anyhow::anyhow!(
-            "union `{}` requires {}-byte alignment; cuda-oxide currently supports union alignments up to 16 bytes",
             union_ty.name(),
             align
         ));
@@ -658,7 +652,8 @@ pub(crate) fn build_union_storage_type(
         fields.push((llvm_field_ty, field_size, field_align, contains_pointer));
     }
 
-    let anchor_int = IntegerType::get(ctx, (align * 8) as u32, Signedness::Signless);
+    let storage_align = align.min(16);
+    let anchor_int = IntegerType::get(ctx, (storage_align * 8) as u32, Signedness::Signless);
     let anchor: TypeHandle = llvm_types::ArrayType::get(ctx, anchor_int.into(), 0).into();
     let mut storage_fields = vec![anchor];
     if size > 0 {
@@ -695,9 +690,9 @@ pub(crate) fn build_union_storage_type(
             union_ty.name()
         )
     })?;
-    if llvm_size != size || llvm_align != align {
+    if llvm_size != size || llvm_align > align {
         return Err(anyhow::anyhow!(
-            "union `{}` storage lowered to size/alignment {}/{} but rustc requires {}/{}",
+            "union `{}` storage lowered to incompatible size/alignment {}/{} but rustc requires {}/{}",
             union_ty.name(),
             llvm_size,
             llvm_align,
@@ -3137,7 +3132,7 @@ mod tests {
     }
 
     #[test]
-    fn union_storage_rejects_unrepresentable_over_alignment() {
+    fn union_storage_preserves_over_aligned_size_and_stride() {
         let mut ctx = make_ctx();
         let u32_ty = mir_uint(&mut ctx, 32);
         let union_ty = MirUnionType::get(
@@ -3149,8 +3144,40 @@ mod tests {
             32,
         );
         let union_data = union_ty.deref(&ctx).clone();
-        let err = build_union_storage_type(&mut ctx, &union_data).unwrap_err();
-        assert!(err.to_string().contains("up to 16 bytes"));
+        let storage = build_union_storage_type(&mut ctx, &union_data).unwrap();
+        assert_eq!(llvm_type_size_align(&ctx, storage), Some((32, 16)));
+
+        let union_handle: TypeHandle = union_ty.into();
+        let array: TypeHandle = MirArrayType::get(&mut ctx, union_handle, 3).into();
+        let llvm_array = convert_type(&mut ctx, array).unwrap();
+        assert_eq!(llvm_type_size_align(&ctx, llvm_array), Some((96, 16)));
+    }
+
+    #[test]
+    fn uninhabited_enum_lowers_to_zero_sized_storage() {
+        let mut ctx = make_ctx();
+        let discr = mir_uint(&mut ctx, 8);
+        let never: TypeHandle = MirEnumType::get_with_encoding(
+            &mut ctx,
+            "Never".into(),
+            discr,
+            vec![],
+            vec![],
+            EnumEncoding {
+                tag_offset: 0,
+                total_size: 0,
+                abi_align: 1,
+                layout_kind: EnumLayoutKind::Empty,
+                carrier_kind: EnumCarrierKind::None,
+                variant_inhabited: vec![],
+                ..EnumEncoding::default()
+            },
+        )
+        .into();
+
+        let storage = convert_type(&mut ctx, never).unwrap();
+        assert!(is_zero_sized_type(&ctx, storage));
+        assert_eq!(llvm_type_size_align(&ctx, storage), Some((0, 1)));
     }
 
     #[test]

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -35,7 +35,7 @@ use crate::convert::types::{
 
 use dialect_mir::ops::MirFuncOp;
 use dialect_mir::types::{
-    MirDisjointSliceType, MirPtrType, MirSliceType, MirStructType, MirUnionType,
+    MirArrayType, MirDisjointSliceType, MirPtrType, MirSliceType, MirStructType, MirUnionType,
 };
 use llvm_export::ops as llvm;
 use pliron::{
@@ -712,7 +712,7 @@ fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
 // Alignment Pre-Pass
 // ============================================================================
 
-/// The real (rustc) alignment of a struct or enum type, when recorded.
+/// The real (rustc) alignment of an aggregate type, when recorded.
 ///
 /// The converted LLVM struct alone can claim too little: an enum that
 /// lowers to `{ i8, [7 x i8] }` looks like "align 1" to LLVM even when
@@ -729,7 +729,37 @@ fn aggregate_over_align(ctx: &Context, ty: TypeHandle) -> Option<u64> {
     if let Some(u) = ty_ref.downcast_ref::<MirUnionType>() {
         return Some(u.abi_align()).filter(|a| *a > 0);
     }
+    if let Some(a) = ty_ref.downcast_ref::<MirArrayType>() {
+        return aggregate_over_align(ctx, a.element_ty);
+    }
     None
+}
+
+#[cfg(test)]
+mod aggregate_alignment_tests {
+    use super::*;
+    use pliron::builtin::types::{IntegerType, Signedness};
+
+    #[test]
+    fn array_inherits_union_abi_alignment() {
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        crate::register(&mut ctx);
+
+        let word: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let union: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "OverAligned".into(),
+            vec!["word".into()],
+            vec![word],
+            32,
+            32,
+        )
+        .into();
+        let array: TypeHandle = MirArrayType::get(&mut ctx, union, 3).into();
+
+        assert_eq!(aggregate_over_align(&ctx, array), Some(32));
+    }
 }
 
 /// Stamp the true ABI alignment onto every `mir.load`, `mir.store`,

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -133,6 +133,26 @@ mod kernels {
                 + components[2].values[1];
         }
     }
+
+    /// `array::map` uses `[MaybeUninit<U>; N]` internally. Keep that union
+    /// usable when `U` has stronger alignment than NVPTX's scalar types.
+    #[kernel]
+    pub fn map_over_aligned_array(mut out: DisjointSlice<f32>) {
+        let tid = thread::index_1d();
+        let t = tid.get() as f32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let components = [0.0_f32, 1.0, 2.0].map(|offset| ScalarPair {
+                values: [t + offset, t + offset + 3.0],
+                padding: [0; 24],
+            });
+            *out_elem = components[0].values[0]
+                + components[0].values[1]
+                + components[1].values[0]
+                + components[1].values[1]
+                + components[2].values[0]
+                + components[2].values[1];
+        }
+    }
 }
 
 fn kernel_body<'a>(ptx: &'a str, kernel_prefix: &str) -> &'a str {
@@ -208,10 +228,18 @@ fn main() {
         .expect("launch runtime_aggregate_array_write");
     let got_runtime_write = d_runtime_write.to_host_vec(&stream).unwrap();
 
+    let mut d_aligned_map = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.map_over_aligned_array(stream.as_ref(), cfg, &mut d_aligned_map) }
+        .expect("launch map_over_aligned_array");
+    let got_aligned_map = d_aligned_map.to_host_vec(&stream).unwrap();
+
     let ptx = std::fs::read_to_string(ptx_path).expect("read generated PTX");
     for kernel in [
         "runtime_aggregate_array_read",
         "runtime_aggregate_array_write",
+        "map_over_aligned_array",
     ] {
         let body = kernel_body(&ptx, kernel);
         assert!(
@@ -258,6 +286,14 @@ fn main() {
             println!(
                 "FAIL tid={tid}: runtime_aggregate_array_write={} expected={want_runtime_write}",
                 got_runtime_write[tid]
+            );
+            failures += 1;
+        }
+        let want_aligned_map = 6.0 * t + 15.0;
+        if (got_aligned_map[tid] - want_aligned_map).abs() > 1.0e-4 {
+            println!(
+                "FAIL tid={tid}: map_over_aligned_array={} expected={want_aligned_map}",
+                got_aligned_map[tid]
             );
             failures += 1;
         }

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -47,6 +47,22 @@ mod kernels {
         padding: [u8; 24],
     }
 
+    #[derive(Clone, Copy)]
+    struct GridShape {
+        counts: [u32; 3],
+        periodic: [bool; 3],
+    }
+
+    #[inline(always)]
+    fn select_grid_field(grid: &GridShape, index: usize) -> u32 {
+        let count = grid.counts[index];
+        if grid.periodic[index] {
+            count + 10
+        } else {
+            count
+        }
+    }
+
     /// Sum a by-value `[u32; 4]` with a `for` loop (the issue-138 shape).
     #[kernel]
     pub fn sum_u32_array(mut out: DisjointSlice<u32>) {
@@ -153,6 +169,22 @@ mod kernels {
                 + components[2].values[1];
         }
     }
+
+    /// Runtime indexing of small array fields through a shared aggregate
+    /// reference should expose constant candidate loads for caller SROA.
+    #[kernel]
+    pub fn runtime_borrowed_array_field(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let index = tid.get();
+        let t = index as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let grid = GridShape {
+                counts: [t, t + 1, t + 2],
+                periodic: [false, true, false],
+            };
+            *out_elem = select_grid_field(&grid, index % 3);
+        }
+    }
 }
 
 fn kernel_body<'a>(ptx: &'a str, kernel_prefix: &str) -> &'a str {
@@ -235,11 +267,19 @@ fn main() {
         .expect("launch map_over_aligned_array");
     let got_aligned_map = d_aligned_map.to_host_vec(&stream).unwrap();
 
+    let mut d_borrowed_field = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.runtime_borrowed_array_field(stream.as_ref(), cfg, &mut d_borrowed_field) }
+        .expect("launch runtime_borrowed_array_field");
+    let got_borrowed_field = d_borrowed_field.to_host_vec(&stream).unwrap();
+
     let ptx = std::fs::read_to_string(ptx_path).expect("read generated PTX");
     for kernel in [
         "runtime_aggregate_array_read",
         "runtime_aggregate_array_write",
         "map_over_aligned_array",
+        "runtime_borrowed_array_field",
     ] {
         let body = kernel_body(&ptx, kernel);
         assert!(
@@ -294,6 +334,15 @@ fn main() {
             println!(
                 "FAIL tid={tid}: map_over_aligned_array={} expected={want_aligned_map}",
                 got_aligned_map[tid]
+            );
+            failures += 1;
+        }
+        let component = tid % 3;
+        let want_borrowed_field = tid as u32 + component as u32 + u32::from(component == 1) * 10;
+        if got_borrowed_field[tid] != want_borrowed_field {
+            println!(
+                "FAIL tid={tid}: runtime_borrowed_array_field={} expected={want_borrowed_field}",
+                got_borrowed_field[tid]
             );
             failures += 1;
         }

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -63,6 +63,33 @@ mod kernels {
         }
     }
 
+    trait LaneCount {
+        const LANES: usize;
+    }
+
+    struct TwoLanes;
+
+    impl LaneCount for TwoLanes {
+        const LANES: usize = 2;
+    }
+
+    /// The issue-384 shape: a generic helper switching on an associated
+    /// const. Collector dead-edge pruning and importer translation must fold
+    /// `L::LANES` to the same `switchInt` edge, or the dead `panic!` arm gets
+    /// pulled into device codegen by one of them. The live arm goes through
+    /// `get_unchecked`, whose ub-checks precondition adds a
+    /// `RuntimeChecks`-guarded edge that both walks must also fold
+    /// identically (to the device value, never the host session's).
+    fn lane_sum<L: LaneCount>(values: &[u32; 4]) -> u32 {
+        match L::LANES {
+            2 => {
+                // SAFETY: indices 0 and 1 are in bounds of a `[u32; 4]`.
+                unsafe { *values.get_unchecked(0) + *values.get_unchecked(1) }
+            }
+            _ => panic!("unsupported lane count"),
+        }
+    }
+
     /// Sum a by-value `[u32; 4]` with a `for` loop (the issue-138 shape).
     #[kernel]
     pub fn sum_u32_array(mut out: DisjointSlice<u32>) {
@@ -185,6 +212,18 @@ mod kernels {
             *out_elem = select_grid_field(&grid, index % 3);
         }
     }
+
+    /// Associated-const switch with a dead panic arm (issue-384 shape) must
+    /// compile and take the instantiated edge on the device.
+    #[kernel]
+    pub fn associated_const_lane_sum(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let t = tid.get() as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let values = [t, t + 1, t + 2, t + 3];
+            *out_elem = lane_sum::<TwoLanes>(&values);
+        }
+    }
 }
 
 fn kernel_body<'a>(ptx: &'a str, kernel_prefix: &str) -> &'a str {
@@ -274,6 +313,13 @@ fn main() {
         .expect("launch runtime_borrowed_array_field");
     let got_borrowed_field = d_borrowed_field.to_host_vec(&stream).unwrap();
 
+    let mut d_lane_sum = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.associated_const_lane_sum(stream.as_ref(), cfg, &mut d_lane_sum) }
+        .expect("launch associated_const_lane_sum");
+    let got_lane_sum = d_lane_sum.to_host_vec(&stream).unwrap();
+
     let ptx = std::fs::read_to_string(ptx_path).expect("read generated PTX");
     for kernel in [
         "runtime_aggregate_array_read",
@@ -343,6 +389,15 @@ fn main() {
             println!(
                 "FAIL tid={tid}: runtime_borrowed_array_field={} expected={want_borrowed_field}",
                 got_borrowed_field[tid]
+            );
+            failures += 1;
+        }
+        // lane_sum::<TwoLanes> adds elements 0 and 1: t + (t + 1)
+        let want_lane_sum = 2 * tid as u32 + 1;
+        if got_lane_sum[tid] != want_lane_sum {
+            println!(
+                "FAIL tid={tid}: associated_const_lane_sum={} expected={want_lane_sum}",
+                got_lane_sum[tid]
             );
             failures += 1;
         }

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -329,9 +329,7 @@ fn main() {
     ] {
         let body = kernel_body(&ptx, kernel);
         assert!(
-            !body.contains(".local")
-                && !body.contains("ld.local")
-                && !body.contains("st.local"),
+            !body.contains(".local") && !body.contains("ld.local") && !body.contains("st.local"),
             "small runtime aggregate indexing must not use local memory:\n{body}"
         );
     }

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -40,6 +40,13 @@ mod kernels {
         pub y: u32,
     }
 
+    #[derive(Clone, Copy)]
+    #[repr(C, align(32))]
+    struct ScalarPair {
+        values: [f32; 2],
+        padding: [u8; 24],
+    }
+
     /// Sum a by-value `[u32; 4]` with a `for` loop (the issue-138 shape).
     #[kernel]
     pub fn sum_u32_array(mut out: DisjointSlice<u32>) {
@@ -74,6 +81,83 @@ mod kernels {
             *out_elem = acc;
         }
     }
+
+    /// Runtime reads from small owned arrays should remain in SSA.
+    #[kernel]
+    pub fn runtime_aggregate_array_read(mut out: DisjointSlice<f32>) {
+        let tid = thread::index_1d();
+        let index = tid.get();
+        let t = index as f32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let components = [
+                ScalarPair {
+                    values: [t, t + 3.0],
+                    padding: [0; 24],
+                },
+                ScalarPair {
+                    values: [t + 1.0, t + 4.0],
+                    padding: [0; 24],
+                },
+                ScalarPair {
+                    values: [t + 2.0, t + 5.0],
+                    padding: [0; 24],
+                },
+            ];
+            let selected = components[index % components.len()];
+            *out_elem = selected.values[0] + selected.values[1];
+        }
+    }
+
+    /// Runtime writes through small owned arrays should use scalarizable
+    /// constant element addresses rather than one dynamic GEP.
+    #[kernel]
+    pub fn runtime_aggregate_array_write(mut out: DisjointSlice<f32>) {
+        let tid = thread::index_1d();
+        let index = tid.get();
+        let t = index as f32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let zero = ScalarPair {
+                values: [0.0; 2],
+                padding: [0; 24],
+            };
+            let mut components = [zero; 3];
+            components[index % components.len()] = ScalarPair {
+                values: [t, t + 3.0],
+                padding: [0; 24],
+            };
+            *out_elem = components[0].values[0]
+                + components[0].values[1]
+                + components[1].values[0]
+                + components[1].values[1]
+                + components[2].values[0]
+                + components[2].values[1];
+        }
+    }
+}
+
+fn kernel_body<'a>(ptx: &'a str, kernel_prefix: &str) -> &'a str {
+    let marker = format!(".entry {kernel_prefix}(");
+    let entry = ptx
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing PTX entry with prefix {kernel_prefix}"));
+    let body_start = ptx[entry..]
+        .find('{')
+        .map(|offset| entry + offset)
+        .expect("kernel entry has a body");
+    let mut depth = 0_u32;
+    for (offset, byte) in ptx.as_bytes()[body_start..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &ptx[body_start..=body_start + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated PTX body for {kernel_prefix}");
 }
 
 fn main() {
@@ -110,6 +194,34 @@ fn main() {
         .expect("launch sum_point_array");
     let got_pts = d_pts.to_host_vec(&stream).unwrap();
 
+    let mut d_runtime_read = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.runtime_aggregate_array_read(stream.as_ref(), cfg, &mut d_runtime_read) }
+        .expect("launch runtime_aggregate_array_read");
+    let got_runtime_read = d_runtime_read.to_host_vec(&stream).unwrap();
+
+    let mut d_runtime_write = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.runtime_aggregate_array_write(stream.as_ref(), cfg, &mut d_runtime_write) }
+        .expect("launch runtime_aggregate_array_write");
+    let got_runtime_write = d_runtime_write.to_host_vec(&stream).unwrap();
+
+    let ptx = std::fs::read_to_string(ptx_path).expect("read generated PTX");
+    for kernel in [
+        "runtime_aggregate_array_read",
+        "runtime_aggregate_array_write",
+    ] {
+        let body = kernel_body(&ptx, kernel);
+        assert!(
+            !body.contains(".local")
+                && !body.contains("ld.local")
+                && !body.contains("st.local"),
+            "small runtime aggregate indexing must not use local memory:\n{body}"
+        );
+    }
+
     let mut failures = 0usize;
     for tid in 0..N {
         let t = tid as u32;
@@ -131,10 +243,28 @@ fn main() {
             );
             failures += 1;
         }
+        let t = t as f32;
+        let component = tid % 3;
+        let want_runtime_read = 2.0 * t + 3.0 + 2.0 * component as f32;
+        if (got_runtime_read[tid] - want_runtime_read).abs() > 1.0e-4 {
+            println!(
+                "FAIL tid={tid}: runtime_aggregate_array_read={} expected={want_runtime_read}",
+                got_runtime_read[tid]
+            );
+            failures += 1;
+        }
+        let want_runtime_write = 2.0 * t + 3.0;
+        if (got_runtime_write[tid] - want_runtime_write).abs() > 1.0e-4 {
+            println!(
+                "FAIL tid={tid}: runtime_aggregate_array_write={} expected={want_runtime_write}",
+                got_runtime_write[tid]
+            );
+            failures += 1;
+        }
     }
 
     if failures == 0 {
-        println!("array_for_loop: PASS ({N} threads, both array for-loops summed correctly)");
+        println!("array_for_loop: PASS ({N} threads, array iteration/indexing is correct)");
     } else {
         println!("array_for_loop: FAIL ({failures} mismatches)");
         std::process::exit(1);

--- a/crates/rustc-codegen-cuda/examples/array_index/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/array_index/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 #
 # Expected results:
 #   - Constant index read: PASS (uses extractvalue)
-#   - Runtime index read: PASS (uses alloca+gep+load, inefficient but works)
+#   - Runtime index read: PASS (small fixed arrays stay in SSA)
 #   - Constant index write: FAIL (MirInsertFieldOp doesn't support arrays yet)
 #   - Runtime index write: FAIL (ProjectionElem::Index not implemented for writes)
 

--- a/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
@@ -16,7 +16,7 @@
 //! | Operation | Index Type | Expected Result          |
 //! |-----------|------------|--------------------------|
 //! | Read      | Constant   | ✓ PASS (extractvalue)    |
-//! | Read      | Runtime    | ✓ PASS (alloca+gep+load) |
+//! | Read      | Runtime    | ✓ PASS (SSA for small arrays) |
 //! | Write     | Constant   | ✗ FAIL (not implemented) |
 //! | Write     | Runtime    | ✗ FAIL (not implemented) |
 //!
@@ -75,11 +75,12 @@ mod kernels {
     // =============================================================================
     // SECTION 2: Runtime Index Reads (SHOULD WORK)
     //
-    // These use ProjectionElem::Index → MirExtractArrayElementOp → alloca+gep+load
+    // These use ProjectionElem::Index → MirExtractArrayElementOp. Small fixed
+    // arrays lower to SSA extracts/selects; larger arrays use memory.
     // =============================================================================
 
     /// Test: Read array element at runtime index
-    /// Expected: PASS (but inefficient - copies whole array per read)
+    /// Expected: PASS
     #[kernel]
     pub fn test_runtime_index_read(index: u32, mut out: DisjointSlice<u32>) {
         let idx = thread::index_1d();
@@ -105,7 +106,7 @@ mod kernels {
             // Sum using runtime index in loop
             let mut sum: u32 = 0;
             for i in 0..4 {
-                sum += arr[i]; // Each iteration: alloca + store whole array + gep + load
+                sum += arr[i];
             }
 
             *out_elem = sum; // 1 + 2 + 3 + 4 = 10
@@ -125,7 +126,7 @@ mod kernels {
 
             // Runtime index read
             let i = index as usize;
-            let dynamic = arr[i]; // alloca+gep+load
+            let dynamic = arr[i];
 
             *out_elem = first + dynamic;
         }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -127,7 +127,7 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::mono::{CodegenUnit, MonoItem};
 use rustc_middle::mir::visit::Visitor;
-use rustc_middle::mir::{ConstOperand, ConstValue, Location, TerminatorKind};
+use rustc_middle::mir::{BasicBlock, ConstOperand, ConstValue, Location, START_BLOCK, TerminatorKind};
 use rustc_middle::ty::{Instance, InstanceKind, Ty, TyCtxt, TyKind, TypeVisitableExt, TypingEnv};
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -980,21 +980,27 @@ impl<'tcx> DeviceCollector<'tcx> {
                     );
                 }
 
-                // Fail fast with an actionable diagnostic when this body
-                // contains panic-formatting machinery the device pipeline
-                // cannot compile (issue #76). Skip for drop glue shims:
-                // their MIR is compiler-generated and may contain panic
-                // paths (e.g. for assertion failures) that are unreachable
-                // in practice; the mir-importer handles these via its
-                // existing unreachable-block patching.
+                let reachable = self.reachable_basic_blocks(mir, func.instance);
+
+                // Fail fast with an actionable diagnostic when a feasible
+                // block contains panic-formatting machinery the device
+                // pipeline cannot compile (issue #76). Skip for drop glue
+                // shims: their MIR is compiler-generated and may contain
+                // panic paths (e.g. for assertion failures) that are
+                // unreachable in practice; the mir-importer handles these
+                // via its existing unreachable-block patching.
                 if !matches!(func.instance.def, InstanceKind::DropGlue(..)) {
-                    self.check_panic_machinery(mir, &func, &ctx);
+                    self.check_panic_machinery(mir, &reachable, &func, &ctx);
                 }
 
-                // Walk all basic blocks looking for calls.
+                // Walk feasible basic blocks looking for calls. Monomorphized
+                // core MIR can retain constant type-property branches; their
+                // dead arms must not pull panic/ZST-only helpers into device
+                // codegen.
                 // Pass the caller so we can substitute its args into callees
                 // and attribute diagnostics to the right discovery path.
-                for bb_data in mir.basic_blocks.iter() {
+                for bb in reachable {
+                    let bb_data = &mir.basic_blocks[bb];
                     if let Some(ref terminator) = bb_data.terminator {
                         self.process_terminator(terminator, mir, &func, &ctx);
                     }
@@ -1008,6 +1014,89 @@ impl<'tcx> DeviceCollector<'tcx> {
             functions: self.result,
             device_externs: self.device_externs,
             requires_ptx_bundle_merge: false,
+        }
+    }
+
+    fn reachable_basic_blocks(
+        &self,
+        mir: &rustc_middle::mir::Body<'tcx>,
+        instance: Instance<'tcx>,
+    ) -> Vec<BasicBlock> {
+        let mut reachable = Vec::new();
+        let mut seen = HashSet::new();
+        let mut frontier = VecDeque::from([START_BLOCK]);
+        seen.insert(START_BLOCK);
+
+        while let Some(bb) = frontier.pop_front() {
+            reachable.push(bb);
+            let Some(terminator) = &mir.basic_blocks[bb].terminator else {
+                continue;
+            };
+            let constant_target = match &terminator.kind {
+                TerminatorKind::SwitchInt { discr, targets } => {
+                    self.constant_operand_bits_in_block(mir, bb, discr, instance)
+                        .map(|value| targets.target_for_value(value))
+                }
+                _ => None,
+            };
+            let successors: Vec<_> = match constant_target {
+                Some(target) => vec![target],
+                None => terminator.successors().collect(),
+            };
+            for successor in successors {
+                if mir.basic_blocks[successor].is_cleanup {
+                    continue;
+                }
+                if seen.insert(successor) {
+                    frontier.push_back(successor);
+                }
+            }
+        }
+
+        reachable
+    }
+
+    fn constant_operand_bits_in_block(
+        &self,
+        mir: &rustc_middle::mir::Body<'tcx>,
+        bb: BasicBlock,
+        operand: &rustc_middle::mir::Operand<'tcx>,
+        instance: Instance<'tcx>,
+    ) -> Option<u128> {
+        let eval = |constant: &ConstOperand<'tcx>| {
+            let typing_env = TypingEnv::fully_monomorphized();
+            instance
+                .instantiate_mir_and_normalize_erasing_regions(
+                    self.tcx,
+                    typing_env,
+                    rustc_middle::ty::EarlyBinder::bind(constant.const_),
+                )
+                .try_eval_bits(self.tcx, typing_env)
+        };
+        let local = match operand {
+            rustc_middle::mir::Operand::Constant(constant) => return eval(constant),
+            rustc_middle::mir::Operand::RuntimeChecks(check) => {
+                return Some(check.value(self.tcx.sess) as u128);
+            }
+            rustc_middle::mir::Operand::Copy(place)
+            | rustc_middle::mir::Operand::Move(place) => place.as_local()?,
+        };
+        let statement = mir.basic_blocks[bb].statements.iter().rev().find(|statement| {
+            !matches!(
+                statement.kind,
+                rustc_middle::mir::StatementKind::StorageLive(_)
+                    | rustc_middle::mir::StatementKind::StorageDead(_)
+            )
+        })?;
+        let (destination, rvalue) = statement.kind.as_assign()?;
+        if destination.as_local() != Some(local) {
+            return None;
+        }
+        match rvalue {
+            rustc_middle::mir::Rvalue::Use(rustc_middle::mir::Operand::Constant(constant)) => {
+                eval(constant)
+            }
+            _ => None,
         }
     }
 
@@ -2182,10 +2271,12 @@ impl<'tcx> DeviceCollector<'tcx> {
     fn check_panic_machinery(
         &self,
         mir: &rustc_middle::mir::Body<'tcx>,
+        reachable: &[BasicBlock],
         func: &CollectedFunction<'tcx>,
         ctx: &DiscoveryCtx,
     ) {
-        for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
+        for &bb in reachable {
+            let bb_data = &mir.basic_blocks[bb];
             let Some(term) = &bb_data.terminator else {
                 continue;
             };

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -127,7 +127,9 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::mono::{CodegenUnit, MonoItem};
 use rustc_middle::mir::visit::Visitor;
-use rustc_middle::mir::{BasicBlock, ConstOperand, ConstValue, Location, START_BLOCK, TerminatorKind};
+use rustc_middle::mir::{
+    BasicBlock, ConstOperand, ConstValue, Location, START_BLOCK, TerminatorKind,
+};
 use rustc_middle::ty::{Instance, InstanceKind, Ty, TyCtxt, TyKind, TypeVisitableExt, TypingEnv};
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -1033,10 +1035,9 @@ impl<'tcx> DeviceCollector<'tcx> {
                 continue;
             };
             let constant_target = match &terminator.kind {
-                TerminatorKind::SwitchInt { discr, targets } => {
-                    self.constant_operand_bits_in_block(mir, bb, discr, instance)
-                        .map(|value| targets.target_for_value(value))
-                }
+                TerminatorKind::SwitchInt { discr, targets } => self
+                    .constant_operand_bits_in_block(mir, bb, discr, instance)
+                    .map(|value| targets.target_for_value(value)),
                 _ => None,
             };
             let successors: Vec<_> = match constant_target {
@@ -1056,6 +1057,19 @@ impl<'tcx> DeviceCollector<'tcx> {
         reachable
     }
 
+    /// Fold a `SwitchInt` discriminant to constant bits, mirroring the
+    /// mir-importer's reachability fold exactly.
+    ///
+    /// Pruning here is only safe if the importer provably takes the same
+    /// edge: any block the importer translates must have had its calls
+    /// collected. The importer folds `ConstantKind::Allocated` scalars from
+    /// the rustc_public body, and rustc_public's `BodyBuilder` eagerly
+    /// evaluates every MIR constant (`visit_const_operand` rewrites each
+    /// evaluatable constant to `Const::Val`), so the instantiate+`eval`
+    /// below folds precisely the constants the importer folds: both succeed
+    /// exactly when const-eval yields a scalar, and both fail together when
+    /// it does not. `RuntimeChecks` flags fold to the shared device value on
+    /// both sides.
     fn constant_operand_bits_in_block(
         &self,
         mir: &rustc_middle::mir::Body<'tcx>,
@@ -1075,19 +1089,30 @@ impl<'tcx> DeviceCollector<'tcx> {
         };
         let local = match operand {
             rustc_middle::mir::Operand::Constant(constant) => return eval(constant),
-            rustc_middle::mir::Operand::RuntimeChecks(check) => {
-                return Some(check.value(self.tcx.sess) as u128);
+            // The DEVICE value, never `check.value(self.tcx.sess)`: the
+            // importer translates every RuntimeChecks flag to the shared
+            // constant, so pruning with the session value (checks stay on in
+            // dev-profile device builds) would drop a SwitchInt edge the
+            // importer still translates, leaving calls to functions this
+            // collector never gathered.
+            rustc_middle::mir::Operand::RuntimeChecks(_) => {
+                return Some(mir_importer::DEVICE_RUNTIME_CHECKS as u128);
             }
-            rustc_middle::mir::Operand::Copy(place)
-            | rustc_middle::mir::Operand::Move(place) => place.as_local()?,
+            rustc_middle::mir::Operand::Copy(place) | rustc_middle::mir::Operand::Move(place) => {
+                place.as_local()?
+            }
         };
-        let statement = mir.basic_blocks[bb].statements.iter().rev().find(|statement| {
-            !matches!(
-                statement.kind,
-                rustc_middle::mir::StatementKind::StorageLive(_)
-                    | rustc_middle::mir::StatementKind::StorageDead(_)
-            )
-        })?;
+        let statement = mir.basic_blocks[bb]
+            .statements
+            .iter()
+            .rev()
+            .find(|statement| {
+                !matches!(
+                    statement.kind,
+                    rustc_middle::mir::StatementKind::StorageLive(_)
+                        | rustc_middle::mir::StatementKind::StorageDead(_)
+                )
+            })?;
         let (destination, rvalue) = statement.kind.as_assign()?;
         if destination.as_local() != Some(local) {
             return None;
@@ -1095,6 +1120,12 @@ impl<'tcx> DeviceCollector<'tcx> {
         match rvalue {
             rustc_middle::mir::Rvalue::Use(rustc_middle::mir::Operand::Constant(constant)) => {
                 eval(constant)
+            }
+            // The importer's lookback folds a RuntimeChecks assignment source
+            // too; fold it here (to the same device value) so both walks keep
+            // selecting the same edge for `_x = RuntimeChecks; switchInt(_x)`.
+            rustc_middle::mir::Rvalue::Use(rustc_middle::mir::Operand::RuntimeChecks(_)) => {
+                Some(mir_importer::DEVICE_RUNTIME_CHECKS as u128)
             }
             _ => None,
         }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -1339,7 +1339,15 @@ impl<'tcx> DeviceCollector<'tcx> {
     fn drop_glue_is_noop(&self, instance: Instance<'tcx>) -> bool {
         use rustc_public::rustc_internal;
         rustc_internal::run(self.tcx, || {
-            mir_importer::drop_instance_is_noop(&rustc_internal::stable(instance))
+            // Consult the type-level wrapper when the dropped type is at
+            // hand: it applies the same reductions (e.g. `array::Drain`
+            // to its element type) that the importer's `translate_drop`
+            // uses, keeping collection and emission in lockstep.
+            if let InstanceKind::DropGlue(_, Some(dropped_ty)) = instance.def {
+                mir_importer::drop_glue_is_noop(rustc_internal::stable(dropped_ty))
+            } else {
+                mir_importer::drop_instance_is_noop(&rustc_internal::stable(instance))
+            }
         })
         .unwrap_or(false)
     }


### PR DESCRIPTION
Fixes #397.

## Summary

- lower runtime extraction from fixed arrays of up to 16 elements as constant `extractvalue` plus value selects
- lower accesses to compiler-owned small local arrays as constant-address selections, including nested loads and stores
- retain ordinary dynamic GEP lowering for larger arrays and borrowed/external pointers
- add a bounded post-inline full-unroll pass (maximum trip count 16, threshold 512, no partial/runtime unrolling) before final O2 cleanup
- extend the GPU `array_for_loop` regression with nested aggregate runtime reads/writes and PTX local-memory assertions

The local-pointer restriction is intentional: speculatively touching all candidate elements is safe for compiler-owned local storage, but would change observable access behavior for shared or externally borrowed arrays.

## Validation

- `cargo test -p mir-lower -p mir-importer -p cuda-oxide-codegen`
- `cargo clippy -p mir-lower -p mir-importer -p cuda-oxide-codegen -- -D warnings`
- `cargo oxide run array_for_loop` on RTX 3080
- downstream GPU regression: runtime checks pass and strict PTX audit reports zero local-memory/stack warnings across five kernels