### PR TITLE
test(mir-lower): fix clippy `unnecessary_mut_passed` under `-D warnings`

### DIFF
--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -810,8 +810,8 @@ fn test_shuffle_i64_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
-    let i64_ty = IntegerType::get(&mut ctx, 64, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
     // Kernel args: [mask (i32), value (i64), lane/delta (i32)].
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i64_ty.into(), i32_ty.into()]);
@@ -1887,7 +1887,7 @@ fn test_cvt_rz_f16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
 
     let mut ctx = make_test_ctx();
     let f32_ty = FP32Type::get(&ctx);
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
 
     let lo_val = entry.deref(&ctx).get_argument(0);
@@ -1913,7 +1913,7 @@ fn test_cvt_rn_relu_f16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error
 
     let mut ctx = make_test_ctx();
     let f32_ty = FP32Type::get(&ctx);
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
 
     let lo_val = entry.deref(&ctx).get_argument(0);
@@ -1939,7 +1939,7 @@ fn test_cvt_rn_relu_bf16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Erro
 
     let mut ctx = make_test_ctx();
     let f32_ty = FP32Type::get(&ctx);
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
 
     let lo_val = entry.deref(&ctx).get_argument(0);
@@ -1965,7 +1965,7 @@ fn test_cvt_rz_bf16x2_f32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
 
     let mut ctx = make_test_ctx();
     let f32_ty = FP32Type::get(&ctx);
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(), f32_ty.into()]);
 
     let lo_val = entry.deref(&ctx).get_argument(0);
@@ -2294,7 +2294,7 @@ fn test_dp4a_s32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
 
@@ -2321,7 +2321,7 @@ fn test_dp4a_u32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
 
@@ -2348,7 +2348,7 @@ fn test_dp2a_s32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
 
@@ -2375,7 +2375,7 @@ fn test_dp2a_u32_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i32_ty.into(), i32_ty.into()]);
 


### PR DESCRIPTION
## Summary

Closes #401 . The repo's clippy gate (`just clippy`, i.e.`cargo clippy --all-targets --lib --tests -- -D warnings`) fails on `main`: 10 call sites in `crates/mir-lower/tests/lowering_test.rs`pass `&mut ctx` to pliron's `IntegerType::get`, which only needs `&Context`, so clippy's `unnecessary_mut_passed` lint fires and `. Changing unnecessary `&mut` to `&` solves this problem.

## Changes

- `crates/mir-lower/tests/lowering_test.rs`: change 10 `IntegerType::get(&mut ctx, ...)` calls to `IntegerType::get(&ctx, ...)`.

## Testing

Before (clean `main`):

```text
error: the function `IntegerType::get` doesn't need a mutable reference
   --> crates/mir-lower/tests/lowering_test.rs:813:35
    |
813 |     let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
    |                                   ^^^^^^^^
    = note: `-D clippy::unnecessary-mut-passed` implied by `-D warnings`
...
error: could not compile `mir-lower` (test "lowering_test") due to 10 previous errors
```

After (this branch): `cargo clippy --all-targets --lib --tests -- -D warnings` finishes clean.

- [ ] `cargo oxide run <example>` passes - N/A
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable) - N/A

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files — N/A (no new files)