### PR TITLE
Lint workspace test targets in CI, and fix the one site that fails

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,10 +27,14 @@ jobs:
           sub-packages: '["nvcc", "cudart-dev"]'
           non-cuda-sub-packages: '["libcurand-dev"]'
 
+      # `--all-targets` covers tests, benches and examples, matching the two
+      # steps below and the `just clippy` recipe. Without it a lint that fires
+      # only in a test target passes here and fails for anyone running the
+      # recipe locally.
       - name: Run clippy (workspace crates)
         env:
           CUDA_TOOLKIT_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       # `rustc-codegen-cuda` and each example under examples/ are their own
       # standalone workspaces (the codegen backend is swapped in via

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -2802,7 +2802,7 @@ mod tests {
         let map = build_enum_slot_map(&mut ctx, enum_ty).unwrap();
         assert_eq!(map.field_slots, vec![None]);
         let lowered_pointer = convert_type(&mut ctx, pointer).unwrap();
-        let carrier: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+        let carrier: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
         assert_eq!(
             struct_fields(&ctx, map.llvm_struct_ty),
             vec![lowered_pointer, carrier, pad(&mut ctx, 4)]


### PR DESCRIPTION
Closes #401

## Summary

`just clippy` fails on `main`:

```text
error: the function `IntegerType::get` doesn't need a mutable reference
    --> crates/mir-lower/src/convert/types.rs:2805:52
     |
2805 |     let carrier: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
     |                                                ^^^^^^^^
     |
     = note: `-D clippy::unnecessary-mut-passed` implied by `-D warnings`
```

pliron's `IntegerType::get` takes `&Context`. Rust accepts the implicit downgrade from `&mut`, and `clippy::unnecessary_mut_passed` does not.

## Two changes, of slightly different kinds

They are separable, and I have put them together because each is a few lines and neither is much use alone. Say the word and I will split them.

**A lint fix**, one line in a `#[cfg(test)]` module:

```diff
-let carrier: TypeHandle = IntegerType::get(&mut ctx, 32, Signedness::Signless).into();
+let carrier: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
```

**A CI change**, adding `--all-targets` to one workflow step. The clippy workflow runs three steps and only the first omits it:

| step | before |
|---|---|
| workspace crates | `cargo clippy --workspace -- -D warnings` |
| rustc-codegen-cuda | `cargo clippy --all-targets -- -D warnings` |
| examples loop | `cargo clippy --all-targets -- -D warnings` |

So no test target in a workspace crate is linted in CI. That is why this lint sat on `main` while failing for anyone running the local recipe, as #401 worked out when it was filed.

The lint fix alone closes the issue. Without the CI change the next lint confined to a test target lands just as quietly, so the two belong in one commit.

## Scope

`crates/mir-lower/src/convert/types.rs:2805` is the only site left in the workspace. The ten in `crates/mir-lower/tests/lowering_test.rs` that #401 quoted are already gone, as @honeyspoon noted on the issue; this one is in a test module inside `src/`, which is a different file and still present.

The CI step now compiles workspace test targets, so it costs more runner time than before. `unit-tests.yml` already compiles test targets for most of these packages, and clippy checks without linking, so nothing new is needed on the runner beyond the toolkit the job already installs.

## Validation

```text
$ cargo clippy --workspace --all-targets -- -D warnings     # the new CI command
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo clippy --all-targets --lib --tests -- -D warnings   # just clippy
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test -p mir-lower
test result: ok. 143 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo fmt --all -- --check
(clean)
```

Reverting only the one-line change reproduces the failure under both commands, so the workflow step does gate on it:

```text
error: the function `IntegerType::get` doesn't need a mutable reference
    --> crates/mir-lower/src/convert/types.rs:2805:52
error: could not compile `mir-lower` (lib test) due to 1 previous error
```

- [ ] `cargo oxide run <example>` passes
- [x] `cargo test --workspace` passes
- [ ] New example added (if applicable)

No example added: this is a lint fix in a test module and a workflow flag. No device code changes.

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new files)
