### PR TITLE
Clean up unsafe launch compile-fail fixture

### DIFF
--- a/crates/cuda-macros/tests/compile_fail/launch_requires_unsafe.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_requires_unsafe.rs
@@ -8,8 +8,6 @@
 //! Everything else in this file type-checks; the only error is the missing
 //! `unsafe` block.
 
-#![allow(unreachable_code, unused_variables, unused_mut)]
-
 use cuda_macros::cuda_launch;
 
 // Stand-in for the marker struct `#[kernel]` generates for a kernel
@@ -20,9 +18,10 @@ impl cuda_host::CudaKernel for __dummy_CudaKernel {
     const PTX_NAME: &'static str = "dummy";
 }
 
-fn main() {
-    let stream: std::sync::Arc<cuda_core::CudaStream> = todo!();
-    let module: std::sync::Arc<cuda_core::CudaModule> = todo!();
+fn launch_without_unsafe(
+    stream: std::sync::Arc<cuda_core::CudaStream>,
+    module: std::sync::Arc<cuda_core::CudaModule>,
+) {
     let x = 1.0f32;
 
     cuda_launch! {
@@ -34,3 +33,5 @@ fn main() {
     }
     .unwrap();
 }
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_requires_unsafe.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_requires_unsafe.stderr
@@ -1,13 +1,13 @@
 error[E0133]: call to unsafe function `launch_kernel_on_stream` is unsafe and requires unsafe block
-  --> tests/compile_fail/launch_requires_unsafe.rs:28:5
+  --> tests/compile_fail/launch_requires_unsafe.rs:27:5
    |
-28 | /     cuda_launch! {
-29 | |         kernel: dummy,
-30 | |         stream: stream,
-31 | |         module: module,
-32 | |         config: cuda_core::LaunchConfig::for_num_elems(1),
-33 | |         args: [x]
-34 | |     }
+27 | /     cuda_launch! {
+28 | |         kernel: dummy,
+29 | |         stream: stream,
+30 | |         module: module,
+31 | |         config: cuda_core::LaunchConfig::for_num_elems(1),
+32 | |         args: [x]
+33 | |     }
    | |_____^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior


### PR DESCRIPTION
Closes #418

## Summary

Remove the `todo!()` placeholders from the synchronous unsafe-launch compile-fail fixture.

The fixture now places the bare `cuda_launch!` invocation in a `launch_without_unsafe` function whose stream and module values are supplied as parameters. This keeps the entire invocation type-checked without requiring executable CUDA objects or diverging placeholder expressions.

The change also removes the no-longer-needed crate-level lint allowances and updates the trybuild snapshot line numbers.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p cuda-macros --test macro_guard cuda_launch_requires_unsafe
```

This is test-fixture cleanup only. Runtime behavior and the `cuda_launch!` implementation are unchanged.
