### PR TITLE
Avoid duplicate local traversal in PlaceGraph::exit_fn

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -360,22 +360,26 @@ impl PlaceGraph {
         // Copy ret
         self.copy_place(old_frame.return_destination, callee_ret);
 
-        // TODO: the following two loops can probably be merged
-        // Remove ref edges into about to be deallocated places (necessary to prevent dangling references)
+        // Remove ref edges into places that are about to be deallocated.
+        // This is necessary to prevent dangling references.
         let mut ref_edges = vec![];
+        let mut alloc_ids = vec![];
+
         for pidx in old_frame.locals.right_values() {
             self.visit_transitive_subfields(*pidx, |node| {
                 ref_edges.extend(self.pointers_to(node).iter().map(|(_, edge)| edge));
                 VisitAction::Continue
             });
+            alloc_ids.push(self.places[*pidx].alloc_id);
         }
+
         for edge in ref_edges {
             self.remove_edge(edge);
         }
 
-        // Deallocate places
-        for pidx in old_frame.locals.right_values() {
-            self.memory.deallocate(self.places[*pidx].alloc_id);
+        // Deallocate places.
+        for alloc_id in alloc_ids {
+            self.memory.deallocate(alloc_id);
         }
     }
 


### PR DESCRIPTION
Closes #427 

## Summary

Collect frame allocation IDs while traversing the frame locals for incoming reference edges.

This removes the second traversal over `old_frame.locals.right_values()` without changing the cleanup ordering.

## Changes

* Collect each local's allocation ID during the existing reference-edge traversal.
* Remove all collected reference edges after the traversal completes.
* Deallocate the collected allocation IDs afterward.
* Remove the resolved TODO.
* Clarify the cleanup comments.

## Rationale

The previous implementation traversed the popped frame's locals twice.

A direct interleaving of edge removal and allocation deallocation would change the temporary state of the place graph. This implementation instead preserves the existing three-phase behavior:

1. Collect reference edges and allocation IDs.
2. Remove all reference edges.
3. Deallocate all allocations.

This keeps the refactor narrow and avoids introducing changes to reference or aliasing behavior.

## Testing

* `cargo fmt --check`
* `cargo build`
* `cargo test`
