### PR TITLE
feat(cuda-macros): raise ptx_asm! output limit to 16

### DIFF
--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -402,7 +402,7 @@ unsafe {
 }
 ```
 
-The surface supports up to 8 `out` operands, up to 16 `in` operands, and
+The surface supports up to 16 `out` operands, up to 16 `in` operands, and
 `clobber("memory")`. Every `out` constraint must be `=`-prefixed (e.g.
 `"=r"`); with two or more `out` operands the snippet returns a tuple under
 the hood, destructured into the output places in declaration order:
@@ -424,7 +424,7 @@ unsafe {
 
 `options(register_only)` requires an `out` operand and cannot be combined
 with clobbers. `options(may_diverge)` must be paired with `register_only`.
-More than 8 outputs, read-write operands, and the `"C"` constraint are not
+More than 16 outputs, read-write operands, and the `"C"` constraint are not
 implemented yet.
 
 ## Source Layout

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -74,7 +74,7 @@ pub fn gpu_printf(input: TokenStream) -> TokenStream {
 /// Literal PTX registers that begin with `%` must be escaped as `%%`, matching
 /// CUDA C++ inline PTX. Literal `$` labels can be written normally.
 ///
-/// The surface supports up to 8 `out` operands (each constraint prefixed
+/// The surface supports up to 16 `out` operands (each constraint prefixed
 /// with `=`, e.g. `"=r"`), up to 16 `in` operands, `clobber("memory")`,
 /// `options(register_only)`, and the explicit
 /// `options(register_only, may_diverge)` opt-in. With two or more `out`

--- a/crates/cuda-macros/src/ptx_asm.rs
+++ b/crates/cuda-macros/src/ptx_asm.rs
@@ -12,7 +12,7 @@ use syn::{
 };
 
 const MAX_PTX_ASM_INPUTS: usize = 16;
-const MAX_PTX_ASM_OUTPUTS: usize = 8;
+const MAX_PTX_ASM_OUTPUTS: usize = 16;
 const REGISTER_ONLY_OPTION: &str = "register_only";
 const MAY_DIVERGE_OPTION: &str = "may_diverge";
 const REGISTER_ONLY_MAY_DIVERGE_OPTIONS: &str = "register_only,may_diverge";
@@ -522,12 +522,19 @@ mod tests {
     #[test]
     fn rejects_too_many_outputs() {
         let input: PtxAsmInput = syn::parse_str(
-            r#""nop;", out("=r") a, out("=r") b, out("=r") c, out("=r") d, out("=r") e, out("=r") f, out("=r") g, out("=r") h, out("=r") i"#,
+            r#""nop;",
+            out("=r") a, out("=r") b, out("=r") c, out("=r") d,
+            out("=r") e, out("=r") f, out("=r") g, out("=r") h,
+            out("=r") i, out("=r") j, out("=r") k, out("=r") l,
+            out("=r") m, out("=r") n, out("=r") o, out("=r") p,
+            out("=r") q"#,
         )
         .unwrap();
+
         let err = build_ptx_asm(input).unwrap_err();
+
         assert!(
-            err.to_string().contains("at most 8 output operands"),
+            err.to_string().contains("at most 16 output operands"),
             "unexpected error: {err}"
         );
     }

--- a/crates/cuda-macros/tests/compile_fail/ptx_asm_output_limit.rs
+++ b/crates/cuda-macros/tests/compile_fail/ptx_asm_output_limit.rs
@@ -13,8 +13,18 @@ fn main() {
     let g: u32;
     let h: u32;
     let i: u32;
+    let j: u32;
+    let k: u32;
+    let l: u32;
+    let m: u32;
+    let n: u32;
+    let o: u32;
+    let p: u32;
+    let q: u32;
 
     unsafe {
-        ptx_asm!("nop;", out("=r") a, out("=r") b, out("=r") c, out("=r") d, out("=r") e, out("=r") f, out("=r") g, out("=r") h, out("=r") i);
+        ptx_asm!(
+            "nop;", out("=r") a, out("=r") b, out("=r") c, out("=r") d, out("=r") e, out("=r") f, out("=r") g, out("=r") h, out("=r") i, out("=r") j, out("=r") k, out("=r") l, out("=r") m, out("=r") n, out("=r") o, out("=r") p, out("=r") q,
+        );
     }
 }

--- a/crates/cuda-macros/tests/compile_fail/ptx_asm_output_limit.stderr
+++ b/crates/cuda-macros/tests/compile_fail/ptx_asm_output_limit.stderr
@@ -1,5 +1,5 @@
-error: ptx_asm! supports at most 8 output operands
-  --> tests/compile_fail/ptx_asm_output_limit.rs:18:18
+error: ptx_asm! supports at most 16 output operands
+  --> tests/compile_fail/ptx_asm_output_limit.rs:27:13
    |
-18 | ...   ptx_asm!("nop;", out("=r") a, out("=r") b, out("=r") c, out("=r") d, out("=r") e, out("=r") f, out("=r") g, out("=r") h, out("...
-   |                ^^^^^^
+27 | ...   "nop;", out("=r") a, out("=r") b, out("=r") c, out("=r") d, out("=r") e, out("=r") f, out("=r") g, out("=r") h, out("=r") i, o...
+   |       ^^^^^^

--- a/crates/cuda-macros/tests/pass/ptx_asm_multi_output.rs
+++ b/crates/cuda-macros/tests/pass/ptx_asm_multi_output.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Validates that `ptx_asm!` supports multiple `out` operands (2, 4, and 8).
+//! Validates that `ptx_asm!` supports multiple `out` operands (2, 4, 8, and 16).
 
 #![allow(dead_code, unused_variables)]
 
@@ -135,6 +135,55 @@ fn eight_outputs() {
     }
 
     let _ = (a, b, c, d, e, f, g, h);
+}
+
+/// Sixteen outputs with one input (maximum supported count).
+fn sixteen_outputs() {
+    let a: u32;
+    let b: u32;
+    let c: u32;
+    let d: u32;
+    let e: u32;
+    let f: u32;
+    let g: u32;
+    let h: u32;
+    let i: u32;
+    let j: u32;
+    let k: u32;
+    let l: u32;
+    let m: u32;
+    let n: u32;
+    let o: u32;
+    let p: u32;
+
+    unsafe {
+        ptx_asm!(
+            "mov.b32 %0, %16;
+             mov.b32 %1, %16;
+             mov.b32 %2, %16;
+             mov.b32 %3, %16;
+             mov.b32 %4, %16;
+             mov.b32 %5, %16;
+             mov.b32 %6, %16;
+             mov.b32 %7, %16;
+             mov.b32 %8, %16;
+             mov.b32 %9, %16;
+             mov.b32 %10, %16;
+             mov.b32 %11, %16;
+             mov.b32 %12, %16;
+             mov.b32 %13, %16;
+             mov.b32 %14, %16;
+             mov.b32 %15, %16;",
+            out("=r") a, out("=r") b, out("=r") c, out("=r") d,
+            out("=r") e, out("=r") f, out("=r") g, out("=r") h,
+            out("=r") i, out("=r") j, out("=r") k, out("=r") l,
+            out("=r") m, out("=r") n, out("=r") o, out("=r") p,
+            in("r") 42u32,
+            options(register_only),
+        );
+    }
+
+    let _ = (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);
 }
 
 /// Mixed output types (integer and floating point).

--- a/crates/rustc-codegen-cuda/examples/inline_ptx/README.md
+++ b/crates/rustc-codegen-cuda/examples/inline_ptx/README.md
@@ -30,7 +30,7 @@ document. If this page ever disagrees with those, they win.
 unsafe {
     ptx_asm!(
         "<template>",
-        out("<constraint>") <place>,   // output operands (up to 8)
+        out("<constraint>") <place>,   // output operands (up to 16)
         in("<constraint>") <expr>,     // input operands (up to 16)
         clobber("<name>"),             // side-effect declarations
         options(<option>, ...),        // assembly options

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -112,6 +112,7 @@ aggregate relocations can be represented without losing provenance.
 | Feature | Status | Description |
 |:--------|:-------|:------------|
 | `ptx_asm!` Macro | **Partial** | CUDA inline PTX with `%0` operands, `in`, up to 16 `out` operands (each with an `=`-prefixed constraint; two or more `out`s return a tuple destructured into the output places in declaration order), up to 16 inputs, CUDA register constraints `h`, `r`, `l`, `q`, `f`, and `d`, immediate integer constraint `n`, `clobber("memory")`, and `options(register_only)` for pure register snippets. By default, snippets are treated as side-effecting and stay inside their current control flow. Use `options(register_only, may_diverge)` only for pure snippets that are safe to move across divergent control flow; **never** use it for `.sync` instructions or collectives. More than 16 outputs, read-write operands, and the `"C"` constraint are not implemented yet. |
+
 ---
 
 ## Runtime Library: Safety

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -111,8 +111,7 @@ aggregate relocations can be represented without losing provenance.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| `ptx_asm!` Macro | **Partial** | CUDA inline PTX with `%0` operands, `in`, up to 8 `out` operands (each with an `=`-prefixed constraint; two or more `out`s return a tuple destructured into the output places in declaration order), up to 16 inputs, CUDA register constraints `h`, `r`, `l`, `q`, `f`, and `d`, immediate integer constraint `n`, `clobber("memory")`, and `options(register_only)` for pure register snippets. By default, snippets are treated as side-effecting and stay inside their current control flow. Use `options(register_only, may_diverge)` only for pure snippets that are safe to move across divergent control flow; **never** use it for `.sync` instructions or collectives. More than 8 outputs, read-write operands, and the `"C"` constraint are not implemented yet. |
-
+| `ptx_asm!` Macro | **Partial** | CUDA inline PTX with `%0` operands, `in`, up to 16 `out` operands (each with an `=`-prefixed constraint; two or more `out`s return a tuple destructured into the output places in declaration order), up to 16 inputs, CUDA register constraints `h`, `r`, `l`, `q`, `f`, and `d`, immediate integer constraint `n`, `clobber("memory")`, and `options(register_only)` for pure register snippets. By default, snippets are treated as side-effecting and stay inside their current control flow. Use `options(register_only, may_diverge)` only for pure snippets that are safe to move across divergent control flow; **never** use it for `.sync` instructions or collectives. More than 16 outputs, read-write operands, and the `"C"` constraint are not implemented yet. |
 ---
 
 ## Runtime Library: Safety


### PR DESCRIPTION
Closes #501 

## Summary

Raise the maximum number of `ptx_asm!` output operands from 8 to 16.

## Changes

* Increase `MAX_PTX_ASM_OUTPUTS` from 8 to 16.
* Add a compile-pass case exercising exactly 16 output operands.
* Verify operand indexing with 16 outputs followed by an input referenced as `%16`.
* Update the unit boundary test to reject 17 outputs.
* Update the trybuild compile-fail case and expected diagnostic for 17 outputs.
* Update the macro documentation, crate README, supported-features matrix, and inline PTX example documentation.

## Implementation notes

No importer, NVVM dialect, or lowering changes are required.

The macro already:

* Generates output bindings dynamically from the number of declared outputs.
* Represents multiple outputs as a tuple return value.
* Destructures the tuple into the destination places in declaration order.

The downstream inline PTX pipeline also derives the result count from the output constraints rather than from a fixed output limit. This change therefore only raises the procedural macro validation boundary.

## Validation

* `cargo fmt --all -- --check`
* `cargo test -p cuda-macros`
* `cargo clippy -p cuda-macros --tests -- -D warnings`
* `TRYBUILD=overwrite cargo test -p cuda-macros --test ptx_asm`

The trybuild suite passes with:

* Exactly 16 outputs accepted.
* 17 outputs rejected with the updated diagnostic.
