### PR TITLE
feat(cargo-oxide): implement cargo oxide update

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -296,6 +296,18 @@ anyway).
 
 Explicitly builds (or rebuilds) the codegen backend. Normally this happens automatically on every `run`/`build`/`pipeline` command, but `setup` is useful after pulling new changes or for CI.
 
+### `cargo oxide update [--force]`
+
+Refreshes the shared codegen backend cache used by projects outside this
+repository (`~/.cargo/cuda-oxide/`). Inside the cuda-oxide workspace the local
+source tree is authoritative, so the default path prints how to run
+`cargo oxide setup`; pass `--force` to run setup from this command.
+
+```bash
+cargo oxide update
+cargo oxide update --force
+```
+
 ## Backend Discovery
 
 When `cargo oxide` needs the `librustc_codegen_cuda.so` backend, it searches in this order:
@@ -351,6 +363,3 @@ crates/cargo-oxide/
 | Command                         | Description                                             |
 |---------------------------------|---------------------------------------------------------|
 | `cargo oxide bench <example>`   | GPU profiling (nsys/ncu integration), report TFLOPS     |
-| `cargo oxide clean`             | Remove generated PTX/LL/LTOIR artifacts and build caches|
-| `cargo oxide update`            | Update the cached codegen backend to latest version     |
-| `cargo oxide inspect <example>` | Show generated PTX without the full pipeline dump       |

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -358,8 +358,34 @@ fn invalidate_cache(cache_dir: &Path) {
         "Detected upgraded cargo-oxide; refreshing cached backend at {} (issue #49).",
         cache_dir.display()
     );
+    clear_cache_contents(cache_dir);
+}
+
+/// Drop the cached `.so` and source tree used by external projects.
+///
+/// Used by `cargo oxide update` for an explicit refresh, distinct from the
+/// automatic upgrade path in [`invalidate_cache`].
+pub fn clear_cached_backend() -> Option<PathBuf> {
+    let cache_dir = cache_directory()?;
+    eprintln!(
+        "Clearing cached codegen backend at {}...",
+        cache_dir.display()
+    );
+    clear_cache_contents(&cache_dir);
+    Some(cache_dir)
+}
+
+fn clear_cache_contents(cache_dir: &Path) {
     let _ = std::fs::remove_file(cache_dir.join("librustc_codegen_cuda.so"));
     let _ = std::fs::remove_dir_all(cache_dir.join("src"));
+}
+
+/// Invalidate the shared cache and rebuild via auto-fetch (external projects).
+///
+/// Returns the path to the freshly cached `.so`.
+pub fn refresh_cached_backend() -> PathBuf {
+    let _ = clear_cached_backend();
+    auto_fetch_and_build()
 }
 
 /// Builds the backend from a local source tree.
@@ -860,6 +886,21 @@ mod tests {
         let dir = tempdir();
         let so = dir.join("does_not_exist.so");
         assert_eq!(cached_backend_status(&so, None), CacheStatus::Fresh);
+    }
+
+    #[test]
+    fn clear_cache_contents_removes_so_and_src_tree() {
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        let src = dir.join("src/crates/rustc-codegen-cuda");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(&so, b"old").unwrap();
+        std::fs::write(src.join("lib.rs"), b"fn main() {}").unwrap();
+
+        clear_cache_contents(&dir);
+
+        assert!(!so.exists());
+        assert!(!dir.join("src").exists());
     }
 
     /// A backend source input newer than the cached `.so` must report

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -4245,6 +4245,62 @@ pub fn setup(ctx: &Context) {
     }
 }
 
+/// How `cargo oxide update` should behave for the current project mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdatePlan {
+    /// Inside the monorepo: tell the user to run `setup` (non-destructive).
+    AdviseSetup,
+    /// Inside the monorepo with `--force`: rebuild via `setup`.
+    RunSetup,
+    /// Outside the monorepo: clear and rebuild the shared cache.
+    RefreshCache,
+}
+
+pub fn plan_update(is_workspace: bool, force: bool) -> UpdatePlan {
+    match (is_workspace, force) {
+        (true, false) => UpdatePlan::AdviseSetup,
+        (true, true) => UpdatePlan::RunSetup,
+        (false, _) => UpdatePlan::RefreshCache,
+    }
+}
+
+/// Refresh the codegen backend used by this project.
+///
+/// Inside the cuda-oxide workspace the authoritative backend is the local
+/// source tree, so the default path points at `cargo oxide setup`. Outside
+/// the workspace, the shared `~/.cargo/cuda-oxide/` cache is cleared and
+/// rebuilt via the auto-fetch path.
+pub fn update(ctx: &Context, force: bool) {
+    if std::env::var_os("CUDA_OXIDE_BACKEND").is_some() {
+        eprintln!("Error: CUDA_OXIDE_BACKEND is set, so `cargo oxide update` will not");
+        eprintln!("modify the shared cache. Unset CUDA_OXIDE_BACKEND and re-run, or");
+        eprintln!("rebuild the pinned backend path yourself.");
+        std::process::exit(1);
+    }
+
+    match plan_update(ctx.is_workspace, force) {
+        UpdatePlan::AdviseSetup => {
+            println!("Inside the cuda-oxide workspace the codegen backend is built from");
+            println!("local source (`crates/rustc-codegen-cuda`).");
+            println!();
+            println!("Run `cargo oxide setup` to rebuild and publish to the shared cache,");
+            println!("or pass `--force` to run setup from this command.");
+        }
+        UpdatePlan::RunSetup => {
+            println!("`--force` requested inside the workspace; running setup...");
+            println!();
+            setup(ctx);
+        }
+        UpdatePlan::RefreshCache => {
+            println!("Refreshing the shared codegen backend cache for external projects...");
+            println!();
+            let so = backend::refresh_cached_backend();
+            println!();
+            println!("✓ Cached backend ready at {}", so.display());
+        }
+    }
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -7880,6 +7936,14 @@ components = ["rust-src", "rustc-dev", "llvm-tools"]
             "stable-x86_64-unknown-linux-gnu\nactive because: default",
             "nightly-2026-04-03"
         ));
+    }
+
+    #[test]
+    fn plan_update_selects_advise_setup_or_cache_refresh() {
+        assert_eq!(plan_update(true, false), UpdatePlan::AdviseSetup);
+        assert_eq!(plan_update(true, true), UpdatePlan::RunSetup);
+        assert_eq!(plan_update(false, false), UpdatePlan::RefreshCache);
+        assert_eq!(plan_update(false, true), UpdatePlan::RefreshCache);
     }
 
     #[test]

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -4270,11 +4270,34 @@ pub fn plan_update(is_workspace: bool, force: bool) -> UpdatePlan {
 /// source tree, so the default path points at `cargo oxide setup`. Outside
 /// the workspace, the shared `~/.cargo/cuda-oxide/` cache is cleared and
 /// rebuilt via the auto-fetch path.
-pub fn update(ctx: &Context, force: bool) {
+/// The backend pin that outranks the shared cache `update` refreshes, if any.
+///
+/// Both the `CUDA_OXIDE_BACKEND` env var and a `.cargo/cuda-oxide.toml`
+/// `backend` entry sit above the cache in backend discovery, so a refreshed
+/// cache would never be consulted while either is set. `update` refuses
+/// rather than mislead.
+fn update_pin_refusal(ctx: &Context) -> Option<String> {
     if std::env::var_os("CUDA_OXIDE_BACKEND").is_some() {
-        eprintln!("Error: CUDA_OXIDE_BACKEND is set, so `cargo oxide update` will not");
-        eprintln!("modify the shared cache. Unset CUDA_OXIDE_BACKEND and re-run, or");
-        eprintln!("rebuild the pinned backend path yourself.");
+        return Some(
+            "CUDA_OXIDE_BACKEND is set, so `cargo oxide update` will not\n\
+             modify the shared cache. Unset CUDA_OXIDE_BACKEND and re-run, or\n\
+             rebuild the pinned backend path yourself."
+                .to_string(),
+        );
+    }
+    ctx.config.backend.as_deref().map(|pinned| {
+        format!(
+            "`.cargo/cuda-oxide.toml` pins the backend to {}, so\n\
+             `cargo oxide update` will not modify the shared cache. Remove the\n\
+             `backend` entry and re-run, or rebuild the pinned path yourself.",
+            pinned.display()
+        )
+    })
+}
+
+pub fn update(ctx: &Context, force: bool) {
+    if let Some(refusal) = update_pin_refusal(ctx) {
+        eprintln!("Error: {refusal}");
         std::process::exit(1);
     }
 
@@ -7944,6 +7967,22 @@ components = ["rust-src", "rustc-dev", "llvm-tools"]
         assert_eq!(plan_update(true, true), UpdatePlan::RunSetup);
         assert_eq!(plan_update(false, false), UpdatePlan::RefreshCache);
         assert_eq!(plan_update(false, true), UpdatePlan::RefreshCache);
+    }
+
+    /// A `.cargo/cuda-oxide.toml` backend pin outranks the shared cache, so
+    /// `update` must refuse just like it does for `CUDA_OXIDE_BACKEND`.
+    #[test]
+    fn update_refuses_when_the_config_pins_a_backend() {
+        let pinned = test_context(OxideConfig {
+            backend: Some(PathBuf::from("/tmp/pinned-backend.so")),
+            ..OxideConfig::default()
+        });
+        let refusal = update_pin_refusal(&pinned).expect("config pin must refuse update");
+        assert!(refusal.contains("pins the backend"), "{refusal}");
+        assert!(refusal.contains("/tmp/pinned-backend.so"), "{refusal}");
+
+        let unpinned = test_context(OxideConfig::default());
+        assert_eq!(update_pin_refusal(&unpinned), None);
     }
 
     #[test]

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -757,13 +757,13 @@ fn main() {
             commands::setup(&ctx);
         }
         Commands::Update { force } => {
-            // AdviseSetup / RefreshCache plan from passive context; RunSetup
-            // rebuilds via setup which resolves the backend on demand.
-            let ctx = if force {
-                commands::resolve_context()
-            } else {
-                commands::resolve_passive_context()
-            };
+            // All plans resolve passively. `setup` only needs
+            // `ctx.codegen_crate`, which the passive resolver provides
+            // identically, while eager resolution would auto-fetch and build
+            // the backend before `update` runs: a double clone+build ahead of
+            // the RefreshCache arm's own clear-and-rebuild, and a wasted
+            // build ahead of the pinned-backend refusals.
+            let ctx = commands::resolve_passive_context();
             commands::update(&ctx, force);
         }
     }

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -26,6 +26,7 @@
 //! cargo oxide doctor                  # check environment
 //! cargo oxide clean                   # remove local build outputs
 //! cargo oxide setup                   # explicitly build/install backend
+//! cargo oxide update                  # refresh cached backend (external)
 //! ```
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum, error::ErrorKind};
@@ -318,6 +319,13 @@ enum Commands {
     Doctor,
     /// Build and cache the codegen backend
     Setup,
+    /// Refresh the cached codegen backend (or run setup inside the workspace)
+    Update {
+        /// Inside the workspace, run `setup` instead of only advising it.
+        /// Outside the workspace, refresh is already the default.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -421,6 +429,10 @@ fn validate_materialization_cli(cli: &Cli) -> Result<(), String> {
         ),
         Commands::Setup => Err(
             "--materialize-cubin cannot be used with setup because setup only builds the codegen backend"
+                .to_string(),
+        ),
+        Commands::Update { .. } => Err(
+            "--materialize-cubin cannot be used with update because update only refreshes the codegen backend"
                 .to_string(),
         ),
         Commands::MaterializerProvenance => Err(
@@ -744,6 +756,16 @@ fn main() {
             let ctx = commands::resolve_context();
             commands::setup(&ctx);
         }
+        Commands::Update { force } => {
+            // AdviseSetup / RefreshCache plan from passive context; RunSetup
+            // rebuilds via setup which resolves the backend on demand.
+            let ctx = if force {
+                commands::resolve_context()
+            } else {
+                commands::resolve_passive_context()
+            };
+            commands::update(&ctx, force);
+        }
     }
 }
 
@@ -817,6 +839,23 @@ mod tests {
             Cli::try_parse_from(["cargo-oxide", "clean"]).expect("clean command should parse");
 
         assert!(matches!(cli.command, Commands::Clean));
+    }
+
+    #[test]
+    fn update_parser_accepts_force_flag() {
+        let plain =
+            Cli::try_parse_from(["cargo-oxide", "update"]).expect("update command should parse");
+        let Commands::Update { force } = plain.command else {
+            panic!("expected Update");
+        };
+        assert!(!force);
+
+        let forced = Cli::try_parse_from(["cargo-oxide", "update", "--force"])
+            .expect("update --force should parse");
+        let Commands::Update { force } = forced.command else {
+            panic!("expected Update");
+        };
+        assert!(force);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `cargo oxide update [--force]` to refresh `~/.cargo/cuda-oxide/` for external projects.
- Inside the monorepo, default path points at `cargo oxide setup`; `--force` runs setup.
- Remove shipped `clean` / `inspect` / `update` rows from README Future Commands.
- Unit tests cover CLI parsing, update planning, and cache clearing (no GPU).

Closes #530

## Test plan
- [x] `cargo test -p cargo-oxide plan_update`
- [x] `cargo test -p cargo-oxide update_parser`
- [x] `cargo test -p cargo-oxide clear_cache_contents`
- [x] `cargo oxide update --help`
- [x] In-repo `cargo oxide update` prints setup advice (non-destructive)