### PR TITLE
feat(cuda-core): safe PreparedLaunch for cluster + cooperative kernels

### DIFF
--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -996,6 +996,13 @@ impl<C: KernelLaunchContract> PreparedLaunch<C> {
                 Err(error) => return Err(error.into()),
             };
             validate_cluster_residency(C::SPEC.kernel_name, cluster, active_clusters)?;
+            // Deliberate error reuse: `active_clusters * cluster_blocks` is a
+            // device-capacity product over the cluster dimension, and
+            // `DimensionProductOverflow { Cluster }` is the closest existing
+            // diagnostic. The arm is unreachable in practice: both factors fit
+            // in u32 (`active_clusters` is driver-reported, `cluster_blocks`
+            // was validated against the u32 `max_cluster_size` above), so the
+            // product always fits in u64. `checked_mul` keeps the math honest.
             clustered_resident_blocks = Some(
                 u64::from(active_clusters)
                     .checked_mul(cluster_blocks)

--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -602,12 +602,6 @@ pub enum LaunchContractError {
         /// Requested cluster dimensions.
         cluster: (u32, u32, u32),
     },
-    /// Safe cooperative-residency validation for clustered launches is not
-    /// available through the non-cluster occupancy query.
-    ClusteredCooperativeValidationUnsupported {
-        /// Kernel being prepared.
-        kernel: &'static str,
-    },
     /// A cooperative grid cannot be fully resident on the device.
     CooperativeGridTooLarge {
         /// Kernel being prepared.
@@ -813,10 +807,6 @@ impl Display for LaunchContractError {
                 f,
                 "{kernel}: no cluster with shape {cluster:?} can be resident"
             ),
-            Self::ClusteredCooperativeValidationUnsupported { kernel } => write!(
-                f,
-                "{kernel}: clustered cooperative residency cannot be validated by this API"
-            ),
             Self::CooperativeGridTooLarge {
                 kernel,
                 blocks,
@@ -962,13 +952,6 @@ impl<C: KernelLaunchContract> PreparedLaunch<C> {
                 C::SPEC.kernel_name,
                 context.supports_cooperative_launch()?,
             )?;
-            if C::SPEC.cluster.is_some() {
-                return Err(
-                    LaunchContractError::ClusteredCooperativeValidationUnsupported {
-                        kernel: C::SPEC.kernel_name,
-                    },
-                );
-            }
         }
 
         // Perform the only persistent function mutation after all checks that
@@ -978,6 +961,12 @@ impl<C: KernelLaunchContract> PreparedLaunch<C> {
         if contract_dynamic_max > function_max_dynamic {
             function.set_max_dynamic_shared_memory_bytes(contract_dynamic_max)?;
         }
+
+        // Cluster occupancy is reused for cooperative residency when both
+        // modes are declared: a cooperative clustered grid must fit entirely
+        // in the concurrent cluster capacity reported by
+        // `cuOccupancyMaxActiveClusters`.
+        let mut clustered_resident_blocks: Option<u64> = None;
 
         if let Some(cluster) = C::SPEC.cluster {
             let max_cluster_size = function.max_potential_cluster_size(
@@ -1007,16 +996,30 @@ impl<C: KernelLaunchContract> PreparedLaunch<C> {
                 Err(error) => return Err(error.into()),
             };
             validate_cluster_residency(C::SPEC.kernel_name, cluster, active_clusters)?;
+            clustered_resident_blocks = Some(
+                u64::from(active_clusters)
+                    .checked_mul(cluster_blocks)
+                    .ok_or(LaunchContractError::DimensionProductOverflow {
+                        kernel: C::SPEC.kernel_name,
+                        dimension: LaunchDimension::Cluster,
+                    })?,
+            );
         }
 
         if C::SPEC.cooperative {
-            let block_threads =
-                shape_product(C::SPEC.kernel_name, LaunchDimension::Block, raw.block_dim)?;
-            let active_per_sm = function
-                .max_active_blocks_per_multiprocessor(block_threads as u32, raw.shared_mem_bytes)?;
-            let multiprocessors = context.multiprocessor_count()?;
-            let resident_capacity = u64::from(active_per_sm) * u64::from(multiprocessors);
             let blocks = shape_product(C::SPEC.kernel_name, LaunchDimension::Grid, raw.grid_dim)?;
+            let resident_capacity = if let Some(capacity) = clustered_resident_blocks {
+                capacity
+            } else {
+                let block_threads =
+                    shape_product(C::SPEC.kernel_name, LaunchDimension::Block, raw.block_dim)?;
+                let active_per_sm = function.max_active_blocks_per_multiprocessor(
+                    block_threads as u32,
+                    raw.shared_mem_bytes,
+                )?;
+                let multiprocessors = context.multiprocessor_count()?;
+                u64::from(active_per_sm) * u64::from(multiprocessors)
+            };
             validate_cooperative_residency(C::SPEC.kernel_name, blocks, resident_capacity)?;
         }
 
@@ -1823,6 +1826,43 @@ mod tests {
                 resident_capacity: 80,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn clustered_cooperative_residency_uses_active_cluster_capacity() {
+        // A (2,1,1) cluster with 4 concurrent clusters can host 8 blocks.
+        // A fully-resident cooperative grid of 8 blocks therefore passes, while
+        // 10 blocks (5 clusters) must fail with CooperativeGridTooLarge.
+        let cluster_blocks = 2u64;
+        let active_clusters = 4u64;
+        let resident_capacity = active_clusters * cluster_blocks;
+
+        assert!(validate_cooperative_residency(KERNEL, 8, resident_capacity).is_ok());
+        assert!(matches!(
+            validate_cooperative_residency(KERNEL, 10, resident_capacity),
+            Err(LaunchContractError::CooperativeGridTooLarge {
+                blocks: 10,
+                resident_capacity: 8,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn combined_cluster_cooperative_spec_is_expressible() {
+        let spec = exact_spec((128, 1, 1))
+            .with_cluster((2, 1, 1))
+            .with_cooperative();
+        assert_eq!(spec.cluster(), Some((2, 1, 1)));
+        assert!(spec.cooperative());
+
+        // Static geometry still requires the grid to be an integer number of
+        // clusters even when cooperative residency is also required.
+        assert!(validate_static(spec, raw((4, 1, 1), (128, 1, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((3, 1, 1), (128, 1, 1), 0)),
+            Err(LaunchContractError::ClusterDoesNotDivideGrid { .. })
         ));
     }
 

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -160,10 +160,11 @@ the marker emitted by `#[launch_contract]` is merged with alignment requests in
 the body and reachable local helpers, and the stronger value reaches PTX.
 Prelinked external helpers keep the alignment recorded when they were compiled.
 
-Cluster and cooperative contracts are validated separately. A contract that
-combines both currently fails preparation because the available occupancy query
-cannot prove the combined residency rule; the unsafe launch method remains the
-explicit expert escape hatch.
+Cluster and cooperative contracts may be declared together. Preparation proves
+cluster geometry first (`cuOccupancyMaxActiveClusters`), then checks that the
+full grid fits in that concurrent cluster capacity so a cooperative
+`grid::sync()` cannot hang waiting for non-resident blocks. Oversized grids
+fail with `LaunchContractError::CooperativeGridTooLarge`.
 
 This closes the unsafe gap from issue #115. A 1-D contract rejects a 2-D launch
 in safe code, while an uncontracted or deliberately mismatched launch requires

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -180,9 +180,12 @@ module. Generic loading also merges all PTX bundles, so those specializations
 must match and have no conflicting entry definitions. Preparation and launch
 are safe after this one-time binding.
 
-Cluster and cooperative requirements are each checked against the live device.
-Combining them currently fails preparation because cuda-oxide cannot yet prove
-the combined residency limit with the available occupancy query.
+Cluster and cooperative requirements are each checked against the live device,
+and they may be combined. For a clustered cooperative kernel, preparation first
+proves the cluster shape with `cuOccupancyMaxActiveClusters`, then requires the
+whole grid to fit in that concurrent cluster capacity so a cooperative
+`grid::sync()` cannot hang on non-resident blocks. Oversized grids fail
+preparation with `LaunchContractError::CooperativeGridTooLarge`.
 
 ### `#[cluster_launch(x, y, z)]`
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -6934,14 +6934,6 @@ impl Parse for CudaLaunchInput {
             let _ = input.parse::<Token![,]>();
         }
 
-        if cluster_dim.is_some() && cooperative.is_some() {
-            return Err(syn::Error::new(
-                input.span(),
-                "cuda_launch!: `cluster_dim` and `cooperative` are mutually exclusive — \
-                 cooperative cluster launches are not yet supported by this macro",
-            ));
-        }
-
         Ok(CudaLaunchInput {
             kernel: kernel.ok_or_else(|| syn::Error::new(input.span(), "missing 'kernel'"))?,
             stream: stream.ok_or_else(|| syn::Error::new(input.span(), "missing 'stream'"))?,
@@ -7018,7 +7010,9 @@ impl Parse for CudaLaunchInput {
 /// | `cooperative` | `bool`            | *(optional)* Set `true` to launch via `cuLaunchKernelEx` with `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` (required for `grid::sync()`) |
 /// | `args`        | `[arg, ...]`      | Kernel arguments (see below)                  |
 ///
-/// `cluster_dim` and `cooperative` are mutually exclusive at this layer.
+/// `cluster_dim` and `cooperative` may be combined. When both are set and
+/// `cooperative` is `true`, the expansion calls
+/// [`cuda_core::launch_kernel_ex_cooperative_on_stream`].
 ///
 /// # Argument forms
 ///
@@ -7037,7 +7031,10 @@ impl Parse for CudaLaunchInput {
 pub fn cuda_launch(input: TokenStream) -> TokenStream {
     track_codegen_environment();
     let input = parse_macro_input!(input as CudaLaunchInput);
+    expand_cuda_launch(input).into()
+}
 
+fn expand_cuda_launch(input: CudaLaunchInput) -> TokenStream2 {
     let stream = &input.stream;
     let module = &input.module;
     let config = &input.config;
@@ -7147,13 +7144,40 @@ pub fn cuda_launch(input: TokenStream) -> TokenStream {
         format_ident!("{}{}", INSTANTIATE_PREFIX, kernel_base),
     );
 
-    // Generate the launch call — regular, cluster, or cooperative.
+    // Generate the launch call — regular, cluster, cooperative, or both.
     //
     // All paths use the stream-aware cuda_core helpers. Those helpers bind the
     // stream's owning CUDA context to the calling thread and then delegate to
     // the raw cuLaunchKernel/cuLaunchKernelEx wrappers.
-    let launch_call = if let Some(cdim) = cluster_dim {
-        quote! {
+    let launch_call = match (&cluster_dim, &cooperative) {
+        (Some(cdim), Some(coop)) => quote! {
+            {
+                let #config_ident = #config;
+                let #cooperative_ident: bool = #coop;
+                if #cooperative_ident {
+                    cuda_core::launch_kernel_ex_cooperative_on_stream(
+                        &#function_ident,
+                        #config_ident.grid_dim,
+                        #config_ident.block_dim,
+                        #config_ident.shared_mem_bytes,
+                        #cdim,
+                        (#stream).as_ref(),
+                        &mut #args_ident,
+                    )
+                } else {
+                    cuda_core::launch_kernel_ex_on_stream(
+                        &#function_ident,
+                        #config_ident.grid_dim,
+                        #config_ident.block_dim,
+                        #config_ident.shared_mem_bytes,
+                        #cdim,
+                        (#stream).as_ref(),
+                        &mut #args_ident,
+                    )
+                }
+            }
+        },
+        (Some(cdim), None) => quote! {
             {
                 let #config_ident = #config;
                 cuda_core::launch_kernel_ex_on_stream(
@@ -7166,9 +7190,8 @@ pub fn cuda_launch(input: TokenStream) -> TokenStream {
                     &mut #args_ident,
                 )
             }
-        }
-    } else if let Some(coop) = cooperative {
-        quote! {
+        },
+        (None, Some(coop)) => quote! {
             {
                 let #config_ident = #config;
                 let #cooperative_ident: bool = #coop;
@@ -7192,9 +7215,8 @@ pub fn cuda_launch(input: TokenStream) -> TokenStream {
                     )
                 }
             }
-        }
-    } else {
-        quote! {
+        },
+        (None, None) => quote! {
             {
                 let #config_ident = #config;
                 cuda_core::launch_kernel_on_stream(
@@ -7206,7 +7228,7 @@ pub fn cuda_launch(input: TokenStream) -> TokenStream {
                     &mut #args_ident,
                 )
             }
-        }
+        },
     };
 
     let expanded = if has_closure {
@@ -7279,7 +7301,7 @@ pub fn cuda_launch(input: TokenStream) -> TokenStream {
         }
     };
 
-    TokenStream::from(expanded)
+    expanded
 }
 
 // ============================================================================
@@ -7871,6 +7893,31 @@ mod tests {
         assert!(
             !expanded.contains("launch_kernel_ex_on_stream"),
             "cluster-only call should be replaced by the combined one:\n{expanded}"
+        );
+    }
+
+    #[test]
+    fn cuda_launch_accepts_combined_cluster_and_cooperative() {
+        let input: CudaLaunchInput = parse_quote! {
+            kernel: clustered_grid_sync_kernel,
+            stream: stream,
+            module: module,
+            config: config,
+            cluster_dim: (2, 1, 1),
+            cooperative: true,
+            args: []
+        };
+        assert!(input.cluster_dim.is_some());
+        assert!(input.cooperative.is_some());
+
+        let expanded = expand_cuda_launch(input).to_string().replace(' ', "");
+        assert!(
+            expanded.contains("launch_kernel_ex_cooperative_on_stream"),
+            "expected combined cluster+cooperative cuda_launch expansion:\n{expanded}"
+        );
+        assert!(
+            !expanded.contains("launch_kernel_cooperative_on_stream"),
+            "non-cluster cooperative helper must not be used when cluster_dim is set:\n{expanded}"
         );
     }
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -7012,7 +7012,7 @@ impl Parse for CudaLaunchInput {
 ///
 /// `cluster_dim` and `cooperative` may be combined. When both are set and
 /// `cooperative` is `true`, the expansion calls
-/// [`cuda_core::launch_kernel_ex_cooperative_on_stream`].
+/// `cuda_core::launch_kernel_ex_cooperative_on_stream`.
 ///
 /// # Argument forms
 ///
@@ -7231,7 +7231,7 @@ fn expand_cuda_launch(input: CudaLaunchInput) -> TokenStream2 {
         },
     };
 
-    let expanded = if has_closure {
+    if has_closure {
         let closure_expr = closure_info.expect("has_closure but no closure_info");
 
         // The on-wire PTX name comes from the kernel's
@@ -7299,9 +7299,7 @@ fn expand_cuda_launch(input: CudaLaunchInput) -> TokenStream2 {
                 #launch_call
             }
         }
-    };
-
-    expanded
+    }
 }
 
 // ============================================================================

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
@@ -50,10 +50,11 @@ The 21 checks split into three layers:
 launches through the typed path: both kernels carry
 `#[cooperative_launch]` inside a `#[cuda_module]` module, so their
 generated launch methods submit via `cuLaunchKernelEx` with
-`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`. The same module also holds a
-compile-only kernel combining `#[cluster_launch(2, 1, 1)]` with
-`#[cooperative_launch]`, pinning that the two attributes are accepted
-together.
+`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`. The same module also holds
+`test_cluster_coop_grid_sync`, which combines `#[cluster_launch(2, 1, 1)]`
+with `#[cooperative_launch]` and a `#[launch_contract]`. On Hopper+ that
+kernel is prepared and launched through the safe `PreparedLaunch` path;
+pre-Hopper devices print that the combined mode was not exercised.
 
 ### Layer 2 — typed cooperative-groups handles (5 checks)
 

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
@@ -27,7 +27,8 @@ use cuda_device::cooperative_groups::{
     this_grid, this_thread_block, warp_reduce, warp_scan,
 };
 use cuda_device::{
-    DisjointSlice, SharedArray, cluster_launch, cooperative_launch, grid, kernel, thread, warp,
+    DisjointSlice, SharedArray, cluster_launch, cooperative_launch, grid, kernel, launch_bounds,
+    launch_contract, thread, warp,
 };
 use cuda_host::{cuda_launch, cuda_module};
 

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
@@ -20,7 +20,7 @@
 //! op/type matrix. The generated `coop_groups_demo.ptx` is also handy
 //! for inspecting how each kernel actually lowers.
 
-use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig, LaunchConfig1D};
 use cuda_device::cooperative_groups::{
     ThreadGroup, WarpCollective, block_reduce, block_scan, coalesced_threads,
     ops::{BitAnd, BitOr, BitXor, Max, Min, Sum},
@@ -145,22 +145,43 @@ mod grid_sync_kernels {
         }
     }
 
-    /// Compile-only pin: `#[cluster_launch]` and `#[cooperative_launch]` may
-    /// be combined, because `cuLaunchKernelEx` accepts the cluster-dimension
-    /// and cooperative attributes in the same call. The generated launch
-    /// methods route through
-    /// `cuda_core::launch_kernel_ex_cooperative_on_stream`. This kernel is
-    /// never launched at runtime here; it only pins that the combination
-    /// keeps compiling end to end (macro expansion, host launch methods, and
-    /// device PTX).
+    /// Combined cluster + cooperative launch: each cluster of 2 blocks writes
+    /// markers, then `grid::sync()` publishes them to every block. Preparation
+    /// must accept both attributes and prove the grid fits in concurrent
+    /// cluster capacity (Hopper+).
     #[kernel]
     #[cluster_launch(2, 1, 1)]
     #[cooperative_launch]
-    pub fn test_cluster_coop_compile_only(mut out: DisjointSlice<u32>) {
-        let gid = thread::index_1d();
+    #[launch_bounds(128)]
+    #[launch_contract(domain = 1, block = (128, 1, 1))]
+    pub fn test_cluster_coop_grid_sync(
+        mut markers: DisjointSlice<u32>,
+        mut out: DisjointSlice<u32>,
+    ) {
+        let block_id = thread::blockIdx_x();
+        let n = thread::gridDim_x();
+
+        if thread::threadIdx_x() == 0 {
+            unsafe {
+                *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
+            }
+        }
+
         grid::sync();
-        if let Some(slot) = out.get_mut(gid) {
-            *slot = 1;
+
+        if thread::threadIdx_x() == 0 {
+            let base = markers.as_mut_ptr() as *const u32;
+            let mut sum: u32 = 0;
+            let mut i: u32 = 0;
+            while i < n {
+                unsafe {
+                    sum = sum.wrapping_add(*base.add(i as usize));
+                }
+                i += 1;
+            }
+            unsafe {
+                *out.get_unchecked_mut(block_id as usize) = sum;
+            }
         }
     }
 }
@@ -642,8 +663,12 @@ fn main() {
     // Typed handle for the `#[cuda_module]` grid-sync kernels. Their
     // `#[cooperative_launch]` attribute makes the generated launch methods
     // submit cooperative launches, so no per-call flag is needed.
-    let grid_sync_module = grid_sync_kernels::from_module(module.clone())
-        .expect("Failed to initialize typed grid-sync module");
+    // SAFETY: `module` was loaded from this example's own PTX bundle, which
+    // contains the grid-sync and cluster-coop entry points declared below.
+    let grid_sync_module = unsafe {
+        grid_sync_kernels::from_module(module.clone())
+            .expect("Failed to initialize typed grid-sync module")
+    };
 
     const N: usize = 256;
     let cfg = LaunchConfig {
@@ -746,6 +771,76 @@ fn main() {
     if !ok {
         println!("  observed sums: {:?}", host);
         std::process::exit(1);
+    }
+
+    // --- cluster + cooperative (Hopper+) ---
+    println!("\n--- cluster + cooperative grid::sync() (PreparedLaunch) ---");
+    const CLUSTER_COOP_BLOCKS: u32 = 4; // divisible by #[cluster_launch(2, 1, 1)]
+    const CLUSTER_COOP_THREADS: u32 = 128;
+    match ctx.supports_cluster_launch() {
+        Ok(false) => {
+            println!(
+                "  cluster+cooperative: not exercised (device lacks cluster launch / Hopper+)"
+            );
+        }
+        Err(error) => {
+            println!("  cluster support query failed: {error}");
+            std::process::exit(1);
+        }
+        Ok(true) => {
+            let cluster_config = LaunchConfig1D::new(CLUSTER_COOP_BLOCKS, CLUSTER_COOP_THREADS, 0);
+            let prepared =
+                match grid_sync_module.prepare_test_cluster_coop_grid_sync(cluster_config) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        println!("  prepare failed: {error}");
+                        std::process::exit(1);
+                    }
+                };
+            let mut markers =
+                DeviceBuffer::<u32>::zeroed(&stream, CLUSTER_COOP_BLOCKS as usize).unwrap();
+            let mut sums =
+                DeviceBuffer::<u32>::zeroed(&stream, CLUSTER_COOP_BLOCKS as usize).unwrap();
+            grid_sync_module
+                .test_cluster_coop_grid_sync(stream.as_ref(), &prepared, &mut markers, &mut sums)
+                .expect("test_cluster_coop_grid_sync launch failed");
+            let host = sums.to_host_vec(&stream).unwrap();
+            let expected: u32 = (1..=CLUSTER_COOP_BLOCKS).sum();
+            let ok = host.iter().all(|&s| s == expected);
+            println!(
+                "  every block saw the full barrier-flushed marker sum {} : {}",
+                expected,
+                if ok { "yes" } else { "NO" }
+            );
+            if !ok {
+                println!("  observed sums: {:?}", host);
+                std::process::exit(1);
+            }
+
+            // Oversized cooperative clustered grid must fail preparation with a
+            // clear residency error rather than hanging at launch.
+            let too_large = LaunchConfig1D::new(1_048_576, CLUSTER_COOP_THREADS, 0);
+            match grid_sync_module.prepare_test_cluster_coop_grid_sync(too_large) {
+                Err(error) => {
+                    let message = error.to_string();
+                    let ok = message.contains("cooperative grid")
+                        || message.contains("cluster")
+                        || message.contains("resident");
+                    println!(
+                        "  oversized prepare rejected cleanly: {}",
+                        if ok { "yes" } else { "NO" }
+                    );
+                    if !ok {
+                        println!("  unexpected prepare error: {message}");
+                        std::process::exit(1);
+                    }
+                }
+                Ok(_) => {
+                    println!("  oversized prepare unexpectedly succeeded");
+                    std::process::exit(1);
+                }
+            }
+        }
     }
 
     // =========================================================================

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/src/main.rs
@@ -162,6 +162,9 @@ mod grid_sync_kernels {
         let n = thread::gridDim_x();
 
         if thread::threadIdx_x() == 0 {
+            // SAFETY: the host sizes `markers` to exactly gridDim.x elements,
+            // so `block_id` indexes in bounds, and only thread 0 of each
+            // block writes its own slot, so the writes are disjoint.
             unsafe {
                 *markers.get_unchecked_mut(block_id as usize) = block_id + 1;
             }
@@ -174,11 +177,18 @@ mod grid_sync_kernels {
             let mut sum: u32 = 0;
             let mut i: u32 = 0;
             while i < n {
+                // SAFETY: `i < n = gridDim.x` and `markers` holds gridDim.x
+                // elements, so `base.add(i)` stays in bounds. Every block's
+                // marker write happened before `grid::sync()`, so the
+                // cross-block reads are data-race free.
                 unsafe {
                     sum = sum.wrapping_add(*base.add(i as usize));
                 }
                 i += 1;
             }
+            // SAFETY: the host sizes `out` to exactly gridDim.x elements, so
+            // `block_id` indexes in bounds, and only thread 0 of each block
+            // writes its own slot.
             unsafe {
                 *out.get_unchecked_mut(block_id as usize) = sum;
             }

--- a/cuda-oxide-book/gpu-programming/launching-kernels.md
+++ b/cuda-oxide-book/gpu-programming/launching-kernels.md
@@ -152,6 +152,14 @@ cannot represent active Y/Z dimensions, and `PreparedLaunch<vecadd>` cannot be
 used with another kernel. Preparation may fail; once it succeeds, the branded
 launch can be reused safely.
 
+Cluster and cooperative attributes may be declared together
+(`#[cluster_launch(...)]` + `#[cooperative_launch]`). Preparation proves the
+cluster shape with `cuOccupancyMaxActiveClusters`, then requires the whole
+grid to fit in that concurrent cluster capacity so a cooperative
+`grid::sync()` cannot hang on non-resident blocks. An oversized grid fails
+preparation with `LaunchContractError::CooperativeGridTooLarge` (or a related
+cluster residency error) instead of submitting an unsound launch.
+
 For a contracted kernel, the raw escape hatch is named `vecadd_unchecked` and
 remains unsafe. Uncontracted kernels expose only unsafe raw launch methods.
 


### PR DESCRIPTION
## Summary

- Enable safe `PreparedLaunch` for kernels that declare both `#[cluster_launch]` and `#[cooperative_launch]`
- Prove cooperative residency from `cuOccupancyMaxActiveClusters` capacity (`active_clusters * blocks_per_cluster`) instead of rejecting with `ClusteredCooperativeValidationUnsupported`
- Allow `cuda_launch!` to pass both `cluster_dim` and `cooperative`, expanding to `launch_kernel_ex_cooperative_on_stream`
- Extend `coop_groups_demo` to prepare + launch a contracted cluster+cooperative kernel on Hopper+, and to assert oversized preparation fails cleanly
- Document the combined mode in `cuda-host` README and the launching-kernels book chapter

Closes #480

## Test plan

- [x] `cargo test -p cuda-core --lib launch::`
- [x] `cargo test -p cuda-macros --lib cooperative_plus_cluster cuda_launch_accepts_combined`
- [x] `cargo oxide run coop_groups_demo` on Hopper+ (exercises prepared cluster+coop launch + oversized prepare rejection)
- [x] `cargo oxide run coop_groups_demo` on pre-Hopper (prints that cluster+cooperative was not exercised; other checks still PASS)
- [x] Confirm `cuda_launch! { ..., cluster_dim: (...), cooperative: true, ... }` compiles and routes through the combined helper