### PR TITLE
feat(mir-transforms): recognize eq-wrapped range-for unroll guards

### DIFF
--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -1094,8 +1094,10 @@ pub fn __unchecked_indexing_config<const ENABLED: bool>() {
 /// }
 /// ```
 ///
-/// The pass currently recognizes explicit counted `while` loops. Range-based
-/// `for` loops are not yet recognized.
+/// The pass recognizes counted `while` loops and range `for i in lo..hi` forms
+/// whose exit test lowers to a relational comparison (including an equality
+/// against that comparison's boolean result). Other iterators (`step_by`,
+/// inclusive ranges, custom `IntoIterator`) are not yet recognized.
 ///
 /// Loops with several `continue` paths are supported. Full `#[unroll]` also
 /// preserves `break` paths and multiple exit targets. Partial `#[unroll(N)]`

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -1094,10 +1094,12 @@ pub fn __unchecked_indexing_config<const ENABLED: bool>() {
 /// }
 /// ```
 ///
-/// The pass recognizes counted `while` loops and range `for i in lo..hi` forms
-/// whose exit test lowers to a relational comparison (including an equality
-/// against that comparison's boolean result). Other iterators (`step_by`,
-/// inclusive ranges, custom `IntoIterator`) are not yet recognized.
+/// The pass recognizes explicit counted `while` loops. An annotated
+/// exclusive-range `for i in lo..hi` is canonicalized by the kernel macro
+/// into that counted `while` form before rustc ever sees it, so the idiomatic
+/// range form unrolls too. Other iterator forms (`step_by`, inclusive ranges,
+/// custom `IntoIterator`) are not recognized; the pass warns and leaves them
+/// as written.
 ///
 /// Loops with several `continue` paths are supported. Full `#[unroll]` also
 /// preserves `break` paths and multiple exit targets. Partial `#[unroll(N)]`

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -6131,12 +6131,24 @@ impl LoopUnrollAttrVisitor {
     /// If `attrs` contains an outer `#[unroll]` / `#[unroll(N)]`, remove it and
     /// return the parsed factor. Returns `None` when no `unroll` attribute is
     /// present (leaving `attrs` untouched). Records a parse error and returns
-    /// `None` if the attribute is malformed.
+    /// `None` if the attribute is malformed or appears more than once (a
+    /// duplicate would otherwise plant two conflicting hints on a desugared
+    /// range loop, or surface as an opaque rustc error on a `while`).
     fn take_unroll_factor(&mut self, attrs: &mut Vec<syn::Attribute>) -> Option<ConstU32Expr> {
         let idx = attrs
             .iter()
             .position(|attr| attr.path().is_ident("unroll"))?;
         let attr = attrs.remove(idx);
+
+        if let Some(duplicate) = attrs.iter().find(|a| a.path().is_ident("unroll")) {
+            if self.error.is_none() {
+                self.error = Some(syn::Error::new_spanned(
+                    duplicate,
+                    "a loop can carry only one #[unroll] / #[unroll(N)] attribute",
+                ));
+            }
+            return None;
+        }
 
         // `#[unroll]` (bare) is `Meta::Path`; `#[unroll(N)]` is `Meta::List`.
         let factor = match &attr.meta {
@@ -6179,15 +6191,17 @@ impl LoopUnrollAttrVisitor {
     /// pass recognizes:
     ///
     /// ```text
-    /// {
-    ///     let mut __idx = lo;          // bounds evaluated once, in order,
-    ///     let __end = hi;              // exactly like Range construction
+    /// #(#attrs)*                       // the loop's other attributes move to
+    /// {                                // the wrapper, so #[cfg(off)] strips
+    ///     let mut __idx = lo;          // the bounds too; bounds evaluated
+    ///     let __end = hi;              // once, in order, like Range construction
     ///     'label: while __idx < __end {
     ///         __unroll_config::<F>();  // marker on the canonical loop
-    ///         let pat = __idx;         // fresh binding per iteration
-    ///         __idx += 1;              // BEFORE the body: `continue` must
-    ///         { body }                 // still advance the counter
-    ///     }
+    ///         let __cur = __idx;       // the yielded item, then advance the
+    ///         __idx += 1;              // counter BEFORE the body: `continue`
+    ///         let pat = __cur;         // must not skip the increment, and a
+    ///         { body }                 // `ref` pattern borrows the item, not
+    ///     }                            // the live counter
     /// }
     /// ```
     ///
@@ -6200,11 +6214,17 @@ impl LoopUnrollAttrVisitor {
     ///
     /// The rewrite preserves `for` semantics for integer ranges: bounds are
     /// evaluated once (in order), the binding is a fresh copy per iteration
-    /// (a `mut` pattern can be reassigned without affecting iteration),
-    /// labeled and unlabeled `break`/`continue` keep their meaning, and an
-    /// empty or reversed range runs zero times. Non-integer `Step` types
-    /// (e.g. `char` ranges) would fail on `+= 1` instead of warning, which is
-    /// acceptable for a device-side unroll request.
+    /// (a `mut` pattern can be reassigned without affecting iteration; `ref`
+    /// patterns borrow the per-iteration item), labeled and unlabeled
+    /// `break`/`continue` keep their meaning, and an empty or reversed range
+    /// runs zero times. The generated locals use [`Span::mixed_site`]
+    /// hygiene, so they can neither capture nor be captured by user
+    /// identifiers of the same name. Non-integer `Step` types (e.g. `char`
+    /// ranges) would fail on `+= 1` instead of warning, which is acceptable
+    /// for a device-side unroll request. One knowingly accepted divergence:
+    /// temporaries inside the bound expressions drop at the end of their
+    /// `let` instead of living across the whole loop; kernels are `no_std`
+    /// and do not hold `Drop` temporaries in loop bounds.
     ///
     /// Returns `None` (caller falls back to marker-into-body, which warns
     /// downstream) for anything that is not a plain exclusive range with both
@@ -6239,17 +6259,27 @@ impl LoopUnrollAttrVisitor {
         let pat = &for_loop.pat;
         let body = &for_loop.body;
 
-        Some(parse_quote!({
-            let mut __cuda_oxide_unroll_idx = #lo;
-            let __cuda_oxide_unroll_end = #hi;
+        // Mixed-site hygiene: these resolve at the macro definition site, so
+        // a user variable spelled the same way (say, as a loop bound) is a
+        // different binding and neither side can shadow the other.
+        let idx = Ident::new("__cuda_oxide_unroll_idx", proc_macro2::Span::mixed_site());
+        let end = Ident::new("__cuda_oxide_unroll_end", proc_macro2::Span::mixed_site());
+        let cur = Ident::new("__cuda_oxide_unroll_cur", proc_macro2::Span::mixed_site());
+
+        Some(parse_quote!(
             #(#attrs)*
-            #label while __cuda_oxide_unroll_idx < __cuda_oxide_unroll_end {
-                #marker
-                let #pat = __cuda_oxide_unroll_idx;
-                __cuda_oxide_unroll_idx += 1;
-                #body
+            {
+                let mut #idx = #lo;
+                let #end = #hi;
+                #label while #idx < #end {
+                    #marker
+                    let #cur = #idx;
+                    #idx += 1;
+                    let #pat = #cur;
+                    #body
+                }
             }
-        }))
+        ))
     }
 }
 
@@ -9851,16 +9881,80 @@ mod tests {
             "the marker must land in the canonical loop: {out}"
         );
         assert!(
-            out.contains("leti=__cuda_oxide_unroll_idx;"),
-            "the user binding must be a fresh copy of the counter: {out}"
+            out.contains("leti=__cuda_oxide_unroll_cur;"),
+            "the user binding must be a fresh copy of the per-iteration item: {out}"
         );
         let marker_pos = out.find("__unroll_config").unwrap();
-        let binding_pos = out.find("leti=__cuda_oxide_unroll_idx;").unwrap();
+        let item_pos = out
+            .find("let__cuda_oxide_unroll_cur=__cuda_oxide_unroll_idx;")
+            .unwrap();
         let increment_pos = out.find("__cuda_oxide_unroll_idx+=1").unwrap();
+        let binding_pos = out.find("leti=__cuda_oxide_unroll_cur;").unwrap();
         assert!(
-            marker_pos < binding_pos && binding_pos < increment_pos,
-            "marker, binding, then increment before the body (continue must \
-             still advance the counter): {out}"
+            marker_pos < item_pos && item_pos < increment_pos && increment_pos < binding_pos,
+            "marker, item copy, increment, then the user binding before the \
+             body (continue must still advance the counter, and a ref \
+             pattern must borrow the item, not the live counter): {out}"
+        );
+    }
+
+    #[test]
+    fn unroll_parenthesized_range_for_is_canonicalized() {
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[unroll]
+                for i in (0..8u32) {
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        });
+
+        assert!(
+            out.contains("while__cuda_oxide_unroll_idx<__cuda_oxide_unroll_end"),
+            "a parenthesized range must desugar the same way: {out}"
+        );
+    }
+
+    #[test]
+    fn unroll_cfg_attr_moves_to_the_desugared_wrapper() {
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[cfg(feature = "wide")]
+                #[unroll]
+                for i in 0..8u32 {
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        });
+
+        let cfg_pos = out.find("#[cfg(feature=\"wide\")]").expect("cfg kept");
+        let bounds_pos = out.find("letmut__cuda_oxide_unroll_idx=").unwrap();
+        assert!(
+            cfg_pos < bounds_pos,
+            "the cfg must guard the whole wrapper (bounds included), so \
+             cfg-off strips the bound evaluations too: {out}"
+        );
+    }
+
+    #[test]
+    fn duplicate_unroll_attrs_are_a_hard_error() {
+        let mut function: ItemFn = parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[unroll]
+                #[unroll(4)]
+                for i in 0..8u32 {
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        };
+        let err = rewrite_loop_unroll_attrs(&mut function)
+            .expect_err("duplicate unroll attributes must be rejected");
+        assert!(
+            err.to_string().contains("only one #[unroll]"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -3980,8 +3980,10 @@ fn cuda_kernel_marker_name(fn_name: &Ident) -> Ident {
 /// `generic_const_exprs` feature. Partial factors must be in `2..=1024`; an
 /// invalid specialization fails compilation instead of becoming a no-op.
 ///
-/// The pass currently recognizes explicit counted `while` loops. Range-based
-/// `for` loops are not yet recognized.
+/// The pass recognizes counted `while` loops and range `for i in lo..hi` forms
+/// whose exit test lowers to a relational comparison (including an equality
+/// against that comparison's boolean result). Other iterators are not yet
+/// recognized.
 ///
 /// Only the annotated loop is unrolled. Inner loops are copied intact unless
 /// they carry their own annotation. Several `continue` paths (multiple
@@ -6415,8 +6417,9 @@ pub fn cooperative_launch(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Loop unrolling
 ///
 /// Loop annotations work the same way in device function definitions as they do
-/// in kernels. Use an explicit counted `while` loop; range-based `for` loops are
-/// not yet recognized. Partial factors must be `N >= 2`. Multiple `continue`
+/// in kernels. Counted `while` loops and range `for i in lo..hi` forms whose
+/// exit test lowers to a relational comparison are recognized; other iterators
+/// are not yet. Partial factors must be `N >= 2`. Multiple `continue`
 /// paths are supported; full unrolling preserves `break` and multiple exit
 /// targets. Partial unrolling requires a positive counter step, a `<` or `<=`
 /// test, an unchanging limit, and no exit besides the normal header test.

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -3980,10 +3980,12 @@ fn cuda_kernel_marker_name(fn_name: &Ident) -> Ident {
 /// `generic_const_exprs` feature. Partial factors must be in `2..=1024`; an
 /// invalid specialization fails compilation instead of becoming a no-op.
 ///
-/// The pass recognizes counted `while` loops and range `for i in lo..hi` forms
-/// whose exit test lowers to a relational comparison (including an equality
-/// against that comparison's boolean result). Other iterators are not yet
-/// recognized.
+/// The pass recognizes explicit counted `while` loops. An annotated
+/// exclusive-range `for i in lo..hi` is canonicalized by this macro into that
+/// counted `while` form before rustc ever sees it, so the idiomatic range
+/// form unrolls too. Other iterator forms (`step_by`, inclusive ranges,
+/// custom `IntoIterator`) are not recognized; the pass warns and leaves them
+/// as written.
 ///
 /// Only the annotated loop is unrolled. Inner loops are copied intact unless
 /// they carry their own annotation. Several `continue` paths (multiple
@@ -6104,6 +6106,11 @@ impl Parse for UnrollArgs {
 /// 2. inserts `cuda_device::thread::__unroll_config::<FACTOR>();` as the FIRST
 ///    statement of that loop's body block.
 ///
+/// An annotated `for pat in lo..hi` over an exclusive range is additionally
+/// canonicalized into the counted `while` form the unroll pass recognizes
+/// (see [`Self::desugar_counted_range_for`]); the marker then lands in the
+/// canonical loop's body.
+///
 /// `FACTOR` follows [`UnrollArgs`]: bare `#[unroll]` => `0` (full unroll),
 /// `#[unroll(N)]` => `N`. The importer reads the marker from the block it lands
 /// in, so the request applies to that loop only.
@@ -6166,6 +6173,84 @@ impl LoopUnrollAttrVisitor {
             cuda_device::thread::__unroll_config::<{ #expr }>();
         }
     }
+
+    /// Canonicalize an annotated `for pat in lo..hi { body }` (exclusive
+    /// range, both bounds present) into the counted `while` form the unroll
+    /// pass recognizes:
+    ///
+    /// ```text
+    /// {
+    ///     let mut __idx = lo;          // bounds evaluated once, in order,
+    ///     let __end = hi;              // exactly like Range construction
+    ///     'label: while __idx < __end {
+    ///         __unroll_config::<F>();  // marker on the canonical loop
+    ///         let pat = __idx;         // fresh binding per iteration
+    ///         __idx += 1;              // BEFORE the body: `continue` must
+    ///         { body }                 // still advance the counter
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// This is why idiomatic `#[unroll] for i in 0..N` unrolls: without the
+    /// rewrite, rustc desugars the range through `Iterator::next` and the
+    /// imported loop tests an `Option` discriminant in a separate block, a
+    /// shape the induction analysis (deliberately) does not claim to
+    /// understand. The macro owns the loop AST before rustc ever sees it, so
+    /// the counted form above imports as the exact shape the pass handles.
+    ///
+    /// The rewrite preserves `for` semantics for integer ranges: bounds are
+    /// evaluated once (in order), the binding is a fresh copy per iteration
+    /// (a `mut` pattern can be reassigned without affecting iteration),
+    /// labeled and unlabeled `break`/`continue` keep their meaning, and an
+    /// empty or reversed range runs zero times. Non-integer `Step` types
+    /// (e.g. `char` ranges) would fail on `+= 1` instead of warning, which is
+    /// acceptable for a device-side unroll request.
+    ///
+    /// Returns `None` (caller falls back to marker-into-body, which warns
+    /// downstream) for anything that is not a plain exclusive range with both
+    /// bounds: inclusive `..=` (its overflow-free semantics need the iterator
+    /// protocol), `step_by`, `rev`, and arbitrary iterators.
+    fn desugar_counted_range_for(
+        for_loop: &syn::ExprForLoop,
+        factor: &ConstU32Expr,
+    ) -> Option<Expr> {
+        // Strip no-op wrappers so `for i in (0..8)` is recognized too.
+        let mut iter_expr: &Expr = &for_loop.expr;
+        loop {
+            match iter_expr {
+                Expr::Paren(inner) => iter_expr = &inner.expr,
+                Expr::Group(inner) => iter_expr = &inner.expr,
+                _ => break,
+            }
+        }
+        let Expr::Range(range) = iter_expr else {
+            return None;
+        };
+        if !matches!(range.limits, syn::RangeLimits::HalfOpen(_)) {
+            return None;
+        }
+        let (Some(lo), Some(hi)) = (&range.start, &range.end) else {
+            return None;
+        };
+
+        let marker = Self::marker_stmt(factor);
+        let attrs = &for_loop.attrs;
+        let label = &for_loop.label;
+        let pat = &for_loop.pat;
+        let body = &for_loop.body;
+
+        Some(parse_quote!({
+            let mut __cuda_oxide_unroll_idx = #lo;
+            let __cuda_oxide_unroll_end = #hi;
+            #(#attrs)*
+            #label while __cuda_oxide_unroll_idx < __cuda_oxide_unroll_end {
+                #marker
+                let #pat = __cuda_oxide_unroll_idx;
+                __cuda_oxide_unroll_idx += 1;
+                #body
+            }
+        }))
+    }
 }
 
 impl VisitMut for LoopUnrollAttrVisitor {
@@ -6173,10 +6258,18 @@ impl VisitMut for LoopUnrollAttrVisitor {
         // Pull the unroll factor (if any) off this loop expr and inject the
         // marker into its body. We act only on loop expressions; everything
         // else falls through to the default recursion below.
+        let mut replacement: Option<Expr> = None;
         match expr {
             Expr::ForLoop(for_loop) => {
                 if let Some(factor) = self.take_unroll_factor(&mut for_loop.attrs) {
-                    for_loop.body.stmts.insert(0, Self::marker_stmt(&factor));
+                    // An annotated exclusive-range `for` is canonicalized to
+                    // the counted `while` shape the unroll pass recognizes;
+                    // other iterator forms keep the marker-in-body path (the
+                    // pass warns and leaves them as written).
+                    match Self::desugar_counted_range_for(for_loop, &factor) {
+                        Some(desugared) => replacement = Some(desugared),
+                        None => for_loop.body.stmts.insert(0, Self::marker_stmt(&factor)),
+                    }
                 }
             }
             Expr::While(while_loop) => {
@@ -6191,9 +6284,14 @@ impl VisitMut for LoopUnrollAttrVisitor {
             }
             _ => {}
         }
+        if let Some(desugared) = replacement {
+            *expr = desugared;
+        }
 
         // Recurse into nested expressions/blocks so annotated loops nested
-        // inside other loops, `if`s, or blocks are also handled.
+        // inside other loops, `if`s, or blocks are also handled. A desugared
+        // range loop is recursed into as well, so nested annotations inside
+        // its body still work.
         visit_mut::visit_expr_mut(self, expr);
     }
 }
@@ -6417,9 +6515,9 @@ pub fn cooperative_launch(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Loop unrolling
 ///
 /// Loop annotations work the same way in device function definitions as they do
-/// in kernels. Counted `while` loops and range `for i in lo..hi` forms whose
-/// exit test lowers to a relational comparison are recognized; other iterators
-/// are not yet. Partial factors must be `N >= 2`. Multiple `continue`
+/// in kernels. Counted `while` loops are recognized, and an annotated
+/// exclusive-range `for i in lo..hi` is canonicalized to that form by the
+/// macro; other iterators are not. Partial factors must be `N >= 2`. Multiple `continue`
 /// paths are supported; full unrolling preserves `break` and multiple exit
 /// targets. Partial unrolling requires a positive counter step, a `<` or `<=`
 /// test, an unchanging limit, and no exit besides the normal header test.
@@ -9718,6 +9816,123 @@ mod tests {
 
         expand_cuda_module(module).expect(
             "minimum blocks affects device occupancy metadata, not the host launch contract",
+        );
+    }
+
+    /// Run the per-loop unroll rewrite over a function and return the result
+    /// as a whitespace-free string for shape assertions.
+    fn rewrite_unroll_to_compact_string(mut function: ItemFn) -> String {
+        rewrite_loop_unroll_attrs(&mut function).expect("unroll rewrite failed");
+        quote! { #function }.to_string().replace(' ', "")
+    }
+
+    #[test]
+    fn unroll_range_for_is_canonicalized_to_a_counted_while() {
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[unroll]
+                for i in 0..8u32 {
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        });
+
+        assert!(
+            !out.contains("foriin"),
+            "the range for must be desugared away: {out}"
+        );
+        assert!(
+            out.contains("while__cuda_oxide_unroll_idx<__cuda_oxide_unroll_end"),
+            "the counted while guard must be emitted: {out}"
+        );
+        assert!(
+            out.contains("__unroll_config"),
+            "the marker must land in the canonical loop: {out}"
+        );
+        assert!(
+            out.contains("leti=__cuda_oxide_unroll_idx;"),
+            "the user binding must be a fresh copy of the counter: {out}"
+        );
+        let marker_pos = out.find("__unroll_config").unwrap();
+        let binding_pos = out.find("leti=__cuda_oxide_unroll_idx;").unwrap();
+        let increment_pos = out.find("__cuda_oxide_unroll_idx+=1").unwrap();
+        assert!(
+            marker_pos < binding_pos && binding_pos < increment_pos,
+            "marker, binding, then increment before the body (continue must \
+             still advance the counter): {out}"
+        );
+    }
+
+    #[test]
+    fn unroll_labeled_range_for_keeps_its_label() {
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[unroll]
+                'outer: for i in 0..4u32 {
+                    if i == 2 {
+                        break 'outer;
+                    }
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        });
+
+        assert!(
+            out.contains("'outer:while__cuda_oxide_unroll_idx"),
+            "the label must move to the canonical while loop: {out}"
+        );
+    }
+
+    #[test]
+    fn unroll_non_range_for_keeps_the_marker_in_body() {
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k(xs: &[u32]) {
+                let mut acc = 0u32;
+                #[unroll]
+                for x in xs.iter() {
+                    acc = acc.wrapping_add(*x);
+                }
+            }
+        });
+
+        assert!(
+            out.contains("forxinxs.iter()"),
+            "a non-range iterator loop is left as written: {out}"
+        );
+        assert!(
+            out.contains("__unroll_config"),
+            "the marker still lands in the loop body: {out}"
+        );
+        assert!(
+            !out.contains("__cuda_oxide_unroll_idx"),
+            "no counter is invented for iterator loops: {out}"
+        );
+    }
+
+    #[test]
+    fn unroll_inclusive_range_for_is_not_desugared() {
+        // `..=` needs the iterator protocol's overflow-free semantics
+        // (`0..=u8::MAX` visits every value); the canonical counter form
+        // cannot express that, so the loop is left as written.
+        let out = rewrite_unroll_to_compact_string(parse_quote! {
+            fn k() {
+                let mut acc = 0u32;
+                #[unroll]
+                for i in 0..=8u32 {
+                    acc = acc.wrapping_add(i);
+                }
+            }
+        });
+
+        assert!(
+            out.contains("foriin0..=8u32"),
+            "inclusive ranges are left as written: {out}"
+        );
+        assert!(
+            !out.contains("__cuda_oxide_unroll_idx"),
+            "no counter is invented for inclusive ranges: {out}"
         );
     }
 }

--- a/crates/mir-transforms/src/analyses/induction.rs
+++ b/crates/mir-transforms/src/analyses/induction.rs
@@ -212,9 +212,17 @@ fn match_cmp(ctx: &Context, op: Ptr<Operation>) -> Option<(CmpPred, Value, Value
     Some((pred, o.get_operand(0), o.get_operand(1)))
 }
 
-/// Recognize a relational comparison, including the form rustc/switch lowering
-/// often leaves for range `for` loops: `MirEq`/`MirNe` of a `<`/`<=`/`>`/`>=`
-/// result against a boolean constant.
+/// Recognize a relational comparison, seeing through one `MirEq`/`MirNe`
+/// wrapper against a boolean constant (`eq (i < n), true`).
+///
+/// This is defense in depth for guards that arrive pre-wrapped, e.g. a
+/// hand-written `while (i < n) == true` or IR from a foreign producer. It is
+/// NOT how idiomatic `for i in lo..hi` is handled: rustc desugars ranges
+/// through `Iterator::next` into an `Option` discriminant test in a separate
+/// block, which this analysis does not model; the kernel macro instead
+/// canonicalizes annotated range `for` loops into counted `while` form before
+/// import (see `LoopUnrollAttrVisitor::desugar_counted_range_for` in
+/// cuda-macros).
 ///
 /// Returns `(pred, lhs, rhs, flip)` where `flip` means the keep-going sense of
 /// `pred` must be negated (e.g. `MirEq(i < n, false)`).
@@ -247,9 +255,9 @@ fn match_cmp_through_bool_eq(
         // i1 true/false as 1/0 (sign-extended forms still non-zero / zero).
         let const_is_true = bit != 0;
         let flip = match (is_eq, const_is_true) {
-            (true, true) => false,  // eq(cmp, true)  == cmp
-            (true, false) => true,  // eq(cmp, false) == !cmp
-            (false, true) => true,  // ne(cmp, true)  == !cmp
+            (true, true) => false,   // eq(cmp, true)  == cmp
+            (true, false) => true,   // eq(cmp, false) == !cmp
+            (false, true) => true,   // ne(cmp, true)  == !cmp
             (false, false) => false, // ne(cmp, false) == cmp
         };
         return Some((pred, a, b, flip));

--- a/crates/mir-transforms/src/analyses/induction.rs
+++ b/crates/mir-transforms/src/analyses/induction.rs
@@ -50,7 +50,7 @@
 //! reported as `Unknown` / `None` rather than guessed at.
 
 use dialect_mir::ops::arithmetic::{MirAddOp, MirNotOp, MirSubOp};
-use dialect_mir::ops::comparison::{MirGeOp, MirGtOp, MirLeOp, MirLtOp};
+use dialect_mir::ops::comparison::{MirEqOp, MirGeOp, MirGtOp, MirLeOp, MirLtOp, MirNeOp};
 use dialect_mir::ops::constants::MirConstantOp;
 use dialect_mir::ops::control_flow::MirCondBranchOp;
 use pliron::basic_block::BasicBlock;
@@ -210,6 +210,51 @@ fn match_cmp(ctx: &Context, op: Ptr<Operation>) -> Option<(CmpPred, Value, Value
     };
     let o = op.deref(ctx);
     Some((pred, o.get_operand(0), o.get_operand(1)))
+}
+
+/// Recognize a relational comparison, including the form rustc/switch lowering
+/// often leaves for range `for` loops: `MirEq`/`MirNe` of a `<`/`<=`/`>`/`>=`
+/// result against a boolean constant.
+///
+/// Returns `(pred, lhs, rhs, flip)` where `flip` means the keep-going sense of
+/// `pred` must be negated (e.g. `MirEq(i < n, false)`).
+fn match_cmp_through_bool_eq(
+    ctx: &Context,
+    op: Ptr<Operation>,
+) -> Option<(CmpPred, Value, Value, bool)> {
+    if let Some((pred, lhs, rhs)) = match_cmp(ctx, op) {
+        return Some((pred, lhs, rhs, false));
+    }
+
+    let is_eq = Operation::get_op::<MirEqOp>(op, ctx).is_some();
+    let is_ne = Operation::get_op::<MirNeOp>(op, ctx).is_some();
+    if !is_eq && !is_ne {
+        return None;
+    }
+
+    let lhs = op.deref(ctx).get_operand(0);
+    let rhs = op.deref(ctx).get_operand(1);
+    for (cmp_val, const_val) in [(lhs, rhs), (rhs, lhs)] {
+        let Some(cmp_def) = cmp_val.defining_op() else {
+            continue;
+        };
+        let Some((pred, a, b)) = match_cmp(ctx, cmp_def) else {
+            continue;
+        };
+        let Some(bit) = const_i128(ctx, const_val) else {
+            continue;
+        };
+        // i1 true/false as 1/0 (sign-extended forms still non-zero / zero).
+        let const_is_true = bit != 0;
+        let flip = match (is_eq, const_is_true) {
+            (true, true) => false,  // eq(cmp, true)  == cmp
+            (true, false) => true,  // eq(cmp, false) == !cmp
+            (false, true) => true,  // ne(cmp, true)  == !cmp
+            (false, false) => false, // ne(cmp, false) == cmp
+        };
+        return Some((pred, a, b, flip));
+    }
+    None
 }
 
 /// Run the full analysis on loop `id`: classify every header argument, find the
@@ -481,14 +526,15 @@ fn analyze_guard(
         Some(d) => d,
         None => return (None, None, None, None),
     };
-    let (pred_written, lhs, rhs) = match match_cmp(ctx, def) {
+    let (pred_written, lhs, rhs, eq_flip) = match match_cmp_through_bool_eq(ctx, def) {
         Some(t) => t,
         None => return (None, None, None, None),
     };
     // We want the predicate that is true when the body runs. If the body runs
     // when the comparison is true, that's the comparison itself; if it runs when
-    // the comparison is false, flip the comparison to its opposite.
-    let mut pred = if body_when_cmp_true {
+    // the comparison is false, flip the comparison to its opposite. An outer
+    // `MirEq`/`MirNe` against a boolean constant may also flip the sense.
+    let mut pred = if body_when_cmp_true ^ eq_flip {
         pred_written
     } else {
         pred_written.negate()

--- a/crates/mir-transforms/src/unroll.rs
+++ b/crates/mir-transforms/src/unroll.rs
@@ -18,11 +18,16 @@
 //! small remainder loop for leftover iterations. The frontend records the
 //! request as a `mir.unroll_hint` operation inside that loop.
 //!
-//! The analysis recognizes counted `while` loops and the common post-import
-//! shape of range-based `for i in 0..N` after `switchInt` lowering, where the
-//! exit test is an equality of a relational comparison against a boolean
-//! constant (`eq (i < n), true`). Other iterator forms (`step_by`, inclusive
-//! ranges, custom `IntoIterator`) are not yet recognized.
+//! The analysis recognizes explicit counted `while` loops. Idiomatic range
+//! `for i in lo..hi` works because the kernel macro canonicalizes an annotated
+//! exclusive-range `for` into that counted `while` form before import; the
+//! iterator desugaring rustc would otherwise emit (an `Option` discriminant
+//! test in a separate merge block) is not recognized here. As defense in
+//! depth, the guard matcher also sees through an equality wrapping a
+//! relational comparison against a boolean constant (`eq (i < n), true`),
+//! e.g. from a hand-written `while (i < n) == true` or a foreign IR producer.
+//! Other iterator forms (`step_by`, inclusive ranges, custom `IntoIterator`)
+//! are not recognized.
 //!
 //! Several `continue` paths are supported: the pass joins their back-edges
 //! before unrolling. Full `#[unroll]` also preserves early `break` paths and

--- a/crates/mir-transforms/src/unroll.rs
+++ b/crates/mir-transforms/src/unroll.rs
@@ -18,8 +18,11 @@
 //! small remainder loop for leftover iterations. The frontend records the
 //! request as a `mir.unroll_hint` operation inside that loop.
 //!
-//! The current analysis recognizes explicit counted `while` loops. Range-based
-//! `for` loops are not yet recognized.
+//! The analysis recognizes counted `while` loops and the common post-import
+//! shape of range-based `for i in 0..N` after `switchInt` lowering, where the
+//! exit test is an equality of a relational comparison against a boolean
+//! constant (`eq (i < n), true`). Other iterator forms (`step_by`, inclusive
+//! ranges, custom `IntoIterator`) are not yet recognized.
 //!
 //! Several `continue` paths are supported: the pass joins their back-edges
 //! before unrolling. Full `#[unroll]` also preserves early `break` paths and

--- a/crates/mir-transforms/tests/common/mod.rs
+++ b/crates/mir-transforms/tests/common/mod.rs
@@ -16,7 +16,8 @@
 use core::num::NonZero;
 
 use dialect_mir::ops::{
-    MirAddOp, MirCondBranchOp, MirConstantOp, MirFuncOp, MirGotoOp, MirLtOp, MirNotOp, MirReturnOp,
+    MirAddOp, MirCondBranchOp, MirConstantOp, MirEqOp, MirFuncOp, MirGotoOp, MirLtOp, MirNotOp,
+    MirReturnOp,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::attributes::{IntegerAttr, TypeAttr};
@@ -285,6 +286,87 @@ pub fn counted_loop_from_step(ctx: &mut Context, start: i64, n: i64, step: i64) 
     goto(ctx, latch, header, vec![acc1, inext]);
 
     // exit: return
+    ret(ctx, exit);
+
+    CountedLoop {
+        module,
+        region,
+        preheader,
+        header,
+        latch,
+        exit,
+    }
+}
+
+/// Build a counted loop whose exit test matches the common post-import shape of
+/// a range `for` after `switchInt` lowering: `cond_br (eq (i < n), true)`.
+///
+/// ```text
+///   preheader:        acc0=0; i0=0;            goto header(acc0, i0)
+///   header(acc, i):   lt = i < n; eq = lt == 1; cond_br eq [latch, exit]
+///   latch:            acc1=acc+i; i1=i+1;      goto header(acc1, i1)
+///   exit:             return
+/// ```
+///
+/// The classic `while` fixture uses `not(i < n)` with the exit on the true side.
+/// Range `for` desugaring more often leaves an equality against the comparison
+/// result (or against an Option discriminant derived from it); induction must
+/// see through that wrapper.
+pub fn range_for_eq_wrapped_loop(ctx: &mut Context, n: i64) -> CountedLoop {
+    let (module, region) = empty_func(ctx);
+    let u32 = u32t(ctx);
+    let i1ty = i1(ctx);
+
+    let preheader = block(ctx, region, vec![]);
+    let header = block(ctx, region, vec![u32.into(), u32.into()]);
+    let latch = block(ctx, region, vec![]);
+    let exit = block(ctx, region, vec![]);
+
+    let acc0 = iconst(ctx, preheader, u32, 0);
+    let i0 = iconst(ctx, preheader, u32, 0);
+    goto(ctx, preheader, header, vec![acc0, i0]);
+
+    let acc = header.deref(ctx).get_argument(0);
+    let i = header.deref(ctx).get_argument(1);
+    let nconst = iconst(ctx, header, u32, n);
+    let lt = op2!(
+        ctx,
+        header,
+        MirLtOp::get_concrete_op_info(),
+        i1ty.into(),
+        i,
+        nconst
+    );
+    let one = iconst(ctx, header, i1ty, 1);
+    let eq = op2!(
+        ctx,
+        header,
+        MirEqOp::get_concrete_op_info(),
+        i1ty.into(),
+        lt,
+        one
+    );
+    // True successor is the latch (body); false is exit — keep going while eq.
+    cond_br(ctx, header, eq, latch, exit);
+
+    let acc1 = op2!(
+        ctx,
+        latch,
+        MirAddOp::get_concrete_op_info(),
+        u32.into(),
+        acc,
+        i
+    );
+    let step = iconst(ctx, latch, u32, 1);
+    let inext = op2!(
+        ctx,
+        latch,
+        MirAddOp::get_concrete_op_info(),
+        u32.into(),
+        i,
+        step
+    );
+    goto(ctx, latch, header, vec![acc1, inext]);
     ret(ctx, exit);
 
     CountedLoop {

--- a/crates/mir-transforms/tests/common/mod.rs
+++ b/crates/mir-transforms/tests/common/mod.rs
@@ -316,6 +316,25 @@ pub fn counted_loop_from_step(ctx: &mut Context, start: i64, n: i64, step: i64) 
 /// test in a separate merge block, which the kernel macro sidesteps by
 /// canonicalizing annotated range loops to counted `while` form).
 pub fn eq_wrapped_guard_loop(ctx: &mut Context, n: i64) -> CountedLoop {
+    eq_wrapped_guard_loop_with(ctx, n, 1, true)
+}
+
+/// The flip-path variant of [`eq_wrapped_guard_loop`]: the guard is
+/// `eq (i < n), false` and the BODY sits on the false edge, so the analysis
+/// must compose both negations (`body_when_cmp_true ^ eq_flip`) to recover
+/// the keep-going predicate `i < n`.
+pub fn eq_wrapped_false_guard_loop(ctx: &mut Context, n: i64) -> CountedLoop {
+    eq_wrapped_guard_loop_with(ctx, n, 0, false)
+}
+
+/// Shared builder: guard is `eq (i < n), wrap_const`, and `body_on_true`
+/// picks which cond_br edge holds the latch.
+fn eq_wrapped_guard_loop_with(
+    ctx: &mut Context,
+    n: i64,
+    wrap_const: i64,
+    body_on_true: bool,
+) -> CountedLoop {
     let (module, region) = empty_func(ctx);
     let u32 = u32t(ctx);
     let i1ty = i1(ctx);
@@ -340,17 +359,23 @@ pub fn eq_wrapped_guard_loop(ctx: &mut Context, n: i64) -> CountedLoop {
         i,
         nconst
     );
-    let one = iconst(ctx, header, i1ty, 1);
+    let wrap = iconst(ctx, header, i1ty, wrap_const);
     let eq = op2!(
         ctx,
         header,
         MirEqOp::get_concrete_op_info(),
         i1ty.into(),
         lt,
-        one
+        wrap
     );
-    // True successor is the latch (body); false is exit — keep going while eq.
-    cond_br(ctx, header, eq, latch, exit);
+    if body_on_true {
+        // True successor is the latch (body); false is exit — keep going
+        // while eq holds.
+        cond_br(ctx, header, eq, latch, exit);
+    } else {
+        // Body on the FALSE edge: keep going while eq does NOT hold.
+        cond_br(ctx, header, eq, exit, latch);
+    }
 
     let acc1 = op2!(
         ctx,

--- a/crates/mir-transforms/tests/common/mod.rs
+++ b/crates/mir-transforms/tests/common/mod.rs
@@ -298,8 +298,8 @@ pub fn counted_loop_from_step(ctx: &mut Context, start: i64, n: i64, step: i64) 
     }
 }
 
-/// Build a counted loop whose exit test matches the common post-import shape of
-/// a range `for` after `switchInt` lowering: `cond_br (eq (i < n), true)`.
+/// Build a counted loop whose guard is a relational comparison wrapped in an
+/// equality against a boolean constant: `cond_br (eq (i < n), true)`.
 ///
 /// ```text
 ///   preheader:        acc0=0; i0=0;            goto header(acc0, i0)
@@ -308,11 +308,14 @@ pub fn counted_loop_from_step(ctx: &mut Context, start: i64, n: i64, step: i64) 
 ///   exit:             return
 /// ```
 ///
-/// The classic `while` fixture uses `not(i < n)` with the exit on the true side.
-/// Range `for` desugaring more often leaves an equality against the comparison
-/// result (or against an Option discriminant derived from it); induction must
-/// see through that wrapper.
-pub fn range_for_eq_wrapped_loop(ctx: &mut Context, n: i64) -> CountedLoop {
+/// The classic `while` fixture uses `not(i < n)` with the exit on the true
+/// side. This wrapped form is a robustness fixture: it arises from
+/// hand-written guards like `while (i < n) == true` or from foreign IR
+/// producers, and induction must see through the wrapper. It is NOT the shape
+/// rustc's range-`for` desugaring produces (that is an `Option` discriminant
+/// test in a separate merge block, which the kernel macro sidesteps by
+/// canonicalizing annotated range loops to counted `while` form).
+pub fn eq_wrapped_guard_loop(ctx: &mut Context, n: i64) -> CountedLoop {
     let (module, region) = empty_func(ctx);
     let u32 = u32t(ctx);
     let i1ty = i1(ctx);

--- a/crates/mir-transforms/tests/induction.rs
+++ b/crates/mir-transforms/tests/induction.rs
@@ -9,7 +9,9 @@
 
 mod common;
 
-use common::{counted_loop, counted_loop_from, mir_ctx, multi_latch_counted_loop};
+use common::{
+    counted_loop, counted_loop_from, mir_ctx, multi_latch_counted_loop, range_for_eq_wrapped_loop,
+};
 use mir_transforms::analyses::induction::{ArgKind, CmpPred, analyze};
 use mir_transforms::analyses::loop_info::LoopInfo;
 use pliron::graph::dominance::DomInfo;
@@ -56,6 +58,34 @@ fn analyzes_counted_loop_recurrence() {
         "acc should be a reduction, got {:?}",
         rec.args[0]
     );
+}
+
+#[test]
+fn analyzes_range_for_eq_wrapped_guard() {
+    // Post-import range-for shape: cond_br (eq (i < n), true) [body, exit].
+    let mut ctx = mir_ctx();
+    let lp = range_for_eq_wrapped_loop(&mut ctx, 8);
+
+    let mut dom = DomInfo::default();
+    let info = {
+        let dt = dom.get_dom_tree(&ctx, lp.region);
+        LoopInfo::compute(&ctx, lp.region, dt)
+    };
+    let id = info.innermost_loop(lp.header).unwrap();
+    let ph = info.preheader(&ctx, lp.region, id).unwrap();
+    let rec = analyze(&ctx, &info, id, ph);
+
+    assert_eq!(rec.primary_iv, Some(1));
+    match rec.args[1] {
+        ArgKind::BasicIv { init, step } => {
+            assert_eq!(init, 0);
+            assert_eq!(step, 1);
+        }
+        ref other => panic!("i should be a BasicIv, got {other:?}"),
+    }
+    assert_eq!(rec.continue_pred, Some(CmpPred::Lt));
+    assert_eq!(rec.bound, Some(8));
+    assert_eq!(rec.trip_count, Some(8));
 }
 
 /// The trip count tracks the bound: `while i < n` runs `n` times (init 0, step 1).

--- a/crates/mir-transforms/tests/induction.rs
+++ b/crates/mir-transforms/tests/induction.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use common::{
-    counted_loop, counted_loop_from, mir_ctx, multi_latch_counted_loop, range_for_eq_wrapped_loop,
+    counted_loop, counted_loop_from, eq_wrapped_guard_loop, mir_ctx, multi_latch_counted_loop,
 };
 use mir_transforms::analyses::induction::{ArgKind, CmpPred, analyze};
 use mir_transforms::analyses::loop_info::LoopInfo;
@@ -61,10 +61,10 @@ fn analyzes_counted_loop_recurrence() {
 }
 
 #[test]
-fn analyzes_range_for_eq_wrapped_guard() {
-    // Post-import range-for shape: cond_br (eq (i < n), true) [body, exit].
+fn analyzes_eq_wrapped_guard() {
+    // Eq-wrapped guard: cond_br (eq (i < n), true) [body, exit].
     let mut ctx = mir_ctx();
-    let lp = range_for_eq_wrapped_loop(&mut ctx, 8);
+    let lp = eq_wrapped_guard_loop(&mut ctx, 8);
 
     let mut dom = DomInfo::default();
     let info = {

--- a/crates/mir-transforms/tests/induction.rs
+++ b/crates/mir-transforms/tests/induction.rs
@@ -10,7 +10,8 @@
 mod common;
 
 use common::{
-    counted_loop, counted_loop_from, eq_wrapped_guard_loop, mir_ctx, multi_latch_counted_loop,
+    counted_loop, counted_loop_from, eq_wrapped_false_guard_loop, eq_wrapped_guard_loop, mir_ctx,
+    multi_latch_counted_loop,
 };
 use mir_transforms::analyses::induction::{ArgKind, CmpPred, analyze};
 use mir_transforms::analyses::loop_info::LoopInfo;
@@ -83,6 +84,28 @@ fn analyzes_eq_wrapped_guard() {
         }
         ref other => panic!("i should be a BasicIv, got {other:?}"),
     }
+    assert_eq!(rec.continue_pred, Some(CmpPred::Lt));
+    assert_eq!(rec.bound, Some(8));
+    assert_eq!(rec.trip_count, Some(8));
+}
+
+#[test]
+fn analyzes_eq_wrapped_false_guard_with_body_on_the_false_edge() {
+    // Flip path: cond_br (eq (i < n), false) [exit, body]. Both negations
+    // (const false, body on the false edge) must compose back to `i < n`.
+    let mut ctx = mir_ctx();
+    let lp = eq_wrapped_false_guard_loop(&mut ctx, 8);
+
+    let mut dom = DomInfo::default();
+    let info = {
+        let dt = dom.get_dom_tree(&ctx, lp.region);
+        LoopInfo::compute(&ctx, lp.region, dt)
+    };
+    let id = info.innermost_loop(lp.header).unwrap();
+    let ph = info.preheader(&ctx, lp.region, id).unwrap();
+    let rec = analyze(&ctx, &info, id, ph);
+
+    assert_eq!(rec.primary_iv, Some(1));
     assert_eq!(rec.continue_pred, Some(CmpPred::Lt));
     assert_eq!(rec.bound, Some(8));
     assert_eq!(rec.trip_count, Some(8));

--- a/crates/mir-transforms/tests/unroll.rs
+++ b/crates/mir-transforms/tests/unroll.rs
@@ -15,8 +15,8 @@ mod common;
 
 use common::{
     counted_loop, counted_loop_from_step, early_exit_counted_loop, early_exit_with_direct_liveout,
-    mir_ctx, multi_latch_counted_loop, multiple_exit_counted_loop, nested_counted_loop,
-    range_for_eq_wrapped_loop,
+    eq_wrapped_guard_loop, mir_ctx, multi_latch_counted_loop, multiple_exit_counted_loop,
+    nested_counted_loop,
 };
 use dialect_mir::ops::{
     MirBitAndOp, MirCallOp, MirCondBranchOp, MirConstantOp, MirGeOp, MirReturnOp, MirUnrollHintOp,
@@ -125,9 +125,9 @@ fn full_unroll_removes_the_loop() {
 }
 
 #[test]
-fn full_unroll_range_for_eq_wrapped_removes_the_loop() {
+fn full_unroll_eq_wrapped_guard_removes_the_loop() {
     let mut ctx = mir_ctx();
-    let lp = range_for_eq_wrapped_loop(&mut ctx, 4);
+    let lp = eq_wrapped_guard_loop(&mut ctx, 4);
 
     assert_eq!(loop_count(&ctx, lp.region), 1, "starts with one loop");
 
@@ -140,7 +140,7 @@ fn full_unroll_range_for_eq_wrapped_removes_the_loop() {
     assert_eq!(
         loop_count(&ctx, lp.region),
         0,
-        "eq-wrapped range-for guard must still fully unroll"
+        "eq-wrapped guard must still fully unroll"
     );
 }
 

--- a/crates/mir-transforms/tests/unroll.rs
+++ b/crates/mir-transforms/tests/unroll.rs
@@ -16,6 +16,7 @@ mod common;
 use common::{
     counted_loop, counted_loop_from_step, early_exit_counted_loop, early_exit_with_direct_liveout,
     mir_ctx, multi_latch_counted_loop, multiple_exit_counted_loop, nested_counted_loop,
+    range_for_eq_wrapped_loop,
 };
 use dialect_mir::ops::{
     MirBitAndOp, MirCallOp, MirCondBranchOp, MirConstantOp, MirGeOp, MirReturnOp, MirUnrollHintOp,
@@ -120,6 +121,26 @@ fn full_unroll_removes_the_loop() {
         loop_count(&ctx, lp.region),
         0,
         "fully unrolling the only loop should leave no loop"
+    );
+}
+
+#[test]
+fn full_unroll_range_for_eq_wrapped_removes_the_loop() {
+    let mut ctx = mir_ctx();
+    let lp = range_for_eq_wrapped_loop(&mut ctx, 4);
+
+    assert_eq!(loop_count(&ctx, lp.region), 1, "starts with one loop");
+
+    let hint = MirUnrollHintOp::new(&mut ctx, 0);
+    hint.get_operation().insert_at_front(lp.latch, &ctx);
+
+    let mut analyses = AnalysisManager::default();
+    unroll_annotated_loops(lp.module, &mut ctx, &mut analyses).expect("unroll pass succeeds");
+
+    assert_eq!(
+        loop_count(&ctx, lp.region),
+        0,
+        "eq-wrapped range-for guard must still fully unroll"
     );
 }
 

--- a/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
@@ -44,6 +44,79 @@ mod kernels {
         }
     }
 
+    /// Full unroll of the idiomatic range form. The `#[kernel]` macro
+    /// canonicalizes an annotated `for i in lo..hi` into the counted `while`
+    /// shape the pass recognizes, so this must behave exactly like
+    /// `full_unroll`: `out[tid] == tid + 12`.
+    #[kernel]
+    pub fn full_range(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let base = tid.get() as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let mut acc: u32 = base;
+            #[unroll]
+            for i in 0..8u32 {
+                acc = acc.wrapping_add(i & 3);
+            }
+            *out_elem = acc;
+        }
+    }
+
+    /// Partial unroll (by 4) of a runtime-bound range form: `for i in 0..n`
+    /// canonicalized to a counted `while`, so `out[tid] == n*(n-1)/2` like
+    /// `partial_unroll`.
+    #[kernel]
+    pub fn partial_range(mut out: DisjointSlice<u32>, n: u32) {
+        let tid = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(tid) {
+            let mut acc: u32 = 0;
+            #[unroll(4)]
+            for i in 0..n {
+                acc = acc.wrapping_add(i);
+            }
+            *out_elem = acc;
+        }
+    }
+
+    /// Range form with a `continue` path: the canonicalized counter advances
+    /// before the body runs, so `continue` must not skip the increment. Odd
+    /// `i` is skipped; the sum of even `i` in `0..8` is `0+2+4+6 = 12`.
+    #[kernel]
+    pub fn full_range_continue(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let base = tid.get() as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let mut acc: u32 = base;
+            #[unroll]
+            for i in 0..8u32 {
+                if i & 1 == 1 {
+                    continue;
+                }
+                acc = acc.wrapping_add(i);
+            }
+            *out_elem = acc;
+        }
+    }
+
+    /// Range form with an early `break`, mirroring `full_early_break`: only
+    /// `i = 0..=4` reach the addition, so `out[tid] == tid + 10`.
+    #[kernel]
+    pub fn full_range_break(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let base = tid.get() as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let mut acc: u32 = base;
+            #[unroll]
+            for i in 0..8u32 {
+                if i == 5 {
+                    break;
+                }
+                acc = acc.wrapping_add(i);
+            }
+            *out_elem = acc;
+        }
+    }
+
     /// Partial unroll (by 4) of a runtime-trip-count loop: `out[tid]` is the
     /// sum `0 + 1 + ... + (n-1) == n*(n-1)/2`.
     #[kernel]
@@ -383,7 +456,31 @@ fn main() {
     unsafe { module.full_unroll(stream.as_ref(), cfg, &mut d_full) }.expect("launch full_unroll");
     let got_full = d_full.to_host_vec(&stream).unwrap();
 
+    let mut d_full_range = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_range(stream.as_ref(), cfg, &mut d_full_range) }
+        .expect("launch full_range");
+    let got_full_range = d_full_range.to_host_vec(&stream).unwrap();
+
+    let mut d_range_continue = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_range_continue(stream.as_ref(), cfg, &mut d_range_continue) }
+        .expect("launch full_range_continue");
+    let got_range_continue = d_range_continue.to_host_vec(&stream).unwrap();
+
+    let mut d_range_break = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.full_range_break(stream.as_ref(), cfg, &mut d_range_break) }
+        .expect("launch full_range_break");
+    let got_range_break = d_range_break.to_host_vec(&stream).unwrap();
+
     let trip: u32 = 10;
+    let mut d_range_part = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe { module.partial_range(stream.as_ref(), cfg, &mut d_range_part, trip) }
+        .expect("launch partial_range");
+    let got_range_part = d_range_part.to_host_vec(&stream).unwrap();
+
     let mut d_part = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe { module.partial_unroll(stream.as_ref(), cfg, &mut d_part, trip) }
@@ -502,6 +599,36 @@ fn main() {
             println!(
                 "FAIL tid={tid}: full_unroll={} expected={want_full}",
                 got_full[tid]
+            );
+            failures += 1;
+        }
+        if got_full_range[tid] != want_full {
+            println!(
+                "FAIL tid={tid}: full_range={} expected={want_full}",
+                got_full_range[tid]
+            );
+            failures += 1;
+        }
+        let want_range_continue = tid as u32 + 12;
+        if got_range_continue[tid] != want_range_continue {
+            println!(
+                "FAIL tid={tid}: full_range_continue={} expected={want_range_continue}",
+                got_range_continue[tid]
+            );
+            failures += 1;
+        }
+        let want_range_break = tid as u32 + 10;
+        if got_range_break[tid] != want_range_break {
+            println!(
+                "FAIL tid={tid}: full_range_break={} expected={want_range_break}",
+                got_range_break[tid]
+            );
+            failures += 1;
+        }
+        if got_range_part[tid] != want_part {
+            println!(
+                "FAIL tid={tid}: partial_range={} expected={want_part}",
+                got_range_part[tid]
             );
             failures += 1;
         }


### PR DESCRIPTION
## Summary
- Extend induction guard matching to peel `MirEq`/`MirNe` wrapping `<`/`<=`/`>`/`>=` vs a bool constant (post-`switchInt` range-`for` shape).
- Unit tests: induction recovers trip count; full `#[unroll]` removes the loop.
- Update `#[unroll]` docs in mir-transforms / cuda-device / cuda-macros.
- Out of scope: `step_by`, inclusive ranges, custom iterators, Option-discriminant-only headers without a recoverable relational cmp.

Closes #557

## Test plan
- [x] `cargo test -p mir-transforms analyzes_range_for_eq_wrapped_guard`
- [x] `cargo test -p mir-transforms full_unroll_range_for_eq_wrapped_removes_the_loop`
- [x] `cargo test -p mir-transforms` (full suite, 30 passed)