### PR TITLE
Emit CUDA diagnostics for gpu_assert! messages

### DIFF
--- a/crates/cuda-device/src/debug.rs
+++ b/crates/cuda-device/src/debug.rs
@@ -57,21 +57,23 @@ include!("generated/debug_control.rs");
 /// // Simple assertion
 /// gpu_assert!(x >= 0);
 ///
-/// // With custom message (message is ignored in current impl)
+/// // With a custom string-literal message
 /// gpu_assert!(idx < len, "Index out of bounds");
 /// ```
 ///
 /// # Behavior
 ///
 /// When the condition is false:
-/// - The kernel execution is aborted via `trap()`
+/// - The no-message form aborts kernel execution via [`trap()`]
+/// - The message form reports the message and call-site metadata via CUDA's
+///   device-side `__assertfail` system call
 /// - The CUDA driver reports an error to the host
 /// - Other threads may continue briefly before the error propagates
 ///
 /// # Notes
 ///
 /// - Use sparingly in performance-critical code
-/// - The message argument is currently ignored (will be supported with assertfail)
+/// - Custom messages must be string literals
 /// - For debugging, consider using [`breakpoint()`] instead
 #[macro_export]
 macro_rules! gpu_assert {
@@ -80,12 +82,85 @@ macro_rules! gpu_assert {
             $crate::debug::trap();
         }
     };
-    ($cond:expr, $msg:expr) => {
+    ($cond:expr, $msg:literal) => {{
         if !$cond {
-            // TODO (npasham): Use llvm.nvvm.assertfail for better error messages with file/line
-            $crate::debug::trap();
+            const __GPU_ASSERT_MESSAGE_TEXT: &str = $msg;
+            const __GPU_ASSERT_MESSAGE: [u8; __GPU_ASSERT_MESSAGE_TEXT.len() + 1] =
+                $crate::debug::__gpu_assert_c_string::<{ __GPU_ASSERT_MESSAGE_TEXT.len() + 1 }>(
+                    __GPU_ASSERT_MESSAGE_TEXT,
+                );
+
+            const __GPU_ASSERT_FILE_TEXT: &str = file!();
+            const __GPU_ASSERT_FILE: [u8; __GPU_ASSERT_FILE_TEXT.len() + 1] =
+                $crate::debug::__gpu_assert_c_string::<{ __GPU_ASSERT_FILE_TEXT.len() + 1 }>(
+                    __GPU_ASSERT_FILE_TEXT,
+                );
+
+            const __GPU_ASSERT_FUNCTION_TEXT: &str = module_path!();
+            const __GPU_ASSERT_FUNCTION: [u8; __GPU_ASSERT_FUNCTION_TEXT.len() + 1] =
+                $crate::debug::__gpu_assert_c_string::<{ __GPU_ASSERT_FUNCTION_TEXT.len() + 1 }>(
+                    __GPU_ASSERT_FUNCTION_TEXT,
+                );
+
+            $crate::debug::__gpu_assertfail(
+                __GPU_ASSERT_MESSAGE.as_ptr(),
+                __GPU_ASSERT_FILE.as_ptr(),
+                line!(),
+                __GPU_ASSERT_FUNCTION.as_ptr(),
+                1,
+            );
         }
+    }};
+    ($cond:expr, $msg:expr) => {
+        compile_error!("gpu_assert! messages must be string literals")
     };
+}
+
+/// Builds a null-terminated byte array for CUDA assertion metadata.
+///
+/// This helper is public only because [`gpu_assert!`] expands in downstream
+/// crates. It is evaluated at compile time by the message form of the macro.
+#[doc(hidden)]
+pub const fn __gpu_assert_c_string<const N: usize>(value: &str) -> [u8; N] {
+    let bytes = value.as_bytes();
+    assert!(
+        N == bytes.len() + 1,
+        "GPU assertion C string has an invalid length"
+    );
+
+    let mut output = [0; N];
+    let mut index = 0;
+    while index < bytes.len() {
+        assert!(
+            bytes[index] != 0,
+            "gpu_assert! strings must not contain NUL bytes"
+        );
+        output[index] = bytes[index];
+        index += 1;
+    }
+    output
+}
+
+/// Internal CUDA assertion-failure wrapper.
+///
+/// This function is recognized by the cuda-oxide compiler and lowered to
+/// CUDA's device-side `__assertfail(message, file, line, function, char_size)`
+/// system call. Do not call directly.
+///
+/// # Safety
+///
+/// This function only works within CUDA kernel context. Calling it from host
+/// code will panic.
+#[doc(hidden)]
+#[inline(never)]
+pub fn __gpu_assertfail(
+    _message: *const u8,
+    _file: *const u8,
+    _line: u32,
+    _function: *const u8,
+    _char_size: usize,
+) {
+    unreachable!("__gpu_assertfail called outside CUDA kernel context")
 }
 
 // =============================================================================

--- a/crates/dialect-nvvm/src/ops/debug.rs
+++ b/crates/dialect-nvvm/src/ops/debug.rs
@@ -14,6 +14,7 @@
 //! │ ReadPtxSregClockOp       │ %clock / read.ptx.sreg.clock │ 32-bit clock counter    │
 //! │ ReadPtxSregClock64Op     │ %clock64 / ...clock64        │ 64-bit clock counter    │
 //! │ ReadPtxSregGlobaltimerOp │ %globaltimer / ...globaltimer│ Global timer counter    │
+//! │ AssertFailOp             │ call @__assertfail           │ Assertion diagnostics   │
 //! │ VprintfOp                │ vprintf / call @vprintf      │ Formatted output        │
 //! └──────────────────────────┴──────────────────────────────┴─────────────────────────┘
 //! ```
@@ -33,6 +34,127 @@ use pliron::{
     verify_err,
 };
 use pliron_derive::pliron_op;
+
+// =============================================================================
+// Assertion Operations
+// =============================================================================
+
+/// CUDA device-side assertion failure operation.
+///
+/// Corresponds to CUDA's
+/// `__assertfail(message, file, line, function, char_size)` system call.
+///
+/// # Operands
+///
+/// * `message` - Pointer to a null-terminated assertion message
+/// * `file` - Pointer to a null-terminated source file name
+/// * `line` - Source line number (`u32`)
+/// * `function` - Pointer to null-terminated function or module context
+/// * `char_size` - Size of one message character (`usize`, 64-bit on NVPTX64)
+///
+/// # Results
+///
+/// This operation has no results.
+///
+/// # Verification
+///
+/// - Must have five operands and no results
+/// - Message, file, and function operands must be MIR pointers
+/// - Line must be a 32-bit integer
+/// - Character size must be a 64-bit integer
+#[pliron_op(
+    name = "nvvm.assertfail",
+    format,
+    interfaces = [NOpdsInterface<5>, NResultsInterface<0>],
+)]
+pub struct AssertFailOp;
+
+impl AssertFailOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        AssertFailOp { op }
+    }
+
+    /// Create a CUDA assertion failure operation.
+    pub fn build(
+        ctx: &mut Context,
+        message: pliron::value::Value,
+        file: pliron::value::Value,
+        line: pliron::value::Value,
+        function: pliron::value::Value,
+        char_size: pliron::value::Value,
+    ) -> Ptr<Operation> {
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![],
+            vec![message, file, line, function, char_size],
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for AssertFailOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = &*self.get_operation().deref(ctx);
+
+        if op.get_num_operands() != 5 || op.get_num_results() != 0 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.assertfail requires five operands and no results"
+            );
+        }
+
+        for operand in [0, 1, 3] {
+            let ty = op.get_operand(operand).get_type(ctx);
+            if ty.deref(ctx).downcast_ref::<MirPtrType>().is_none() {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.assertfail message, file, and function operands must be MIR pointers"
+                );
+            }
+        }
+
+        let line_ty = op.get_operand(2).get_type(ctx);
+        let line_ty_obj = line_ty.deref(ctx);
+        let line_ty = match line_ty_obj.downcast_ref::<IntegerType>() {
+            Some(ty) => ty,
+            None => {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.assertfail line operand must be a 32-bit integer"
+                );
+            }
+        };
+        if line_ty.width() != 32 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.assertfail line operand must be a 32-bit integer"
+            );
+        }
+
+        let char_size_ty = op.get_operand(4).get_type(ctx);
+        let char_size_ty_obj = char_size_ty.deref(ctx);
+        let char_size_ty = match char_size_ty_obj.downcast_ref::<IntegerType>() {
+            Some(ty) => ty,
+            None => {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.assertfail character-size operand must be a 64-bit integer"
+                );
+            }
+        };
+        if char_size_ty.width() != 64 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.assertfail character-size operand must be a 64-bit integer"
+            );
+        }
+
+        Ok(())
+    }
+}
 
 // =============================================================================
 // Printf Operations
@@ -135,5 +257,6 @@ impl Verify for VprintfOp {
 
 /// Register debug operations with the context.
 pub(super) fn register(ctx: &mut Context) {
+    AssertFailOp::register(ctx);
     VprintfOp::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -79,6 +79,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("atomic.rs", "NvvmAtomicCmpxchgOp"),
         ("cluster.rs", "ReadPtxSregClusterIdxOp"),
         ("cluster.rs", "ReadPtxSregNclusterIdOp"),
+        ("debug.rs", "AssertFailOp"),
         ("debug.rs", "VprintfOp"),
         ("grid.rs", "GridSyncOp"),
         ("wgmma.rs", "WgmmaMakeSmemDescOp"),

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -5,8 +5,8 @@
 
 use dialect_mir::types::{MirPtrType, address_space};
 use dialect_nvvm::ops::{
-    ActiveMaskOp, AtomicOrdering, AtomicRmwKind, AtomicScope, BarWarpSyncOp, Barrier0Op,
-    ClusterBarrierModeAttr, ClusterBarrierOp, CpAsyncCa4Op, CpAsyncCaZfill4Op,
+    ActiveMaskOp, AssertFailOp, AtomicOrdering, AtomicRmwKind, AtomicScope, BarWarpSyncOp,
+    Barrier0Op, ClusterBarrierModeAttr, ClusterBarrierOp, CpAsyncCa4Op, CpAsyncCaZfill4Op,
     CpAsyncMbarrierArriveNoIncOp, CpAsyncMbarrierArriveNoIncSharedOp, CpAsyncMbarrierArriveOp,
     CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, Dp2aS32Op, Dp2aU32Op, Dp4aS32Op, Dp4aU32Op,
     ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr, LdmatrixLayoutAttr,
@@ -4314,6 +4314,44 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
 
     let vprintf = VprintfOp::build(&mut ctx, pointer, pointer);
     assert!(VprintfOp::new(vprintf).verify(&ctx).is_ok());
+
+    let i64_signless_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let assertfail = AssertFailOp::build(&mut ctx, pointer, pointer, u32_value, pointer, u64_value);
+    assert!(AssertFailOp::new(assertfail).verify(&ctx).is_ok());
+    for (operands, results) in [
+        // message must be a MIR pointer
+        (
+            vec![u32_value, pointer, u32_value, pointer, u64_value],
+            vec![],
+        ),
+        // line must be a 32-bit integer
+        (
+            vec![pointer, pointer, u64_value, pointer, u64_value],
+            vec![],
+        ),
+        // char size must be a 64-bit integer
+        (
+            vec![pointer, pointer, u32_value, pointer, u32_value],
+            vec![],
+        ),
+        // wrong operand count
+        (vec![pointer, pointer, u32_value], vec![]),
+        // must have no results
+        (
+            vec![pointer, pointer, u32_value, pointer, u64_value],
+            vec![i64_signless_ty.into()],
+        ),
+    ] {
+        let invalid = Operation::new(
+            &mut ctx,
+            AssertFailOp::get_concrete_op_info(),
+            results,
+            operands,
+            vec![],
+            0,
+        );
+        assert!(AssertFailOp::new(invalid).verify(&ctx).is_err());
+    }
     let bad_vprintf = Operation::new(
         &mut ctx,
         VprintfOp::get_concrete_op_info(),

--- a/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/debug.rs
@@ -9,18 +9,116 @@
 //! - `clock()` - 32-bit GPU clock counter
 //! - `clock64()` - 64-bit GPU clock counter
 //! - `globaltimer()` - 64-bit GPU global timer
+//! - `__gpu_assertfail()` - Device-side assertion diagnostics
 //! - `__gpu_vprintf()` - Formatted output to host console
 
 use super::super::helpers::emit_store_result_and_goto;
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::values::ValueMap;
-use dialect_nvvm::ops::VprintfOp;
+use dialect_mir::ops::MirConstructTupleOp;
+use dialect_mir::types::MirTupleType;
+use dialect_nvvm::ops::{AssertFailOp, VprintfOp};
 use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
 use pliron::input_err;
 use pliron::location::{Located, Location};
+use pliron::op::Op;
 use pliron::operation::Operation;
 use rustc_public::mir;
+
+/// Emits `__gpu_assertfail()`: CUDA device-side assertion diagnostics.
+///
+/// # Generated Operation
+///
+/// `nvvm.assertfail` - Maps to CUDA
+/// `__assertfail(message, file, line, function, char_size)`
+///
+/// # Arguments
+///
+/// * `args[0]` - Pointer to null-terminated assertion message
+/// * `args[1]` - Pointer to null-terminated source file name
+/// * `args[2]` - Source line number (`u32`)
+/// * `args[3]` - Pointer to null-terminated function or module context
+/// * `args[4]` - Character size (`usize`)
+#[allow(clippy::too_many_arguments)]
+pub fn emit_assertfail(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    use crate::translator::rvalue;
+
+    if args.len() != 5 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "__gpu_assertfail expects 5 arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let mut translated_args = Vec::with_capacity(5);
+    let mut last_op = prev_op;
+    for arg in args {
+        let (value, next_op) =
+            rvalue::translate_operand(ctx, body, arg, value_map, block_ptr, last_op, loc.clone())?;
+        translated_args.push(value);
+        last_op = next_op;
+    }
+
+    let assertfail_op = AssertFailOp::build(
+        ctx,
+        translated_args[0],
+        translated_args[1],
+        translated_args[2],
+        translated_args[3],
+        translated_args[4],
+    );
+    assertfail_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        assertfail_op.insert_after(ctx, prev);
+    } else {
+        assertfail_op.insert_at_front(block_ptr, ctx);
+    }
+
+    // The Rust placeholder returns `()`. Materialize the unit value so the
+    // normal call destination and success edge remain well-formed if the CUDA
+    // system call is treated conservatively as returning void.
+    let unit_ty = MirTupleType::get(ctx, vec![]);
+    let unit_op = Operation::new(
+        ctx,
+        MirConstructTupleOp::get_concrete_op_info(),
+        vec![unit_ty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    unit_op.deref_mut(ctx).set_loc(loc.clone());
+    unit_op.insert_after(ctx, assertfail_op);
+
+    let unit_value = unit_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        unit_value,
+        target,
+        block_ptr,
+        unit_op,
+        value_map,
+        block_map,
+        loc,
+        "__gpu_assertfail call without target block",
+    )
+}
 
 /// Emits `__gpu_vprintf()`: Formatted output to host console.
 ///

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2421,6 +2421,18 @@ fn try_dispatch_intrinsic(
         // =================================================================
         // Debug & Profiling (from intrinsics::debug)
         // =================================================================
+        "cuda_device::debug::__gpu_assertfail" => Ok(Some(intrinsics::debug::emit_assertfail(
+            ctx,
+            body,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+        )?)),
         "cuda_device::debug::__gpu_vprintf" => Ok(Some(intrinsics::debug::emit_vprintf(
             ctx,
             body,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -36,9 +36,9 @@ use dialect_mir::ops::{
     MirStoreOp, MirSubOp, MirUndefOp, MirUnreachableOp, MirUnrollHintOp,
 };
 use dialect_nvvm::ops::{
-    InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp,
-    ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp, VprintfOp, WgmmaMakeSmemDescOp,
-    WgmmaMmaM64N64K16F32Bf16Op,
+    AssertFailOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
+    NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp, VprintfOp,
+    WgmmaMakeSmemDescOp, WgmmaMmaM64N64K16F32Bf16Op,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -895,6 +895,23 @@ impl MirToLlvmConversion for InlinePtxOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::asm::convert_inline_ptx(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for AssertFailOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::debug::convert_assertfail(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/debug.rs
+++ b/crates/mir-lower/src/convert/intrinsics/debug.rs
@@ -66,7 +66,11 @@ pub(crate) fn convert_assertfail(
     let callee = CallOpCallable::Direct(sym_name);
     let call_op = llvm::CallOp::new(ctx, callee, func_ty, operands);
     rewriter.insert_operation(ctx, call_op.get_operation());
-    rewriter.replace_operation(ctx, op, call_op.get_operation());
+    // AssertFailOp has no results, so there are no uses to rewire;
+    // erase the original op, the same pattern the zero-result cp.async
+    // control ops use. replace_operation trips the result-count check
+    // because the void call carries no replacement values.
+    rewriter.erase_operation(ctx, op);
 
     Ok(())
 }

--- a/crates/mir-lower/src/convert/intrinsics/debug.rs
+++ b/crates/mir-lower/src/convert/intrinsics/debug.rs
@@ -10,6 +10,7 @@
 //! | `Clock`        | `llvm_nvvm_read_ptx_sreg_clock`         | `mov %r, %clock`        |
 //! | `Clock64`      | `llvm_nvvm_read_ptx_sreg_clock64`       | `mov %rd, %clock64`     |
 //! | `Globaltimer`  | `llvm_nvvm_read_ptx_sreg_globaltimer`   | `mov %rd, %globaltimer` |
+//! | `AssertFail`   | `call @__assertfail`                    | assertion system call   |
 //! | `Vprintf`      | `call @vprintf`                         | `call vprintf`          |
 
 use crate::helpers;
@@ -24,6 +25,51 @@ use pliron::irbuild::rewriter::Rewriter;
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
+
+pub(crate) fn convert_assertfail(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.len() != 5 {
+        return pliron::input_err_noloc!(
+            "__assertfail requires 5 operands, got {}",
+            operands.len()
+        );
+    }
+
+    let void_ty = llvm_types::VoidType::get(ctx);
+    let i8_ptr_ty = llvm_types::PointerType::get(ctx, 0);
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
+
+    let func_ty = llvm_types::FuncType::get(
+        ctx,
+        void_ty.into(),
+        vec![
+            i8_ptr_ty.into(),
+            i8_ptr_ty.into(),
+            i32_ty.into(),
+            i8_ptr_ty.into(),
+            i64_ty.into(),
+        ],
+        false,
+    );
+
+    let parent_block = op.deref(ctx).get_parent_block().unwrap();
+    helpers::ensure_intrinsic_declared(ctx, parent_block, "__assertfail", func_ty)
+        .map_err(|e| pliron::input_error_noloc!("{}", e))?;
+
+    let sym_name: pliron::identifier::Identifier = "__assertfail".try_into().unwrap();
+    let callee = CallOpCallable::Direct(sym_name);
+    let call_op = llvm::CallOp::new(ctx, callee, func_ty, operands);
+    rewriter.insert_operation(ctx, call_op.get_operation());
+    rewriter.replace_operation(ctx, op, call_op.get_operation());
+
+    Ok(())
+}
 
 pub(crate) fn convert_vprintf(
     ctx: &mut Context,

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -265,6 +265,143 @@ fn test_globaltimer_lowers_to_intrinsic_call() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[test]
+fn test_assertfail_lowers_to_direct_call() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    dialect_nvvm::register(&mut ctx);
+    mir_lower::register(&mut ctx);
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_ptr = module.get_operation();
+
+    let func_name = "kernel_func";
+    let u8_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        8,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, u8_ty.into(), false);
+    let u32_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        32,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let u64_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        64,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let arg_tys: Vec<pliron::r#type::TypeHandle> = vec![
+        ptr_ty.into(),
+        ptr_ty.into(),
+        u32_ty.into(),
+        ptr_ty.into(),
+        u64_ty.into(),
+    ];
+    let func_ty = pliron::builtin::types::FunctionType::get(&ctx, arg_tys.clone(), vec![]);
+
+    let func_op_ptr = Operation::new(
+        &mut ctx,
+        mir::MirFuncOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        1,
+    );
+    let func_ty_attr = pliron::builtin::attributes::TypeAttr::new(func_ty.into());
+    let func = mir::MirFuncOp::new(&mut ctx, func_op_ptr, func_ty_attr);
+    func.set_symbol_name(&mut ctx, func_name.try_into().unwrap());
+
+    let region = func.get_operation().deref(&ctx).get_region(0);
+    let block = {
+        let b = pliron::basic_block::BasicBlock::new(&mut ctx, None, arg_tys);
+        b.insert_at_back(region, &ctx);
+        b
+    };
+
+    let message = block.deref(&ctx).get_argument(0);
+    let file = block.deref(&ctx).get_argument(1);
+    let line = block.deref(&ctx).get_argument(2);
+    let function = block.deref(&ctx).get_argument(3);
+    let char_size = block.deref(&ctx).get_argument(4);
+
+    let assertfail_op =
+        nvvm::AssertFailOp::build(&mut ctx, message, file, line, function, char_size);
+    assertfail_op.insert_at_back(block, &ctx);
+
+    let ret_op_ptr = Operation::new(
+        &mut ctx,
+        mir::MirReturnOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        0,
+    );
+    ret_op_ptr.insert_at_back(block, &ctx);
+
+    let module_region = module.get_operation().deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    const EXTERN: &str = "__assertfail";
+
+    let mut found_decl = false;
+    let mut found_call = false;
+    let module_op = module_ptr.deref(&ctx);
+    let region = module_op.get_region(0);
+    let block = region.deref(&ctx).iter(&ctx).next().unwrap();
+
+    for op in block.deref(&ctx).iter(&ctx) {
+        let Some(func_op) = Operation::get_op::<llvm_export::ops::FuncOp>(op, &ctx) else {
+            continue;
+        };
+        let name = func_op.get_symbol_name(&ctx).to_string();
+
+        if name == EXTERN {
+            found_decl = true;
+        } else if name == func_name {
+            let func_region = func_op.get_operation().deref(&ctx).get_region(0);
+            for func_block in func_region.deref(&ctx).iter(&ctx) {
+                for body_op in func_block.deref(&ctx).iter(&ctx) {
+                    if let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx)
+                        && let CallOpCallable::Direct(sym) = call.callee(&ctx)
+                        && sym.to_string() == EXTERN
+                    {
+                        found_call = true;
+                        assert_eq!(
+                            body_op.deref(&ctx).get_num_operands(),
+                            5,
+                            "__assertfail call must forward all five operands"
+                        );
+                        // (The LLVM dialect models a void call as a single
+                        // void-typed result; the exporter prints it with no
+                        // destination, so only the operand shape matters here.)
+                    }
+                    assert!(
+                        Operation::get_op::<nvvm::AssertFailOp>(body_op, &ctx).is_none(),
+                        "nvvm.assertfail must be fully consumed by the lowering"
+                    );
+                }
+            }
+        }
+    }
+
+    assert!(
+        found_decl,
+        "Expected `{EXTERN}` declaration in lowered module"
+    );
+    assert!(
+        found_call,
+        "Expected call to `{EXTERN}` in lowered kernel body"
+    );
+    Ok(())
+}
+
 /// Lower a single zero-operand, i32-result special-register op and assert it
 /// emits a declaration of and direct call to `intrinsic` (and no inline asm).
 fn assert_sreg_i32_lowers_to_intrinsic(

--- a/crates/rustc-codegen-cuda/examples/debug/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/debug/src/main.rs
@@ -181,6 +181,44 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     // ====================================================================
+    // Manually invoked failing mode: `debug --fail-assert`
+    //
+    // A failing device-side assert poisons the CUDA context, so this mode
+    // runs INSTEAD of the normal test suite, never alongside it. The
+    // driver prints the assertion message (file:line: Assertion `...`
+    // failed) to stderr and the sync returns CUDA_ERROR_ASSERT (710).
+    // ====================================================================
+    if std::env::args().any(|a| a == "--fail-assert") {
+        println!("--- Failing mode: gpu_assert!() with negative input ---");
+        let input: Vec<i32> = vec![0, 1, -3, 3]; // lane 2 fails `val >= 0`
+        let n = input.len();
+        let input_dev = DeviceBuffer::from_host(&stream, &input)?;
+        let mut output_dev = DeviceBuffer::<i32>::zeroed(&stream, n)?;
+
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        let launch = unsafe {
+            module.assert_test(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(n as u32),
+                &input_dev,
+                &mut output_dev,
+            )
+        };
+        let result = launch.and_then(|_| stream.synchronize());
+        match result {
+            Err(e) => {
+                println!("✓ assertion failure surfaced as expected: {e:?}");
+                println!("  (assertion message printed to stderr by the CUDA driver)");
+                return Ok(());
+            }
+            Ok(()) => {
+                println!("✗ FAILED: kernel with a failing gpu_assert! completed normally");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // ====================================================================
     // Test 1: Clock cycles measurement
     // ====================================================================
     println!("--- Test 1: clock64() / globaltimer() measurement ---");


### PR DESCRIPTION
Closes #439 

## Summary

Implement device-side assertion diagnostics for the message form of `gpu_assert!`.

Failed assertions now call CUDA's `__assertfail` system call with the supplied message, source file, source line, module context, and character size.

## Changes

* Add the hidden `cuda_device::debug::__gpu_assertfail` compiler placeholder.
* Update the message form of `gpu_assert!` to generate null-terminated static metadata.
* Add a typed `nvvm.assertfail` dialect operation.
* Add MIR importer dispatch and operand translation for the new placeholder.
* Lower `nvvm.assertfail` to:

```llvm
declare void @__assertfail(ptr, ptr, i32, ptr, i64)
```

* Add dialect verification and lowering coverage.
* Extend the debug example with an isolated assertion-failure mode.
* Update the assertion documentation.

## Behavior

Before:

```rust
gpu_assert!(value >= 0, "value must be non-negative");
```

failed through `trap()` and discarded the message.

After:

```rust
gpu_assert!(value >= 0, "value must be non-negative");
```

reports the message and call-site metadata through CUDA's device-side assertion mechanism.

The no-message form remains unchanged and continues to use `trap()`.

## Scope limitations

* Assertion messages must be string literals.
* Formatted messages are not supported.
* Ordinary Rust `assert!` lowering is unchanged.
* `module_path!()` is used as the available function context.

## Validation

* [ ] `cargo fmt --check`
* [ ] `cargo test -p dialect-nvvm`
* [ ] `cargo test -p mir-importer`
* [ ] `cargo test -p mir-lower`
* [ ] `cargo test -p cuda-device`
* [ ] `cargo oxide pipeline debug`
* [ ] Confirm generated IR declares and calls `__assertfail`
* [ ] `cargo oxide run debug`
* [ ] `cargo oxide run debug -- --assert-failure`

