### PR TITLE
Translate CopyForDeref as a place read

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1601,6 +1601,15 @@ pub fn translate_rvalue(
         mir::Rvalue::CopyForDeref(place) => {
             // CopyForDeref is semantically a place read. Any load or projection
             // operations emitted by translate_place are already inserted and tracked.
+            //
+            // Note: on the pinned toolchain the MIR optimization pipeline
+            // (copy-prop/GVN) eliminates every CopyForDeref before the
+            // optimized MIR reaches this importer; nested-deref kernels
+            // (`**rr`, including through raw pointers) were probed and none
+            // produce one here today. This arm is defensive coverage so a
+            // future toolchain bump or lower mir-opt-level cannot regress
+            // valid nested-deref kernels into an "unsupported construct"
+            // failure.
             let (value, last_inserted) =
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc)?;
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -20,6 +20,7 @@
 //! | `Use(operand)`      | `mir.load` of the source slot (no op for constants)   |
 //! | `Aggregate`         | `mir.construct_tuple/struct/enum/array`               |
 //! | `Repeat`            | `mir.construct_array` (array repeat syntax)           |
+//! | `CopyForDeref`      | Same place-read lowering as `Copy`/`Move`             |
 //!
 //! # Key Functions
 //!
@@ -1597,16 +1598,28 @@ pub fn translate_rvalue(
 
             Ok((Some(op), result, prev_op_after_operand))
         }
-        _ => {
-            // TODO (npasham): Handle other Rvalue variants
-            input_err!(
-                loc,
-                TranslationErr::unsupported(format!(
-                    "Rvalue variant {:?} not yet implemented",
-                    rvalue
-                ))
-            )
+        mir::Rvalue::CopyForDeref(place) => {
+            // CopyForDeref is semantically a place read. Any load or projection
+            // operations emitted by translate_place are already inserted and tracked.
+            let (value, last_inserted) =
+                translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc)?;
+
+            Ok((None, value, last_inserted))
         }
+        mir::Rvalue::Len(place) => input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Rvalue::Len for place {:?} not yet implemented",
+                place
+            ))
+        ),
+        mir::Rvalue::ThreadLocalRef(item) => input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Rvalue::ThreadLocalRef {:?} is not supported in device code",
+                item
+            ))
+        ),
     }
 }
 


### PR DESCRIPTION
Closes #437 

## Summary

* translate `Rvalue::CopyForDeref` through the existing `translate_place` path
* preserve helper-operation insertion and ordering from place translation
* explicitly reject `Rvalue::Len` and `Rvalue::ThreadLocalRef`
* remove the wildcard rvalue arm and its generic TODO
* document `CopyForDeref` as a supported rvalue

## Rationale

Rustc defines `CopyForDeref` as a read from a `Place`. The importer already implements place reads through `translate_place`, including slot loads, projections, ZST handling, ghost locals, and operation-order bookkeeping.

Delegating to that function avoids introducing a redundant MIR operation or a second place-reading implementation.

The slot address-space classifier already treats `CopyForDeref` like `Use(Copy)` and `Use(Move)`, so this change aligns rvalue emission with the existing analysis behavior.

The remaining unimplemented variants are enumerated explicitly:

* `Len` remains a separate follow-up because arrays and slice metadata require different lowering paths.
* `ThreadLocalRef` remains unsupported because device-side thread-local storage requires an explicit storage and lowering model.

Removing the wildcard makes future additions to rustc's `Rvalue` enum fail during compilation rather than being silently routed to a generic runtime diagnostic.

## Testing

```text
cargo fmt --all -- --check
cargo check -p mir-importer
cargo test -p mir-importer
cargo clippy -p mir-importer --all-targets -- -D warnings
scripts/smoketest.sh --compile-only --no-color --only '^ref_index_projections$'
```

## Scope

No changes were made to:

* `mir-lower`
* MIR dialect operations
* LLVM or NVVM lowering
* place projection behavior
* array or slice length lowering
* thread-local storage support
