### PR TITLE
Remove stale Literal::ty TODO

### DIFF
--- a/crates/fuzzer/rustlantis/mir/src/syntax.rs
+++ b/crates/fuzzer/rustlantis/mir/src/syntax.rs
@@ -422,7 +422,7 @@ impl TyId {
         }
     }
 
-    // If doesn't contain printer
+    // If it doesn't contain printer
     pub fn determ_printable(self, tcx: &TyCtxt) -> bool {
         !self.contains(tcx, |tcx, ty| ty.is_any_ptr(tcx))
     }
@@ -602,7 +602,6 @@ pub enum UnOp {
 }
 
 impl Literal {
-    // TODO: this doesn't need tcx
     pub fn ty(&self) -> TyId {
         match self {
             Literal::Int(_, IntTy::I8) => TyCtxt::I8,


### PR DESCRIPTION
## Summary

Remove the obsolete TODO comment above `Literal::ty()`.

The method already determines its `TyId` without requiring a `TyCtxt`, so the comment no longer describes pending work.

## Changes

* Remove the stale `TODO: this doesn't need tcx` comment from `mir/src/syntax.rs`.
* Preserve the existing `Literal::ty()` API and implementation.

## Validation

* [ ] `cargo fmt --check`
* [ ] `cargo test --workspace`
