### PR TITLE
docs: Make mir-importer error examples compile

### DIFF
--- a/crates/mir-importer/src/error.rs
+++ b/crates/mir-importer/src/error.rs
@@ -10,15 +10,19 @@
 //!
 //! # Usage
 //!
-//! ```rust,ignore
-//! use pliron::input_err;
-//! use crate::error::TranslationErr;
+//! ```rust,no_run
+//! use mir_importer::{TranslationErr, TranslationResult};
+//! use pliron::{input_err, input_err_noloc, location::Location};
 //!
-//! // With location (preferred - shows where in MIR the error occurred):
-//! return input_err!(loc, TranslationErr::unsupported("f16 type"));
+//! // With location (preferred because it identifies the MIR source):
+//! fn reject_unsupported_construct(loc: Location) -> TranslationResult<()> {
+//!     input_err!(loc, TranslationErr::unsupported("f16 type"))
+//! }
 //!
-//! // Without location (when source span isn't available):
-//! return input_err_noloc!(TranslationErr::type_error("expected i32, got f32"));
+//! // Without location when no source span is available:
+//! fn reject_type_mismatch() -> TranslationResult<()> {
+//!     input_err_noloc!(TranslationErr::type_error("expected i32, got f32"))
+//! }
 //! ```
 
 use thiserror::Error;


### PR DESCRIPTION
Closes #487 

## Summary

* Convert the ignored `mir-importer` error usage snippet into a compiling `no_run` doctest.
* Import `TranslationErr` and `TranslationResult` through the public crate API.
* Import both Pliron result-producing macros used by the example.
* Add function contexts for the location-aware and location-free error cases.

## Motivation

The previous snippet was not self-contained and could drift because rustdoc did not compile it. Making it a `no_run` doctest ensures that the documented API remains synchronized with the actual error-handling interfaces.

## Validation

* `cargo fmt --check`
* `cargo test -p mir-importer --doc`

No production code or runtime behavior is changed.
