### PR TITLE
feat: link libdevice.10.bc at IR level via llvm-link on the PTX path

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -393,9 +393,11 @@ pub struct Toolchain {
 impl Toolchain {
     /// Discover LLVM 21+ tools from the Rust sysroot and `PATH`.
     ///
-    /// Discovery is explicit and does not read cuda-oxide environment knobs.
-    /// It may return a toolchain without `opt`; that toolchain can compile only
-    /// with [`Optimization::None`].
+    /// Discovery is explicit and does not read cuda-oxide environment knobs,
+    /// with one exception: `llvm-link` (used for IR-level libdevice linking)
+    /// honors `CUDA_OXIDE_LLVM_LINK` and otherwise must share the chosen
+    /// `llc`'s LLVM major. It may return a toolchain without `opt`; that
+    /// toolchain can compile only with [`Optimization::None`].
     pub fn discover() -> Result<Self, CompileError> {
         let opts = BackendOptions::default();
         let inner = LlvmToolchain::resolve(&opts).ok_or_else(|| CompileError::Toolchain {
@@ -413,6 +415,12 @@ impl Toolchain {
     }
 
     /// Use explicit LLVM tools, verifying that they run and share one major.
+    ///
+    /// `llvm-link` is not an explicit parameter: it is taken from
+    /// `CUDA_OXIDE_LLVM_LINK` when set, otherwise discovered next to `llc`,
+    /// in the Rust sysroot, or on `PATH`, requiring the same LLVM major as
+    /// `llc`. It stays unset (disabling IR-level libdevice linking) when
+    /// nothing resolves.
     pub fn from_paths(llc: impl Into<PathBuf>, opt: Option<PathBuf>) -> Result<Self, CompileError> {
         let llc = llc.into();
         let llc_text = llc.to_string_lossy().into_owned();

--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::error::PipelineError;
-use crate::llvm_tools::{LlvmToolchain, OptTool, probe_runnable};
+use crate::llvm_tools::{LlvmToolchain, OptTool, probe_runnable, resolve_sibling_tool};
 use crate::options::BackendOptions;
 use crate::pipeline::{
     ModuleArtifactKind, ModulePipelineRequest, OutputFiles, compile_translated_module,
@@ -443,6 +443,12 @@ impl Toolchain {
             }
         }
 
+        let llvm_link = resolve_sibling_tool(
+            "llvm-link",
+            "CUDA_OXIDE_LLVM_LINK",
+            &llc_text,
+            llc_tool.major,
+        );
         let inner = LlvmToolchain {
             llc_path: llc_tool.path,
             llc_major: llc_tool.major,
@@ -451,6 +457,7 @@ impl Toolchain {
                 path: tool.path,
                 major: tool.major,
             }),
+            llvm_link,
             diagnostics: Vec::new(),
         };
         let selection = describe_selection("explicit toolchain", &inner);

--- a/crates/cuda-oxide-codegen/src/llvm_tools.rs
+++ b/crates/cuda-oxide-codegen/src/llvm_tools.rs
@@ -65,8 +65,10 @@ pub struct LlvmToolchain {
     /// (either `opts.no_opt` or no same-major `opt` exists).
     pub opt: Option<OptTool>,
     /// The matched `llvm-link` for libdevice linking; `None` when no
-    /// same-major `llvm-link` is available (the caller falls back to the
-    /// NVVM IR path or warns about unresolved `__nv_*` calls).
+    /// same-major `llvm-link` is available. The backend decision probes the
+    /// same discovery ([`libdevice_ir_linking_available`]) and falls back to
+    /// the NVVM IR path, so libdevice kernels never reach `llc` with this
+    /// unset.
     pub llvm_link: Option<OptTool>,
     /// Tool-selection diagnostics for the caller to report or retain.
     pub diagnostics: Vec<String>,
@@ -112,7 +114,8 @@ impl LlvmToolchain {
 
         // Resolve llvm-link for libdevice linking. Same discovery pattern
         // as opt: env var, sibling, sysroot, versioned on PATH. Silently
-        // None when absent (the pipeline falls back to NVVM IR or warns).
+        // None when absent (the backend decision then avoids the PTX path
+        // for libdevice kernels).
         let llvm_link =
             resolve_sibling_tool("llvm-link", "CUDA_OXIDE_LLVM_LINK", &llc_path, llc_major);
 
@@ -376,6 +379,21 @@ pub(crate) fn resolve_sibling_tool(
     } else {
         candidates.into_iter().next()
     }
+}
+
+/// Decision-time capability probe for IR-level libdevice linking.
+///
+/// True only when the `llc` that [`LlvmToolchain::resolve`] would pick is
+/// runnable AND a same-major `llvm-link` resolves for it. The PTX-vs-NVVM
+/// backend decision is made before the toolchain itself is resolved, so it
+/// must probe the same discovery logic: committing to the PTX path on
+/// libdevice file existence alone would later emit PTX with unresolved
+/// `.extern .func __nv_*` whenever `llvm-link` turns out to be missing.
+pub(crate) fn libdevice_ir_linking_available(opts: &BackendOptions) -> bool {
+    let Some((llc_path, llc_major, _)) = resolve_llc(opts) else {
+        return false;
+    };
+    resolve_sibling_tool("llvm-link", "CUDA_OXIDE_LLVM_LINK", &llc_path, llc_major).is_some()
 }
 
 /// Runs `cmd --version` and, on success, returns the tool with its parsed

--- a/crates/cuda-oxide-codegen/src/llvm_tools.rs
+++ b/crates/cuda-oxide-codegen/src/llvm_tools.rs
@@ -93,7 +93,7 @@ impl LlvmToolchain {
                 let major = probe_runnable(&path).and_then(|t| t.major);
                 OptTool { path, major }
             });
-            let sibling = sibling_opt_candidates(&llc_path)
+            let sibling = sibling_tool_candidates(&llc_path, "opt")
                 .into_iter()
                 .find_map(|c| probe_runnable(&c));
             let mut others: Vec<OptTool> = Vec::new();
@@ -279,38 +279,11 @@ pub(crate) fn parse_llvm_major(version_output: &str) -> Option<u32> {
     digits.parse().ok()
 }
 
-/// `opt` paths co-located with `llc_path`, most specific first: the
-/// version-suffixed twin (`/usr/bin/llc-21` -> `/usr/bin/opt-21`), then the
-/// plain `opt` in the same directory. A bare `llc` name (resolved through
-/// `PATH`) yields bare `opt` names.
-pub(crate) fn sibling_opt_candidates(llc_path: &str) -> Vec<String> {
-    let p = Path::new(llc_path);
-    let dir = p.parent().filter(|d| !d.as_os_str().is_empty());
-
-    let mut names: Vec<String> = Vec::new();
-    if let Some(suffix) = p
-        .file_name()
-        .and_then(|b| b.to_str())
-        .and_then(|b| b.strip_prefix("llc"))
-        && !suffix.is_empty()
-    {
-        names.push(format!("opt{suffix}"));
-    }
-    names.push("opt".to_string());
-
-    names
-        .into_iter()
-        .map(|n| match dir {
-            Some(d) => d.join(&n).to_string_lossy().into_owned(),
-            None => n,
-        })
-        .collect()
-}
-
 /// Paths co-located with `llc_path` for a given tool name, most specific
 /// first: the version-suffixed twin (`/usr/bin/llc-21` ->
-/// `/usr/bin/<tool>-21`), then the plain name in the same directory.
-fn sibling_tool_candidates(llc_path: &str, tool: &str) -> Vec<String> {
+/// `/usr/bin/<tool>-21`), then the plain name in the same directory. A bare
+/// `llc` name (resolved through `PATH`) yields bare tool names.
+pub(crate) fn sibling_tool_candidates(llc_path: &str, tool: &str) -> Vec<String> {
     let p = Path::new(llc_path);
     let dir = p.parent().filter(|d| !d.as_os_str().is_empty());
 
@@ -463,16 +436,16 @@ mod tests {
     #[test]
     fn sibling_candidates_mirror_the_llc_name() {
         assert_eq!(
-            sibling_opt_candidates("/usr/bin/llc-21"),
+            sibling_tool_candidates("/usr/bin/llc-21", "opt"),
             ["/usr/bin/opt-21", "/usr/bin/opt"]
         );
         assert_eq!(
-            sibling_opt_candidates("/usr/lib/llvm/21/bin/llc"),
+            sibling_tool_candidates("/usr/lib/llvm/21/bin/llc", "opt"),
             ["/usr/lib/llvm/21/bin/opt"]
         );
         // Bare PATH names stay bare so they resolve through PATH.
-        assert_eq!(sibling_opt_candidates("llc-22"), ["opt-22", "opt"]);
-        assert_eq!(sibling_opt_candidates("llc"), ["opt"]);
+        assert_eq!(sibling_tool_candidates("llc-22", "opt"), ["opt-22", "opt"]);
+        assert_eq!(sibling_tool_candidates("llc", "opt"), ["opt"]);
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/src/llvm_tools.rs
+++ b/crates/cuda-oxide-codegen/src/llvm_tools.rs
@@ -46,10 +46,10 @@ pub struct OptTool {
     pub major: Option<u32>,
 }
 
-/// The `opt` / `llc` pair the pipeline will use, resolved once per
-/// compilation so both `optimize_ll` and `generate_ptx` agree on it.
-/// Future version-conditional IR emission should key off `llc_major` here
-/// rather than re-probing binaries.
+/// The `opt` / `llc` / `llvm-link` set the pipeline will use, resolved once
+/// per compilation so `optimize_ll`, `generate_ptx`, and `link_libdevice`
+/// agree on it. Future version-conditional IR emission should key off
+/// `llc_major` here rather than re-probing binaries.
 // mir-importer pipeline plumbing; not part of the frontend contract.
 #[doc(hidden)]
 #[derive(Debug, Clone)]
@@ -64,6 +64,10 @@ pub struct LlvmToolchain {
     /// The matched `opt` for the middle-end; `None` skips `opt -O2`
     /// (either `opts.no_opt` or no same-major `opt` exists).
     pub opt: Option<OptTool>,
+    /// The matched `llvm-link` for libdevice linking; `None` when no
+    /// same-major `llvm-link` is available (the caller falls back to the
+    /// NVVM IR path or warns about unresolved `__nv_*` calls).
+    pub llvm_link: Option<OptTool>,
     /// Tool-selection diagnostics for the caller to report or retain.
     pub diagnostics: Vec<String>,
 }
@@ -106,11 +110,18 @@ impl LlvmToolchain {
             (choice.into_opt(), diagnostics)
         };
 
+        // Resolve llvm-link for libdevice linking. Same discovery pattern
+        // as opt: env var, sibling, sysroot, versioned on PATH. Silently
+        // None when absent (the pipeline falls back to NVVM IR or warns).
+        let llvm_link =
+            resolve_sibling_tool("llvm-link", "CUDA_OXIDE_LLVM_LINK", &llc_path, llc_major);
+
         Some(LlvmToolchain {
             llc_path,
             llc_major,
             llc_from_env,
             opt,
+            llvm_link,
             diagnostics,
         })
     }
@@ -293,6 +304,80 @@ pub(crate) fn sibling_opt_candidates(llc_path: &str) -> Vec<String> {
         .collect()
 }
 
+/// Paths co-located with `llc_path` for a given tool name, most specific
+/// first: the version-suffixed twin (`/usr/bin/llc-21` ->
+/// `/usr/bin/<tool>-21`), then the plain name in the same directory.
+fn sibling_tool_candidates(llc_path: &str, tool: &str) -> Vec<String> {
+    let p = Path::new(llc_path);
+    let dir = p.parent().filter(|d| !d.as_os_str().is_empty());
+
+    let mut names: Vec<String> = Vec::new();
+    if let Some(suffix) = p
+        .file_name()
+        .and_then(|b| b.to_str())
+        .and_then(|b| b.strip_prefix("llc"))
+        && !suffix.is_empty()
+    {
+        names.push(format!("{tool}{suffix}"));
+    }
+    names.push(tool.to_string());
+
+    names
+        .into_iter()
+        .map(|n| match dir {
+            Some(d) => d.join(&n).to_string_lossy().into_owned(),
+            None => n,
+        })
+        .collect()
+}
+
+/// Resolve an LLVM tool (e.g., `llvm-link`) co-located with the chosen
+/// `llc`, matched to the same LLVM major. Discovery order:
+///
+/// 1. Explicit env var (always used if set)
+/// 2. Co-located binary next to `llc`
+/// 3. Sysroot llvm-tools, then versioned names on PATH
+///
+/// Returns `None` silently when no same-major candidate exists.
+pub(crate) fn resolve_sibling_tool(
+    tool: &str,
+    env_var: &str,
+    llc_path: &str,
+    llc_major: Option<u32>,
+) -> Option<OptTool> {
+    if let Ok(path) = std::env::var(env_var) {
+        return probe_runnable(&path);
+    }
+
+    // Co-located sibling next to llc.
+    let sibling = sibling_tool_candidates(llc_path, tool)
+        .into_iter()
+        .find_map(|c| probe_runnable(&c));
+    if let Some(ref s) = sibling
+        && (llc_major.is_none() || s.major == llc_major)
+    {
+        return sibling;
+    }
+
+    // Sysroot and versioned on PATH.
+    let mut candidates: Vec<OptTool> = Vec::new();
+    if let Some(p) = sysroot_tool(tool)
+        && let Some(t) = probe_runnable(&p)
+    {
+        candidates.push(t);
+    }
+    for name in [format!("{tool}-22"), format!("{tool}-21"), tool.to_string()] {
+        if let Some(t) = probe_runnable(&name) {
+            candidates.push(t);
+        }
+    }
+    if let Some(llc_m) = llc_major {
+        candidates.into_iter().find(|t| t.major == Some(llc_m))
+    } else {
+        candidates.into_iter().next()
+    }
+}
+
 /// Runs `cmd --version` and, on success, returns the tool with its parsed
 /// major. `None` means the binary does not exist or is not runnable.
 pub(crate) fn probe_runnable(cmd: &str) -> Option<OptTool> {
@@ -370,6 +455,23 @@ mod tests {
         // Bare PATH names stay bare so they resolve through PATH.
         assert_eq!(sibling_opt_candidates("llc-22"), ["opt-22", "opt"]);
         assert_eq!(sibling_opt_candidates("llc"), ["opt"]);
+    }
+
+    #[test]
+    fn sibling_tool_candidates_generates_versioned_and_plain() {
+        assert_eq!(
+            sibling_tool_candidates("/usr/bin/llc-21", "llvm-link"),
+            ["/usr/bin/llvm-link-21", "/usr/bin/llvm-link"]
+        );
+        assert_eq!(
+            sibling_tool_candidates("/usr/lib/llvm/21/bin/llc", "llvm-link"),
+            ["/usr/lib/llvm/21/bin/llvm-link"]
+        );
+        assert_eq!(
+            sibling_tool_candidates("llc-22", "llvm-link"),
+            ["llvm-link-22", "llvm-link"]
+        );
+        assert_eq!(sibling_tool_candidates("llc", "llvm-link"), ["llvm-link"]);
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/src/options.rs
+++ b/crates/cuda-oxide-codegen/src/options.rs
@@ -29,9 +29,10 @@ pub struct BackendOptions {
 }
 
 impl BackendOptions {
-    /// Reads the historical `CUDA_OXIDE_*` variables. The ONLY env access in
-    /// this crate outside this crate's own tests; called by rustc-pipeline
-    /// hosts, never by the backend itself.
+    /// Reads the historical `CUDA_OXIDE_*` variables; called by rustc-pipeline
+    /// hosts, never by the backend itself. The only other env access in this
+    /// crate is `CUDA_OXIDE_LLVM_LINK` in `llvm_tools::resolve_sibling_tool`
+    /// (a per-toolchain tool override, not a compile option).
     pub fn from_env() -> Self {
         Self {
             target_arch: std::env::var("CUDA_OXIDE_TARGET").ok(),

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -214,8 +214,20 @@ pub fn compile_translated_module(
     // Discover libdevice.10.bc early so the backend decision can account for
     // IR-level linking. When available, `needs_libdevice` no longer forces the
     // NVVM IR path — the PTX path links libdevice at the LLVM IR level instead.
+    // "Available" requires BOTH the bitcode file and a same-major `llvm-link`
+    // for the `llc` this compilation will use: deciding from file existence
+    // alone would commit to the PTX path and then ship PTX with unresolved
+    // `.extern .func __nv_*` (a cuModuleLoad-time failure) whenever the
+    // linker is missing. Without either piece, libdevice kernels fall back
+    // to the NVVM IR path as they did before IR-level linking existed.
     let libdevice_path = libnvvm_sys::find_libdevice().ok();
-    let can_ir_link_libdevice = libdevice_path.is_some();
+    let can_ir_link_libdevice = libdevice_path.is_some()
+        && match request.toolchain {
+            ToolchainPolicy::Discover => {
+                crate::llvm_tools::libdevice_ir_linking_available(request.backend)
+            }
+            ToolchainPolicy::Explicit(toolchain) => toolchain.llvm_link.is_some(),
+        };
 
     // Choose the intrinsic ABI while calls are still typed MIR. Generated
     // intrinsics may have different LLVM signatures for `llc` and libNVVM, so
@@ -398,7 +410,7 @@ pub fn compile_translated_module(
     if request.trace.verbose {
         request.trace.emit("\n=== Generating PTX ===");
     }
-    let ptx_libdevice = if needs_libdevice {
+    let ptx_libdevice = if needs_libdevice && can_ir_link_libdevice {
         libdevice_path.as_deref()
     } else {
         None

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -211,10 +211,17 @@ pub fn compile_translated_module(
         add_device_extern_declarations(ctx, module, request.device_externs)?;
     }
 
+    // Discover libdevice.10.bc early so the backend decision can account for
+    // IR-level linking. When available, `needs_libdevice` no longer forces the
+    // NVVM IR path — the PTX path links libdevice at the LLVM IR level instead.
+    let libdevice_path = libnvvm_sys::find_libdevice().ok();
+    let can_ir_link_libdevice = libdevice_path.is_some();
+
     // Choose the intrinsic ABI while calls are still typed MIR. Generated
     // intrinsics may have different LLVM signatures for `llc` and libNVVM, so
     // discovering NVVM mode only after lowering is too late.
-    let backend_selection = select_pre_lowering_backend(ctx, module, request.output_policy);
+    let backend_selection =
+        select_pre_lowering_backend(ctx, module, request.output_policy, can_ir_link_libdevice);
     let generated_requirements = collect_generated_intrinsic_requirements_for_backend(
         ctx,
         module,
@@ -252,11 +259,19 @@ pub fn compile_translated_module(
             request_nvvm_ir: true
         }
     );
-    if needs_libdevice && !requested_nvvm_ir && emit_nvvm_ir && request.trace.verbose {
-        request.trace.emit(
-            "\n=== Detected CUDA libdevice (`__nv_*`) calls; \
-             auto-emitting NVVM IR (skip llc) ===",
-        );
+    if needs_libdevice && request.trace.verbose {
+        if !emit_nvvm_ir && can_ir_link_libdevice {
+            request.trace.emit(format!(
+                "\n=== Detected CUDA libdevice (`__nv_*`) calls; \
+                 linking libdevice.10.bc at IR level ({}) ===",
+                libdevice_path.as_ref().unwrap().display()
+            ));
+        } else if !requested_nvvm_ir && emit_nvvm_ir {
+            request.trace.emit(
+                "\n=== Detected CUDA libdevice (`__nv_*`) calls; \
+                 auto-emitting NVVM IR (skip llc) ===",
+            );
+        }
     }
 
     // NVVM pointer syntax depends on the target. Detect the feature floor from
@@ -383,6 +398,11 @@ pub fn compile_translated_module(
     if request.trace.verbose {
         request.trace.emit("\n=== Generating PTX ===");
     }
+    let ptx_libdevice = if needs_libdevice {
+        libdevice_path.as_deref()
+    } else {
+        None
+    };
     let generated = match request.toolchain {
         ToolchainPolicy::Discover => generate_ptx(
             request.files.llvm_ir,
@@ -391,6 +411,7 @@ pub fn compile_translated_module(
             request.backend,
             request.trace.sink,
             &generated_requirements,
+            ptx_libdevice,
         )?,
         ToolchainPolicy::Explicit(toolchain) => generate_ptx_with_toolchain(
             request.files.llvm_ir,
@@ -399,6 +420,7 @@ pub fn compile_translated_module(
             request.backend,
             toolchain,
             &generated_requirements,
+            ptx_libdevice,
         )?,
     };
     if request.trace.verbose {
@@ -430,13 +452,14 @@ fn select_pre_lowering_backend(
     ctx: &Context,
     module: Ptr<Operation>,
     output_policy: OutputPolicy,
+    can_ir_link_libdevice: bool,
 ) -> PreLoweringBackendSelection {
     // The rustc frontend supplies typed MIR, while the standalone frontend may
     // also supply an already-lowered LLVM declaration in the same module.
     // Inspect both representations before choosing an intrinsic ABI.
     let needs_libdevice =
         typed_mir_uses_libdevice(ctx, module) || module_uses_libdevice(ctx, module);
-    let emit_nvvm_ir = should_emit_nvvm_ir(output_policy, needs_libdevice);
+    let emit_nvvm_ir = should_emit_nvvm_ir(output_policy, needs_libdevice, can_ir_link_libdevice);
     let intrinsic_backend = if emit_nvvm_ir {
         mir_lower::IntrinsicBackend::LibNvvm
     } else {
@@ -481,10 +504,27 @@ fn typed_op_uses_libdevice(ctx: &Context, op: Ptr<Operation>) -> bool {
     false
 }
 
-fn should_emit_nvvm_ir(policy: OutputPolicy, needs_libdevice: bool) -> bool {
+/// Determines whether the pipeline should emit NVVM IR instead of PTX.
+///
+/// When `can_ir_link_libdevice` is true, `__nv_*` calls will be resolved by
+/// linking `libdevice.10.bc` at the LLVM IR level (via `llvm-link`), so
+/// `needs_libdevice` alone no longer forces the NVVM IR path. This avoids the
+/// legacy LLVM 7 dialect that cannot represent f16 on pre-Blackwell targets.
+fn should_emit_nvvm_ir(
+    policy: OutputPolicy,
+    needs_libdevice: bool,
+    can_ir_link_libdevice: bool,
+) -> bool {
     match policy {
         OutputPolicy::SelfContainedPtx => false,
-        OutputPolicy::ExternalLinkAllowed { request_nvvm_ir } => request_nvvm_ir || needs_libdevice,
+        OutputPolicy::ExternalLinkAllowed { request_nvvm_ir } => {
+            if request_nvvm_ir {
+                return true;
+            }
+            // Fall back to NVVM IR only when the kernel needs libdevice AND
+            // we cannot resolve the calls via IR-level linking.
+            needs_libdevice && !can_ir_link_libdevice
+        }
     }
 }
 
@@ -565,8 +605,16 @@ mod tests {
 
     #[test]
     fn standalone_never_silently_switches_to_a_linkable_artifact() {
-        assert!(!should_emit_nvvm_ir(OutputPolicy::SelfContainedPtx, false));
-        assert!(!should_emit_nvvm_ir(OutputPolicy::SelfContainedPtx, true));
+        assert!(!should_emit_nvvm_ir(
+            OutputPolicy::SelfContainedPtx,
+            false,
+            false
+        ));
+        assert!(!should_emit_nvvm_ir(
+            OutputPolicy::SelfContainedPtx,
+            true,
+            false
+        ));
     }
 
     #[test]
@@ -577,28 +625,71 @@ mod tests {
         let requested = OutputPolicy::ExternalLinkAllowed {
             request_nvvm_ir: true,
         };
-        assert!(!should_emit_nvvm_ir(automatic, false));
-        assert!(should_emit_nvvm_ir(automatic, true));
-        assert!(should_emit_nvvm_ir(requested, false));
+        // No libdevice, no IR linking available → PTX path.
+        assert!(!should_emit_nvvm_ir(automatic, false, false));
+        // Libdevice needed, no IR linking → falls back to NVVM IR.
+        assert!(should_emit_nvvm_ir(automatic, true, false));
+        // Explicit NVVM IR request always wins.
+        assert!(should_emit_nvvm_ir(requested, false, false));
     }
 
     #[test]
-    fn typed_libdevice_selection_happens_before_lowering() {
+    fn ir_linking_avoids_nvvm_ir_for_libdevice() {
+        let automatic = OutputPolicy::ExternalLinkAllowed {
+            request_nvvm_ir: false,
+        };
+        // Libdevice needed, IR linking available → PTX path (not NVVM IR).
+        assert!(!should_emit_nvvm_ir(automatic, true, true));
+        // No libdevice needed, IR linking available → PTX path (unchanged).
+        assert!(!should_emit_nvvm_ir(automatic, false, true));
+        // Explicit NVVM IR request still forces NVVM IR even with IR linking.
+        let requested = OutputPolicy::ExternalLinkAllowed {
+            request_nvvm_ir: true,
+        };
+        assert!(should_emit_nvvm_ir(requested, false, true));
+    }
+
+    #[test]
+    fn typed_libdevice_without_ir_linking_falls_back_to_nvvm() {
         let mut ctx = Context::new();
         let module =
             typed_mir_test_module(&mut ctx, &[dialect_mir::rust_intrinsics::CALLEE_SIN_F32]);
+        // No IR-level linking: libdevice forces NVVM IR (legacy behavior).
         let selection = select_pre_lowering_backend(
             &ctx,
             module,
             OutputPolicy::ExternalLinkAllowed {
                 request_nvvm_ir: false,
             },
+            false,
         );
         assert!(selection.needs_libdevice);
         assert!(selection.emit_nvvm_ir);
         assert_eq!(
             selection.intrinsic_backend,
             mir_lower::IntrinsicBackend::LibNvvm
+        );
+    }
+
+    #[test]
+    fn typed_libdevice_with_ir_linking_stays_on_ptx_path() {
+        let mut ctx = Context::new();
+        let module =
+            typed_mir_test_module(&mut ctx, &[dialect_mir::rust_intrinsics::CALLEE_SIN_F32]);
+        // IR-level linking available: libdevice does NOT force NVVM IR.
+        let selection = select_pre_lowering_backend(
+            &ctx,
+            module,
+            OutputPolicy::ExternalLinkAllowed {
+                request_nvvm_ir: false,
+            },
+            true,
+        );
+        assert!(selection.needs_libdevice);
+        assert!(!selection.emit_nvvm_ir);
+        assert_eq!(
+            selection.intrinsic_backend,
+            mir_lower::IntrinsicBackend::LlvmNvptx
         );
     }
 
@@ -613,13 +704,14 @@ mod tests {
             OutputPolicy::ExternalLinkAllowed {
                 request_nvvm_ir: true,
             },
+            false,
         );
         assert!(!nvvm.needs_libdevice);
         assert!(nvvm.emit_nvvm_ir);
         assert_eq!(nvvm.intrinsic_backend, mir_lower::IntrinsicBackend::LibNvvm);
 
         let standalone =
-            select_pre_lowering_backend(&ctx, ordinary, OutputPolicy::SelfContainedPtx);
+            select_pre_lowering_backend(&ctx, ordinary, OutputPolicy::SelfContainedPtx, false);
         assert!(!standalone.emit_nvvm_ir);
         assert_eq!(
             standalone.intrinsic_backend,

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -23,9 +23,19 @@ use std::path::{Path, PathBuf};
 /// avoids the legacy NVVM IR path (which uses the LLVM 7 dialect and cannot
 /// represent f16 types on pre-Blackwell targets).
 ///
-/// Returns the linked `.ll` path on success, `None` on failure (with a
-/// diagnostic). The caller falls through to the unlinked IR when linking is
-/// unavailable.
+/// `--internalize --only-needed` mirrors clang's
+/// `LinkOnlyNeeded | InternalizeLinkedSymbols`: libdevice bodies have plain
+/// external linkage, so without both flags all ~350 definitions are pulled
+/// in, survive GlobalDCE, and llc exports every one as a `.visible .func
+/// __nv_*` PTX body (a one-call kernel balloons from ~130 to ~22,000 lines
+/// and later cuLink/nvJitLink steps hit duplicate-symbol collisions). With
+/// the flags, only the referenced bodies are imported, as `internal`, and
+/// `opt -O2` inlines or discards them.
+///
+/// Failure is a hard error: the pipeline chooses the PTX path for a
+/// libdevice kernel only after confirming `llvm-link` is resolvable, so a
+/// link failure here must not degrade into PTX with unresolved
+/// `.extern .func __nv_*` that only fails later at cuModuleLoad.
 fn link_libdevice(
     ll_path: &Path,
     libdevice_path: &Path,
@@ -33,12 +43,20 @@ fn link_libdevice(
     diagnostic_sink: Option<fn(&str)>,
     diagnostics: &mut Vec<String>,
     verbose: bool,
-) -> Option<PathBuf> {
-    let llvm_link = toolchain.llvm_link.as_ref()?;
+) -> Result<PathBuf, PipelineError> {
+    let Some(llvm_link) = toolchain.llvm_link.as_ref() else {
+        return Err(PipelineError::PtxGeneration(
+            "libdevice linking is required, but no `llvm-link` matching the selected `llc` \
+             is available; install the matching LLVM tools or set CUDA_OXIDE_LLVM_LINK"
+                .to_string(),
+        ));
+    };
 
     let linked_path = ll_path.with_extension("linked.ll");
     match std::process::Command::new(&llvm_link.path)
         .arg("-S")
+        .arg("--internalize")
+        .arg("--only-needed")
         .arg(ll_path)
         .arg(libdevice_path)
         .arg("-o")
@@ -57,34 +75,20 @@ fn link_libdevice(
                     ),
                 );
             }
-            Some(linked_path)
+            Ok(linked_path)
         }
-        Ok(output) => {
-            record_diagnostic(
-                diagnostics,
-                diagnostic_sink,
-                format!(
-                    "warning: llvm-link ({}) failed with status {}:\n{}\n\
-                     warning: continuing without libdevice; `__nv_*` calls may be unresolved",
-                    llvm_link.path,
-                    output.status,
-                    String::from_utf8_lossy(&output.stderr).trim()
-                ),
-            );
-            None
-        }
-        Err(error) => {
-            record_diagnostic(
-                diagnostics,
-                diagnostic_sink,
-                format!(
-                    "warning: failed to run llvm-link ({}): {error}\n\
-                     warning: continuing without libdevice; `__nv_*` calls may be unresolved",
-                    llvm_link.path
-                ),
-            );
-            None
-        }
+        Ok(output) => Err(PipelineError::PtxGeneration(format!(
+            "llvm-link ({}) failed with status {} while linking libdevice ({}):\n{}",
+            llvm_link.path,
+            output.status,
+            libdevice_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))),
+        Err(error) => Err(PipelineError::PtxGeneration(format!(
+            "failed to run llvm-link ({}) while linking libdevice ({}): {error}",
+            llvm_link.path,
+            libdevice_path.display()
+        ))),
     }
 }
 
@@ -359,16 +363,17 @@ fn generate_ptx_impl(
     // Link libdevice at the IR level when the kernel uses `__nv_*` calls.
     // This resolves (and later inlines) CUDA math functions without forcing
     // the legacy NVVM IR path, which cannot represent f16 on pre-Blackwell.
-    let linked = libdevice_path.and_then(|lp| {
-        link_libdevice(
+    let linked = match libdevice_path {
+        Some(lp) => Some(link_libdevice(
             ll_path,
             lp,
             toolchain,
             diagnostic_sink,
             &mut diagnostics,
             opts.verbose,
-        )
-    });
+        )?),
+        None => None,
+    };
     let post_link_input: &Path = linked.as_deref().unwrap_or(ll_path);
 
     // Run the LLVM middle-end (opt -O2) before llc. Feature detection above
@@ -651,6 +656,118 @@ mod tests {
             "{diagnostics:?}"
         );
         drop(diagnostics);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// `__nv_*` function definitions in `ptx` that no PTX `call` references.
+    ///
+    /// A definition line carries `.func`/`.entry` and opens a body (it does
+    /// not end with `;` like the forward declarations llc prints for
+    /// callees). Anything imported from libdevice but never called is bloat
+    /// that `--internalize --only-needed` + `opt` must have eliminated.
+    fn unreferenced_nv_definitions(ptx: &str) -> Vec<String> {
+        let mut defined: Vec<String> = Vec::new();
+        for line in ptx.lines() {
+            let trimmed = line.trim();
+            if !trimmed.contains(".func") || trimmed.ends_with(';') {
+                continue;
+            }
+            if let Some(idx) = trimmed.find("__nv_") {
+                let name: String = trimmed[idx..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .collect();
+                defined.push(name);
+            }
+        }
+        defined.retain(|name| {
+            !ptx.lines()
+                .any(|line| line.contains("call") && line.contains(name.as_str()))
+        });
+        defined
+    }
+
+    /// Regression test for IR-level libdevice linking: without
+    /// `--internalize --only-needed` on the `llvm-link` invocation, all ~350
+    /// libdevice bodies keep external linkage, survive `opt -O2`, and a
+    /// one-call kernel's PTX balloons from ~130 to ~22,000 lines with 349
+    /// exported `.visible .func __nv_*` definitions.
+    #[test]
+    fn linked_libdevice_ptx_has_no_unreferenced_nv_definitions() {
+        // Needs a full toolchain (llc + same-major opt and llvm-link) and a
+        // discoverable libdevice.10.bc; skip quietly on machines without a
+        // CUDA toolkit or LLVM tools.
+        let opts = BackendOptions {
+            target_arch: Some("sm_80".to_string()),
+            ..BackendOptions::default()
+        };
+        let Some(toolchain) = LlvmToolchain::resolve(&opts) else {
+            return;
+        };
+        if toolchain.opt.is_none() || toolchain.llvm_link.is_none() {
+            return;
+        }
+        let Ok(libdevice) = libnvvm_sys::find_libdevice() else {
+            return;
+        };
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_libdevice_link_{}_{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let ll_path = root.join("kernel.ll");
+        let ptx_path = root.join("kernel.ptx");
+        std::fs::write(
+            &ll_path,
+            "target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\"\n\
+             target triple = \"nvptx64-nvidia-cuda\"\n\
+             \n\
+             declare float @__nv_sinf(float)\n\
+             \n\
+             define ptx_kernel void @kernel(ptr %out, float %x) {\n\
+               %s = call float @__nv_sinf(float %x)\n\
+               store float %s, ptr %out\n\
+               ret void\n\
+             }\n",
+        )
+        .unwrap();
+
+        let target = generate_ptx_with_toolchain(
+            &ll_path,
+            &ptx_path,
+            DebugKind::Off,
+            &opts,
+            &toolchain,
+            &GeneratedModuleRequirements::default(),
+            Some(&libdevice),
+        )
+        .unwrap();
+        assert_eq!(target, "sm_80");
+
+        let ptx = std::fs::read_to_string(&ptx_path).unwrap();
+        assert!(
+            ptx.contains(".visible .entry kernel"),
+            "the kernel itself must stay exported:\n{ptx}"
+        );
+        assert!(
+            !ptx.contains(".visible .func __nv_"),
+            "libdevice bodies must be internalized, not exported:\n{ptx}"
+        );
+        let unreferenced = unreferenced_nv_definitions(&ptx);
+        assert!(
+            unreferenced.is_empty(),
+            "linked PTX contains unreferenced __nv_* definitions: {unreferenced:?}"
+        );
+        assert!(
+            ptx.lines().count() < 1_000,
+            "linked PTX for a one-call kernel should be O(100) lines, got {}",
+            ptx.lines().count()
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -16,6 +16,78 @@ use crate::target::{
 use llvm_export::export::DebugKind;
 use std::path::{Path, PathBuf};
 
+/// Links `libdevice.10.bc` into the emitted IR using `llvm-link`.
+///
+/// Resolves `__nv_*` calls (CUDA math library) at the IR level so they are
+/// inlined and optimized by `opt -O2` before `llc` lowers to PTX. This
+/// avoids the legacy NVVM IR path (which uses the LLVM 7 dialect and cannot
+/// represent f16 types on pre-Blackwell targets).
+///
+/// Returns the linked `.ll` path on success, `None` on failure (with a
+/// diagnostic). The caller falls through to the unlinked IR when linking is
+/// unavailable.
+fn link_libdevice(
+    ll_path: &Path,
+    libdevice_path: &Path,
+    toolchain: &LlvmToolchain,
+    diagnostic_sink: Option<fn(&str)>,
+    diagnostics: &mut Vec<String>,
+    verbose: bool,
+) -> Option<PathBuf> {
+    let llvm_link = toolchain.llvm_link.as_ref()?;
+
+    let linked_path = ll_path.with_extension("linked.ll");
+    match std::process::Command::new(&llvm_link.path)
+        .arg("-S")
+        .arg(ll_path)
+        .arg(libdevice_path)
+        .arg("-o")
+        .arg(&linked_path)
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            if verbose {
+                record_diagnostic(
+                    diagnostics,
+                    diagnostic_sink,
+                    format!(
+                        "llvm-link: linked libdevice ({}) → {}",
+                        libdevice_path.display(),
+                        linked_path.display()
+                    ),
+                );
+            }
+            Some(linked_path)
+        }
+        Ok(output) => {
+            record_diagnostic(
+                diagnostics,
+                diagnostic_sink,
+                format!(
+                    "warning: llvm-link ({}) failed with status {}:\n{}\n\
+                     warning: continuing without libdevice; `__nv_*` calls may be unresolved",
+                    llvm_link.path,
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            );
+            None
+        }
+        Err(error) => {
+            record_diagnostic(
+                diagnostics,
+                diagnostic_sink,
+                format!(
+                    "warning: failed to run llvm-link ({}): {error}\n\
+                     warning: continuing without libdevice; `__nv_*` calls may be unresolved",
+                    llvm_link.path
+                ),
+            );
+            None
+        }
+    }
+}
+
 /// Runs LLVM's middle-end (`opt -O2`) on the emitted IR before `llc`.
 ///
 /// This is what consumes the per-op ABI alignment we emit: the
@@ -143,6 +215,7 @@ pub fn generate_ptx(
     opts: &BackendOptions,
     diagnostic_sink: Option<fn(&str)>,
     generated: &GeneratedModuleRequirements,
+    libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
     let Some(toolchain) = LlvmToolchain::resolve(opts) else {
         return Err(PipelineError::PtxGeneration(
@@ -165,11 +238,15 @@ pub fn generate_ptx(
     }
     if opts.verbose {
         diagnostics.push(format!(
-            "LLVM toolchain: llc = {}, opt = {}",
+            "LLVM toolchain: llc = {}, opt = {}, llvm-link = {}",
             crate::llvm_tools::describe_tool(&toolchain.llc_path, toolchain.llc_major),
             match &toolchain.opt {
                 Some(tool) => crate::llvm_tools::describe_tool(&tool.path, tool.major),
                 None => "(skipped)".to_string(),
+            },
+            match &toolchain.llvm_link {
+                Some(tool) => crate::llvm_tools::describe_tool(&tool.path, tool.major),
+                None => "(not found)".to_string(),
             }
         ));
     }
@@ -185,6 +262,7 @@ pub fn generate_ptx(
         },
         false,
         diagnostic_sink,
+        libdevice_path,
     )?;
     diagnostics.append(&mut generated.diagnostics);
     generated.diagnostics = diagnostics;
@@ -202,6 +280,7 @@ pub(crate) fn generate_ptx_with_toolchain(
     opts: &BackendOptions,
     toolchain: &LlvmToolchain,
     generated: &GeneratedModuleRequirements,
+    libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
     generate_ptx_impl(
         ll_path,
@@ -214,6 +293,7 @@ pub(crate) fn generate_ptx_with_toolchain(
         },
         true,
         None,
+        libdevice_path,
     )
 }
 
@@ -224,6 +304,7 @@ fn generate_ptx_impl(
     backend: PtxBackend<'_>,
     strict_optimization: bool,
     diagnostic_sink: Option<fn(&str)>,
+    libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
     let PtxBackend {
         options: opts,
@@ -275,6 +356,21 @@ fn generate_ptx_impl(
     validate_ptx_isa_for_llvm_major(requirements.ptx_isa, toolchain.llc_major)
         .map_err(PipelineError::PtxGeneration)?;
 
+    // Link libdevice at the IR level when the kernel uses `__nv_*` calls.
+    // This resolves (and later inlines) CUDA math functions without forcing
+    // the legacy NVVM IR path, which cannot represent f16 on pre-Blackwell.
+    let linked = libdevice_path.and_then(|lp| {
+        link_libdevice(
+            ll_path,
+            lp,
+            toolchain,
+            diagnostic_sink,
+            &mut diagnostics,
+            opts.verbose,
+        )
+    });
+    let post_link_input: &Path = linked.as_deref().unwrap_or(ll_path);
+
     // Run the LLVM middle-end (opt -O2) before llc. Feature detection above
     // intentionally reads the original (pre-opt) IR so the target is determined
     // by what the source actually needs, not what opt elides.
@@ -296,13 +392,13 @@ fn generate_ptx_impl(
         None
     } else {
         let (optimized, mut opt_diagnostics) =
-            optimize_ll(ll_path, toolchain, opts, strict_optimization)?;
+            optimize_ll(post_link_input, toolchain, opts, strict_optimization)?;
         for diagnostic in opt_diagnostics.drain(..) {
             record_diagnostic(&mut diagnostics, diagnostic_sink, diagnostic);
         }
         optimized
     };
-    let llc_input: &Path = optimized.as_deref().unwrap_or(ll_path);
+    let llc_input: &Path = optimized.as_deref().unwrap_or(post_link_input);
 
     let llc_desc = if toolchain.llc_from_env {
         format!("llc_override ({})", toolchain.llc_path)
@@ -480,6 +576,7 @@ mod tests {
                 path: "/bin/false".to_string(),
                 major: Some(21),
             }),
+            llvm_link: None,
             diagnostics: Vec::new(),
         };
         let opts = BackendOptions::default();
@@ -533,6 +630,7 @@ mod tests {
             &opts,
             Some(collect_legacy_diagnostic),
             &GeneratedModuleRequirements::default(),
+            None,
         )
         .unwrap_err();
         assert!(matches!(error, PipelineError::PtxGeneration(_)));

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -659,6 +659,76 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
+    /// Whether `c` can appear in a PTX identifier (`followsym`).
+    fn is_ptx_identifier_char(c: char) -> bool {
+        c.is_ascii_alphanumeric() || c == '_' || c == '$'
+    }
+
+    /// Whether `line` contains `name` as a complete identifier token.
+    ///
+    /// A plain substring check treats `__nv_sin` as present in a line that
+    /// only mentions `__nv_sinf`, so a call to the latter would wrongly mark
+    /// the former as referenced. Require the match to end at a
+    /// non-identifier character (and not to be the tail of a longer
+    /// identifier either).
+    fn contains_identifier_token(line: &str, name: &str) -> bool {
+        let mut search_from = 0;
+        while let Some(pos) = line[search_from..].find(name) {
+            let start = search_from + pos;
+            let end = start + name.len();
+            let before_ok = line[..start]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !is_ptx_identifier_char(c));
+            let after_ok = line[end..]
+                .chars()
+                .next()
+                .is_none_or(|c| !is_ptx_identifier_char(c));
+            if before_ok && after_ok {
+                return true;
+            }
+            search_from = start + 1;
+        }
+        false
+    }
+
+    /// Names of `.visible .func` symbols in `ptx` that start with `__nv_`.
+    ///
+    /// llc prints void-returning definitions as `.visible .func __nv_foo(`
+    /// but value-returning ones as
+    /// `.visible .func  (.param .b32 func_retval0) __nv_clz(`, so a naive
+    /// `.visible .func __nv_` substring check misses everything with a
+    /// return value. Skip past the optional return-parameter clause and
+    /// inspect the declared symbol name itself.
+    fn exported_nv_functions(ptx: &str) -> Vec<String> {
+        let mut exported: Vec<String> = Vec::new();
+        for line in ptx.lines() {
+            let Some(rest) = line.trim_start().strip_prefix(".visible") else {
+                continue;
+            };
+            let Some(idx) = rest.find(".func") else {
+                continue;
+            };
+            let mut rest = rest[idx + ".func".len()..].trim_start();
+            // Skip the `(.param .b32 func_retval0)` clause of
+            // value-returning functions.
+            if let Some(after_open) = rest.strip_prefix('(') {
+                let Some(close) = after_open.find(')') else {
+                    continue;
+                };
+                rest = after_open[close + 1..].trim_start();
+            }
+            let name: String = rest
+                .chars()
+                .take_while(|c| is_ptx_identifier_char(*c))
+                .collect();
+            if name.starts_with("__nv_") {
+                exported.push(name);
+            }
+        }
+        exported
+    }
+
     /// `__nv_*` function definitions in `ptx` that no PTX `call` references.
     ///
     /// A definition line carries `.func`/`.entry` and opens a body (it does
@@ -675,16 +745,46 @@ mod tests {
             if let Some(idx) = trimmed.find("__nv_") {
                 let name: String = trimmed[idx..]
                     .chars()
-                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .take_while(|c| is_ptx_identifier_char(*c))
                     .collect();
                 defined.push(name);
             }
         }
         defined.retain(|name| {
             !ptx.lines()
-                .any(|line| line.contains("call") && line.contains(name.as_str()))
+                .any(|line| line.contains("call") && contains_identifier_token(line, name))
         });
         defined
+    }
+
+    /// Toolchain-free coverage for the PTX detectors used by the libdevice
+    /// link regression test (which skips on machines without llc/opt/
+    /// llvm-link/libdevice).
+    #[test]
+    fn nv_detectors_handle_retval_clauses_and_identifier_boundaries() {
+        let ptx = "\
+.visible .entry kernel(
+.visible .func __nv_void_helper(
+.visible .func  (.param .b32 func_retval0) __nv_clz(
+.func  (.param .b32 func_retval0) __nv_internal_only(
+\tcall.uni (retval0), __nv_sinf, (param0);
+";
+        // Value-returning exports (retval clause between `.func` and the
+        // name) must be caught, internal (non-.visible) ones must not.
+        assert_eq!(exported_nv_functions(ptx), ["__nv_void_helper", "__nv_clz"]);
+
+        // `__nv_sin` is not referenced by a call to `__nv_sinf`.
+        let call_line = "\tcall.uni (retval0), __nv_sinf, (param0);";
+        assert!(contains_identifier_token(call_line, "__nv_sinf"));
+        assert!(!contains_identifier_token(call_line, "__nv_sin"));
+        assert!(!contains_identifier_token("x__nv_sinf(", "__nv_sinf"));
+
+        let defs_and_call = "\
+.visible .func __nv_sin(
+.func  (.param .b32 func_retval0) __nv_sinf(
+\tcall.uni (retval0), __nv_sinf, (param0);
+";
+        assert_eq!(unreferenced_nv_definitions(defs_and_call), ["__nv_sin"]);
     }
 
     /// Regression test for IR-level libdevice linking: without
@@ -747,16 +847,19 @@ mod tests {
             Some(&libdevice),
         )
         .unwrap();
-        assert_eq!(target, "sm_80");
+        assert_eq!(target.target, "sm_80");
 
         let ptx = std::fs::read_to_string(&ptx_path).unwrap();
         assert!(
             ptx.contains(".visible .entry kernel"),
             "the kernel itself must stay exported:\n{ptx}"
         );
+        let exported = exported_nv_functions(&ptx);
         assert!(
-            !ptx.contains(".visible .func __nv_"),
-            "libdevice bodies must be internalized, not exported:\n{ptx}"
+            exported.is_empty(),
+            "libdevice bodies must be internalized, not exported; found {} `.visible .func` \
+             definitions: {exported:?}",
+            exported.len()
         );
         let unreferenced = unreferenced_nv_definitions(&ptx);
         assert!(

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -425,6 +425,7 @@ fn stale_compilation_artifact_paths(
 ) -> Vec<std::path::PathBuf> {
     [
         "ll",
+        "linked.ll",
         "ptx",
         "target",
         "options",
@@ -470,6 +471,7 @@ mod tests {
         fs::create_dir_all(&root).unwrap();
         for suffix in [
             "ll",
+            "linked.ll",
             "ptx",
             "target",
             "options",
@@ -500,7 +502,7 @@ mod tests {
 
         assert_eq!(result.artifact_kind, CompilationArtifactKind::NvvmIr);
         assert_ne!(fs::read(&result.ll_path).unwrap(), b"stale");
-        for suffix in ["ptx", "ltoir", "cubin", "cubin.target"] {
+        for suffix in ["linked.ll", "ptx", "ltoir", "cubin", "cubin.target"] {
             assert!(!root.join(format!("kernel.{suffix}")).exists(), "{suffix}");
         }
         assert_ne!(fs::read(root.join("kernel.target")).unwrap(), b"stale");

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -426,6 +426,7 @@ fn stale_compilation_artifact_paths(
     [
         "ll",
         "linked.ll",
+        "linked.opt.ll",
         "ptx",
         "target",
         "options",
@@ -472,6 +473,7 @@ mod tests {
         for suffix in [
             "ll",
             "linked.ll",
+            "linked.opt.ll",
             "ptx",
             "target",
             "options",
@@ -502,7 +504,14 @@ mod tests {
 
         assert_eq!(result.artifact_kind, CompilationArtifactKind::NvvmIr);
         assert_ne!(fs::read(&result.ll_path).unwrap(), b"stale");
-        for suffix in ["linked.ll", "ptx", "ltoir", "cubin", "cubin.target"] {
+        for suffix in [
+            "linked.ll",
+            "linked.opt.ll",
+            "ptx",
+            "ltoir",
+            "cubin",
+            "cubin.target",
+        ] {
             assert!(!root.join(format!("kernel.{suffix}")).exists(), "{suffix}");
         }
         assert_ne!(fs::read(root.join("kernel.target")).unwrap(), b"stale");


### PR DESCRIPTION
## Summary

When a kernel uses both f16 types (MMA/WMMA) and libdevice calls (`__nv_*` math functions), the pipeline auto-forces NVVM IR mode. On pre-Blackwell targets (sm<100), this selects the legacy LLVM 7 dialect which rejects f16 -- making f16 and libdevice mutually exclusive. Fix: link `libdevice.10.bc` at the LLVM IR level via `llvm-link` before `opt` and `llc`, keeping everything on the PTX path which has no f16 restrictions.

## Motivation

The PTX path (`llc`) handles f16 natively. The NVVM IR path uses `legalize_for_nvvm()` which rewrites the module to LLVM 7 syntax and rejects f16 on pre-Blackwell. Libdevice calls (`__nv_sinf`, `__nv_sqrtf`, etc.) currently force the NVVM IR path because libNVVM resolves them -- but this creates an impossible constraint for kernels that also use f16.

The fix matches what `build_and_run.sh` already does (line 91): `llvm-link kernel.ll libdevice.10.bc -o linked.bc`, then `opt -O2`, then `llc`. The `__nv_*` calls get resolved and inlined during `opt`, producing self-contained PTX.

## Implementation

- **cuda-oxide-codegen** (`llvm_tools.rs`): add `llvm_link: Option<OptTool>` to `LlvmToolchain`, resolved with the same co-located/sysroot/PATH discovery as `opt`. Add generic `resolve_sibling_tool()` and `sibling_tool_candidates()` helpers.
- **cuda-oxide-codegen** (`ptx.rs`): add `link_libdevice()` function that runs `llvm-link -S`. Insert linking step before `opt -O2` in `generate_ptx_impl()`. Pass `libdevice_path: Option<&Path>` through `generate_ptx()` and `generate_ptx_with_toolchain()`.
- **cuda-oxide-codegen** (`pipeline.rs`): modify `should_emit_nvvm_ir()` so `needs_libdevice` only forces NVVM IR when `libdevice.10.bc` is not found. Discover `libdevice.10.bc` early via `libnvvm_sys::find_libdevice()` so the backend decision accounts for IR-level linking availability.
- **cuda-oxide-codegen** (`api.rs`): resolve `llvm-link` as sibling tool in `Toolchain::from_paths()`.

Pipeline with libdevice: `.ll → llvm-link libdevice.10.bc → opt -O2 → llc → .ptx`

Fallback (no `libdevice.10.bc` or no `llvm-link`): existing NVVM IR path unchanged.

## Testing

Validated on RTX A2000 (sm_86), nightly-2026-04-03:
```
cargo test -p cuda-oxide-codegen   # 120 passed (107 unit + 12 integration + 1 doc)
cargo test -p mir-importer         # 805 passed
cargo fmt --all -- --check         # clean
cargo clippy -p cuda-oxide-codegen --tests -- -D warnings  # clean
scripts/smoketest.sh               # 133/141 passed (8 failures are sm_90+ features)
```

## Related

- Complementary to #390/#391 (reducing unnecessary libdevice deps for scalar float ops) -- this PR handles the case where libdevice IS needed but shouldn't force NVVM IR
- `build_and_run.sh:91` -- reference implementation of the `llvm-link` pipeline
- `crates/libnvvm-sys/src/lib.rs:780` -- `find_libdevice()` discovery