### PR TITLE
Clarify unsupported backend compilation

### DIFF
--- a/crates/fuzzer/rustlantis/difftest/src/backends.rs
+++ b/crates/fuzzer/rustlantis/difftest/src/backends.rs
@@ -109,7 +109,7 @@ pub struct BackendInitError(pub String);
 
 pub trait Backend: Send + Sync {
     fn compile(&self, _: &Source, _: &Path) -> ProcessOutput {
-        panic!("not implemented")
+        unimplemented!("this backend does not support compilation")
     }
 
     fn execute(&self, source: &Source, target: &Path) -> ExecResult {


### PR DESCRIPTION
Closes #433 

## Summary

* Replace the generic `panic!("not implemented")` in the default `Backend::compile` implementation with `unimplemented!`.
* Clarify that some backends intentionally do not support a separate compilation phase.

## Rationale

Miri overrides `Backend::execute` and executes source code directly, so it does not implement `compile`. Using `unimplemented!` makes this intentional limitation explicit without changing the trait contract or runtime behavior.

## Testing

```text
cargo build
RUST_LOG=debug cargo test
```

No functional behavior change is intended.
