### PR TITLE
codegen: attribute target selection to whoever chose the target

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -532,6 +532,7 @@ impl Compiler {
         let ptx_path = scratch.path().join("module.ptx");
         let backend_options = BackendOptions {
             target_arch: Some(options.target.sm()),
+            target_arch_source: "the requested Target",
             device_arch_hint: None,
             no_opt: options.optimization == Optimization::None,
             no_fma: !options.fma_contraction,
@@ -672,12 +673,30 @@ pub enum CompileError {
         /// Rejected module name.
         name: String,
     },
-    /// CUDA target text could not be parsed.
+    /// CUDA target text could not be parsed by [`Target::parse`].
+    ///
+    /// A target that parses but cannot lower the module's detected features
+    /// is reported as [`CompileError::TargetSelection`] instead.
     #[error("invalid CUDA target `{target}`: {reason}")]
     InvalidTarget {
         /// Rejected target text.
         target: String,
         /// Parser explanation.
+        reason: String,
+    },
+    /// The pipeline rejected the requested target: unparsable, unable to lower
+    /// a feature the module uses, or below a floor an intrinsic imposes.
+    ///
+    /// `reason` arrives already phrased for a user and names the target where
+    /// that helps, so it is the whole message. Formatting it under a fixed
+    /// "invalid CUDA target `{target}`" prefix would call a valid
+    /// architecture invalid and name it twice.
+    #[error("{reason}")]
+    TargetSelection {
+        /// Target that was rejected, in canonical `sm_XX` spelling once it
+        /// parsed at all.
+        target: String,
+        /// Full explanation, suitable for display on its own.
         reason: String,
     },
     /// The owned top-level module was erased or replaced through an edit.
@@ -769,6 +788,7 @@ impl CompileError {
         match self {
             Self::InvalidModuleName { .. }
             | Self::InvalidTarget { .. }
+            | Self::TargetSelection { .. }
             | Self::InvalidModule { .. }
             | Self::InvalidOptions { .. } => CompilationStage::Input,
             Self::Toolchain { .. } => CompilationStage::Toolchain,
@@ -805,6 +825,9 @@ impl From<PipelineError> for CompileError {
             }
             PipelineError::UnsupportedLinking { symbols } => Self::UnsupportedLinking { symbols },
             PipelineError::Export(message) => Self::Export { message },
+            PipelineError::TargetSelection { target, reason } => {
+                Self::TargetSelection { target, reason }
+            }
             PipelineError::PtxGeneration(message) => Self::Codegen { message },
             PipelineError::Optimization(message) => Self::OptimizationFailed { message },
             PipelineError::NoBody(message) | PipelineError::Translation(message) => {

--- a/crates/cuda-oxide-codegen/src/error.rs
+++ b/crates/cuda-oxide-codegen/src/error.rs
@@ -28,6 +28,12 @@ pub enum PipelineError {
     UnsupportedLinking { symbols: Vec<String> },
     /// LLVM IR export failed.
     Export(String),
+    /// The requested CUDA target could not be parsed, or cannot lower a
+    /// feature the module needs. Distinct from `PtxGeneration`: this is a
+    /// problem with the requested target itself, decided before `llc` runs.
+    /// `reason` is already fully phrased for a user; `target` is carried
+    /// separately so callers can match on it.
+    TargetSelection { target: String, reason: String },
     /// PTX generation via `llc` failed.
     PtxGeneration(String),
     /// The requested LLVM middle-end optimization failed.
@@ -65,6 +71,7 @@ impl std::fmt::Display for PipelineError {
                 "standalone PTX cannot resolve external symbols: {symbols:?}"
             ),
             Self::Export(msg) => write!(f, "Export failed: {}", msg),
+            Self::TargetSelection { reason, .. } => write!(f, "{reason}"),
             Self::PtxGeneration(msg) => write!(f, "PTX generation failed: {}", msg),
             Self::Optimization(msg) => write!(f, "LLVM optimization failed: {msg}"),
         }

--- a/crates/cuda-oxide-codegen/src/options.rs
+++ b/crates/cuda-oxide-codegen/src/options.rs
@@ -9,11 +9,19 @@ use std::path::PathBuf;
 /// backend. `run_pipeline` (mir-importer) builds one from the environment at
 /// its own boundary. The experimental API builds one from typed compile
 /// options without reading the environment.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct BackendOptions {
     /// Hard target override (`llc -mcpu=`), e.g. `"sm_120"`.
     pub target_arch: Option<String>,
+    /// Human-readable name for whatever set `target_arch`, used only to
+    /// describe target provenance in diagnostics and errors (e.g.
+    /// `"CUDA_OXIDE_TARGET"` for the env-driven rustc pipeline, or a
+    /// caller-facing description for the standalone experimental API).
+    ///
+    /// Keep this in step with `target_arch`: whoever writes one writes the
+    /// other, or a target error names a source the caller never used.
+    pub target_arch_source: &'static str,
     /// Advisory local-GPU arch; used only when it satisfies detected features.
     pub device_arch_hint: Option<String>,
     /// Skip the `opt -O2` middle-end.
@@ -28,6 +36,21 @@ pub struct BackendOptions {
     pub opt_override: Option<PathBuf>,
 }
 
+impl Default for BackendOptions {
+    fn default() -> Self {
+        Self {
+            target_arch: None,
+            target_arch_source: "CUDA_OXIDE_TARGET",
+            device_arch_hint: None,
+            no_opt: false,
+            no_fma: false,
+            verbose: false,
+            llc_override: None,
+            opt_override: None,
+        }
+    }
+}
+
 impl BackendOptions {
     /// Reads the historical `CUDA_OXIDE_*` variables. The ONLY env access in
     /// this crate outside this crate's own tests; called by rustc-pipeline
@@ -35,6 +58,7 @@ impl BackendOptions {
     pub fn from_env() -> Self {
         Self {
             target_arch: std::env::var("CUDA_OXIDE_TARGET").ok(),
+            target_arch_source: "CUDA_OXIDE_TARGET",
             device_arch_hint: std::env::var("CUDA_OXIDE_DEVICE_ARCH").ok(),
             no_opt: std::env::var("CUDA_OXIDE_NO_OPT").is_ok(),
             no_fma: std::env::var("CUDA_OXIDE_NO_FMA").is_ok(),

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -254,6 +254,7 @@ fn generate_ptx_impl(
     //   3. neither set -- the feature floor.
     let (target, target_source) = resolve_ptx_target_with_generated(
         explicit_override.as_deref(),
+        opts.target_arch_source,
         device_hint.as_deref(),
         detected,
         generated,

--- a/crates/cuda-oxide-codegen/src/target.rs
+++ b/crates/cuda-oxide-codegen/src/target.rs
@@ -1621,18 +1621,20 @@ pub(crate) fn resolve_ptx_target_with_generated(
                 .parse::<CudaArch>()
                 .map_err(|error| PipelineError::TargetSelection {
                     target: target.to_string(),
-                    reason: format!("invalid CUDA target `{target}`: {error}"),
+                    // `error` already reads "invalid CUDA target `x`: ...";
+                    // only the provenance needs to be added here.
+                    reason: format!("{error} (target from {explicit_override_source})"),
                 })?;
         validate_target_features(&parsed, detected).map_err(|reason| {
             PipelineError::TargetSelection {
                 target: parsed.sm(),
-                reason,
+                reason: format!("{reason} (target from {explicit_override_source})"),
             }
         })?;
         validate_generated_target(&parsed.sm(), generated).map_err(|reason| {
             PipelineError::TargetSelection {
                 target: parsed.sm(),
-                reason,
+                reason: format!("{reason} (target from {explicit_override_source})"),
             }
         })?;
         return Ok((parsed.sm(), explicit_override_source));
@@ -4577,6 +4579,48 @@ mod tests {
         assert!(resolve_ptx_target(Some("sm_90a"), "CUDA_OXIDE_TARGET", None, impossible).is_err());
         assert!(
             resolve_ptx_target(Some("sm_100a"), "CUDA_OXIDE_TARGET", None, impossible).is_err()
+        );
+    }
+
+    #[test]
+    fn rejected_explicit_targets_name_the_source_that_chose_them() {
+        let parse_failure = resolve_ptx_target(
+            Some("not-a-target"),
+            "PipelineConfig::target_arch",
+            None,
+            DetectedFeatures::Sm80,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            parse_failure.contains("invalid CUDA target `not-a-target`"),
+            "{parse_failure}"
+        );
+        assert!(
+            parse_failure.contains("(target from PipelineConfig::target_arch)"),
+            "{parse_failure}"
+        );
+        assert_eq!(
+            parse_failure.matches("invalid CUDA target").count(),
+            1,
+            "parse errors must not double-wrap the parser's own prefix: {parse_failure}"
+        );
+
+        let floor_rejection = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            DetectedFeatures::Sm80,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            floor_rejection.contains("cannot lower detected feature Sm80"),
+            "{floor_rejection}"
+        );
+        assert!(
+            floor_rejection.contains("(target from CUDA_OXIDE_TARGET)"),
+            "{floor_rejection}"
         );
     }
 

--- a/crates/cuda-oxide-codegen/src/target.rs
+++ b/crates/cuda-oxide-codegen/src/target.rs
@@ -1595,11 +1595,13 @@ pub fn validate_target_features(
 #[cfg(test)]
 pub fn resolve_ptx_target(
     explicit_override: Option<&str>,
+    explicit_override_source: &'static str,
     device_hint: Option<&str>,
     detected: DetectedFeatures,
 ) -> Result<(String, &'static str), PipelineError> {
     resolve_ptx_target_with_generated(
         explicit_override,
+        explicit_override_source,
         device_hint,
         detected,
         &GeneratedModuleRequirements::default(),
@@ -1608,17 +1610,32 @@ pub fn resolve_ptx_target(
 
 pub(crate) fn resolve_ptx_target_with_generated(
     explicit_override: Option<&str>,
+    explicit_override_source: &'static str,
     device_hint: Option<&str>,
     detected: DetectedFeatures,
     generated: &GeneratedModuleRequirements,
 ) -> Result<(String, &'static str), PipelineError> {
     if let Some(target) = explicit_override {
-        let parsed = target.parse::<CudaArch>().map_err(|error| {
-            PipelineError::PtxGeneration(format!("invalid CUDA_OXIDE_TARGET `{target}`: {error}"))
+        let parsed =
+            target
+                .parse::<CudaArch>()
+                .map_err(|error| PipelineError::TargetSelection {
+                    target: target.to_string(),
+                    reason: format!("invalid CUDA target `{target}`: {error}"),
+                })?;
+        validate_target_features(&parsed, detected).map_err(|reason| {
+            PipelineError::TargetSelection {
+                target: parsed.sm(),
+                reason,
+            }
         })?;
-        validate_target_features(&parsed, detected).map_err(PipelineError::PtxGeneration)?;
-        validate_generated_target(&parsed.sm(), generated).map_err(PipelineError::PtxGeneration)?;
-        return Ok((parsed.sm(), "CUDA_OXIDE_TARGET"));
+        validate_generated_target(&parsed.sm(), generated).map_err(|reason| {
+            PipelineError::TargetSelection {
+                target: parsed.sm(),
+                reason,
+            }
+        })?;
+        return Ok((parsed.sm(), explicit_override_source));
     }
 
     if let Some(device) = device_hint.filter(|target| {
@@ -2073,6 +2090,7 @@ mod tests {
         assert_eq!(
             resolve_ptx_target_with_generated(
                 Some("sm_101a"),
+                "CUDA_OXIDE_TARGET",
                 None,
                 DetectedFeatures::Basic,
                 &llvm,
@@ -2083,6 +2101,7 @@ mod tests {
         assert!(
             resolve_ptx_target_with_generated(
                 Some("sm_103a"),
+                "CUDA_OXIDE_TARGET",
                 None,
                 DetectedFeatures::Basic,
                 &llvm,
@@ -2092,6 +2111,7 @@ mod tests {
         assert_eq!(
             resolve_ptx_target_with_generated(
                 None,
+                "CUDA_OXIDE_TARGET",
                 Some("sm_101a"),
                 DetectedFeatures::Basic,
                 &llvm,
@@ -2102,6 +2122,7 @@ mod tests {
         assert_eq!(
             resolve_ptx_target_with_generated(
                 None,
+                "CUDA_OXIDE_TARGET",
                 Some("sm_101a"),
                 DetectedFeatures::Basic,
                 &libnvvm,
@@ -2110,7 +2131,14 @@ mod tests {
             ("sm_100a".into(), "feature requirement")
         );
         assert_eq!(
-            resolve_ptx_target_with_generated(None, None, DetectedFeatures::Basic, &llvm).unwrap(),
+            resolve_ptx_target_with_generated(
+                None,
+                "CUDA_OXIDE_TARGET",
+                None,
+                DetectedFeatures::Basic,
+                &llvm
+            )
+            .unwrap(),
             ("sm_100a".into(), "feature requirement")
         );
 
@@ -2294,10 +2322,15 @@ mod tests {
         let bf16 = GeneratedModuleRequirements::from_targets(vec![bf16]);
         assert!(!generated_target_satisfied("sm_89", &bf16));
         assert!(generated_target_satisfied("sm_90", &bf16));
-        let error =
-            resolve_ptx_target_with_generated(Some("sm_89"), None, DetectedFeatures::Basic, &bf16)
-                .unwrap_err()
-                .to_string();
+        let error = resolve_ptx_target_with_generated(
+            Some("sm_89"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            DetectedFeatures::Basic,
+            &bf16,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(error.contains("packed_atomic_add_bf16x2"), "{error}");
         assert!(error.contains("sm_90 or newer"), "{error}");
     }
@@ -2597,15 +2630,26 @@ mod tests {
         );
         assert_eq!(select_target(requirements.features).unwrap(), "sm_80");
 
-        let lower_target =
-            resolve_ptx_target(Some("sm_75"), None, requirements.features).unwrap_err();
+        let lower_target = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .unwrap_err();
         assert!(
             lower_target
                 .to_string()
                 .contains("cannot lower detected feature Sm80"),
             "{lower_target}"
         );
-        let (target, _) = resolve_ptx_target(Some("sm_80"), None, requirements.features).unwrap();
+        let (target, _) = resolve_ptx_target(
+            Some("sm_80"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .unwrap();
         assert_eq!(target, "sm_80");
 
         for near_miss in [
@@ -2670,9 +2714,14 @@ mod tests {
             Some("+ptx62")
         );
         assert_eq!(
-            resolve_ptx_target(Some("sm_70"), None, DetectedFeatures::Basic)
-                .unwrap()
-                .0,
+            resolve_ptx_target(
+                Some("sm_70"),
+                "CUDA_OXIDE_TARGET",
+                None,
+                DetectedFeatures::Basic
+            )
+            .unwrap()
+            .0,
             "sm_70"
         );
 
@@ -2690,13 +2739,23 @@ mod tests {
             );
         }
         assert_eq!(select_target(DetectedFeatures::Sm90).unwrap(), "sm_90");
-        let rejected = resolve_ptx_target(Some("sm_80"), None, DetectedFeatures::Sm90)
-            .expect_err("native bf16x2 atomic add must reject sm_80")
-            .to_string();
+        let rejected = resolve_ptx_target(
+            Some("sm_80"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            DetectedFeatures::Sm90,
+        )
+        .expect_err("native bf16x2 atomic add must reject sm_80")
+        .to_string();
         assert!(rejected.contains("cannot lower detected feature Sm90"));
-        let near_miss = resolve_ptx_target(Some("sm_89"), None, DetectedFeatures::Sm90)
-            .expect_err("the architecture immediately below sm_90 must be rejected")
-            .to_string();
+        let near_miss = resolve_ptx_target(
+            Some("sm_89"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            DetectedFeatures::Sm90,
+        )
+        .expect_err("the architecture immediately below sm_90 must be rejected")
+        .to_string();
         assert!(near_miss.contains("cannot lower detected feature Sm90"));
 
         let both = "atom.global.add.noftz.f16x2 $0, [$1], $2; \
@@ -2858,15 +2917,26 @@ mod tests {
         );
         assert_eq!(select_target(requirements.features).unwrap(), "sm_80");
 
-        let lower_target =
-            resolve_ptx_target(Some("sm_75"), None, requirements.features).unwrap_err();
+        let lower_target = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .unwrap_err();
         assert!(
             lower_target
                 .to_string()
                 .contains("cannot lower detected feature Sm80"),
             "{lower_target}"
         );
-        let (target, _) = resolve_ptx_target(Some("sm_80"), None, requirements.features).unwrap();
+        let (target, _) = resolve_ptx_target(
+            Some("sm_80"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .unwrap();
         assert_eq!(target, "sm_80");
 
         for near_miss in [
@@ -2932,7 +3002,8 @@ mod tests {
         assert_eq!(requirements.features, DetectedFeatures::Sm80);
         assert_eq!(requirements.ptx_isa, PtxIsaRequirement::Ptx70);
         let (target, _) =
-            resolve_ptx_target(None, None, requirements.features).expect("auto-resolve");
+            resolve_ptx_target(None, "CUDA_OXIDE_TARGET", None, requirements.features)
+                .expect("auto-resolve");
         assert_eq!(target, "sm_80");
 
         for near_miss in [
@@ -2960,9 +3031,14 @@ mod tests {
         let sm_80: CudaArch = "sm_80".parse().unwrap();
         assert!(validate_target_features(&sm_75, requirements.features).is_err());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
-            .expect_err("sm_75 must not accept TF32 tensor-core MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_75 must not accept TF32 tensor-core MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm80"),
             "{error}"
@@ -3028,7 +3104,8 @@ mod tests {
         );
         let requirements = detect_module_requirements_in_llvm_text(representative);
         let (target, _) =
-            resolve_ptx_target(None, None, requirements.features).expect("auto-resolve");
+            resolve_ptx_target(None, "CUDA_OXIDE_TARGET", None, requirements.features)
+                .expect("auto-resolve");
         assert_eq!(target, "sm_80");
 
         for near_miss in [
@@ -3065,9 +3142,14 @@ mod tests {
         let sm_80: CudaArch = "sm_80".parse().unwrap();
         assert!(validate_target_features(&sm_75, requirements.features).is_err());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
-            .expect_err("sm_75 must not accept INT8 tensor-core MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_75 must not accept INT8 tensor-core MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm80"),
             "{error}"
@@ -3158,9 +3240,14 @@ mod tests {
         let sm_80: CudaArch = "sm_80".parse().unwrap();
         assert!(validate_target_features(&sm_75, requirements.features).is_err());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
-            .expect_err("sm_75 must not accept dense m16 INT4 MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_75 must not accept dense m16 INT4 MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm80"),
             "{error}"
@@ -3443,7 +3530,8 @@ mod tests {
         );
         let requirements = detect_module_requirements_in_llvm_text(representative);
         let (target, _) =
-            resolve_ptx_target(None, None, requirements.features).expect("auto-resolve");
+            resolve_ptx_target(None, "CUDA_OXIDE_TARGET", None, requirements.features)
+                .expect("auto-resolve");
         assert_eq!(target, "sm_75");
         assert_eq!(
             required_ptx_feature("sm_75", requirements.ptx_isa),
@@ -3457,9 +3545,14 @@ mod tests {
         assert!(validate_target_features(&sm_70, requirements.features).is_err());
         assert!(validate_target_features(&sm_75, requirements.features).is_ok());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_70"), None, requirements.features)
-            .expect_err("sm_70 must not accept m8n8k16 INT8 MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_70"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_70 must not accept m8n8k16 INT8 MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm75"),
             "{error}"
@@ -3514,8 +3607,13 @@ mod tests {
                 ptx_isa: PtxIsaRequirement::Ptx70,
             }
         );
-        let (target, _) = resolve_ptx_target(None, None, combined_requirements.features)
-            .expect("combined m8 and m16 MMA should auto-resolve");
+        let (target, _) = resolve_ptx_target(
+            None,
+            "CUDA_OXIDE_TARGET",
+            None,
+            combined_requirements.features,
+        )
+        .expect("combined m8 and m16 MMA should auto-resolve");
         assert_eq!(target, "sm_80");
     }
 
@@ -3594,9 +3692,14 @@ mod tests {
         assert!(validate_target_features(&sm_72, requirements.features).is_err());
         assert!(validate_target_features(&sm_75, requirements.features).is_ok());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_72"), None, requirements.features)
-            .expect_err("sm_72 must not accept m8n8k32 INT4 MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_72"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_72 must not accept m8n8k32 INT4 MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm75"),
             "{error}"
@@ -3648,7 +3751,7 @@ mod tests {
         }
         assert!(!arch_satisfies("sm_72", features));
         assert_eq!(
-            resolve_ptx_target(None, Some("sm_120"), features).unwrap(),
+            resolve_ptx_target(None, "CUDA_OXIDE_TARGET", Some("sm_120"), features).unwrap(),
             ("sm_120".to_string(), "detected GPU")
         );
 
@@ -3742,9 +3845,14 @@ mod tests {
         let sm_80: CudaArch = "sm_80".parse().unwrap();
         assert!(validate_target_features(&sm_75, requirements.features).is_err());
         assert!(validate_target_features(&sm_80, requirements.features).is_ok());
-        let error = resolve_ptx_target(Some("sm_75"), None, requirements.features)
-            .expect_err("sm_75 must not accept FP64 tensor-core MMA")
-            .to_string();
+        let error = resolve_ptx_target(
+            Some("sm_75"),
+            "CUDA_OXIDE_TARGET",
+            None,
+            requirements.features,
+        )
+        .expect_err("sm_75 must not accept FP64 tensor-core MMA")
+        .to_string();
         assert!(
             error.contains("cannot lower detected feature Sm80"),
             "{error}"
@@ -4466,8 +4574,10 @@ mod tests {
         let impossible = DetectedFeatures::Wgmma | DetectedFeatures::MatrixBlackwell;
         let error = select_target(impossible).expect_err("families have no common target");
         assert!(error.contains("do not share a compatible GPU architecture"));
-        assert!(resolve_ptx_target(Some("sm_90a"), None, impossible).is_err());
-        assert!(resolve_ptx_target(Some("sm_100a"), None, impossible).is_err());
+        assert!(resolve_ptx_target(Some("sm_90a"), "CUDA_OXIDE_TARGET", None, impossible).is_err());
+        assert!(
+            resolve_ptx_target(Some("sm_100a"), "CUDA_OXIDE_TARGET", None, impossible).is_err()
+        );
     }
 
     #[test]
@@ -4663,5 +4773,47 @@ mod tests {
         assert!(!arch_satisfies("sm_80", DetectedFeatures::Sm90));
         assert!(!arch_satisfies("sm_80a", DetectedFeatures::Basic));
         assert!(!arch_satisfies("sm_90f", DetectedFeatures::Tma));
+    }
+
+    #[test]
+    fn resolve_ptx_target_threads_a_caller_supplied_source_label() {
+        let (target, source) = resolve_ptx_target(
+            Some("sm_80"),
+            "the requested Target",
+            None,
+            DetectedFeatures::Basic,
+        )
+        .unwrap();
+        assert_eq!(target, "sm_80");
+        assert_eq!(source, "the requested Target");
+    }
+
+    #[test]
+    fn resolve_ptx_target_failure_does_not_assume_an_env_var_source() {
+        let error = resolve_ptx_target(
+            Some("sm_75"),
+            "the requested Target",
+            None,
+            DetectedFeatures::Wgmma,
+        )
+        .unwrap_err();
+        assert!(matches!(error, PipelineError::TargetSelection { .. }));
+        assert!(
+            !error.to_string().contains("CUDA_OXIDE_TARGET"),
+            "a standalone caller that never set CUDA_OXIDE_TARGET should not see it blamed: {error}"
+        );
+
+        let parse_error = resolve_ptx_target(
+            Some("not-a-target"),
+            "the requested Target",
+            None,
+            DetectedFeatures::Basic,
+        )
+        .unwrap_err();
+        assert!(matches!(parse_error, PipelineError::TargetSelection { .. }));
+        assert!(
+            !parse_error.to_string().contains("CUDA_OXIDE_TARGET"),
+            "{parse_error}"
+        );
     }
 }

--- a/crates/cuda-oxide-codegen/tests/target_provenance.rs
+++ b/crates/cuda-oxide-codegen/tests/target_provenance.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Pins the public shape of target-selection failures.
+//!
+//! Target and feature-floor rejections are decided before `llc` is reached, so
+//! they belong to [`CompilationStage::Input`]. They used to arrive as
+//! `PipelineError::PtxGeneration`, which the standalone API surfaced as a
+//! codegen failure and phrased in terms of the `CUDA_OXIDE_TARGET` environment
+//! variable that a standalone caller never sets.
+
+use cuda_oxide_codegen::__private::PipelineError;
+use cuda_oxide_codegen::experimental::{CompilationStage, CompileError};
+
+#[test]
+fn target_selection_maps_to_an_input_stage_compile_error() {
+    let error = CompileError::from(PipelineError::TargetSelection {
+        target: "sm_75".to_string(),
+        reason: "CUDA target sm_75 cannot lower detected feature Sm80".to_string(),
+    });
+
+    let CompileError::TargetSelection { target, reason } = &error else {
+        panic!("expected CompileError::TargetSelection, got {error:?}");
+    };
+    assert_eq!(target, "sm_75");
+    assert_eq!(
+        reason,
+        "CUDA target sm_75 cannot lower detected feature Sm80"
+    );
+    assert_eq!(error.stage(), CompilationStage::Input);
+}
+
+#[test]
+fn a_rejected_target_is_not_reported_as_an_unparsable_one() {
+    let error = CompileError::from(PipelineError::TargetSelection {
+        target: "sm_75".to_string(),
+        reason: "CUDA target sm_75 cannot lower detected feature Sm80".to_string(),
+    });
+
+    // sm_75 parses. Rendering the reason under an "invalid CUDA target
+    // `sm_75`" prefix would call a valid architecture invalid and name it
+    // twice.
+    let text = error.to_string();
+    assert_eq!(text, "CUDA target sm_75 cannot lower detected feature Sm80");
+    assert!(!text.contains("invalid CUDA target"), "{text}");
+    assert_eq!(text.matches("sm_75").count(), 1, "{text}");
+}
+
+#[test]
+fn an_unparsable_target_still_maps_to_the_input_stage() {
+    let error = CompileError::from(PipelineError::TargetSelection {
+        target: "not-a-target".to_string(),
+        reason: "invalid CUDA target `not-a-target`: unrecognised architecture".to_string(),
+    });
+    assert_eq!(error.stage(), CompilationStage::Input);
+    assert!(error.to_string().starts_with("invalid CUDA target"));
+}
+
+#[test]
+fn target_parse_failures_from_the_typed_api_keep_their_own_variant() {
+    let error = cuda_oxide_codegen::experimental::Target::parse("sm_bogus").unwrap_err();
+    assert!(
+        matches!(error, CompileError::InvalidTarget { .. }),
+        "Target::parse still reports a parse failure, got {error:?}"
+    );
+    assert_eq!(error.stage(), CompilationStage::Input);
+}

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -149,6 +149,14 @@ pub struct PipelineConfig {
     ///
     /// Normally set by `cargo oxide --arch` or `CUDA_OXIDE_TARGET`.
     pub target_arch: Option<String>,
+    /// Human-readable name for whatever set `target_arch`, used when a target
+    /// error has to say where the target came from.
+    ///
+    /// Defaults to `"PipelineConfig::target_arch"`. A caller that read the
+    /// target from somewhere the user would recognise sets its own label:
+    /// `rustc-codegen-cuda` reads `CUDA_OXIDE_TARGET` itself and says so.
+    /// Only meaningful when `target_arch` is `Some`.
+    pub target_arch_source: &'static str,
     /// Detected architecture of the local GPU (`CUDA_OXIDE_DEVICE_ARCH`).
     ///
     /// Used only when no explicit target is provided.
@@ -172,11 +180,33 @@ impl Default for PipelineConfig {
             show_llvm_dialect: false,
             emit_nvvm_ir: false,
             target_arch: None,
+            target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
             allow_fma_contraction: true,
         }
     }
+}
+
+/// Merges `config` over the environment-derived backend defaults.
+///
+/// Environment-derived compatibility options are read once at the rustc
+/// frontend boundary. Explicit pipeline configuration retains precedence.
+fn backend_options_for(config: &PipelineConfig) -> BackendOptions {
+    let mut backend_options = BackendOptions::from_env();
+    if config.target_arch.is_some() {
+        backend_options.target_arch = config.target_arch.clone();
+        // The label travels with the value it describes. Overriding the
+        // target and leaving `from_env`'s "CUDA_OXIDE_TARGET" in place made
+        // every target error blame an env var the caller may never have set.
+        backend_options.target_arch_source = config.target_arch_source;
+    }
+    if config.device_arch_hint.is_some() {
+        backend_options.device_arch_hint = config.device_arch_hint.clone();
+    }
+    backend_options.verbose = backend_options.verbose || config.verbose;
+    backend_options.no_fma = !config.allow_fma_contraction;
+    backend_options
 }
 
 /// Runs the full compilation pipeline on collected functions.
@@ -290,17 +320,7 @@ pub fn run_pipeline(
         .join(format!("{}.ptx", config.output_name));
     let stale_artifacts = stale_compilation_artifact_paths(&config.output_dir, &config.output_name);
 
-    // Environment-derived compatibility options are read once at the rustc
-    // frontend boundary. Explicit pipeline configuration retains precedence.
-    let mut backend_options = BackendOptions::from_env();
-    if config.target_arch.is_some() {
-        backend_options.target_arch = config.target_arch.clone();
-    }
-    if config.device_arch_hint.is_some() {
-        backend_options.device_arch_hint = config.device_arch_hint.clone();
-    }
-    backend_options.verbose = backend_options.verbose || config.verbose;
-    backend_options.no_fma = !config.allow_fma_contraction;
+    let backend_options = backend_options_for(config);
 
     let request = ModulePipelineRequest::for_rust_pipeline(
         device_externs,
@@ -484,6 +504,7 @@ mod tests {
             show_llvm_dialect: false,
             emit_nvvm_ir: true,
             target_arch: Some("sm_86".to_string()),
+            target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
             allow_fma_contraction: true,
@@ -528,6 +549,7 @@ mod tests {
             show_llvm_dialect: false,
             emit_nvvm_ir: true,
             target_arch: Some("sm_86".to_string()),
+            target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
             allow_fma_contraction: true,
@@ -576,6 +598,7 @@ mod tests {
             show_llvm_dialect: false,
             emit_nvvm_ir: true,
             target_arch: Some("sm_86".to_string()),
+            target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
             allow_fma_contraction: true,
@@ -600,5 +623,39 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("clean up temp output dir");
+    }
+
+    #[test]
+    fn an_explicit_config_target_is_labelled_as_its_own_source() {
+        let config = PipelineConfig {
+            target_arch: Some("sm_86".to_string()),
+            ..PipelineConfig::default()
+        };
+        let options = backend_options_for(&config);
+        assert_eq!(options.target_arch.as_deref(), Some("sm_86"));
+        assert_eq!(options.target_arch_source, "PipelineConfig::target_arch");
+    }
+
+    #[test]
+    fn a_caller_supplied_label_survives_the_override() {
+        let config = PipelineConfig {
+            target_arch: Some("sm_86".to_string()),
+            target_arch_source: "cargo oxide --arch",
+            ..PipelineConfig::default()
+        };
+        assert_eq!(
+            backend_options_for(&config).target_arch_source,
+            "cargo oxide --arch"
+        );
+    }
+
+    #[test]
+    fn the_env_label_stands_when_the_config_sets_no_target() {
+        let config = PipelineConfig::default();
+        assert_eq!(config.target_arch, None);
+        assert_eq!(
+            backend_options_for(&config).target_arch_source,
+            "CUDA_OXIDE_TARGET"
+        );
     }
 }

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -687,6 +687,7 @@ pub fn generate_device_code<'tcx>(
             show_llvm_dialect: show_llvm,
             emit_nvvm_ir,
             target_arch,
+            target_arch_source: "CUDA_OXIDE_TARGET",
             device_arch_hint,
             debug_kind,
             allow_fma_contraction,


### PR DESCRIPTION
One of three parts of #357, split so each can be reviewed on its own. #357 bundled eight unrelated fixes across 12 files, which put the small ones behind a dependency discussion. The three parts are independent: each applies cleanly to `main` alone, and they merge cleanly in any order. #357 will be closed once all three are open.

Sibling parts: #415 (clone, liveness and diagnostic paths), #417 (scratch directory on tempfile).

## Summary

A rejected target produced an error naming `CUDA_OXIDE_TARGET`, and classified the failure as a codegen stage failure. Both are wrong for every caller that reaches target selection by some other route.

## Changes

* `BackendOptions` carries `target_arch_source` alongside `target_arch`, and `resolve_ptx_target` reports the label it was given.
* `PipelineConfig` carries the same label, defaulting to `PipelineConfig::target_arch` and set to `CUDA_OXIDE_TARGET` by `rustc-codegen-cuda`, which reads that variable itself.
* The environment and config merge moves into `backend_options_for`, so the precedence is testable without running a compilation.
* Target and feature-floor rejections travel as `PipelineError::TargetSelection` and land in `CompilationStage::Input`.
* `CompileError` gains a matching `TargetSelection` variant.
* New `tests/target_provenance.rs`, plus three `mir-importer` tests over the label precedence.

## Rationale

`resolve_ptx_target` hardcoded `"CUDA_OXIDE_TARGET"` as the provenance of any explicit override, because the env-driven rustc pipeline was once the only caller. The standalone experimental API passes a `Target` the caller built in Rust and never touches the environment, so a caller who requested `sm_75` for a module needing `sm_80` was told to go and look at an environment variable they had never set.

The same mis-attribution existed one layer up: `PipelineConfig::target_arch` replaced `target_arch` and left `from_env`'s label behind, so a caller setting the config field directly was still blamed on the environment. That is fixed here too, which is the only in-tree site that needed the new mechanism.

Target and feature-floor rejections are decided before `llc` is reached and describe the caller's request, so `Codegen` was the wrong stage for them.

`CompileError::TargetSelection` is a new variant rather than a reuse of `InvalidTarget`. `InvalidTarget` renders as ``invalid CUDA target `{target}`: {reason}``, which suits a parse failure from `Target::parse` and misdescribes a feature-floor rejection: `sm_75` is a valid architecture, and the reason text already names it, so routing feature-floor failures through `InvalidTarget` called a valid target invalid and printed the architecture twice. `TargetSelection` renders its reason alone, which is already phrased for a user. `InvalidTarget` keeps its parse-failure meaning and its rustdoc now points at the new variant.

`target_arch_source` stays `&'static str`. Every label in the tree is a fixed string. Widening it to `Cow<'static, str>`, which would let a caller build a label carrying the target text itself, can wait until a caller needs one.

## Validation

* `cargo check --workspace --all-targets`
* `cargo test -p cuda-oxide-codegen` (123 passed)
* `cargo test -p mir-importer` (804 passed)
* `cargo clippy --workspace -- -D warnings`
* `cargo clippy -p mir-importer --all-targets -- -D warnings`
* `cargo fmt --all -- --check`
* `(cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)`
* `(cd crates/rustc-codegen-cuda && cargo check)`, since this adds a field to a `PipelineConfig` literal in `device_codegen.rs` and that crate is excluded from the workspace
* `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
