### PR TITLE
docs: include llvm-tools in manual rustup install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ nix run github:NVlabs/cuda-oxide#new my-project   # bootstrap a project
 # Toolchain installed automatically via rust-toolchain.toml
 # Manual install if needed:
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev llvm-tools --toolchain nightly-2026-04-03
 ```
 
 #### CUDA

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -39,11 +39,13 @@ If you need to install manually:
 
 ```bash
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev llvm-tools --toolchain nightly-2026-04-03
 ```
 
-`rust-src` provides the standard library source for cross-compilation and
-`rustc-dev` exposes compiler internals that the codegen backend links against.
+`rust-src` provides the standard library source for cross-compilation,
+`rustc-dev` exposes compiler internals that the codegen backend links against,
+and `llvm-tools` installs the toolchain-bundled `llc` used for PTX generation
+(also required by `cargo oxide doctor`).
 
 ## Install CUDA
 

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -240,13 +240,14 @@ If you need to install it manually:
 
 ```bash
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev rust-analyzer --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev rust-analyzer llvm-tools --toolchain nightly-2026-04-03
 ```
 
-The two extra components are required by the codegen backend:
+These components are required by the codegen backend and doctor:
 
 - `rust-src` -- source of the Rust standard library, needed for cross-compiling to the NVPTX target.
 - `rustc-dev` -- compiler internals that the backend links against.
+- `llvm-tools` -- toolchain-bundled `llc` used to lower LLVM IR to PTX (doctor's floor check).
 
 ---
 
@@ -321,8 +322,8 @@ If everything is configured correctly, this compiles a Rust kernel to PTX, launc
 :::{tip}
 **Common issues:**
 
-- `No working llc-21 or llc-22 found on PATH` -- install LLVM 21+ (`sudo apt install llvm-21`), add `/usr/lib/llvm-21/bin` to your `PATH`, or set `CUDA_OXIDE_LLC=/usr/bin/llc-21`.
+- `No working llc-21 or llc-22 found on PATH` -- prefer `rustup component add llvm-tools --toolchain nightly-2026-04-03`, or install LLVM 21+ (`sudo apt install llvm-21`), add `/usr/lib/llvm-21/bin` to your `PATH`, or set `CUDA_OXIDE_LLC=/usr/bin/llc-21`.
 - `'stddef.h' file not found` when building host `cuda-bindings` -- install clang dev headers: `sudo apt install clang-21` (or `libclang-common-21-dev`).
 - `cuda.h not found` -- Set `CUDA_TOOLKIT_PATH` to your CUDA install root, or ensure `/usr/local/cuda/include/cuda.h` exists.
-- `rust-src component missing` -- Run `rustup component add rust-src --toolchain nightly-2026-04-03`.
+- `rust-src` / `llvm-tools` component missing -- Run `rustup component add rust-src llvm-tools --toolchain nightly-2026-04-03`.
 :::


### PR DESCRIPTION
## Summary
- Add `llvm-tools` to manual `rustup component add` commands in the book and root README.
- Note that doctor expects the toolchain-bundled `llc`.

Closes #549

## Test plan
- [x] Cross-checked against `DOCTOR_REQUIRED_COMPONENTS` / `rust-toolchain.toml`