### PR TITLE
feat(cuda-device): add f16x2 and bf16x2 unpacking to f32

### DIFF
--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -9,3 +9,136 @@
 //! are more efficient than scalar Rust casts.
 
 include!("generated/convert.rs");
+
+// =============================================================================
+// Packed f16x2 unpacking
+// =============================================================================
+//
+// The generated conversions above all run f32 -> packed narrow type. The
+// inverse is hand-written because there is nothing to generate it from: the
+// pinned LLVM metadata has no f16x2-to-f32x2 intrinsic (every `ff2f16x2_*`
+// record is the packing direction), and PTX has no single unpacking
+// instruction either. Splitting a packed pair is a `mov.b32` into two 16-bit
+// registers followed by two `cvt.f32.f16`, which is what the casts below
+// lower to.
+//
+// These matter because packed f16 is the layout that gives the only reliably
+// wide global loads: reading weights as `u32`/`u64` and unpacking in registers
+// beats four scalar `f16` loads. Doing that inline at every call site is where
+// the manual `from_bits`/shift/mask arithmetic came from.
+
+/// Unpacks a packed `f16x2` into its two `f32` values, low half first.
+///
+/// This is the inverse of [`cvt_f16x2_f32`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // One 32-bit load carrying two f16 weights.
+/// let packed = unsafe { *(ptr as *const u32) };
+/// let (w0, w1) = convert::cvt_f32x2_f16x2(packed);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32x2_f16x2(packed: u32) -> (f32, f32) {
+    let lo = f16::from_bits(packed as u16);
+    let hi = f16::from_bits((packed >> 16) as u16);
+    (lo as f32, hi as f32)
+}
+
+/// Unpacks the low half of a packed `f16x2` to `f32`.
+///
+/// Prefer [`cvt_f32x2_f16x2`] when both halves are needed; this exists for the
+/// case where only one is, so the other conversion is not emitted at all.
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32_f16x2_lo(packed: u32) -> f32 {
+    f16::from_bits(packed as u16) as f32
+}
+
+/// Unpacks the high half of a packed `f16x2` to `f32`.
+///
+/// See [`cvt_f32_f16x2_lo`].
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32_f16x2_hi(packed: u32) -> f32 {
+    f16::from_bits((packed >> 16) as u16) as f32
+}
+
+/// Unpacks a packed `bf16x2` into its two `f32` values, low half first.
+///
+/// This is the inverse of [`cvt_rz_bf16x2_f32`]. `bf16` shares `f32`'s exponent
+/// range, so widening is an exact shift into the high half of the mantissa
+/// rather than a conversion.
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32x2_bf16x2(packed: u32) -> (f32, f32) {
+    (
+        f32::from_bits(packed << 16),
+        f32::from_bits(packed & 0xFFFF_0000),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trips through the generated packer so the halves cannot silently
+    /// swap: `cvt_f16x2_f32` documents the first argument as the low half.
+    ///
+    /// The packer is a device intrinsic and panics on the host, so the packed
+    /// words here are written out by hand instead.
+    #[test]
+    fn unpacks_halves_in_the_documented_order() {
+        // 1.0 = 0x3C00, 2.0 = 0x4000 in f16.
+        let packed = 0x4000_3C00;
+        let (lo, hi) = cvt_f32x2_f16x2(packed);
+        assert_eq!(lo, 1.0, "low half must come from the low 16 bits");
+        assert_eq!(hi, 2.0, "high half must come from the high 16 bits");
+        assert_eq!(cvt_f32_f16x2_lo(packed), 1.0);
+        assert_eq!(cvt_f32_f16x2_hi(packed), 2.0);
+    }
+
+    /// A negative value in one half must not bleed into the other, which is
+    /// what an arithmetic shift instead of a logical one would do.
+    #[test]
+    fn sign_bits_stay_in_their_own_half() {
+        // -1.0 = 0xBC00 in the high half, 1.0 = 0x3C00 in the low half.
+        let (lo, hi) = cvt_f32x2_f16x2(0xBC00_3C00);
+        assert_eq!(lo, 1.0);
+        assert_eq!(hi, -1.0);
+    }
+
+    #[test]
+    fn unpacks_bf16_pairs() {
+        // bf16 is the top 16 bits of the f32 bit pattern.
+        let one = (1.0f32.to_bits() >> 16) as u32; // 0x3F80
+        let two = (2.0f32.to_bits() >> 16) as u32; // 0x4000
+        let packed = (two << 16) | one;
+        let (lo, hi) = cvt_f32x2_bf16x2(packed);
+        assert_eq!(lo, 1.0);
+        assert_eq!(hi, 2.0);
+    }
+
+    /// Every f16 bit pattern that is not a NaN must survive the trip, including
+    /// subnormals and both zeroes.
+    #[test]
+    fn every_finite_f16_pattern_round_trips() {
+        for bits in 0u16..=u16::MAX {
+            let expected = f16::from_bits(bits);
+            if expected.is_nan() {
+                continue;
+            }
+            let (lo, _) = cvt_f32x2_f16x2(bits as u32);
+            assert_eq!(
+                lo, expected as f32,
+                "low-half mismatch for f16 bits {bits:#06x}"
+            );
+            let (_, hi) = cvt_f32x2_f16x2((bits as u32) << 16);
+            assert_eq!(
+                hi, expected as f32,
+                "high-half mismatch for f16 bits {bits:#06x}"
+            );
+        }
+    }
+}

--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -26,6 +26,10 @@ include!("generated/convert.rs");
 // wide global loads: reading weights as `u32`/`u64` and unpacking in registers
 // beats four scalar `f16` loads. Doing that inline at every call site is where
 // the manual `from_bits`/shift/mask arithmetic came from.
+//
+// Names follow this module's generated convention, `cvt_<dst>_<src>`: the
+// destination comes first, so `cvt_f32x2_f16x2` reads "two f32 from a packed
+// f16x2".
 
 /// Unpacks a packed `f16x2` into its two `f32` values, low half first.
 ///
@@ -70,6 +74,14 @@ pub fn cvt_f32_f16x2_hi(packed: u32) -> f32 {
 /// This is the inverse of [`cvt_rz_bf16x2_f32`]. `bf16` shares `f32`'s exponent
 /// range, so widening is an exact shift into the high half of the mantissa
 /// rather than a conversion.
+///
+/// # Warning
+///
+/// `cuda_device::tcgen05::cvt_f32x2_bf16x2` is a **different function** with
+/// the same identifier and the opposite direction: it packs two `f32` into a
+/// `bf16x2` `u32`. Its name comes from the LLVM `ff2bf16x2` record family,
+/// which is source-first, whereas names in this module are destination-first
+/// (`cvt_<dst>_<src>`).
 #[must_use]
 #[inline(always)]
 pub fn cvt_f32x2_bf16x2(packed: u32) -> (f32, f32) {
@@ -79,15 +91,34 @@ pub fn cvt_f32x2_bf16x2(packed: u32) -> (f32, f32) {
     )
 }
 
+/// Unpacks the low half of a packed `bf16x2` to `f32`.
+///
+/// Prefer [`cvt_f32x2_bf16x2`] when both halves are needed; this exists for the
+/// case where only one is, so the other conversion is not emitted at all.
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32_bf16x2_lo(packed: u32) -> f32 {
+    f32::from_bits(packed << 16)
+}
+
+/// Unpacks the high half of a packed `bf16x2` to `f32`.
+///
+/// See [`cvt_f32_bf16x2_lo`].
+#[must_use]
+#[inline(always)]
+pub fn cvt_f32_bf16x2_hi(packed: u32) -> f32 {
+    f32::from_bits(packed & 0xFFFF_0000)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Round-trips through the generated packer so the halves cannot silently
-    /// swap: `cvt_f16x2_f32` documents the first argument as the low half.
+    /// Pins the half ordering so the halves cannot silently swap:
+    /// `cvt_f16x2_f32` documents the first argument as the low half.
     ///
-    /// The packer is a device intrinsic and panics on the host, so the packed
-    /// words here are written out by hand instead.
+    /// The generated packer is device-only and panics on the host, so the
+    /// packed words here are hand-written constants rather than packer output.
     #[test]
     fn unpacks_halves_in_the_documented_order() {
         // 1.0 = 0x3C00, 2.0 = 0x4000 in f16.
@@ -118,12 +149,27 @@ mod tests {
         let (lo, hi) = cvt_f32x2_bf16x2(packed);
         assert_eq!(lo, 1.0);
         assert_eq!(hi, 2.0);
+        assert_eq!(cvt_f32_bf16x2_lo(packed), 1.0);
+        assert_eq!(cvt_f32_bf16x2_hi(packed), 2.0);
     }
 
-    /// Every f16 bit pattern that is not a NaN must survive the trip, including
-    /// subnormals and both zeroes.
+    /// Same guard as the f16 sign test: a negative half must not bleed into
+    /// the other half through the shift or the mask.
     #[test]
-    fn every_finite_f16_pattern_round_trips() {
+    fn bf16_sign_bits_stay_in_their_own_half() {
+        // -1.0 = 0xBF80 in the high half, 1.0 = 0x3F80 in the low half.
+        let packed = 0xBF80_3F80;
+        let (lo, hi) = cvt_f32x2_bf16x2(packed);
+        assert_eq!(lo, 1.0);
+        assert_eq!(hi, -1.0);
+        assert_eq!(cvt_f32_bf16x2_lo(packed), 1.0);
+        assert_eq!(cvt_f32_bf16x2_hi(packed), -1.0);
+    }
+
+    /// Every f16 bit pattern that is not a NaN must survive the trip,
+    /// including subnormals, both zeroes, and both infinities.
+    #[test]
+    fn every_non_nan_f16_pattern_round_trips() {
         for bits in 0u16..=u16::MAX {
             let expected = f16::from_bits(bits);
             if expected.is_nan() {

--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -143,8 +143,8 @@ mod tests {
     #[test]
     fn unpacks_bf16_pairs() {
         // bf16 is the top 16 bits of the f32 bit pattern.
-        let one = (1.0f32.to_bits() >> 16) as u32; // 0x3F80
-        let two = (2.0f32.to_bits() >> 16) as u32; // 0x4000
+        let one = 1.0f32.to_bits() >> 16; // 0x3F80
+        let two = 2.0f32.to_bits() >> 16; // 0x4000
         let packed = (two << 16) | one;
         let (lo, hi) = cvt_f32x2_bf16x2(packed);
         assert_eq!(lo, 1.0);

--- a/crates/rustc-codegen-cuda/examples/cvt_packed/README.md
+++ b/crates/rustc-codegen-cuda/examples/cvt_packed/README.md
@@ -1,0 +1,31 @@
+# cvt_packed
+
+Behavior example for the packed conversion functions in
+`cuda_device::convert` (sm_80+).
+
+The first kernel packs the same `(lo = 1.0065, hi = -1.0065)` pair with all
+five generated packers (`cvt_f16x2_f32`, `cvt_rz_f16x2_f32`,
+`cvt_rn_relu_f16x2_f32`, `cvt_rn_relu_bf16x2_f32`, `cvt_rz_bf16x2_f32`).
+The input sits on opposite sides of the nearest and toward-zero results in
+both f16 and bf16, so the host checks the exact packed bits rather than a
+tolerance that could let the wrong rounding mode pass. A second launch
+checks that the ReLU variants canonicalize NaN inputs.
+
+The second kernel round-trips: it packs with the generated
+`cvt_f16x2_f32` / `cvt_rz_bf16x2_f32`, then unpacks the words with the
+hand-written unpackers `cvt_f32x2_f16x2`, `cvt_f32_f16x2_{lo,hi}`,
+`cvt_f32x2_bf16x2`, and `cvt_f32_bf16x2_{lo,hi}`, writing the widened `f32`
+values out. Widening is exact in both formats, so the host again compares
+exact bits:
+
+- f16 rn: `1.0065 -> 0x3C07 -> 1.0068359375`
+- bf16 rz: `1.0065 -> 0x3F80 -> 1.0`
+
+The f16 unpackers are the only place an example runs the runtime
+u16-to-f16 transmute + fpext path on the device.
+
+Run with:
+
+```bash
+cargo oxide run cvt_packed
+```

--- a/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
@@ -21,18 +21,30 @@
 //! pass. A second launch verifies that the ReLU variants produce CUDA's
 //! canonical NaN for NaN inputs.
 //!
+//! A third launch exercises the hand-written unpackers: it packs with the
+//! generated `cvt_f16x2_f32` / `cvt_rz_bf16x2_f32` and unpacks with
+//! `cvt_f32x2_f16x2`, `cvt_f32_f16x2_{lo,hi}`, `cvt_f32x2_bf16x2`, and
+//! `cvt_f32_bf16x2_{lo,hi}`, writing the widened `f32` values out. Widening
+//! is exact in both formats, so the host again checks exact bits. This is
+//! the only example that runs the runtime u16-to-f16 transmute + fpext path
+//! on the device.
+//!
 //! Run: cargo oxide run cvt_packed
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::convert::{
-    cvt_f16x2_f32, cvt_rn_relu_bf16x2_f32, cvt_rn_relu_f16x2_f32, cvt_rz_bf16x2_f32,
-    cvt_rz_f16x2_f32,
+    cvt_f16x2_f32, cvt_f32_bf16x2_hi, cvt_f32_bf16x2_lo, cvt_f32_f16x2_hi, cvt_f32_f16x2_lo,
+    cvt_f32x2_bf16x2, cvt_f32x2_f16x2, cvt_rn_relu_bf16x2_f32, cvt_rn_relu_f16x2_f32,
+    cvt_rz_bf16x2_f32, cvt_rz_f16x2_f32,
 };
 use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_module;
 
-/// Number of conversion results produced by the kernel.
+/// Number of conversion results produced by the packing kernel.
 const NUM_VARIANTS: usize = 5;
+
+/// Number of unpacked f32 values produced by the round-trip kernel.
+const NUM_UNPACKED: usize = 8;
 
 // =============================================================================
 // KERNEL
@@ -53,6 +65,34 @@ mod kernels {
                 *out.get_unchecked_mut(2) = cvt_rn_relu_f16x2_f32(lo, hi);
                 *out.get_unchecked_mut(3) = cvt_rn_relu_bf16x2_f32(lo, hi);
                 *out.get_unchecked_mut(4) = cvt_rz_bf16x2_f32(lo, hi);
+            }
+        }
+    }
+
+    /// Thread 0 packs (lo, hi) with the generated packers, unpacks the words
+    /// with the hand-written unpackers, and writes the widened f32 results:
+    ///
+    ///   out[0..2] = cvt_f32x2_f16x2(cvt_f16x2_f32(lo, hi))
+    ///   out[2..4] = cvt_f32_f16x2_lo / cvt_f32_f16x2_hi of the same word
+    ///   out[4..6] = cvt_f32x2_bf16x2(cvt_rz_bf16x2_f32(lo, hi))
+    ///   out[6..8] = cvt_f32_bf16x2_lo / cvt_f32_bf16x2_hi of the same word
+    #[kernel]
+    pub fn cvt_packed_unpack(lo: f32, hi: f32, mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        if idx.get() == 0 {
+            let f16_word = cvt_f16x2_f32(lo, hi);
+            let bf16_word = cvt_rz_bf16x2_f32(lo, hi);
+            let (f16_lo, f16_hi) = cvt_f32x2_f16x2(f16_word);
+            let (bf16_lo, bf16_hi) = cvt_f32x2_bf16x2(bf16_word);
+            unsafe {
+                *out.get_unchecked_mut(0) = f16_lo;
+                *out.get_unchecked_mut(1) = f16_hi;
+                *out.get_unchecked_mut(2) = cvt_f32_f16x2_lo(f16_word);
+                *out.get_unchecked_mut(3) = cvt_f32_f16x2_hi(f16_word);
+                *out.get_unchecked_mut(4) = bf16_lo;
+                *out.get_unchecked_mut(5) = bf16_hi;
+                *out.get_unchecked_mut(6) = cvt_f32_bf16x2_lo(bf16_word);
+                *out.get_unchecked_mut(7) = cvt_f32_bf16x2_hi(bf16_word);
             }
         }
     }
@@ -148,12 +188,61 @@ fn main() {
         }
     }
 
+    // --- Pack/unpack round trip ---
+    // The generated packers narrow (lossy, rounding-mode dependent); the
+    // hand-written unpackers widen exactly. So the round trip lands on the
+    // narrowed value widened back to f32, and the host can check exact bits:
+    //   f16 rn:  1.0065 -> 0x3C07 -> 1.0068359375
+    //   bf16 rz: 1.0065 -> 0x3F80 -> 1.0
+    let mut unpack_dev = DeviceBuffer::<f32>::zeroed(&stream, NUM_UNPACKED).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.cvt_packed_unpack(&stream, cfg, lo, hi, &mut unpack_dev) }
+        .expect("Unpack kernel launch failed");
+    let unpacked = unpack_dev.to_host_vec(&stream).unwrap();
+    assert_eq!(unpacked.len(), NUM_UNPACKED);
+
+    // Exactly 1 + 7/1024: the f16 value 0x3C07 widened to f32 (see table above).
+    let f16_widened = 1.0_f32 + 7.0 / 1024.0;
+    let unpack_labels = [
+        "cvt_f32x2_f16x2 lo",
+        "cvt_f32x2_f16x2 hi",
+        "cvt_f32_f16x2_lo",
+        "cvt_f32_f16x2_hi",
+        "cvt_f32x2_bf16x2 lo",
+        "cvt_f32x2_bf16x2 hi",
+        "cvt_f32_bf16x2_lo",
+        "cvt_f32_bf16x2_hi",
+    ];
+    let unpack_expected = [
+        f16_widened,
+        -f16_widened,
+        f16_widened,
+        -f16_widened,
+        1.0,
+        -1.0,
+        1.0,
+        -1.0,
+    ];
+    for i in 0..NUM_UNPACKED {
+        let got = unpacked[i];
+        let want = unpack_expected[i];
+        if got.to_bits() == want.to_bits() {
+            println!("[{i}] {}: PASS ({got})", unpack_labels[i]);
+        } else {
+            eprintln!(
+                "[{i}] {}: FAIL, expected {want}, got {got}",
+                unpack_labels[i]
+            );
+            failures += 1;
+        }
+    }
+
     // --- Summary ---
     println!();
     if failures == 0 {
         println!(
-            "SUCCESS: all {} packed cvt variants produced correct results",
-            NUM_VARIANTS
+            "SUCCESS: all {} packed cvt variants and {} unpacked values produced correct results",
+            NUM_VARIANTS, NUM_UNPACKED
         );
     } else {
         eprintln!("{failures} check(s) failed");


### PR DESCRIPTION
`cuda_device::convert` has 19 generated conversions and every one runs f32 -> packed narrow type. The inverse is missing, so reading packed f16 pairs means open-coding the bit arithmetic at each call site:

```rust
let w0 = f16::from_bits((quad & 0xFFFF) as u16) as f32;
let w1 = f16::from_bits(((quad >> 16) & 0xFFFF) as u16) as f32;
```

## Added

| Function | Purpose |
|---|---|
| `cvt_f32x2_f16x2(u32) -> (f32, f32)` | inverse of `cvt_f16x2_f32` |
| `cvt_f32_f16x2_lo` / `_hi` | one half only, so the other conversion is not emitted |
| `cvt_f32x2_bf16x2(u32) -> (f32, f32)` | inverse of `cvt_rz_bf16x2_f32` |

## Why hand-written rather than generated

Worth justifying, since the preference is to route intrinsics through the generator. I checked the pinned LLVM metadata: **2569 NVVM intrinsics, none of which unpack.**

- Every `ff2f16x2_*` and `ff2bf16x2_*` record is the *packing* direction.
- The `*_to_f16x2_*` records take fp8/fp4 sources, not f16x2.
- PTX has no single unpacking instruction either: a split is `mov.b32` into two 16-bit registers plus two `cvt.f32.f16`, which is exactly what these casts lower to.

So there is nothing for the generator to admit. These are plain safe functions — no `ptx_asm!`, no `unsafe`.

## Tests

- **Half ordering** — `cvt_f16x2_f32` documents its first argument as the low half, so a swap here would be silent. Pinned in both directions.
- **Sign isolation** — a negative value in one half must not bleed into the other, which is what an arithmetic shift instead of a logical one would do.
- **Exhaustive** — all 65536 f16 bit patterns round-trip, including subnormals and both zeroes, skipping only NaN since it is not `==`-comparable.

4 tests, `fmt --check` clean, zero warnings.
