### PR TITLE
Use HashSet membership in overlap checks

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -360,7 +360,7 @@ impl PlaceGraph {
         // Copy ret
         self.copy_place(old_frame.return_destination, callee_ret);
 
-        // TODO: the following to loops can probably be merged
+        // TODO: the following two loops can probably be merged
         // Remove ref edges into about to be deallocated places (necessary to prevent dangling references)
         let mut ref_edges = vec![];
         for pidx in old_frame.locals.right_values() {
@@ -533,8 +533,8 @@ impl PlaceGraph {
         }
     }
 
-    /// Assigns a discriminant to a enum-typed place, and invalidates all variant projections
-    /// of the enum. If the old and new discrimiant are equal, all variants are still invalidated.
+    /// Assigns a discriminant to an enum-typed place, and invalidates all variant projections
+    /// of the enum. If the old and new discriminant are equal, all variants are still invalidated.
     /// This is not necessary if the discriminant assignment originates from a SetDiscriminant statement,
     /// but it's needed if it originates from assigning a whole enum from another enum.
     pub fn assign_discriminant(&mut self, p: impl ToPlaceIndex, discriminant: Option<VariantIdx>) {
@@ -1012,19 +1012,10 @@ impl PlaceGraph {
             return false;
         }
 
-        let a_sub: Vec<PlaceIndex> = self.subfields(a);
+        let a_sub = self.subfields(a);
+        let b_sub: HashSet<PlaceIndex> = self.subfields(b).into_iter().collect();
 
-        let b_sub: Vec<PlaceIndex> = self.subfields(b);
-
-        // TODO: should I use a hashmap here?
-        for a_node in a_sub {
-            for b_node in &b_sub {
-                if a_node == *b_node {
-                    return true;
-                }
-            }
-        }
-        false
+        a_sub.into_iter().any(|a_node| b_sub.contains(&a_node))
     }
 
     pub fn assign_literal(&mut self, p: impl ToPlaceIndex, val: Option<Literal>) {


### PR DESCRIPTION
Closes #424 

## Summary

Replace the nested subfield comparison in `PlaceGraph::overlap` with explicit `HashSet` membership checking.

The change:

* Collects one transitive-subfield collection into a `HashSet<PlaceIndex>`.
* Uses `Iterator::any` and `HashSet::contains` to detect a shared node.
* Removes the existing hash-map TODO.
* Preserves the early returns for identical places and different allocation IDs.

The intersection phase changes from `O(n * m)` comparisons to expected `O(n + m)` work. No measured performance improvement is claimed for small collections.

## Testing

```text
cargo test -p generate overlap_check
RUST_LOG=debug cargo test
```

The existing `overlap_check` unit test covers positive, symmetric, and disjoint overlap cases.

## Scope

Only `generate/src/pgraph.rs` is modified. No behavioral changes are intended.
