### PR TITLE
docs(book): document compile-time policy configuration

### DIFF
--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -91,6 +91,111 @@ returns `CUDA_ERROR_ASSERT`.
 
 ---
 
+## Compile-time policy configuration
+
+```rust
+use cuda_device::config::{
+    Atom, AtomKind, AtomSpec, Block, Cluster, ColumnMajor, Global, Layout,
+    MemorySpace, Policy, PolicyId, Register, RowMajor, Scope, Shape, Shape1,
+    Shape2, Shape3, Shared, TensorMemory, Thread, Tile, TileSpec, Warp,
+    WarpGroup,
+};
+```
+
+Policies describe compile-time kernel configurations using zero-sized Rust
+types. A generic kernel is monomorphized once for every concrete policy type;
+the policy is not passed as a runtime kernel argument.
+
+```rust
+trait VectorPolicy: Policy {
+    type BlockTile: TileSpec;
+    type ElementAtom: AtomSpec;
+
+    const MAX_THREADS: u32;
+    const MIN_BLOCKS: u32;
+    const UNROLL: u32;
+}
+
+enum SmallTilePolicy {}
+
+impl Policy for SmallTilePolicy {
+    const ID: PolicyId =
+        PolicyId::new(0x706f_6c69_6379_5f63, 1);
+}
+```
+
+| API                  | Description                                                                             |
+| :------------------- |:----------------------------------------------------------------------------------------|
+| `Policy`             | Minimal base trait for a named compile-time kernel policy                               |
+| `PolicyId`           | Explicit stable identity containing a project-specific namespace and policy-local value |
+| `Shape`              | Trait exposing a static shape's rank, extents, and checked element count                |
+| `Shape1<D0>`         | One-dimensional compile-time shape                                                      |
+| `Shape2<D0, D1>`     | Two-dimensional compile-time shape                                                      |
+| `Shape3<D0, D1, D2>` | Three-dimensional compile-time shape                                                    |
+| `Tile<S, L, M, Q>`   | Metadata-only description combining shape, layout, memory space, and execution scope    |
+| `TileSpec`           | Type-level access to the components of a tile description                               |
+| `Atom<K, S, Q>`      | Metadata-only description of an operation, logical footprint, and participating threads |
+| `AtomKind`           | Open marker trait identifying a domain-specific operation                               |
+| `AtomSpec`           | Type-level access to an atom's operation kind, shape, and scope                         |
+| `Layout`             | Open trait for memory-order metadata                                                    |
+| `RowMajor`           | Layout whose rightmost coordinate is contiguous                                         |
+| `ColumnMajor`        | Layout whose leftmost coordinate is contiguous                                          |
+| `MemorySpace`        | Open trait describing a CUDA storage location                                           |
+| `Global`             | Device global-memory marker                                                             |
+| `Shared`             | Per-block shared-memory marker                                                          |
+| `Register`           | Thread-local register-storage marker                                                    |
+| `TensorMemory`       | Hardware tensor-memory marker                                                           |
+| `Scope`              | Open trait describing the threads cooperating on an operation                           |
+| `Thread`             | Single-thread execution scope                                                           |
+| `Warp`               | Single-warp execution scope                                                             |
+| `WarpGroup`          | Hardware warpgroup execution scope                                                      |
+| `Block`              | Thread-block execution scope                                                            |
+| `Cluster`            | Thread-block-cluster execution scope                                                    |
+
+`Tile` and `Atom` are descriptions only. They do not allocate storage, provide
+pointer access, emit GPU instructions, synchronize threads, or establish a
+safety property. A domain-specific policy trait gives those descriptors
+meaning and validates supported combinations.
+
+`PolicyId` values are supplied explicitly by the policy library. They are not
+derived from Rust `TypeId`, type names, compiler mangling, or hashes. Keep an ID
+stable while the policy's generated behavior remains unchanged and allocate a
+new value when that behavior changes.
+
+Policy-associated constants can currently be used in compile-time
+`launch_bounds` and partial-loop `unroll` expressions:
+
+```rust
+use cuda_device::{kernel, launch_bounds};
+
+#[kernel]
+#[launch_bounds(P::MAX_THREADS, P::MIN_BLOCKS)]
+pub unsafe fn transform<P: VectorPolicy>(
+    input: *const u32,
+    output: *mut u32,
+    count: u32,
+) {
+    let mut lane = 0;
+
+    #[unroll(P::UNROLL)]
+    while lane < count {
+        // ...
+        lane += 1;
+    }
+}
+```
+
+Generic policy expressions require `#![feature(generic_const_exprs)]`.
+`launch_contract` fields, cluster dimensions, and dynamic shared-memory sizes
+currently remain literal.
+
+See the
+[`policy_config`](https://github.com/NVlabs/cuda-oxide/tree/main/crates/rustc-codegen-cuda/examples/policy_config)
+example for two concrete policies that generate independent PTX
+specializations and policy-specific prepared launches.
+
+---
+
 ## Thread Identification
 
 ```rust
@@ -447,6 +552,7 @@ debug::prof_trigger::<7>();     // Nsight profiler trigger
 | Module               | Description                                                      | Min SM   |
 |:---------------------|:-----------------------------------------------------------------|:---------|
 | `thread`             | Thread/block IDs, `index_1d`, `sync_threads`                     | All      |
+| `config`             | Compile-time policies, shapes, tiles, atoms, layouts, memory spaces, and scopes | All |
 | `disjoint`           | `DisjointSlice<T>` — typed writes completed by a launch proof    | All      |
 | `shared`             | `SharedArray<T, N>`, `DynamicSharedArray<T>`                     | All      |
 | `warp`               | Shuffle, vote, match, lane/warp ID                               | All      |

--- a/cuda-oxide-book/gpu-programming/launching-kernels.md
+++ b/cuda-oxide-book/gpu-programming/launching-kernels.md
@@ -155,6 +155,301 @@ launch can be reused safely.
 For a contracted kernel, the raw escape hatch is named `vecadd_unchecked` and
 remains unsafe. Uncontracted kernels expose only unsafe raw launch methods.
 
+## Compile-time policy configuration
+
+A kernel policy is a named collection of compile-time choices. It can describe
+tile shapes, operation atoms, launch bounds, loop-unroll factors, or any other
+configuration that a kernel library wants to expose.
+
+Policies are represented by Rust types rather than runtime values. A generic
+kernel is monomorphized once for every concrete policy type used by the host:
+
+```text
+transform::<SmallTilePolicy> -> transform_TID_<A>
+transform::<WideTilePolicy>  -> transform_TID_<B>
+```
+
+Each specialization has its own PTX entry point and its own folded constants.
+The policy is not passed as a kernel argument, and the generated kernel does not
+contain a runtime branch that selects a policy.
+
+### Define a domain-specific policy
+
+`cuda_device::config::Policy` deliberately contains only a stable identifier.
+Kernel libraries extend it with associated types and constants that are
+meaningful for their domain:
+
+```rust
+use cuda_device::config::{
+    Atom, AtomKind, AtomSpec, Block, Global, Policy, PolicyId, RowMajor, Shape1,
+    Thread, Tile, TileSpec,
+};
+
+enum XorRotate {}
+impl AtomKind for XorRotate {}
+
+trait VectorPolicy: Policy {
+    type BlockTile: TileSpec<
+        Layout = RowMajor,
+        MemorySpace = Global,
+        Scope = Block,
+    >;
+
+    type ElementAtom: AtomSpec<
+        Kind = XorRotate,
+        Scope = Thread,
+    >;
+
+    const MAX_THREADS: u32;
+    const MIN_BLOCKS: u32;
+    const ITEMS_PER_THREAD: u32;
+    const UNROLL: u32;
+    const TAG: u32;
+}
+```
+
+`Tile`, `Atom`, `Shape`, layout, memory-space, and scope types are metadata.
+They do not allocate memory, provide pointer access, emit an instruction, or
+synchronize threads. The domain-specific trait and kernel implementation decide
+what those descriptions mean and which combinations are valid.
+
+### Define concrete policies
+
+A concrete policy implements both `Policy` and the domain-specific policy
+trait:
+
+```rust
+enum SmallTilePolicy {}
+
+impl Policy for SmallTilePolicy {
+    const ID: PolicyId =
+        PolicyId::new(0x706f_6c69_6379_5f63, 1);
+}
+
+impl VectorPolicy for SmallTilePolicy {
+    type BlockTile =
+        Tile<Shape1<1024>, RowMajor, Global, Block>;
+
+    type ElementAtom =
+        Atom<XorRotate, Shape1<1>, Thread>;
+
+    const MAX_THREADS: u32 = 64;
+    const MIN_BLOCKS: u32 = 2;
+    const ITEMS_PER_THREAD: u32 = 16;
+    const UNROLL: u32 = 2;
+    const TAG: u32 = 0x1357_9bdf;
+}
+```
+
+A second policy can select a different tile, launch bound, and unroll factor
+without duplicating the kernel:
+
+```rust
+enum WideTilePolicy {}
+
+impl Policy for WideTilePolicy {
+    const ID: PolicyId =
+        PolicyId::new(0x706f_6c69_6379_5f63, 2);
+}
+
+impl VectorPolicy for WideTilePolicy {
+    type BlockTile =
+        Tile<Shape1<4096>, RowMajor, Global, Block>;
+
+    type ElementAtom =
+        Atom<XorRotate, Shape1<1>, Thread>;
+
+    const MAX_THREADS: u32 = 256;
+    const MIN_BLOCKS: u32 = 1;
+    const ITEMS_PER_THREAD: u32 = 16;
+    const UNROLL: u32 = 4;
+    const TAG: u32 = 0x2468_ace0;
+}
+```
+
+`PolicyId` is an explicit library-facing identity. Its namespace and value are
+supplied by the policy author and must remain stable while the policy's
+generated behavior remains unchanged. It is not derived from Rust `TypeId`,
+compiler mangling, a type name, or a compiler-generated hash.
+
+cuda-oxide does not maintain a global policy-ID registry. A policy library is
+responsible for choosing its namespace and preventing duplicate IDs.
+
+### Use policy constants in a kernel
+
+Policy-associated constants can be used by supported compile-time attributes:
+
+```rust
+use cuda_device::{
+    cuda_module, kernel, launch_bounds, launch_contract, thread,
+};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_bounds(P::MAX_THREADS, P::MIN_BLOCKS)]
+    #[launch_contract(domain = 1)]
+    pub unsafe fn transform<P: VectorPolicy>(
+        input: *const u32,
+        output: *mut u32,
+        count: u32,
+    ) {
+        let base =
+            thread::index_1d().get()
+                * P::ITEMS_PER_THREAD as usize;
+
+        let mut lane = 0;
+
+        #[unroll(P::UNROLL)]
+        while lane < count {
+            let index = base + lane as usize;
+
+            // SAFETY: the caller provides readable and writable storage
+            // for every active thread and keeps count within the tile.
+            let value =
+                unsafe { input.add(index).read_volatile() } ^ P::TAG;
+
+            unsafe {
+                output.add(index).write_volatile(value);
+            }
+
+            lane += 1;
+        }
+    }
+}
+```
+
+rustc resolves the associated constants after monomorphization. cuda-oxide
+therefore sees concrete values for each specialization:
+
+```text
+SmallTilePolicy:
+  launch_bounds = (64, 2)
+  unroll         = 2
+
+WideTilePolicy:
+  launch_bounds = (256, 1)
+  unroll         = 4
+```
+
+`MAX_THREADS` specifies the maximum block size accepted by that specialization.
+It does not force every launch to use exactly that number of threads.
+
+`MIN_BLOCKS` is a compiler occupancy hint represented by PTX
+`.minnctapersm`. It is not a grid or block dimension and is not enforced as
+launch geometry.
+
+`UNROLL` is a partial-unroll factor. `UNROLL = 4` groups four loop iterations
+per transformed loop body; it does not limit the loop to four iterations.
+Runtime bounds and remainder iterations are preserved.
+
+Invalid or unevaluatable policy expressions produce compilation errors instead
+of silently using default values.
+
+### Prepare a policy-specific launch
+
+Generic kernels generate generic host methods whose policy parameter selects
+the concrete kernel specialization:
+
+```rust
+use cuda_core::LaunchConfig1D;
+
+let small_launch =
+    module.prepare_transform::<SmallTilePolicy>(
+        LaunchConfig1D::new(1, 64, 0),
+    )?;
+
+let wide_launch =
+    module.prepare_transform::<WideTilePolicy>(
+        LaunchConfig1D::new(1, 256, 0),
+    )?;
+```
+
+The generated launch contract is evaluated independently for each
+specialization:
+
+* `SmallTilePolicy` rejects blocks larger than 64 threads.
+* `WideTilePolicy` rejects blocks larger than 256 threads.
+
+A prepared launch remains branded for the selected kernel specialization. A
+`PreparedLaunch` created for one policy cannot be passed to another policy's
+launch method.
+
+The policy changes compile-time code generation and launch validation, but it
+does not prove raw-pointer memory safety. Kernels that accept raw pointers
+remain unsafe to call:
+
+```rust
+// SAFETY: the pointers cover the complete policy tile and remain valid
+// until the stream completes the launch.
+unsafe {
+    module.transform::<SmallTilePolicy>(
+        &stream,
+        &small_launch,
+        input,
+        output,
+        count,
+    )?;
+}
+```
+
+### Current limitations
+
+Policy expressions are currently supported first for:
+
+* `#[launch_bounds(...)]`
+* partial loop `#[unroll(...)]`
+
+Generic constant expressions require Rust's `generic_const_exprs` feature:
+
+```rust
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+```
+
+The following values currently remain literal rather than policy-derived:
+
+* `launch_contract` fields
+* cluster dimensions
+* dynamic shared-memory sizes
+
+A policy-derived maximum launch bound can still be combined with a host launch
+contract. The contract and the policy maximum are checked separately for each
+monomorphized specialization.
+
+Any additional named constants referenced by a policy-derived launch-bound
+maximum must be visible at module scope because the host launch contract is
+generated beside the kernel function.
+
+### Complete example
+
+The
+[`policy_config`](https://github.com/NVlabs/cuda-oxide/tree/main/crates/rustc-codegen-cuda/examples/policy_config)
+example defines two policies for one generic kernel and verifies that they
+produce:
+
+* distinct host-addressable PTX entries
+* distinct `.maxntid` and `.minnctapersm` directives
+* folded policy-specific constants
+* different partial-unroll factors in raw LLVM IR
+* policy-specific prepared-launch validation
+
+Build and inspect the generated artifacts without a GPU:
+
+```bash
+cargo oxide build policy_config
+
+cargo run --release \
+  --manifest-path crates/rustc-codegen-cuda/examples/policy_config/Cargo.toml \
+  -- --verify-ptx
+```
+
+Use `--release` for the verifier because compiler-generated specialization
+names can differ between build profiles. `PolicyId` remains the explicit,
+profile-independent policy identity.
+
 ## `cuda_launch!` -- unsafe lower-level launch
 
 `cuda_launch!` is the explicit, unsafe escape hatch below `#[cuda_module]`.


### PR DESCRIPTION
Closes #495 
Partially addresses #479.

## Summary

Documents the compile-time policy configuration model demonstrated by the existing `policy_config` example.

The new documentation explains:

* `Policy` and stable `PolicyId` values
* domain-specific policy traits
* metadata-only `Shape`, `Tile`, and `Atom` descriptors
* monomorphized kernel specializations
* policy-dependent `launch_bounds` and partial loop unrolling
* per-specialization validation through `PreparedLaunch`
* current limitations on generic policy expressions

The API quick reference now also includes the principal `cuda_device::config` types and the `config` module.

## Files changed

* `cuda-oxide-book/gpu-programming/launching-kernels.md`

  * Adds a `Compile-time policy configuration` section.
  * Links the conceptual model to the existing `policy_config` example.
  * Documents supported attributes, host launch behavior, and current boundaries.

* `cuda-oxide-book/appendix/api-quick-reference.md`

  * Adds a concise policy configuration reference.
  * Adds `cuda_device::config` to the module table.

## Validation

```bash
make -C cuda-oxide-book setup
make -C cuda-oxide-book SPHINXOPTS="-W --keep-going" html

cargo oxide build policy_config
cargo run --release \
  --manifest-path crates/rustc-codegen-cuda/examples/policy_config/Cargo.toml \
  -- --verify-ptx
```

The example verifier does not require a GPU.

## Scope

This PR only documents `policy_config`. VMM/P2P and `KernelFamily` documentation remain separate work items.
