### PR TITLE
feat(cuda-device): over-aligned element types with a checked slice view

### DIFF
--- a/crates/cuda-device/src/bf16x2.rs
+++ b/crates/cuda-device/src/bf16x2.rs
@@ -5,5 +5,10 @@
 //!
 //! Each `u32` stores two bf16 values. The first value uses the low 16 bits.
 //! The second value uses the high 16 bits.
+//!
+//! The packing here is the ALU format for SIMD arithmetic. For over-aligned
+//! *memory element* types that make loads and stores single wide transactions,
+//! see [`crate::vector`]. For multi-register *value* groups, see
+//! [`crate::cusimd::CuSimd`].
 
 include!("generated/bf16x2.rs");

--- a/crates/cuda-device/src/cusimd.rs
+++ b/crates/cuda-device/src/cusimd.rs
@@ -17,6 +17,11 @@
 //! N values of type T that travel together through registers. All access
 //! methods use **copy semantics** - we copy values out, not reference them.
 //!
+//! For the *memory* counterpart - over-aligned element types whose alignment
+//! makes loads and stores single wide transactions - see [`crate::vector`]
+//! (e.g. [`crate::vector::F32x4`]). For packed 16-bit ALU pairs, see
+//! [`crate::f16x2`] / [`crate::bf16x2`].
+//!
 //! # Example
 //!
 //! ```rust,ignore

--- a/crates/cuda-device/src/f16x2.rs
+++ b/crates/cuda-device/src/f16x2.rs
@@ -5,5 +5,11 @@
 //!
 //! Each `u32` stores two f16 values. The first value uses the low 16 bits.
 //! The second value uses the high 16 bits.
+//!
+//! The packing here is the ALU format for SIMD arithmetic. For over-aligned
+//! *memory element* types that make loads and stores single wide transactions
+//! (e.g. eight packed halves moving as one 128-bit access), see
+//! [`crate::vector`]. For multi-register *value* groups, see
+//! [`crate::cusimd::CuSimd`].
 
 include!("generated/f16x2.rs");

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -37,6 +37,7 @@ pub mod shared;
 pub mod tcgen05;
 pub mod thread;
 pub mod tma;
+pub mod vector;
 pub mod view;
 pub mod warp;
 pub mod wgmma;

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -55,6 +55,21 @@
 //! assumption, and to fail loudly on the cases where it does not hold: a slice
 //! taken at a hand-computed offset, a sub-slice starting at an odd index, or a
 //! length that is not a whole number of vectors.
+//!
+//! # Host-side story
+//!
+//! `cuda-core` does not depend on `cuda-device`, so these types carry no
+//! `DeviceCopy` impl, and the orphan rule stops downstream crates from adding
+//! one: a `DeviceBuffer<F32x4>` cannot be filled from host values of these
+//! types. That is fine, because the intended flow keeps host buffers *flat*:
+//!
+//! - Allocate and fill a `DeviceBuffer<f32>` as usual, pass it to a kernel
+//!   taking `&[f32]`, and take the view **inside the kernel** with
+//!   [`as_vectors`] / [`as_vectors_mut`]. This needs no host-side type at all.
+//! - Or reinterpret the flat buffer once at the boundary with `cuda-core`'s
+//!   `DeviceBuffer::cast_chunks`, using a host-defined `#[repr(C, align(16))]`
+//!   element that implements `DeviceCopy`, and launch a kernel that takes that
+//!   element type directly.
 
 use core::mem::{align_of, size_of};
 

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -70,6 +70,19 @@
 //!   `DeviceBuffer::cast_chunks`, using a host-defined `#[repr(C, align(16))]`
 //!   element that implements `DeviceCopy`, and launch a kernel that takes that
 //!   element type directly.
+//!
+//! # Related "N x scalar" types
+//!
+//! cuda-device spells grouped scalars three ways, for three different jobs:
+//!
+//! - **This module**: over-aligned *memory element* types. The grouping lives
+//!   in the type's alignment so that loads and stores are wide transactions.
+//! - [`crate::cusimd::CuSimd`]: *register* groups. N values travelling
+//!   together through registers (e.g. `tcgen05.ld` results), with copy
+//!   semantics and no memory-layout claim at all.
+//! - [`crate::f16x2`] / [`crate::bf16x2`]: *packed arithmetic* pairs. Two
+//!   16-bit values in one `u32` operated on by a single SIMD instruction;
+//!   the packing is the ALU format, not an alignment trick.
 
 use core::mem::{align_of, size_of};
 

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -173,19 +173,38 @@ define_vector!(
 /// The tail is not silently dropped. A slice of 10 `f32` viewed as `F32x4` is an
 /// error rather than two vectors and a discarded remainder, because discarding
 /// data is the kind of thing that should be written down at the call site.
+///
+/// # Empty slices
+///
+/// An empty input always yields `Some` empty view, regardless of its base
+/// address: there is nothing to access, so there is no alignment to violate.
+/// This makes the literal `&[]` (whose dangling base is only aligned for the
+/// scalar) and an aligned empty sub-slice of a real buffer behave identically.
 #[must_use]
 pub fn as_vectors<V: Vector>(slice: &[V::Elem]) -> Option<&[V]> {
     let len = vector_len::<V>(slice.len(), slice.as_ptr() as usize)?;
+    if len == 0 {
+        // `from_raw_parts` requires a base aligned for `V` even at length 0,
+        // and an empty input's base may only be aligned for the scalar. The
+        // empty view does not need the base at all.
+        return Some(&[]);
+    }
     // SAFETY: length divides exactly and the base is aligned for `V`, both
     // checked above. `V` is `repr(C)` over `LANES` values of `Elem`, so `len`
     // vectors cover exactly `slice.len()` elements.
     Some(unsafe { core::slice::from_raw_parts(slice.as_ptr().cast::<V>(), len) })
 }
 
-/// Mutable [`as_vectors`].
+/// Mutable [`as_vectors`]. Shares its semantics, including the empty-slice
+/// case: any empty input yields `Some` empty view.
 #[must_use]
 pub fn as_vectors_mut<V: Vector>(slice: &mut [V::Elem]) -> Option<&mut [V]> {
     let len = vector_len::<V>(slice.len(), slice.as_ptr() as usize)?;
+    if len == 0 {
+        // As in `as_vectors`: no access will happen, and the possibly
+        // scalar-aligned base must not reach `from_raw_parts_mut`.
+        return Some(&mut []);
+    }
     // SAFETY: as `as_vectors`, and the exclusive borrow of `slice` is consumed
     // for the lifetime of the result, so no aliasing view coexists.
     Some(unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast::<V>(), len) })
@@ -194,6 +213,12 @@ pub fn as_vectors_mut<V: Vector>(slice: &mut [V::Elem]) -> Option<&mut [V]> {
 /// Shared checks: exact division and alignment.
 #[inline]
 fn vector_len<V: Vector>(elems: usize, addr: usize) -> Option<usize> {
+    if elems == 0 {
+        // Uniform empty-slice semantics: nothing will be accessed, so the
+        // base address (which for a literal `&[]` is a dangling pointer with
+        // only the scalar's alignment) is irrelevant.
+        return Some(0);
+    }
     if V::LANES == 0 || size_of::<V::Elem>() == 0 {
         return None;
     }
@@ -334,6 +359,34 @@ mod tests {
             as_vectors::<F32x2>(off2).is_some(),
             "8-byte aligned and 14 divides by 2"
         );
+    }
+
+    /// Every empty input views as an empty vector slice, whatever its base
+    /// address: the literal `&[]` (dangling, scalar-aligned base) and an
+    /// empty sub-slice at a misaligned offset behave identically.
+    #[test]
+    fn empty_slices_always_view() {
+        let empty = as_vectors::<F32x4>(&[]).expect("literal empty slice");
+        assert!(empty.is_empty());
+        assert!(is_viewable::<F32x4>(&[]));
+        let mut none: [f32; 0] = [];
+        assert!(
+            as_vectors_mut::<F32x4>(&mut none)
+                .expect("empty mut")
+                .is_empty()
+        );
+
+        let backing = [F32x4::splat(0.0); 2];
+        let flat: &[f32] =
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 8) };
+        // Zero-length sub-slice at a misaligned offset: still an empty view.
+        let sub = &flat[1..1];
+        assert!(
+            as_vectors::<F32x4>(sub)
+                .expect("empty sub-slice")
+                .is_empty()
+        );
+        assert!(is_viewable::<F32x4>(sub));
     }
 
     #[test]

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -1,0 +1,376 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Over-aligned element types, and a checked way to view a flat slice as them.
+//!
+//! Memory transaction width is set by the alignment of the *element type*, not by
+//! how many elements a loop touches. Measured on sm_86, a `#[repr(C, align(16))]`
+//! quad of `f32` compiles to one `LDG.E.128` plus one `STG.E.128`, while the same
+//! four values at natural alignment compile to four scalar accesses. Static
+//! length alone changes nothing: reading four adjacent elements out of a
+//! `&[f32]`, however it is spelled, stays scalar because the element type is
+//! still 4-byte aligned.
+//!
+//! So reaching a wide access is a question of *choosing an element type*, and the
+//! obstacle is that buffers usually arrive flat. Copying into an aligned buffer
+//! defeats the point. What is needed is a view: check the alignment and length
+//! once at the boundary, then every access through the view is wide.
+//!
+//! ```rust,ignore
+//! // Flat input, checked once.
+//! let quads: &[F32x4] = vector::as_vectors(input).ok_or(Unaligned)?;
+//! // Every read through `quads` is a 128-bit transaction.
+//! let q = quads[i];
+//! ```
+//!
+//! # Alignment is necessary but not sufficient for a wide *load*
+//!
+//! Measured on sm_86, with the element type 16-byte aligned throughout, only the
+//! way the value is *consumed* changes the load:
+//!
+//! ```text
+//! how the element is used                     LDG          STG
+//! `*out = input[i]`, never decomposed         LDG.E.128    STG.E.128
+//! lanes read, whole value assembled+stored    LDG.E x4     STG.E.128
+//! lanes read, scalar stored                   LDG.E x4     STG.E
+//! ```
+//!
+//! Touching individual lanes lets the optimiser split the local apart, and it
+//! then loads the lanes separately no matter how the type is aligned. The store
+//! side has no such condition: it widens whenever a whole value is assembled.
+//!
+//! So these types buy width on the paths that **move** data - staging global to
+//! shared memory, copying, packing - and not on paths that immediately do
+//! elementwise arithmetic. That is the same split CUTLASS and cuTile arrive at:
+//! wide loads feed shared memory, and compute reads from there. If a kernel
+//! needs both, stage through shared memory rather than expecting one loop to get
+//! a wide load and lane access at once.
+//!
+//! # Why the check nearly always passes
+//!
+//! Device allocations are 256-byte aligned, so a buffer's base satisfies any of
+//! these types. The check exists to make that a guarantee rather than an
+//! assumption, and to fail loudly on the cases where it does not hold: a slice
+//! taken at a hand-computed offset, a sub-slice starting at an odd index, or a
+//! length that is not a whole number of vectors.
+
+use core::mem::{align_of, size_of};
+
+/// An over-aligned group of scalars that moves in one memory transaction.
+///
+/// Implemented only by the types in this module. The bound exists so
+/// [`as_vectors`] can relate a vector type to its scalar element and check both
+/// invariants; it is deliberately not something callers implement, because a
+/// wrong `LANES` would make the length check admit an out-of-bounds view.
+///
+/// # Safety
+///
+/// An implementor must be `#[repr(C)]`, contain exactly `LANES` values of
+/// `Elem` and nothing else, and carry an alignment of at least
+/// `size_of::<Elem>() * LANES`.
+pub unsafe trait Vector: Copy {
+    /// Scalar type of each lane.
+    type Elem: Copy;
+    /// Lanes in the vector.
+    const LANES: usize;
+}
+
+/// Define an over-aligned vector type plus its `Vector` impl and accessors.
+macro_rules! define_vector {
+    (
+        $(#[$doc:meta])*
+        $name:ident, $elem:ty, $lanes:literal, $align:literal
+    ) => {
+        $(#[$doc])*
+        #[repr(C, align($align))]
+        #[derive(Clone, Copy, PartialEq, Debug)]
+        pub struct $name(pub [$elem; $lanes]);
+
+        // SAFETY: `repr(C)` over exactly `$lanes` values of `$elem`, with
+        // `align($align)` and `$align == size_of::<$elem>() * $lanes` checked by
+        // `layout_matches_the_declared_contract` below.
+        unsafe impl Vector for $name {
+            type Elem = $elem;
+            const LANES: usize = $lanes;
+        }
+
+        impl $name {
+            /// Build a vector from its lanes.
+            #[must_use]
+            #[inline(always)]
+            pub const fn new(lanes: [$elem; $lanes]) -> Self {
+                Self(lanes)
+            }
+
+            /// Every lane equal to `value`.
+            #[must_use]
+            #[inline(always)]
+            pub const fn splat(value: $elem) -> Self {
+                Self([value; $lanes])
+            }
+
+            /// The lanes, by value.
+            #[must_use]
+            #[inline(always)]
+            pub const fn to_array(self) -> [$elem; $lanes] {
+                self.0
+            }
+
+            /// The lanes, as a slice.
+            #[must_use]
+            #[inline(always)]
+            pub fn as_slice(&self) -> &[$elem] {
+                &self.0
+            }
+
+            /// The lanes, mutably.
+            #[must_use]
+            #[inline(always)]
+            pub fn as_mut_slice(&mut self) -> &mut [$elem] {
+                &mut self.0
+            }
+        }
+    };
+}
+
+define_vector!(
+    /// Two `f32` in one 64-bit transaction.
+    F32x2, f32, 2, 8
+);
+define_vector!(
+    /// Four `f32` in one 128-bit transaction. The `float4` equivalent.
+    F32x4, f32, 4, 16
+);
+define_vector!(
+    /// Two `f64` in one 128-bit transaction.
+    F64x2, f64, 2, 16
+);
+define_vector!(
+    /// Two `u32` in one 64-bit transaction.
+    U32x2, u32, 2, 8
+);
+define_vector!(
+    /// Four `u32` in one 128-bit transaction.
+    U32x4, u32, 4, 16
+);
+define_vector!(
+    /// Four `u16` in one 64-bit transaction.
+    U16x4, u16, 4, 8
+);
+define_vector!(
+    /// Eight `u16` in one 128-bit transaction. The width packed f16 pairs use.
+    U16x8, u16, 8, 16
+);
+
+/// View a flat slice as over-aligned vectors, or `None` if it does not divide.
+///
+/// Fails when the length is not a multiple of `V::LANES`, or when the base
+/// pointer is not aligned for `V`. Both are checked once here; every access
+/// through the returned slice is then a full-width transaction.
+///
+/// The tail is not silently dropped. A slice of 10 `f32` viewed as `F32x4` is an
+/// error rather than two vectors and a discarded remainder, because discarding
+/// data is the kind of thing that should be written down at the call site.
+#[must_use]
+pub fn as_vectors<V: Vector>(slice: &[V::Elem]) -> Option<&[V]> {
+    let len = vector_len::<V>(slice.len(), slice.as_ptr() as usize)?;
+    // SAFETY: length divides exactly and the base is aligned for `V`, both
+    // checked above. `V` is `repr(C)` over `LANES` values of `Elem`, so `len`
+    // vectors cover exactly `slice.len()` elements.
+    Some(unsafe { core::slice::from_raw_parts(slice.as_ptr().cast::<V>(), len) })
+}
+
+/// Mutable [`as_vectors`].
+#[must_use]
+pub fn as_vectors_mut<V: Vector>(slice: &mut [V::Elem]) -> Option<&mut [V]> {
+    let len = vector_len::<V>(slice.len(), slice.as_ptr() as usize)?;
+    // SAFETY: as `as_vectors`, and the exclusive borrow of `slice` is consumed
+    // for the lifetime of the result, so no aliasing view coexists.
+    Some(unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast::<V>(), len) })
+}
+
+/// Shared checks: exact division and alignment.
+#[inline]
+fn vector_len<V: Vector>(elems: usize, addr: usize) -> Option<usize> {
+    if V::LANES == 0 || size_of::<V::Elem>() == 0 {
+        return None;
+    }
+    if !elems.is_multiple_of(V::LANES) {
+        return None;
+    }
+    if !addr.is_multiple_of(align_of::<V>()) {
+        return None;
+    }
+    Some(elems / V::LANES)
+}
+
+/// Whether a slice could be viewed as `V`, without building the view.
+///
+/// For deciding between a wide path and a scalar fallback before committing to
+/// either.
+#[must_use]
+pub fn is_viewable<V: Vector>(slice: &[V::Elem]) -> bool {
+    vector_len::<V>(slice.len(), slice.as_ptr() as usize).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `unsafe impl Vector` blocks assert a layout; this checks it, since a
+    /// wrong `LANES` or a too-small alignment would make the view unsound.
+    #[test]
+    fn layout_matches_the_declared_contract() {
+        macro_rules! check {
+            ($t:ty) => {{
+                type V = $t;
+                let payload = size_of::<<V as Vector>::Elem>() * <V as Vector>::LANES;
+                assert_eq!(
+                    size_of::<V>(),
+                    payload,
+                    "{} must be exactly its lanes, with no padding",
+                    stringify!($t)
+                );
+                assert!(
+                    align_of::<V>() >= payload,
+                    "{} alignment {} is below its {payload}-byte payload",
+                    stringify!($t),
+                    align_of::<V>()
+                );
+                // Only 64- and 128-bit transactions are worth over-aligning for.
+                assert!(
+                    align_of::<V>() == 8 || align_of::<V>() == 16,
+                    "{} has alignment {}, which is not a transaction width",
+                    stringify!($t),
+                    align_of::<V>()
+                );
+            }};
+        }
+        check!(F32x2);
+        check!(F32x4);
+        check!(F64x2);
+        check!(U32x2);
+        check!(U32x4);
+        check!(U16x4);
+        check!(U16x8);
+    }
+
+    #[test]
+    fn views_a_divisible_aligned_slice() {
+        // Over-aligned backing store, so the base is suitable for F32x4.
+        let backing = [
+            F32x4::new([1.0, 2.0, 3.0, 4.0]),
+            F32x4::new([5.0, 6.0, 7.0, 8.0]),
+        ];
+        let flat: &[f32] =
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 8) };
+        let quads = as_vectors::<F32x4>(flat).expect("aligned and divisible");
+        assert_eq!(quads.len(), 2);
+        assert_eq!(quads[0].to_array(), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(quads[1].to_array(), [5.0, 6.0, 7.0, 8.0]);
+    }
+
+    /// A length that does not divide is refused rather than truncated, so a
+    /// dropped tail cannot go unnoticed.
+    #[test]
+    fn refuses_a_length_that_does_not_divide() {
+        let backing = [F32x4::splat(0.0); 4];
+        let base = backing.as_ptr().cast::<f32>();
+        for len in [1usize, 2, 3, 5, 6, 7, 9, 10, 15] {
+            let flat: &[f32] = unsafe { core::slice::from_raw_parts(base, len) };
+            assert!(
+                as_vectors::<F32x4>(flat).is_none(),
+                "{len} f32 is not a whole number of F32x4"
+            );
+        }
+        for len in [0usize, 4, 8, 12, 16] {
+            let flat: &[f32] = unsafe { core::slice::from_raw_parts(base, len) };
+            assert_eq!(as_vectors::<F32x4>(flat).map(<[F32x4]>::len), Some(len / 4));
+        }
+    }
+
+    /// A misaligned base is refused. This is the case the check exists for: a
+    /// sub-slice starting at an odd element has the right length and the wrong
+    /// address, and would otherwise fault or read the wrong data.
+    #[test]
+    fn refuses_a_misaligned_base() {
+        let backing = [F32x4::splat(0.0); 4];
+        let flat: &[f32] =
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 16) };
+        // Offsets 4, 8, 12 stay 16-byte aligned; 1, 2, 3, 5 do not.
+        for off in [4usize, 8, 12] {
+            assert!(
+                as_vectors::<F32x4>(&flat[off..]).is_some(),
+                "offset {off} is still 16-byte aligned"
+            );
+        }
+        for off in [1usize, 2, 3, 5, 6, 7] {
+            let tail = &flat[off..];
+            if !tail.len().is_multiple_of(4) {
+                continue; // rejected on length, not the point here
+            }
+            assert!(
+                as_vectors::<F32x4>(tail).is_none(),
+                "offset {off} is not 16-byte aligned and must be refused"
+            );
+        }
+    }
+
+    /// A narrower vector accepts bases a wider one rejects, which is the useful
+    /// fallback: 64-bit where 128-bit will not fit.
+    #[test]
+    fn narrower_vectors_accept_more_bases() {
+        let backing = [F32x4::splat(0.0); 4];
+        let flat: &[f32] =
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 16) };
+        let off2 = &flat[2..]; // 8-byte aligned, 14 elements
+        assert!(
+            as_vectors::<F32x4>(off2).is_none(),
+            "not 16-byte aligned, and 14 does not divide by 4"
+        );
+        assert!(
+            as_vectors::<F32x2>(off2).is_some(),
+            "8-byte aligned and 14 divides by 2"
+        );
+    }
+
+    #[test]
+    fn mutable_view_writes_through() {
+        let mut backing = [F32x4::splat(0.0); 2];
+        {
+            let flat: &mut [f32] =
+                unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<f32>(), 8) };
+            let quads = as_vectors_mut::<F32x4>(flat).unwrap();
+            quads[1] = F32x4::new([9.0, 8.0, 7.0, 6.0]);
+        }
+        assert_eq!(backing[1].to_array(), [9.0, 8.0, 7.0, 6.0]);
+    }
+
+    #[test]
+    fn is_viewable_agrees_with_as_vectors() {
+        let backing = [F32x4::splat(0.0); 4];
+        let flat: &[f32] =
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 16) };
+        for off in 0..8usize {
+            let tail = &flat[off..];
+            assert_eq!(
+                is_viewable::<F32x4>(tail),
+                as_vectors::<F32x4>(tail).is_some(),
+                "disagreement at offset {off}"
+            );
+        }
+    }
+
+    #[test]
+    fn lanes_round_trip() {
+        let v = F32x4::new([1.5, -2.5, 3.5, -4.5]);
+        assert_eq!(v.to_array(), [1.5, -2.5, 3.5, -4.5]);
+        assert_eq!(v.as_slice(), &[1.5, -2.5, 3.5, -4.5]);
+        assert_eq!(U16x8::splat(7).to_array(), [7u16; 8]);
+        let mut m = F32x2::splat(0.0);
+        m.as_mut_slice()[1] = 4.0;
+        assert_eq!(m.to_array(), [0.0, 4.0]);
+    }
+}

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -213,6 +213,18 @@ pub fn as_vectors_mut<V: Vector>(slice: &mut [V::Elem]) -> Option<&mut [V]> {
 /// Shared checks: exact division and alignment.
 #[inline]
 fn vector_len<V: Vector>(elems: usize, addr: usize) -> Option<usize> {
+    // Compile-time check of the `Vector` contract every view relies on: a `V`
+    // whose size is not exactly `LANES * size_of::<Elem>()` would make the
+    // element count and the byte extent disagree, and every index through the
+    // view would then read the wrong bytes. Evaluated when `vector_len` is
+    // instantiated for a `V`, so a malformed impl fails the build instead of
+    // silently misindexing.
+    const {
+        assert!(
+            size_of::<V>() == V::LANES * size_of::<V::Elem>(),
+            "Vector impl violates its contract: size_of::<V>() must equal LANES * size_of::<V::Elem>()"
+        );
+    }
     if elems == 0 {
         // Uniform empty-slice semantics: nothing will be accessed, so the
         // base address (which for a literal `&[]` is a dangling pointer with

--- a/crates/cuda-device/src/vector.rs
+++ b/crates/cuda-device/src/vector.rs
@@ -296,10 +296,10 @@ mod tests {
     /// address, and would otherwise fault or read the wrong data.
     #[test]
     fn refuses_a_misaligned_base() {
-        let backing = [F32x4::splat(0.0); 4];
+        let backing = [F32x4::splat(0.0); 8];
         let flat: &[f32] =
-            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 16) };
-        // Offsets 4, 8, 12 stay 16-byte aligned; 1, 2, 3, 5 do not.
+            unsafe { core::slice::from_raw_parts(backing.as_ptr().cast::<f32>(), 32) };
+        // Offsets 4, 8, 12 stay 16-byte aligned; 1, 2, 3, 5, 6, 7 do not.
         for off in [4usize, 8, 12] {
             assert!(
                 as_vectors::<F32x4>(&flat[off..]).is_some(),
@@ -307,12 +307,12 @@ mod tests {
             );
         }
         for off in [1usize, 2, 3, 5, 6, 7] {
-            let tail = &flat[off..];
-            if !tail.len().is_multiple_of(4) {
-                continue; // rejected on length, not the point here
-            }
+            // Take exactly 12 elements so the length divides by 4 and the
+            // only possible ground for rejection is the misaligned base.
+            let sub = &flat[off..off + 12];
+            assert!(sub.len().is_multiple_of(4), "length must not be the reason");
             assert!(
-                as_vectors::<F32x4>(tail).is_none(),
+                as_vectors::<F32x4>(sub).is_none(),
                 "offset {off} is not 16-byte aligned and must be refused"
             );
         }

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -4919,6 +4919,14 @@ fn validate_ptr_to_array_constant_type(
     }
 
     if let Some(array_ty) = ty_obj.downcast_ref::<dialect_mir::types::MirArrayType>() {
+        // A zero-length array has no element values: its initializer is empty
+        // and nothing can ever be read through it, so the element-type
+        // restriction below is vacuous. This admits promoted empty-slice
+        // constants such as `&[]` (which rustc promotes to `&[T; 0]`) for any
+        // element type, including structs.
+        if array_ty.size() == 0 {
+            return Ok(());
+        }
         let element_ty = array_ty.element_type();
         drop(ty_obj);
         return validate_ptr_to_array_constant_type(ctx, element_ty, loc);

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -124,6 +124,37 @@ vector_suite! {
     f64x4_a32: f64; 4; align 32; size 32; "double4_32a",
 }
 
+/// Kernels over *flat* `f32` buffers: no over-aligned host type at all. The
+/// view is taken inside the kernel with `cuda_device::vector::as_vectors`,
+/// which is the intended path when the host allocation is flat.
+#[cuda_module]
+mod view_kernels {
+    use cuda_device::vector::{self, F32x4};
+    use cuda_device::{DisjointSlice, kernel, thread};
+
+    /// Copy one `F32x4` quad per thread between flat `f32` buffers through
+    /// checked [`vector::as_vectors`] views. The quad is moved whole, never
+    /// decomposed into lanes, so both the load and the store fuse into
+    /// 128-bit transactions (`ld/st.global.v4.f32`).
+    #[kernel]
+    pub fn f32x4_view_copy(input: &[f32], mut output: DisjointSlice<f32>) {
+        let i = thread::index_1d().get();
+        let out_len = output.len();
+        // SAFETY: `DisjointSlice` grants this launch exclusive access to the
+        // whole output buffer; the flat view aliases nothing else.
+        let out_flat = unsafe { core::slice::from_raw_parts_mut(output.as_mut_ptr(), out_len) };
+        let Some(quads) = vector::as_vectors::<F32x4>(input) else {
+            return;
+        };
+        let Some(out_quads) = vector::as_vectors_mut::<F32x4>(out_flat) else {
+            return;
+        };
+        if i < quads.len() && i < out_quads.len() {
+            out_quads[i] = quads[i];
+        }
+    }
+}
+
 fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
@@ -136,6 +167,21 @@ fn main() {
     let module = kernels::from_module(module).expect("Failed to initialize typed module");
 
     let rows = run_all(&module, &stream, cfg, N);
+
+    // Flat-buffer path: allocate and fill as plain `f32`, take the `F32x4`
+    // view inside the kernel. One quad per thread.
+    let flat: Vec<f32> = (0..N * 4).map(|i| i as f32 * 0.25 + 1.0).collect();
+    let flat_in = DeviceBuffer::from_host(&stream, &flat).expect("flat input");
+    let mut flat_out = DeviceBuffer::<f32>::zeroed(&stream, N * 4).expect("flat output");
+    let view_module = ctx
+        .load_module_from_file("vectorization.ptx")
+        .expect("Failed to load vectorization.ptx for view kernels");
+    let view_module =
+        view_kernels::from_module(view_module).expect("Failed to initialize view module");
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { view_module.f32x4_view_copy(&stream, cfg, &flat_in, &mut flat_out) }
+        .expect("f32x4_view_copy launch");
+    let flat_round_trip = flat_out.to_host_vec(&stream).expect("flat readback") == flat;
 
     // Inspect the PTX we just launched to report/assert the codegen shape.
     let ptx = std::fs::read_to_string("vectorization.ptx")
@@ -174,6 +220,24 @@ fn main() {
         );
     }
 
+    // The in-kernel `as_vectors::<F32x4>` view over a flat `&[f32]` parameter
+    // must reach the same 128-bit transactions as the over-aligned parameter
+    // types above: this is the checked-view path the `vector` module ships.
+    let view_body = kernel_body(&ptx, "f32x4_view_copy");
+    if !flat_round_trip {
+        errors += 1;
+        println!("  !! f32x4_view_copy round-trip copy mismatch");
+    }
+    for dir in ["ld", "st"] {
+        match find_128bit_global(view_body, dir) {
+            Some(line) => println!("f32x4_view_copy: {line}"),
+            None => {
+                errors += 1;
+                println!("  !! f32x4_view_copy has no 128-bit {dir}.global vector op");
+            }
+        }
+    }
+
     if errors == 0 {
         println!(
             "\n\u{2713} SUCCESS: {} CUDA vector types -- layout, copy, and codegen all correct",
@@ -193,6 +257,20 @@ fn kernel_body<'a>(ptx: &'a str, name: &str) -> &'a str {
     let body = &ptx[start..];
     let end = body.find("\n}").map_or(body.len(), |e| e + 2);
     &body[..end]
+}
+
+/// First 128-bit vector global memory op of direction `dir` (`ld`/`st`) in a
+/// kernel body. llc's spelling of the 128-bit transaction varies by version
+/// (`ld.global.v4.f32` on older llc, `ld.global.v2.b64` on llc-21/22); every
+/// accepted form is a single 128-bit access.
+fn find_128bit_global<'a>(body: &'a str, dir: &str) -> Option<&'a str> {
+    let prefix = format!("{dir}.global.v");
+    body.lines().map(str::trim).find(|t| {
+        t.starts_with(&prefix)
+            && [".v4.f32", ".v4.b32", ".v2.f64", ".v2.b64"]
+                .iter()
+                .any(|w| t.contains(w))
+    })
 }
 
 /// First global memory op mnemonic in a kernel body (e.g. `ld.global.v2.b64`).


### PR DESCRIPTION
Transaction width is set by the alignment of the *element type*, not by how many elements a loop touches. Measured on sm_86, four safe spellings of "read four adjacent f32":

| element types | LDG | STG |
|---|---|---|
| `F32x4` → `F32x4` (align 16) | **LDG.E.128** ×1 | **STG.E.128** ×1 |
| same payload at align 4 | LDG.E ×4 | STG.E ×4 |
| `&[f32]` → `F32x4` | LDG.E ×4 | **STG.E.128** ×1 |
| `&[f32]` → `f32` | LDG.E ×4 | STG.E ×1 |

Row three is the load-bearing one: a single kernel with scalar loads and a wide store, differing only in the types at each end.

So reaching a wide access means *choosing an element type*, and the obstacle is that buffers arrive flat. Copying into an aligned buffer defeats the purpose. This adds the types plus a view — check alignment and length once, then accesses through it are wide.

```rust
let quads: &[F32x4] = vector::as_vectors(input).ok_or(Unaligned)?;
```

Seven types covering the 64- and 128-bit widths for f32, f64, u32, u16.

## Refuses rather than truncates

10 `f32` viewed as `F32x4` is an error, not two vectors and a dropped tail. A misaligned base is likewise refused — that is the case the check exists for: a sub-slice starting at an odd element has the right length and the wrong address.

`Vector` is `unsafe` because a wrong `LANES` would make the length check admit an out-of-bounds view. A test asserts the layout each `unsafe impl` claims, so the invariant is checked rather than trusted.

## The caveat, documented rather than left to be found

**Alignment is necessary but not sufficient for a wide load.** With the type 16-byte aligned throughout, only how the value is *consumed* changes it:

```
never decomposed                 LDG.E.128   STG.E.128
lanes read, whole value stored   LDG.E x4    STG.E.128
lanes read, scalar stored        LDG.E x4    STG.E
```

Touching individual lanes lets the optimiser split the local apart and load them separately regardless of alignment; the store side has no such condition.

So these buy width on paths that **move** data — staging global to shared, copying, packing — and not on paths doing immediate elementwise arithmetic. The module says so up front, because "just use an aligned type" only half holds.

## Pairs with #513

Aligned types are only reachable if a buffer can *be* one. #513 adds the length-adjusting cast that makes that possible without every producer and consumer agreeing at once. Either can land alone; together they are the usable form.

8 tests, `clippy --all-targets` clean.