### PR TITLE
Add `Uniform<T>`, a launch-uniform scalar witness, and make `tile_2d32_rt` safe

### DIFF
--- a/crates/cuda-core/src/launch.rs
+++ b/crates/cuda-core/src/launch.rs
@@ -170,6 +170,11 @@ impl KernelLaunchConfig for LaunchConfig3D {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BlockRequirement {
     /// The launch must use exactly these `(x, y, z)` block dimensions.
+    ///
+    /// A kernel compiled by cuda-oxide also carries this shape as PTX
+    /// `.reqntid`, so the CUDA driver rejects a differing block on any axis
+    /// independently of this check. Preparation still reports the mismatch
+    /// first, with the kernel name and both shapes.
     Exact((u32, u32, u32)),
     /// The block may contain at most this many threads in total.
     ///

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -36,6 +36,7 @@ pub mod shared;
 pub mod tcgen05;
 pub mod thread;
 pub mod tma;
+pub mod uniform;
 pub mod view;
 pub mod warp;
 pub mod wgmma;
@@ -74,6 +75,9 @@ pub use tcgen05::{
 };
 pub use thread::*;
 pub use tma::TmaDescriptor;
+#[doc(hidden)]
+pub use uniform::__LaunchContractUniform;
+pub use uniform::Uniform;
 pub use view::{
     ColView32, ColViewIter32, InBounds32, InBoundsMut32, LinearTiles, LocalIndex32, MatrixView32,
     RowMajorTiles, RowView32, RowViewIter32, RuntimeRowMajorTiles, RuntimeTileMut32,

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -982,6 +982,44 @@ const fn validate_launch_bounds(max_threads: u32) {
     );
 }
 
+/// Compile-time marker carrying an exact block shape to the device compiler.
+///
+/// `#[launch_contract(block = (x, y, z))]` already binds the host launch to one
+/// block shape. This marker gives the same fact to the device compiler, which
+/// emits `.reqntid x, y, z`. The CUDA driver then rejects a launch whose block
+/// dimensions differ on any axis, so the exact-block obligation is enforced by
+/// the compiled artifact rather than by the host check alone.
+///
+/// # How it works
+///
+/// 1. `#[launch_contract]` injects `__launch_contract_block_config::<X, Y, Z>()`
+///    at kernel start.
+/// 2. The MIR importer detects the call and extracts the const generics.
+/// 3. The marker call is removed during compilation.
+/// 4. LLVM export emits `!nvvm.annotations` with `reqntidx`, `reqntidy` and
+///    `reqntidz`.
+/// 5. The NVPTX backend emits `.reqntid x, y, z`.
+///
+/// # Relationship to `#[launch_bounds]`
+///
+/// `.maxntid` and `.reqntid` on one entry is a ptxas error, so a kernel
+/// carrying both attributes emits `.reqntid` alone. An exact block shape
+/// implies the thread maximum that `.maxntid` would have declared, so nothing
+/// the device compiler relies on is lost. `.minnctapersm` from
+/// `#[launch_bounds(max, min)]` is unaffected and still emitted.
+#[inline(never)]
+pub fn __launch_contract_block_config<const X: u32, const Y: u32, const Z: u32>() {
+    const { validate_contract_block(X, Y, Z) }
+    // Detected at compile time and removed. No runtime code is generated.
+}
+
+const fn validate_contract_block(x: u32, y: u32, z: u32) {
+    assert!(
+        x > 0 && y > 0 && z > 0,
+        "launch_contract block dimensions must all be greater than zero"
+    );
+}
+
 /// Compiler marker for opt-in unchecked slice/array indexing.
 ///
 /// `#[kernel(unchecked_indexing)]` inserts this call. The MIR importer records

--- a/crates/cuda-device/src/uniform.rs
+++ b/crates/cuda-device/src/uniform.rs
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Launch-uniform scalar witnesses.
+//!
+//! Some device APIs need a value that is identical in every thread of a launch.
+//! A per-thread value in their place describes two different grids over one
+//! buffer, and two threads that disagree can resolve the same element from
+//! different coordinates. [`crate::DisjointSlice::tile_2d32_rt`] is the
+//! motivating case: its row pitch has to be launch-uniform for the tiles it
+//! hands out to be disjoint.
+//!
+//! A kernel scalar parameter is uniform by construction. The host marshals one
+//! value into the launch packet, and every thread of every block reads those
+//! same bytes. [`Uniform<T>`] captures that fact in the type system:
+//!
+//! ```rust,ignore
+//! #[kernel]
+//! #[launch_contract(domain = 2, coordinates = u32, block = (16, 16, 1))]
+//! pub fn scale(n: Uniform<u32>, mut c: DisjointSlice<f32, RuntimeRowMajorTiles<1, 1>>) {
+//!     // `n` came from the launch packet, so no `unsafe` is needed here.
+//!     if let Some(mut tile) = c.tile_2d32_rt(coord, n) { /* ... */ }
+//! }
+//! ```
+//!
+//! The host method still takes a plain `u32`; `#[cuda_module]` wraps it. There
+//! is no constructor, so device code cannot manufacture a witness from a
+//! thread-dependent value. The one escape hatch is
+//! [`Uniform::new_unchecked`], for a value proven uniform some other way.
+
+/// A scalar proven identical in every thread of the launch.
+///
+/// The only safe source is a kernel parameter. `#[repr(transparent)]` makes the
+/// ABI identical to `T`, so the kernel entry receives the value directly and no
+/// constructor runs on the device.
+///
+/// The private field is what carries the proof: no code outside this module
+/// can name it, so no code outside this module can build a witness. Adding a
+/// public constructor, or deriving anything that rebuilds the value from parts,
+/// would defeat it.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Uniform<T> {
+    value: T,
+}
+
+impl<T: Copy> Clone for Uniform<T> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+/// Copying a launch-uniform value leaves it launch-uniform.
+impl<T: Copy> Copy for Uniform<T> {}
+
+impl<T> Uniform<T> {
+    /// Assert that `value` is identical in every thread of this launch.
+    ///
+    /// Prefer declaring the kernel parameter as `Uniform<T>`, which carries the
+    /// same proof with no obligation.
+    ///
+    /// # Safety
+    ///
+    /// `value` must be the same in every thread of the launch. A value derived
+    /// from `threadIdx`, `blockIdx`, a per-thread load, or any branch on those
+    /// does not qualify. Block and grid dimensions do qualify; see
+    /// [`block_dim_x`] and its siblings for witnesses that need no `unsafe`.
+    #[inline(always)]
+    pub const unsafe fn new_unchecked(value: T) -> Self {
+        Self { value }
+    }
+
+    /// Return the underlying value.
+    ///
+    /// The result is an ordinary scalar. Arithmetic on it loses the proof
+    /// unless every operand is itself uniform, which is what the operator
+    /// implementations below preserve.
+    #[inline(always)]
+    pub const fn get(&self) -> T
+    where
+        T: Copy,
+    {
+        self.value
+    }
+}
+
+/// Uniformity is closed under arithmetic whose operands are all uniform.
+///
+/// Every thread evaluates the same operator over the same inputs, so the result
+/// is the same in every thread. Wrapping and saturating forms are used because
+/// a panic on overflow would be a divergent side effect in device code.
+macro_rules! uniform_binop {
+    ($($method:ident: $doc:literal),* $(,)?) => {
+        impl Uniform<u32> {
+            $(
+                #[doc = $doc]
+                #[inline(always)]
+                pub fn $method(self, other: Self) -> Self {
+                    Self {
+                        value: self.value.$method(other.value),
+                    }
+                }
+            )*
+        }
+    };
+}
+
+uniform_binop! {
+    wrapping_add: "Wrapping addition of two uniform values.",
+    wrapping_sub: "Wrapping subtraction of two uniform values.",
+    wrapping_mul: "Wrapping multiplication of two uniform values.",
+    saturating_add: "Saturating addition of two uniform values.",
+    saturating_sub: "Saturating subtraction of two uniform values.",
+    min: "The smaller of two uniform values.",
+    max: "The larger of two uniform values.",
+}
+
+impl Uniform<u32> {
+    /// Multiply by a compile-time constant.
+    ///
+    /// A constant is the same in every thread, so the product stays uniform.
+    /// This is a const parameter rather than an ordinary argument precisely
+    /// because an argument could carry a per-thread value.
+    #[inline(always)]
+    pub const fn wrapping_mul_const<const C: u32>(self) -> Self {
+        Self {
+            value: self.value.wrapping_mul(C),
+        }
+    }
+
+    /// Add a compile-time constant.
+    #[inline(always)]
+    pub const fn wrapping_add_const<const C: u32>(self) -> Self {
+        Self {
+            value: self.value.wrapping_add(C),
+        }
+    }
+}
+
+mod uniform_sealed {
+    pub trait Sealed {}
+}
+
+impl<T> uniform_sealed::Sealed for Uniform<T> {}
+
+/// Compiler-facing proof that a kernel parameter is cuda-device's own
+/// [`Uniform<T>`] over the expected scalar.
+///
+/// `#[cuda_module]` selects a parameter's host ABI from the spelling of its
+/// type, so a local type also named `Uniform` would otherwise choose the
+/// scalar host signature while presenting a different device layout. This
+/// trait is sealed, and `#[cuda_module]` bounds every `Uniform` parameter by
+/// it, so Rust resolves aliases and rejects a look-alike before any launch is
+/// generated.
+#[doc(hidden)]
+pub trait __LaunchContractUniform<Scalar>: uniform_sealed::Sealed {}
+
+impl<T> __LaunchContractUniform<T> for Uniform<T> {}
+
+/// Threads per block on X, which the launch fixes for every thread.
+///
+/// A launch has one block shape, so every thread reads the same value. These
+/// are witnesses that need no `unsafe`, unlike a value the kernel computes.
+#[inline(always)]
+pub fn block_dim_x() -> Uniform<u32> {
+    // SAFETY: `%ntid.x` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::blockDim_x()) }
+}
+
+/// Threads per block on Y.
+#[inline(always)]
+pub fn block_dim_y() -> Uniform<u32> {
+    // SAFETY: `%ntid.y` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::blockDim_y()) }
+}
+
+/// Threads per block on Z.
+#[inline(always)]
+pub fn block_dim_z() -> Uniform<u32> {
+    // SAFETY: `%ntid.z` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::blockDim_z()) }
+}
+
+/// Blocks per grid on X.
+#[inline(always)]
+pub fn grid_dim_x() -> Uniform<u32> {
+    // SAFETY: `%nctaid.x` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::gridDim_x()) }
+}
+
+/// Blocks per grid on Y.
+#[inline(always)]
+pub fn grid_dim_y() -> Uniform<u32> {
+    // SAFETY: `%nctaid.y` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::gridDim_y()) }
+}
+
+/// Blocks per grid on Z.
+#[inline(always)]
+pub fn grid_dim_z() -> Uniform<u32> {
+    // SAFETY: `%nctaid.z` is a launch-wide constant.
+    unsafe { Uniform::new_unchecked(crate::thread::gridDim_z()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn uniform_is_abi_identical_to_its_scalar() {
+        assert_eq!(size_of::<Uniform<u32>>(), size_of::<u32>());
+        assert_eq!(align_of::<Uniform<u32>>(), align_of::<u32>());
+        assert_eq!(size_of::<Uniform<u64>>(), size_of::<u64>());
+    }
+
+    #[test]
+    fn arithmetic_over_uniform_operands_stays_uniform() {
+        // SAFETY: test-local constants are trivially uniform.
+        let a = unsafe { Uniform::new_unchecked(6u32) };
+        let b = unsafe { Uniform::new_unchecked(7u32) };
+        assert_eq!(a.wrapping_mul(b).get(), 42);
+        assert_eq!(a.wrapping_add(b).get(), 13);
+        assert_eq!(b.wrapping_sub(a).get(), 1);
+        assert_eq!(a.min(b).get(), 6);
+        assert_eq!(a.max(b).get(), 7);
+        assert_eq!(a.wrapping_mul_const::<4>().get(), 24);
+        assert_eq!(a.wrapping_add_const::<4>().get(), 10);
+    }
+
+    #[test]
+    fn wrapping_arithmetic_does_not_panic_at_the_boundary() {
+        // SAFETY: test-local constants are trivially uniform.
+        let max = unsafe { Uniform::new_unchecked(u32::MAX) };
+        let one = unsafe { Uniform::new_unchecked(1u32) };
+        assert_eq!(max.wrapping_add(one).get(), 0);
+        assert_eq!(max.saturating_add(one).get(), u32::MAX);
+        let zero = unsafe { Uniform::new_unchecked(0u32) };
+        assert_eq!(zero.saturating_sub(one).get(), 0);
+    }
+}

--- a/crates/cuda-device/src/view.rs
+++ b/crates/cuda-device/src/view.rs
@@ -21,6 +21,7 @@
 
 use crate::DisjointSlice;
 use crate::thread::{Index1D, ThreadCoord2D32, ThreadIndex32};
+use crate::uniform::Uniform;
 use core::marker::PhantomData;
 use core::mem::size_of;
 
@@ -1088,29 +1089,38 @@ impl<'a, T, const ROWS: usize, const COLS: usize>
     /// Zero-sized element types are rejected, as for every mutable view:
     /// distinct threads would otherwise share one address.
     ///
-    /// # Safety
+    /// # Why the stride is a [`Uniform<u32>`]
     ///
-    /// `stride` must be the same value in **every** thread of the launch, and
-    /// it must be the row width actually used for this slice. Passing a
-    /// kernel scalar argument (such as `n`) satisfies this automatically:
-    /// every thread reads the same argument. The danger is a stride computed
-    /// per thread. Two threads that disagree about the row width describe
-    /// two different grids over the same memory, and their "disjoint" tiles
-    /// can land on the same elements. With 1x1 tiles: thread `(1, 0)` with
-    /// stride 5 resolves flat index `1*5 + 0 = 5`, while thread `(0, 5)`
-    /// with stride 100 resolves `0*100 + 5 = 5`. Same element, two `&mut`, a
-    /// data race. This is the same obligation as
-    /// [`crate::thread::index_2d_runtime`]; when the row width is known at
-    /// compile time, prefer the fully safe [`tile_2d32`], which makes a
-    /// mismatch a type error.
+    /// Two threads that disagree about the row width describe two different
+    /// grids over the same memory, and their "disjoint" tiles can land on the
+    /// same elements. With 1x1 tiles: thread `(1, 0)` with stride 5 resolves
+    /// flat index `1*5 + 0 = 5`, while thread `(0, 5)` with stride 100
+    /// resolves `0*100 + 5 = 5`. Same element, two `&mut`, a data race.
+    ///
+    /// A [`Uniform<u32>`] rules that out. Its only safe source is a kernel
+    /// scalar parameter, which the host marshals once into the launch packet,
+    /// so every thread reads the same value. Under a uniform stride the
+    /// `last_col < stride` check below keeps each tile inside one logical row,
+    /// which makes the coordinate-to-offset mapping injective and the tiles of
+    /// distinct threads disjoint.
+    ///
+    /// The stride still has to be the row width this slice actually uses for
+    /// the kernel to compute the intended result. That is a correctness
+    /// requirement rather than a safety one: a uniform stride that misdescribes
+    /// the layout gives wrong answers inside the slice, never aliasing or an
+    /// out-of-bounds access.
+    ///
+    /// When the row width is known at compile time, prefer [`tile_2d32`],
+    /// which makes a mismatch a type error.
     ///
     /// [`tile_2d32`]: DisjointSlice::tile_2d32
     #[inline(always)]
-    pub unsafe fn tile_2d32_rt<'kernel>(
+    pub fn tile_2d32_rt<'kernel>(
         &mut self,
         thread: ThreadCoord2D32<'kernel>,
-        stride: u32,
+        stride: Uniform<u32>,
     ) -> Option<RuntimeTileMut32<'_, T, ROWS, COLS>> {
+        let stride = stride.get();
         let start = checked_runtime_tile_start::<T, ROWS, COLS>(
             thread.row(),
             thread.col(),
@@ -1124,7 +1134,7 @@ impl<'a, T, const ROWS: usize, const COLS: usize>
         // SAFETY: the scalar-only helper checked the complete rectangle.
         // The `&mut self` borrow keeps at most one tile live per thread, and
         // a re-minted coordinate re-derives the same rectangle. Across
-        // threads, the caller asserts a launch-uniform pitch, under which
+        // threads, `Uniform<u32>` proves a launch-uniform pitch, under which
         // distinct hardware coordinates map to disjoint row and column bands.
         Some(unsafe {
             RuntimeTileMut32::from_checked_ptr(self.as_mut_ptr().add(start as usize), stride)

--- a/crates/cuda-device/tests/compile_fail/runtime_tile_scope_escape.rs
+++ b/crates/cuda-device/tests/compile_fail/runtime_tile_scope_escape.rs
@@ -4,7 +4,7 @@
  */
 
 use cuda_device::thread::{LaunchContextRef, __internal};
-use cuda_device::{DisjointSlice, RuntimeRowMajorTiles, RuntimeTileMut32};
+use cuda_device::{DisjointSlice, RuntimeRowMajorTiles, RuntimeTileMut32, Uniform};
 
 static mut SAVED: Option<RuntimeTileMut32<'static, f32, 1, 1>> = None;
 
@@ -13,7 +13,9 @@ fn cannot_stash_a_tile_beyond_its_parent<'kernel>(
     mut c: DisjointSlice<'_, f32, RuntimeRowMajorTiles<1, 1>>,
 ) {
     let coord = __internal::coord_2d_u32(launch_context);
-    let tile = unsafe { c.tile_2d32_rt(coord, 64) };
+    // SAFETY: a literal is trivially the same in every thread.
+    let stride = unsafe { Uniform::new_unchecked(64) };
+    let tile = c.tile_2d32_rt(coord, stride);
     unsafe {
         SAVED = tile;
     }

--- a/crates/cuda-device/tests/compile_fail/runtime_tile_scope_escape.stderr
+++ b/crates/cuda-device/tests/compile_fail/runtime_tile_scope_escape.stderr
@@ -1,23 +1,23 @@
 error[E0597]: `c` does not live long enough
-  --> tests/compile_fail/runtime_tile_scope_escape.rs:16:25
+  --> tests/compile_fail/runtime_tile_scope_escape.rs:18:16
    |
 13 |     mut c: DisjointSlice<'_, f32, RuntimeRowMajorTiles<1, 1>>,
    |     ----- binding `c` declared here
 ...
-16 |     let tile = unsafe { c.tile_2d32_rt(coord, 64) };
-   |                         ^ borrowed value does not live long enough
-17 |     unsafe {
-18 |         SAVED = tile;
+18 |     let tile = c.tile_2d32_rt(coord, stride);
+   |                ^ borrowed value does not live long enough
+19 |     unsafe {
+20 |         SAVED = tile;
    |         ------------ assignment requires that `c` is borrowed for `'static`
-19 |     }
-20 | }
+21 |     }
+22 | }
    |  - `c` dropped here while still borrowed
 
 error: lifetime may not live long enough
-  --> tests/compile_fail/runtime_tile_scope_escape.rs:18:9
+  --> tests/compile_fail/runtime_tile_scope_escape.rs:20:9
    |
 13 |     mut c: DisjointSlice<'_, f32, RuntimeRowMajorTiles<1, 1>>,
    |     ----- has type `DisjointSlice<'1, f32, RuntimeRowMajorTiles<1, 1>>`
 ...
-18 |         SAVED = tile;
+20 |         SAVED = tile;
    |         ^^^^^^^^^^^^ assignment requires that `'1` must outlive `'static`

--- a/crates/cuda-device/tests/compile_fail/runtime_tile_token_reuse.rs
+++ b/crates/cuda-device/tests/compile_fail/runtime_tile_token_reuse.rs
@@ -4,15 +4,17 @@
  */
 
 use cuda_device::thread::{LaunchContextRef, __internal};
-use cuda_device::{DisjointSlice, RuntimeRowMajorTiles};
+use cuda_device::{DisjointSlice, RuntimeRowMajorTiles, Uniform};
 
 fn cannot_mint_two_tiles_from_one_coordinate<'kernel>(
     launch_context: LaunchContextRef<'kernel, __internal::Domain2, __internal::U32Coordinates>,
     mut c: DisjointSlice<'_, f32, RuntimeRowMajorTiles<1, 1>>,
 ) {
     let coord = __internal::coord_2d_u32(launch_context);
-    let _first = unsafe { c.tile_2d32_rt(coord, 64) };
-    let _second = unsafe { c.tile_2d32_rt(coord, 64) };
+    // SAFETY: a literal is trivially the same in every thread.
+    let stride = unsafe { Uniform::new_unchecked(64) };
+    let _first = c.tile_2d32_rt(coord, stride);
+    let _second = c.tile_2d32_rt(coord, stride);
 }
 
 fn main() {}

--- a/crates/cuda-device/tests/compile_fail/runtime_tile_token_reuse.stderr
+++ b/crates/cuda-device/tests/compile_fail/runtime_tile_token_reuse.stderr
@@ -1,9 +1,10 @@
 error[E0382]: use of moved value: `coord`
-  --> tests/compile_fail/runtime_tile_token_reuse.rs:15:43
+  --> tests/compile_fail/runtime_tile_token_reuse.rs:17:34
    |
 13 |     let coord = __internal::coord_2d_u32(launch_context);
    |         ----- move occurs because `coord` has type `ThreadCoord2D32<'_>`, which does not implement the `Copy` trait
-14 |     let _first = unsafe { c.tile_2d32_rt(coord, 64) };
-   |                                          ----- value moved here
-15 |     let _second = unsafe { c.tile_2d32_rt(coord, 64) };
-   |                                           ^^^^^ value used here after move
+...
+16 |     let _first = c.tile_2d32_rt(coord, stride);
+   |                                 ----- value moved here
+17 |     let _second = c.tile_2d32_rt(coord, stride);
+   |                                  ^^^^^ value used here after move

--- a/crates/cuda-device/tests/compile_fail/uniform_cannot_be_forged_in_safe_code.rs
+++ b/crates/cuda-device/tests/compile_fail/uniform_cannot_be_forged_in_safe_code.rs
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! A launch-uniform witness has no safe constructor. Without this, a kernel
+//! could wrap a per-thread value and hand it to `tile_2d32_rt`, whose
+//! disjointness argument assumes every thread passes the same stride.
+
+use cuda_device::Uniform;
+
+fn main() {
+    let _from_struct_literal = Uniform::<u32> { value: 7 };
+}

--- a/crates/cuda-device/tests/compile_fail/uniform_cannot_be_forged_in_safe_code.stderr
+++ b/crates/cuda-device/tests/compile_fail/uniform_cannot_be_forged_in_safe_code.stderr
@@ -1,0 +1,5 @@
+error[E0451]: field `value` of struct `Uniform` is private
+  --> tests/compile_fail/uniform_cannot_be_forged_in_safe_code.rs:13:49
+   |
+13 |     let _from_struct_literal = Uniform::<u32> { value: 7 };
+   |                                                 ^^^^^ private field

--- a/crates/cuda-device/tests/compile_fail/uniform_new_unchecked_requires_unsafe.rs
+++ b/crates/cuda-device/tests/compile_fail/uniform_new_unchecked_requires_unsafe.rs
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! The escape hatch that asserts uniformity is `unsafe`, so wrapping a
+//! per-thread value is never silent. `threadIdx.x` differs across a block and
+//! is the exact value the witness must exclude.
+
+use cuda_device::Uniform;
+use cuda_device::thread;
+
+fn main() {
+    let _from_thread_index = Uniform::new_unchecked(thread::threadIdx_x());
+}

--- a/crates/cuda-device/tests/compile_fail/uniform_new_unchecked_requires_unsafe.stderr
+++ b/crates/cuda-device/tests/compile_fail/uniform_new_unchecked_requires_unsafe.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function `Uniform::<T>::new_unchecked` is unsafe and requires unsafe block
+  --> tests/compile_fail/uniform_new_unchecked_requires_unsafe.rs:14:30
+   |
+14 |     let _from_thread_index = Uniform::new_unchecked(thread::threadIdx_x());
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/crates/cuda-device/tests/thread_index_safety.rs
+++ b/crates/cuda-device/tests/thread_index_safety.rs
@@ -9,4 +9,5 @@ fn thread_index_safety_compile_failures() {
     t.compile_fail("tests/compile_fail/thread_index_*.rs");
     t.compile_fail("tests/compile_fail/thread_coord_*.rs");
     t.compile_fail("tests/compile_fail/runtime_tile_*.rs");
+    t.compile_fail("tests/compile_fail/uniform_*.rs");
 }

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -138,6 +138,13 @@ host-side maximum. For example, `prepare_transform::<SmallPolicy>` can enforce
 maximum, not an exact size; declare `block = (x, y, z)` when the full shape must
 match.
 
+An exact `block` is additionally carried into the compiled artifact as
+`.reqntid x, y, z`, which the CUDA driver enforces per axis. Preparation and
+the driver check the shape on independent paths, so a mismatch is rejected even
+when preparation is bypassed. A thread maximum gives no such guarantee: under
+`.maxntid 256, 1, 1` the driver accepts `(16, 16, 1)` as readily as
+`(256, 1, 1)`.
+
 For contracted kernels, raw `LaunchConfig` is available only through generated
 unsafe methods such as `reduce_unchecked`. Uncontracted generated methods are
 also unsafe because there is no prepared proof for their raw configuration.

--- a/crates/cuda-host/README.md
+++ b/crates/cuda-host/README.md
@@ -73,7 +73,14 @@ Kernel parameters are mapped into host launch parameters:
 | `&[T]` | `&DeviceBuffer<T>` |
 | `&mut [T]` | `&mut DeviceBuffer<T>` |
 | `DisjointSlice<T>` | `&mut DeviceBuffer<T>` |
+| `Uniform<T>` | `T` |
 | `Copy` scalar, struct, closure, or raw pointer | unchanged |
+
+A `Uniform<T>` parameter takes the bare scalar on the host because the host is
+what makes the value uniform: one marshalled value reaches every thread of the
+launch. The device side receives the witness, which is what device APIs needing
+a launch-uniform scalar (such as `DisjointSlice::tile_2d32_rt`) require in place
+of an `unsafe` assertion.
 
 Because the launches are ordinary methods, rust-analyzer and rustc can complete
 kernel names, show argument names, and type-check arguments before the program

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -143,7 +143,18 @@ reduce_unchecked: raw LaunchConfig             -> unsafe expert path
 
 `block` is exact. If it is omitted, `#[launch_bounds]` supplies the compiled
 maximum total threads per block. For example, a limit of 256 accepts both
-`(256, 1, 1)` and `(16, 16, 1)`. Dynamic shared memory is either exact
+`(256, 1, 1)` and `(16, 16, 1)`.
+
+An exact `block` also reaches the device compiler, which emits
+`.reqntid x, y, z` in place of `.maxntid`. The CUDA driver enforces that per
+axis, so a launch whose block differs is refused even when it never passed
+through preparation. Preparation and the driver therefore check the same
+requirement on independent paths, and the raw `_unchecked` path is covered by
+the second. The two directives cannot coexist on one entry, so a kernel
+declaring both `#[launch_bounds]` and an exact `block` emits `.reqntid` alone.
+The occupancy hint `.minnctapersm` is unaffected.
+
+Dynamic shared memory is either exact
 (`dynamic_shared = BYTES`) or an inclusive range. The byte extent is an author
 promise; the alignment is a compiler-visible minimum and is merged with any
 higher `DynamicSharedArray<T, ALIGN>` request in the body or a reachable local

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -760,6 +760,11 @@ struct CudaModuleParam {
     mutable_slice: bool,
     disjoint_slice_ty: Option<Type>,
     disjoint_slice_elem: Option<TokenStream2>,
+    /// Declared type and carried scalar of a `Uniform<T>` parameter, used to
+    /// bound the generated impl by the sealed proof trait so a local type also
+    /// named `Uniform` cannot borrow the scalar host ABI.
+    uniform_ty: Option<Type>,
+    uniform_scalar: Option<TokenStream2>,
     /// Integer classification of a scalar parameter's declared type, used to
     /// decide which scalars may appear in `requires` relations. Always
     /// `Other` for non-scalar parameters.
@@ -788,6 +793,15 @@ enum ScalarIntClass {
 }
 
 fn scalar_int_class(ty: &Type) -> ScalarIntClass {
+    // A `Uniform<T>` parameter is marshalled as `T` and is evaluated as `T` on
+    // the host, so a relation over it has the same widening behaviour as one
+    // over the bare scalar.
+    if let Some(scalar) = cuda_module_uniform_scalar(ty)
+        && let Ok(scalar) = syn::parse2::<Type>(scalar)
+    {
+        return scalar_int_class(&scalar);
+    }
+
     let Type::Path(type_path) = ty else {
         return ScalarIntClass::Other;
     };
@@ -1325,6 +1339,9 @@ fn cuda_module_kernel(
     if let Some(contract) = launch_contract.as_ref() {
         add_cuda_module_disjoint_contract_bounds(&mut generics, &params, contract.domain);
     }
+    // A `Uniform` parameter carries its proof with or without a launch
+    // contract, so this bound is not conditional on one.
+    add_cuda_module_uniform_bounds(&mut generics, &params);
     let is_generic = has_codegen_generics(&item_fn.sig.generics);
     let cfg_attrs = cuda_module_cfg_attrs(&item_fn.attrs)?;
     let mut effective_cfg_attrs = ancestor_cfg_attrs.to_vec();
@@ -2532,6 +2549,10 @@ fn cuda_module_param_from_typed(pat_type: &syn::PatType) -> syn::Result<CudaModu
     let disjoint_slice_ty = disjoint_slice_elem
         .as_ref()
         .map(|_| pat_type.ty.as_ref().clone());
+    let uniform_scalar = cuda_module_uniform_scalar(&pat_type.ty);
+    let uniform_ty = uniform_scalar
+        .as_ref()
+        .map(|_| pat_type.ty.as_ref().clone());
     Ok(CudaModuleParam {
         name,
         sync_host_ty,
@@ -2540,6 +2561,8 @@ fn cuda_module_param_from_typed(pat_type: &syn::PatType) -> syn::Result<CudaModu
         mutable_slice,
         disjoint_slice_ty,
         disjoint_slice_elem,
+        uniform_ty,
+        uniform_scalar,
         scalar_int: scalar_int_class(&pat_type.ty),
     })
 }
@@ -2582,6 +2605,17 @@ fn cuda_module_host_type(
         ));
     }
 
+    // A `Uniform<T>` parameter is marshalled exactly like `T`. The host takes
+    // the bare scalar because the host is what makes the value uniform: one
+    // marshalled value reaches every thread of the launch.
+    if let Some(scalar) = cuda_module_uniform_scalar(ty) {
+        return Ok((
+            quote! { #scalar },
+            quote! { #scalar },
+            CudaModuleParamMarshal::Scalar,
+        ));
+    }
+
     if matches!(ty, Type::Reference(_)) {
         return Err(syn::Error::new_spanned(
             ty,
@@ -2605,6 +2639,31 @@ fn cuda_module_slice_elem(ty: &Type) -> Option<(TokenStream2, bool)> {
     };
     let elem = &slice.elem;
     Some((quote! { #elem }, type_ref.mutability.is_some()))
+}
+
+/// Scalar carried by a `Uniform<T>` kernel parameter, if the type is spelled
+/// that way.
+///
+/// The host method takes the bare `T`: the host is the source of the
+/// uniformity proof, since it marshals one value into the launch packet for
+/// the whole grid. `Uniform<T>` is `#[repr(transparent)]`, so the launch packet
+/// is byte-identical either way.
+fn cuda_module_uniform_scalar(ty: &Type) -> Option<TokenStream2> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Uniform" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let scalar = args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })?;
+    Some(quote! { #scalar })
 }
 
 fn cuda_module_disjoint_slice_elem(ty: &Type) -> Option<TokenStream2> {
@@ -2651,6 +2710,22 @@ fn add_cuda_module_disjoint_contract_bounds(
         generics.make_where_clause().predicates.push(parse_quote! {
             for<#bound_lifetime> #device_ty:
                 ::cuda_device::__LaunchContractDisjointSlice<#element_ty, #domain>
+        });
+    }
+}
+
+/// Requires every `Uniform<T>` parameter to be cuda-device's own type.
+///
+/// The host ABI for these parameters is chosen from the spelling `Uniform<T>`,
+/// so without this bound a local type of the same name would be marshalled as
+/// a bare `T` while presenting whatever layout it liked.
+fn add_cuda_module_uniform_bounds(generics: &mut syn::Generics, params: &[CudaModuleParam]) {
+    for param in params {
+        let (Some(device_ty), Some(scalar_ty)) = (&param.uniform_ty, &param.uniform_scalar) else {
+            continue;
+        };
+        generics.make_where_clause().predicates.push(parse_quote! {
+            #device_ty: ::cuda_device::__LaunchContractUniform<#scalar_ty>
         });
     }
 }
@@ -5773,6 +5848,8 @@ fn requires_params_from_inputs(
             mutable_slice: false,
             disjoint_slice_ty: None,
             disjoint_slice_elem: None,
+            uniform_ty: None,
+            uniform_scalar: None,
             scalar_int: scalar_int_class(ty),
         });
         params.push(param);

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -5509,6 +5509,13 @@ fn substitute_type(ty: &Type, param: &syn::Ident, replacement: &Type) -> TokenSt
 /// and `.minnctapersm` PTX directives. This helps the CUDA compiler optimize
 /// register allocation and occupancy.
 ///
+/// `.maxntid` bounds the product `x * y * z`, so a 256-thread maximum admits
+/// `(256, 1, 1)`, `(16, 16, 1)` and `(4, 8, 8)` alike. Use
+/// `#[launch_contract(block = (x, y, z))]` to require one exact shape; that
+/// emits `.reqntid` instead, which the driver enforces per axis. A kernel
+/// carrying both attributes emits `.reqntid` alone, because ptxas rejects an
+/// entry declaring both directives. `.minnctapersm` composes with either.
+///
 /// # Usage
 ///
 /// ```ignore
@@ -5691,8 +5698,15 @@ pub fn launch_bounds(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// still validates every relation for well-formedness at compile time
 /// (unknown identifiers and unsupported grammar are errors at the attribute
 /// site), but no launcher exists to evaluate the relations at runtime. That
-/// is the same enforcement story as the geometry keys such as `block` and
-/// `dynamic_shared`.
+/// is the same enforcement story as `dynamic_shared`.
+///
+/// An exact `block` is the one key that also holds without a generated
+/// launcher. The shape reaches the device compiler as `.reqntid x, y, z`, and
+/// the CUDA driver refuses any launch whose block differs on any axis, so a
+/// standalone contracted kernel and an `_unchecked` raw launch are both
+/// covered. `.reqntid` and `.maxntid` cannot appear on one entry, so a kernel
+/// declaring an exact `block` emits `.reqntid` in place of the maximum that
+/// `#[launch_bounds]` would otherwise contribute.
 #[proc_macro_attribute]
 pub fn launch_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as LaunchContractArgs);
@@ -5807,13 +5821,25 @@ fn inject_launch_contract_markers(args: &LaunchContractArgs, input: &mut ItemFn)
         }
     };
     input.block.stmts.insert(0, contract_marker);
+    let mut next = 1;
+
+    // Give the exact block shape to the device compiler as well, so ptxas
+    // emits `.reqntid` and the driver rejects a mismatched block on every
+    // axis. Without this the shape is known only to the host check.
+    if let Some((x, y, z)) = args.exact_block {
+        let block_marker: syn::Stmt = parse_quote! {
+            ::cuda_device::thread::__launch_contract_block_config::<#x, #y, #z>();
+        };
+        input.block.stmts.insert(next, block_marker);
+        next += 1;
+    }
 
     if dynamic_shared_max(args.dynamic_shared) != 0 {
         let alignment = args.dynamic_shared_alignment as usize;
         let alignment_marker: syn::Stmt = parse_quote! {
             ::cuda_device::shared::__dynamic_shared_alignment::<#alignment>();
         };
-        input.block.stmts.insert(1, alignment_marker);
+        input.block.stmts.insert(next, alignment_marker);
     }
 }
 
@@ -8728,6 +8754,48 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn launch_contract_injects_the_block_marker_only_for_an_exact_block() {
+        let exact: LaunchContractArgs =
+            syn::parse_str("domain = 2, block = (8, 8, 1), dynamic_shared = 0").unwrap();
+        let mut kernel: ItemFn = parse_quote! { fn kernel() {} };
+        inject_launch_contract_markers(&exact, &mut kernel);
+        let expanded = quote!(#kernel).to_string().replace(' ', "");
+        assert_eq!(
+            expanded.matches("__launch_contract_block_config").count(),
+            1
+        );
+        assert!(expanded.contains("__launch_contract_block_config::<8u32,8u32,1u32>"));
+
+        // Without an exact block the kernel keeps whatever `#[launch_bounds]`
+        // declares, so no exact shape reaches the device compiler.
+        let bounded: LaunchContractArgs = syn::parse_str("domain = 1, dynamic_shared = 0").unwrap();
+        let mut unbounded_kernel: ItemFn = parse_quote! { fn unbounded_kernel() {} };
+        inject_launch_contract_markers(&bounded, &mut unbounded_kernel);
+        assert!(
+            !quote!(#unbounded_kernel)
+                .to_string()
+                .contains("__launch_contract_block_config")
+        );
+    }
+
+    #[test]
+    fn launch_contract_keeps_every_marker_when_block_and_shared_are_both_declared() {
+        let args: LaunchContractArgs = syn::parse_str(
+            "domain = 1, block = (256, 1, 1), dynamic_shared = 128, dynamic_shared_alignment = 32",
+        )
+        .unwrap();
+        let mut kernel: ItemFn = parse_quote! { fn kernel() {} };
+        inject_launch_contract_markers(&args, &mut kernel);
+        let expanded = quote!(#kernel).to_string();
+        assert_eq!(expanded.matches("__launch_contract_config").count(), 1);
+        assert_eq!(
+            expanded.matches("__launch_contract_block_config").count(),
+            1
+        );
+        assert_eq!(expanded.matches("__dynamic_shared_alignment").count(), 1);
     }
 
     /// The `requires` demo module used by the size-requirement tests: two

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_fake_uniform.rs
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_fake_uniform.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `#[cuda_module]` picks a parameter's host ABI from the spelling `Uniform<T>`,
+//! so a local type of that name would otherwise be marshalled as a bare `T`
+//! while presenting a different device layout. The sealed proof trait rejects
+//! it before any launch is generated.
+
+use cuda_device::{cuda_module, kernel, launch_contract};
+
+#[repr(C)]
+pub struct Uniform<T> {
+    value: T,
+    extra: u64,
+}
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel]
+    #[launch_contract(domain = 1, block = (64, 1, 1))]
+    pub fn lookalike(stride: Uniform<u32>) {
+        let _ = stride.value;
+    }
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/launch_contract_fake_uniform.stderr
+++ b/crates/cuda-macros/tests/compile_fail/launch_contract_fake_uniform.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Uniform<u32>: cuda_device::__LaunchContractUniform<u32>` is not satisfied
+  --> tests/compile_fail/launch_contract_fake_uniform.rs:17:1
+   |
+17 | #[cuda_module]
+   | ^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `cuda_device::__LaunchContractUniform<u32>` is not implemented for `Uniform<u32>`
+  --> tests/compile_fail/launch_contract_fake_uniform.rs:12:1
+   |
+12 | pub struct Uniform<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^
+help: the trait `cuda_device::__LaunchContractUniform<T>` is implemented for `cuda_device::Uniform<T>`
+  --> $WORKSPACE/crates/cuda-device/src/uniform.rs
+   |
+   | impl<T> __LaunchContractUniform<T> for Uniform<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `cuda_module` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+ 9 + #![feature(trivial_bounds)]
+   |

--- a/crates/cuda-macros/tests/launch_contract_semantics.rs
+++ b/crates/cuda-macros/tests/launch_contract_semantics.rs
@@ -9,9 +9,11 @@
 fn launch_contract_types_are_resolved_semantically() {
     let t = trybuild::TestCases::new();
     t.pass("tests/pass/launch_contract_disjoint_aliases.rs");
+    t.pass("tests/pass/launch_contract_uniform_scalar.rs");
     t.pass("tests/pass/kernel_launch_context_api.rs");
     t.compile_fail("tests/compile_fail/launch_contract_misleading_index_alias.rs");
     t.compile_fail("tests/compile_fail/launch_contract_fake_disjoint_slice.rs");
+    t.compile_fail("tests/compile_fail/launch_contract_fake_uniform.rs");
     t.compile_fail("tests/compile_fail/launch_contract_untrusted_loaders.rs");
     t.compile_fail("tests/compile_fail/launch_contract_wrong_const_brand.rs");
     t.compile_fail("tests/compile_fail/launch_contract_reordered_disjoint_alias.rs");

--- a/crates/cuda-macros/tests/pass/launch_contract_uniform_scalar.rs
+++ b/crates/cuda-macros/tests/pass/launch_contract_uniform_scalar.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `Uniform<T>` kernel parameter is marshalled as a bare `T` on the host,
+//! because the host is what makes the value uniform: one marshalled value
+//! reaches every thread of the launch. The device side receives the witness,
+//! so `tile_2d32_rt` needs no `unsafe`.
+
+use cuda_device::{
+    DisjointSlice, RuntimeRowMajorTiles, Uniform, cuda_module, kernel, launch_contract, thread,
+};
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    #[kernel(launch_context = lc)]
+    #[launch_contract(domain = 2, coordinates = u32, block = (8, 8, 1))]
+    pub fn write_cells(
+        stride: Uniform<u32>,
+        mut out: DisjointSlice<f32, RuntimeRowMajorTiles<1, 1>>,
+    ) {
+        let coord = thread::coord_2d_u32(lc);
+        if let Some(mut cell) = out.tile_2d32_rt(coord, stride) {
+            cell.at_const::<0, 0>().write(1.0);
+        }
+    }
+
+    /// Uniformity is closed under arithmetic whose operands are all uniform,
+    /// so a derived stride keeps the witness.
+    #[kernel(launch_context = lc)]
+    #[launch_contract(domain = 2, coordinates = u32, block = (8, 8, 1))]
+    pub fn write_doubled_stride(
+        stride: Uniform<u32>,
+        mut out: DisjointSlice<f32, RuntimeRowMajorTiles<1, 1>>,
+    ) {
+        let coord = thread::coord_2d_u32(lc);
+        let doubled = stride.wrapping_mul_const::<2>();
+        if let Some(mut cell) = out.tile_2d32_rt(coord, doubled) {
+            cell.at_const::<0, 0>().write(2.0);
+        }
+    }
+}
+
+/// The generated host method takes a plain `u32`, not a `Uniform<u32>`.
+fn host_signature_takes_the_bare_scalar(
+    module: &kernels::LoadedModule,
+    stream: &cuda_core::CudaStream,
+    out: &mut cuda_core::DeviceBuffer<f32>,
+) -> Result<(), cuda_core::LaunchContractError> {
+    let prepared = module.prepare_write_cells(cuda_core::LaunchConfig2D::new((1, 1), (8, 8), 0))?;
+    module.write_cells(stream, &prepared, 64u32, out)
+}
+
+fn main() {
+    let _ = host_signature_takes_the_bare_scalar;
+}

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -40,7 +40,8 @@ use super::{
     literals::{format_float_literal, format_half_literal},
     names::{decode_intrinsic_identifier, has_device_prefix, strip_device_prefix},
     state::{
-        KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState, PredecessorMap,
+        KernelBlockGeometry, KernelClusterConfig, KernelInfo, KernelLaunchBounds,
+        ModuleExportState, PredecessorMap,
     },
 };
 
@@ -224,12 +225,27 @@ impl<'a> ModuleExportState<'a> {
             }
 
             // Check for launch bounds attributes (from #[launch_bounds(max, min)])
-            // These will be emitted as nvvm.annotations metadata for maxntid and minctasm
-            if let Some(max_threads) = get_int("maxntid") {
+            // and an exact block shape (from #[launch_contract(block = (x,y,z))]).
+            // These are emitted as nvvm.annotations metadata for maxntid,
+            // minctasm and reqntid.
+            let exact_block = match (
+                get_int("reqntid_x"),
+                get_int("reqntid_y"),
+                get_int("reqntid_z"),
+            ) {
+                (Some(x), Some(y), Some(z)) => Some(KernelBlockGeometry::ExactBlock(x, y, z)),
+                _ => None,
+            };
+            // An exact shape displaces the thread maximum: ptxas rejects an
+            // entry carrying both directives, and the shape already bounds the
+            // thread count on every axis.
+            let geometry =
+                exact_block.or_else(|| get_int("maxntid").map(KernelBlockGeometry::MaxThreads));
+            if let Some(geometry) = geometry {
                 let min_blocks = get_int("minctasm");
                 self.launch_bounds_kernels.push(KernelLaunchBounds {
                     name: fixed_func_name.clone(),
-                    max_threads,
+                    geometry,
                     min_blocks: if min_blocks == Some(0) {
                         None
                     } else {

--- a/crates/llvm-export/src/export/metadata.rs
+++ b/crates/llvm-export/src/export/metadata.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use super::state::ModuleExportState;
+use super::state::{KernelBlockGeometry, ModuleExportState};
 
 pub(super) fn needs_nvvm_annotations(
     state: &ModuleExportState,
@@ -82,11 +82,19 @@ pub(super) fn emit_nvvm_annotations(
     let launch_bounds_kernels: Vec<_> = state
         .launch_bounds_kernels
         .iter()
-        .map(|bounds| (bounds.name.clone(), bounds.max_threads, bounds.min_blocks))
+        .map(|bounds| (bounds.name.clone(), bounds.geometry, bounds.min_blocks))
         .collect();
 
-    for (name, max_threads, min_blocks) in launch_bounds_kernels {
-        for (key, value) in [("maxntidx", max_threads), ("maxntidy", 1), ("maxntidz", 1)] {
+    for (name, geometry, min_blocks) in launch_bounds_kernels {
+        let annotations = match geometry {
+            KernelBlockGeometry::ExactBlock(x, y, z) => {
+                [("reqntidx", x), ("reqntidy", y), ("reqntidz", z)]
+            }
+            KernelBlockGeometry::MaxThreads(max_threads) => {
+                [("maxntidx", max_threads), ("maxntidy", 1), ("maxntidz", 1)]
+            }
+        };
+        for (key, value) in annotations {
             let md_id = state.alloc_metadata_id();
             write!(output, "!{md_id} = !{{").unwrap();
             emit_function_reference(output, state, &name)?;
@@ -149,7 +157,7 @@ mod tests {
     use super::*;
     use crate::export::config::DebugKind;
     use crate::export::state::{
-        KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState,
+        KernelBlockGeometry, KernelClusterConfig, KernelInfo, KernelLaunchBounds, ModuleExportState,
     };
     use pliron::context::Context;
 
@@ -189,7 +197,7 @@ mod tests {
         });
         state.launch_bounds_kernels.push(KernelLaunchBounds {
             name: "bounded".into(),
-            max_threads: 256,
+            geometry: KernelBlockGeometry::MaxThreads(256),
             min_blocks: Some(2),
         });
 
@@ -230,7 +238,7 @@ mod tests {
         });
         state.launch_bounds_kernels.push(KernelLaunchBounds {
             name: "clustered_bounded".into(),
-            max_threads: 128,
+            geometry: KernelBlockGeometry::MaxThreads(128),
             min_blocks: None,
         });
 
@@ -244,6 +252,58 @@ mod tests {
         assert!(output.contains("!1 = !{ptr @clustered_bounded, !\"maxntidx\", i32 128}"));
         assert!(output.contains("!2 = !{ptr @clustered_bounded, !\"maxntidy\", i32 1}"));
         assert!(output.contains("!3 = !{ptr @clustered_bounded, !\"maxntidz\", i32 1}"));
+        assert_eq!(state.next_metadata_id(), 4);
+    }
+
+    #[test]
+    fn exact_block_emits_reqntid_and_suppresses_maxntid() {
+        let ctx = Context::new();
+        let mut state = test_state(&ctx);
+        state.all_kernels.push(KernelInfo {
+            name: "exact".into(),
+        });
+        // The kernel carries both `#[launch_bounds(256, 2)]` and an exact
+        // `#[launch_contract(block = ...)]`, which is the shape of the
+        // `cuda_module_contract` example. ptxas rejects an entry declaring both
+        // `.maxntid` and `.reqntid`, so only `.reqntid` may survive. The
+        // occupancy hint is independent and stays.
+        state.launch_bounds_kernels.push(KernelLaunchBounds {
+            name: "exact".into(),
+            geometry: KernelBlockGeometry::ExactBlock(256, 1, 1),
+            min_blocks: Some(2),
+        });
+
+        let mut output = String::new();
+        emit_nvvm_annotations(&mut output, &mut state, true).unwrap();
+
+        assert!(output.contains("!1 = !{ptr @exact, !\"reqntidx\", i32 256}"));
+        assert!(output.contains("!2 = !{ptr @exact, !\"reqntidy\", i32 1}"));
+        assert!(output.contains("!3 = !{ptr @exact, !\"reqntidz\", i32 1}"));
+        assert!(output.contains("!4 = !{ptr @exact, !\"minctasm\", i32 2}"));
+        assert!(!output.contains("maxntid"));
+        assert_eq!(state.next_metadata_id(), 5);
+    }
+
+    #[test]
+    fn exact_block_without_launch_bounds_still_emits_reqntid() {
+        let ctx = Context::new();
+        let mut state = test_state(&ctx);
+        state.all_kernels.push(KernelInfo {
+            name: "contract_only".into(),
+        });
+        state.launch_bounds_kernels.push(KernelLaunchBounds {
+            name: "contract_only".into(),
+            geometry: KernelBlockGeometry::ExactBlock(16, 16, 1),
+            min_blocks: None,
+        });
+
+        let mut output = String::new();
+        emit_nvvm_annotations(&mut output, &mut state, true).unwrap();
+
+        assert!(output.contains("!1 = !{ptr @contract_only, !\"reqntidx\", i32 16}"));
+        assert!(output.contains("!2 = !{ptr @contract_only, !\"reqntidy\", i32 16}"));
+        assert!(output.contains("!3 = !{ptr @contract_only, !\"reqntidz\", i32 1}"));
+        assert!(!output.contains("maxntid"));
         assert_eq!(state.next_metadata_id(), 4);
     }
 

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -29,10 +29,29 @@ pub(super) struct KernelClusterConfig {
     pub(super) dim_z: u32,
 }
 
-/// Launch bounds for a kernel (from `#[launch_bounds(max, min)]` attribute).
+/// Block geometry declared for a kernel entry.
+///
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`, so an entry
+/// declares one or the other. An exact shape is the stronger statement and
+/// displaces a thread maximum, which is why these are alternatives rather than
+/// two fields.
+#[derive(Clone, Copy)]
+pub(super) enum KernelBlockGeometry {
+    /// Maximum threads per block from `#[launch_bounds(max, _)]`, emitted as
+    /// `maxntid*`. Bounds the product `x * y * z` and says nothing per axis.
+    MaxThreads(u32),
+    /// Exact block shape from `#[launch_contract(block = (x, y, z))]`, emitted
+    /// as `reqntid*`. The CUDA driver enforces it per axis at launch.
+    ExactBlock(u32, u32, u32),
+}
+
+/// Launch geometry for a kernel, from `#[launch_bounds(max, min)]` and from an
+/// exact `#[launch_contract(block = (x, y, z))]`.
+///
+/// A kernel declaring neither is never recorded.
 pub(super) struct KernelLaunchBounds {
     pub(super) name: String,
-    pub(super) max_threads: u32,
+    pub(super) geometry: KernelBlockGeometry,
     pub(super) min_blocks: Option<u32>, // None if not specified (0 in attribute)
 }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -69,6 +69,19 @@ pub struct LaunchBounds {
     pub min_blocks: u32,
 }
 
+/// Exact block shape declared by `#[launch_contract(block = (x, y, z))]`.
+///
+/// Detected by scanning MIR for
+/// `cuda_device::thread::__launch_contract_block_config::<X, Y, Z>()` marker
+/// calls. Emitted as `.reqntid x, y, z`, which the CUDA driver enforces per
+/// axis at launch.
+#[derive(Debug, Clone, Copy)]
+pub struct ContractBlock {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
 /// Minimum extern-shared alignment declared by `#[launch_contract]`.
 #[derive(Debug, Clone, Copy)]
 pub struct DynamicSharedAlignment {
@@ -218,6 +231,109 @@ fn detect_launch_bounds_config(
         }
     }
     Ok(detected)
+}
+
+/// Scans MIR for `__launch_contract_block_config::<X, Y, Z>()` and extracts the
+/// exact block shape declared by `#[launch_contract(block = (x, y, z))]`.
+///
+/// Returns `Some(ContractBlock)` if found, `None` otherwise.
+fn detect_contract_block_config(
+    body: &mir::Body,
+    reachable: &std::collections::BTreeSet<usize>,
+) -> Result<Option<ContractBlock>, String> {
+    use rustc_public::ty::TyConstKind;
+
+    let mut detected: Option<ContractBlock> = None;
+    for &block_idx in reachable {
+        let block = &body.blocks[block_idx];
+        let mir::TerminatorKind::Call { func, .. } = &block.terminator.kind else {
+            continue;
+        };
+        let mir::Operand::Constant(constant) = func else {
+            continue;
+        };
+        let ConstantKind::ZeroSized = constant.const_.kind() else {
+            continue;
+        };
+        let TyKind::RigidTy(RigidTy::FnDef(def_id, args)) = constant.const_.ty().kind() else {
+            continue;
+        };
+
+        let definition_name = def_id.name();
+        if def_id.krate().name.as_str() != "cuda_device"
+            || (definition_name != "__launch_contract_block_config"
+                && !definition_name.ends_with("::__launch_contract_block_config"))
+        {
+            continue;
+        }
+
+        if args.0.len() != 3 {
+            return Err(format!(
+                "cuda_device launch-contract block marker has {} generic arguments; expected exactly 3",
+                args.0.len()
+            ));
+        }
+        let mut values = [0u32; 3];
+        for (index, (axis, arg)) in ["x", "y", "z"].into_iter().zip(args.0.iter()).enumerate() {
+            let rustc_public::ty::GenericArgKind::Const(value) = arg else {
+                return Err(format!(
+                    "cuda_device launch-contract block {axis} argument is not a constant"
+                ));
+            };
+            let raw = match value.kind() {
+                TyConstKind::Value(_, allocation) => allocation.read_uint().map_err(|error| {
+                    format!("could not read launch-contract block {axis} constant: {error:?}")
+                })?,
+                _ => u128::from(value.eval_target_usize().map_err(|error| {
+                    format!("could not evaluate launch-contract block {axis} constant: {error:?}")
+                })?),
+            };
+            values[index] = u32::try_from(raw).map_err(|_| {
+                format!("launch-contract block {axis} value {raw} does not fit in u32")
+            })?;
+            if values[index] == 0 {
+                return Err(format!(
+                    "launch-contract block {axis} dimension must be greater than zero"
+                ));
+            }
+        }
+        let shape = ContractBlock {
+            x: values[0],
+            y: values[1],
+            z: values[2],
+        };
+        if let Some(existing) = detected {
+            if existing.x != shape.x || existing.y != shape.y || existing.z != shape.z {
+                return Err(format!(
+                    "a kernel contains conflicting cuda_device launch-contract block markers: ({}, {}, {}) and ({}, {}, {})",
+                    existing.x, existing.y, existing.z, shape.x, shape.y, shape.z,
+                ));
+            }
+        } else {
+            detected = Some(shape);
+        }
+    }
+    Ok(detected)
+}
+
+/// Rejects an exact block shape that needs more threads than
+/// `#[launch_bounds]` allows.
+///
+/// An exact block displaces the thread maximum in the emitted PTX, because
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`. A maximum
+/// below the required thread count would therefore be dropped in silence, and
+/// the kernel would launch at a shape its author ruled out. A maximum at or
+/// above the required count is redundant rather than contradictory, since
+/// `.reqntid` is the stronger statement, so it stays allowed.
+fn validate_block_against_bounds(bounds: LaunchBounds, block: ContractBlock) -> Result<(), String> {
+    let required = u64::from(block.x) * u64::from(block.y) * u64::from(block.z);
+    if required > u64::from(bounds.max_threads) {
+        return Err(format!(
+            "a kernel declares #[launch_contract(block = ({}, {}, {}))], needing {} threads per block, and #[launch_bounds({})], allowing at most {}",
+            block.x, block.y, block.z, required, bounds.max_threads, bounds.max_threads,
+        ));
+    }
+    Ok(())
 }
 
 /// Scans MIR for the `__unchecked_indexing_config::<ENABLED>()` marker
@@ -1103,6 +1219,23 @@ pub fn translate_body(
                 return input_err_noloc!(TranslationErr::invalid_op(error));
             }
         };
+
+        // Detect the exact block shape from #[launch_contract(block = (x,y,z))].
+        // The exporter emits this as reqntid and suppresses maxntid, which ptxas
+        // rejects alongside it.
+        let contract_block = match detect_contract_block_config(body, &reachable) {
+            Ok(block) => block,
+            Err(error) => {
+                return input_err_noloc!(TranslationErr::invalid_op(error));
+            }
+        };
+
+        if let (Some(bounds), Some(block)) = (launch_bounds, contract_block)
+            && let Err(error) = validate_block_against_bounds(bounds, block)
+        {
+            return input_err_noloc!(TranslationErr::invalid_op(error));
+        }
+
         if let Some(launch_bounds) = launch_bounds {
             use pliron::builtin::attributes::IntegerAttr;
             use pliron::builtin::types::Signedness;
@@ -1142,6 +1275,34 @@ pub fn translate_body(
                         launch_bounds.max_threads
                     );
                 }
+            }
+        }
+
+        if let Some(contract_block) = contract_block {
+            use pliron::builtin::attributes::IntegerAttr;
+            use pliron::builtin::types::Signedness;
+            use pliron::utils::apint::APInt;
+            use std::num::NonZero;
+
+            let u32_ty = pliron::builtin::types::IntegerType::get(ctx, 32, Signedness::Unsigned);
+            let width = NonZero::new(32).unwrap();
+
+            let mut op_mut = mir_func_op.get_operation().deref_mut(ctx);
+            for (key, value) in [
+                ("reqntid_x", contract_block.x),
+                ("reqntid_y", contract_block.y),
+                ("reqntid_z", contract_block.z),
+            ] {
+                let attr = IntegerAttr::new(u32_ty, APInt::from_u32(value, width));
+                let key: Identifier = key.try_into().unwrap();
+                op_mut.attributes.set(key, attr);
+            }
+
+            if std::env::var("CUDA_OXIDE_VERBOSE").is_ok() {
+                eprintln!(
+                    "  Launch contract block detected: reqntid={}x{}x{}",
+                    contract_block.x, contract_block.y, contract_block.z
+                );
             }
         }
     }
@@ -1326,6 +1487,34 @@ mod tests {
             validate_monomorphized_successor_shape(4, 4, &[vec![4], vec![], vec![], vec![]])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn an_exact_block_may_not_need_more_threads_than_launch_bounds_allows() {
+        let block = |x, y, z| ContractBlock { x, y, z };
+        let bounds = |max_threads| LaunchBounds {
+            max_threads,
+            min_blocks: 0,
+        };
+
+        // The shapes the `cuda_module_contract` example declares: the maximum
+        // equals the required thread count on every axis product.
+        assert!(validate_block_against_bounds(bounds(256), block(256, 1, 1)).is_ok());
+        assert!(validate_block_against_bounds(bounds(64), block(8, 8, 1)).is_ok());
+        // A maximum above the requirement is redundant, and allowed.
+        assert!(validate_block_against_bounds(bounds(1024), block(16, 16, 1)).is_ok());
+
+        // A maximum below the requirement contradicts it. Without this the
+        // exporter would drop the maximum and emit the larger shape.
+        let error = validate_block_against_bounds(bounds(128), block(16, 16, 1))
+            .expect_err("256 threads exceed a 128-thread maximum");
+        assert!(error.contains("256 threads per block"), "{error}");
+        assert!(error.contains("at most 128"), "{error}");
+        assert!(validate_block_against_bounds(bounds(255), block(256, 1, 1)).is_err());
+
+        // The product is computed in u64, so a shape whose axes multiply past
+        // u32 is rejected rather than wrapping to a value under the maximum.
+        assert!(validate_block_against_bounds(bounds(1024), block(65_536, 65_536, 1)).is_err());
     }
 
     #[test]

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2791,6 +2791,8 @@ fn try_dispatch_intrinsic(
         | "cuda_device::thread::__launch_bounds_config"
         | "cuda_device::__launch_contract_config"
         | "cuda_device::thread::__launch_contract_config"
+        | "cuda_device::__launch_contract_block_config"
+        | "cuda_device::thread::__launch_contract_block_config"
         | "cuda_device::__unchecked_indexing_config"
         | "cuda_device::thread::__unchecked_indexing_config" => {
             let expected_marker = match name {
@@ -2798,6 +2800,10 @@ fn try_dispatch_intrinsic(
                 | "cuda_device::thread::__launch_bounds_config" => "__launch_bounds_config",
                 "cuda_device::__launch_contract_config"
                 | "cuda_device::thread::__launch_contract_config" => "__launch_contract_config",
+                "cuda_device::__launch_contract_block_config"
+                | "cuda_device::thread::__launch_contract_block_config" => {
+                    "__launch_contract_block_config"
+                }
                 "cuda_device::__unchecked_indexing_config"
                 | "cuda_device::thread::__unchecked_indexing_config" => {
                     "__unchecked_indexing_config"

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -344,6 +344,9 @@ fn propagate_kernel_attrs(
             "cluster_dim_z",
             "maxntid",
             "minctasm",
+            "reqntid_x",
+            "reqntid_y",
+            "reqntid_z",
         ]
         .iter()
         .filter_map(|key_str| {

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
@@ -362,47 +362,64 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    for entry in ["aligned_dynamic_shared", "mixed_abi"] {
-        let start = ptx
-            .find(&format!(".visible .entry {entry}("))
-            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
-        let rest = &ptx[start..];
-        let end = rest[1..]
-            .find(".visible .entry ")
-            .map_or(rest.len(), |offset| offset + 1);
-        if !rest[..end].contains(".maxntid 256, 1, 1") {
-            return Err(format!("PTX entry {entry} lost its launch bounds").into());
-        }
-    }
-
-    for entry in [
-        "helper_contract_32",
-        "helper_contract_256",
-        "explicit_aligned_u32",
+    // A kernel declaring an exact `block` carries that shape into PTX as
+    // `.reqntid`, which the driver enforces on every axis. A kernel bounded
+    // only by `#[launch_bounds]` keeps `.maxntid`, which bounds the thread
+    // count and permits any shape reaching it.
+    for (entry, geometry) in [
+        ("aligned_dynamic_shared", ".reqntid 256, 1, 1"),
+        ("mixed_abi", ".reqntid 256, 1, 1"),
+        ("strided_scale", ".reqntid 128, 1, 1"),
+        ("helper_contract_32", ".reqntid 32, 1, 1"),
+        ("helper_contract_256", ".reqntid 32, 1, 1"),
+        ("explicit_aligned_u32", ".maxntid 32, 1, 1"),
     ] {
-        let start = ptx
-            .find(&format!(".visible .entry {entry}("))
-            .ok_or_else(|| format!("missing PTX entry {entry}"))?;
-        let rest = &ptx[start..];
-        let end = rest[1..]
-            .find(".visible .entry ")
-            .map_or(rest.len(), |offset| offset + 1);
-        if !rest[..end].contains(".maxntid 32, 1, 1") {
-            return Err(format!("PTX entry {entry} lost its launch bounds").into());
-        }
+        verify_entry_geometry(&ptx, &format!(".visible .entry {entry}("), entry, geometry)?;
     }
 
-    let generic_start = ptx
-        .find(".visible .entry generic_aligned_TID_")
-        .ok_or("missing generic_aligned PTX specialization")?;
-    let generic_rest = &ptx[generic_start..];
-    let generic_end = generic_rest[1..]
-        .find(".visible .entry ")
-        .map_or(generic_rest.len(), |offset| offset + 1);
-    if !generic_rest[..generic_end].contains(".maxntid 64, 1, 1") {
-        return Err("generic_aligned PTX specialization lost its launch bounds".into());
-    }
+    verify_entry_geometry(
+        &ptx,
+        ".visible .entry generic_aligned_TID_",
+        "generic_aligned specialization",
+        ".maxntid 64, 1, 1",
+    )?;
 
     println!("SUCCESS: prepared-launch PTX contract verified");
+    Ok(())
+}
+
+/// Assert one entry's launch geometry, and that it declares exactly one of the
+/// two mutually exclusive directives.
+///
+/// ptxas rejects an entry carrying both `.maxntid` and `.reqntid`
+/// ("Conflicting directives: .maxntid and .reqntid cannot both be specified"),
+/// so a kernel with an exact block emits `.reqntid` in place of the thread
+/// maximum. Every kernel here declares `#[launch_bounds]`, so this is the case
+/// that would regress if the exporter stopped suppressing one of them.
+fn verify_entry_geometry(
+    ptx: &str,
+    anchor: &str,
+    entry: &str,
+    expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = ptx
+        .find(anchor)
+        .ok_or_else(|| format!("missing PTX entry {entry}"))?;
+    let rest = &ptx[start..];
+    let end = rest[1..]
+        .find(".visible .entry ")
+        .map_or(rest.len(), |offset| offset + 1);
+    let body = &rest[..end];
+
+    if !body.contains(expected) {
+        return Err(format!("PTX entry {entry} lost its launch geometry `{expected}`").into());
+    }
+    if body.contains(".maxntid") && body.contains(".reqntid") {
+        return Err(format!(
+            "PTX entry {entry} declares both .maxntid and .reqntid, which ptxas rejects"
+        )
+        .into());
+    }
+
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
@@ -747,6 +747,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
     for marker in [
         "__launch_contract_config",
+        "__launch_contract_block_config",
         "__launch_bounds_config",
         "make_kernel_scope",
     ] {
@@ -768,8 +769,19 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("sgemm_tiled_views", safe_tiled),
         ("sgemm_tiled_raw", raw_tiled),
     ] {
-        if !body.contains(".maxntid 256, 1, 1") {
-            return Err(format!("{name} lost its 256-thread launch bound").into());
+        // These kernels declare `block = (16, 16, 1)`, so the exact shape
+        // reaches the device compiler as `.reqntid` and the driver rejects any
+        // other block on any axis. A thread maximum cannot express this shape:
+        // it bounds the product alone, and its per-axis fields would claim one
+        // thread on Y for a block that has sixteen. `.maxntid` must therefore
+        // be absent, and ptxas rejects an entry carrying both regardless.
+        if !body.contains(".reqntid 16, 16, 1") {
+            return Err(format!("{name} lost its exact 16x16 block shape").into());
+        }
+        if body.contains(".maxntid") {
+            return Err(
+                format!("{name} declares both .maxntid and .reqntid, which ptxas rejects").into(),
+            );
         }
         verify_no_calls(name, body)?;
         // Every bounds fact is proven through sentinel scalar checks; nothing

--- a/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
@@ -16,7 +16,7 @@
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig2D};
 use cuda_device::{
-    ColView32, DisjointSlice, MatrixView32, RowView32, RuntimeRowMajorTiles, SharedArray,
+    ColView32, DisjointSlice, MatrixView32, RowView32, RuntimeRowMajorTiles, SharedArray, Uniform,
     cuda_module, kernel, launch_bounds, launch_contract, thread,
 };
 
@@ -84,7 +84,7 @@ mod kernels {
         requires = (k >= 1, a.len() >= m * k, b.len() >= k * n, c.len() >= m * n))]
     pub fn sgemm_naive_views(
         m: u32,
-        n: u32,
+        n: Uniform<u32>,
         k: u32,
         alpha: f32,
         a: &[f32], // M x K matrix
@@ -96,12 +96,12 @@ mod kernels {
         let row = coord.row();
         let col = coord.col();
         // No barriers in this kernel, so out-of-range threads may leave early.
-        if row >= m || col >= n {
+        if row >= m || col >= n.get() {
             return;
         }
 
         let a_mat = MatrixView32::new(a, k);
-        let b_mat = MatrixView32::new(b, n);
+        let b_mat = MatrixView32::new(b, n.get());
         // The `requires` contract proves the buffer sizes and `k >= 1` on
         // the host, so for a contracted launch every proof below succeeds and
         // the beta epilogue always runs.
@@ -113,9 +113,9 @@ mod kernels {
             for (x, y) in pair {
                 sum += x * y;
             }
-            // SAFETY: `n` is a kernel scalar argument, so every thread of the
-            // launch passes the same value, and `n` is C's actual row width.
-            if let Some(mut cell) = unsafe { c.tile_2d32_rt(coord, n) } {
+            // `n` is a `Uniform<u32>`, so its launch-uniformity is proven by
+            // the kernel ABI and no `unsafe` is needed here.
+            if let Some(mut cell) = c.tile_2d32_rt(coord, n) {
                 let previous = cell.at_const::<0, 0>().read();
                 cell.at_const::<0, 0>().write(alpha * sum + beta * previous);
             }
@@ -206,7 +206,7 @@ mod kernels {
         requires = (k >= 1, a.len() >= m * k, b.len() >= k * n, c.len() >= m * n))]
     pub fn sgemm_tiled_views(
         m: u32,
-        n: u32,
+        n: Uniform<u32>,
         k: u32,
         alpha: f32,
         a: &[f32], // M x K matrix
@@ -225,7 +225,7 @@ mod kernels {
         let ty = thread::threadIdx_y();
 
         let a_mat = MatrixView32::new(a, k);
-        let b_mat = MatrixView32::new(b, n);
+        let b_mat = MatrixView32::new(b, n.get());
         let a_row = a_mat.row(row, k).unwrap_or(RowView32::empty());
         let b_col = b_mat.col(col, k).unwrap_or(ColView32::empty());
 
@@ -263,9 +263,9 @@ mod kernels {
 
         // Epilogue after the final barrier: one rectangle proof for this
         // thread's C cell. Out-of-range threads get `None` and simply skip.
-        // SAFETY: `n` is a kernel scalar argument, so every thread of the
-        // launch passes the same value, and `n` is C's actual row width.
-        if let Some(mut cell) = unsafe { c.tile_2d32_rt(coord, n) } {
+        // `n` is a `Uniform<u32>`, so its launch-uniformity is proven by the
+        // kernel ABI and no `unsafe` is needed here.
+        if let Some(mut cell) = c.tile_2d32_rt(coord, n) {
             let previous = cell.at_const::<0, 0>().read();
             cell.at_const::<0, 0>().write(alpha * sum + beta * previous);
         }

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
@@ -313,6 +313,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
     for marker in [
         "__launch_contract_config",
+        "__launch_contract_block_config",
         "__launch_bounds_config",
         "make_kernel_scope",
     ] {
@@ -337,9 +338,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("safe_tile", safe_tile),
         ("raw_tile", raw_tile),
     ] {
-        if !body.contains(".maxntid 64, 1, 1") {
-            return Err(format!("{name} lost its 64-thread launch bound").into());
-        }
+        verify_exact_block(name, body, ".reqntid 64, 1, 1")?;
         verify_u32_coordinates(name, body)?;
         verify_no_calls(name, body)?;
         let branches = conditional_branches(body);
@@ -363,9 +362,10 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("safe_epilogue", safe_epilogue),
         ("raw_epilogue", raw_epilogue),
     ] {
-        if !body.contains(".maxntid 64, 1, 1") {
-            return Err(format!("{name} lost its 64-thread launch bound").into());
-        }
+        // A 2-D contract records its real shape. A thread maximum bounds the
+        // product alone, so its per-axis fields would claim one thread on Y
+        // for a block that has eight.
+        verify_exact_block(name, body, ".reqntid 8, 8, 1")?;
         verify_u32_coordinates(name, body)?;
         verify_no_calls(name, body)?;
         for register in ["%ctaid.y", "%ntid.y", "%tid.y"] {
@@ -462,6 +462,27 @@ fn entry_body<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::erro
         .map(|offset| open + 1 + offset + 2)
         .ok_or_else(|| format!("PTX entry `{name}` has no closing brace"))?;
     Ok(&rest[..close])
+}
+
+/// A kernel declaring an exact `block` in its launch contract carries that
+/// shape into PTX as `.reqntid`, which the driver enforces on every axis.
+///
+/// `.reqntid` displaces `.maxntid`: ptxas rejects an entry declaring both, and
+/// an exact shape already bounds the thread count.
+fn verify_exact_block(
+    name: &str,
+    body: &str,
+    expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !body.contains(expected) {
+        return Err(format!("{name} lost its exact block shape `{expected}`").into());
+    }
+    if body.contains(".maxntid") {
+        return Err(
+            format!("{name} declares both .maxntid and .reqntid, which ptxas rejects").into(),
+        );
+    }
+    Ok(())
 }
 
 fn verify_u32_coordinates(name: &str, body: &str) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -635,6 +635,8 @@ fn is_launch_metadata_marker_path(fn_path: &str) -> bool {
             | "cuda_device::thread::__launch_bounds_config"
             | "cuda_device::__launch_contract_config"
             | "cuda_device::thread::__launch_contract_config"
+            | "cuda_device::__launch_contract_block_config"
+            | "cuda_device::thread::__launch_contract_block_config"
             | "cuda_device::__unchecked_indexing_config"
             | "cuda_device::thread::__unchecked_indexing_config"
     ) || fn_path.strip_prefix("cuda_device::").is_some_and(|path| {
@@ -642,6 +644,8 @@ fn is_launch_metadata_marker_path(fn_path: &str) -> bool {
             || path.starts_with("thread::__launch_bounds_config::<")
             || path.starts_with("__launch_contract_config::<")
             || path.starts_with("thread::__launch_contract_config::<")
+            || path.starts_with("__launch_contract_block_config::<")
+            || path.starts_with("thread::__launch_contract_block_config::<")
             || path.starts_with("__unchecked_indexing_config::<")
             || path.starts_with("thread::__unchecked_indexing_config::<")
     })

--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -258,6 +258,19 @@ The generated PTX includes these directives:
 .entry optimized_kernel .maxntid 256, 1, 1 .minnctapersm 2 { ... }
 ```
 
+`.maxntid` bounds the product `x * y * z`, so a 256-thread bound admits
+`(256, 1, 1)`, `(16, 16, 1)` and `(4, 8, 8)` alike. Add
+`#[launch_contract(block = (x, y, z))]` when one exact shape is required. That
+emits `.reqntid` in place of `.maxntid`, which the driver enforces per axis:
+
+```text
+.entry exact_kernel .reqntid 256, 1, 1 .minnctapersm 2 { ... }
+```
+
+The two directives are mutually exclusive; ptxas rejects an entry declaring
+both, so a contracted kernel emits `.reqntid` alone. `.minnctapersm` is an
+occupancy hint and composes with either.
+
 :::{tip}
 `#[launch_bounds]` must appear **after** `#[kernel]`:
 

--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -250,6 +250,47 @@ runtime strides have the same type. If you can pin the stride at compile
 time, prefer `index_2d::<S>()`. If you can't, the `unsafe` keyword on
 `index_2d_runtime` is the marker that the safety obligation is yours.
 
+#### Discharging uniformity with `Uniform<T>`
+
+The *launch* establishes "every thread passed the same value": the host
+marshals one scalar into the launch packet, and every thread of every block
+reads those same bytes. A kernel body has no comparable way to establish it
+about one of its own locals.
+
+`Uniform<T>` is that fact as a type. Declare the parameter and the obligation is
+discharged by the kernel ABI:
+
+```rust
+#[kernel(launch_context = lc)]
+#[launch_contract(domain = 2, coordinates = u32, block = (16, 16, 1))]
+pub fn write_c(n: Uniform<u32>, mut c: DisjointSlice<f32, RuntimeRowMajorTiles<1, 1>>) {
+    let coord = thread::coord_2d_u32(lc);
+    // No `unsafe`: `n` proves its own launch-uniformity.
+    if let Some(mut cell) = c.tile_2d32_rt(coord, n) {
+        cell.at_const::<0, 0>().write(1.0);
+    }
+}
+```
+
+The host method still takes a plain `u32`; `#[cuda_module]` wraps it, and
+`#[repr(transparent)]` keeps the launch packet byte-identical. There is no
+constructor, so device code cannot promote a per-thread value into a witness.
+`Uniform::new_unchecked` remains for a value proven uniform some other way, and
+`block_dim_x()` and its siblings return witnesses directly, since a launch has
+one block shape.
+
+Why this is enough for `tile_2d32_rt`: under a uniform stride the
+`last_col < stride` check keeps each tile inside one logical row, which makes
+the coordinate-to-offset mapping injective, so distinct threads own disjoint
+elements. Two threads disagreeing about the pitch is exactly the case that
+breaks it. With 1x1 tiles, thread `(1, 0)` at stride 5 resolves flat index 5,
+and thread `(0, 5)` at stride 100 also resolves 5: one element, two `&mut`.
+
+The stride still has to be the row width the buffer actually uses for the
+kernel to compute the intended result. That is a correctness requirement rather
+than a safety one; a uniform stride that misdescribes the layout gives wrong
+answers inside the slice, never aliasing or an out-of-bounds access.
+
 ### The GEMM pattern
 
 For const-stride 2D kernels (the common case -- tiled GEMM, stencil

--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -179,6 +179,21 @@ The two annotations provide the checked facts:
 - `block = (64, 1, 1)` requires exactly 64 threads in each block. The launch
   may still contain many blocks.
 
+An exact `block` is checked twice, in two places that fail independently.
+Preparation rejects a mismatched launch configuration on the host, before any
+driver call. The shape also reaches the device compiler, which emits
+`.reqntid 64, 1, 1`, so the CUDA driver refuses any launch whose block differs
+on any axis. The second check covers the paths the first one cannot see: an
+`unsafe` raw launch, and a module whose loaded PTX is not the artifact the
+generated Rust markers describe.
+
+`.reqntid` replaces `.maxntid` for a contracted kernel. ptxas rejects an entry
+declaring both, and an exact shape already bounds the thread count. A kernel
+carrying only `#[launch_bounds]` keeps `.maxntid`, which bounds the product
+`x * y * z` and admits every shape reaching it. That difference is the reason a
+thread bound cannot stand in for a block shape: under `.maxntid 64, 1, 1` the
+driver accepts `(8, 8, 1)` and `(4, 4, 4)` alongside `(64, 1, 1)`.
+
 For 2-D tiles, use `thread::coord_2d_u32(launch_context)` with
 `RowMajorTiles<ROWS, COLS, ROW_STRIDE>`. `ROW_STRIDE` is the logical row pitch
 in elements and must match the buffer's layout. The buffer length does not


### PR DESCRIPTION
Depends on #514 and is branched from it. GitHub shows both commits until
that one merges; the change under review here is the second commit,
`Add Uniform<T> and make DisjointSlice::tile_2d32_rt safe`. It touches no
compiler crates, so the two are independent in substance.

`DisjointSlice::tile_2d32_rt` took a `u32` row pitch and was `unsafe`, with the
caller carrying an obligation the type system could not see: the stride has to
be the same value in every thread of the launch. Two threads that disagree
describe two different grids over one buffer, and their "disjoint" tiles can
overlap. With 1x1 tiles, thread (1, 0) at stride 5 and thread (0, 5) at stride
100 both resolve flat index 5, giving one element two `&mut`.

`Uniform<T>` turns that premise into a type.

## The witness

`Uniform<T>` is a `#[repr(transparent)]` newtype with a private field and no
public constructor. rustc materialises it from the launch packet as a kernel
parameter, which is what makes it unforgeable in safe device code: the host
marshals one value for the whole grid, so every thread reads the same bytes.

`#[cuda_module]` maps a `Uniform<T>` parameter to a plain `T` on the host,
since the host is the source of the uniformity. A sealed
`__LaunchContractUniform` bound rejects a local type also named `Uniform`,
which would otherwise take the scalar host ABI while presenting a different
device layout.

`Uniform::new_unchecked` remains for a value proven uniform some other way, and
`block_dim_x()` and its siblings return witnesses with no obligation, since a
launch has one block shape. Uniformity is closed under arithmetic whose
operands are all uniform, so `wrapping_mul` and its siblings preserve the
witness.

## Why the witness is sufficient

The old obligation had two clauses, and one of them is a safety property.
Under a uniform stride the `last_col < stride` check keeps each tile inside one
logical row, which makes the coordinate-to-offset mapping injective, so
distinct threads own disjoint elements. "The stride is the true row width"
governs only whether the kernel computes the intended result: a uniform stride
that misdescribes the layout gives wrong answers inside the slice, never
aliasing or an out-of-bounds access. The documentation separates the two.

## API change

`tile_2d32_rt` changes from `unsafe fn(..., u32)` to `fn(..., Uniform<u32>)`.
Both `gemm_views` safe kernels lose their `unsafe` blocks.

## Cost

None. PTX differs in parameter shape and instruction scheduling, and the
generated SASS is byte-identical at identical register counts.

## Note for review

A `Uniform<T>` parameter takes the aggregate `.param .align N .b8 [N]` path in
place of `.param .u32`. Alignment and size are correct at u8, u16, u32 and u64,
and ptxas absorbs the difference, so this costs nothing at runtime. Teaching
kernel-boundary scalarization to unwrap `repr(transparent)` newtypes would
still tidy the emitted IR.
