### PR TITLE
Mark async launch trybuild stubs as unreachable

### DIFF
--- a/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.rs
+++ b/crates/cuda-macros/tests/compile_fail/async_launch_macro_requires_unsafe.rs
@@ -14,7 +14,7 @@ struct FakeModule;
 
 impl FakeModule {
     fn load_function(&self, _name: &str) -> Result<cuda_core::CudaFunction, ()> {
-        unimplemented!()
+        unreachable!("this trybuild fixture never executes module loading")
     }
 }
 

--- a/crates/cuda-macros/tests/pass/async_launch_macro_in_unsafe.rs
+++ b/crates/cuda-macros/tests/pass/async_launch_macro_in_unsafe.rs
@@ -14,7 +14,7 @@ struct FakeModule;
 
 impl FakeModule {
     fn load_function(&self, _name: &str) -> Result<cuda_core::CudaFunction, ()> {
-        unimplemented!()
+        unreachable!("this trybuild fixture never executes module loading")
     }
 }
 


### PR DESCRIPTION
Closes #420

## Summary

Replace misleading `unimplemented!()` calls in the async launch trybuild fixtures with explicit `unreachable!()` stubs.

The `FakeModule::load_function` implementations exist only to satisfy the interface required by the `cuda_launch_async!` macro expansion. Neither fixture executes module loading, so these methods are intentionally unreachable rather than unfinished functionality.

## Changes

* Update `tests/compile_fail/async_launch_macro_requires_unsafe.rs`.
* Update `tests/pass/async_launch_macro_in_unsafe.rs`.
* Use the same explicit unreachable message in both fixtures:

```rust
unreachable!("this trybuild fixture never executes module loading")
```

## Behavior

This is test-fixture cleanup only.

The change does not affect:

* async launch macro behavior;
* runtime code;
* unsafe-call enforcement;
* trybuild registration;
* the expected E0133 compile-fail output.

No `.stderr` update is required.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p cuda-macros --test macro_guard cuda_launch_requires_unsafe
cargo test -p cuda-macros --features async --test macro_guard cuda_launch_requires_unsafe
```
