### PR TITLE
feat(swizzle): XOR swizzles for shared memory, with the conflict arithmetic

### DIFF
--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -34,6 +34,7 @@ pub mod mma_frag;
 pub mod prmt;
 pub mod ptx;
 pub mod shared;
+pub mod swizzle;
 pub mod tcgen05;
 pub mod thread;
 pub mod tma;

--- a/crates/cuda-device/src/swizzle.rs
+++ b/crates/cuda-device/src/swizzle.rs
@@ -1,0 +1,305 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! XOR swizzles for shared memory, and the bank-conflict arithmetic to pick one.
+//!
+//! Shared memory is 32 banks of 4 bytes, and the bank is
+//! `(byte_offset / 4) % 32`. A warp that reads one column of a row-major tile
+//! whose row stride is a multiple of 32 elements has every lane land on the same
+//! bank, which serialises the access 32 ways:
+//!
+//! ```text
+//! column access, f32 tile          worst conflict   banks used
+//! row stride 32                    32-way            1 of 32
+//! row stride 64                    32-way            1 of 32
+//! row stride 16                    16-way            2 of 32
+//! row stride 33 (padded)            1-way           32 of 32
+//! ```
+//!
+//! Padding the stride to 33 fixes it and wastes a column per row, which also
+//! breaks the alignment that wide accesses need. The alternative is to permute
+//! the offsets instead of spacing them out: XOR part of the address with bits
+//! taken from higher up, so lanes that shared a bank no longer do.
+//!
+//! ```text
+//! row stride 32 with a swizzle     worst conflict   banks used
+//! Swizzle<5, 0, 5>                  1-way           32 of 32
+//! Swizzle<3, 0, 5>                  4-way            8 of 32
+//! Swizzle<2, 0, 5>                  8-way            4 of 32
+//! ```
+//!
+//! Fewer scattered bits leaves proportionally more conflict, so five bits -
+//! exactly the 32 banks - is the choice worth defaulting to. Combinations
+//! that would not be self-inverse, such as `Swizzle<5, 0, 4>`, are rejected
+//! at compile time rather than silently misbehaving.
+//!
+//! # Relation to the index algebra
+//!
+//! A swizzle is not an affine sum of digits, so it cannot be written as a
+//! mixed-radix numeral and the compact-layout argument says nothing about it
+//! directly. It composes with that argument anyway, for a simpler reason: a
+//! swizzle is a **bijection** on the index space, and applying a bijection to a
+//! set of pairwise-disjoint indices leaves them pairwise disjoint. So swizzling
+//! a disjoint access pattern is always safe, and the only thing to get right is
+//! that reads and writes use the same swizzle.
+//!
+//! This module is analysis and address arithmetic only. It does not allocate or
+//! access shared memory; combine it with [`crate::shared::SharedArray`].
+
+/// Shared memory banks.
+pub const BANKS: usize = 32;
+/// Bytes per bank in one cycle.
+pub const BANK_WIDTH_BYTES: usize = 4;
+/// Threads whose accesses are serviced together.
+pub const WARP_LANES: usize = 32;
+
+/// An XOR swizzle: `x ^ (((x >> S) & ((1 << B) - 1)) << M)`.
+///
+/// `B` bits are taken from bit `S` upward and XORed into the address starting at
+/// bit `M`. Larger `B` scatters across more banks; `S` selects which part of the
+/// address drives the scatter, and is normally the log2 of the row stride so
+/// that the row index does the scattering.
+///
+/// # Choosing parameters
+///
+/// For a row-major tile of `f32` with a row stride of `2^S` elements, and a warp
+/// reading a column, `Swizzle<5, 0, S>` is conflict-free: five bits is exactly
+/// the 32 banks. Fewer bits leaves proportionally more conflict, which the table
+/// in the module docs shows and the tests pin.
+///
+/// # Constraint
+///
+/// `M + B <= S` is required, and checked at compile time. Without it the XOR
+/// target bits overlap the bits being read, and the swizzle stops being its own
+/// inverse - so a store and a load through the same swizzle would disagree. It
+/// remains a bijection, but an involution is what makes it usable as "apply on
+/// the way in, apply again on the way out".
+pub struct Swizzle<const B: usize, const M: usize, const S: usize>;
+
+impl<const B: usize, const M: usize, const S: usize> Swizzle<B, M, S> {
+    /// Compile-time check that the swizzle is an involution.
+    const INVOLUTION: () = assert!(
+        M + B <= S,
+        "Swizzle<B, M, S> requires M + B <= S, otherwise applying it twice does \
+         not restore the original offset"
+    );
+
+    /// Bits scattered.
+    pub const BITS: usize = B;
+    /// Distinct offsets the swizzle can map onto, from one source group.
+    pub const SPREAD: usize = 1 << B;
+
+    /// Apply the swizzle to an element offset.
+    ///
+    /// Self-inverse: `apply(apply(x)) == x`.
+    #[must_use]
+    #[inline(always)]
+    pub const fn apply(offset: usize) -> usize {
+        // Force the involution check; it is a compile error if M + B > S.
+        let () = Self::INVOLUTION;
+        offset ^ (((offset >> S) & ((1 << B) - 1)) << M)
+    }
+
+    /// Undo the swizzle. Identical to [`Self::apply`], since it is an involution.
+    ///
+    /// Provided under its own name so call sites read in the direction they mean.
+    #[must_use]
+    #[inline(always)]
+    pub const fn undo(offset: usize) -> usize {
+        Self::apply(offset)
+    }
+}
+
+/// Bank an element offset lands in.
+#[must_use]
+#[inline(always)]
+pub const fn bank_of(elem_offset: usize, elem_size: usize) -> usize {
+    (elem_offset * elem_size / BANK_WIDTH_BYTES) % BANKS
+}
+
+/// Worst-case serialisation for the offsets one warp accesses.
+///
+/// Returns the largest number of lanes landing on a single bank: `1` is
+/// conflict-free, `32` is fully serialised. Lanes hitting the *same address*
+/// still count here, even though the hardware broadcasts them, so this is a
+/// conservative bound rather than an exact cycle count.
+#[must_use]
+pub const fn conflict_degree(offsets: &[usize; WARP_LANES], elem_size: usize) -> usize {
+    let mut counts = [0usize; BANKS];
+    let mut lane = 0;
+    while lane < WARP_LANES {
+        let b = bank_of(offsets[lane], elem_size);
+        counts[b] += 1;
+        lane += 1;
+    }
+    let mut worst = 0;
+    let mut b = 0;
+    while b < BANKS {
+        if counts[b] > worst {
+            worst = counts[b];
+        }
+        b += 1;
+    }
+    worst
+}
+
+/// Distinct banks the offsets touch.
+#[must_use]
+pub const fn banks_used(offsets: &[usize; WARP_LANES], elem_size: usize) -> usize {
+    let mut seen = [false; BANKS];
+    let mut lane = 0;
+    while lane < WARP_LANES {
+        seen[bank_of(offsets[lane], elem_size)] = true;
+        lane += 1;
+    }
+    let mut n = 0;
+    let mut b = 0;
+    while b < BANKS {
+        if seen[b] {
+            n += 1;
+        }
+        b += 1;
+    }
+    n
+}
+
+/// Offsets a warp touches reading one column of a row-major tile.
+///
+/// Lane `i` reads row `i`, the pattern that conflicts worst and the reason
+/// swizzling exists.
+#[must_use]
+pub const fn column_offsets(row_stride_elems: usize, col: usize) -> [usize; WARP_LANES] {
+    let mut out = [0usize; WARP_LANES];
+    let mut lane = 0;
+    while lane < WARP_LANES {
+        out[lane] = lane * row_stride_elems + col;
+        lane += 1;
+    }
+    out
+}
+
+/// Offsets a warp touches reading one row.
+///
+/// Contiguous, so it is conflict-free without a swizzle. Provided to check that
+/// a swizzle chosen for the column case does not spoil the row case.
+#[must_use]
+pub const fn row_offsets(row: usize, row_stride_elems: usize) -> [usize; WARP_LANES] {
+    let mut out = [0usize; WARP_LANES];
+    let mut lane = 0;
+    while lane < WARP_LANES {
+        out[lane] = row * row_stride_elems + lane;
+        lane += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const F32: usize = 4;
+
+    /// Apply a swizzle across a whole offset array.
+    fn swizzled<const B: usize, const M: usize, const S: usize>(
+        offsets: [usize; WARP_LANES],
+    ) -> [usize; WARP_LANES] {
+        let mut out = [0usize; WARP_LANES];
+        for (o, &i) in out.iter_mut().zip(offsets.iter()) {
+            *o = Swizzle::<B, M, S>::apply(i);
+        }
+        out
+    }
+
+    /// The problem, quantified. A column of a stride-32 f32 tile puts every lane
+    /// on one bank.
+    #[test]
+    fn column_access_conflicts_without_a_swizzle() {
+        for stride in [32usize, 64, 128] {
+            let o = column_offsets(stride, 0);
+            assert_eq!(
+                conflict_degree(&o, F32),
+                32,
+                "stride {stride} should be fully serialised"
+            );
+            assert_eq!(banks_used(&o, F32), 1);
+        }
+        // A stride of 16 halves it, and 33 avoids it by wasting a column.
+        assert_eq!(conflict_degree(&column_offsets(16, 0), F32), 16);
+        assert_eq!(conflict_degree(&column_offsets(33, 0), F32), 1);
+    }
+
+    /// The fix, quantified, and the reason to prefer five bits.
+    #[test]
+    fn swizzle_removes_the_column_conflict() {
+        let base = column_offsets(32, 0);
+        assert_eq!(conflict_degree(&swizzled::<5, 0, 5>(base), F32), 1);
+        assert_eq!(banks_used(&swizzled::<5, 0, 5>(base), F32), 32);
+        // Fewer scattered bits leaves proportionally more conflict.
+        assert_eq!(conflict_degree(&swizzled::<3, 0, 5>(base), F32), 4);
+        assert_eq!(conflict_degree(&swizzled::<2, 0, 5>(base), F32), 8);
+    }
+
+    /// A swizzle must not spoil the access it was not chosen for.
+    #[test]
+    fn row_access_stays_conflict_free() {
+        for row in [0usize, 1, 7, 31] {
+            let o = row_offsets(row, 32);
+            assert_eq!(conflict_degree(&o, F32), 1, "row {row} unswizzled");
+            assert_eq!(
+                conflict_degree(&swizzled::<5, 0, 5>(o), F32),
+                1,
+                "row {row} swizzled"
+            );
+        }
+    }
+
+    /// The property that lets a swizzle compose with a disjoint access pattern:
+    /// it is a permutation, so it cannot make two distinct offsets collide.
+    #[test]
+    fn swizzle_is_a_bijection() {
+        const SPAN: usize = 1 << 10;
+        let mut seen = [false; SPAN];
+        for x in 0..SPAN {
+            let y = Swizzle::<5, 0, 5>::apply(x);
+            assert!(y < SPAN, "{x} mapped outside the span, to {y}");
+            assert!(!seen[y], "two offsets collided on {y}");
+            seen[y] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "the map must be onto");
+    }
+
+    /// Self-inverse, which is what makes "apply going in, apply coming out"
+    /// correct. The `M + B <= S` constraint is what guarantees it, and it is
+    /// enforced at compile time.
+    #[test]
+    fn swizzle_is_its_own_inverse() {
+        for x in 0..(1usize << 10) {
+            assert_eq!(Swizzle::<5, 0, 5>::undo(Swizzle::<5, 0, 5>::apply(x)), x);
+            assert_eq!(Swizzle::<3, 0, 5>::undo(Swizzle::<3, 0, 5>::apply(x)), x);
+            assert_eq!(Swizzle::<2, 1, 5>::undo(Swizzle::<2, 1, 5>::apply(x)), x);
+        }
+    }
+
+    #[test]
+    fn bank_arithmetic_wraps_at_thirty_two() {
+        assert_eq!(bank_of(0, F32), 0);
+        assert_eq!(bank_of(1, F32), 1);
+        assert_eq!(bank_of(31, F32), 31);
+        assert_eq!(bank_of(32, F32), 0, "wraps after 32 words");
+        // An f64 element spans two words, so consecutive elements skip a bank.
+        assert_eq!(bank_of(1, 8), 2);
+        assert_eq!(bank_of(16, 8), 0);
+    }
+
+    /// Usable in const position, so a conflict-free choice can be asserted at
+    /// compile time rather than measured in a profiler.
+    #[test]
+    fn analysis_runs_at_compile_time() {
+        const OFFSETS: [usize; WARP_LANES] = column_offsets(32, 0);
+        const UNSWIZZLED: usize = conflict_degree(&OFFSETS, F32);
+        const _: () = assert!(UNSWIZZLED == 32);
+        assert_eq!(UNSWIZZLED, 32);
+    }
+}

--- a/crates/cuda-device/src/swizzle.rs
+++ b/crates/cuda-device/src/swizzle.rs
@@ -73,9 +73,20 @@ pub const WARP_LANES: usize = 32;
 ///
 /// `M + B <= S` is required, and checked at compile time. Without it the XOR
 /// target bits overlap the bits being read, and the swizzle stops being its own
-/// inverse - so a store and a load through the same swizzle would disagree. It
-/// remains a bijection, but an involution is what makes it usable as "apply on
-/// the way in, apply again on the way out".
+/// inverse - so a store and a load through the same swizzle would disagree.
+/// Some rejected combinations are not even bijections: at `M == S` the sourced
+/// bits are XORed with themselves and zeroed outright, collapsing distinct
+/// offsets. An involution is what makes the type usable as "apply on the way
+/// in, apply again on the way out".
+///
+/// # Relation to CuTe's `Swizzle`
+///
+/// CuTe's `Swizzle<B, M, S>` measures its shift `S` relative to the base `M`
+/// (source bits start at `M + S`), while this type's `S` is the absolute
+/// source-bit position. A CuTe `Swizzle<B, M, S>` is this type's
+/// `Swizzle<B, M, M + S>`; conversely, `Swizzle<B, M, S>` here corresponds to
+/// CuTe's `Swizzle<B, M, S - M>`. The conventions coincide only at `M == 0`,
+/// so translate the third parameter explicitly when porting a CuTe layout.
 pub struct Swizzle<const B: usize, const M: usize, const S: usize>;
 
 impl<const B: usize, const M: usize, const S: usize> Swizzle<B, M, S> {

--- a/crates/cuda-device/tests/compile_fail/swizzle_non_involutive.rs
+++ b/crates/cuda-device/tests/compile_fail/swizzle_non_involutive.rs
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `Swizzle<B, M, S>` requires `M + B <= S`. Without it the XOR target bits
+//! overlap the bits being read, so applying the swizzle twice does not restore
+//! the original offset and a store/load pair through it would disagree.
+
+use cuda_device::swizzle::Swizzle;
+
+// M + B = 5, S = 4: the target bits overlap the source bits, so applying the
+// swizzle twice would not restore the offset. A const context forces the
+// involution check to be evaluated.
+const BAD: usize = Swizzle::<5, 0, 4>::apply(0);
+
+fn main() {
+    let _ = BAD;
+}

--- a/crates/cuda-device/tests/compile_fail/swizzle_non_involutive.stderr
+++ b/crates/cuda-device/tests/compile_fail/swizzle_non_involutive.stderr
@@ -1,0 +1,21 @@
+error[E0080]: evaluation panicked: Swizzle<B, M, S> requires M + B <= S, otherwise applying it twice does not restore the original offset
+ --> $RUST/core/src/panic.rs
+  |
+  |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `cuda_device::swizzle::Swizzle::<5, 0, 4>::INVOLUTION` failed here
+  |
+ ::: src/swizzle.rs
+  |
+  |       const INVOLUTION: () = assert!(
+  |  ____________________________-
+  | |         M + B <= S,
+  | |         "Swizzle<B, M, S> requires M + B <= S, otherwise applying it twice does \
+  | |          not restore the original offset"
+  | |     );
+  | |_____- in this macro invocation
+
+note: erroneous constant encountered
+ --> src/swizzle.rs
+  |
+  |         let () = Self::INVOLUTION;
+  |                  ^^^^^^^^^^^^^^^^

--- a/crates/cuda-device/tests/thread_index_safety.rs
+++ b/crates/cuda-device/tests/thread_index_safety.rs
@@ -9,4 +9,5 @@ fn thread_index_safety_compile_failures() {
     t.compile_fail("tests/compile_fail/thread_index_*.rs");
     t.compile_fail("tests/compile_fail/thread_coord_*.rs");
     t.compile_fail("tests/compile_fail/runtime_tile_*.rs");
+    t.compile_fail("tests/compile_fail/swizzle_*.rs");
 }

--- a/crates/rustc-codegen-cuda/examples/swizzle_smem/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/swizzle_smem/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "swizzle_smem"
+version = "0.1.0"
+edition = "2024"
+authors = ["Nihal Pasham <nihalp@nvidia.com>"]
+license = "Apache-2.0"
+
+# Mark as standalone crate (not part of parent workspace)
+[workspace]
+
+# This example demonstrates XOR-swizzled SharedArray indexing (swizzle module).
+# Build with:
+#   cargo oxide run swizzle_smem
+
+[dependencies]
+# Device-side intrinsics (thread indexing, barriers, SharedArray, swizzle, etc.)
+cuda-device = { path = "../../../cuda-device" }
+
+# Host-side utilities (CudaKernel trait, etc.)
+cuda-host = { path = "../../../cuda-host" }
+
+# Host-side CUDA runtime (with HMM support)
+cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/swizzle_smem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/swizzle_smem/src/main.rs
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Swizzled Shared Memory Example
+//!
+//! A 32x32 f32 tile transpose through shared memory, indexed via
+//! `Swizzle<5, 0, 5>` so both the row-wise store and the column-wise load
+//! are bank-conflict-free without padding the stride.
+//!
+//! Build and run with:
+//!   cargo oxide run swizzle_smem
+
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::{DisjointSlice, SharedArray, kernel, swizzle::Swizzle, thread};
+use cuda_host::cuda_module;
+
+/// Tile edge; the tile is DIM x DIM, one element per thread of a DIM x DIM block.
+const DIM: usize = 32;
+
+// =============================================================================
+// KERNELS
+// =============================================================================
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Transpose one 32x32 tile through a swizzled shared-memory staging buffer.
+    ///
+    /// The store writes rows and the load reads columns; with a stride-32 tile
+    /// the column read would serialise 32-way, so both sides go through
+    /// `Swizzle<5, 0, 5>`. The swizzle is its own inverse, so as long as both
+    /// sides use it, the data comes back out where it went in.
+    #[kernel]
+    pub fn swizzled_transpose(input: &[f32], mut output: DisjointSlice<f32, thread::Index2D<DIM>>) {
+        static mut TILE: SharedArray<f32, { DIM * DIM }> = SharedArray::UNINIT;
+
+        let tx = thread::threadIdx_x() as usize;
+        let ty = thread::threadIdx_y() as usize;
+
+        // Row-major store: lane index varies along the row (conflict-free even
+        // unswizzled; the swizzle must not spoil it).
+        unsafe {
+            TILE[Swizzle::<5, 0, 5>::apply(ty * DIM + tx)] = input[ty * DIM + tx];
+        }
+
+        thread::sync_threads();
+
+        // Column read: without the swizzle every lane of a warp would hit the
+        // same bank. Through the same swizzle it is conflict-free.
+        unsafe {
+            if let Some(idx) = thread::index_2d::<DIM>()
+                && let Some(out_elem) = output.get_mut(idx)
+            {
+                *out_elem = TILE[Swizzle::<5, 0, 5>::apply(tx * DIM + ty)];
+            }
+        }
+    }
+}
+
+// =============================================================================
+// HOST CODE
+// =============================================================================
+
+fn main() {
+    println!("=== Swizzled Shared Memory Example ===\n");
+
+    let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
+    let stream = ctx.default_stream();
+
+    const N: usize = DIM * DIM;
+
+    let module = ctx
+        .load_module_from_file("swizzle_smem.ptx")
+        .expect("Failed to load PTX module");
+    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+
+    let cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (DIM as u32, DIM as u32, 1),
+        shared_mem_bytes: 0,
+    };
+
+    let input_host: Vec<f32> = (0..N).map(|i| i as f32).collect();
+    let input_dev = DeviceBuffer::from_host(&stream, &input_host).unwrap();
+    let mut out_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
+
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.swizzled_transpose((stream).as_ref(), cfg, &input_dev, &mut out_dev) }
+        .expect("Kernel launch failed");
+
+    let out_result = out_dev.to_host_vec(&stream).unwrap();
+
+    // Verify: output is the transpose of input. Any swizzle mismatch between
+    // the store and the load scrambles the tile, so this checks the involution
+    // on device, not just the transpose.
+    for row in 0..DIM {
+        for col in 0..DIM {
+            let expected = input_host[col * DIM + row];
+            let got = out_result[row * DIM + col];
+            if (got - expected).abs() > 1e-5 {
+                eprintln!("Mismatch at ({row}, {col}): expected {expected}, got {got}");
+                std::process::exit(1);
+            }
+        }
+    }
+    println!("Output[0..5] = {:?}", &out_result[0..5]);
+    println!("✓ SUCCESS: swizzled shared-memory transpose is correct");
+}


### PR DESCRIPTION
The swizzle surface in this crate today selects a **hardware** pattern for an engine to apply during a transfer — `Tcgen05SwizzleMode`, the WGMMA descriptor fields. There is nothing for the SIMT path, where a kernel lays shared memory out itself and needs the index arithmetic. The book discusses bank conflicts in `advanced/shared-memory-and-synchronization.md` without giving users a way to compute them. This adds that.

## The problem, quantified

Shared memory is 32 banks of 4 bytes. A warp reading one column of a row-major tile whose row stride is a multiple of 32 elements puts every lane on the same bank:

```
column access, f32 tile      worst conflict   banks used
row stride 32                32-way            1 of 32
row stride 64                32-way            1 of 32
row stride 16                16-way            2 of 32
row stride 33 (padded)        1-way           32 of 32
```

Padding to 33 fixes it, wastes a column per row, and breaks the alignment that wide accesses need. The alternative is to *permute* rather than space out:

```
row stride 32 with a swizzle
Swizzle<5, 0, 5>              1-way           32 of 32
Swizzle<3, 0, 5>              4-way            8 of 32
Swizzle<2, 0, 5>              8-way            4 of 32
```

Five bits is exactly the 32 banks, so `Swizzle<5, 0, 5>` is the default worth reaching for. The tests pin this entire table, so the numbers cannot drift from the documentation.

## Why it is safe over a disjoint access pattern

A swizzle is not an affine function of the index digits, so the compact-layout reasoning used elsewhere in the crate says nothing about it directly. It composes anyway, for a simpler reason: `x ^ (((x >> S) & ((1 << B) - 1)) << M)` is a **bijection** on the index space, and applying a bijection to pairwise-disjoint indices leaves them pairwise disjoint. So swizzling a disjoint pattern cannot introduce aliasing. The only thing to get right is that reads and writes use the same swizzle.

Both properties are tested directly — bijection over a 1024-offset span, and self-inverse.

## The involution constraint is compile-enforced

`M + B <= S` is required. Without it the XOR target bits overlap the bits being read; it stays a bijection but stops being its own inverse, so a store and a load through it would disagree. A `const` assertion rejects the bad case:

```
error[E0080]: evaluation panicked: Swizzle<B, M, S> requires M + B <= S,
otherwise applying it twice does not restore the original offset
```

with a trybuild case pinning that rejection. The check earned its keep immediately — it rejected `Swizzle<5, 0, 4>` in my own first draft of the tests, which I had written assuming it was valid.

## Scope

Pure `const` index arithmetic: `bank_of`, `conflict_degree`, `banks_used`, `column_offsets`, `row_offsets`. It does not allocate, does not touch shared memory, and does not interact with the TMA/tcgen05 descriptor modes — those remain the right tool when the engine is doing the transfer. This is for the case where the kernel is doing it.

## Verification

`fmt --check`, `clippy --workspace --all-targets -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc`, and `cargo test -p cuda-device` clean on `nightly-2026-04-03`. The trybuild fixture was generated on that toolchain.
