### PR TITLE
docs(oxide-artifacts): reference Windows support issue

### DIFF
--- a/crates/oxide-artifacts/README.md
+++ b/crates/oxide-artifacts/README.md
@@ -190,4 +190,4 @@ extension with codec and decompressed-size metadata.
 
 ## TODO
 
-- Consider Windows support later.
+- Windows support is tracked in [#139](https://github.com/NVlabs/cuda-oxide/issues/139).


### PR DESCRIPTION
Closes #489

Summary

Replace the generic Windows support TODO in the oxide-artifacts README with a direct reference to #139.

This keeps the documentation connected to the existing Windows MSVC support discussion without changing the crate's current supported-platform claims.

Related to #139.

Changes
Replace the untracked Windows TODO with a link to #139.
Leave the remainder of the oxide-artifacts documentation unchanged.
Validation

Documentation-only change. Verified the Markdown link and rendered text.

No code or runtime validation is required.