### PR TITLE
Reuse primitive integer type IDs in generation

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
+++ b/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
@@ -189,24 +189,7 @@ impl GenerationCtx {
                 Shl | Shr => {
                     // left operand same type as lhs, right can be uint or int
                     let l = self.choose_operand(&[lhs_ty], lhs)?;
-                    // TODO: use a compile time concat
-                    let r = self.choose_operand(
-                        &[
-                            TyCtxt::ISIZE,
-                            TyCtxt::I8,
-                            TyCtxt::I16,
-                            TyCtxt::I32,
-                            TyCtxt::I64,
-                            TyCtxt::I128,
-                            TyCtxt::USIZE,
-                            TyCtxt::U8,
-                            TyCtxt::U16,
-                            TyCtxt::U32,
-                            TyCtxt::U64,
-                            TyCtxt::U128,
-                        ],
-                        lhs,
-                    )?;
+                    let r = self.choose_operand(&TyCtxt::INTEGER_TYPES, lhs)?;
                     (l, r)
                 }
                 Eq | Ne | Lt | Le | Ge | Gt => {
@@ -668,22 +651,7 @@ impl GenerationCtx {
     fn generate_switch_int_params(&self) -> Result<TerminatorParams> {
         trace!("generating a SwitchInt terminator");
         let (places, weights) = PlaceSelector::for_known_val(self.tcx.clone())
-            .of_tys(&[
-                TyCtxt::ISIZE,
-                TyCtxt::I8,
-                TyCtxt::I16,
-                TyCtxt::I32,
-                TyCtxt::I64,
-                TyCtxt::I128,
-                TyCtxt::USIZE,
-                TyCtxt::U8,
-                TyCtxt::U16,
-                TyCtxt::U32,
-                TyCtxt::U64,
-                TyCtxt::U128,
-                // Ty::Char,
-                // Ty::Bool,
-            ])
+            .of_tys(&TyCtxt::INTEGER_TYPES)
             .into_weighted(&self.pt)
             .ok_or(SelectionError::Exhausted)?;
 

--- a/crates/fuzzer/rustlantis/mir/src/tyctxt.rs
+++ b/crates/fuzzer/rustlantis/mir/src/tyctxt.rs
@@ -54,6 +54,20 @@ impl TyCtxt {
     pub const U128: TyId = TyId::from_usize_unchecked(14);
     pub const F32: TyId = TyId::from_usize_unchecked(15);
     pub const F64: TyId = TyId::from_usize_unchecked(16);
+    pub const INTEGER_TYPES: [TyId; 12] = [
+        Self::ISIZE,
+        Self::I8,
+        Self::I16,
+        Self::I32,
+        Self::I64,
+        Self::I128,
+        Self::USIZE,
+        Self::U8,
+        Self::U16,
+        Self::U32,
+        Self::U64,
+        Self::U128,
+    ];
 
     pub fn from_primitives(config: TyConfig) -> Self {
         let primitives: [TyKind; 17] = [


### PR DESCRIPTION
Closes #422 

## Summary

* Add `TyCtxt::INTEGER_TYPES` containing all primitive signed and unsigned integer type IDs.
* Use the shared constant when selecting shift right-hand operands.
* Reuse the same constant when selecting `SwitchInt` candidates.
* Remove the obsolete compile-time concatenation TODO and duplicated arrays.

## Rationale

The generation code previously maintained multiple copies of the same twelve `TyId`s.

The existing `TyKind::INTS` and `TyKind::UINTS` constants cannot be used directly because generation selectors consume `TyId` slices rather than `TyKind` values. Keeping the shared list on `TyCtxt` places it alongside the primitive `TyId` definitions and makes it reusable by generator components.

This is a refactoring only and does not change the set or ordering of eligible integer types.

## Testing

* `cargo fmt --all -- --check`
* `cargo test --workspace`
