### PR TITLE
codegen: report NVVM IR target rejections at the input stage

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -804,7 +804,8 @@ pub enum CompileError {
     #[error("{reason}")]
     TargetSelection {
         /// Target that was rejected, in canonical `sm_XX` spelling once it
-        /// parsed at all.
+        /// parsed at all. Empty when nothing supplied a target to reject, as
+        /// on the NVVM IR route, which requires an explicit one.
         target: String,
         /// Full explanation, suitable for display on its own.
         reason: String,

--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -101,12 +101,19 @@ pub(crate) fn resolve_nvvm_target_with_generated(
     automatic_features: Option<DetectedFeatures>,
     generated: &GeneratedModuleRequirements,
 ) -> Result<CudaArch, PipelineError> {
+    // A target the caller requested, or one detected from the device, is an
+    // input to compilation, so its rejection is classified as
+    // `TargetSelection` and reported at `CompilationStage::Input`. Only the
+    // failures that belong to the export itself stay `Export`.
     let parse = |target: &str, source: &str| {
-        target.parse::<CudaArch>().map_err(|error| {
-            PipelineError::Export(format!(
-                "cannot select an NVVM IR dialect from the {source} `{target}`: {error}"
-            ))
-        })
+        target
+            .parse::<CudaArch>()
+            .map_err(|error| PipelineError::TargetSelection {
+                target: target.to_string(),
+                reason: format!(
+                    "cannot select an NVVM IR dialect from the {source} `{target}`: {error}"
+                ),
+            })
     };
 
     // libNVVM chooses the final PTX version itself, but still reject a future
@@ -117,9 +124,19 @@ pub(crate) fn resolve_nvvm_target_with_generated(
     if let Some(target) = explicit_target {
         let parsed = parse(target, "explicit CUDA target")?;
         if let Some(features) = automatic_features {
-            validate_target_features(&parsed, features).map_err(PipelineError::Export)?;
+            validate_target_features(&parsed, features).map_err(|reason| {
+                PipelineError::TargetSelection {
+                    target: parsed.sm(),
+                    reason,
+                }
+            })?;
         }
-        validate_generated_target(&parsed.sm(), generated).map_err(PipelineError::Export)?;
+        validate_generated_target(&parsed.sm(), generated).map_err(|reason| {
+            PipelineError::TargetSelection {
+                target: parsed.sm(),
+                reason,
+            }
+        })?;
         return Ok(parsed);
     }
 
@@ -150,12 +167,16 @@ pub(crate) fn resolve_nvvm_target_with_generated(
         return parse(&target, "generated-intrinsic requirement");
     }
 
-    Err(PipelineError::Export(
-        "NVVM IR requires a concrete CUDA target because pre-Blackwell and Blackwell+ \
-         use different LLVM dialects; pass `cargo oxide ... --arch sm_XX` (or set \
-         CUDA_OXIDE_TARGET)"
+    // Nothing supplied a target, so there is none to name. The caller still
+    // has to act on their own input, which is why this reports at
+    // `CompilationStage::Input` alongside the rejections above.
+    Err(PipelineError::TargetSelection {
+        target: String::new(),
+        reason: "NVVM IR requires a concrete CUDA target because pre-Blackwell and Blackwell+ \
+                 use different LLVM dialects; pass `cargo oxide ... --arch sm_XX` (or set \
+                 CUDA_OXIDE_TARGET)"
             .to_string(),
-    ))
+    })
 }
 
 // mir-importer pipeline plumbing; not part of the frontend contract.
@@ -500,6 +521,63 @@ mod tests {
         assert!(
             resolve_nvvm_target(None, Some("not-an-arch"), Some(DetectedFeatures::Basic)).is_err()
         );
+    }
+
+    /// Every rejection the NVVM IR resolver attributes to a target is decided
+    /// before any export runs, so it reports at `CompilationStage::Input`.
+    #[test]
+    fn nvvm_target_rejections_report_the_input_stage() {
+        let f16 = generated_intrinsic_target_by_marker("v1:i0014").unwrap();
+        let below_floor = GeneratedModuleRequirements::from_targets(vec![f16])
+            .for_backend(GeneratedIntrinsicBackend::LibNvvm);
+        let none = GeneratedModuleRequirements::default();
+
+        for (case, error) in [
+            (
+                "unparsable explicit target",
+                resolve_nvvm_target_with_generated(Some("sm_9x"), None, None, &none).unwrap_err(),
+            ),
+            (
+                "unparsable device hint",
+                resolve_nvvm_target_with_generated(
+                    None,
+                    Some("not-an-arch"),
+                    Some(DetectedFeatures::Basic),
+                    &none,
+                )
+                .unwrap_err(),
+            ),
+            (
+                "target below a detected feature floor",
+                resolve_nvvm_target_with_generated(
+                    Some("sm_70"),
+                    None,
+                    Some(DetectedFeatures::Movmatrix),
+                    &none,
+                )
+                .unwrap_err(),
+            ),
+            (
+                "target below a generated intrinsic floor",
+                resolve_nvvm_target_with_generated(Some("sm_70"), None, None, &below_floor)
+                    .unwrap_err(),
+            ),
+            (
+                "no target supplied at all",
+                resolve_nvvm_target_with_generated(None, None, None, &none).unwrap_err(),
+            ),
+        ] {
+            assert!(
+                matches!(error, PipelineError::TargetSelection { .. }),
+                "{case}: got {error:?}"
+            );
+            let compile_error = crate::api::CompileError::from(error);
+            assert_eq!(
+                compile_error.stage(),
+                crate::api::CompilationStage::Input,
+                "{case}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #416, which you asked to track separately when you merged it:

> One follow-up to track separately: the NVVM-IR path's resolver still reports target rejections as `Export-stage`.

## Summary

`resolve_nvvm_target_with_generated` returned `PipelineError::Export` for every failure it could produce, so a target the caller requested and the compiler refused arrived as an export failure. Passing `--arch sm_9x` on the NVVM IR route reports:

```text
Export failed: cannot select an NVVM IR dialect from the explicit CUDA target `sm_9x`: invalid CUDA target `sm_9x`: compute capability must contain at least two digits
```

Nothing has been exported at that point. The target is rejected before any export runs, and the caller sees a stage that points at the wrong part of the pipeline.

#416 gave the PTX resolver `PipelineError::TargetSelection` for exactly these rejections, which reaches the caller as `CompilationStage::Input`. This applies the same classification on the NVVM IR route.

## Changes

* Classify the rejections the resolver attributes to a target as `TargetSelection`: an unparsable explicit target, an unparsable device-architecture hint, a target below a detected feature floor, a target below a generated-intrinsic floor, and the case where nothing supplied a target at all.
* Carry the rejected target in the error, canonical `sm_XX` once it parsed, and the raw text when it did not.
* Document what an empty `target` field means on `CompileError::TargetSelection`, since the no-target-supplied case has none to name.
* Message text is unchanged, so the wording an operator sees stays the same and existing assertions still match. Only the stage and the variant change.

## Rationale

The boundary follows what the PTX resolver already does with the same helpers.

Rejections attributable to a requested or detected target become `Input`: the caller chose the target and the caller can change it.

Two failures keep reporting as `Export`:

* `select_target_with_generated` fails when no target satisfies the module at all. The PTX resolver classifies this away from `Input` too, as `PtxGeneration`. It reports a module the compiler cannot place on any target, which is not something a caller fixes by naming a different one.
* `generated_ptx_isa_requirement` rejects a catalogue PTX floor this compiler cannot spell. It is decided before any target is chosen, so there is no target to attribute it to.

The no-target-supplied case is the one judgement call here. It reports at `Input` because the caller has to act on their own input, and its diagnostic already tells them which knob to reach for. It carries an empty `target`, since nothing was rejected. If you prefer a dedicated variant for that case, say so and I will split it out; the other four are unaffected either way.

## Validation

```text
$ cargo test -p cuda-oxide-codegen
test export::tests::nvvm_target_rejections_report_the_input_stage ... ok
test result: ok. 121 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 15 passed; 0 failed (public_api)
test result: ok. 4 passed; 0 failed (target_provenance)
test result: ok. 1 passed; 0 failed (spine_kernel_ptx)
test result: ok. 1 passed; 0 failed (multithreaded)
test result: ok. 1 passed; 0 failed (doc-tests)

$ cargo clippy --workspace -- -D warnings
$ cargo fmt --all -- --check
$ cargo check --workspace --all-targets
$ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p cuda-oxide-codegen
(all clean)
```

The new test walks all five rejection paths and asserts both the variant and `CompilationStage::Input`. Reverting only the classification and keeping the test reproduces the old behaviour:

```text
unparsable explicit target: got Export("cannot select an NVVM IR dialect from the
explicit CUDA target `sm_9x`: invalid CUDA target `sm_9x`: compute capability must
contain at least two digits")
```

- [ ] `cargo oxide run <example>` passes
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable)

No example added: this changes how a failure is classified for an API caller, and the paths are covered by the unit test above. No device code is affected.

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)
