### PR TITLE
Publish the backend to the shared cache on setup

### DIFF
--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -599,12 +599,45 @@ fn auto_fetch_and_build() -> PathBuf {
     let codegen_crate = src_dir.join("crates/rustc-codegen-cuda");
     let built_so = build_backend_from_source(&codegen_crate);
     if built_so.exists() {
-        std::fs::copy(&built_so, &so_path).expect("Failed to copy backend to cache");
-        write_toolchain_fingerprint(&cache_dir);
+        install_backend_into(&cache_dir, &built_so).expect("Failed to copy backend to cache");
         eprintln!("✓ Backend cached at {}", so_path.display());
     }
 
     so_path
+}
+
+/// Copies a freshly built backend into `cache_dir` and records the toolchain
+/// fingerprint beside it.
+///
+/// The fingerprint must be written whenever the `.so` is. A `.so` installed
+/// without one falls back to the mtime checks, which cannot see a toolchain
+/// swap, so the next lookup would load a backend linked against the wrong
+/// `librustc_driver`.
+///
+/// Takes the directory explicitly so it can be exercised without touching
+/// `CARGO_HOME`.
+fn install_backend_into(cache_dir: &Path, built_so: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(cache_dir)?;
+    let so_path = cache_dir.join("librustc_codegen_cuda.so");
+    std::fs::copy(built_so, &so_path)?;
+    write_toolchain_fingerprint(cache_dir);
+    Ok(so_path)
+}
+
+/// Publishes a freshly built backend to the shared cache at
+/// `~/.cargo/cuda-oxide/`.
+///
+/// That path is what step 4 of the discovery order resolves to, and it is the
+/// only one a project outside this repository can reach: `find_workspace_root`
+/// walks up from the current directory looking for `crates/rustc-codegen-cuda`
+/// and finds nothing from an unrelated crate.
+///
+/// Returns `None` when the cache directory cannot be determined or the copy
+/// fails. Callers treat this as best effort: a failure leaves the in-repo build
+/// usable and costs external projects only a rebuild.
+pub fn publish_to_cache(built_so: &Path) -> Option<PathBuf> {
+    let cache_dir = cache_directory()?;
+    install_backend_into(&cache_dir, built_so).ok()
 }
 
 /// Returns the active rustc sysroot path (e.g., `~/.rustup/toolchains/nightly-...`).
@@ -888,6 +921,63 @@ mod tests {
             cached_backend_status(&so, Some(&dir)),
             CacheStatus::StaleVsBinary,
             "binary staleness must win over source staleness"
+        );
+    }
+
+    /// Installing must leave both the `.so` and the toolchain fingerprint in
+    /// the cache. A `.so` written without a fingerprint defers to the mtime
+    /// checks, which cannot see a toolchain swap, so the next lookup would
+    /// load a backend linked against a `librustc_driver` that no longer
+    /// resolves.
+    #[test]
+    fn installing_writes_both_the_backend_and_its_fingerprint() {
+        let dir = tempdir();
+        let source = dir.join("built.so");
+        std::fs::write(&source, b"built").unwrap();
+
+        let cache = dir.join("cache");
+        let installed = install_backend_into(&cache, &source).expect("install must succeed");
+
+        assert_eq!(
+            installed,
+            cache.join("librustc_codegen_cuda.so"),
+            "the backend must land under the cache directory"
+        );
+        assert_eq!(
+            std::fs::read(&installed).unwrap(),
+            b"built",
+            "the installed backend must be the one that was built"
+        );
+
+        // Only assert the fingerprint when a rustc is present to produce one;
+        // `write_toolchain_fingerprint` is best effort by design.
+        if current_toolchain_fingerprint().is_some() {
+            assert!(
+                cache.join(TOOLCHAIN_FINGERPRINT_FILE).exists(),
+                "installing must record the toolchain fingerprint"
+            );
+        }
+    }
+
+    /// Installing into a cache that already holds an older backend must
+    /// replace it. This is the case `cargo oxide setup` hits on every run
+    /// after the first.
+    #[test]
+    fn installing_replaces_an_existing_cached_backend() {
+        let dir = tempdir();
+        let cache = dir.join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::write(cache.join("librustc_codegen_cuda.so"), b"stale").unwrap();
+
+        let source = dir.join("built.so");
+        std::fs::write(&source, b"fresh").unwrap();
+
+        let installed = install_backend_into(&cache, &source).expect("install must succeed");
+
+        assert_eq!(
+            std::fs::read(&installed).unwrap(),
+            b"fresh",
+            "an existing cached backend must be overwritten, not kept"
         );
     }
 

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -2963,12 +2963,31 @@ pub fn setup(ctx: &Context) {
     println!("Building cuda-oxide codegen backend...");
     println!();
 
-    backend::build_backend_from_source(&ctx.codegen_crate);
+    let built_so = backend::build_backend_from_source(&ctx.codegen_crate);
 
     println!();
     println!("✓ Backend is ready. You can now use:");
     println!("  cargo oxide run <example>");
     println!("  cargo oxide build <example>");
+
+    // A project outside this repository resolves the backend through the
+    // shared cache, since `find_workspace_root` finds no
+    // `crates/rustc-codegen-cuda` above it. Publishing the build there keeps
+    // those projects on the backend that was just built instead of on whatever
+    // the cache last held.
+    match backend::publish_to_cache(&built_so) {
+        Some(path) => {
+            println!();
+            println!("✓ Published to {}", path.display());
+            println!("  Projects outside this repo will now use this build.");
+        }
+        None => {
+            eprintln!();
+            eprintln!("Warning: could not publish the backend to the shared cache.");
+            eprintln!("Projects outside this repo may keep using an older build.");
+            eprintln!("Set CUDA_OXIDE_BACKEND to this build to override.");
+        }
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #444

## Summary

`cargo oxide setup` built the backend and reported "Backend is ready" without writing it to `~/.cargo/cuda-oxide/`. That cache is step 4 of the discovery order and the only backend a project outside the repository can reach, since `find_workspace_root` finds no `crates/rustc-codegen-cuda` above an unrelated crate. `setup` now publishes what it built and reports the path, so external projects use the backend the developer just made rather than whatever the cache last held.

## Changes

- Extract `install_backend_into` from `auto_fetch_and_build`. It copies the `.so` and writes the toolchain fingerprint beside it. The fingerprint has to accompany the `.so`, or the next lookup falls back to the mtime checks, which cannot see a toolchain swap. It takes the cache directory explicitly so it is testable without touching `CARGO_HOME`.
- Add `publish_to_cache`, which resolves the cache directory and delegates.
- Call it from `setup` and report the published path. The copy is best effort: on failure it warns and points at `CUDA_OXIDE_BACKEND` rather than failing the command, since the in-repo build is still usable.
- Add two unit tests: installing writes both artifacts, and installing over an existing cached backend replaces it, which is the path `setup` takes on every run after the first.

No change to the discovery order or to the existing staleness checks.

## Testing

Unit and lint, on this branch off `main`:

```text
$ cargo test -p cargo-oxide
test backend::tests::installing_writes_both_the_backend_and_its_fingerprint ... ok
test backend::tests::installing_replaces_an_existing_cached_backend ... ok
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo clippy -p cargo-oxide --all-targets -- -D warnings
(no warnings)

$ RUSTDOCFLAGS="-D warnings" cargo doc -p cargo-oxide --no-deps
(no warnings)
```

End to end, against the bug in #444. Starting from no cache:

```text
$ rm -rf ~/.cargo/cuda-oxide
$ cargo oxide setup
✓ Backend built: .../crates/rustc-codegen-cuda/target/.../librustc_codegen_cuda.so

✓ Backend is ready. You can now use:
  cargo oxide run <example>
  cargo oxide build <example>

✓ Published to /home/<user>/.cargo/cuda-oxide/librustc_codegen_cuda.so
  Projects outside this repo will now use this build.

$ ls ~/.cargo/cuda-oxide/
librustc_codegen_cuda.so  toolchain-fingerprint.txt
```

A project outside the repository then builds against the cache alone, with `CUDA_OXIDE_BACKEND` unset. Before this change the same build failed with `FORBIDDEN CRATE IN DEVICE CODE` on `f64::acos` against a two month old cache:

```text
$ env -u CUDA_OXIDE_BACKEND cargo oxide run <external-project>
  dim    points   exp max err   log max err
    3      4096     3.220e-15     3.331e-16
   10      4096     3.331e-16     3.886e-16
   50      2048     1.665e-16     2.706e-16

PASSED
```

In-repo examples are unaffected, since they resolve to the local build at step 3:

```text
$ cargo oxide run asin_acos_smoke
SUCCESS: 14 cases × 4 variants within 2 ULP of host libm
```

- [x] `cargo oxide run <example>` passes
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable)

No example added: the change is in the build tool rather than in codegen, and the behavior is covered by the unit tests plus the end to end run above.

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)