### PR TITLE
feat(cuda-device): add f32 and f64 warp reduce utilities

### DIFF
--- a/crates/cuda-device/src/warp.rs
+++ b/crates/cuda-device/src/warp.rs
@@ -918,6 +918,148 @@ pub fn is_elected_sync(mask: u32) -> bool {
     elect_sync(mask).1
 }
 
+// =============================================================================
+// Warp-Level Reductions (f32)
+// =============================================================================
+//
+// Butterfly shuffle reduction utilities for f32 values. These use
+// `shuffle_xor_f32` with a full-warp mask (0xFFFF_FFFF) to reduce a
+// value across all 32 lanes, producing the result in every lane.
+
+/// Reduce-sum a scalar f32 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the sum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f32 = per_lane_value;
+/// let total = warp::reduce_sum_f32(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_sum_f32(mut val: f32) -> f32 {
+    val = val + shuffle_xor_f32(val, 16);
+    val = val + shuffle_xor_f32(val, 8);
+    val = val + shuffle_xor_f32(val, 4);
+    val = val + shuffle_xor_f32(val, 2);
+    val = val + shuffle_xor_f32(val, 1);
+    val
+}
+
+/// Reduce-max a scalar f32 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the maximum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f32 = per_lane_value;
+/// let global_max = warp::reduce_max_f32(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_max_f32(mut val: f32) -> f32 {
+    val = f32::max(val, shuffle_xor_f32(val, 16));
+    val = f32::max(val, shuffle_xor_f32(val, 8));
+    val = f32::max(val, shuffle_xor_f32(val, 4));
+    val = f32::max(val, shuffle_xor_f32(val, 2));
+    val = f32::max(val, shuffle_xor_f32(val, 1));
+    val
+}
+
+/// Reduce-min a scalar f32 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the minimum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f32 = per_lane_value;
+/// let global_min = warp::reduce_min_f32(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_min_f32(mut val: f32) -> f32 {
+    val = f32::min(val, shuffle_xor_f32(val, 16));
+    val = f32::min(val, shuffle_xor_f32(val, 8));
+    val = f32::min(val, shuffle_xor_f32(val, 4));
+    val = f32::min(val, shuffle_xor_f32(val, 2));
+    val = f32::min(val, shuffle_xor_f32(val, 1));
+    val
+}
+
+// =============================================================================
+// Warp-Level Reductions (f64)
+// =============================================================================
+//
+// Butterfly shuffle reduction utilities for f64 values. These use
+// `shuffle_xor_f64` with a full-warp mask (0xFFFF_FFFF) to reduce a
+// value across all 32 lanes, producing the result in every lane.
+
+/// Reduce-sum a scalar f64 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the sum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f64 = per_lane_value;
+/// let total = warp::reduce_sum_f64(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_sum_f64(mut val: f64) -> f64 {
+    val = val + shuffle_xor_f64(val, 16);
+    val = val + shuffle_xor_f64(val, 8);
+    val = val + shuffle_xor_f64(val, 4);
+    val = val + shuffle_xor_f64(val, 2);
+    val = val + shuffle_xor_f64(val, 1);
+    val
+}
+
+/// Reduce-max a scalar f64 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the maximum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f64 = per_lane_value;
+/// let global_max = warp::reduce_max_f64(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_max_f64(mut val: f64) -> f64 {
+    val = f64::max(val, shuffle_xor_f64(val, 16));
+    val = f64::max(val, shuffle_xor_f64(val, 8));
+    val = f64::max(val, shuffle_xor_f64(val, 4));
+    val = f64::max(val, shuffle_xor_f64(val, 2));
+    val = f64::max(val, shuffle_xor_f64(val, 1));
+    val
+}
+
+/// Reduce-min a scalar f64 across all 32 lanes using butterfly shuffles.
+///
+/// After this call, every lane holds the minimum of all input values.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let val: f64 = per_lane_value;
+/// let global_min = warp::reduce_min_f64(val);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn reduce_min_f64(mut val: f64) -> f64 {
+    val = f64::min(val, shuffle_xor_f64(val, 16));
+    val = f64::min(val, shuffle_xor_f64(val, 8));
+    val = f64::min(val, shuffle_xor_f64(val, 4));
+    val = f64::min(val, shuffle_xor_f64(val, 2));
+    val = f64::min(val, shuffle_xor_f64(val, 1));
+    val
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cuda-device/src/warp.rs
+++ b/crates/cuda-device/src/warp.rs
@@ -27,19 +27,15 @@
 //!     let gid = thread::index_1d();
 //!     let lane = warp::lane_id();
 //!
-//!     let mut val = data[gid.get()];
+//!     let val = data[gid.get()];
 //!
-//!     // Butterfly reduction using shuffle_xor
-//!     val = val + warp::shuffle_xor_f32(val, 16);
-//!     val = val + warp::shuffle_xor_f32(val, 8);
-//!     val = val + warp::shuffle_xor_f32(val, 4);
-//!     val = val + warp::shuffle_xor_f32(val, 2);
-//!     val = val + warp::shuffle_xor_f32(val, 1);
+//!     // Butterfly reduction across the full warp; every lane gets the sum.
+//!     let sum = warp::reduce_sum_f32(val);
 //!
-//!     // Lane 0 has the sum
+//!     // Every lane holds the sum; lane 0 writes it out.
 //!     if lane == 0 {
 //!         let warp_idx = gid.get() / 32;
-//!         *out.get_unchecked_mut(warp_idx) = val;
+//!         *out.get_unchecked_mut(warp_idx) = sum;
 //!     }
 //! }
 //! ```
@@ -930,6 +926,15 @@ pub fn is_elected_sync(mask: u32) -> bool {
 ///
 /// After this call, every lane holds the sum of all input values.
 ///
+/// Any NaN input propagates to every lane, as with ordinary `f32` addition.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -951,6 +956,16 @@ pub fn reduce_sum_f32(mut val: f32) -> f32 {
 ///
 /// After this call, every lane holds the maximum of all input values.
 ///
+/// A NaN in one lane is ignored because `f32::max` returns the non-NaN
+/// operand; the result is NaN only if every lane holds NaN.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -971,6 +986,16 @@ pub fn reduce_max_f32(mut val: f32) -> f32 {
 /// Reduce-min a scalar f32 across all 32 lanes using butterfly shuffles.
 ///
 /// After this call, every lane holds the minimum of all input values.
+///
+/// A NaN in one lane is ignored because `f32::min` returns the non-NaN
+/// operand; the result is NaN only if every lane holds NaN.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
 ///
 /// # Example
 ///
@@ -1001,6 +1026,15 @@ pub fn reduce_min_f32(mut val: f32) -> f32 {
 ///
 /// After this call, every lane holds the sum of all input values.
 ///
+/// Any NaN input propagates to every lane, as with ordinary `f64` addition.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -1022,6 +1056,16 @@ pub fn reduce_sum_f64(mut val: f64) -> f64 {
 ///
 /// After this call, every lane holds the maximum of all input values.
 ///
+/// A NaN in one lane is ignored because `f64::max` returns the non-NaN
+/// operand; the result is NaN only if every lane holds NaN.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -1042,6 +1086,16 @@ pub fn reduce_max_f64(mut val: f64) -> f64 {
 /// Reduce-min a scalar f64 across all 32 lanes using butterfly shuffles.
 ///
 /// After this call, every lane holds the minimum of all input values.
+///
+/// A NaN in one lane is ignored because `f64::min` returns the non-NaN
+/// operand; the result is NaN only if every lane holds NaN.
+///
+/// # Convergence
+///
+/// The shuffles inside use the full-warp mask (`u32::MAX`), so all 32 lanes
+/// must be converged and participate. Calling this from divergent control
+/// flow, or from a block with fewer than 32 threads, is undefined; see
+/// [`redux_sync_add`] for the participation contract.
 ///
 /// # Example
 ///
@@ -1090,5 +1144,11 @@ mod tests {
             shuffle_down_f64,
             shuffle_up_f64,
         ];
+    }
+
+    #[test]
+    fn warp_reduce_signatures_stay_stable() {
+        let _: [fn(f32) -> f32; 3] = [reduce_sum_f32, reduce_max_f32, reduce_min_f32];
+        let _: [fn(f64) -> f64; 3] = [reduce_sum_f64, reduce_max_f64, reduce_min_f64];
     }
 }

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/README.md
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/README.md
@@ -15,6 +15,10 @@ output remain unchanged.
 2. **warp_reduce_sum_down**: Sequential reduction using `shuffle_down` - only lane 0 gets sum
 3. **warp_broadcast**: Broadcast lane 0's value to all lanes using `shuffle`
 4. **test_lane_id**: Verify `lane_id()` intrinsic
+5. **warp_reduce_sum_util / warp_reduce_max_util / warp_reduce_min_util**:
+   The packaged `warp::reduce_{sum,max,min}_f32` utilities - every lane
+   writes the reduced value it received, and the host checks all of them
+6. **warp_reduce_sum_f64_util**: The f64 flavor, `warp::reduce_sum_f64`
 
 ## Key Concepts Demonstrated
 
@@ -57,6 +61,22 @@ let lane = warp::lane_id();  // 0-31 within the warp
 let warp_id = warp::warp_id();  // Which warp in the block
 ```
 
+### Packaged Reduce Utilities
+
+The hand-rolled butterfly above is also available as one-call utilities,
+for both precisions:
+
+```rust
+let total = warp::reduce_sum_f32(val);      // every lane gets the sum
+let hi = warp::reduce_max_f32(val);         // every lane gets the max
+let lo = warp::reduce_min_f32(val);         // every lane gets the min
+let total_f64 = warp::reduce_sum_f64(val);  // f64 flavors too
+```
+
+They use the full-warp mask, so all 32 lanes must be converged and
+participate; calling them from divergent control flow or from a block
+with fewer than 32 threads is undefined.
+
 ## Build and Run
 
 ```bash
@@ -85,6 +105,14 @@ Warp sums: [496.0, 496.0, 496.0, 496.0, 496.0, 496.0, 496.0, 496.0]
 
 --- Test 4: Lane ID ---
 ✓ Lane IDs correct: 0-31 pattern for each warp
+
+--- Test 5: Reduce Utilities (f32) ---
+✓ reduce_sum_f32 correct: all 256 lanes hold 496
+✓ reduce_max_f32 correct: all 256 lanes hold 31
+✓ reduce_min_f32 correct: all 256 lanes hold 0
+
+--- Test 6: Reduce Utility (f64) ---
+✓ reduce_sum_f64 correct: all 256 lanes hold 496
 
 ✓ SUCCESS: All warp tests passed!
 ```
@@ -126,6 +154,9 @@ val = max(val, warp::shuffle_xor_f32(val, 4));
 val = max(val, warp::shuffle_xor_f32(val, 2));
 val = max(val, warp::shuffle_xor_f32(val, 1));
 ```
+
+This is exactly what `warp::reduce_max_f32(val)` packages; prefer the
+utility unless you need a non-standard offset schedule.
 
 ### Prefix Sum (Scan)
 

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
@@ -7,7 +7,8 @@
 
 //! Unified Warp Reduction Example
 //!
-//! Demonstrates warp-level primitives: shuffle_xor, shuffle_down, shuffle (broadcast).
+//! Demonstrates warp-level primitives: shuffle_xor, shuffle_down, shuffle (broadcast),
+//! and the packaged reduce utilities (reduce_sum/max/min for f32 and f64).
 //! Uses butterfly reduction pattern for efficient parallel sum.
 //!
 //! Build and run with:
@@ -113,6 +114,78 @@ mod kernels {
             unsafe {
                 *out.get_unchecked_mut(gid.get()) = lane;
             }
+        }
+    }
+
+    /// Reduce-sum utility - every lane writes the warp sum it received.
+    #[kernel]
+    pub fn warp_reduce_sum_util(data: &[f32], mut out: DisjointSlice<f32>) {
+        let gid = thread::index_1d();
+
+        let val = if gid.in_bounds(out.len()) {
+            data[gid.get()]
+        } else {
+            0.0
+        };
+
+        let sum = warp::reduce_sum_f32(val);
+
+        if let Some(out_elem) = out.get_mut(gid) {
+            *out_elem = sum;
+        }
+    }
+
+    /// Reduce-max utility - every lane writes the warp maximum it received.
+    #[kernel]
+    pub fn warp_reduce_max_util(data: &[f32], mut out: DisjointSlice<f32>) {
+        let gid = thread::index_1d();
+
+        let val = if gid.in_bounds(out.len()) {
+            data[gid.get()]
+        } else {
+            0.0
+        };
+
+        let max = warp::reduce_max_f32(val);
+
+        if let Some(out_elem) = out.get_mut(gid) {
+            *out_elem = max;
+        }
+    }
+
+    /// Reduce-min utility - every lane writes the warp minimum it received.
+    #[kernel]
+    pub fn warp_reduce_min_util(data: &[f32], mut out: DisjointSlice<f32>) {
+        let gid = thread::index_1d();
+
+        let val = if gid.in_bounds(out.len()) {
+            data[gid.get()]
+        } else {
+            0.0
+        };
+
+        let min = warp::reduce_min_f32(val);
+
+        if let Some(out_elem) = out.get_mut(gid) {
+            *out_elem = min;
+        }
+    }
+
+    /// Reduce-sum utility (f64) - every lane writes the warp sum it received.
+    #[kernel]
+    pub fn warp_reduce_sum_f64_util(data: &[f64], mut out: DisjointSlice<f64>) {
+        let gid = thread::index_1d();
+
+        let val = if gid.in_bounds(out.len()) {
+            data[gid.get()]
+        } else {
+            0.0
+        };
+
+        let sum = warp::reduce_sum_f64(val);
+
+        if let Some(out_elem) = out.get_mut(gid) {
+            *out_elem = sum;
         }
     }
 }
@@ -280,6 +353,76 @@ fn main() {
         println!("✓ Lane IDs correct: 0-31 pattern for each warp");
     } else {
         println!("✗ Lane ID test failed!");
+        std::process::exit(1);
+    }
+
+    // ===== Test 5: Reduce utilities (f32) =====
+    // Each warp holds lane indices 0-31: sum = 496, max = 31, min = 0.
+    // All values are exact in f32, so exact comparison is safe, and every
+    // lane must observe the reduced value (not just lane 0).
+    println!("\n--- Test 5: Reduce Utilities (f32) ---");
+
+    let mut sum_out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_reduce_sum_util((stream).as_ref(), cfg, &data_dev, &mut sum_out_dev) }
+        .expect("Kernel launch failed");
+    let sum_result = sum_out_dev.to_host_vec(&stream).unwrap();
+    if sum_result.iter().all(|&x| x == 496.0) {
+        println!("✓ reduce_sum_f32 correct: all {} lanes hold 496", N);
+    } else {
+        println!("✗ reduce_sum_f32 failed: {:?}", &sum_result[0..8]);
+        std::process::exit(1);
+    }
+
+    let mut max_out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_reduce_max_util((stream).as_ref(), cfg, &data_dev, &mut max_out_dev) }
+        .expect("Kernel launch failed");
+    let max_result = max_out_dev.to_host_vec(&stream).unwrap();
+    if max_result.iter().all(|&x| x == 31.0) {
+        println!("✓ reduce_max_f32 correct: all {} lanes hold 31", N);
+    } else {
+        println!("✗ reduce_max_f32 failed: {:?}", &max_result[0..8]);
+        std::process::exit(1);
+    }
+
+    // Seed with a sentinel so a kernel that never wrote would be caught
+    // (the expected minimum is 0.0, which a zeroed buffer already holds).
+    let min_sentinel = vec![-1.0f32; N];
+    let mut min_out_dev = DeviceBuffer::from_host(&stream, &min_sentinel).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.warp_reduce_min_util((stream).as_ref(), cfg, &data_dev, &mut min_out_dev) }
+        .expect("Kernel launch failed");
+    let min_result = min_out_dev.to_host_vec(&stream).unwrap();
+    if min_result.iter().all(|&x| x == 0.0) {
+        println!("✓ reduce_min_f32 correct: all {} lanes hold 0", N);
+    } else {
+        println!("✗ reduce_min_f32 failed: {:?}", &min_result[0..8]);
+        std::process::exit(1);
+    }
+
+    // ===== Test 6: Reduce utility (f64) =====
+    println!("\n--- Test 6: Reduce Utility (f64) ---");
+    let data_f64_host: Vec<f64> = (0..N).map(|i| (i % 32) as f64).collect();
+    let data_f64_dev = DeviceBuffer::from_host(&stream, &data_f64_host).unwrap();
+    let mut f64_out_dev = DeviceBuffer::<f64>::zeroed(&stream, N).unwrap();
+
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.warp_reduce_sum_f64_util((stream).as_ref(), cfg, &data_f64_dev, &mut f64_out_dev)
+    }
+    .expect("Kernel launch failed");
+
+    let f64_result = f64_out_dev.to_host_vec(&stream).unwrap();
+    let expected_sum_f64 = (0..32).sum::<i32>() as f64;
+    let all_lanes_correct = f64_result.iter().all(|&x| x == expected_sum_f64);
+    if all_lanes_correct {
+        println!(
+            "✓ reduce_sum_f64 correct: all {} lanes hold {}",
+            N, expected_sum_f64
+        );
+    } else {
+        println!("✗ reduce_sum_f64 failed: {:?}", &f64_result[0..8]);
         std::process::exit(1);
     }
 


### PR DESCRIPTION
`warp::redux_sync_*` is integer-only. The surface is `redux_sync_add/and/or/xor` plus `redux_sync_{min,max}_{i32,u32}`, with no float form — which mirrors PTX, where `redux.sync` defines only integer operand types. It is a hardware limit, not a gap in the bindings.

The consequence is that anyone reducing floats across a warp writes the same butterfly shuffle by hand. This adds it once, for both precisions:

```
reduce_sum_f32   reduce_max_f32   reduce_min_f32
reduce_sum_f64   reduce_max_f64   reduce_min_f64
```

Each is five XOR shuffles at offsets 16, 8, 4, 2, 1, built on the existing `shuffle_xor_f32` / `shuffle_xor_f64`.

## Notes for review

**Every lane ends with the reduced value**, not just lane 0. That is deliberate — it lets a caller feed the result straight into a block-level reduction without a second barrier, and it is the property a block reduce built on top of these depends on.

**Safe functions, not `unsafe`.** These are warp-synchronous but take no pointers and require no convergence beyond what the underlying shuffle intrinsics already document, so there is no additional obligation to put behind `unsafe`.

`#[must_use]` on all six: the return value is the entire point, so discarding one is always a mistake.

Uses `f32::max` / `f32::min` for the max and min variants rather than an open-coded compare, so the NaN behaviour follows whatever those lower to rather than being independently specified here.

`fmt --check` clean, no warnings, no new dependencies.
