### PR TITLE
Mark __assertfail noreturn and emit unreachable

### DIFF
--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -195,6 +195,7 @@ impl<'a> ModuleExportState<'a> {
         // Check for kernel attribute
         let kernel_key: pliron::identifier::Identifier = "gpu_kernel".try_into().unwrap();
         let attrs = &func.get_operation().deref(self.ctx).attributes;
+        let is_noreturn = crate::ops::op_noreturn(self.ctx, func.get_operation());
         let is_kernel = attrs
             .get::<pliron::builtin::attributes::StringAttr>(&kernel_key)
             .is_some();
@@ -290,6 +291,10 @@ impl<'a> ModuleExportState<'a> {
                 }
             }
             write!(output, ")").unwrap();
+
+            if is_noreturn {
+                write!(output, " noreturn").unwrap();
+            }
 
             // Check if this is a known convergent intrinsic
             let is_convergent_intrinsic = Self::is_convergent_intrinsic(&fixed_func_name);

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -1194,6 +1194,7 @@ impl<'a> ModuleExportState<'a> {
         output: &mut String,
     ) -> Result<(), String> {
         let op_ref = op.get_operation().deref(self.ctx);
+        let is_noreturn = crate::ops::op_noreturn(self.ctx, op.get_operation());
         let callee = op.callee(self.ctx);
         let func_ty = op.callee_type(self.ctx);
         let func_ty_ref = func_ty.deref(self.ctx);
@@ -1394,7 +1395,8 @@ impl<'a> ModuleExportState<'a> {
         // performs a barrier / shuffle / vote, `opt -O2` must not sink or
         // duplicate the call across divergent control flow. opt strips the
         // attribute from calls it proves never reach a convergent op.
-        writeln!(output, ") #0").unwrap();
+        let noreturn_attr = if is_noreturn { " noreturn" } else { "" };
+        writeln!(output, "){noreturn_attr} #0").unwrap();
         self.convergent_used = true;
 
         if normalize_pointer_result {

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -276,6 +276,25 @@ pub mod ops {
     /// default for user-authored inline PTX.
     const INLINE_ASM_SIDEEFFECT_KEY: &str = "cuda_oxide_inline_asm_sideeffect";
 
+    /// Op-attribute key marking a function declaration or call as non-returning.
+    const OP_NORETURN_KEY: &str = "cuda_oxide_op_noreturn";
+
+    /// Mark an LLVM function declaration or call as non-returning.
+    pub fn set_op_noreturn(ctx: &mut Context, op: Ptr<Operation>) {
+        let key = Identifier::try_new(OP_NORETURN_KEY.to_string()).expect("valid identifier");
+        op.deref_mut(ctx).attributes.set(key, BoolAttr::new(true));
+    }
+
+    /// Return whether an LLVM function declaration or call is non-returning.
+    pub fn op_noreturn(ctx: &Context, op: Ptr<Operation>) -> bool {
+        let key = Identifier::try_new(OP_NORETURN_KEY.to_string()).expect("valid identifier");
+        op.deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&key)
+            .map(|attr| bool::from((*attr).clone()))
+            .unwrap_or(false)
+    }
+
     /// Debug type metadata for a local variable described by `llvm.dbg.declare`.
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub enum DebugLocalTypeKind {

--- a/crates/mir-lower/src/convert/intrinsics/debug.rs
+++ b/crates/mir-lower/src/convert/intrinsics/debug.rs
@@ -22,6 +22,7 @@ use pliron::context::{Context, Ptr};
 use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
 use pliron::irbuild::inserter::Inserter;
 use pliron::irbuild::rewriter::Rewriter;
+use pliron::linked_list::ContainsLinkedList;
 use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
@@ -58,18 +59,39 @@ pub(crate) fn convert_assertfail(
         false,
     );
 
-    let parent_block = op.deref(ctx).get_parent_block().unwrap();
-    helpers::ensure_intrinsic_declared(ctx, parent_block, "__assertfail", func_ty)
-        .map_err(|e| pliron::input_error_noloc!("{}", e))?;
+    let parent_block = op
+        .deref(ctx)
+        .get_parent_block()
+        .ok_or_else(|| pliron::input_error_noloc!("nvvm.assertfail has no parent block"))?;
+
+    // Everything after assertfail in the same block is unreachable.
+    // Collect first, then erase in reverse order so uses disappear before defs.
+    let trailing_ops: Vec<_> = parent_block
+        .deref(ctx)
+        .iter(ctx)
+        .skip_while(|candidate| *candidate != op)
+        .skip(1)
+        .collect();
+
+    let declaration =
+        helpers::ensure_intrinsic_declared(ctx, parent_block, "__assertfail", func_ty)
+            .map_err(|error| pliron::input_error_noloc!("{error}"))?;
+    llvm::set_op_noreturn(ctx, declaration);
 
     let sym_name: pliron::identifier::Identifier = "__assertfail".try_into().unwrap();
     let callee = CallOpCallable::Direct(sym_name);
     let call_op = llvm::CallOp::new(ctx, callee, func_ty, operands);
+    llvm::set_op_noreturn(ctx, call_op.get_operation());
+
+    for dead_op in trailing_ops.into_iter().rev() {
+        rewriter.erase_operation(ctx, dead_op);
+    }
+
     rewriter.insert_operation(ctx, call_op.get_operation());
-    // AssertFailOp has no results, so there are no uses to rewire;
-    // erase the original op, the same pattern the zero-result cp.async
-    // control ops use. replace_operation trips the result-count check
-    // because the void call carries no replacement values.
+
+    let unreachable = llvm::UnreachableOp::new(ctx);
+    rewriter.insert_operation(ctx, unreachable.get_operation());
+
     rewriter.erase_operation(ctx, op);
 
     Ok(())

--- a/crates/mir-lower/src/helpers.rs
+++ b/crates/mir-lower/src/helpers.rs
@@ -262,7 +262,7 @@ pub fn create_i64_constant(
 ///
 /// # Returns
 ///
-/// `Ok(())` if the intrinsic was already declared or was successfully created,
+/// Returns the existing or newly created LLVM function declaration,
 /// or an error if the IR structure is invalid.
 ///
 /// # IR Navigation
@@ -299,7 +299,7 @@ pub fn ensure_intrinsic_declared(
     llvm_block: Ptr<BasicBlock>,
     intrinsic_name: &str,
     func_ty: pliron::r#type::TypedHandle<llvm_export::types::FuncType>,
-) -> Result<(), anyhow::Error> {
+) -> Result<Ptr<pliron::operation::Operation>, anyhow::Error> {
     // Navigate from block to parent function
     let func_op = llvm_block
         .deref(ctx)
@@ -326,25 +326,27 @@ pub fn ensure_intrinsic_declared(
         .map_err(|e| anyhow::anyhow!("Invalid intrinsic name '{}': {:?}", intrinsic_name, e))?;
 
     // Check if the intrinsic is already declared
-    let mut already_declared = false;
+    let mut existing_declaration = None;
     for existing_op in module_block.deref(ctx).iter(ctx) {
         if let Some(existing_func) =
             pliron::operation::Operation::get_op::<llvm::FuncOp>(existing_op, ctx)
             && existing_func.get_symbol_name(ctx) == sym_name
         {
-            already_declared = true;
+            existing_declaration = Some(existing_op);
             break;
         }
     }
 
     // If not declared, create a function declaration (no body)
-    if !already_declared {
-        let func_decl = llvm::FuncOp::new(ctx, sym_name, func_ty);
-        // Insert before the current function (keeps intrinsics at top of module)
-        func_decl.get_operation().insert_before(ctx, func_op);
+    if let Some(existing_declaration) = existing_declaration {
+        return Ok(existing_declaration);
     }
 
-    Ok(())
+    let func_decl = llvm::FuncOp::new(ctx, sym_name, func_ty);
+    let func_decl_op = func_decl.get_operation();
+    func_decl_op.insert_before(ctx, func_op);
+
+    Ok(func_decl_op)
 }
 
 // ============================================================================

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -138,9 +138,11 @@ use pliron::{
     irbuild::dialect_conversion::{
         DialectConversion, DialectConversionRewriter, OperandsInfo, apply_dialect_conversion,
     },
+    irbuild::{listener::Recorder, rewriter::IRRewriter},
     location::Located,
     op::{Op, op_cast},
     operation::Operation,
+    opts::simplify_cfg::remove_blocks_inside_op,
     result::Result,
     r#type::{TypeHandle, Typed, type_impls},
 };
@@ -363,6 +365,14 @@ pub fn lower_mir_to_llvm_with_options(
     // pliron's DialectConversion now reports an IRStatus (Changed/Unchanged);
     // lowering only cares about success, so discard it.
     apply_dialect_conversion(ctx, &mut conversion, module_op)?;
+    // Conversions of diverging ops (e.g. `nvvm.assertfail`) erase everything
+    // after the noreturn call, including the block's terminator. A successor
+    // whose only predecessor was that terminator is now unreachable, and if it
+    // still carries block arguments it cannot be exported (a PHI needs one
+    // incoming value per predecessor). Erase every block the entry can no
+    // longer reach.
+    let mut rewriter = IRRewriter::<Recorder>::default();
+    remove_blocks_inside_op(module_op, ctx, &mut rewriter);
     Ok(())
 }
 

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -266,7 +266,7 @@ fn test_globaltimer_lowers_to_intrinsic_call() -> Result<(), anyhow::Error> {
 }
 
 #[test]
-fn test_assertfail_lowers_to_direct_call() -> Result<(), anyhow::Error> {
+fn test_assertfail_lowers_to_noreturn_call_and_unreachable() -> Result<(), anyhow::Error> {
     use dialect_mir::types::MirPtrType;
 
     let mut ctx = Context::new();
@@ -332,6 +332,7 @@ fn test_assertfail_lowers_to_direct_call() -> Result<(), anyhow::Error> {
         nvvm::AssertFailOp::build(&mut ctx, message, file, line, function, char_size);
     assertfail_op.insert_at_back(block, &ctx);
 
+    // This return must be removed by lowering because __assertfail never returns.
     let ret_op_ptr = Operation::new(
         &mut ctx,
         mir::MirReturnOp::get_concrete_op_info(),
@@ -346,47 +347,79 @@ fn test_assertfail_lowers_to_direct_call() -> Result<(), anyhow::Error> {
     let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
     func.get_operation().insert_at_back(module_block, &ctx);
 
-    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
 
     const EXTERN: &str = "__assertfail";
 
     let mut found_decl = false;
     let mut found_call = false;
+    let mut found_unreachable = false;
+
     let module_op = module_ptr.deref(&ctx);
     let region = module_op.get_region(0);
     let block = region.deref(&ctx).iter(&ctx).next().unwrap();
 
     for op in block.deref(&ctx).iter(&ctx) {
-        let Some(func_op) = Operation::get_op::<llvm_export::ops::FuncOp>(op, &ctx) else {
+        let Some(func_op) = Operation::get_op::<llvm::FuncOp>(op, &ctx) else {
             continue;
         };
         let name = func_op.get_symbol_name(&ctx).to_string();
 
         if name == EXTERN {
             found_decl = true;
-        } else if name == func_name {
-            let func_region = func_op.get_operation().deref(&ctx).get_region(0);
-            for func_block in func_region.deref(&ctx).iter(&ctx) {
-                for body_op in func_block.deref(&ctx).iter(&ctx) {
-                    if let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx)
-                        && let CallOpCallable::Direct(sym) = call.callee(&ctx)
-                        && sym.to_string() == EXTERN
-                    {
-                        found_call = true;
-                        assert_eq!(
-                            body_op.deref(&ctx).get_num_operands(),
-                            5,
-                            "__assertfail call must forward all five operands"
-                        );
-                        // (The LLVM dialect models a void call as a single
-                        // void-typed result; the exporter prints it with no
-                        // destination, so only the operand shape matters here.)
-                    }
+            assert!(
+                llvm::op_noreturn(&ctx, func_op.get_operation()),
+                "__assertfail declaration must be marked noreturn"
+            );
+            continue;
+        }
+
+        if name != func_name {
+            continue;
+        }
+
+        let func_region = func_op.get_operation().deref(&ctx).get_region(0);
+        for func_block in func_region.deref(&ctx).iter(&ctx) {
+            let body_ops: Vec<_> = func_block.deref(&ctx).iter(&ctx).collect();
+
+            for (index, body_op) in body_ops.iter().copied().enumerate() {
+                if let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx)
+                    && let CallOpCallable::Direct(sym) = call.callee(&ctx)
+                    && sym.to_string() == EXTERN
+                {
+                    found_call = true;
+
                     assert!(
-                        Operation::get_op::<nvvm::AssertFailOp>(body_op, &ctx).is_none(),
-                        "nvvm.assertfail must be fully consumed by the lowering"
+                        llvm::op_noreturn(&ctx, body_op),
+                        "__assertfail call must be marked noreturn"
+                    );
+                    assert_eq!(
+                        body_op.deref(&ctx).get_num_operands(),
+                        5,
+                        "__assertfail call must forward all five operands"
+                    );
+                    assert!(
+                        body_ops.get(index + 1).is_some_and(|next| {
+                            Operation::get_op::<llvm::UnreachableOp>(*next, &ctx).is_some()
+                        }),
+                        "llvm.unreachable must immediately follow __assertfail"
+                    );
+                    assert_eq!(
+                        index + 2,
+                        body_ops.len(),
+                        "no operations may remain after llvm.unreachable"
                     );
                 }
+
+                if Operation::get_op::<llvm::UnreachableOp>(body_op, &ctx).is_some() {
+                    found_unreachable = true;
+                }
+
+                assert!(
+                    Operation::get_op::<nvvm::AssertFailOp>(body_op, &ctx).is_none(),
+                    "nvvm.assertfail must be fully consumed by the lowering"
+                );
             }
         }
     }
@@ -399,6 +432,29 @@ fn test_assertfail_lowers_to_direct_call() -> Result<(), anyhow::Error> {
         found_call,
         "Expected call to `{EXTERN}` in lowered kernel body"
     );
+    assert!(
+        found_unreachable,
+        "__assertfail must terminate the block with llvm.unreachable"
+    );
+
+    let module = Operation::get_op::<ModuleOp>(module_ptr, &ctx).unwrap();
+    let ir =
+        llvm_export::export::export_module_to_string(&ctx, &module).map_err(anyhow::Error::msg)?;
+
+    let declaration = ir
+        .lines()
+        .find(|line| line.contains("declare void @__assertfail("))
+        .expect("expected exported __assertfail declaration");
+    assert!(declaration.contains("noreturn"), "{ir}");
+
+    let lines: Vec<_> = ir.lines().collect();
+    let call_line = lines
+        .iter()
+        .position(|line| line.contains("call void @__assertfail("))
+        .expect("expected exported __assertfail call");
+    assert!(lines[call_line].contains("noreturn"), "{ir}");
+    assert_eq!(lines[call_line + 1].trim(), "unreachable", "{ir}");
+
     Ok(())
 }
 

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -141,6 +141,150 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn test_assertfail_orphaned_successor_block_is_removed() -> Result<(), anyhow::Error> {
+    use dialect_mir::types::MirPtrType;
+
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    dialect_nvvm::register(&mut ctx);
+    mir_lower::register(&mut ctx);
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_ptr = module.get_operation();
+
+    let func_name = "kernel_func";
+    let u8_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        8,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let ptr_ty = MirPtrType::get_generic(&mut ctx, u8_ty.into(), false);
+    let u32_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        32,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let u64_ty = pliron::builtin::types::IntegerType::get(
+        &ctx,
+        64,
+        pliron::builtin::types::Signedness::Unsigned,
+    );
+    let arg_tys: Vec<pliron::r#type::TypeHandle> = vec![
+        ptr_ty.into(),
+        ptr_ty.into(),
+        u32_ty.into(),
+        ptr_ty.into(),
+        u64_ty.into(),
+    ];
+    let func_ty = pliron::builtin::types::FunctionType::get(&ctx, arg_tys.clone(), vec![]);
+
+    let func_op_ptr = Operation::new(
+        &mut ctx,
+        mir::MirFuncOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        1,
+    );
+    let func_ty_attr = pliron::builtin::attributes::TypeAttr::new(func_ty.into());
+    let func = mir::MirFuncOp::new(&mut ctx, func_op_ptr, func_ty_attr);
+    func.set_symbol_name(&mut ctx, func_name.try_into().unwrap());
+
+    let region = func.get_operation().deref(&ctx).get_region(0);
+    let entry = {
+        let b = pliron::basic_block::BasicBlock::new(&mut ctx, None, arg_tys);
+        b.insert_at_back(region, &ctx);
+        b
+    };
+    // A block reachable only through the assert's success edge, carrying a
+    // block argument: the CFG a constant-false `gpu_assert!` leaves behind
+    // after MIR optimization folds the direct edge away.
+    let tail = {
+        let b = pliron::basic_block::BasicBlock::new(&mut ctx, None, vec![u32_ty.into()]);
+        b.insert_at_back(region, &ctx);
+        b
+    };
+
+    let message = entry.deref(&ctx).get_argument(0);
+    let file = entry.deref(&ctx).get_argument(1);
+    let line = entry.deref(&ctx).get_argument(2);
+    let function = entry.deref(&ctx).get_argument(3);
+    let char_size = entry.deref(&ctx).get_argument(4);
+
+    let assertfail_op =
+        nvvm::AssertFailOp::build(&mut ctx, message, file, line, function, char_size);
+    assertfail_op.insert_at_back(entry, &ctx);
+
+    // The success edge forwards `line` into the tail block's argument.
+    // Lowering erases this branch (the call never returns), orphaning the
+    // tail block, which then cannot be exported: a block argument needs one
+    // PHI incoming value per predecessor and there are none left.
+    let goto_op = Operation::new(
+        &mut ctx,
+        mir::MirGotoOp::get_concrete_op_info(),
+        vec![],
+        vec![line],
+        vec![tail],
+        0,
+    );
+    goto_op.insert_at_back(entry, &ctx);
+
+    let ret_op = Operation::new(
+        &mut ctx,
+        mir::MirReturnOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![],
+        0,
+    );
+    ret_op.insert_at_back(tail, &ctx);
+
+    let module_region = module.get_operation().deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let mut found_kernel = false;
+    let module_op = module_ptr.deref(&ctx);
+    let region = module_op.get_region(0);
+    let block = region.deref(&ctx).iter(&ctx).next().unwrap();
+    for op in block.deref(&ctx).iter(&ctx) {
+        let Some(func_op) = Operation::get_op::<llvm::FuncOp>(op, &ctx) else {
+            continue;
+        };
+        if func_op.get_symbol_name(&ctx).to_string() != func_name {
+            continue;
+        }
+        found_kernel = true;
+        let func_region = func_op.get_operation().deref(&ctx).get_region(0);
+        let blocks: Vec<_> = func_region.deref(&ctx).iter(&ctx).collect();
+        for block in blocks.iter().skip(1) {
+            assert!(
+                !block.preds(&ctx).is_empty(),
+                "an unreachable block survived lowering; with block arguments \
+                 it cannot be exported (a PHI needs an incoming value per \
+                 predecessor and there are none)"
+            );
+        }
+    }
+    assert!(found_kernel, "Kernel function not found");
+
+    let module = Operation::get_op::<ModuleOp>(module_ptr, &ctx).unwrap();
+    let ir =
+        llvm_export::export::export_module_to_string(&ctx, &module).map_err(anyhow::Error::msg)?;
+    let lines: Vec<_> = ir.lines().collect();
+    let call_line = lines
+        .iter()
+        .position(|line| line.contains("call void @__assertfail("))
+        .expect("expected exported __assertfail call");
+    assert_eq!(lines[call_line + 1].trim(), "unreachable", "{ir}");
+
+    Ok(())
+}
+
+#[test]
 fn test_globaltimer_lowers_to_intrinsic_call() -> Result<(), anyhow::Error> {
     let mut ctx = Context::new();
     dialect_mir::register(&mut ctx);


### PR DESCRIPTION
Closes #452 

## Summary

Model CUDA's device-side `__assertfail` system call as non-returning in the LLVM lowering.

The assertion lowering now emits a `noreturn` declaration and call, terminates the block with `llvm.unreachable`, and removes operations that would otherwise remain after the assertion failure.

## Changes

* Add an internal LLVM operation marker for `noreturn`.
* Export `noreturn` on marked function declarations.
* Export `noreturn` on marked call instructions.
* Return the existing or newly created declaration from `ensure_intrinsic_declared`.
* Mark the `__assertfail` declaration and call as non-returning.
* Emit `llvm.unreachable` immediately after the call.
* Remove the unreachable suffix of the containing block.
* Extend the `__assertfail` lowering test to verify:

  * the declaration marker;
  * the call marker;
  * all five forwarded operands;
  * immediate `llvm.unreachable`;
  * removal of the trailing return;
  * textual LLVM IR containing `noreturn`.

## Generated LLVM IR

Before:

```llvm
declare void @__assertfail(ptr, ptr, i32, ptr, i64)

call void @__assertfail(...)
br label %continue
```

After:

```llvm
declare void @__assertfail(ptr, ptr, i32, ptr, i64) noreturn

call void @__assertfail(...) noreturn
unreachable
```

## Behavior

Runtime assertion behavior is unchanged:

* the CUDA driver prints the assertion message with source location;
* synchronization reports `CUDA_ERROR_ASSERT`;
* execution does not continue after the failing assertion.

The change makes that existing runtime contract explicit in LLVM IR so optimization passes can remove dead control flow after the assertion.

## Validation

* [ ] `cargo fmt --all -- --check`
* [ ] `cargo test -p llvm-export`
* [ ] `cargo test -p mir-lower --test lowering_test test_assertfail_lowers_to_noreturn_call_and_unreachable -- --exact --nocapture`
* [ ] `cargo test -p mir-lower`
* [ ] `cargo check`
* [ ] `cargo oxide pipeline debug`
* [ ] Confirm the exported declaration and call contain `noreturn`
* [ ] Confirm `unreachable` immediately follows the call
* [ ] `cargo oxide run debug`
* [ ] `cargo oxide run debug -- --fail-assert`
