### PR TITLE
codegen: tighten the standalone compiler's clone, liveness and diagnostic paths

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -107,6 +107,7 @@ pub struct CompileOptions {
     optimization: Optimization,
     fma_contraction: bool,
     debug_info: DebugInfo,
+    verbose: bool,
 }
 
 impl CompileOptions {
@@ -117,6 +118,7 @@ impl CompileOptions {
             optimization: Optimization::O2,
             fma_contraction: true,
             debug_info: DebugInfo::None,
+            verbose: false,
         }
     }
 
@@ -140,6 +142,17 @@ impl CompileOptions {
         self
     }
 
+    /// Request progress and tool-selection diagnostics.
+    ///
+    /// Without this, [`Compilation::diagnostics`] still reports the
+    /// toolchain's own selection diagnostics and a final success note, but
+    /// omits per-compilation detail such as which target-selection source won
+    /// or why `opt -O2` was skipped.
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
     /// Requested CUDA target.
     pub fn target(&self) -> &Target {
         &self.target
@@ -158,6 +171,11 @@ impl CompileOptions {
     /// Requested device debug-information tier.
     pub fn debug_info(&self) -> DebugInfo {
         self.debug_info
+    }
+
+    /// Whether progress and tool-selection diagnostics were requested.
+    pub fn verbose(&self) -> bool {
+        self.verbose
     }
 }
 
@@ -274,17 +292,7 @@ impl CodegenModule {
     /// lowered LLVM function and exports it as a PTX `.entry`.
     pub fn mark_kernel_entry(&mut self, symbol: &str) -> Result<(), CompileError> {
         let module = self.module.get_operation();
-        module
-            .try_deref(&self.context)
-            .map_err(|error| CompileError::InvalidModule {
-                message: format!("the owned module operation is no longer valid: {error:?}"),
-            })?;
-        if Operation::get_op::<ModuleOp>(module, &self.context).is_none() {
-            return Err(CompileError::InvalidModule {
-                message: "the owned module pointer no longer refers to a builtin.module"
-                    .to_string(),
-            });
-        }
+        validate_live_module_op(module, &self.context)?;
         let function = {
             let region_count = module.deref(&self.context).regions().count();
             if region_count != 1 {
@@ -353,6 +361,28 @@ impl CodegenModule {
     }
 }
 
+/// Confirms `module` still refers to a live `builtin.module` operation in `ctx`.
+///
+/// `CodegenModule::edit`/`inspect` let a caller copy the raw Pliron pointer out
+/// and erase or replace it later; both entry points that resume from a stored
+/// pointer re-check this before touching the operation.
+fn validate_live_module_op(
+    module: pliron::context::Ptr<Operation>,
+    ctx: &Context,
+) -> Result<(), CompileError> {
+    module
+        .try_deref(ctx)
+        .map_err(|error| CompileError::InvalidModule {
+            message: format!("the owned module operation is no longer valid: {error:?}"),
+        })?;
+    if Operation::get_op::<ModuleOp>(module, ctx).is_none() {
+        return Err(CompileError::InvalidModule {
+            message: "the owned module pointer no longer refers to a builtin.module".to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Explicit, reusable pair of LLVM tools.
 #[derive(Clone, Debug)]
 pub struct Toolchain {
@@ -372,12 +402,13 @@ impl Toolchain {
             message: "no runnable LLVM 21+ `llc` was found in the Rust sysroot or PATH".to_string(),
         })?;
         validate_llvm_major("llc", inner.llc_major)?;
-        let diagnostics = inner
+        let mut diagnostics: Vec<Diagnostic> = inner
             .diagnostics
             .iter()
             .cloned()
             .map(|message| Diagnostic::warning(CompilationStage::Toolchain, message))
             .collect();
+        diagnostics.push(describe_selection("discovered toolchain", &inner));
         Ok(Self { inner, diagnostics })
     }
 
@@ -412,18 +443,20 @@ impl Toolchain {
             }
         }
 
-        Ok(Self {
-            inner: LlvmToolchain {
-                llc_path: llc_tool.path,
-                llc_major: llc_tool.major,
-                llc_from_env: false,
-                opt: opt.map(|tool| OptTool {
-                    path: tool.path,
-                    major: tool.major,
-                }),
-                diagnostics: Vec::new(),
-            },
+        let inner = LlvmToolchain {
+            llc_path: llc_tool.path,
+            llc_major: llc_tool.major,
+            llc_from_env: false,
+            opt: opt.map(|tool| OptTool {
+                path: tool.path,
+                major: tool.major,
+            }),
             diagnostics: Vec::new(),
+        };
+        let selection = describe_selection("explicit toolchain", &inner);
+        Ok(Self {
+            inner,
+            diagnostics: vec![selection],
         })
     }
 
@@ -441,6 +474,25 @@ impl Toolchain {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
     }
+}
+
+/// Records which `llc`/`opt` pair a [`Toolchain`] constructor settled on.
+///
+/// Both constructors emit this, so `Compiler::discover()` and
+/// `Compiler::new(Toolchain::from_paths(..))` describe their selection in the
+/// same shape.
+fn describe_selection(kind: &str, inner: &LlvmToolchain) -> Diagnostic {
+    Diagnostic::note(
+        CompilationStage::Toolchain,
+        format!(
+            "{kind}: llc = {}, opt = {}",
+            crate::llvm_tools::describe_tool(&inner.llc_path, inner.llc_major),
+            match &inner.opt {
+                Some(tool) => crate::llvm_tools::describe_tool(&tool.path, tool.major),
+                None => "(none)".to_string(),
+            }
+        ),
+    )
 }
 
 fn validate_llvm_major(tool: &str, major: Option<u32>) -> Result<(), CompileError> {
@@ -478,43 +530,67 @@ impl Compiler {
     }
 
     /// Compile a module without modifying its caller-visible IR.
+    ///
+    /// Compiling clones the input first, so `module` is unchanged and may be
+    /// compiled again. Callers with no further use for `module` can skip that
+    /// clone with [`compile_owned`](Self::compile_owned) instead.
     pub fn compile(
         &self,
         module: &mut CodegenModule,
         options: &CompileOptions,
     ) -> Result<Compilation, CompileError> {
+        Self::check_compile_options(options, &self.toolchain)?;
+
+        let ctx = &mut module.context;
+        let source_module = module.module.get_operation();
+        validate_live_module_op(source_module, ctx)?;
+        let mut mapper = IrMapping::new();
+        let mut rewriter = IRRewriter::<DummyListener>::default();
+        let cloned = clone_operation(source_module, ctx, &mut rewriter, &mut mapper);
+        let guard = EraseGuard {
+            operation: cloned,
+            context: ctx,
+        };
+        self.compile_clone(&mut *guard.context, cloned, options)
+    }
+
+    /// Compile `module`, consuming it.
+    ///
+    /// Skips the clone [`compile`](Self::compile) makes to keep `module`
+    /// usable afterward: destructive compiler passes run directly on the
+    /// owned IR, which is then dropped with `module`. Prefer this for
+    /// single-use modules, especially large ones, where the clone in
+    /// [`compile`](Self::compile) is pure overhead.
+    pub fn compile_owned(
+        &self,
+        mut module: CodegenModule,
+        options: &CompileOptions,
+    ) -> Result<Compilation, CompileError> {
+        Self::check_compile_options(options, &self.toolchain)?;
+
+        let ctx = &mut module.context;
+        let source_module = module.module.get_operation();
+        validate_live_module_op(source_module, ctx)?;
+        self.compile_clone(ctx, source_module, options)
+    }
+
+    fn check_compile_options(
+        options: &CompileOptions,
+        toolchain: &Toolchain,
+    ) -> Result<(), CompileError> {
         if options.debug_info == DebugInfo::Full && options.optimization != Optimization::None {
             return Err(CompileError::InvalidOptions {
                 message: "full variable debug information requires Optimization::None".to_string(),
             });
         }
-        if options.optimization == Optimization::O2 && self.toolchain.inner.opt.is_none() {
+        if options.optimization == Optimization::O2 && toolchain.inner.opt.is_none() {
             return Err(CompileError::OptimizationUnavailable {
                 message:
                     "Optimization::O2 requires an `opt` binary with the same LLVM major as llc"
                         .to_string(),
             });
         }
-
-        let ctx = &mut module.context;
-        let source_module = module.module.get_operation();
-        source_module
-            .try_deref(ctx)
-            .map_err(|error| CompileError::InvalidModule {
-                message: format!("the owned module operation is no longer valid: {error:?}"),
-            })?;
-        if Operation::get_op::<ModuleOp>(source_module, ctx).is_none() {
-            return Err(CompileError::InvalidModule {
-                message: "the owned module pointer no longer refers to a builtin.module"
-                    .to_string(),
-            });
-        }
-        let mut mapper = IrMapping::new();
-        let mut rewriter = IRRewriter::<DummyListener>::default();
-        let cloned = clone_operation(source_module, ctx, &mut rewriter, &mut mapper);
-        let result = self.compile_clone(ctx, cloned, options);
-        Operation::erase(cloned, ctx);
-        result
+        Ok(())
     }
 
     fn compile_clone(
@@ -535,7 +611,7 @@ impl Compiler {
             device_arch_hint: None,
             no_opt: options.optimization == Optimization::None,
             no_fma: !options.fma_contraction,
-            verbose: false,
+            verbose: options.verbose,
             llc_override: None,
             opt_override: None,
         };
@@ -561,6 +637,12 @@ impl Compiler {
             })?;
             let target = Target::parse(&generated.target)?;
             let mut diagnostics = self.toolchain.diagnostics.clone();
+            diagnostics.extend(
+                generated
+                    .diagnostics
+                    .into_iter()
+                    .map(|message| Diagnostic::note(CompilationStage::Codegen, message)),
+            );
             diagnostics.push(Diagnostic::note(
                 CompilationStage::Codegen,
                 format!("generated PTX for {target}"),
@@ -571,6 +653,28 @@ impl Compiler {
                 diagnostics,
             })
         })()
+    }
+}
+
+/// Erases a cloned operation on every exit path, including an unwinding panic.
+///
+/// `Compiler::compile` clones the caller's module before running the
+/// destructive pipeline on the clone. A plain "compile, then erase" sequence
+/// skips the erase if `compile_clone` panics, permanently leaking the clone in
+/// the shared `Context` arena.
+///
+/// `Operation::erase` runs from `Drop`, so a panic inside it while an earlier
+/// panic is already unwinding aborts the process. That is left as-is: an erase
+/// only fails when the arena is already inconsistent, and swallowing the
+/// second panic would hide that corruption behind a leak.
+struct EraseGuard<'ctx> {
+    operation: pliron::context::Ptr<Operation>,
+    context: &'ctx mut Context,
+}
+
+impl Drop for EraseGuard<'_> {
+    fn drop(&mut self) {
+        Operation::erase(self.operation, self.context);
     }
 }
 
@@ -814,5 +918,35 @@ impl From<PipelineError> for CompileError {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn erase_guard_runs_even_when_the_guarded_closure_panics() {
+        let mut module = CodegenModule::new("guarded").unwrap();
+        let ctx = &mut module.context;
+        let source_module = module.module.get_operation();
+        let mut mapper = IrMapping::new();
+        let mut rewriter = IRRewriter::<DummyListener>::default();
+        let cloned = clone_operation(source_module, ctx, &mut rewriter, &mut mapper);
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = EraseGuard {
+                operation: cloned,
+                context: ctx,
+            };
+            panic!("simulated failure inside compile_clone");
+        }))
+        .is_err();
+        assert!(panicked, "the closure should have panicked");
+
+        assert!(
+            cloned.try_deref(&module.context).is_err(),
+            "the cloned operation should be erased even though the guarded closure panicked"
+        );
     }
 }

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -22,7 +22,7 @@ use crate::llvm_tools::LlvmToolchain;
 use crate::lower::{add_device_extern_declarations, lower_to_llvm};
 use crate::options::BackendOptions;
 use crate::prep::{MirPreparation, prepare_mir_module};
-use crate::ptx::{GeneratedPtx, generate_ptx, generate_ptx_with_toolchain};
+use crate::ptx::{generate_ptx, generate_ptx_with_toolchain};
 use crate::target::detect_features_in_llvm_text;
 use crate::verify::verify_operation;
 use llvm_export::export::{DebugKind, NvvmIrDialect};
@@ -261,6 +261,13 @@ pub fn compile_translated_module(
 
     // NVVM pointer syntax depends on the target. Detect the feature floor from
     // the same pre-legalization text the ordinary PTX path would inspect.
+    //
+    // Two full-text renders happen here (`export_llvm_ir` below does its own
+    // render for the real artifact): deliberate, not an oversight. This
+    // preview runs pre-legalization; the real export runs post-legalization
+    // (which mutates the module for the chosen NVVM dialect) through a
+    // different export config. Caching one render for the other would be
+    // unsound.
     let automatic_features = if emit_nvvm_ir {
         let preview = render_llvm_ir(
             ctx,
@@ -385,17 +392,14 @@ pub fn compile_translated_module(
             request.trace.sink,
             &generated_requirements,
         )?,
-        ToolchainPolicy::Explicit(toolchain) => GeneratedPtx {
-            target: generate_ptx_with_toolchain(
-                request.files.llvm_ir,
-                request.files.ptx,
-                request.debug_kind,
-                request.backend,
-                toolchain,
-                &generated_requirements,
-            )?,
-            diagnostics: Vec::new(),
-        },
+        ToolchainPolicy::Explicit(toolchain) => generate_ptx_with_toolchain(
+            request.files.llvm_ir,
+            request.files.ptx,
+            request.debug_kind,
+            request.backend,
+            toolchain,
+            &generated_requirements,
+        )?,
     };
     if request.trace.verbose {
         request.trace.emit(format!(

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -202,7 +202,7 @@ pub(crate) fn generate_ptx_with_toolchain(
     opts: &BackendOptions,
     toolchain: &LlvmToolchain,
     generated: &GeneratedModuleRequirements,
-) -> Result<String, PipelineError> {
+) -> Result<GeneratedPtx, PipelineError> {
     generate_ptx_impl(
         ll_path,
         ptx_path,
@@ -215,7 +215,6 @@ pub(crate) fn generate_ptx_with_toolchain(
         true,
         None,
     )
-    .map(|generated| generated.target)
 }
 
 fn generate_ptx_impl(

--- a/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
@@ -248,6 +248,114 @@ fn compilation_preserves_input_and_is_repeatable() {
 }
 
 #[test]
+fn verbose_option_surfaces_pipeline_diagnostics() {
+    let tools = FakeTools::successful(false);
+    let compiler = tools.compiler();
+    let mut module = CodegenModule::new("verbose").unwrap();
+    add_empty_function(&mut module, true);
+    let options = CompileOptions::new(Target::parse("sm_80").unwrap())
+        .with_optimization(Optimization::None)
+        .with_verbose(true);
+
+    let compilation = compiler.compile(&mut module, &options).unwrap();
+    assert!(
+        compilation
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("Target:")),
+        "expected a verbose target-selection diagnostic, got {:?}",
+        compilation.diagnostics()
+    );
+}
+
+#[test]
+fn the_default_verbose_setting_suppresses_pipeline_diagnostics() {
+    let tools = FakeTools::successful(false);
+    let compiler = tools.compiler();
+    let mut module = CodegenModule::new("quiet").unwrap();
+    add_empty_function(&mut module, true);
+    let options =
+        CompileOptions::new(Target::parse("sm_80").unwrap()).with_optimization(Optimization::None);
+    assert!(!options.verbose(), "verbose defaults to false");
+
+    let compilation = compiler.compile(&mut module, &options).unwrap();
+    assert!(
+        !compilation
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("Target:")),
+        "the verbose target-selection diagnostic must be absent by default, got {:?}",
+        compilation.diagnostics()
+    );
+}
+
+#[test]
+fn from_paths_records_a_toolchain_diagnostic_on_success() {
+    let tools = FakeTools::successful(true);
+    let toolchain = Toolchain::from_paths(tools.llc.clone(), tools.opt.clone()).unwrap();
+    let selection = toolchain
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| diagnostic.message.starts_with("explicit toolchain:"))
+        .expect("explicit toolchain construction should report what it selected");
+    assert_eq!(selection.level, DiagnosticLevel::Note);
+    assert_eq!(selection.stage, CompilationStage::Toolchain);
+    assert!(
+        selection.message.contains(&tools.llc.display().to_string()),
+        "{}",
+        selection.message
+    );
+}
+
+#[test]
+fn discover_records_a_toolchain_diagnostic_on_success() {
+    // Unlike the rest of this suite, discovery cannot be faked: it reads the
+    // Rust sysroot and PATH. Skip where no LLVM 21+ llc exists.
+    let Ok(toolchain) = Toolchain::discover() else {
+        return;
+    };
+    let selection = toolchain
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| diagnostic.message.starts_with("discovered toolchain:"))
+        .expect("discovery should report what it selected");
+    assert_eq!(selection.level, DiagnosticLevel::Note);
+    assert_eq!(selection.stage, CompilationStage::Toolchain);
+    assert!(
+        selection
+            .message
+            .contains(&toolchain.llc_path().display().to_string()),
+        "{}",
+        selection.message
+    );
+}
+
+#[test]
+fn compile_owned_matches_compile_and_leaves_no_reusable_module() {
+    let tools = FakeTools::successful(true);
+    let compiler = tools.compiler();
+    let options = CompileOptions::new(Target::parse("sm_80").unwrap());
+
+    let mut borrowed_module = CodegenModule::new("borrowed").unwrap();
+    add_empty_function(&mut borrowed_module, true);
+    let borrowed = compiler.compile(&mut borrowed_module, &options).unwrap();
+
+    let mut owned_module = CodegenModule::new("owned").unwrap();
+    add_empty_function(&mut owned_module, true);
+    let owned = compiler.compile_owned(owned_module, &options).unwrap();
+
+    assert_eq!(borrowed.ptx(), owned.ptx());
+    assert_eq!(borrowed.target(), owned.target());
+
+    // What the clone in `compile` buys, and what `compile_owned` gives up:
+    // the borrowed module survives its compilation and produces the same PTX
+    // again. `owned_module` was consumed above and cannot be recompiled, which
+    // the type system enforces at every call site.
+    let again = compiler.compile(&mut borrowed_module, &options).unwrap();
+    assert_eq!(again.ptx(), borrowed.ptx());
+}
+
+#[test]
 fn erased_owned_root_is_a_structured_error_not_a_panic() {
     let tools = FakeTools::successful(false);
     let compiler = tools.compiler();


### PR DESCRIPTION
One of three parts of #357, split so each can be reviewed on its own. #357 bundled eight unrelated fixes across 12 files, which put the small ones behind a dependency discussion. The three parts are independent: each applies cleanly to `main` alone, and they merge cleanly in any order. #357 will be closed once all three are open.

Sibling parts: #416 (target selection provenance), #417 (scratch directory on tempfile).

## Summary

Follow-up to #314's `cuda-oxide-codegen` extraction, covering the review findings that stand on their own: a leak on the panic path, an unavoidable module clone, a duplicated liveness check, and diagnostics that the standalone API could neither request nor receive.

## Changes

* `EraseGuard` owns the erase of the cloned module, so a panic inside `compile_clone` no longer leaks it into the shared `Context` arena.
* `Compiler::compile_owned` consumes the module and runs the pipeline on the caller's IR, making the clone opt-in.
* `validate_live_module_op` replaces the liveness check duplicated between `mark_kernel_entry` and the compile entry points.
* `CompileOptions::with_verbose`/`verbose`, so the standalone API can ask for the diagnostics the pipeline has always produced behind `BackendOptions::verbose`.
* `generate_ptx_with_toolchain` returns `GeneratedPtx`, matching the discovery path, and `compile_clone` forwards the diagnostics it receives.
* `Toolchain::discover` and `Toolchain::from_paths` both record which `llc` and `opt` they selected.
* The double LLVM-IR render on the libdevice path is documented in place.

## Rationale

Two paths dropped diagnostics even when asked for them: `generate_ptx_with_toolchain` discarded everything but the resolved target string, and `compile_clone` never copied the pipeline's diagnostics into the `Compilation`. Reporting nothing about toolchain selection left a caller unable to tell which of several installed LLVM versions produced an artifact.

`Operation::erase` still runs from `Drop`, so a panic inside the erase during an unwind aborts. That is left alone and documented: an erase fails only once the arena is already inconsistent, and swallowing the second panic would trade a loud abort for a silent leak.

The double render is documented rather than removed. The preview renders pre-legalisation and the export renders post-legalisation through a different export config, so the two texts describe different module states and caching one for the other would be unsound. Removing the second render needs feature detection that works off the IR rather than off rendered text.

## Validation

* `cargo check --workspace --all-targets`
* `cargo test -p cuda-oxide-codegen` (123 passed)
* `cargo test -p mir-importer` (801 passed)
* `cargo clippy --workspace -- -D warnings`
* `cargo fmt --all -- --check`
* `(cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)`
* `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
