### PR TITLE
Document gpu_assert! device assertion behavior

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -310,7 +310,8 @@ pub fn resolve_doctor_context() -> Context {
 ///
 /// Cleans stale artifacts, sets encoded rustc flags to point at the backend `.so`,
 /// and invokes `cargo run --release` from the example directory. Environment
-/// variables control output format (PTX / NVVM IR) and verbosity.
+/// variables control output format (PTX / NVVM IR) and verbosity. Trailing
+/// `app_args` are forwarded to the example binary after `--`.
 #[allow(clippy::too_many_arguments)]
 pub fn codegen_run(
     ctx: &Context,
@@ -322,6 +323,7 @@ pub fn codegen_run(
     bin: Option<&str>,
     no_fmad: bool,
     materialize_cubin: bool,
+    app_args: &[String],
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -364,6 +366,7 @@ pub fn codegen_run(
             bin,
             no_fmad,
             &materialization,
+            app_args,
         );
         return;
     }
@@ -412,6 +415,9 @@ pub fn codegen_run(
     }
     if let Some(features) = features {
         cmd.args(["--features", features]);
+    }
+    if !app_args.is_empty() {
+        cmd.arg("--").args(app_args);
     }
 
     apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad);
@@ -598,6 +604,7 @@ fn codegen_run_interop(
     bin: Option<&str>,
     no_fmad: bool,
     materialization: &MaterializationMode,
+    app_args: &[String],
 ) {
     reject_interop_output_mode(emit_nvvm_ir, materialization);
 
@@ -622,7 +629,16 @@ fn codegen_run_interop(
         InteropDeviceBuildOptions::standard(no_fmad),
         materialization,
     );
-    run_host_cargo(ctx, example, example_dir, "run", features, bin, verbose);
+    run_host_cargo(
+        ctx,
+        example,
+        example_dir,
+        "run",
+        features,
+        bin,
+        verbose,
+        app_args,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -660,7 +676,16 @@ fn codegen_build_interop(
         InteropDeviceBuildOptions::standard(no_fmad),
         materialization,
     );
-    run_host_cargo(ctx, example, example_dir, "build", features, None, verbose);
+    run_host_cargo(
+        ctx,
+        example,
+        example_dir,
+        "build",
+        features,
+        None,
+        verbose,
+        &[],
+    );
 }
 
 fn reject_interop_output_mode(emit_nvvm_ir: bool, materialization: &MaterializationMode) {
@@ -791,6 +816,7 @@ fn build_interop_device_crate(
     println!("PTX written: {}", ptx_path.display());
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_host_cargo(
     ctx: &Context,
     example: &str,
@@ -799,6 +825,7 @@ fn run_host_cargo(
     features: Option<&str>,
     bin: Option<&str>,
     verbose: bool,
+    app_args: &[String],
 ) {
     let mut cmd = Command::new("cargo");
     cmd.arg(cargo_subcommand)
@@ -812,6 +839,9 @@ fn run_host_cargo(
     }
     if let Some(features) = features {
         cmd.args(["--features", features]);
+    }
+    if cargo_subcommand == "run" && !app_args.is_empty() {
+        cmd.arg("--").args(app_args);
     }
 
     apply_config_env(&mut cmd, ctx);

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -12,6 +12,7 @@
 //!
 //! ```bash
 //! cargo oxide run vecadd              # build + run an example
+//! cargo oxide run debug -- --fail-assert  # forward args to the example binary
 //! cargo oxide build vecadd            # build only
 //! cargo oxide pipeline vecadd         # verbose pipeline dump
 //! cargo oxide sanitize vecadd         # run under NVIDIA Compute Sanitizer
@@ -86,6 +87,10 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Arguments forwarded to the example binary. Use after `--`,
+        /// e.g. `cargo oxide run debug -- --fail-assert`.
+        #[arg(last = true, num_args = 0.., allow_hyphen_values = true)]
+        app_args: Vec<String>,
     },
     /// Build and run an example or project under NVIDIA Compute Sanitizer
     Sanitize {
@@ -388,6 +393,7 @@ fn main() {
             bin,
             verbose,
             no_fmad,
+            app_args,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "run");
@@ -408,6 +414,7 @@ fn main() {
                 bin.as_deref(),
                 no_fmad,
                 materialize_cubin,
+                &app_args,
             );
         }
         Commands::Sanitize {
@@ -810,6 +817,39 @@ mod tests {
             panic!("expected build command");
         };
         assert!(cargo_args.is_empty());
+    }
+
+    #[test]
+    fn run_parser_forwards_trailing_application_args() {
+        let cli = Cli::try_parse_from([
+            "cargo-oxide",
+            "run",
+            "debug",
+            "--",
+            "--fail-assert",
+            "positional",
+        ])
+        .expect("run command with trailing args should parse");
+
+        let Commands::Run {
+            example, app_args, ..
+        } = cli.command
+        else {
+            panic!("expected run command");
+        };
+        assert_eq!(example.as_deref(), Some("debug"));
+        assert_eq!(app_args, strings(&["--fail-assert", "positional"]));
+    }
+
+    #[test]
+    fn run_parser_defaults_to_no_application_args() {
+        let cli =
+            Cli::try_parse_from(["cargo-oxide", "run", "debug"]).expect("run command should parse");
+
+        let Commands::Run { app_args, .. } = cli.command else {
+            panic!("expected run command");
+        };
+        assert!(app_args.is_empty());
     }
 
     #[test]

--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -149,14 +149,27 @@ use cuda_device::{gpu_printf, gpu_assert};
 #[kernel]
 pub fn debug_kernel(data: &[f32]) {
     let idx = thread::index_1d();
-    gpu_printf!("thread %d: val = %f\n", idx.get() as i32, data[idx.get()] as f64);
-    gpu_assert!(data[idx.get()] >= 0.0);
+    let value = data[idx.get()];
+
+    gpu_printf!(
+        "thread %d: val = %f\n",
+        idx.get() as i32,
+        value as f64
+    );
+    gpu_assert!(value >= 0.0, "expected non-negative value");
 }
 ```
 
 `gpu_printf!` compiles to device-side `vprintf` with C vararg promotion.
-`gpu_assert!` traps on failure. The `debug` module also exposes GPU timing
-register reads such as `clock64()` and `globaltimer()`.
+
+`gpu_assert!(condition)` uses `trap()` when the condition is false. The
+string-literal message form, `gpu_assert!(condition, "message")`, calls CUDA's
+device-side `__assertfail` system call. The CUDA driver reports the assertion
+message and call-site metadata, and synchronization returns
+`CUDA_ERROR_ASSERT`.
+
+The `debug` module also exposes GPU timing register reads such as `clock64()`
+and `globaltimer()`.
 
 ## Proc-Macro Re-exports
 

--- a/crates/rustc-codegen-cuda/examples/debug/README.md
+++ b/crates/rustc-codegen-cuda/examples/debug/README.md
@@ -142,15 +142,22 @@ cargo oxide run debug -- --fail-assert
 
 The failing mode runs separately because a device-side assertion leaves the
 current CUDA context in an error state. The CUDA driver prints the assertion
-diagnostic to stderr, and synchronization reports `CUDA_ERROR_ASSERT`.
+diagnostic to stderr, and synchronization reports `CUDA_ERROR_ASSERT`:
+
+```text
+--- Failing mode: gpu_assert!() with negative input ---
+src/main.rs:117: debug::kernels: block: [0,0,0], thread: [2,0,0] Assertion `Expected non-negative value` failed.
+✓ assertion failure surfaced as expected: DriverError(710, "device-side assert triggered")
+  (assertion message printed to stderr by the CUDA driver)
+```
 
 ## Expected Output
 
 ```text
 === GPU Debug & Utility Intrinsics Test (Unified) ===
 
---- Test 1: clock64() cycle measurement ---
-  Average cycles for 100 iterations: ~500-2000
+--- Test 1: clock64() / globaltimer() measurement ---
+  Average cycles for 100 iterations: <varies by GPU>
 ✓ clock_test completed
 
 --- Test 2: trap() with valid input ---
@@ -172,7 +179,9 @@ diagnostic to stderr, and synchronization reports `CUDA_ERROR_ASSERT`.
 ✓ profiler_test PASSED
 
 --- Test 6: #[launch_bounds(128, 4)] ---
-  ✓ launch_bounds_test PASSED
+  Input:  [1, 2, 3, 4, 5, 6, 7, 8]
+  Output: [4, 7, 10, 13, 16, 19, 22, 25]
+✓ launch_bounds_test PASSED
   (Check PTX for .maxntid 128 .minnctapersm 4)
 
 === ALL DEBUG TESTS COMPLETED ===

--- a/crates/rustc-codegen-cuda/examples/debug/README.md
+++ b/crates/rustc-codegen-cuda/examples/debug/README.md
@@ -74,6 +74,12 @@ pub fn assert_test(input: &[i32], mut output: DisjointSlice<i32>) {
 }
 ```
 
+The two forms intentionally use different failure mechanisms:
+
+- `gpu_assert!(condition)` lowers to `trap()`.
+- `gpu_assert!(condition, "message")` lowers to CUDA's device-side
+  `__assertfail` system call and reports the message and call-site metadata.
+
 ### Breakpoints (cuda-gdb)
 
 ```rust
@@ -127,8 +133,16 @@ pub fn launch_bounds_test(...) {
 ## Build and Run
 
 ```bash
+# Run the non-failing debug suite.
 cargo oxide run debug
+
+# Run the isolated assertion-failure path.
+cargo oxide run debug -- --fail-assert
 ```
+
+The failing mode runs separately because a device-side assertion leaves the
+current CUDA context in an error state. The CUDA driver prints the assertion
+diagnostic to stderr, and synchronization reports `CUDA_ERROR_ASSERT`.
 
 ## Expected Output
 
@@ -173,13 +187,14 @@ cargo oxide run debug
 
 ## Debug Functions
 
-| Function              | PTX Instruction          | Purpose            |
-|-----------------------|--------------------------|--------------------|
-| `clock64()`           | `mov.u64 %rd, %clock64`  | Cycle counter      |
-| `trap()`              | `trap`                   | Abort kernel       |
-| `gpu_assert!()`       | `trap` (on failure)      | Runtime assertion  |
-| `breakpoint()`        | `brkpt`                  | Debugger break     |
-| `prof_trigger::<N>()` | `pmevent N`              | Profiler marker    |
+| Function                            | PTX Instruction         | Purpose                               |
+|-------------------------------------|-------------------------|---------------------------------------|
+| `clock64()`                         | `mov.u64 %rd, %clock64` | Cycle counter                         |
+| `trap()`                            | `trap`                  | Abort kernel                          |
+| `gpu_assert!(condition)`            | `trap`                  | Assertion without diagnostic metadata |
+| `gpu_assert!(condition, "message")` | `call.uni __assertfail` | CUDA assertion diagnostic             |
+| `breakpoint()`                      | `brkpt`                 | Debugger break                        |
+| `prof_trigger::<N>()`               | `pmevent N`             | Profiler marker                       |
 
 ## Launch Bounds Explained
 

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -69,7 +69,8 @@ and 65,536 cloned operations. Larger requests warn and are not unrolled.
 use cuda_device::{gpu_printf, gpu_assert, ptx_asm};
 
 gpu_printf!("thread %d: val = %f\n", idx as i32, val as f64);
-gpu_assert!(val >= 0.0);
+gpu_assert!(val.is_finite());
+gpu_assert!(val >= 0.0, "expected non-negative value");
 
 let y: u32;
 unsafe {
@@ -77,11 +78,16 @@ unsafe {
 }
 ```
 
-| Macro                        | Purpose                                              |
-|:-----------------------------|:-----------------------------------------------------|
-| `gpu_printf!(fmt, args...)`  | Device-side formatted output (lowers to `vprintf`)   |
-| `gpu_assert!(condition)`     | Runtime assertion; calls `trap()` on failure         |
-| `ptx_asm!(...)`              | Unsafe CUDA inline PTX                               |
+| Macro                               | Purpose                                                           |
+|:------------------------------------|:------------------------------------------------------------------|
+| `gpu_printf!(fmt, args...)`         | Device-side formatted output (lowers to `vprintf`)                |
+| `gpu_assert!(condition)`            | Runtime assertion; calls `trap()` on failure                      |
+| `gpu_assert!(condition, "message")` | Runtime assertion with CUDA diagnostic; message must be a literal |
+| `ptx_asm!(...)`                     | Unsafe CUDA inline PTX                                            |
+
+The message form lowers to CUDA's device-side `__assertfail` system call.
+The driver reports the message and call-site metadata, and synchronization
+returns `CUDA_ERROR_ASSERT`.
 
 ---
 

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -177,7 +177,7 @@ aggregate relocations can be represented without losing provenance.
 | Feature | Status | Description |
 |:--------|:-------|:------------|
 | `gpu_printf!` Macro | **Full** | Formatted GPU output with full format specifier support. Lowers to `vprintf`. |
-| `gpu_assert!` Macro | **Full** | Runtime GPU assertion. Calls `trap()` if condition is false. |
+| `gpu_assert!` Macro | **Full** | The no-message form calls `trap()` on failure. The string-literal message form calls CUDA's device-side `__assertfail`, reports message and call-site metadata, and surfaces `CUDA_ERROR_ASSERT`. |
 | Debug Intrinsics | **Full** | `clock()`, `clock64()`, `trap()`, `breakpoint()`, `prof_trigger::<N>()`. |
 
 ## Runtime Library: Kernel Launch

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -9,18 +9,23 @@ problems.
 
 ## What happens when a kernel goes wrong
 
-GPU errors fall into three categories:
+GPU errors fall into four categories:
 
-| Failure mode           | What you see                             | Example                                            |
-|:-----------------------|:-----------------------------------------|:---------------------------------------------------|
-| **Silent corruption**  | Wrong results, no error                  | Race condition, off-by-one index                   |
-| **Hardware trap**      | `CUDA_ERROR_ILLEGAL_INSTRUCTION` on host | `gpu_assert!` failure, panic, OOB access           |
-| **Launch failure**     | `DriverError` returned immediately       | Wrong grid dims, missing module, out of resources  |
+| Failure mode          | What you see                                  | Example                                                |
+|:----------------------|:----------------------------------------------|:-------------------------------------------------------|
+| **Silent corruption** | Wrong results, no error                       | Race condition, off-by-one index                       |
+| **Hardware trap**     | `CUDA_ERROR_ILLEGAL_INSTRUCTION` on sync      | `debug::trap()`, no-message `gpu_assert!`, panic, OOB  |
+| **Device assertion**  | Assertion diagnostic plus `CUDA_ERROR_ASSERT` | `gpu_assert!(condition, "message")`                    |
+| **Launch failure**    | `DriverError` returned immediately            | Wrong grid dims, missing module, out of resources      |
 
-The CUDA toolchain does not expose an exception mechanism today (the hardware
-could support it, but nvcc/ptxas do not wire it up). A trap instruction kills
-the kernel and poisons the CUDA context -- subsequent operations on the same
-context will fail until you handle or recreate it.
+The CUDA toolchain does not expose an exception or stack-unwinding mechanism
+today. A hardware trap terminates the kernel without structured assertion
+metadata. CUDA's device-side `__assertfail` system call also terminates
+execution, but reports the assertion message and call-site metadata before
+synchronization returns `CUDA_ERROR_ASSERT`.
+
+Both failures are asynchronous device errors and normally surface when the
+stream or context is synchronized.
 
 ## `gpu_printf!` -- printing from the GPU
 
@@ -63,7 +68,7 @@ requires dynamic dispatch, string allocation, and I/O -- none of which exist on
 the GPU. `gpu_printf!` bypasses all of this by lowering directly to a CUDA
 `vprintf` call.
 
-## `gpu_assert!` and `trap()`
+## `gpu_assert!`, `__assertfail`, and `trap()`
 
 For fatal error checking on the device, use `gpu_assert!` or `debug::trap()`:
 
@@ -73,7 +78,15 @@ use cuda_device::{kernel, thread, debug, gpu_assert, DisjointSlice};
 #[kernel]
 pub fn checked_kernel(data: &[f32], len: u32, mut out: DisjointSlice<f32>) {
     let idx = thread::index_1d();
-    gpu_assert!(idx.get() < len as usize);   // traps if false
+
+    // No-message form: lowers to trap()
+    gpu_assert!(idx.get() < len as usize);
+
+    // String-literal message form: lowers to CUDA's __assertfail
+    gpu_assert!(
+        data[idx.get()] >= 0.0,
+        "expected non-negative input"
+    );
 
     if let Some(out_elem) = out.get_mut(idx) {
         *out_elem = data[idx.get()];
@@ -81,29 +94,40 @@ pub fn checked_kernel(data: &[f32], len: u32, mut out: DisjointSlice<f32>) {
 }
 ```
 
-| Intrinsic                | What it does                | Host effect                                    |
-|:-------------------------|:----------------------------|:-----------------------------------------------|
-| `gpu_assert!(condition)` | Traps if condition is false | `CUDA_ERROR_ILLEGAL_INSTRUCTION`               |
-| `debug::trap()`          | Unconditional trap          | `CUDA_ERROR_ILLEGAL_INSTRUCTION`               |
-| `debug::breakpoint()`    | Emit `brkpt` instruction    | Pauses in cuda-gdb; crashes without debugger   |
+| Operation                           | Device behavior                         | Host effect                          |
+| :---------------------------------- | :-------------------------------------- | :----------------------------------- |
+| `gpu_assert!(condition)`            | Executes `trap()` if false              | `CUDA_ERROR_ILLEGAL_INSTRUCTION`     |
+| `gpu_assert!(condition, "message")` | Calls CUDA's device-side `__assertfail` | Diagnostic plus `CUDA_ERROR_ASSERT`  |
+| `debug::trap()`                     | Executes an unconditional trap          | `CUDA_ERROR_ILLEGAL_INSTRUCTION`     |
+| `debug::breakpoint()`               | Emits `brkpt`                           | Pauses in cuda-gdb; fails without it |
 
-### The trap-and-check pattern
+The message passed to `gpu_assert!` must be a string literal. Formatted
+assertion messages are not currently supported.
 
-A common workflow for catching device-side errors:
+### The launch-and-synchronize pattern
+
+Device failures are normally reported when the stream is synchronized:
 
 ```rust
-// Launch kernel
+// Launch kernel.
 // SAFETY: config matches vecadd's 1D indexing and all buffer bounds.
 unsafe { module.vecadd(&stream, config, &a, &b, &mut c) }
     .expect("Launch failed");
 
-// Synchronize and check for traps
-stream.synchronize().expect("Kernel trapped -- check gpu_assert! conditions");
+// Surface asynchronous traps or device assertions.
+stream.synchronize().expect("Kernel failed on the device");
 ```
 
-If a `gpu_assert!` fires, synchronization returns an error. The error message
-doesn't tell you *which* assertion failed, so use `gpu_printf!` alongside
-assertions to narrow down the problem.
+For `gpu_assert!(condition, "message")`, the CUDA driver prints the message,
+source file, source line, and module context before synchronization returns
+`CUDA_ERROR_ASSERT`.
+
+The no-message form does not carry assertion metadata. Use the message form
+when identifying the failing check matters, or use `gpu_printf!` when runtime
+values also need to be inspected.
+
+Ordinary Rust `assert!`, `debug_assert!`, and `panic!` paths are unchanged and
+continue to use the existing trap-based behavior.
 
 ## Host-side error handling
 

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -25,7 +25,8 @@ execution, but reports the assertion message and call-site metadata before
 synchronization returns `CUDA_ERROR_ASSERT`.
 
 Both failures are asynchronous device errors and normally surface when the
-stream or context is synchronized.
+stream or context is synchronized. Both also leave the CUDA context unusable:
+subsequent operations on the same context keep failing until you recreate it.
 
 ## `gpu_printf!` -- printing from the GPU
 

--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -25,8 +25,11 @@ execution, but reports the assertion message and call-site metadata before
 synchronization returns `CUDA_ERROR_ASSERT`.
 
 Both failures are asynchronous device errors and normally surface when the
-stream or context is synchronized. Both also leave the CUDA context unusable:
-subsequent operations on the same context keep failing until you recreate it.
+stream or context is synchronized. Both also leave the CUDA context unusable,
+but recovery differs: after a device assert (`CUDA_ERROR_ASSERT`), destroy and
+recreate the context to keep using CUDA; after a hardware trap
+(`CUDA_ERROR_ILLEGAL_INSTRUCTION`), CUDA documents the whole process as
+poisoned, so terminate and relaunch it.
 
 ## `gpu_printf!` -- printing from the GPU
 
@@ -501,7 +504,7 @@ for the full profiling toolkit.
 :align: center
 :width: 100%
 
-Debugging decision tree: kernel problems fall into three categories (compile
-error, runtime trap, silent corruption), each with different diagnostic tools.
-Common fixes are shown at the bottom.
+Debugging decision tree: kernel problems fall into three branches (compile
+error, runtime device failure, silent corruption), each with different
+diagnostic tools. Common fixes are shown at the bottom.
 ```

--- a/cuda-oxide-book/gpu-programming/images/debug-workflow.svg
+++ b/cuda-oxide-book/gpu-programming/images/debug-workflow.svg
@@ -67,13 +67,13 @@
     <text x="160" y="88" text-anchor="middle" font-size="12" fill="#b1bac4">Read compiler diagnostics</text>
   </g>
 
-  <!-- ==================== BRANCH 2: Runtime trap (amber) ==================== -->
+  <!-- ==================== BRANCH 2: Runtime device failure (amber) ==================== -->
   <g transform="translate(470, 240)">
     <rect width="320" height="80" rx="12" fill="#161b22" filter="url(#shadow)"/>
     <rect width="320" height="80" rx="12" fill="none" stroke="#e8912d" stroke-width="2"/>
-    <text x="160" y="32" text-anchor="middle" font-size="16" font-weight="700" fill="#e8912d">Runtime trap</text>
-    <text x="160" y="56" text-anchor="middle" font-size="13" fill="#c9d1d9">ILLEGAL_INSTRUCTION,</text>
-    <text x="160" y="72" text-anchor="middle" font-size="13" fill="#c9d1d9">gpu_assert! failure, panic</text>
+    <text x="160" y="32" text-anchor="middle" font-size="16" font-weight="700" fill="#e8912d">Runtime device failure</text>
+    <text x="160" y="56" text-anchor="middle" font-size="13" fill="#c9d1d9">ILLEGAL_INSTRUCTION / ASSERT,</text>
+    <text x="160" y="72" text-anchor="middle" font-size="13" fill="#c9d1d9">trap, panic, gpu_assert!</text>
   </g>
 
   <line x1="630" y1="320" x2="630" y2="362" stroke="#e8912d" stroke-width="2" opacity="0.7"/>
@@ -86,7 +86,7 @@
     <text x="85" y="62" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" fill="#e8912d">gpu_printf!</text>
     <rect x="166" y="42" width="138" height="30" rx="6" fill="rgba(232, 145, 45, 0.12)"/>
     <text x="235" y="62" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" fill="#e8912d">cargo oxide debug</text>
-    <text x="160" y="88" text-anchor="middle" font-size="12" fill="#b1bac4">Print values, step in cuda-gdb</text>
+    <text x="160" y="88" text-anchor="middle" font-size="12" fill="#b1bac4">Read diagnostics, step in cuda-gdb</text>
   </g>
 
   <!-- ==================== BRANCH 3: Silent corruption (purple) ==================== -->


### PR DESCRIPTION
Closes #468 

## Summary

Update the general documentation to reflect the device assertion behavior implemented by #440 and completed by #453.

`gpu_assert!` has two distinct failure paths:

* `gpu_assert!(condition)` lowers to `trap()`.
* `gpu_assert!(condition, "message")` lowers to CUDA's device-side `__assertfail`, reports the assertion message and call-site metadata, and surfaces `CUDA_ERROR_ASSERT`.

Several documentation pages still described both forms as hardware traps producing `CUDA_ERROR_ILLEGAL_INSTRUCTION`.

## Changes

* Update the `cuda-device` README to distinguish the two macro forms.
* Rewrite the `gpu_assert!` section of the error-handling chapter.
* Separate hardware traps from CUDA device assertions in the failure-mode table.
* Update the supported-features matrix.
* Update the API quick reference with both macro signatures.
* Document the debug example's isolated `--fail-assert` mode.
* Update the debug example's instruction table.
* Update the debugging workflow SVG so it covers both illegal-instruction traps and CUDA assertion failures.

## Documented behavior

| Form                                | Lowering                       | Host-visible result                          |
| :---------------------------------- | :----------------------------- | :------------------------------------------- |
| `gpu_assert!(condition)`            | `trap()`                       | `CUDA_ERROR_ILLEGAL_INSTRUCTION`             |
| `gpu_assert!(condition, "message")` | `__assertfail` + `unreachable` | Assertion diagnostic and `CUDA_ERROR_ASSERT` |

Messages remain restricted to string literals. Formatted messages and ordinary Rust `assert!` lowering are unchanged.

## Scope

This is a documentation-only change. It does not modify macro expansion, MIR import, LLVM lowering, optimization, PTX generation, or runtime behavior.

## Validation

* [ ] Review all modified Markdown tables and code blocks.
* [ ] Confirm every updated page distinguishes the no-message and message forms.
* [ ] Confirm ordinary Rust panic and assertion documentation remains trap-based.
* [ ] Validate the SVG as XML:

```bash
xmllint --noout \
  cuda-oxide-book/gpu-programming/images/debug-workflow.svg
```

* [ ] Confirm the debug commands documented in the example match the implementation:

```bash
cargo oxide run debug
cargo oxide run debug -- --fail-assert
```
