### PR TITLE
Decode scalar float constants from MIR bytes

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1689,6 +1689,73 @@ pub fn translate_rvalue(
     }
 }
 
+fn read_float_constant_bits(
+    constant: &mir::ConstOperand,
+    kind_name: &str,
+    byte_width: usize,
+    loc: Location,
+) -> TranslationResult<u128> {
+    let bytes = constant_bytes(constant, kind_name, loc.clone())?;
+
+    if bytes.len() < byte_width {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "{kind_name} constant needs {byte_width} bytes, found {}",
+                bytes.len()
+            ))
+        );
+    }
+
+    Ok(read_uint_from_bytes(&bytes[..byte_width]))
+}
+
+fn translate_float_constant(
+    ctx: &mut Context,
+    constant: &mir::ConstOperand,
+    const_ty: TypeHandle,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
+    use dialect_mir::ops::MirFloatConstantOp;
+    use pliron::builtin::attributes::{FPDoubleAttr, FPSingleAttr};
+
+    let op = Operation::new(
+        ctx,
+        MirFloatConstantOp::get_concrete_op_info(),
+        vec![const_ty],
+        vec![],
+        vec![],
+        0,
+    );
+    op.deref_mut(ctx).set_loc(loc.clone());
+
+    let float_op = MirFloatConstantOp::new(op);
+
+    if const_ty.deref(ctx).is::<MirFP16Type>() {
+        let bits = read_float_constant_bits(constant, "f16", 2, loc.clone())? as u16;
+        float_op.set_attr_float_value_f16(ctx, MirFP16Attr::from_bits(bits));
+    } else if const_ty.deref(ctx).is::<FP32Type>() {
+        let bits = read_float_constant_bits(constant, "f32", 4, loc.clone())? as u32;
+        float_op.set_attr_float_value(ctx, FPSingleAttr::from(f32::from_bits(bits)));
+    } else if const_ty.deref(ctx).is::<FP64Type>() {
+        let bits = read_float_constant_bits(constant, "f64", 8, loc.clone())? as u64;
+        float_op.set_attr_float_value_f64(ctx, FPDoubleAttr::from(f64::from_bits(bits)));
+    } else {
+        unreachable!("translate_float_constant called with a non-float type");
+    }
+
+    if let Some(prev) = prev_op {
+        float_op.get_operation().insert_after(ctx, prev);
+    } else {
+        float_op.get_operation().insert_at_front(block_ptr, ctx);
+    }
+
+    let value = float_op.get_operation().deref(ctx).get_result(0);
+    Ok((value, Some(float_op.get_operation())))
+}
+
 /// Translate a MIR Operand to a pliron IR [`Value`].
 /// Returns the value and the last inserted operation (for proper ordering).
 ///
@@ -1927,7 +1994,18 @@ pub fn translate_operand(
                 .deref(ctx)
                 .is::<dialect_mir::types::MirArrayType>();
 
-            // Parse constant value from debug string (HACK for prototype)
+            if is_float {
+                return translate_float_constant(
+                    ctx,
+                    constant,
+                    const_ty_ptr,
+                    block_ptr,
+                    prev_op,
+                    loc,
+                );
+            }
+
+            // Debug parsing remains temporarily for non-floating constants.
             let const_str = format!("{:?}", constant.const_);
 
             // Handle pointer-to-array constants (byte strings, typed arrays like [f64; 3], etc.)
@@ -1986,165 +2064,6 @@ pub fn translate_operand(
                     prev_op,
                     loc,
                 )
-            } else if is_float {
-                // Parse bytes for float (f16, f32, or f64)
-                use dialect_mir::ops::MirFloatConstantOp;
-
-                if is_float_16 {
-                    let bytes = constant_bytes(constant, "f16", loc.clone())?;
-                    if bytes.len() < 2 {
-                        return input_err!(
-                            loc,
-                            TranslationErr::unsupported(format!(
-                                "f16 constant needs 2 bytes, found {}",
-                                bytes.len()
-                            ))
-                        );
-                    }
-                    let bits = read_uint_from_bytes(&bytes[..2]) as u16;
-                    let float_attr = MirFP16Attr::from_bits(bits);
-
-                    let op = Operation::new(
-                        ctx,
-                        MirFloatConstantOp::get_concrete_op_info(),
-                        vec![const_ty_ptr],
-                        vec![],
-                        vec![],
-                        0,
-                    );
-                    op.deref_mut(ctx).set_loc(loc);
-
-                    let float_op = MirFloatConstantOp::new(op);
-                    float_op.set_attr_float_value_f16(ctx, float_attr);
-
-                    if let Some(prev) = prev_op {
-                        float_op.get_operation().insert_after(ctx, prev);
-                    } else {
-                        float_op.get_operation().insert_at_front(block_ptr, ctx);
-                    }
-
-                    let val = float_op.get_operation().deref(ctx).get_result(0);
-
-                    Ok((val, Some(float_op.get_operation())))
-                } else if is_float_64 {
-                    // Handle f64 (8 bytes)
-                    let float_val = if const_str.contains("bytes: [") {
-                        if let Some(bytes_part) = const_str.split("bytes: [").nth(1) {
-                            let bytes_end = bytes_part.split(']').next().unwrap_or("");
-                            let mut bytes = [0u8; 8];
-                            for (i, byte_str) in bytes_end.split(',').enumerate() {
-                                if i >= 8 {
-                                    break;
-                                }
-                                let b_str = byte_str.trim();
-                                if let Some(num_str) = b_str
-                                    .strip_prefix("Some(")
-                                    .and_then(|s| s.strip_suffix(')'))
-                                    && let Ok(byte) = num_str.parse::<u8>()
-                                {
-                                    bytes[i] = byte;
-                                }
-                            }
-                            f64::from_le_bytes(bytes)
-                        } else {
-                            0.0f64
-                        }
-                    } else {
-                        // Try to parse as literal float
-                        const_str
-                            .split(':')
-                            .next()
-                            .unwrap_or("0.0")
-                            .trim()
-                            .replace('_', "")
-                            .parse()
-                            .unwrap_or(0.0f64)
-                    };
-
-                    let float_attr = pliron::builtin::attributes::FPDoubleAttr::from(float_val);
-
-                    let op = Operation::new(
-                        ctx,
-                        MirFloatConstantOp::get_concrete_op_info(),
-                        vec![const_ty_ptr],
-                        vec![],
-                        vec![],
-                        0,
-                    );
-                    op.deref_mut(ctx).set_loc(loc.clone());
-
-                    let float_op = MirFloatConstantOp::new(op);
-                    float_op.set_attr_float_value_f64(ctx, float_attr);
-
-                    if let Some(prev) = prev_op {
-                        float_op.get_operation().insert_after(ctx, prev);
-                    } else {
-                        float_op.get_operation().insert_at_front(block_ptr, ctx);
-                    }
-
-                    let val = float_op.get_operation().deref(ctx).get_result(0);
-
-                    Ok((val, Some(float_op.get_operation())))
-                } else {
-                    // Handle f32 (4 bytes)
-                    let float_val = if const_str.contains("bytes: [") {
-                        if let Some(bytes_part) = const_str.split("bytes: [").nth(1) {
-                            let bytes_end = bytes_part.split(']').next().unwrap_or("");
-                            let mut bytes = [0u8; 4];
-                            for (i, byte_str) in bytes_end.split(',').enumerate() {
-                                if i >= 4 {
-                                    break;
-                                }
-                                let b_str = byte_str.trim();
-                                if let Some(num_str) = b_str
-                                    .strip_prefix("Some(")
-                                    .and_then(|s| s.strip_suffix(')'))
-                                    && let Ok(byte) = num_str.parse::<u8>()
-                                {
-                                    bytes[i] = byte;
-                                }
-                            }
-                            f32::from_le_bytes(bytes)
-                        } else {
-                            0.0f32
-                        }
-                    } else {
-                        // Try to parse as literal float
-                        const_str
-                            .split(':')
-                            .next()
-                            .unwrap_or("0.0")
-                            .trim()
-                            .replace('_', "")
-                            .parse()
-                            .unwrap_or(0.0f32)
-                    };
-
-                    let float_attr = pliron::builtin::attributes::FPSingleAttr::from(float_val);
-
-                    let op = Operation::new(
-                        ctx,
-                        MirFloatConstantOp::get_concrete_op_info(),
-                        vec![const_ty_ptr],
-                        vec![],
-                        vec![],
-                        0,
-                    );
-                    op.deref_mut(ctx).set_loc(loc);
-
-                    let float_op = MirFloatConstantOp::new(op);
-                    float_op.set_attr_float_value(ctx, float_attr);
-
-                    if let Some(prev) = prev_op {
-                        float_op.get_operation().insert_after(ctx, prev);
-                    } else {
-                        float_op.get_operation().insert_at_front(block_ptr, ctx);
-                    }
-
-                    let val = float_op.get_operation().deref(ctx).get_result(0);
-
-                    Ok((val, Some(float_op.get_operation())))
-                }
             } else if const_ty_ptr
                 .deref(ctx)
                 .is::<dialect_mir::types::MirPtrType>()

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1721,6 +1721,25 @@ fn translate_float_constant(
     use dialect_mir::ops::MirFloatConstantOp;
     use pliron::builtin::attributes::{FPDoubleAttr, FPSingleAttr};
 
+    /// Bit pattern decoded from the MIR constant, tagged by float width.
+    enum FloatBits {
+        F16(u16),
+        F32(u32),
+        F64(u64),
+    }
+
+    // Decode the constant bytes before allocating the op, so a decode
+    // error cannot leave an orphan operation behind in the context.
+    let bits = if const_ty.deref(ctx).is::<MirFP16Type>() {
+        FloatBits::F16(read_float_constant_bits(constant, "f16", 2, loc.clone())? as u16)
+    } else if const_ty.deref(ctx).is::<FP32Type>() {
+        FloatBits::F32(read_float_constant_bits(constant, "f32", 4, loc.clone())? as u32)
+    } else if const_ty.deref(ctx).is::<FP64Type>() {
+        FloatBits::F64(read_float_constant_bits(constant, "f64", 8, loc.clone())? as u64)
+    } else {
+        unreachable!("translate_float_constant called with a non-float type");
+    };
+
     let op = Operation::new(
         ctx,
         MirFloatConstantOp::get_concrete_op_info(),
@@ -1733,17 +1752,16 @@ fn translate_float_constant(
 
     let float_op = MirFloatConstantOp::new(op);
 
-    if const_ty.deref(ctx).is::<MirFP16Type>() {
-        let bits = read_float_constant_bits(constant, "f16", 2, loc.clone())? as u16;
-        float_op.set_attr_float_value_f16(ctx, MirFP16Attr::from_bits(bits));
-    } else if const_ty.deref(ctx).is::<FP32Type>() {
-        let bits = read_float_constant_bits(constant, "f32", 4, loc.clone())? as u32;
-        float_op.set_attr_float_value(ctx, FPSingleAttr::from(f32::from_bits(bits)));
-    } else if const_ty.deref(ctx).is::<FP64Type>() {
-        let bits = read_float_constant_bits(constant, "f64", 8, loc.clone())? as u64;
-        float_op.set_attr_float_value_f64(ctx, FPDoubleAttr::from(f64::from_bits(bits)));
-    } else {
-        unreachable!("translate_float_constant called with a non-float type");
+    match bits {
+        FloatBits::F16(bits) => {
+            float_op.set_attr_float_value_f16(ctx, MirFP16Attr::from_bits(bits));
+        }
+        FloatBits::F32(bits) => {
+            float_op.set_attr_float_value(ctx, FPSingleAttr::from(f32::from_bits(bits)));
+        }
+        FloatBits::F64(bits) => {
+            float_op.set_attr_float_value_f64(ctx, FPDoubleAttr::from(f64::from_bits(bits)));
+        }
     }
 
     if let Some(prev) = prev_op {

--- a/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fp_special_literal_smoke/src/main.rs
@@ -24,6 +24,10 @@
 //! survive into LLVM IR as `float` / `double` SSA values rather than
 //! getting folded into integer `to_bits()` constants by rustc.
 //!
+//! The negative-zero and one-ULP cases additionally verify that the MIR
+//! importer preserves exact scalar `f32` and `f64` bit patterns without
+//! parsing rustc `Debug` output.
+//!
 //! Build and run with:
 //!   cargo oxide run fp_special_literal_smoke
 
@@ -35,13 +39,15 @@ use cuda_host::{cuda_module, ltoir};
 // KERNELS
 // =============================================================================
 
+const F32_ONE_PLUS_ULP: f32 = f32::from_bits(0x3f80_0001);
+const F64_ONE_PLUS_ULP: f64 = f64::from_bits(0x3ff0_0000_0000_0001);
+
 #[cuda_module]
 mod kernels {
     use super::*;
 
-    /// Stores `f32::NAN`, `f32::INFINITY`, `f32::NEG_INFINITY`, and a finite
-    /// control value so the constants reach `format_float_literal` as `float`
-    /// SSA values.
+    /// Stores special values and exact-bit finite values so scalar `f32`
+    /// constants exercise both MIR constant import and LLVM literal export.
     #[kernel]
     pub fn fp_special_literal_f32_kernel(mut out: DisjointSlice<f32>) {
         if thread::index_1d().get() == 0 {
@@ -50,11 +56,13 @@ mod kernels {
                 *out.get_unchecked_mut(1) = f32::INFINITY;
                 *out.get_unchecked_mut(2) = f32::NEG_INFINITY;
                 *out.get_unchecked_mut(3) = 1.5_f32;
+                *out.get_unchecked_mut(4) = -0.0_f32;
+                *out.get_unchecked_mut(5) = F32_ONE_PLUS_ULP;
             }
         }
     }
 
-    /// Same as `fp_special_literal_f32_kernel` for `f64`.
+    /// Same coverage as `fp_special_literal_f32_kernel` for `f64`.
     #[kernel]
     pub fn fp_special_literal_f64_kernel(mut out: DisjointSlice<f64>) {
         if thread::index_1d().get() == 0 {
@@ -63,6 +71,8 @@ mod kernels {
                 *out.get_unchecked_mut(1) = f64::INFINITY;
                 *out.get_unchecked_mut(2) = f64::NEG_INFINITY;
                 *out.get_unchecked_mut(3) = 1.5_f64;
+                *out.get_unchecked_mut(4) = -0.0_f64;
+                *out.get_unchecked_mut(5) = F64_ONE_PLUS_ULP;
             }
         }
     }
@@ -87,7 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ---------- f32 ----------
     {
-        let mut out = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
+        let mut out = DeviceBuffer::<f32>::zeroed(&stream, 6)?;
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.fp_special_literal_f32_kernel(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?;
@@ -96,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ---------- f64 ----------
     {
-        let mut out = DeviceBuffer::<f64>::zeroed(&stream, 4)?;
+        let mut out = DeviceBuffer::<f64>::zeroed(&stream, 6)?;
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.fp_special_literal_f64_kernel(&stream, cfg, &mut out) }?;
         let got = out.to_host_vec(&stream)?;
@@ -143,6 +153,21 @@ fn check_f32_specials(got: &[f32], passed: &mut u32, failed: &mut u32) {
         println!("FAIL f32 control 1.5: got {}", got[3]);
         ok = false;
     }
+    if got[4].to_bits() != 0x8000_0000 {
+        println!(
+            "FAIL f32 negative zero: got bits 0x{:08x}, expected 0x80000000",
+            got[4].to_bits()
+        );
+        ok = false;
+    }
+
+    if got[5].to_bits() != 0x3f80_0001 {
+        println!(
+            "FAIL f32 one-plus-ULP: got bits 0x{:08x}, expected 0x3f800001",
+            got[5].to_bits()
+        );
+        ok = false;
+    }
     if ok {
         println!(
             "PASS f32 specials: NaN={}, +Inf={}, -Inf={}, control={}",
@@ -185,6 +210,21 @@ fn check_f64_specials(got: &[f64], passed: &mut u32, failed: &mut u32) {
     }
     if got[3] != 1.5_f64 {
         println!("FAIL f64 control 1.5: got {}", got[3]);
+        ok = false;
+    }
+    if got[4].to_bits() != 0x8000_0000_0000_0000 {
+        println!(
+            "FAIL f64 negative zero: got bits 0x{:016x}, expected 0x8000000000000000",
+            got[4].to_bits()
+        );
+        ok = false;
+    }
+
+    if got[5].to_bits() != 0x3ff0_0000_0000_0001 {
+        println!(
+            "FAIL f64 one-plus-ULP: got bits 0x{:016x}, expected 0x3ff0000000000001",
+            got[5].to_bits()
+        );
         ok = false;
     }
     if ok {


### PR DESCRIPTION
Closes #526 

## Summary

This PR removes the MIR importer's dependency on rustc `Debug` output when translating scalar `f32` and `f64` constants.

Floating-point constants are now decoded directly from their MIR allocation bytes and reconstructed from their exact IEEE-754 bit patterns.

## Changes

### MIR importer

* Added `read_float_constant_bits` to:

  * retrieve constant bytes through `constant_bytes`;
  * validate the required byte width;
  * decode the value using the target-aware `read_uint_from_bytes` helper.

* Added `translate_float_constant` to centralize scalar float operation creation for:

  * `f16`;
  * `f32`;
  * `f64`.

* Reconstructs scalar values using:

  * `MirFP16Attr::from_bits`;
  * `f32::from_bits`;
  * `f64::from_bits`.

* Dispatches scalar floating-point constants before creating the Debug-formatted `const_str`.

* Removed the previous `f32` and `f64` implementations that:

  * searched the Debug string for `bytes: [...]`;
  * parsed individual `Some(byte)` entries;
  * attempted decimal parsing;
  * silently fell back to `0.0`.

### Regression coverage

Extended `fp_special_literal_smoke` with exact-bit cases for both `f32` and `f64`:

* negative zero;
* the representable value immediately above `1.0`.

The test validates these values with `to_bits()` to ensure that sign and mantissa bits survive the MIR importer and LLVM export pipeline unchanged.

The existing NaN, positive infinity, negative infinity, and finite control cases remain covered.

## Rationale

rustc's `Debug` representation is not a stable serialization format and should not be used as an importer interface.

Reading the MIR constant bytes directly:

* removes the dependency on formatting details;
* avoids silent corruption through `unwrap_or(0.0)`;
* preserves exact IEEE-754 representations;
* reuses the same mechanism already used for `f16`;
* respects target endianness through the existing byte decoder.

## Validation

```text
cargo fmt --all -- --check
cargo test -p mir-importer
cargo clippy -p mir-importer --all-targets -- -D warnings
scripts/smoketest.sh --compile-only --only '^fp_special_literal_smoke$'
scripts/smoketest.sh --only '^fp_special_literal_smoke$'
```

Results:

* 861 MIR importer tests passed.
* MIR importer doctests passed.
* Clippy completed with warnings denied.
* `fp_special_literal_smoke` passed in compile-only mode.
* `fp_special_literal_smoke` passed on an NVIDIA RTX 5060 Laptop GPU targeting `sm_120`.

## Scope

This PR intentionally leaves the remaining Debug-based handling for non-floating constant categories unchanged.
