### PR TITLE
feat(cargo-oxide): expose the device debug policy as --lineinfo / --device-debug

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -63,6 +63,8 @@ cargo oxide update --force          # inside the workspace, run setup via update
 | `-v, --verbose`              | run, sanitize, build, test, emit-ltoir, inspect | Show detailed compilation output           |
 | `--no-fmad`                  | run, sanitize, build, test, emit-ltoir, pipeline, inspect | Keep ordinary multiply and add/subtract operations separate |
 | `--unchecked-indexing`       | run, sanitize, build, test, emit-ltoir, pipeline, inspect | Elide device slice/array bounds checks (UB on OOB) |
+| `--lineinfo`                 | run, sanitize, build, test, emit-ltoir, pipeline, inspect | Emit device line-number info for profilers (nvcc `-lineinfo`) |
+| `--device-debug`             | run, sanitize, build, test, emit-ltoir, pipeline, inspect | Emit full device debug info; disables libNVVM optimization (nvcc `-G`) |
 | `--force`                    | update                           | Inside the workspace, run `setup` instead of advising it |
 | `--async`                    | new                              | Use the async template                          |
 | `--cgdb`                     | debug                            | Use cgdb instead of cuda-gdb                    |
@@ -82,6 +84,20 @@ For NVVM IR and LTOIR, cuda-oxide records the policy in matching `.options`
 and versioned `.target` files and passes `-fma=0` through libNVVM and
 nvJitLink. Keep both sidecars with the artifact when another build system
 consumes it.
+
+`--lineinfo` and `--device-debug` select the device debug policy, mirroring nvcc's
+`-lineinfo` and `-G`. `--lineinfo` preserves source line mappings with optimization
+intact and reaches nvJitLink as `-lineinfo`; `--device-debug` emits full debug
+information and additionally passes `-g` with `-opt=0` to libNVVM, so device
+optimization is disabled. Asking for both yields full debug, because full debug
+already carries line tables.
+
+Both are equivalent to `CUDA_OXIDE_DEBUG=line` and `CUDA_OXIDE_DEBUG=full`, and an
+explicit flag outranks that variable. Omitting the flags exports nothing rather than
+`off`, so an absent flag never cancels a debug level the environment or
+`cuda-oxide.toml` already requested. Because the policy changes what the CUDA compiler
+stages are asked to do, it participates in the codegen fingerprint: switching it
+rebuilds device code instead of reusing artifacts compiled under a different policy.
 
 `--materialize-cubin` moves the remaining libNVVM and nvJitLink work into the
 host build. The executable embeds a native cubin, so deployment does not need

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -972,6 +972,7 @@ pub fn codegen_run(
     bin: Option<&str>,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     materialize_cubin: bool,
     app_args: &[String],
 ) {
@@ -1071,12 +1072,20 @@ pub fn codegen_run(
         cmd.arg("--").args(app_args);
     }
 
-    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad, unchecked_indexing);
+    apply_common_codegen_env(
+        &mut cmd,
+        ctx,
+        verbose,
+        no_fmad,
+        unchecked_indexing,
+        device_debug,
+    );
     let fingerprint = standard_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         emit_nvvm_ir,
         target_arch,
         detected_device_arch.as_deref(),
@@ -1125,6 +1134,7 @@ pub fn codegen_sanitize(
     bin: Option<&str>,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     materialize_cubin: bool,
 ) {
     let example_dir = if ctx.is_workspace {
@@ -1201,6 +1211,7 @@ pub fn codegen_sanitize(
         bin,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         &materialization,
     );
     run_compute_sanitizer(
@@ -1450,6 +1461,7 @@ fn build_interop_device_crate(
         verbose,
         options.no_fmad,
         options.unchecked_indexing,
+        DeviceDebug::Off,
         arch,
         detected_device_arch,
         &ptx_dir,
@@ -1557,6 +1569,7 @@ fn codegen_build_host_binary(
     bin: Option<&str>,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     materialization: &MaterializationMode,
 ) -> PathBuf {
     let mut cmd = Command::new("cargo");
@@ -1569,13 +1582,21 @@ fn codegen_build_host_binary(
         cmd.args(["--features", features]);
     }
 
-    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad, unchecked_indexing);
+    apply_common_codegen_env(
+        &mut cmd,
+        ctx,
+        verbose,
+        no_fmad,
+        unchecked_indexing,
+        device_debug,
+    );
     apply_default_sanitizer_line_tables(&mut cmd, ctx);
     let fingerprint = sanitize_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         arch,
         detected_device_arch,
         None,
@@ -2150,6 +2171,7 @@ pub fn codegen_build(
     features: Option<&str>,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     materialize_cubin: bool,
 ) {
     let target_arch = configured_arch(ctx, arch);
@@ -2195,12 +2217,20 @@ pub fn codegen_build(
         cmd.args(["--features", features]);
     }
 
-    apply_common_codegen_env(&mut cmd, ctx, verbose, no_fmad, unchecked_indexing);
+    apply_common_codegen_env(
+        &mut cmd,
+        ctx,
+        verbose,
+        no_fmad,
+        unchecked_indexing,
+        device_debug,
+    );
     let fingerprint = standard_codegen_fingerprint(
         ctx,
         verbose,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         emit_nvvm_ir,
         target_arch,
         None,
@@ -2239,6 +2269,7 @@ pub fn codegen_inspect_ptx(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
 ) {
     let materialization_enabled = materialization_requested(ctx, false).unwrap_or_else(|error| {
         eprintln!("Error: {error}");
@@ -2269,6 +2300,7 @@ pub fn codegen_inspect_ptx(
         features,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         false,
     );
 
@@ -2313,6 +2345,7 @@ pub fn emit_ltoir(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
 ) {
     let example_dir = if ctx.is_workspace {
         resolve_example_dir(ctx, example)
@@ -2347,6 +2380,7 @@ pub fn emit_ltoir(
         features,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         false,
     );
 
@@ -2495,6 +2529,53 @@ fn finalization_options_from_artifact(
         .with_debug_policy(debug)
 }
 
+/// Device debug-information policy requested on the command line.
+///
+/// Mirrors nvcc: `--lineinfo` is `-lineinfo` (line tables, optimization intact)
+/// and `--device-debug` is `-G` (full debug, libNVVM optimization disabled).
+/// The two are ordered, not exclusive: asking for both yields [`Self::Full`],
+/// because full debug already carries line tables.
+///
+/// This is the CLI surface for a policy that already exists end to end --
+/// `CUDA_OXIDE_DEBUG`, `ArtifactCompileOptions`'s debug bits, and
+/// `FinalizationOptions::with_debug_policy` all predate it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DeviceDebug {
+    /// Request no device debug information (the default).
+    #[default]
+    Off,
+    /// Preserve source line mappings without disabling optimization.
+    LineTables,
+    /// Emit full debug information; libNVVM finalization runs unoptimized.
+    Full,
+}
+
+impl DeviceDebug {
+    /// Resolve the two independent CLI booleans into one ordered policy.
+    #[must_use]
+    pub fn from_flags(lineinfo: bool, device_debug: bool) -> Self {
+        match (device_debug, lineinfo) {
+            (true, _) => Self::Full,
+            (false, true) => Self::LineTables,
+            (false, false) => Self::Off,
+        }
+    }
+
+    /// Value for `CUDA_OXIDE_DEBUG`, or `None` when nothing must be exported.
+    ///
+    /// `Off` deliberately returns `None` rather than `"off"`: exporting `off`
+    /// would override a debug level the surrounding environment had already
+    /// asked for, turning an absent flag into an active opt-out.
+    #[must_use]
+    pub fn env_value(self) -> Option<&'static str> {
+        match self {
+            Self::Off => None,
+            Self::LineTables => Some("line"),
+            Self::Full => Some("full"),
+        }
+    }
+}
+
 /// Options for `cargo oxide build -- ...` / `cargo oxide test -- ...`.
 #[derive(Clone, Copy)]
 pub struct CargoPassthroughOptions<'a> {
@@ -2508,6 +2589,7 @@ pub struct CargoPassthroughOptions<'a> {
     pub no_fmad: bool,
     pub unchecked_indexing: bool,
     pub materialize_cubin: bool,
+    pub device_debug: DeviceDebug,
 }
 
 /// Cargo operations supported by the passthrough path.
@@ -2679,6 +2761,9 @@ fn passthrough_codegen_fingerprint_with_env(
     if opts.unchecked_indexing {
         effective_env.insert("CUDA_OXIDE_UNCHECKED_INDEXING".to_string(), b"1".to_vec());
     }
+    if let Some(level) = opts.device_debug.env_value() {
+        effective_env.insert("CUDA_OXIDE_DEBUG".to_string(), level.as_bytes().to_vec());
+    }
     if opts.emit_nvvm_ir || materialization.enabled() {
         effective_env.insert("CUDA_OXIDE_EMIT_NVVM_IR".to_string(), b"1".to_vec());
     }
@@ -2735,6 +2820,7 @@ fn sanitize_codegen_fingerprint(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     target_arch: Option<&str>,
     detected_device_arch: Option<&str>,
     ptx_dir: Option<&Path>,
@@ -2745,6 +2831,7 @@ fn sanitize_codegen_fingerprint(
         verbose,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         target_arch,
         detected_device_arch,
         ptx_dir,
@@ -2761,6 +2848,7 @@ fn sanitize_codegen_fingerprint_with_env(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     target_arch: Option<&str>,
     detected_device_arch: Option<&str>,
     ptx_dir: Option<&Path>,
@@ -2778,6 +2866,7 @@ fn sanitize_codegen_fingerprint_with_env(
         no_fmad,
         unchecked_indexing,
         materialize_cubin: materialization.enabled(),
+        device_debug,
     };
     let base = passthrough_codegen_fingerprint_with_env(
         ctx,
@@ -2807,6 +2896,7 @@ fn standard_codegen_fingerprint(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     emit_nvvm_ir: bool,
     target_arch: Option<&str>,
     detected_device_arch: Option<&str>,
@@ -2823,6 +2913,7 @@ fn standard_codegen_fingerprint(
         no_fmad,
         unchecked_indexing,
         materialize_cubin: materialization.enabled(),
+        device_debug,
     };
     let base = passthrough_codegen_fingerprint(ctx, &opts, None, target_arch, materialization);
     let mut hash = sha2::Sha256::new();
@@ -2840,6 +2931,7 @@ fn pipeline_codegen_fingerprint(
     ctx: &Context,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     emit_nvvm_ir: bool,
     target_arch: Option<&str>,
     materialization: &MaterializationMode,
@@ -2849,6 +2941,7 @@ fn pipeline_codegen_fingerprint(
         true,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         emit_nvvm_ir,
         target_arch,
         None,
@@ -2872,6 +2965,7 @@ fn interop_codegen_fingerprint(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     target_arch: Option<&str>,
     detected_device_arch: Option<&str>,
     ptx_dir: &Path,
@@ -2883,6 +2977,7 @@ fn interop_codegen_fingerprint(
         verbose,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         false,
         target_arch,
         detected_device_arch,
@@ -2976,6 +3071,7 @@ fn cargo_passthrough_command(
         opts.verbose,
         opts.no_fmad,
         opts.unchecked_indexing,
+        opts.device_debug,
     );
     apply_codegen_configuration(
         &mut cmd,
@@ -3059,6 +3155,7 @@ pub fn codegen_cargo_passthrough(
 /// `dialect-mir` module (pre- and post-`mem2reg`), the LLVM dialect
 /// module, textual LLVM IR, and the final PTX or NVVM IR. After the build,
 /// generated artifacts are printed to stdout.
+#[allow(clippy::too_many_arguments)]
 pub fn codegen_show_pipeline(
     ctx: &Context,
     example: &str,
@@ -3066,6 +3163,7 @@ pub fn codegen_show_pipeline(
     arch: Option<&str>,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
     materialize_cubin: bool,
 ) {
     let target_arch = configured_arch(ctx, arch);
@@ -3128,6 +3226,7 @@ pub fn codegen_show_pipeline(
         ctx,
         no_fmad,
         unchecked_indexing,
+        device_debug,
         emit_nvvm_ir,
         target_arch,
         &materialization,
@@ -3258,6 +3357,7 @@ pub fn codegen_debug(
         false,
         false,
         false,
+        DeviceDebug::Off,
         false,
         target_arch,
         detected_device_arch.as_deref(),
@@ -5170,6 +5270,7 @@ fn apply_common_codegen_env(
     verbose: bool,
     no_fmad: bool,
     unchecked_indexing: bool,
+    device_debug: DeviceDebug,
 ) {
     apply_config_env(cmd, ctx);
     if verbose {
@@ -5180,6 +5281,13 @@ fn apply_common_codegen_env(
     }
     if unchecked_indexing {
         cmd.env("CUDA_OXIDE_UNCHECKED_INDEXING", "1");
+    }
+    // An explicit flag outranks an ambient `CUDA_OXIDE_DEBUG`, matching how
+    // `--no-fmad` outranks `CUDA_OXIDE_NO_FMA`. `DeviceDebug::Off` exports
+    // nothing rather than `off`, so omitting the flag cannot silently cancel a
+    // debug level the environment or project config already asked for.
+    if let Some(level) = device_debug.env_value() {
+        cmd.env("CUDA_OXIDE_DEBUG", level);
     }
     apply_ld_library_path(cmd, ctx);
 }
@@ -5241,6 +5349,7 @@ fn apply_interop_device_codegen_options_with_env(
         verbose,
         options.no_fmad,
         options.unchecked_indexing,
+        DeviceDebug::Off,
     );
     if options.sanitizer_line_tables {
         apply_default_sanitizer_line_tables_with_env(cmd, ctx, env_debug_set);
@@ -6154,7 +6263,14 @@ mod tests {
         });
         let discovery = materializer_discovery_command(&ctx, Path::new("/fake/cargo-oxide"));
         let mut rustc_child = Command::new("cargo");
-        apply_common_codegen_env(&mut rustc_child, &ctx, false, false, false);
+        apply_common_codegen_env(
+            &mut rustc_child,
+            &ctx,
+            false,
+            false,
+            false,
+            DeviceDebug::Off,
+        );
 
         for key in [
             "CUDA_OXIDE_LIBDEVICE",
@@ -6983,6 +7099,7 @@ path = "src/other.rs"
             false,
             true,
             false,
+            DeviceDebug::Off,
             Some("sm_80"),
             None,
             Some(Path::new("/tmp/generated-ptx")),
@@ -7061,6 +7178,7 @@ path = "src/other.rs"
                 false,
                 no_fmad,
                 unchecked_indexing,
+                DeviceDebug::Off,
                 target_arch,
                 detected_device_arch,
                 ptx_dir,
@@ -7097,6 +7215,7 @@ path = "src/other.rs"
             true,
             false,
             false,
+            DeviceDebug::Off,
             false,
             Some("sm_86"),
             None,
@@ -7106,6 +7225,7 @@ path = "src/other.rs"
             &ctx,
             false,
             false,
+            DeviceDebug::Off,
             false,
             Some("sm_86"),
             &materialization,
@@ -7232,6 +7352,7 @@ path = "src/other.rs"
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
         for cargo_args in [
             vec!["--release".to_string()],
@@ -7688,6 +7809,7 @@ MY_OK = "1"
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
         let cargo_args = vec![
             "-p".to_string(),
@@ -7770,6 +7892,7 @@ MY_OK = "1"
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
 
         let cmd =
@@ -7796,6 +7919,7 @@ MY_OK = "1"
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
         let base_cmd =
             cargo_passthrough_command(&ctx, CargoPassthroughSubcommand::Build, &base, &[]).unwrap();
@@ -7942,6 +8066,7 @@ device-owner = { path = "../device-owner" }
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
 
         let cold = cargo_artifact_freshness(&ctx, &base, None);
@@ -8039,6 +8164,7 @@ device-owner = { path = "../device-owner" }
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
         let inherited_env = BTreeMap::new();
         let base_hash = passthrough_codegen_fingerprint_with_env(
@@ -8171,6 +8297,7 @@ device-owner = { path = "../device-owner" }
             no_fmad: false,
             unchecked_indexing: false,
             materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
         };
         let fingerprint = |inherited_env: &BTreeMap<String, Vec<u8>>| {
             passthrough_codegen_fingerprint_with_env(
@@ -8273,7 +8400,7 @@ device-owner = { path = "../device-owner" }
             ..OxideConfig::default()
         });
         let mut cmd = Command::new("cargo");
-        apply_common_codegen_env(&mut cmd, &ctx, false, false, false);
+        apply_common_codegen_env(&mut cmd, &ctx, false, false, false, DeviceDebug::Off);
         cmd.env("CUDA_OXIDE_PTX_DIR", "internal-ptx");
         assert_eq!(
             command_env(&cmd, "CUDA_OXIDE_PTX_DIR").as_deref(),
@@ -9367,5 +9494,63 @@ edition = "2024"
                 "scaffold .gitignore must ignore clean suffix `{suffix}`"
             );
         }
+    }
+
+    #[test]
+    fn device_debug_env_value_matches_the_backend_parser() {
+        // These must be strings `device_debug_kind_with_override` accepts; a typo
+        // would silently fall through to the profile-derived default instead of
+        // failing, so pin them.
+        assert_eq!(DeviceDebug::Off.env_value(), None);
+        assert_eq!(DeviceDebug::LineTables.env_value(), Some("line"));
+        assert_eq!(DeviceDebug::Full.env_value(), Some("full"));
+    }
+
+    #[test]
+    fn passthrough_fingerprint_separates_the_device_debug_policies() {
+        let ctx = test_context(OxideConfig::default());
+        let base = CargoPassthroughOptions {
+            verbose: false,
+            emit_nvvm_ir: false,
+            arch: None,
+            features: None,
+            cargo_target_dir: None,
+            device_codegen_crate: None,
+            device_cfgs: &[],
+            no_fmad: false,
+            unchecked_indexing: false,
+            materialize_cubin: false,
+            device_debug: DeviceDebug::Off,
+        };
+        let line_tables = CargoPassthroughOptions {
+            device_debug: DeviceDebug::LineTables,
+            ..base
+        };
+        let full = CargoPassthroughOptions {
+            device_debug: DeviceDebug::Full,
+            ..base
+        };
+        let materialization = MaterializationMode::default();
+        // Empty inherited env, for the same reason as the sibling fingerprint
+        // tests: an ambient CUDA_OXIDE_DEBUG is folded in on its own, which would
+        // collapse these onto the base.
+        let inherited_env = BTreeMap::new();
+        let fp = |opts: &CargoPassthroughOptions<'_>| {
+            passthrough_codegen_fingerprint_with_env(
+                &ctx,
+                opts,
+                None,
+                None,
+                &materialization,
+                &inherited_env,
+            )
+        };
+        // The policy changes what libNVVM and nvJitLink are asked to do (`-g`,
+        // `-opt=0`, `-lineinfo`), so it must not share a fingerprint with the
+        // default -- otherwise Cargo reuses artifacts built without it.
+        let off = fp(&base);
+        assert_ne!(off, fp(&line_tables));
+        assert_ne!(off, fp(&full));
+        assert_ne!(fp(&line_tables), fp(&full));
     }
 }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -3248,6 +3248,9 @@ pub fn codegen_show_pipeline(
     if unchecked_indexing {
         cmd.env("CUDA_OXIDE_UNCHECKED_INDEXING", "1");
     }
+    if let Some(level) = device_debug.env_value() {
+        cmd.env("CUDA_OXIDE_DEBUG", level);
+    }
 
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
     apply_ld_library_path(&mut cmd, ctx);

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -1590,7 +1590,7 @@ fn codegen_build_host_binary(
         unchecked_indexing,
         device_debug,
     );
-    apply_default_sanitizer_line_tables(&mut cmd, ctx);
+    apply_default_sanitizer_line_tables(&mut cmd, ctx, device_debug);
     let fingerprint = sanitize_codegen_fingerprint(
         ctx,
         verbose,
@@ -5297,12 +5297,20 @@ fn apply_common_codegen_env(
 
 /// Give Compute Sanitizer source line attribution without disabling normal
 /// device optimization. An explicit process or project setting remains
-/// authoritative, including an intentional `CUDA_OXIDE_DEBUG=off`.
-fn apply_default_sanitizer_line_tables(cmd: &mut Command, ctx: &Context) {
+/// authoritative, including an intentional `CUDA_OXIDE_DEBUG=off`. So does an
+/// explicit `--lineinfo` / `--device-debug` flag: `apply_common_codegen_env`
+/// has already exported its level onto `cmd`, and the default must not
+/// overwrite it.
+fn apply_default_sanitizer_line_tables(
+    cmd: &mut Command,
+    ctx: &Context,
+    device_debug: DeviceDebug,
+) {
     apply_default_sanitizer_line_tables_with_env(
         cmd,
         ctx,
         std::env::var_os("CUDA_OXIDE_DEBUG").is_some(),
+        device_debug,
     );
 }
 
@@ -5311,13 +5319,19 @@ fn apply_default_sanitizer_line_tables(cmd: &mut Command, ctx: &Context) {
 ///
 /// `env_debug_set` is presence-only, matching the `var_os` check it replaces.
 /// Injected so a unit test can assert the defaulting without an exported
-/// `CUDA_OXIDE_DEBUG` suppressing it.
+/// `CUDA_OXIDE_DEBUG` suppressing it. `device_debug` carries the CLI flag:
+/// any level other than [`DeviceDebug::Off`] is an explicit request that
+/// outranks the line-tables default.
 fn apply_default_sanitizer_line_tables_with_env(
     cmd: &mut Command,
     ctx: &Context,
     env_debug_set: bool,
+    device_debug: DeviceDebug,
 ) {
-    if !env_debug_set && project_config_env(ctx, "CUDA_OXIDE_DEBUG").is_none() {
+    if device_debug == DeviceDebug::Off
+        && !env_debug_set
+        && project_config_env(ctx, "CUDA_OXIDE_DEBUG").is_none()
+    {
         cmd.env("CUDA_OXIDE_DEBUG", "line-tables");
     }
 }
@@ -5355,7 +5369,7 @@ fn apply_interop_device_codegen_options_with_env(
         DeviceDebug::Off,
     );
     if options.sanitizer_line_tables {
-        apply_default_sanitizer_line_tables_with_env(cmd, ctx, env_debug_set);
+        apply_default_sanitizer_line_tables_with_env(cmd, ctx, env_debug_set, DeviceDebug::Off);
     }
 }
 
@@ -7121,6 +7135,24 @@ path = "src/other.rs"
         assert_eq!(
             command_env(&cmd, CODEGEN_FINGERPRINT_ENV).as_deref(),
             Some(fingerprint.as_str())
+        );
+    }
+
+    #[test]
+    fn sanitize_device_debug_flag_overrides_the_line_tables_default() {
+        let ctx = test_context(OxideConfig::default());
+        let mut cmd = Command::new("cargo");
+
+        // Mirror codegen_build_host_binary's ordering: the flag's level lands
+        // on `cmd` first, then the sanitizer default runs. `env_debug_set` is
+        // injected as false, so with no ambient CUDA_OXIDE_DEBUG the explicit
+        // flag alone must suppress the line-tables default.
+        apply_common_codegen_env(&mut cmd, &ctx, false, false, false, DeviceDebug::Full);
+        apply_default_sanitizer_line_tables_with_env(&mut cmd, &ctx, false, DeviceDebug::Full);
+
+        assert_eq!(
+            command_env(&cmd, "CUDA_OXIDE_DEBUG").as_deref(),
+            Some("full")
         );
     }
 

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -92,6 +92,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -126,6 +136,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -157,6 +177,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -196,6 +226,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -231,6 +271,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -251,6 +301,16 @@ enum Commands {
         /// Also settable via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel
         /// (out-of-bounds indexing becomes UB, like get_unchecked).
         /// Also settable via CUDA_OXIDE_UNCHECKED_INDEXING=1.
@@ -303,6 +363,16 @@ enum Commands {
         /// Settable also via CUDA_OXIDE_NO_FMA=1.
         #[arg(long)]
         no_fmad: bool,
+        /// Emit device line-number information for profilers and Compute
+        /// Sanitizer, leaving optimization intact (nvcc `-lineinfo`).
+        /// Also settable via CUDA_OXIDE_DEBUG=line.
+        #[arg(long)]
+        lineinfo: bool,
+        /// Emit full device debug information; libNVVM finalization runs
+        /// unoptimized (nvcc `-G`). Supersedes --lineinfo.
+        /// Also settable via CUDA_OXIDE_DEBUG=full.
+        #[arg(long)]
+        device_debug: bool,
         /// Elide slice/array bounds checks in every device kernel.
         /// Settable also via CUDA_OXIDE_UNCHECKED_INDEXING=1.
         #[arg(long)]
@@ -486,6 +556,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             app_args,
         } => {
             let ctx = commands::resolve_context();
@@ -507,6 +579,7 @@ fn main() {
                 bin.as_deref(),
                 no_fmad,
                 unchecked_indexing,
+                commands::DeviceDebug::from_flags(lineinfo, device_debug),
                 materialize_cubin,
                 &app_args,
             );
@@ -520,6 +593,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             sanitizer_args,
         } => {
             let ctx = commands::resolve_context();
@@ -539,6 +614,7 @@ fn main() {
                 bin.as_deref(),
                 no_fmad,
                 unchecked_indexing,
+                commands::DeviceDebug::from_flags(lineinfo, device_debug),
                 materialize_cubin,
             );
         }
@@ -550,6 +626,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             cargo_target_dir,
             device_codegen_crate,
             device_cfgs,
@@ -581,6 +659,7 @@ fn main() {
                     features.as_deref(),
                     no_fmad,
                     unchecked_indexing,
+                    commands::DeviceDebug::from_flags(lineinfo, device_debug),
                     materialize_cubin,
                 );
             } else {
@@ -611,6 +690,7 @@ fn main() {
                         no_fmad,
                         unchecked_indexing,
                         materialize_cubin,
+                        device_debug: commands::DeviceDebug::from_flags(lineinfo, device_debug),
                     },
                     &cargo_args,
                 );
@@ -624,6 +704,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             cargo_args,
         } => {
             let ctx = commands::resolve_context();
@@ -648,6 +730,7 @@ fn main() {
                     no_fmad,
                     unchecked_indexing,
                     materialize_cubin,
+                    device_debug: commands::DeviceDebug::from_flags(lineinfo, device_debug),
                 },
                 &cargo_args,
             );
@@ -660,6 +743,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "emit-ltoir");
@@ -672,6 +757,7 @@ fn main() {
                 verbose,
                 no_fmad,
                 unchecked_indexing,
+                commands::DeviceDebug::from_flags(lineinfo, device_debug),
             );
         }
         Commands::Pipeline {
@@ -680,6 +766,8 @@ fn main() {
             arch,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "pipeline");
@@ -697,6 +785,7 @@ fn main() {
                 arch.as_deref(),
                 no_fmad,
                 unchecked_indexing,
+                commands::DeviceDebug::from_flags(lineinfo, device_debug),
                 materialize_cubin,
             );
         }
@@ -707,6 +796,8 @@ fn main() {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
         } => {
             let ctx = commands::resolve_context();
             let example = resolve_example_name(example, &ctx, "inspect");
@@ -718,6 +809,7 @@ fn main() {
                 verbose,
                 no_fmad,
                 unchecked_indexing,
+                commands::DeviceDebug::from_flags(lineinfo, device_debug),
             );
         }
         Commands::Debug {
@@ -980,6 +1072,8 @@ mod tests {
             cargo_args,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             ..
         } = test_cli.command
         else {
@@ -988,6 +1082,8 @@ mod tests {
         assert!(cargo_args.is_empty());
         assert!(!no_fmad);
         assert!(!unchecked_indexing);
+        assert!(!lineinfo, "--lineinfo must default off");
+        assert!(!device_debug, "--device-debug must default off");
 
         let build_args = strings(&["cargo-oxide", "build", "--"]);
         assert!(has_passthrough_separator(&build_args));
@@ -1013,6 +1109,8 @@ mod tests {
         let Commands::Test {
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
             cargo_args,
             ..
         } = cli.command
@@ -1021,6 +1119,8 @@ mod tests {
         };
         assert!(no_fmad);
         assert!(unchecked_indexing);
+        assert!(!lineinfo, "--lineinfo must default off");
+        assert!(!device_debug, "--device-debug must default off");
         assert_eq!(cargo_args, strings(&["-p", "gpu-app"]));
     }
 
@@ -1214,6 +1314,8 @@ mod tests {
             verbose,
             no_fmad,
             unchecked_indexing,
+            lineinfo,
+            device_debug,
         } = cli.command
         else {
             panic!("expected inspect command");
@@ -1225,5 +1327,51 @@ mod tests {
         assert!(verbose);
         assert!(no_fmad);
         assert!(unchecked_indexing);
+        assert!(!lineinfo, "--lineinfo must default off");
+        assert!(!device_debug, "--device-debug must default off");
+    }
+
+    #[test]
+    fn parser_accepts_device_debug_flags() {
+        let cli = Cli::try_parse_from(["cargo-oxide", "build", "vecadd", "--lineinfo"])
+            .expect("--lineinfo should parse");
+        let Commands::Build {
+            lineinfo,
+            device_debug,
+            ..
+        } = cli.command
+        else {
+            panic!("expected build command");
+        };
+        assert!(lineinfo);
+        assert!(!device_debug);
+
+        // #552 gave `test` the codegen flags, so the debug policy belongs there too.
+        let cli = Cli::try_parse_from(["cargo-oxide", "test", "--device-debug"])
+            .expect("--device-debug should parse on test");
+        let Commands::Test {
+            lineinfo,
+            device_debug,
+            ..
+        } = cli.command
+        else {
+            panic!("expected test command");
+        };
+        assert!(!lineinfo);
+        assert!(device_debug);
+    }
+
+    #[test]
+    fn device_debug_flags_resolve_in_nvcc_order() {
+        use commands::DeviceDebug;
+        // Absent flags stay Off so an ambient CUDA_OXIDE_DEBUG survives.
+        assert_eq!(DeviceDebug::from_flags(false, false), DeviceDebug::Off);
+        assert_eq!(
+            DeviceDebug::from_flags(true, false),
+            DeviceDebug::LineTables
+        );
+        assert_eq!(DeviceDebug::from_flags(false, true), DeviceDebug::Full);
+        // Full debug already carries line tables, so it wins over --lineinfo.
+        assert_eq!(DeviceDebug::from_flags(true, true), DeviceDebug::Full);
     }
 }


### PR DESCRIPTION
The device debug policy is already plumbed end to end; only a CLI flag was missing, so device line info was reachable from an env var but not from `cargo oxide`.

| Layer | Already present |
|---|---|
| artifact | `ArtifactCompileOptions` debug bits (`OPTION_DEBUG_LINE_TABLES` / `_FULL`) |
| sidecar | `compile-options-v2` line-table and full-debug constants |
| finalizer | `FinalizationOptions::with_debug_policy` |
| libNVVM | `-g` + `-opt=0` for full debug |
| nvJitLink | `-lineinfo` or `-g` |
| selection | `CUDA_OXIDE_DEBUG` (`off` / `line` / `full`) |

Adds `--lineinfo` and `--device-debug` to the seven subcommands carrying `--no-fmad`, including `test` since #552 gave it the codegen flags.

---

# API decisions, and the alternatives rejected

## 1. Two boolean flags, not one `--device-debug=<level>`

**Chosen:** `--lineinfo` and `--device-debug` as independent booleans, resolved by `DeviceDebug::from_flags`.

**Alternative:** a single valued flag, `--device-debug=off|line|full` (clap `ValueEnum`).

The valued form is tidier and I would prefer it in isolation. I chose two booleans to mirror **nvcc**, where these are `-lineinfo` and `-G` — separate switches that a user already has in muscle memory and in existing build scripts. The cost is having to define what both-at-once means (see below) and two flags where one would do.

## 2. Both flags together yields `Full`, rather than erroring

**Chosen:** ordered resolution — `device_debug` wins.

**Alternative:** clap `conflicts_with`, making the combination a usage error.

Full debug already *carries* line tables, so the combination is redundant rather than contradictory; rejecting it would fail a script that passes both defensively. `from_flags` encodes the order and a test pins all four combinations.

## 3. Absent flags export **nothing**, not `CUDA_OXIDE_DEBUG=off`

**Chosen:** `DeviceDebug::Off.env_value() -> None`.

**Alternative:** always export, so the flag fully determines the level.

Always-exporting would make an *absent* flag silently cancel a level the environment or `cuda-oxide.toml` had already requested — turning an omission into an active opt-out. This follows the existing `apply_default_sanitizer_line_tables`, which documents the same deference ("An explicit process or project setting remains authoritative, including an intentional `CUDA_OXIDE_DEBUG=off`"). A test pins `Off -> None`.

## 4. An explicit flag outranks the environment

**Chosen:** flag wins where given.

Matches `--no-fmad` vs `CUDA_OXIDE_NO_FMA`. Combined with (3): the flag is authoritative when present, invisible when absent — which is the only combination where neither source can surprise you.

## 5. The policy participates in the codegen fingerprint

**Chosen:** threaded through `standard_`, `sanitize_`, `pipeline_` and `interop_codegen_fingerprint`, and the `_with_env` variant added by #563.

**Alternative:** leave it out — it is "just debug info".

It is not: full debug passes `-opt=0` to libNVVM, so it changes generated code. Sharing a fingerprint with the default would let Cargo hand back device code built *without* debug info, which is the silent-stale-artifact failure the fingerprint exists to prevent. A test asserts the three policies produce three distinct fingerprints, using an empty inherited env for the same reason the sibling tests do — an ambient `CUDA_OXIDE_DEBUG` is folded in on its own and would collapse them onto the base.

## 6. `DeviceDebug` mirrors `ArtifactDebugPolicy` rather than reusing it

**Chosen:** a small CLI-side enum in `commands.rs`.

**Alternative:** have the CLI take `oxide_artifacts::ArtifactDebugPolicy` directly.

They differ in one way that matters: `DeviceDebug::Off` means "say nothing", whereas `ArtifactDebugPolicy::None` means "no debug info". Collapsing them would lose decision (3). The conversion happens where the env var is written, and `env_value` is pinned by a test against the strings `device_debug_kind_with_override` accepts — a typo there would silently fall through to the profile-derived default rather than fail.

## 7. `cargo oxide debug` and interop builds pass `Off`

Neither is driven by these flags: `debug` sets its own dump environment, and interop device builds take policy from config. The sanitizer path keeps its existing line-table default, which decision (3) is what makes possible.

# Note on the rebase

Not a clean rebase — `cargo-oxide` moved underneath. **#552** gave `test` the codegen flags, **#555** rewrote the README table, and **#563** refactored the fingerprint tests around `sanitize_codegen_fingerprint_with_env`, which did not exist on my branch. Checking the three files out wholesale showed 367 deletions, i.e. it would have reverted all of that, so I re-applied change by change instead. The rework is strictly better: `test` is now covered rather than deliberately skipped.

# Gates

fmt, clippy `--all-targets -D warnings`, rustdoc `-D warnings` clean on `nightly-2026-04-03`. `cargo test -p cargo-oxide`: 152 passed, 1 failed — `cargo_json_selects_custom_bin_in_configured_target_dir`, which **reproduces identically on an untouched `main`**.

+354/−5; all five deletions are my own `apply_common_codegen_env` call lines gaining a parameter, so no upstream content is reverted.
