### PR TITLE
Restore the #411 review follow-ups: multi-output ptx_asm! verifier, tests, docs

### DIFF
--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -402,11 +402,30 @@ unsafe {
 }
 ```
 
-The initial surface supports zero or one `out`, up to 16 `in` operands, and
-`clobber("memory")`. `options(register_only)` requires an `out` operand and
-cannot be combined with clobbers. `options(may_diverge)` must be paired with
-`register_only`. Multiple outputs, read-write operands, and the `"C"`
-constraint are not implemented yet.
+The surface supports up to 8 `out` operands, up to 16 `in` operands, and
+`clobber("memory")`. Every `out` constraint must be `=`-prefixed (e.g.
+`"=r"`); with two or more `out` operands the snippet returns a tuple under
+the hood, destructured into the output places in declaration order:
+
+```rust
+let sum: u32;
+let prod: u32;
+unsafe {
+    ptx_asm!(
+        "add.u32 %0, %2, %3; mul.lo.u32 %1, %2, %3;",
+        out("=r") sum,
+        out("=r") prod,
+        in("r") x,
+        in("r") y,
+        options(register_only),
+    );
+}
+```
+
+`options(register_only)` requires an `out` operand and cannot be combined
+with clobbers. `options(may_diverge)` must be paired with `register_only`.
+More than 8 outputs, read-write operands, and the `"C"` constraint are not
+implemented yet.
 
 ## Source Layout
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -74,9 +74,25 @@ pub fn gpu_printf(input: TokenStream) -> TokenStream {
 /// Literal PTX registers that begin with `%` must be escaped as `%%`, matching
 /// CUDA C++ inline PTX. Literal `$` labels can be written normally.
 ///
-/// The initial surface supports zero or one `out`, up to 16 `in` operands,
-/// `clobber("memory")`, `options(register_only)`, and the explicit
-/// `options(register_only, may_diverge)` opt-in.
+/// The surface supports up to 8 `out` operands (each constraint prefixed
+/// with `=`, e.g. `"=r"`), up to 16 `in` operands, `clobber("memory")`,
+/// `options(register_only)`, and the explicit
+/// `options(register_only, may_diverge)` opt-in. With two or more `out`
+/// operands the snippet returns a tuple under the hood, destructured into
+/// the output places in declaration order:
+///
+/// ```ignore
+/// let (sum, prod): (u32, u32);
+/// unsafe {
+///     ptx_asm!(
+///         "add.u32 %0, %2, %3; mul.lo.u32 %1, %2, %3;",
+///         out("=r") sum,
+///         out("=r") prod,
+///         in("r") x,
+///         in("r") y,
+///     );
+/// }
+/// ```
 ///
 /// By default, snippets are treated as side-effecting and stay inside their
 /// current control flow. Use `options(register_only)` only for snippets that

--- a/crates/dialect-nvvm/src/ops/asm.rs
+++ b/crates/dialect-nvvm/src/ops/asm.rs
@@ -77,12 +77,15 @@ impl Verify for InlinePtxOp {
         if self.get_attr_ptx_template(ctx).is_none() {
             return verify_err!(op.loc(), "nvvm.inline_ptx requires ptx_template attribute");
         }
-        if self.get_attr_ptx_constraints(ctx).is_none() {
+        let Some(constraints) = self
+            .get_attr_ptx_constraints(ctx)
+            .map(|attr| String::from((*attr).clone()))
+        else {
             return verify_err!(
                 op.loc(),
                 "nvvm.inline_ptx requires ptx_constraints attribute"
             );
-        }
+        };
         if self.get_attr_ptx_sideeffect(ctx).is_none() {
             return verify_err!(
                 op.loc(),
@@ -93,6 +96,20 @@ impl Verify for InlinePtxOp {
             return verify_err!(
                 op.loc(),
                 "nvvm.inline_ptx requires ptx_convergent attribute"
+            );
+        }
+        // Each result binds to exactly one `=`-prefixed output constraint,
+        // in order; a mismatch would mis-bind PTX registers and is only
+        // diagnosed much later (and worse) by llc.
+        let num_outputs = constraints
+            .split(',')
+            .filter(|constraint| constraint.starts_with('='))
+            .count();
+        let num_results = op.get_num_results();
+        if num_results != num_outputs {
+            return verify_err!(
+                op.loc(),
+                "nvvm.inline_ptx has {num_results} results but {num_outputs} `=` output constraints"
             );
         }
         Ok(())

--- a/crates/dialect-nvvm/src/ops/asm.rs
+++ b/crates/dialect-nvvm/src/ops/asm.rs
@@ -69,6 +69,21 @@ impl InlinePtxOp {
         wrapped.set_attr_ptx_convergent(ctx, BoolAttr::new(convergent));
         wrapped.get_operation()
     }
+
+    /// Count the output constraints in an LLVM-style constraint string.
+    ///
+    /// Output constraints are the comma-separated tokens prefixed with `=`
+    /// (e.g. `=r`, `=f`). Each op result binds to exactly one output
+    /// constraint, in order. This is the canonical counting rule; both the
+    /// op verifier and the MIR importer's `ptx_asm!` translation use it so
+    /// they can never disagree on how many results an inline PTX block
+    /// produces.
+    pub fn count_output_constraints(constraints: &str) -> usize {
+        constraints
+            .split(',')
+            .filter(|constraint| constraint.starts_with('='))
+            .count()
+    }
 }
 
 impl Verify for InlinePtxOp {
@@ -101,10 +116,7 @@ impl Verify for InlinePtxOp {
         // Each result binds to exactly one `=`-prefixed output constraint,
         // in order; a mismatch would mis-bind PTX registers and is only
         // diagnosed much later (and worse) by llc.
-        let num_outputs = constraints
-            .split(',')
-            .filter(|constraint| constraint.starts_with('='))
-            .count();
+        let num_outputs = Self::count_output_constraints(&constraints);
         let num_results = op.get_num_results();
         if num_results != num_outputs {
             return verify_err!(

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -9,14 +9,14 @@ use dialect_nvvm::ops::{
     ClusterBarrierModeAttr, ClusterBarrierOp, CpAsyncCa4Op, CpAsyncCaZfill4Op,
     CpAsyncMbarrierArriveNoIncOp, CpAsyncMbarrierArriveNoIncSharedOp, CpAsyncMbarrierArriveOp,
     CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, Dp2aS32Op, Dp2aU32Op, Dp4aS32Op, Dp4aU32Op,
-    ElectSyncOp, FmaBf16x2Op, LdmatrixElementAttr, LdmatrixLayoutAttr, LdmatrixMultiplicityAttr,
-    LdmatrixOp, LdmatrixShapeAttr, LdmatrixStateSpaceAttr, LdmatrixX1Op, LdmatrixX1TransOp,
-    LdmatrixX2Op, LdmatrixX2TransOp, LdmatrixX4Op, LdmatrixX4TransOp, MatchAllSyncI32Op,
-    MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op, MbarrierArriveSharedOp,
-    MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp, MmaM8N8K4F64Op,
-    MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op, MmaM16N8K32S32S8Op,
-    MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp,
-    NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PackedAtomicAddOp,
+    ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr, LdmatrixLayoutAttr,
+    LdmatrixMultiplicityAttr, LdmatrixOp, LdmatrixShapeAttr, LdmatrixStateSpaceAttr, LdmatrixX1Op,
+    LdmatrixX1TransOp, LdmatrixX2Op, LdmatrixX2TransOp, LdmatrixX4Op, LdmatrixX4TransOp,
+    MatchAllSyncI32Op, MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op,
+    MbarrierArriveSharedOp, MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
+    MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op,
+    MmaM16N8K32S32S8Op, MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
+    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PackedAtomicAddOp,
     PackedAtomicAtomicityAttr, PackedAtomicFormatAttr, PackedAtomicOrderingAttr,
     PackedAtomicRoundingAttr, PackedAtomicScopeAttr, PackedAtomicStateSpaceAttr,
     PackedAtomicSubnormalAttr, ReadPtxSregClusterIdxOp, ReadPtxSregDynamicSmemSizeOp,
@@ -4378,4 +4378,61 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
                 .is_err()
         );
     }
+}
+
+#[test]
+fn test_inline_ptx_results_must_match_output_constraints() {
+    let mut ctx = Context::new();
+    dialect_nvvm::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let block = BasicBlock::new(&mut ctx, None, vec![i32_ty.into()]);
+    let input = block.deref(&ctx).get_argument(0);
+
+    let void = InlinePtxOp::build(&mut ctx, vec![], vec![], "membar.gl;", "", true, false);
+    assert!(verify_op(&InlinePtxOp::new(void), &ctx).is_ok());
+
+    let single = InlinePtxOp::build(
+        &mut ctx,
+        vec![i32_ty.into()],
+        vec![input],
+        "add.u32 $0, $1, $1;",
+        "=r,r",
+        false,
+        false,
+    );
+    assert!(verify_op(&InlinePtxOp::new(single), &ctx).is_ok());
+
+    let multi = InlinePtxOp::build(
+        &mut ctx,
+        vec![i32_ty.into(), i32_ty.into()],
+        vec![input],
+        "add.u32 $0, $2, $2; mul.lo.u32 $1, $2, $2;",
+        "=r,=r,r",
+        false,
+        false,
+    );
+    assert!(verify_op(&InlinePtxOp::new(multi), &ctx).is_ok());
+
+    let missing_result = InlinePtxOp::build(
+        &mut ctx,
+        vec![i32_ty.into()],
+        vec![input],
+        "add.u32 $0, $2, $2; mul.lo.u32 $1, $2, $2;",
+        "=r,=r,r",
+        false,
+        false,
+    );
+    assert!(verify_op(&InlinePtxOp::new(missing_result), &ctx).is_err());
+
+    let extra_result = InlinePtxOp::build(
+        &mut ctx,
+        vec![i32_ty.into()],
+        vec![input],
+        "prefetch.global.L1 [$0];",
+        "r",
+        true,
+        false,
+    );
+    assert!(verify_op(&InlinePtxOp::new(extra_result), &ctx).is_err());
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -4436,3 +4436,13 @@ fn test_inline_ptx_results_must_match_output_constraints() {
     );
     assert!(verify_op(&InlinePtxOp::new(extra_result), &ctx).is_err());
 }
+
+#[test]
+fn test_inline_ptx_count_output_constraints() {
+    assert_eq!(InlinePtxOp::count_output_constraints("=r,r,r"), 1);
+    assert_eq!(InlinePtxOp::count_output_constraints("=r,=r,=f,=d,r,l"), 4);
+    assert_eq!(InlinePtxOp::count_output_constraints("r,l,~{memory}"), 0);
+    assert_eq!(InlinePtxOp::count_output_constraints(""), 0);
+    // `=` only counts as an output marker at the start of a token.
+    assert_eq!(InlinePtxOp::count_output_constraints("r,r=f"), 0);
+}

--- a/crates/mir-importer/src/translator/terminator/intrinsics/asm.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/asm.rs
@@ -65,16 +65,6 @@ impl InlinePtxCallKind {
     }
 }
 
-/// Count the number of output constraints in a constraint string.
-///
-/// Output constraints are prefixed with `=` (e.g. `=r`, `=f`).
-fn count_output_constraints(constraints: &str) -> usize {
-    constraints
-        .split(',')
-        .filter(|c| c.starts_with('='))
-        .count()
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn emit_inline_ptx(
     ctx: &mut Context,
@@ -145,8 +135,10 @@ pub fn emit_inline_ptx(
         }
     }
 
-    // Output call: determine how many output constraints we have.
-    let num_outputs = count_output_constraints(&constraints);
+    // Output call: determine how many output constraints we have. Use the
+    // op's canonical counting rule so the importer and the `nvvm.inline_ptx`
+    // verifier can never disagree.
+    let num_outputs = InlinePtxOp::count_output_constraints(&constraints);
 
     if num_outputs <= 1 {
         // Single-output (backward-compatible path): the destination type is the result type.
@@ -325,25 +317,5 @@ mod tests {
 
         assert!(!options.sideeffect);
         assert!(!options.convergent);
-    }
-
-    #[test]
-    fn count_output_constraints_single() {
-        assert_eq!(count_output_constraints("=r,r,r"), 1);
-    }
-
-    #[test]
-    fn count_output_constraints_multi() {
-        assert_eq!(count_output_constraints("=r,=r,=f,=d,r,l"), 4);
-    }
-
-    #[test]
-    fn count_output_constraints_none() {
-        assert_eq!(count_output_constraints("r,l,~{memory}"), 0);
-    }
-
-    #[test]
-    fn count_output_constraints_empty() {
-        assert_eq!(count_output_constraints(""), 0);
     }
 }

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -2526,6 +2526,92 @@ fn test_inline_ptx_op_lowers_to_inline_asm_attrs() -> Result<(), anyhow::Error> 
 }
 
 #[test]
+fn test_multi_result_inline_ptx_lowers_to_struct_asm_and_extractvalues() -> Result<(), anyhow::Error>
+{
+    use llvm_export::types as llvm_types;
+    use pliron::builtin::types::{IntegerType, Signedness};
+    use pliron::r#type::Typed;
+
+    let mut ctx = make_test_ctx();
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![i32_ty.into()]);
+    let input = entry.deref(&ctx).get_argument(0);
+
+    let inline_ptx = nvvm::InlinePtxOp::build(
+        &mut ctx,
+        vec![i32_ty.into(), i32_ty.into()],
+        vec![input],
+        "add.u32 $0, $2, $2; mul.lo.u32 $1, $2, $2;",
+        "=r,=r,r",
+        true,
+        false,
+    );
+    inline_ptx.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let mut asm_result = None;
+    let mut extract_indices = Vec::new();
+    for op in lowered_kernel_body(&ctx, module_ptr) {
+        if let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(op, &ctx) {
+            assert_eq!(
+                inline_asm
+                    .get_attr_inline_asm_template(&ctx)
+                    .map(|s| String::from((*s).clone()))
+                    .as_deref(),
+                Some("add.u32 $0, $2, $2; mul.lo.u32 $1, $2, $2;")
+            );
+            assert_eq!(
+                inline_asm
+                    .get_attr_inline_asm_constraints(&ctx)
+                    .map(|s| String::from((*s).clone()))
+                    .as_deref(),
+                Some("=r,=r,r")
+            );
+            let result = inline_asm.get_operation().deref(&ctx).get_result(0);
+            let result_ty = result.get_type(&ctx);
+            let result_ty = result_ty.deref(&ctx);
+            let struct_ty = result_ty
+                .downcast_ref::<llvm_types::StructType>()
+                .expect("multi-output inline PTX must return an LLVM struct");
+            assert_eq!(struct_ty.num_fields(), 2);
+            for index in 0..2 {
+                assert_eq!(
+                    struct_ty
+                        .field_type(index)
+                        .deref(&ctx)
+                        .downcast_ref::<IntegerType>()
+                        .expect("multi-output inline PTX struct field must stay i32")
+                        .width(),
+                    32
+                );
+            }
+            asm_result = Some(result);
+        } else if let Some(extract) = Operation::get_op::<llvm::ExtractValueOp>(op, &ctx) {
+            let aggregate = extract.get_operation().deref(&ctx).get_operand(0);
+            assert_eq!(
+                Some(aggregate),
+                asm_result,
+                "extractvalue must consume the struct-returning asm result"
+            );
+            extract_indices.push(extract.indices(&ctx));
+        }
+    }
+
+    assert!(
+        asm_result.is_some(),
+        "Expected struct-returning inline PTX asm op"
+    );
+    assert_eq!(
+        extract_indices,
+        vec![vec![0], vec![1]],
+        "each output must be extracted once, in constraint order"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_cluster_grid_compatibility_ops_keep_original_lowering() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 

--- a/crates/rustc-codegen-cuda/examples/inline_ptx/README.md
+++ b/crates/rustc-codegen-cuda/examples/inline_ptx/README.md
@@ -5,6 +5,11 @@ Rust arithmetic, uses a register-only PTX instruction, reads the lane-id
 register (`%%laneid` in the macro string), emits a memory-clobbering
 `membar.gl`, then uses the PTX results in Rust.
 
+A second kernel exercises multi-output `ptx_asm!`: a single asm block with
+two `=r` outputs computes both the sum and the product of two
+thread-dependent values, written to separate buffers the host verifies
+element-wise (the asymmetric results catch swapped output bindings).
+
 Run with:
 
 ```bash

--- a/crates/rustc-codegen-cuda/examples/inline_ptx/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/inline_ptx/src/main.rs
@@ -33,6 +33,40 @@ mod kernels {
             *slot = rust_after;
         }
     }
+
+    /// Multi-output `ptx_asm!`: one asm block yields both the sum and the
+    /// product of two thread-dependent values. The asymmetric data flow
+    /// (sum != product) catches swapped register binding between the two
+    /// `=r` outputs.
+    #[kernel]
+    pub fn inline_ptx_multi_out_kernel(
+        mut sums: DisjointSlice<u32>,
+        mut prods: DisjointSlice<u32>,
+    ) {
+        if let Some((sum_slot, idx)) = sums.get_mut_indexed()
+            && let Some((prod_slot, _)) = prods.get_mut_indexed()
+        {
+            let i = idx.get() as u32;
+            let x = i.wrapping_add(1);
+            let y = i.wrapping_add(2);
+            let sum: u32;
+            let prod: u32;
+
+            unsafe {
+                ptx_asm!(
+                    "add.u32 %0, %2, %3; mul.lo.u32 %1, %2, %3;",
+                    out("=r") sum,
+                    out("=r") prod,
+                    in("r") x,
+                    in("r") y,
+                    options(register_only),
+                );
+            }
+
+            *sum_slot = sum;
+            *prod_slot = prod;
+        }
+    }
 }
 
 fn main() {
@@ -56,6 +90,36 @@ fn main() {
         let expected = (i as u32 * 2) + 3 + (i as u32 % 32);
         if got != expected {
             eprintln!("Mismatch at {i}: expected {expected}, got {got}");
+            std::process::exit(1);
+        }
+    }
+
+    let mut sums_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    let mut prods_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.inline_ptx_multi_out_kernel(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            &mut sums_dev,
+            &mut prods_dev,
+        )
+    }
+    .expect("Kernel launch failed");
+
+    let sums = sums_dev.to_host_vec(&stream).unwrap();
+    let prods = prods_dev.to_host_vec(&stream).unwrap();
+    for i in 0..N {
+        let x = (i as u32).wrapping_add(1);
+        let y = (i as u32).wrapping_add(2);
+        let (got_sum, got_prod) = (sums[i], prods[i]);
+        let (want_sum, want_prod) = (x.wrapping_add(y), x.wrapping_mul(y));
+        if got_sum != want_sum || got_prod != want_prod {
+            eprintln!(
+                "Multi-output mismatch at {i}: expected ({want_sum}, {want_prod}), \
+                 got ({got_sum}, {got_prod})"
+            );
             std::process::exit(1);
         }
     }

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -102,7 +102,7 @@ layout-aware field decoding rather than the primitive byte-slicing rule.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| `ptx_asm!` Macro | **Partial** | CUDA inline PTX with `%0` operands, `in`, zero or one `out`, up to 16 inputs, CUDA register constraints `h`, `r`, `l`, `q`, `f`, and `d`, immediate integer constraint `n`, `clobber("memory")`, and `options(register_only)` for pure register snippets. By default, snippets are treated as side-effecting and stay inside their current control flow. Use `options(register_only, may_diverge)` only for pure snippets that are safe to move across divergent control flow; **never** use it for `.sync` instructions or collectives. Multiple outputs, read-write operands, and the `"C"` constraint are not implemented yet. |
+| `ptx_asm!` Macro | **Partial** | CUDA inline PTX with `%0` operands, `in`, up to 8 `out` operands (each with an `=`-prefixed constraint; two or more `out`s return a tuple destructured into the output places in declaration order), up to 16 inputs, CUDA register constraints `h`, `r`, `l`, `q`, `f`, and `d`, immediate integer constraint `n`, `clobber("memory")`, and `options(register_only)` for pure register snippets. By default, snippets are treated as side-effecting and stay inside their current control flow. Use `options(register_only, may_diverge)` only for pure snippets that are safe to move across divergent control flow; **never** use it for `.sync` instructions or collectives. More than 8 outputs, read-write operands, and the `"C"` constraint are not implemented yet. |
 
 ---
 


### PR DESCRIPTION
PR #411 merged from a head that had been force-pushed from a stale clone, which dropped the maintainer follow-up commits that were on the branch at review time. This restores them on top of current main, re-validated:

- `InlinePtxOp` verifier: result count must equal the number of `=`-prefixed output constraints, with the counting logic deduplicated onto `InlinePtxOp::count_output_constraints` and used by both the verifier and the importer (plus a mid-token edge-case test).
- End-to-end coverage: the `inline_ptx` example gains a host-verified multi-output kernel (one asm block, two `=r` outputs; unequal sum/product results catch swapped register binding), documented in the example README.
- mir-lower lowering test for the multi-result struct-return conversion.
- The three stale doc sites that still said "zero or one `out`" now state the real contract (`cuda-macros` README, the `ptx_asm!` doc comment, and the supported-features appendix).

Validation: 1135 tests across dialect-nvvm / mir-importer / mir-lower / cuda-macros pass; `cargo oxide run inline_ptx` passes on an RTX 5090 including the multi-output kernel; the example directory passes `cargo clippy --all-targets -- -D warnings`; touched-crate clippy matches main's baseline exactly.