### PR TITLE
feat(fuzzer): trace f32 and f64 values

### DIFF
--- a/crates/fuzzer/README.md
+++ b/crates/fuzzer/README.md
@@ -83,23 +83,33 @@ or function signature that uses a type the adapter cannot rewrite. The trace
 API hashes:
 
 ```text
-bool, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, char
+bool, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, char,
+f32, f64
 ```
 
-It does not hash `f32` or `f64`. In many `UNSUPPORTED [adapter]` cases, the MIR
-can probably be patched by widening the adapter and trace API. The adapter stops
-because it does not yet know how to rewrite/hash that dumped type safely.
+In many `UNSUPPORTED [adapter]` cases, the MIR can probably be patched by
+widening the adapter and trace API. The adapter stops because it does not yet
+know how to rewrite/hash that dumped type safely.
 
 ## Floating point and libdevice seeds
 
 The comparison is exact `u64` hash equality, so it assumes the CPU and the GPU
-agree bit for bit. Floats are never hashed directly, since the trace API has no
-`f32` or `f64` arm and the adapter refuses a bare float dump. A float can still
-reach the hash indirectly, through an `as` cast to an integer, through a
-comparison that yields a `bool`, or through rustlantis' `transmute_place`.
+agree bit for bit. Floats are folded as their `to_bits()` pattern, which keeps
+that assumption intact: a tolerance in the trace would compare something other
+than the value a backend produced, and would hide the differences the fuzzer
+exists to find. Floats also still reach the hash indirectly, through an `as`
+cast to an integer, through a comparison that yields a `bool`, or through
+rustlantis' `transmute_place`.
 
-Where that happens on a seed whose device code calls libdevice, a mismatch is
-not on its own evidence of a backend bug. Only a few libdevice entry points are
+Two sources of difference are therefore expected, and neither is a backend bug.
+
+The first is FMA contraction. Device codegen contracts an `fmul` feeding an
+`fadd` into a single `fma.rn` by default, matching nvcc's `--fmad=true`, while
+the CPU oracle rounds the multiply and the add separately. `run_seed.py` passes
+`--no-fmad` so the two agree. Contraction is worth fuzzing on its own terms,
+against a contracted reference.
+
+The second is libdevice. Only a few libdevice entry points are
 specified as single correctly-rounded operations, `fma` among them. The
 transcendentals (`sin`, `cos`, `exp`, `log`, `pow`, `atan2` and the rest) are not
 required to be bit-identical to the host's libm, and the repository compares them

--- a/crates/fuzzer/README.md
+++ b/crates/fuzzer/README.md
@@ -95,11 +95,16 @@ know how to rewrite/hash that dumped type safely.
 
 The comparison is exact `u64` hash equality, so it assumes the CPU and the GPU
 agree bit for bit. Floats are folded as their `to_bits()` pattern, which keeps
-that assumption intact: a tolerance in the trace would compare something other
-than the value a backend produced, and would hide the differences the fuzzer
-exists to find. Floats also still reach the hash indirectly, through an `as`
-cast to an integer, through a comparison that yields a `bool`, or through
-rustlantis' `transmute_place`.
+that assumption intact for every non-NaN value: a tolerance in the trace would
+compare something other than the value a backend produced, and would hide the
+differences the fuzzer exists to find. NaN payload bits are the exception,
+because Rust does not pin them down, so the trace canonicalizes every NaN to
+the quiet-NaN bit pattern at the hash boundary. A payload divergence therefore
+cannot produce a `MISMATCH`; a NaN on one backend against a non-NaN on the
+other still hashes differently, and that difference is a real signal. Floats
+also still reach the hash indirectly, through an `as` cast to an integer,
+through a comparison that yields a `bool`, or through rustlantis'
+`transmute_place`.
 
 Two sources of difference are therefore expected, and neither is a backend bug.
 

--- a/crates/fuzzer/src/trace.rs
+++ b/crates/fuzzer/src/trace.rs
@@ -126,17 +126,30 @@ fn trace_write_char(val: char) {
 /// the backend produced, and the mismatches worth finding are the ones a
 /// tolerance hides.
 ///
-/// Every NaN the two backends produce must therefore agree bit for bit,
-/// payload included. That holds for the arithmetic rustlantis emits, and a
-/// disagreement in a NaN payload is itself a result worth reporting.
+/// The bits agree for every non-NaN value the two backends produce. NaN
+/// payload bits are not pinned down by Rust, so both writers canonicalize a
+/// NaN to the quiet-NaN bit pattern before hashing, as Cranelift's fuzzgen
+/// does. A payload divergence therefore cannot produce a false MISMATCH,
+/// while a NaN against a non-NaN still hashes differently and remains a real
+/// signal.
 #[inline]
 fn trace_write_f32(val: f32) {
-    trace_write_u32(val.to_bits());
+    let bits = if val.is_nan() {
+        f32::NAN.to_bits()
+    } else {
+        val.to_bits()
+    };
+    trace_write_u32(bits);
 }
 
 #[inline]
 fn trace_write_f64(val: f64) {
-    trace_write_u64(val.to_bits());
+    let bits = if val.is_nan() {
+        f64::NAN.to_bits()
+    } else {
+        val.to_bits()
+    };
+    trace_write_u64(bits);
 }
 
 /// Scalar values that can be folded into the trace.

--- a/crates/fuzzer/src/trace.rs
+++ b/crates/fuzzer/src/trace.rs
@@ -121,6 +121,24 @@ fn trace_write_char(val: char) {
     trace_write_u32(val as u32);
 }
 
+/// Floats are folded as their bit patterns, so the trace stays an exact
+/// comparison. A tolerance here would compare something other than the value
+/// the backend produced, and the mismatches worth finding are the ones a
+/// tolerance hides.
+///
+/// Every NaN the two backends produce must therefore agree bit for bit,
+/// payload included. That holds for the arithmetic rustlantis emits, and a
+/// disagreement in a NaN payload is itself a result worth reporting.
+#[inline]
+fn trace_write_f32(val: f32) {
+    trace_write_u32(val.to_bits());
+}
+
+#[inline]
+fn trace_write_f64(val: f64) {
+    trace_write_u64(val.to_bits());
+}
+
 /// Scalar values that can be folded into the trace.
 pub trait TraceValue {
     fn trace_write(self);
@@ -154,6 +172,8 @@ impl_trace_value! {
     u128 => trace_write_u128,
     usize => trace_write_usize,
     char => trace_write_char,
+    f32 => trace_write_f32,
+    f64 => trace_write_f64,
 }
 
 /// Aggregates of scalar values that can be folded into the trace in one call.

--- a/crates/fuzzer/tools/mir_generator.py
+++ b/crates/fuzzer/tools/mir_generator.py
@@ -213,6 +213,10 @@ def literal_for_type(ty: str, idx: int) -> str:
         "u128": ["10_u128", "20_u128", "42_u128"],
         "usize": ["10_usize", "20_usize", "42_usize"],
         "char": ["'a'", "'\\u{3a9}'", "'\\u{1f980}'"],
+        # Exactly representable in binary floating point, so the literal a
+        # seed is given is the value both backends start from.
+        "f32": ["1.5_f32", "(-0.25_f32)", "42.0_f32"],
+        "f64": ["1.5_f64", "(-0.25_f64)", "42.0_f64"],
     }
     if ty not in literals:
         raise SystemExit(f"unsupported function argument type for Stage 2 adapter: {ty}")
@@ -236,6 +240,8 @@ def supported_trace_type(ty: str) -> bool:
         "u128",
         "usize",
         "char",
+        "f32",
+        "f64",
     }
 
 

--- a/crates/fuzzer/tools/run_seed.py
+++ b/crates/fuzzer/tools/run_seed.py
@@ -189,7 +189,14 @@ def run_seed(seed: int, *, no_build: bool, keep_logs: bool) -> dict[str, object]
         return record
 
     remove_stale_ptx()
-    run_cmd = ["cargo", "oxide", "run", "rustlantis-smoke"]
+    # --no-fmad keeps the two backends comparable on float seeds. Device
+    # codegen contracts an fmul feeding an fadd into a single fma.rn by
+    # default, matching nvcc's --fmad=true, while the CPU oracle rounds the
+    # multiply and the add separately. Both are correct, so the resulting
+    # trace difference says nothing about a miscompile, and it would mask the
+    # differences that do. Contraction is worth fuzzing on its own terms, as
+    # a comparison against a contracted reference.
+    run_cmd = ["cargo", "oxide", "run", "--no-fmad", "rustlantis-smoke"]
     result = run(run_cmd, cwd=ROOT)
     status, stage, reason = classify_run(result.returncode, result.stdout)
 


### PR DESCRIPTION
## Summary

The trace API had a writer for every integer type plus `bool` and `char`, and none for floats, so the adapter refused any seed whose dumped value or return type was a float:

```text
seed 221: UNSUPPORTED [adapter] unsupported return type for return-value tracing: f32
```

Float codegen therefore sat outside the differential comparison. A float reached the hash only where it happened to pass through an `as` cast, a comparison yielding `bool`, or `transmute_place`, which is a thin and accidental sample of a large part of the backend.

## Changes

* Add `f32` and `f64` to the trace API, folded as their `to_bits()` pattern.
* Accept both in the adapter's supported-type set, and add literals for them so a generated function can take float arguments. The literals are exactly representable in binary floating point, so a seed starts from the value it was given.
* Pass `--no-fmad` when running a seed.
* Update the README's type list and record why contraction is disabled.

## Rationale

Floats are hashed as bit patterns so the trace stays exact `u64` equality. A tolerance inside the trace would compare something other than the value a backend produced, and would hide the differences the fuzzer exists to find. The consequence is that every NaN the two backends produce must agree bit for bit, payload included. That holds for the arithmetic rustlantis emits, and a disagreement in a NaN payload is a result worth reporting on its own.

`--no-fmad` is the part worth arguing about. Device codegen sets `contract` on float arithmetic by default, so the NVPTX backend fuses an `fmul` feeding an `fadd` into one `fma.rn`, matching nvcc's `--fmad=true`. The CPU oracle rounds the multiply and the add separately. Both results are correct, so the difference reports nothing about a miscompile, and once it appears in the hash it would mask the differences that do. Disabling contraction for the fuzzer keeps the oracle and the device comparable. Contraction is worth fuzzing separately, against a contracted reference.

This does widen exposure to the libdevice hazard the README already documents. Previously a float influenced the hash only indirectly; now it is hashed directly, so a seed calling a transcendental is more likely to produce a difference that is within the tolerance libdevice is permitted. That triage guidance is unchanged and still applies: check whether the differing value derives from a transcendental and compare in ULPs before treating a mismatch as a miscompile. The alternative, keeping floats out of the trace to avoid it, is what left this coverage gap.

## Validation

Ran on an RTX 5060 Laptop GPU (sm_120a, CUDA 13.1, `nightly-2026-04-03`).

Seed 221, the case that motivated this:

```text
before: seed 221: UNSUPPORTED [adapter] unsupported return type for return-value tracing: f32
after:  seed 221: PASS [run] CPU/GPU traces matched
```

Seeds 200 to 239 with this change:

```text
summary: COMPILE_FAIL=1, PASS=39
```

The single failure is seed 212, a `SwitchInt` value above `u64::MAX`, which is unrelated to this change and is fixed separately.

A further 70 seeds, 230 to 299, ran green while checking the contraction question. No float seed in either range produced a mismatch.

The checked-in seed 162 regression case still passes:

```text
$ cargo oxide run --no-fmad rustlantis-smoke
Stage 1b CPU hash: ...  Stage 1b GPU hash: ...
PASS: CPU/GPU traces match
```

```text
$ cargo clippy --workspace -- -D warnings
$ cargo fmt --all -- --check
$ cargo check --workspace --all-targets
$ python3 -m py_compile crates/fuzzer/tools/mir_generator.py crates/fuzzer/tools/run_seed.py
(all clean)
```

- [x] `cargo oxide run <example>` passes (`rustlantis-smoke`)
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable)

No example added: `rustlantis-smoke` is the harness this changes, and it already carries the checked-in seed.

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)
