### PR TITLE
Emit `.reqntid` for kernels declaring an exact launch-contract block

### DIFF
--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -170,6 +170,11 @@ impl KernelLaunchConfig for LaunchConfig3D {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BlockRequirement {
     /// The launch must use exactly these `(x, y, z)` block dimensions.
+    ///
+    /// A kernel compiled by cuda-oxide also carries this shape as PTX
+    /// `.reqntid`, so the CUDA driver rejects a differing block on any axis
+    /// independently of this check. Preparation still reports the mismatch
+    /// first, with the kernel name and both shapes.
     Exact((u32, u32, u32)),
     /// The block may contain at most this many threads in total.
     ///

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -982,6 +982,44 @@ const fn validate_launch_bounds(max_threads: u32) {
     );
 }
 
+/// Compile-time marker carrying an exact block shape to the device compiler.
+///
+/// `#[launch_contract(block = (x, y, z))]` already binds the host launch to one
+/// block shape. This marker gives the same fact to the device compiler, which
+/// emits `.reqntid x, y, z`. The CUDA driver then rejects a launch whose block
+/// dimensions differ on any axis, so the exact-block obligation is enforced by
+/// the compiled artifact rather than by the host check alone.
+///
+/// # How it works
+///
+/// 1. `#[launch_contract]` injects `__launch_contract_block_config::<X, Y, Z>()`
+///    at kernel start.
+/// 2. The MIR importer detects the call and extracts the const generics.
+/// 3. The marker call is removed during compilation.
+/// 4. LLVM export emits `!nvvm.annotations` with `reqntidx`, `reqntidy` and
+///    `reqntidz`.
+/// 5. The NVPTX backend emits `.reqntid x, y, z`.
+///
+/// # Relationship to `#[launch_bounds]`
+///
+/// `.maxntid` and `.reqntid` on one entry is a ptxas error, so a kernel
+/// carrying both attributes emits `.reqntid` alone. An exact block shape
+/// implies the thread maximum that `.maxntid` would have declared, so nothing
+/// the device compiler relies on is lost. `.minnctapersm` from
+/// `#[launch_bounds(max, min)]` is unaffected and still emitted.
+#[inline(never)]
+pub fn __launch_contract_block_config<const X: u32, const Y: u32, const Z: u32>() {
+    const { validate_contract_block(X, Y, Z) }
+    // Detected at compile time and removed. No runtime code is generated.
+}
+
+const fn validate_contract_block(x: u32, y: u32, z: u32) {
+    assert!(
+        x > 0 && y > 0 && z > 0,
+        "launch_contract block dimensions must all be greater than zero"
+    );
+}
+
 /// Compiler marker for opt-in unchecked slice/array indexing.
 ///
 /// `#[kernel(unchecked_indexing)]` inserts this call. The MIR importer records

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -138,6 +138,13 @@ host-side maximum. For example, `prepare_transform::<SmallPolicy>` can enforce
 maximum, not an exact size; declare `block = (x, y, z)` when the full shape must
 match.
 
+An exact `block` is additionally carried into the compiled artifact as
+`.reqntid x, y, z`, which the CUDA driver enforces per axis. Preparation and
+the driver check the shape on independent paths, so a mismatch is rejected even
+when preparation is bypassed. A thread maximum gives no such guarantee: under
+`.maxntid 256, 1, 1` the driver accepts `(16, 16, 1)` as readily as
+`(256, 1, 1)`.
+
 For contracted kernels, raw `LaunchConfig` is available only through generated
 unsafe methods such as `reduce_unchecked`. Uncontracted generated methods are
 also unsafe because there is no prepared proof for their raw configuration.

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -143,7 +143,18 @@ reduce_unchecked: raw LaunchConfig             -> unsafe expert path
 
 `block` is exact. If it is omitted, `#[launch_bounds]` supplies the compiled
 maximum total threads per block. For example, a limit of 256 accepts both
-`(256, 1, 1)` and `(16, 16, 1)`. Dynamic shared memory is either exact
+`(256, 1, 1)` and `(16, 16, 1)`.
+
+An exact `block` also reaches the device compiler, which emits
+`.reqntid x, y, z` in place of `.maxntid`. The CUDA driver enforces that per
+axis, so a launch whose block differs is refused even when it never passed
+through preparation. Preparation and the driver therefore check the same
+requirement on independent paths, and the raw `_unchecked` path is covered by
+the second. The two directives cannot coexist on one entry, so a kernel
+declaring both `#[launch_bounds]` and an exact `block` emits `.reqntid` alone.
+The occupancy hint `.minnctapersm` is unaffected.
+
+Dynamic shared memory is either exact
 (`dynamic_shared = BYTES`) or an inclusive range. The byte extent is an author
 promise; the alignment is a compiler-visible minimum and is merged with any
 higher `DynamicSharedArray<T, ALIGN>` request in the body or a reachable local

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -4766,7 +4766,9 @@ fn is_kernel_configuration_marker(statement: &Stmt) -> bool {
         module == "thread" && marker == "__launch_contract_config"
     } else {
         (module == "thread"
-            && (marker == "__launch_bounds_config" || marker == "__unchecked_indexing_config"))
+            && (marker == "__launch_bounds_config"
+                || marker == "__launch_contract_block_config"
+                || marker == "__unchecked_indexing_config"))
             || (module == "cluster" && marker == "__cluster_config")
             || (module == "shared" && marker == "__dynamic_shared_alignment")
     }
@@ -8699,6 +8701,7 @@ mod tests {
                 unsafe {
                     ::cuda_device::thread::__launch_contract_config::<1, true>();
                 }
+                ::cuda_device::thread::__launch_contract_block_config::<64, 1, 1>();
                 ::cuda_device::cluster::__cluster_config::<2, 1, 1>();
                 ::cuda_device::shared::__dynamic_shared_alignment::<128>();
                 cuda_device::thread::__launch_bounds_config::<4, 1>();
@@ -8714,9 +8717,10 @@ mod tests {
         let markers = top_level_kernel_configuration_markers(&kernel);
         let forwarded = quote!(#(#markers)*).to_string().replace(' ', "");
 
-        assert_eq!(markers.len(), 4);
+        assert_eq!(markers.len(), 5);
         assert!(forwarded.contains("__launch_bounds_config::<64,2>()"));
         assert!(forwarded.contains("__launch_contract_config::<1,true>()"));
+        assert!(forwarded.contains("__launch_contract_block_config::<64,1,1>()"));
         assert!(forwarded.contains("__cluster_config::<2,1,1>()"));
         assert!(forwarded.contains("__dynamic_shared_alignment::<128>()"));
         assert!(!forwarded.contains("unrelated"));

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -5509,6 +5509,13 @@ fn substitute_type(ty: &Type, param: &syn::Ident, replacement: &Type) -> TokenSt
 /// and `.minnctapersm` PTX directives. This helps the CUDA compiler optimize
 /// register allocation and occupancy.
 ///
+/// `.maxntid` bounds the product `x * y * z`, so a 256-thread maximum admits
+/// `(256, 1, 1)`, `(16, 16, 1)` and `(4, 8, 8)` alike. Use
+/// `#[launch_contract(block = (x, y, z))]` to require one exact shape; that
+/// emits `.reqntid` instead, which the driver enforces per axis. A kernel
+/// carrying both attributes emits `.reqntid` alone, because ptxas rejects an
+/// entry declaring both directives. `.minnctapersm` composes with either.
+///
 /// # Usage
 ///
 /// ```ignore
@@ -5691,8 +5698,15 @@ pub fn launch_bounds(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// still validates every relation for well-formedness at compile time
 /// (unknown identifiers and unsupported grammar are errors at the attribute
 /// site), but no launcher exists to evaluate the relations at runtime. That
-/// is the same enforcement story as the geometry keys such as `block` and
-/// `dynamic_shared`.
+/// is the same enforcement story as `dynamic_shared`.
+///
+/// An exact `block` is the one key that also holds without a generated
+/// launcher. The shape reaches the device compiler as `.reqntid x, y, z`, and
+/// the CUDA driver refuses any launch whose block differs on any axis, so a
+/// standalone contracted kernel and an `_unchecked` raw launch are both
+/// covered. `.reqntid` and `.maxntid` cannot appear on one entry, so a kernel
+/// declaring an exact `block` emits `.reqntid` in place of the maximum that
+/// `#[launch_bounds]` would otherwise contribute.
 #[proc_macro_attribute]
 pub fn launch_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as LaunchContractArgs);
@@ -5807,13 +5821,25 @@ fn inject_launch_contract_markers(args: &LaunchContractArgs, input: &mut ItemFn)
         }
     };
     input.block.stmts.insert(0, contract_marker);
+    let mut next = 1;
+
+    // Give the exact block shape to the device compiler as well, so ptxas
+    // emits `.reqntid` and the driver rejects a mismatched block on every
+    // axis. Without this the shape is known only to the host check.
+    if let Some((x, y, z)) = args.exact_block {
+        let block_marker: syn::Stmt = parse_quote! {
+            ::cuda_device::thread::__launch_contract_block_config::<#x, #y, #z>();
+        };
+        input.block.stmts.insert(next, block_marker);
+        next += 1;
+    }
 
     if dynamic_shared_max(args.dynamic_shared) != 0 {
         let alignment = args.dynamic_shared_alignment as usize;
         let alignment_marker: syn::Stmt = parse_quote! {
             ::cuda_device::shared::__dynamic_shared_alignment::<#alignment>();
         };
-        input.block.stmts.insert(1, alignment_marker);
+        input.block.stmts.insert(next, alignment_marker);
     }
 }
 
@@ -8728,6 +8754,48 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn launch_contract_injects_the_block_marker_only_for_an_exact_block() {
+        let exact: LaunchContractArgs =
+            syn::parse_str("domain = 2, block = (8, 8, 1), dynamic_shared = 0").unwrap();
+        let mut kernel: ItemFn = parse_quote! { fn kernel() {} };
+        inject_launch_contract_markers(&exact, &mut kernel);
+        let expanded = quote!(#kernel).to_string().replace(' ', "");
+        assert_eq!(
+            expanded.matches("__launch_contract_block_config").count(),
+            1
+        );
+        assert!(expanded.contains("__launch_contract_block_config::<8u32,8u32,1u32>"));
+
+        // Without an exact block the kernel keeps whatever `#[launch_bounds]`
+        // declares, so no exact shape reaches the device compiler.
+        let bounded: LaunchContractArgs = syn::parse_str("domain = 1, dynamic_shared = 0").unwrap();
+        let mut unbounded_kernel: ItemFn = parse_quote! { fn unbounded_kernel() {} };
+        inject_launch_contract_markers(&bounded, &mut unbounded_kernel);
+        assert!(
+            !quote!(#unbounded_kernel)
+                .to_string()
+                .contains("__launch_contract_block_config")
+        );
+    }
+
+    #[test]
+    fn launch_contract_keeps_every_marker_when_block_and_shared_are_both_declared() {
+        let args: LaunchContractArgs = syn::parse_str(
+            "domain = 1, block = (256, 1, 1), dynamic_shared = 128, dynamic_shared_alignment = 32",
+        )
+        .unwrap();
+        let mut kernel: ItemFn = parse_quote! { fn kernel() {} };
+        inject_launch_contract_markers(&args, &mut kernel);
+        let expanded = quote!(#kernel).to_string();
+        assert_eq!(expanded.matches("__launch_contract_config").count(), 1);
+        assert_eq!(
+            expanded.matches("__launch_contract_block_config").count(),
+            1
+        );
+        assert_eq!(expanded.matches("__dynamic_shared_alignment").count(), 1);
     }
 
     /// The `requires` demo module used by the size-requirement tests: two

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -40,7 +40,8 @@ use super::{
     literals::{format_float_literal, format_half_literal},
     names::{decode_intrinsic_identifier, has_device_prefix, strip_device_prefix},
     state::{
-        KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState, PredecessorMap,
+        KernelBlockGeometry, KernelClusterConfig, KernelInfo, KernelLaunchBounds,
+        ModuleExportState, PredecessorMap,
     },
 };
 
@@ -224,12 +225,27 @@ impl<'a> ModuleExportState<'a> {
             }
 
             // Check for launch bounds attributes (from #[launch_bounds(max, min)])
-            // These will be emitted as nvvm.annotations metadata for maxntid and minctasm
-            if let Some(max_threads) = get_int("maxntid") {
+            // and an exact block shape (from #[launch_contract(block = (x,y,z))]).
+            // These are emitted as nvvm.annotations metadata for maxntid,
+            // minctasm and reqntid.
+            let exact_block = match (
+                get_int("reqntid_x"),
+                get_int("reqntid_y"),
+                get_int("reqntid_z"),
+            ) {
+                (Some(x), Some(y), Some(z)) => Some(KernelBlockGeometry::ExactBlock(x, y, z)),
+                _ => None,
+            };
+            // An exact shape displaces the thread maximum: ptxas rejects an
+            // entry carrying both directives, and the shape already bounds the
+            // thread count on every axis.
+            let geometry =
+                exact_block.or_else(|| get_int("maxntid").map(KernelBlockGeometry::MaxThreads));
+            if let Some(geometry) = geometry {
                 let min_blocks = get_int("minctasm");
                 self.launch_bounds_kernels.push(KernelLaunchBounds {
                     name: fixed_func_name.clone(),
-                    max_threads,
+                    geometry,
                     min_blocks: if min_blocks == Some(0) {
                         None
                     } else {

--- a/crates/llvm-export/src/export/metadata.rs
+++ b/crates/llvm-export/src/export/metadata.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use super::state::ModuleExportState;
+use super::state::{KernelBlockGeometry, ModuleExportState};
 
 pub(super) fn needs_nvvm_annotations(
     state: &ModuleExportState,
@@ -82,11 +82,19 @@ pub(super) fn emit_nvvm_annotations(
     let launch_bounds_kernels: Vec<_> = state
         .launch_bounds_kernels
         .iter()
-        .map(|bounds| (bounds.name.clone(), bounds.max_threads, bounds.min_blocks))
+        .map(|bounds| (bounds.name.clone(), bounds.geometry, bounds.min_blocks))
         .collect();
 
-    for (name, max_threads, min_blocks) in launch_bounds_kernels {
-        for (key, value) in [("maxntidx", max_threads), ("maxntidy", 1), ("maxntidz", 1)] {
+    for (name, geometry, min_blocks) in launch_bounds_kernels {
+        let annotations = match geometry {
+            KernelBlockGeometry::ExactBlock(x, y, z) => {
+                [("reqntidx", x), ("reqntidy", y), ("reqntidz", z)]
+            }
+            KernelBlockGeometry::MaxThreads(max_threads) => {
+                [("maxntidx", max_threads), ("maxntidy", 1), ("maxntidz", 1)]
+            }
+        };
+        for (key, value) in annotations {
             let md_id = state.alloc_metadata_id();
             write!(output, "!{md_id} = !{{").unwrap();
             emit_function_reference(output, state, &name)?;
@@ -149,7 +157,7 @@ mod tests {
     use super::*;
     use crate::export::config::DebugKind;
     use crate::export::state::{
-        KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState,
+        KernelBlockGeometry, KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState,
     };
     use pliron::context::Context;
 
@@ -189,7 +197,7 @@ mod tests {
         });
         state.launch_bounds_kernels.push(KernelLaunchBounds {
             name: "bounded".into(),
-            max_threads: 256,
+            geometry: KernelBlockGeometry::MaxThreads(256),
             min_blocks: Some(2),
         });
 
@@ -230,7 +238,7 @@ mod tests {
         });
         state.launch_bounds_kernels.push(KernelLaunchBounds {
             name: "clustered_bounded".into(),
-            max_threads: 128,
+            geometry: KernelBlockGeometry::MaxThreads(128),
             min_blocks: None,
         });
 
@@ -244,6 +252,58 @@ mod tests {
         assert!(output.contains("!1 = !{ptr @clustered_bounded, !\"maxntidx\", i32 128}"));
         assert!(output.contains("!2 = !{ptr @clustered_bounded, !\"maxntidy\", i32 1}"));
         assert!(output.contains("!3 = !{ptr @clustered_bounded, !\"maxntidz\", i32 1}"));
+        assert_eq!(state.next_metadata_id(), 4);
+    }
+
+    #[test]
+    fn exact_block_emits_reqntid_and_suppresses_maxntid() {
+        let ctx = Context::new();
+        let mut state = test_state(&ctx);
+        state.all_kernels.push(KernelInfo {
+            name: "exact".into(),
+        });
+        // The kernel carries both `#[launch_bounds(256, 2)]` and an exact
+        // `#[launch_contract(block = ...)]`, which is the shape of the
+        // `cuda_module_contract` example. ptxas rejects an entry declaring both
+        // `.maxntid` and `.reqntid`, so only `.reqntid` may survive. The
+        // occupancy hint is independent and stays.
+        state.launch_bounds_kernels.push(KernelLaunchBounds {
+            name: "exact".into(),
+            geometry: KernelBlockGeometry::ExactBlock(256, 1, 1),
+            min_blocks: Some(2),
+        });
+
+        let mut output = String::new();
+        emit_nvvm_annotations(&mut output, &mut state, true).unwrap();
+
+        assert!(output.contains("!1 = !{ptr @exact, !\"reqntidx\", i32 256}"));
+        assert!(output.contains("!2 = !{ptr @exact, !\"reqntidy\", i32 1}"));
+        assert!(output.contains("!3 = !{ptr @exact, !\"reqntidz\", i32 1}"));
+        assert!(output.contains("!4 = !{ptr @exact, !\"minctasm\", i32 2}"));
+        assert!(!output.contains("maxntid"));
+        assert_eq!(state.next_metadata_id(), 5);
+    }
+
+    #[test]
+    fn exact_block_without_launch_bounds_still_emits_reqntid() {
+        let ctx = Context::new();
+        let mut state = test_state(&ctx);
+        state.all_kernels.push(KernelInfo {
+            name: "contract_only".into(),
+        });
+        state.launch_bounds_kernels.push(KernelLaunchBounds {
+            name: "contract_only".into(),
+            geometry: KernelBlockGeometry::ExactBlock(16, 16, 1),
+            min_blocks: None,
+        });
+
+        let mut output = String::new();
+        emit_nvvm_annotations(&mut output, &mut state, true).unwrap();
+
+        assert!(output.contains("!1 = !{ptr @contract_only, !\"reqntidx\", i32 16}"));
+        assert!(output.contains("!2 = !{ptr @contract_only, !\"reqntidy\", i32 16}"));
+        assert!(output.contains("!3 = !{ptr @contract_only, !\"reqntidz\", i32 1}"));
+        assert!(!output.contains("maxntid"));
         assert_eq!(state.next_metadata_id(), 4);
     }
 

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -29,10 +29,29 @@ pub(super) struct KernelClusterConfig {
     pub(super) dim_z: u32,
 }
 
-/// Launch bounds for a kernel (from `#[launch_bounds(max, min)]` attribute).
+/// Block geometry declared for a kernel entry.
+///
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`, so an entry
+/// declares one or the other. An exact shape is the stronger statement and
+/// displaces a thread maximum, which is why these are alternatives rather than
+/// two fields.
+#[derive(Clone, Copy)]
+pub(super) enum KernelBlockGeometry {
+    /// Maximum threads per block from `#[launch_bounds(max, _)]`, emitted as
+    /// `maxntid*`. Bounds the product `x * y * z` and says nothing per axis.
+    MaxThreads(u32),
+    /// Exact block shape from `#[launch_contract(block = (x, y, z))]`, emitted
+    /// as `reqntid*`. The CUDA driver enforces it per axis at launch.
+    ExactBlock(u32, u32, u32),
+}
+
+/// Launch geometry for a kernel, from `#[launch_bounds(max, min)]` and from an
+/// exact `#[launch_contract(block = (x, y, z))]`.
+///
+/// A kernel declaring neither is never recorded.
 pub(super) struct KernelLaunchBounds {
     pub(super) name: String,
-    pub(super) max_threads: u32,
+    pub(super) geometry: KernelBlockGeometry,
     pub(super) min_blocks: Option<u32>, // None if not specified (0 in attribute)
 }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -69,6 +69,19 @@ pub struct LaunchBounds {
     pub min_blocks: u32,
 }
 
+/// Exact block shape declared by `#[launch_contract(block = (x, y, z))]`.
+///
+/// Detected by scanning MIR for
+/// `cuda_device::thread::__launch_contract_block_config::<X, Y, Z>()` marker
+/// calls. Emitted as `.reqntid x, y, z`, which the CUDA driver enforces per
+/// axis at launch.
+#[derive(Debug, Clone, Copy)]
+pub struct ContractBlock {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
 /// Minimum extern-shared alignment declared by `#[launch_contract]`.
 #[derive(Debug, Clone, Copy)]
 pub struct DynamicSharedAlignment {
@@ -218,6 +231,109 @@ fn detect_launch_bounds_config(
         }
     }
     Ok(detected)
+}
+
+/// Scans MIR for `__launch_contract_block_config::<X, Y, Z>()` and extracts the
+/// exact block shape declared by `#[launch_contract(block = (x, y, z))]`.
+///
+/// Returns `Some(ContractBlock)` if found, `None` otherwise.
+fn detect_contract_block_config(
+    body: &mir::Body,
+    reachable: &std::collections::BTreeSet<usize>,
+) -> Result<Option<ContractBlock>, String> {
+    use rustc_public::ty::TyConstKind;
+
+    let mut detected: Option<ContractBlock> = None;
+    for &block_idx in reachable {
+        let block = &body.blocks[block_idx];
+        let mir::TerminatorKind::Call { func, .. } = &block.terminator.kind else {
+            continue;
+        };
+        let mir::Operand::Constant(constant) = func else {
+            continue;
+        };
+        let ConstantKind::ZeroSized = constant.const_.kind() else {
+            continue;
+        };
+        let TyKind::RigidTy(RigidTy::FnDef(def_id, args)) = constant.const_.ty().kind() else {
+            continue;
+        };
+
+        let definition_name = def_id.name();
+        if def_id.krate().name.as_str() != "cuda_device"
+            || (definition_name != "__launch_contract_block_config"
+                && !definition_name.ends_with("::__launch_contract_block_config"))
+        {
+            continue;
+        }
+
+        if args.0.len() != 3 {
+            return Err(format!(
+                "cuda_device launch-contract block marker has {} generic arguments; expected exactly 3",
+                args.0.len()
+            ));
+        }
+        let mut values = [0u32; 3];
+        for (index, (axis, arg)) in ["x", "y", "z"].into_iter().zip(args.0.iter()).enumerate() {
+            let rustc_public::ty::GenericArgKind::Const(value) = arg else {
+                return Err(format!(
+                    "cuda_device launch-contract block {axis} argument is not a constant"
+                ));
+            };
+            let raw = match value.kind() {
+                TyConstKind::Value(_, allocation) => allocation.read_uint().map_err(|error| {
+                    format!("could not read launch-contract block {axis} constant: {error:?}")
+                })?,
+                _ => u128::from(value.eval_target_usize().map_err(|error| {
+                    format!("could not evaluate launch-contract block {axis} constant: {error:?}")
+                })?),
+            };
+            values[index] = u32::try_from(raw).map_err(|_| {
+                format!("launch-contract block {axis} value {raw} does not fit in u32")
+            })?;
+            if values[index] == 0 {
+                return Err(format!(
+                    "launch-contract block {axis} dimension must be greater than zero"
+                ));
+            }
+        }
+        let shape = ContractBlock {
+            x: values[0],
+            y: values[1],
+            z: values[2],
+        };
+        if let Some(existing) = detected {
+            if existing.x != shape.x || existing.y != shape.y || existing.z != shape.z {
+                return Err(format!(
+                    "a kernel contains conflicting cuda_device launch-contract block markers: ({}, {}, {}) and ({}, {}, {})",
+                    existing.x, existing.y, existing.z, shape.x, shape.y, shape.z,
+                ));
+            }
+        } else {
+            detected = Some(shape);
+        }
+    }
+    Ok(detected)
+}
+
+/// Rejects an exact block shape that needs more threads than
+/// `#[launch_bounds]` allows.
+///
+/// An exact block displaces the thread maximum in the emitted PTX, because
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`. A maximum
+/// below the required thread count would therefore be dropped in silence, and
+/// the kernel would launch at a shape its author ruled out. A maximum at or
+/// above the required count is redundant rather than contradictory, since
+/// `.reqntid` is the stronger statement, so it stays allowed.
+fn validate_block_against_bounds(bounds: LaunchBounds, block: ContractBlock) -> Result<(), String> {
+    let required = u64::from(block.x) * u64::from(block.y) * u64::from(block.z);
+    if required > u64::from(bounds.max_threads) {
+        return Err(format!(
+            "a kernel declares #[launch_contract(block = ({}, {}, {}))], needing {} threads per block, and #[launch_bounds({})], allowing at most {}",
+            block.x, block.y, block.z, required, bounds.max_threads, bounds.max_threads,
+        ));
+    }
+    Ok(())
 }
 
 /// Scans MIR for the `__unchecked_indexing_config::<ENABLED>()` marker
@@ -1103,6 +1219,23 @@ pub fn translate_body(
                 return input_err_noloc!(TranslationErr::invalid_op(error));
             }
         };
+
+        // Detect the exact block shape from #[launch_contract(block = (x,y,z))].
+        // The exporter emits this as reqntid and suppresses maxntid, which ptxas
+        // rejects alongside it.
+        let contract_block = match detect_contract_block_config(body, &reachable) {
+            Ok(block) => block,
+            Err(error) => {
+                return input_err_noloc!(TranslationErr::invalid_op(error));
+            }
+        };
+
+        if let (Some(bounds), Some(block)) = (launch_bounds, contract_block)
+            && let Err(error) = validate_block_against_bounds(bounds, block)
+        {
+            return input_err_noloc!(TranslationErr::invalid_op(error));
+        }
+
         if let Some(launch_bounds) = launch_bounds {
             use pliron::builtin::attributes::IntegerAttr;
             use pliron::builtin::types::Signedness;
@@ -1142,6 +1275,34 @@ pub fn translate_body(
                         launch_bounds.max_threads
                     );
                 }
+            }
+        }
+
+        if let Some(contract_block) = contract_block {
+            use pliron::builtin::attributes::IntegerAttr;
+            use pliron::builtin::types::Signedness;
+            use pliron::utils::apint::APInt;
+            use std::num::NonZero;
+
+            let u32_ty = pliron::builtin::types::IntegerType::get(ctx, 32, Signedness::Unsigned);
+            let width = NonZero::new(32).unwrap();
+
+            let mut op_mut = mir_func_op.get_operation().deref_mut(ctx);
+            for (key, value) in [
+                ("reqntid_x", contract_block.x),
+                ("reqntid_y", contract_block.y),
+                ("reqntid_z", contract_block.z),
+            ] {
+                let attr = IntegerAttr::new(u32_ty, APInt::from_u32(value, width));
+                let key: Identifier = key.try_into().unwrap();
+                op_mut.attributes.set(key, attr);
+            }
+
+            if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
+                eprintln!(
+                    "  Launch contract block detected: reqntid={}x{}x{}",
+                    contract_block.x, contract_block.y, contract_block.z
+                );
             }
         }
     }
@@ -1326,6 +1487,34 @@ mod tests {
             validate_monomorphized_successor_shape(4, 4, &[vec![4], vec![], vec![], vec![]])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn an_exact_block_may_not_need_more_threads_than_launch_bounds_allows() {
+        let block = |x, y, z| ContractBlock { x, y, z };
+        let bounds = |max_threads| LaunchBounds {
+            max_threads,
+            min_blocks: 0,
+        };
+
+        // The shapes the `cuda_module_contract` example declares: the maximum
+        // equals the required thread count on every axis product.
+        assert!(validate_block_against_bounds(bounds(256), block(256, 1, 1)).is_ok());
+        assert!(validate_block_against_bounds(bounds(64), block(8, 8, 1)).is_ok());
+        // A maximum above the requirement is redundant, and allowed.
+        assert!(validate_block_against_bounds(bounds(1024), block(16, 16, 1)).is_ok());
+
+        // A maximum below the requirement contradicts it. Without this the
+        // exporter would drop the maximum and emit the larger shape.
+        let error = validate_block_against_bounds(bounds(128), block(16, 16, 1))
+            .expect_err("256 threads exceed a 128-thread maximum");
+        assert!(error.contains("256 threads per block"), "{error}");
+        assert!(error.contains("at most 128"), "{error}");
+        assert!(validate_block_against_bounds(bounds(255), block(256, 1, 1)).is_err());
+
+        // The product is computed in u64, so a shape whose axes multiply past
+        // u32 is rejected rather than wrapping to a value under the maximum.
+        assert!(validate_block_against_bounds(bounds(1024), block(65_536, 65_536, 1)).is_err());
     }
 
     #[test]

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2791,6 +2791,8 @@ fn try_dispatch_intrinsic(
         | "cuda_device::thread::__launch_bounds_config"
         | "cuda_device::__launch_contract_config"
         | "cuda_device::thread::__launch_contract_config"
+        | "cuda_device::__launch_contract_block_config"
+        | "cuda_device::thread::__launch_contract_block_config"
         | "cuda_device::__unchecked_indexing_config"
         | "cuda_device::thread::__unchecked_indexing_config" => {
             let expected_marker = match name {
@@ -2798,6 +2800,10 @@ fn try_dispatch_intrinsic(
                 | "cuda_device::thread::__launch_bounds_config" => "__launch_bounds_config",
                 "cuda_device::__launch_contract_config"
                 | "cuda_device::thread::__launch_contract_config" => "__launch_contract_config",
+                "cuda_device::__launch_contract_block_config"
+                | "cuda_device::thread::__launch_contract_block_config" => {
+                    "__launch_contract_block_config"
+                }
                 "cuda_device::__unchecked_indexing_config"
                 | "cuda_device::thread::__unchecked_indexing_config" => {
                     "__unchecked_indexing_config"

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -344,6 +344,9 @@ fn propagate_kernel_attrs(
             "cluster_dim_z",
             "maxntid",
             "minctasm",
+            "reqntid_x",
+            "reqntid_y",
+            "reqntid_z",
         ]
         .iter()
         .filter_map(|key_str| {

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
@@ -362,47 +362,64 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    for entry in ["aligned_dynamic_shared", "mixed_abi"] {
-        let start = ptx
-            .find(&format!(".visible .entry {entry}("))
-            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
-        let rest = &ptx[start..];
-        let end = rest[1..]
-            .find(".visible .entry ")
-            .map_or(rest.len(), |offset| offset + 1);
-        if !rest[..end].contains(".maxntid 256, 1, 1") {
-            return Err(format!("PTX entry {entry} lost its launch bounds").into());
-        }
-    }
-
-    for entry in [
-        "helper_contract_32",
-        "helper_contract_256",
-        "explicit_aligned_u32",
+    // A kernel declaring an exact `block` carries that shape into PTX as
+    // `.reqntid`, which the driver enforces on every axis. A kernel bounded
+    // only by `#[launch_bounds]` keeps `.maxntid`, which bounds the thread
+    // count and permits any shape reaching it.
+    for (entry, geometry) in [
+        ("aligned_dynamic_shared", ".reqntid 256, 1, 1"),
+        ("mixed_abi", ".reqntid 256, 1, 1"),
+        ("strided_scale", ".reqntid 128, 1, 1"),
+        ("helper_contract_32", ".reqntid 32, 1, 1"),
+        ("helper_contract_256", ".reqntid 32, 1, 1"),
+        ("explicit_aligned_u32", ".maxntid 32, 1, 1"),
     ] {
-        let start = ptx
-            .find(&format!(".visible .entry {entry}("))
-            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
-        let rest = &ptx[start..];
-        let end = rest[1..]
-            .find(".visible .entry ")
-            .map_or(rest.len(), |offset| offset + 1);
-        if !rest[..end].contains(".maxntid 32, 1, 1") {
-            return Err(format!("PTX entry {entry} lost its launch bounds").into());
-        }
+        verify_entry_geometry(&ptx, &format!(".visible .entry {entry}("), entry, geometry)?;
     }
 
-    let generic_start = ptx
-        .find(".visible .entry generic_aligned_TID_")
-        .ok_or("missing generic_aligned PTX specialization")?;
-    let generic_rest = &ptx[generic_start..];
-    let generic_end = generic_rest[1..]
-        .find(".visible .entry ")
-        .map_or(generic_rest.len(), |offset| offset + 1);
-    if !generic_rest[..generic_end].contains(".maxntid 64, 1, 1") {
-        return Err("generic_aligned PTX specialization lost its launch bounds".into());
-    }
+    verify_entry_geometry(
+        &ptx,
+        ".visible .entry generic_aligned_TID_",
+        "generic_aligned specialization",
+        ".maxntid 64, 1, 1",
+    )?;
 
     println!("SUCCESS: prepared-launch PTX contract verified");
+    Ok(())
+}
+
+/// Assert one entry's launch geometry, and that it declares exactly one of the
+/// two mutually exclusive directives.
+///
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`
+/// ("Conflicting directives: .maxntid and .reqntid cannot both be specified"),
+/// so a kernel with an exact block emits `.reqntid` in place of the thread
+/// maximum. Every kernel here declares `#[launch_bounds]`, so this is the case
+/// that would regress if the exporter stopped suppressing one of them.
+fn verify_entry_geometry(
+    ptx: &str,
+    anchor: &str,
+    entry: &str,
+    expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = ptx
+        .find(anchor)
+        .ok_or_else(|| format!("missing PTX entry {entry}"))?;
+    let rest = &ptx[start..];
+    let end = rest[1..]
+        .find(".visible .entry ")
+        .map_or(rest.len(), |offset| offset + 1);
+    let body = &rest[..end];
+
+    if !body.contains(expected) {
+        return Err(format!("PTX entry {entry} lost its launch geometry `{expected}`").into());
+    }
+    if body.contains(".maxntid") && body.contains(".reqntid") {
+        return Err(format!(
+            "PTX entry {entry} declares both .maxntid and .reqntid, which ptxas rejects"
+        )
+        .into());
+    }
+
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
@@ -363,16 +363,17 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // A kernel declaring an exact `block` carries that shape into PTX as
-    // `.reqntid`, which the driver enforces on every axis. A kernel bounded
-    // only by `#[launch_bounds]` keeps `.maxntid`, which bounds the thread
-    // count and permits any shape reaching it.
+    // `.reqntid`, which the driver enforces on every axis. Every kernel in
+    // this example declares one, including the generic and the explicitly
+    // instantiated kernels whose contracts expand before `#[kernel]` and
+    // reach the entry wrapper through marker forwarding.
     for (entry, geometry) in [
         ("aligned_dynamic_shared", ".reqntid 256, 1, 1"),
         ("mixed_abi", ".reqntid 256, 1, 1"),
         ("strided_scale", ".reqntid 128, 1, 1"),
         ("helper_contract_32", ".reqntid 32, 1, 1"),
         ("helper_contract_256", ".reqntid 32, 1, 1"),
-        ("explicit_aligned_u32", ".maxntid 32, 1, 1"),
+        ("explicit_aligned_u32", ".reqntid 32, 1, 1"),
     ] {
         verify_entry_geometry(&ptx, &format!(".visible .entry {entry}("), entry, geometry)?;
     }
@@ -381,7 +382,7 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
         &ptx,
         ".visible .entry generic_aligned_TID_",
         "generic_aligned specialization",
-        ".maxntid 64, 1, 1",
+        ".reqntid 64, 1, 1",
     )?;
 
     println!("SUCCESS: prepared-launch PTX contract verified");

--- a/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
@@ -747,6 +747,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
     for marker in [
         "__launch_contract_config",
+        "__launch_contract_block_config",
         "__launch_bounds_config",
         "make_kernel_scope",
     ] {
@@ -768,8 +769,19 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("sgemm_tiled_views", safe_tiled),
         ("sgemm_tiled_raw", raw_tiled),
     ] {
-        if !body.contains(".maxntid 256, 1, 1") {
-            return Err(format!("{name} lost its 256-thread launch bound").into());
+        // These kernels declare `block = (16, 16, 1)`, so the exact shape
+        // reaches the device compiler as `.reqntid` and the driver rejects any
+        // other block on any axis. A thread maximum cannot express this shape:
+        // it bounds the product alone, and its per-axis fields would claim one
+        // thread on Y for a block that has sixteen. `.maxntid` must therefore
+        // be absent, and ptxas rejects an entry carrying both regardless.
+        if !body.contains(".reqntid 16, 16, 1") {
+            return Err(format!("{name} lost its exact 16x16 block shape").into());
+        }
+        if body.contains(".maxntid") {
+            return Err(
+                format!("{name} declares both .maxntid and .reqntid, which ptxas rejects").into(),
+            );
         }
         verify_no_calls(name, body)?;
         // Every bounds fact is proven through sentinel scalar checks; nothing

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
@@ -313,6 +313,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
     for marker in [
         "__launch_contract_config",
+        "__launch_contract_block_config",
         "__launch_bounds_config",
         "make_kernel_scope",
     ] {
@@ -337,9 +338,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("safe_tile", safe_tile),
         ("raw_tile", raw_tile),
     ] {
-        if !body.contains(".maxntid 64, 1, 1") {
-            return Err(format!("{name} lost its 64-thread launch bound").into());
-        }
+        verify_exact_block(name, body, ".reqntid 64, 1, 1")?;
         verify_u32_coordinates(name, body)?;
         verify_no_calls(name, body)?;
         let branches = conditional_branches(body);
@@ -363,9 +362,10 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("safe_epilogue", safe_epilogue),
         ("raw_epilogue", raw_epilogue),
     ] {
-        if !body.contains(".maxntid 64, 1, 1") {
-            return Err(format!("{name} lost its 64-thread launch bound").into());
-        }
+        // A 2-D contract records its real shape. A thread maximum bounds the
+        // product alone, so its per-axis fields would claim one thread on Y
+        // for a block that has eight.
+        verify_exact_block(name, body, ".reqntid 8, 8, 1")?;
         verify_u32_coordinates(name, body)?;
         verify_no_calls(name, body)?;
         for register in ["%ctaid.y", "%ntid.y", "%tid.y"] {
@@ -462,6 +462,27 @@ fn entry_body<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::erro
         .map(|offset| open + 1 + offset + 2)
         .ok_or_else(|| format!("PTX entry `{name}` has no closing brace"))?;
     Ok(&rest[..close])
+}
+
+/// A kernel declaring an exact `block` in its launch contract carries that
+/// shape into PTX as `.reqntid`, which the driver enforces on every axis.
+///
+/// `.reqntid` displaces `.maxntid`: ptxas rejects an entry declaring both, and
+/// an exact shape already bounds the thread count.
+fn verify_exact_block(
+    name: &str,
+    body: &str,
+    expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !body.contains(expected) {
+        return Err(format!("{name} lost its exact block shape `{expected}`").into());
+    }
+    if body.contains(".maxntid") {
+        return Err(
+            format!("{name} declares both .maxntid and .reqntid, which ptxas rejects").into(),
+        );
+    }
+    Ok(())
 }
 
 fn verify_u32_coordinates(name: &str, body: &str) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -635,6 +635,8 @@ fn is_launch_metadata_marker_path(fn_path: &str) -> bool {
             | "cuda_device::thread::__launch_bounds_config"
             | "cuda_device::__launch_contract_config"
             | "cuda_device::thread::__launch_contract_config"
+            | "cuda_device::__launch_contract_block_config"
+            | "cuda_device::thread::__launch_contract_block_config"
             | "cuda_device::__unchecked_indexing_config"
             | "cuda_device::thread::__unchecked_indexing_config"
     ) || fn_path.strip_prefix("cuda_device::").is_some_and(|path| {
@@ -642,6 +644,8 @@ fn is_launch_metadata_marker_path(fn_path: &str) -> bool {
             || path.starts_with("thread::__launch_bounds_config::<")
             || path.starts_with("__launch_contract_config::<")
             || path.starts_with("thread::__launch_contract_config::<")
+            || path.starts_with("__launch_contract_block_config::<")
+            || path.starts_with("thread::__launch_contract_block_config::<")
             || path.starts_with("__unchecked_indexing_config::<")
             || path.starts_with("thread::__unchecked_indexing_config::<")
     })

--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -258,6 +258,19 @@ The generated PTX includes these directives:
 .entry optimized_kernel .maxntid 256, 1, 1 .minnctapersm 2 { ... }
 ```
 
+`.maxntid` bounds the product `x * y * z`, so a 256-thread bound admits
+`(256, 1, 1)`, `(16, 16, 1)` and `(4, 8, 8)` alike. Add
+`#[launch_contract(block = (x, y, z))]` when one exact shape is required. That
+emits `.reqntid` in place of `.maxntid`, which the driver enforces per axis:
+
+```text
+.entry exact_kernel .reqntid 256, 1, 1 .minnctapersm 2 { ... }
+```
+
+The two directives are mutually exclusive; ptxas rejects an entry declaring
+both, so a contracted kernel emits `.reqntid` alone. `.minnctapersm` is an
+occupancy hint and composes with either.
+
 :::{tip}
 `#[launch_bounds]` must appear **after** `#[kernel]`:
 

--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -179,6 +179,21 @@ The two annotations provide the checked facts:
 - `block = (64, 1, 1)` requires exactly 64 threads in each block. The launch
   may still contain many blocks.
 
+An exact `block` is checked twice, in two places that fail independently.
+Preparation rejects a mismatched launch configuration on the host, before any
+driver call. The shape also reaches the device compiler, which emits
+`.reqntid 64, 1, 1`, so the CUDA driver refuses any launch whose block differs
+on any axis. The second check covers the paths the first one cannot see: an
+`unsafe` raw launch, and a module whose loaded PTX is not the artifact the
+generated Rust markers describe.
+
+`.reqntid` replaces `.maxntid` for a contracted kernel. ptxas rejects an entry
+declaring both, and an exact shape already bounds the thread count. A kernel
+carrying only `#[launch_bounds]` keeps `.maxntid`, which bounds the product
+`x * y * z` and admits every shape reaching it. That difference is the reason a
+thread bound cannot stand in for a block shape: under `.maxntid 64, 1, 1` the
+driver accepts `(8, 8, 1)` and `(4, 4, 4)` alongside `(64, 1, 1)`.
+
 For 2-D tiles, use `thread::coord_2d_u32(launch_context)` with
 `RowMajorTiles<ROWS, COLS, ROW_STRIDE>`. `ROW_STRIDE` is the logical row pitch
 in elements and must match the buffer's layout. The buffer length does not


### PR DESCRIPTION
`#[launch_contract(block = (x, y, z))]` binds a launch to one block shape, and
that shape was known only to the host. `prepare_*` checked it and returned a
typed error on a mismatch, while a raw `_unchecked` launch, or a module whose
PTX reached the driver by another route, went unchecked.

This carries the shape into the compiled artifact as `.reqntid x, y, z`, which
the CUDA driver enforces per axis at every launch. Preparation and the driver
check the same requirement on independent paths.

## What changes

`#[launch_contract]` injects `__launch_contract_block_config::<X, Y, Z>()`
alongside the existing contract marker. The MIR importer reads it, mir-lower
propagates `reqntid_x/y/z`, and llvm-export emits the matching
`!nvvm.annotations` entries.

`.maxntid` and `.reqntid` cannot appear on one entry; ptxas rejects the pair
with "Conflicting directives: .maxntid and .reqntid cannot both be specified".
A kernel declaring an exact block therefore emits `.reqntid` in place of the
thread maximum. `.minnctapersm` is independent and still emitted.

`KernelLaunchBounds` carries a `KernelBlockGeometry` enum (`Exact` from a
launch-contract block, `Max` from `#[launch_bounds]`, or absent), so the
exporter picks `.reqntid` or `.maxntid` from the geometry's provenance
rather than a bare thread count.

## Correcting the emitted geometry

`.maxntid` bounds the product `x * y * z` and says nothing per axis. Every
non-1-D contract was emitting `.maxntid N, 1, 1`, declaring one thread on Y for
blocks of 8 or 16. The driver checks only the product, so this was harmless,
and it is replaced by the real shape.

## Rejecting a contradictory pair

A `#[launch_bounds(max)]` below the exact block's thread count is now an error.
The exact block displaces the maximum in the emitted PTX, so the maximum would
otherwise be dropped in silence and the kernel would launch at a shape its
author ruled out. `#[cuda_module]` already diagnosed this at the attribute
site. The check added here sits in the MIR importer, which sees both markers
regardless of attribute order, and covers standalone contracted kernels that
reach the device compiler without passing through the module path. A maximum
at or above the required count is redundant and stays allowed.

## Change in behaviour

An `unsafe` raw launch of a contracted kernel with a differing block shape now
fails with a driver error. The checked path already rejected that launch.

## Verification

- `.reqntid` is fail-closed: an out-of-range shape makes ptxas warn and the
  driver reject every launch.
- SASS is byte-identical between `.reqntid` and the `.maxntid` it replaces, at
  identical register counts and zero spills, for all four `gemm_views` kernels.
  The whole cubin difference is an `EIATTR_REQNTID` record in place of
  `EIATTR_MAX_THREADS`.
- The `cuda_module_contract`, `gemm_views` and `proof_carrying_views` PTX
  harnesses assert the expected directive per entry, and that no entry declares
  both.

