### PR TITLE
Fix Miri handling of nonzero program exit codes

### DIFF
--- a/crates/fuzzer/rustlantis/Cargo.lock
+++ b/crates/fuzzer/rustlantis/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "log",
  "rayon",
  "serde",
+ "serde_json",
  "tempfile",
 ]
 
@@ -317,6 +318,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -531,6 +538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +561,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/fuzzer/rustlantis/difftest/Cargo.toml
+++ b/crates/fuzzer/rustlantis/difftest/Cargo.toml
@@ -13,4 +13,5 @@ env_logger = "0.11.3"
 log = "0.4.17"
 rayon = "1.7.0"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tempfile = "3.3.0"

--- a/crates/fuzzer/rustlantis/difftest/src/backends.rs
+++ b/crates/fuzzer/rustlantis/difftest/src/backends.rs
@@ -30,6 +30,15 @@ impl ClearEnv for Command {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RustcDiagnostic {
+    #[serde(rename = "$message_type")]
+    message_type: String,
+    message: String,
+    level: String,
+    rendered: Option<String>,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ProcessOutput {
     pub status: ExitStatus,
@@ -305,6 +314,38 @@ impl Miri {
     }
 }
 
+fn parse_miri_stderr(stderr: Vec<u8>) -> (Vec<u8>, bool) {
+    let mut rendered_stderr = Vec::with_capacity(stderr.len());
+    let mut has_error = false;
+
+    for line in stderr.split_inclusive(|byte| *byte == b'\n') {
+        let json = line.strip_suffix(b"\n").unwrap_or(line);
+
+        match serde_json::from_slice::<RustcDiagnostic>(json) {
+            Ok(diagnostic) if diagnostic.message_type == "diagnostic" => {
+                has_error |= diagnostic.level == "error" || diagnostic.level.starts_with("error:");
+
+                if let Some(rendered) = diagnostic.rendered {
+                    rendered_stderr.extend_from_slice(rendered.as_bytes());
+
+                    if !rendered.ends_with('\n') {
+                        rendered_stderr.push(b'\n');
+                    }
+                } else {
+                    rendered_stderr.extend_from_slice(diagnostic.message.as_bytes());
+                    rendered_stderr.push(b'\n');
+                }
+            }
+            _ => {
+                // Preserve stderr produced by the interpreted program.
+                rendered_stderr.extend_from_slice(line);
+            }
+        }
+    }
+
+    (rendered_stderr, has_error)
+}
+
 impl Backend for Miri {
     fn execute(&self, source: &Source, _: &Path) -> ExecResult {
         debug!("Executing with Miri {source}");
@@ -320,16 +361,19 @@ impl Backend for Miri {
 
         command
             .clear_env(&["PATH", "DEVELOPER_DIR"])
-            .args([OsStr::new("--sysroot"), self.sysroot.as_os_str()]);
+            .args([OsStr::new("--sysroot"), self.sysroot.as_os_str()])
+            .arg("--error-format=json");
 
-        let miri_out = run_compile_command(command, source);
+        let mut miri_out = run_compile_command(command, source);
+        let (stderr, miri_failed) = parse_miri_stderr(miri_out.stderr);
 
-        // FIXME: we assume the source always exits with 0, and any non-zero return code
-        // came from Miri itself (e.g. UB and type check errors)
-        if !miri_out.status.success() {
-            return Err(CompExecError(miri_out.into()));
+        miri_out.stderr = stderr;
+
+        if miri_failed || miri_out.status.code().is_none() {
+            Err(CompExecError(miri_out.into()))
+        } else {
+            Ok(miri_out.into())
         }
-        Ok(miri_out.into())
     }
 }
 

--- a/crates/fuzzer/rustlantis/difftest/tests/inputs/nonzero_exit.rs
+++ b/crates/fuzzer/rustlantis/difftest/tests/inputs/nonzero_exit.rs
@@ -1,0 +1,4 @@
+fn main() -> std::process::ExitCode {
+    eprintln!("expected stderr");
+    std::process::ExitCode::from(1)
+}

--- a/crates/fuzzer/rustlantis/difftest/tests/test.rs
+++ b/crates/fuzzer/rustlantis/difftest/tests/test.rs
@@ -40,3 +40,31 @@ fn ub() {
     println!("{}", results);
     assert_eq!(results.has_ub(), Some(true));
 }
+
+#[test]
+fn nonzero_exit_is_not_a_backend_error() {
+    let config = config::load("tests/config.toml");
+    let backends = backends::from_config(config);
+
+    let results = run_diff_test(
+        &Source::File("tests/inputs/nonzero_exit.rs".into()),
+        backends,
+    );
+
+    for backend_name in ["miri", "llvm"] {
+        let output = results[backend_name].as_ref().unwrap_or_else(|error| {
+            panic!("{backend_name} treated a normal nonzero exit as an error: {error:?}")
+        });
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{backend_name} did not preserve the program exit code"
+        );
+        assert_eq!(
+            output.stderr.to_string_lossy(),
+            "expected stderr\n",
+            "{backend_name} did not preserve program stderr"
+        );
+    }
+}


### PR DESCRIPTION
Closes #429 

## Summary

Fix the Miri backend so that a valid program returning a nonzero exit code is not classified as a backend error.

## Problem

The backend previously treated every unsuccessful Miri process status as `CompExecError`. This conflated two distinct cases:

* Miri or rustc reported a diagnostic error.
* The interpreted program completed normally with a nonzero exit code.

Compiled backends already preserve the second case as `Ok(ProcessOutput)`, so Miri behaved inconsistently.

## Changes

* Run Miri with `--error-format=json`.
* Parse structured rustc diagnostics from Miri stderr.
* Classify error-level diagnostics as `CompExecError`.
* Treat termination without an exit code as a backend error.
* Preserve stderr produced directly by the interpreted program.
* Convert structured diagnostics back to their rendered human-readable form.
* Add `serde_json` to the `difftest` dependencies.
* Add a regression test covering a valid program that:

  * writes to stderr;
  * exits with status code 1;
  * remains an `Ok` result for both Miri and LLVM.

## Validation

Executed from `crates/fuzzer/rustlantis`:

```text
cargo fmt --all --check
cargo check -p difftest
cargo test -p difftest nonzero_exit_is_not_a_backend_error -- --nocapture
cargo test -p difftest
```

All four `difftest` integration tests pass, including the existing invalid MIR and undefined-behavior cases.
