### PR TITLE
Make generated intrinsic checks warning-free

### DIFF
--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -4048,7 +4048,7 @@ fn render_raw_mod(catalog: &CatalogFile, hash: &str) -> String {
         }
         output.push_str("}\n\n");
     }
-    output.push_str("#[cfg(test)]\nmod tests {\n");
+    output.push_str("#[cfg(test)]\n#[allow(clippy::type_complexity)]\nmod tests {\n");
     for record in &catalog.intrinsics {
         let arguments = record.rust.arguments.join(", ");
         writeln!(

--- a/crates/cuda-intrinsics-gen/src/resolve.rs
+++ b/crates/cuda-intrinsics-gen/src/resolve.rs
@@ -35380,8 +35380,12 @@ scope = "system"
             target_contract(vec![selector("kind", "f16")], &[("sm_100a", "8.60")]),
         ] {
             assert!(
-                resolve_target_contract("tcgen05_mma", &invalid.selectors, std::slice::from_ref(&invalid))
-                    .is_err(),
+                resolve_target_contract(
+                    "tcgen05_mma",
+                    &invalid.selectors,
+                    std::slice::from_ref(&invalid)
+                )
+                .is_err(),
                 "{invalid:?}"
             );
         }

--- a/crates/cuda-intrinsics-gen/src/resolve.rs
+++ b/crates/cuda-intrinsics-gen/src/resolve.rs
@@ -35355,7 +35355,7 @@ scope = "system"
             resolve_target_contract(
                 "tcgen05_mma",
                 &[selector("kind", "i8"), selector("scale_d", "false")],
-                &[valid.clone()],
+                std::slice::from_ref(&valid),
             )
             .unwrap_err()
             .to_string()
@@ -35380,7 +35380,7 @@ scope = "system"
             target_contract(vec![selector("kind", "f16")], &[("sm_100a", "8.60")]),
         ] {
             assert!(
-                resolve_target_contract("tcgen05_mma", &invalid.selectors, &[invalid.clone()])
+                resolve_target_contract("tcgen05_mma", &invalid.selectors, std::slice::from_ref(&invalid))
                     .is_err(),
                 "{invalid:?}"
             );

--- a/crates/cuda-intrinsics/src/generated/mod.rs
+++ b/crates/cuda-intrinsics/src/generated/mod.rs
@@ -881,6 +881,7 @@ pub mod wgmma {
 }
 
 #[cfg(test)]
+#[allow(clippy::type_complexity)]
 mod tests {
     #[test]
     fn public_abs_bf16x2_reexports_abi_i0070() {

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -1116,8 +1116,8 @@ fn test_shuffle_i64_lowers_to_inline_asm() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 
     let mut ctx = make_test_ctx();
-    let i32_ty = IntegerType::get(&mut ctx, 32, Signedness::Signless);
-    let i64_ty = IntegerType::get(&mut ctx, 64, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
     // Kernel args: [mask (i32), value (i64), lane/delta (i32)].
     let (module_ptr, entry) =
         build_test_kernel(&mut ctx, vec![i32_ty.into(), i64_ty.into(), i32_ty.into()]);
@@ -2638,7 +2638,7 @@ fn test_cluster_grid_compatibility_ops_keep_original_lowering() -> Result<(), an
                 .get_attr_inline_asm_template(&ctx)
                 .map(|value| String::from((*value).clone()))?;
             (template.contains("%clusterid") || template.contains("%nclusterid"))
-                .then(|| (template, asm))
+                .then_some((template, asm))
         })
         .collect::<Vec<_>>();
     assert_eq!(lowered.len(), 2);
@@ -6157,11 +6157,11 @@ fn test_ldmatrix_rejects_wrong_result_arity() {
         0,
     );
     let ldmatrix = nvvm::LdmatrixOp::new(op);
-    ldmatrix.set_attr_nvvm_ldmatrix_shape(&mut ctx, nvvm::LdmatrixShapeAttr::M8n8);
-    ldmatrix.set_attr_nvvm_ldmatrix_multiplicity(&mut ctx, nvvm::LdmatrixMultiplicityAttr::X1);
-    ldmatrix.set_attr_nvvm_ldmatrix_layout(&mut ctx, nvvm::LdmatrixLayoutAttr::Normal);
-    ldmatrix.set_attr_nvvm_ldmatrix_element(&mut ctx, nvvm::LdmatrixElementAttr::B16);
-    ldmatrix.set_attr_nvvm_ldmatrix_state_space(&mut ctx, nvvm::LdmatrixStateSpaceAttr::Shared);
+    ldmatrix.set_attr_nvvm_ldmatrix_shape(&ctx, nvvm::LdmatrixShapeAttr::M8n8);
+    ldmatrix.set_attr_nvvm_ldmatrix_multiplicity(&ctx, nvvm::LdmatrixMultiplicityAttr::X1);
+    ldmatrix.set_attr_nvvm_ldmatrix_layout(&ctx, nvvm::LdmatrixLayoutAttr::Normal);
+    ldmatrix.set_attr_nvvm_ldmatrix_element(&ctx, nvvm::LdmatrixElementAttr::B16);
+    ldmatrix.set_attr_nvvm_ldmatrix_state_space(&ctx, nvvm::LdmatrixStateSpaceAttr::Shared);
     op.insert_at_back(entry, &ctx);
     append_return(&mut ctx, entry);
 


### PR DESCRIPTION
Closes #441 

## Summary

* emit a localized `clippy::type_complexity` allowance for the generated intrinsic ABI test module;
* replace two cloned single-element slices with `std::slice::from_ref`;
* regenerate the managed `cuda-intrinsics` module.

## Rationale

The generated ABI re-export tests deliberately spell out each complete `unsafe fn(...)` signature. The explicit type assignments verify that the public intrinsic and its canonical ABI entry remain type-compatible before their addresses are compared.

Clippy classifies some of these signatures as overly complex, but introducing generated aliases for every signature would increase the generated surface without strengthening the ABI check. This change therefore suppresses `type_complexity` only for the generated ABI test module.

The two resolver changes remove unnecessary clones and follow Clippy's recommended `std::slice::from_ref` representation.

## Scope

This change does not modify:

* intrinsic signatures;
* the ABI ledger;
* overlay contracts;
* generated lowering;
* target requirements;
* runtime behavior.

`crates/cuda-intrinsics/src/generated/mod.rs` was regenerated through `cuda-intrinsics-gen` and was not edited manually.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p cuda-intrinsics-gen
cargo run -p cuda-intrinsics-gen -- check
cargo clippy --all-targets -- -D warnings
```
