### PR TITLE
feat(cargo-oxide): polish new-project scaffold

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -4018,6 +4018,16 @@ fn scaffold_readme(name: &str, async_mode: bool) -> String {
     } else {
         "cuda-oxide"
     };
+    let template_notes = if async_mode {
+        "The template is a vector-add kernel launched through `cuda-async`:\n\
+         `vecadd_async` returns a lazy `DeviceOperation` scheduled on the\n\
+         stream pool. See the cuda-oxide book getting-started chapter for the\n\
+         next steps."
+    } else {
+        "The template is a vector-add kernel. It uses `#[launch_contract]` and\n\
+         `PreparedLaunch` so geometry is checked before launch. See the\n\
+         cuda-oxide book getting-started chapter for the next steps."
+    };
     format!(
         r#"# {name}
 
@@ -4037,9 +4047,7 @@ Fix anything doctor reports before building.
 cargo oxide run
 ```
 
-The template is a vector-add kernel. The sync template uses
-`#[launch_contract]` and `PreparedLaunch` so geometry is checked before
-launch. See the cuda-oxide book getting-started chapter for the next steps.
+{template_notes}
 "#
     )
 }
@@ -4177,7 +4185,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 "#
         .to_string()
     } else {
-        r#"use cuda_device::{kernel, thread, DisjointSlice};
+        r#"use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};
 use cuda_host::cuda_module;
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
 
@@ -4260,8 +4268,11 @@ pub fn scaffold_new(name: &str, async_mode: bool) {
     let files = scaffold_files(name, async_mode);
     std::fs::write(project_dir.join("Cargo.toml"), files.cargo_toml)
         .expect("Failed to write Cargo.toml");
-    std::fs::write(project_dir.join("rust-toolchain.toml"), files.rust_toolchain_toml)
-        .expect("Failed to write rust-toolchain.toml");
+    std::fs::write(
+        project_dir.join("rust-toolchain.toml"),
+        files.rust_toolchain_toml,
+    )
+    .expect("Failed to write rust-toolchain.toml");
     std::fs::write(project_dir.join(".gitignore"), files.gitignore)
         .expect("Failed to write .gitignore");
     std::fs::write(project_dir.join("README.md"), files.readme).expect("Failed to write README.md");
@@ -6502,7 +6513,17 @@ device-owner = { path = "../device-owner" }
         assert!(files.readme.contains("cargo oxide doctor"));
         assert!(files.readme.contains("cargo oxide run"));
         assert!(files.gitignore.contains("/target/"));
-        assert!(files.main_rs.contains("#[launch_contract(domain = 1, block = (256, 1, 1))]"));
+        // The template uses the launch_bounds / launch_contract attribute
+        // macros, so the cuda_device import must bring them in; a scaffolded
+        // project fails to compile without this exact line.
+        assert!(files.main_rs.starts_with(
+            "use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};"
+        ));
+        assert!(
+            files
+                .main_rs
+                .contains("#[launch_contract(domain = 1, block = (256, 1, 1))]")
+        );
         assert!(files.main_rs.contains("prepare_vecadd"));
         assert!(files.main_rs.contains("LaunchConfig1D"));
         assert!(!files.main_rs.contains("LaunchConfig::for_num_elems"));
@@ -6515,6 +6536,10 @@ device-owner = { path = "../device-owner" }
         assert!(files.cargo_toml.contains("tokio"));
         assert!(files.readme.contains("async cuda-oxide"));
         assert!(files.readme.contains("cargo oxide doctor"));
+        // The async README must stand alone: it describes the async launch
+        // path and never talks about "the sync template".
+        assert!(files.readme.contains("DeviceOperation"));
+        assert!(!files.readme.contains("sync template"));
         assert!(files.gitignore.contains("**/*.ptx"));
         assert!(files.main_rs.contains("vecadd_async"));
     }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -3992,21 +3992,60 @@ channel = "nightly-2026-04-03"
 components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]
 "#;
 
-/// Scaffold a new standalone cuda-oxide project.
-pub fn scaffold_new(name: &str, async_mode: bool) {
-    let project_dir = PathBuf::from(name);
-    if project_dir.exists() {
-        eprintln!("Error: directory '{}' already exists.", name);
-        std::process::exit(1);
-    }
+const SCAFFOLD_GITIGNORE: &str = "\
+/target/
+**/*.ptx
+**/*.ll
+**/*.bc
+**/*.cubin
+**/*.ltoir
+.DS_Store
+";
 
-    let src_dir = project_dir.join("src");
-    std::fs::create_dir_all(&src_dir).unwrap_or_else(|e| {
-        eprintln!("Error creating directory: {}", e);
-        std::process::exit(1);
-    });
+/// File contents produced by `cargo oxide new`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ScaffoldFiles {
+    cargo_toml: String,
+    rust_toolchain_toml: String,
+    gitignore: String,
+    readme: String,
+    main_rs: String,
+}
 
-    let cargo_toml = if async_mode {
+fn scaffold_readme(name: &str, async_mode: bool) -> String {
+    let mode = if async_mode {
+        "async cuda-oxide"
+    } else {
+        "cuda-oxide"
+    };
+    format!(
+        r#"# {name}
+
+Scaffolded {mode} project.
+
+## Setup
+
+```bash
+cargo oxide doctor
+```
+
+Fix anything doctor reports before building.
+
+## Run
+
+```bash
+cargo oxide run
+```
+
+The template is a vector-add kernel. The sync template uses
+`#[launch_contract]` and `PreparedLaunch` so geometry is checked before
+launch. See the cuda-oxide book getting-started chapter for the next steps.
+"#
+    )
+}
+
+fn scaffold_cargo_toml(name: &str, async_mode: bool) -> String {
+    if async_mode {
         format!(
             r#"[package]
 name = "{name}"
@@ -4039,9 +4078,11 @@ cuda-host = {{ git = "{GIT_REPO}" }}
 cuda-core = {{ git = "{GIT_REPO}" }}
 "#
         )
-    };
+    }
+}
 
-    let main_rs = if async_mode {
+fn scaffold_main_rs(async_mode: bool) -> String {
+    if async_mode {
         r#"use cuda_device::{kernel, thread, DisjointSlice};
 use cuda_host::cuda_module;
 use cuda_async::device_context::init_device_contexts;
@@ -4138,13 +4179,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         r#"use cuda_device::{kernel, thread, DisjointSlice};
 use cuda_host::cuda_module;
-use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
 
 #[cuda_module]
 mod kernels {
     use super::*;
 
     #[kernel]
+    #[launch_bounds(256)]
+    #[launch_contract(domain = 1, block = (256, 1, 1))]
     pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
         let idx = thread::index_1d();
         let idx_raw = idx.get();
@@ -4153,34 +4196,26 @@ mod kernels {
         }
     }
 }
-fn main() {
-    let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
     const N: usize = 1024;
     let a_host: Vec<f32> = (0..N).map(|i| i as f32).collect();
     let b_host: Vec<f32> = (0..N).map(|i| (i * 2) as f32).collect();
 
-    let a_dev = DeviceBuffer::from_host(&stream, &a_host).unwrap();
-    let b_dev = DeviceBuffer::from_host(&stream, &b_host).unwrap();
-    let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    let a_dev = DeviceBuffer::from_host(&stream, &a_host)?;
+    let b_dev = DeviceBuffer::from_host(&stream, &b_host)?;
+    let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
 
-    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    // SAFETY: this is a 1D launch and `vecadd` guards its index against the
-    // output length before writing.
-    unsafe {
-        module.vecadd(
-            &stream,
-            LaunchConfig::for_num_elems(N as u32),
-            &a_dev,
-            &b_dev,
-            &mut c_dev,
-        )
-    }
-    .expect("Kernel launch failed");
+    // SAFETY: this package owns the embedded device bundle produced for the
+    // kernels module above.
+    let module = unsafe { kernels::load(&ctx)? };
+    let prepared = module.prepare_vecadd(LaunchConfig1D::new((N as u32).div_ceil(256), 256, 0))?;
+    module.vecadd(&stream, &prepared, &a_dev, &b_dev, &mut c_dev)?;
 
-    let c_host = c_dev.to_host_vec(&stream).unwrap();
-
+    let c_host = c_dev.to_host_vec(&stream)?;
     let errors = (0..N)
         .filter(|&i| (c_host[i] - (a_host[i] + b_host[i])).abs() > 1e-5)
         .count();
@@ -4191,21 +4226,53 @@ fn main() {
         eprintln!("FAILED: {} errors", errors);
         std::process::exit(1);
     }
+    Ok(())
 }
 "#
         .to_string()
-    };
+    }
+}
 
-    std::fs::write(project_dir.join("Cargo.toml"), cargo_toml).expect("Failed to write Cargo.toml");
-    std::fs::write(project_dir.join("rust-toolchain.toml"), RUST_TOOLCHAIN_TOML)
+fn scaffold_files(name: &str, async_mode: bool) -> ScaffoldFiles {
+    ScaffoldFiles {
+        cargo_toml: scaffold_cargo_toml(name, async_mode),
+        rust_toolchain_toml: RUST_TOOLCHAIN_TOML.to_string(),
+        gitignore: SCAFFOLD_GITIGNORE.to_string(),
+        readme: scaffold_readme(name, async_mode),
+        main_rs: scaffold_main_rs(async_mode),
+    }
+}
+
+/// Scaffold a new standalone cuda-oxide project.
+pub fn scaffold_new(name: &str, async_mode: bool) {
+    let project_dir = PathBuf::from(name);
+    if project_dir.exists() {
+        eprintln!("Error: directory '{}' already exists.", name);
+        std::process::exit(1);
+    }
+
+    let src_dir = project_dir.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap_or_else(|e| {
+        eprintln!("Error creating directory: {}", e);
+        std::process::exit(1);
+    });
+
+    let files = scaffold_files(name, async_mode);
+    std::fs::write(project_dir.join("Cargo.toml"), files.cargo_toml)
+        .expect("Failed to write Cargo.toml");
+    std::fs::write(project_dir.join("rust-toolchain.toml"), files.rust_toolchain_toml)
         .expect("Failed to write rust-toolchain.toml");
-    std::fs::write(src_dir.join("main.rs"), main_rs).expect("Failed to write src/main.rs");
+    std::fs::write(project_dir.join(".gitignore"), files.gitignore)
+        .expect("Failed to write .gitignore");
+    std::fs::write(project_dir.join("README.md"), files.readme).expect("Failed to write README.md");
+    std::fs::write(src_dir.join("main.rs"), files.main_rs).expect("Failed to write src/main.rs");
 
     let mode = if async_mode { " (async)" } else { "" };
     println!("✓ Created cuda-oxide project '{}'{}", name, mode);
     println!();
     println!("  cd {}", name);
-    println!("  cargo oxide run {}", name);
+    println!("  cargo oxide doctor");
+    println!("  cargo oxide run");
 }
 
 /// Locate an executable by name, first via `which` (PATH lookup), then by
@@ -6426,5 +6493,29 @@ device-owner = { path = "../device-owner" }
             std::env::remove_var("CUDA_OXIDE_TARGET");
         }
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn scaffold_sync_template_uses_launch_contract_and_docs() {
+        let files = scaffold_files("demo_kernel", false);
+        assert!(files.cargo_toml.contains("name = \"demo_kernel\""));
+        assert!(files.readme.contains("cargo oxide doctor"));
+        assert!(files.readme.contains("cargo oxide run"));
+        assert!(files.gitignore.contains("/target/"));
+        assert!(files.main_rs.contains("#[launch_contract(domain = 1, block = (256, 1, 1))]"));
+        assert!(files.main_rs.contains("prepare_vecadd"));
+        assert!(files.main_rs.contains("LaunchConfig1D"));
+        assert!(!files.main_rs.contains("LaunchConfig::for_num_elems"));
+    }
+
+    #[test]
+    fn scaffold_async_template_keeps_async_deps_and_docs() {
+        let files = scaffold_files("async_demo", true);
+        assert!(files.cargo_toml.contains("cuda-async"));
+        assert!(files.cargo_toml.contains("tokio"));
+        assert!(files.readme.contains("async cuda-oxide"));
+        assert!(files.readme.contains("cargo oxide doctor"));
+        assert!(files.gitignore.contains("**/*.ptx"));
+        assert!(files.main_rs.contains("vecadd_async"));
     }
 }

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -36,6 +36,8 @@ This generates a ready-to-run project:
 ```text
 my_first_kernel/
 ├── Cargo.toml          # dependencies on cuda-device, cuda-host, cuda-core
+├── README.md           # doctor + run instructions
+├── .gitignore          # target/ and generated device artifacts
 ├── rust-toolchain.toml # pins the required nightly toolchain
 └── src/
     └── main.rs          # kernel + host code in one file

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -58,8 +58,9 @@ You should see `PASSED: all 1024 elements correct`. The generated template is a 
 Here's a vector addition with a twist: the element-wise addition is factored out into a plain helper function. Both the kernel and the helper live in the same file alongside host code:
 
 ```rust
-use cuda_device::{cuda_module, kernel, thread, DisjointSlice};
-use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};
+use cuda_host::cuda_module;
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
 
 /// Plain helper function -- no annotation needed.
 /// The compiler discovers it automatically because `vecadd` calls it.
@@ -72,6 +73,8 @@ mod kernels {
     use super::*;
 
     #[kernel]
+    #[launch_bounds(256)]
+    #[launch_contract(domain = 1, block = (256, 1, 1))]
     pub fn vecadd(a: &[f32], b: &[f32], mut c: DisjointSlice<f32>) {
         let idx = thread::index_1d();
         let i = idx.get();
@@ -81,32 +84,25 @@ mod kernels {
     }
 }
 
-fn main() {
-    let ctx = CudaContext::new(0).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
     const N: usize = 1024;
     let a_host: Vec<f32> = (0..N).map(|i| i as f32).collect();
     let b_host: Vec<f32> = (0..N).map(|i| (i * 2) as f32).collect();
 
-    let a_dev = DeviceBuffer::from_host(&stream, &a_host).unwrap();
-    let b_dev = DeviceBuffer::from_host(&stream, &b_host).unwrap();
-    let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+    let a_dev = DeviceBuffer::from_host(&stream, &a_host)?;
+    let b_dev = DeviceBuffer::from_host(&stream, &b_host)?;
+    let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
 
-    let module = kernels::load(&ctx).expect("Failed to load embedded module");
-    // SAFETY: `for_num_elems` is 1D and all three buffers contain N elements.
-    unsafe {
-        module.vecadd(
-            &stream,
-            LaunchConfig::for_num_elems(N as u32),
-            &a_dev,
-            &b_dev,
-            &mut c_dev,
-        )
-    }
-    .unwrap();
+    // SAFETY: this package owns the embedded device bundle produced for the
+    // kernels module above.
+    let module = unsafe { kernels::load(&ctx)? };
+    let prepared = module.prepare_vecadd(LaunchConfig1D::new((N as u32).div_ceil(256), 256, 0))?;
+    module.vecadd(&stream, &prepared, &a_dev, &b_dev, &mut c_dev)?;
 
-    let c_host = c_dev.to_host_vec(&stream).unwrap();
+    let c_host = c_dev.to_host_vec(&stream)?;
     let errors = (0..N)
         .filter(|&i| (c_host[i] - (a_host[i] + b_host[i])).abs() > 1e-5)
         .count();
@@ -117,6 +113,7 @@ fn main() {
         eprintln!("FAILED: {} errors", errors);
         std::process::exit(1);
     }
+    Ok(())
 }
 ```
 
@@ -149,26 +146,25 @@ The `#[device]` attribute exists but serves a different purpose: it marks a func
 `#[cuda_module]` wraps the inline kernel module and generates a typed host API:
 
 ```rust
-let module = kernels::load(&ctx)?;
-// SAFETY: this is a 1D launch and all three buffers contain N elements.
-unsafe {
-    module.vecadd(
-        &stream,
-        LaunchConfig::for_num_elems(N as u32),
-        &a_dev,
-        &b_dev,
-        &mut c_dev,
-    )
-}?;
+// SAFETY: this package owns the embedded device bundle produced for the
+// kernels module above.
+let module = unsafe { kernels::load(&ctx)? };
+let prepared = module.prepare_vecadd(LaunchConfig1D::new((N as u32).div_ceil(256), 256, 0))?;
+module.vecadd(&stream, &prepared, &a_dev, &b_dev, &mut c_dev)?;
 ```
 
 The loader reads the embedded device artifact from the host binary, caches kernel
 function handles, and exposes each `#[kernel]` as a Rust method. The method
 signature mirrors the kernel signature, with device slices mapped to
-`DeviceBuffer` borrows. This checks argument types, but a raw `LaunchConfig`
-does not prove that a 1D-index kernel was given a 1D launch. Raw generated
-launch methods are therefore unsafe. A declared launch contract enables the
-safe prepared path shown in [Launching Kernels](../gpu-programming/launching-kernels.md).
+`DeviceBuffer` borrows. Because `vecadd` declares a `#[launch_contract]`, the
+module also generates `prepare_vecadd`: it takes a rank-preserving
+`LaunchConfig1D` and validates it against the contract and the live device
+limits, returning a `PreparedLaunch<vecadd>` proof that the safe `vecadd`
+method consumes. Loading is the one remaining unsafe step -- the caller vouches
+that the embedded bundle matches the module's declared ABI. Kernels without a
+contract expose only raw, unsafe launch methods, because a raw `LaunchConfig`
+does not prove that a 1D-index kernel was given a 1D launch. The full prepared
+path is covered in [Launching Kernels](../gpu-programming/launching-kernels.md).
 
 `load_kernel_module` and `cuda_launch!` remain available as lower-level APIs
 for manual sidecar artifact loading and custom launch code. `cuda_launch!`
@@ -180,7 +176,7 @@ be wrapped in `unsafe { }`.
 Slices cross the host/device ABI as their `(ptr, len)` components -- the host passes them as two kernel arguments, and the device compiler reassembles the slice in the entry block. Structs and closures by value travel as one byval `.param` instead, so the host packet pushes the whole aggregate as a single slot (this matches what the launcher actually does and avoids mismatches with field-by-field declarations). All of this is fully transparent -- the kernel signature still looks like ordinary Rust:
 
 ```text
-Host:   unsafe { module.vecadd(&stream, raw_config, &data, ...) }
+Host:   module.vecadd(&stream, &prepared, &data, ...)
           → extracts (ptr, len) for the slice, passes two args
 
 PTX:    .entry kernel(.param .u64 ptr, .param .u64 len, ...)


### PR DESCRIPTION
## Summary

- Generate `README.md` with `cargo oxide doctor` / `cargo oxide run` steps
- Generate `.gitignore` for `target/` and common device artifacts
- Default the sync template to `#[launch_contract]` + `PreparedLaunch`
- Update the getting-started book tree listing
- Unit-test scaffold file contents (no GPU)

Closes #507

## Test plan

- [x] `cargo test -p cargo-oxide scaffold_`
- [x] `cargo run -p cargo-oxide -- new smoke_scaffold` writes README, `.gitignore`, and contract-based `main.rs`
- [x] CI unit-tests workflow