### PR TITLE
test(cuda-oxide-codegen): resolve ptxas through the toolkit contract

### DIFF
--- a/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
@@ -271,6 +271,31 @@ fn build_unused_helper(module: &mut CodegenModule) {
     });
 }
 
+/// Locate `ptxas`. Discovery order, mirroring the toolkit contract that
+/// `crates/cuda-bindings/build.rs` and `cargo oxide doctor`'s
+/// `cuda_toolkit_root` already implement:
+///
+/// 1. `CUDA_TOOLKIT_PATH`, then `CUDA_HOME` — first non-empty one wins
+/// 2. `/usr/local/cuda`, the conventional default prefix
+/// 3. bare `ptxas`, leaving resolution to `PATH`
+///
+/// Step 3 is what CI relies on, since the toolkit action puts `ptxas` on `PATH`.
+/// Steps 1 and 2 are what a local checkout relies on: the build scripts fully
+/// support a toolkit installed at any prefix, so this test should not be the one
+/// place that ignores where it was told the toolkit lives.
+fn find_ptxas() -> std::path::PathBuf {
+    ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
+        .iter()
+        .filter_map(|var| std::env::var(var).ok())
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| std::path::PathBuf::from(root).join("bin/ptxas"))
+        .chain(std::iter::once(std::path::PathBuf::from(
+            "/usr/local/cuda/bin/ptxas",
+        )))
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("ptxas"))
+}
+
 #[test]
 fn spine_add_kernel_emits_entry_and_validates() {
     let mut module = CodegenModule::new("spine_module").unwrap();
@@ -327,14 +352,10 @@ fn spine_add_kernel_emits_entry_and_validates() {
     let cubin_path = dir.join("spine.cubin");
     std::fs::write(&ptx_path, &ptx).unwrap();
 
-    let ptxas = if std::path::Path::new("/usr/local/cuda/bin/ptxas").exists() {
-        "/usr/local/cuda/bin/ptxas"
-    } else {
-        "ptxas"
-    };
+    let ptxas = find_ptxas();
     // Capture the Result before cleanup so the scratch dir is always removed,
     // even when ptxas is absent and `.output()` would otherwise panic.
-    let ptxas_result = std::process::Command::new(ptxas)
+    let ptxas_result = std::process::Command::new(&ptxas)
         .arg("-arch=sm_120")
         .arg("--compile-only")
         .arg(&ptx_path)
@@ -345,7 +366,14 @@ fn spine_add_kernel_emits_entry_and_validates() {
     // Cleanup before any assert or expect so the dir is reclaimed on all paths.
     let _ = std::fs::remove_dir_all(&dir);
 
-    let out = ptxas_result.expect("ptxas runs");
+    let out = ptxas_result.unwrap_or_else(|error| {
+        panic!(
+            "could not run {}: {error}\nThis test needs `ptxas` from a CUDA \
+             toolkit (no GPU required). Point CUDA_TOOLKIT_PATH or CUDA_HOME at \
+             the install root, or put `ptxas` on PATH.",
+            ptxas.display()
+        )
+    });
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
     assert!(
         out.status.success(),


### PR DESCRIPTION
## Summary

Fixes #566. `spine_kernel_ptx` located `ptxas` by probing a hardcoded
`/usr/local/cuda/bin/ptxas` and then falling back to bare `ptxas` on `PATH`,
never consulting `CUDA_TOOLKIT_PATH` or `CUDA_HOME`. A checkout whose toolkit
lives at any other prefix failed the workspace suite even with the variable
pointing straight at a working `ptxas`:

```
$ ls $CUDA_TOOLKIT_PATH/bin/ptxas
/home/user/cuda-13.3/bin/ptxas

$ cargo test -p cuda-oxide-codegen --test spine_kernel_ptx
ptxas runs: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Putting that same toolkit's `bin` on `PATH` made it pass unchanged, which
isolates discovery as the only cause.

## Why this is an inconsistency, not just bad luck

`CUDA_TOOLKIT_PATH` → `CUDA_HOME` → `/usr/local/cuda` is the contract the rest of
the repo already implements:

- `crates/cuda-bindings/build.rs` resolves `cuda.h` through it, and says so in
  its own failure message: *"Set CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA Toolkit
  install root; when neither is set, /usr/local/cuda is used."*
- `cargo oxide doctor`'s `cuda_toolkit_root` implements that precedence, with a
  doc comment noting it is kept in lockstep by hand with that build script.

This test implemented only the last step. `unit-tests.yml` even sets
`CUDA_TOOLKIT_PATH` for this job — the test ignored it and passed only because
`Jimver/cuda-toolkit` also puts `ptxas` on `PATH`.

To be clear on scope: **test-only.** No production discovery path is affected and
CI is correct today. The cost is local — `/usr/local/cuda` needs root, so a
user-prefix install is the normal arrangement on a shared or unprivileged
machine, and `ptxas` is CPU-only, making this exactly the kind of test that
should run there.

## Approach

Resolve in the documented order, with the bare-`ptxas` `PATH` fallback kept
**last** so CI behavior is unchanged, and blank values skipped so an empty
variable cannot shadow the later candidates.

The failure message now names the path tried and the variables that would fix
it. The previous raw `io::Error` named neither, and its `NotFound` reads as
easily as the PTX file being missing as `ptxas` itself:

```
could not run ptxas: No such file or directory (os error 2)
This test needs `ptxas` from a CUDA toolkit (no GPU required). Point
CUDA_TOOLKIT_PATH or CUDA_HOME at the install root, or put `ptxas` on PATH.
```

## Verification

No GPU required. Toolkit at `~/cuda-13.3`, nothing at `/usr/local/cuda`:

| Case | Result |
| --- | --- |
| `CUDA_TOOLKIT_PATH` only | passes (**was failing**) |
| `CUDA_HOME` only | passes |
| neither set, `ptxas` on `PATH` (current CI shape) | passes |
| `CUDA_TOOLKIT_PATH="  "` + `ptxas` on `PATH` | passes — blank does not shadow |
| nothing anywhere | fails with the actionable message above |

`cargo fmt` and `cargo clippy -p cuda-oxide-codegen --all-targets` are clean.
