### PR TITLE
feat(disjoint): bounds-checked write/read for algorithm-guaranteed uniqueness

### DIFF
--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -312,6 +312,11 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     ///
     /// - `idx` must be less than `self.len()` (bounds checked, but not the data race below).
     /// - No two threads may write to the same index simultaneously.
+    ///
+    /// `T: Copy` is required because the write overwrites the slot without
+    /// running a destructor on the previous value. Restricting to `Copy` keeps
+    /// that from being a leak, and matches [`Self::read`]. Device buffers hold
+    /// plain data, so this costs nothing in practice.
     /// - No thread may read an index while another thread writes to it,
     ///   unless explicit synchronization (e.g., `sync_threads()`) separates the accesses.
     ///
@@ -335,10 +340,15 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     /// ```
     #[inline]
     #[must_use]
-    pub unsafe fn write(&mut self, idx: usize, value: T) -> bool {
+    pub unsafe fn write(&mut self, idx: usize, value: T) -> bool
+    where
+        T: Copy,
+    {
         if idx < self.len {
-            // SAFETY: bounds check passed above. The caller guarantees
-            // no two threads write to the same index.
+            // SAFETY: bounds check passed above. The caller guarantees no two
+            // threads write to the same index. `T: Copy` means the slot being
+            // overwritten has no destructor to run, so not dropping the old
+            // value cannot leak.
             unsafe { core::ptr::write(self.ptr.add(idx), value) };
             true
         } else {

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -302,15 +302,19 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     /// Write a value at the given index with bounds checking.
     ///
     /// This is a convenience method that combines bounds checking with
-    /// a direct write, avoiding the need for `unsafe` + `get_unchecked_mut`
+    /// a direct write, avoiding the need for `get_unchecked_mut`
     /// at every write site.
     ///
     /// Returns `true` if the write succeeded (index was in bounds),
     /// `false` otherwise.
     ///
-    /// # Data Race Safety
+    /// # Safety
     ///
-    /// The caller must ensure no two threads write to the same index.
+    /// - `idx` must be less than `self.len()` (bounds checked, but not the data race below).
+    /// - No two threads may write to the same index simultaneously.
+    /// - No thread may read an index while another thread writes to it,
+    ///   unless explicit synchronization (e.g., `sync_threads()`) separates the accesses.
+    ///
     /// This is NOT enforced by the type system (unlike `get_mut` which
     /// uses `ThreadIndex`). Use this only when the algorithm guarantees
     /// unique write indices through means other than `ThreadIndex`,
@@ -325,11 +329,13 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     /// // Before: verbose unsafe pattern
     /// unsafe { *output.get_unchecked_mut(row * n + col) = value; }
     ///
-    /// // After: bounds-checked write
-    /// output.write(row * n + col, value);
+    /// // After: bounds-checked unsafe write
+    /// // SAFETY: each thread writes to a unique (row, col) index.
+    /// unsafe { output.write(row * n + col, value) };
     /// ```
     #[inline]
-    pub fn write(&mut self, idx: usize, value: T) -> bool {
+    #[must_use]
+    pub unsafe fn write(&mut self, idx: usize, value: T) -> bool {
         if idx < self.len {
             // SAFETY: bounds check passed above. The caller guarantees
             // no two threads write to the same index.
@@ -346,22 +352,23 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     /// This reads by value (copies the element), which is appropriate for
     /// scalar types like `f32`, `u32`, etc.
     ///
-    /// # Data Race Safety
+    /// # Safety
     ///
-    /// The caller must ensure no other thread is writing to the same index
-    /// concurrently. Reading from indices that are only written by other
-    /// `DisjointSlice` instances requires synchronization (e.g.,
-    /// `sync_threads()`).
+    /// - No thread may write to the same index while this read occurs.
+    /// - If this index was written by another thread, explicit synchronization
+    ///   (e.g., `sync_threads()`) must separate the write from this read.
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// if let Some(val) = output.read(row * n + col) {
+    /// // SAFETY: no concurrent writes to this index.
+    /// if let Some(val) = unsafe { output.read(row * n + col) } {
     ///     // use val
     /// }
     /// ```
     #[inline]
-    pub fn read(&self, idx: usize) -> Option<T>
+    #[must_use]
+    pub unsafe fn read(&self, idx: usize) -> Option<T>
     where
         T: Copy,
     {

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -298,6 +298,80 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
         );
         unsafe { &mut *self.ptr.add(idx) }
     }
+
+    /// Write a value at the given index with bounds checking.
+    ///
+    /// This is a convenience method that combines bounds checking with
+    /// a direct write, avoiding the need for `unsafe` + `get_unchecked_mut`
+    /// at every write site.
+    ///
+    /// Returns `true` if the write succeeded (index was in bounds),
+    /// `false` otherwise.
+    ///
+    /// # Data Race Safety
+    ///
+    /// The caller must ensure no two threads write to the same index.
+    /// This is NOT enforced by the type system (unlike `get_mut` which
+    /// uses `ThreadIndex`). Use this only when the algorithm guarantees
+    /// unique write indices through means other than `ThreadIndex`,
+    /// such as:
+    /// - Warp reduction where only lane 0 writes
+    /// - Scatter operations with known-unique destinations
+    /// - Manual bounds checking in tiled algorithms
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Before: verbose unsafe pattern
+    /// unsafe { *output.get_unchecked_mut(row * n + col) = value; }
+    ///
+    /// // After: bounds-checked write
+    /// output.write(row * n + col, value);
+    /// ```
+    #[inline]
+    pub fn write(&mut self, idx: usize, value: T) -> bool {
+        if idx < self.len {
+            // SAFETY: bounds check passed above. The caller guarantees
+            // no two threads write to the same index.
+            unsafe { core::ptr::write(self.ptr.add(idx), value) };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Read a value at the given index with bounds checking.
+    ///
+    /// Returns `Some(value)` if the index is in bounds, `None` otherwise.
+    /// This reads by value (copies the element), which is appropriate for
+    /// scalar types like `f32`, `u32`, etc.
+    ///
+    /// # Data Race Safety
+    ///
+    /// The caller must ensure no other thread is writing to the same index
+    /// concurrently. Reading from indices that are only written by other
+    /// `DisjointSlice` instances requires synchronization (e.g.,
+    /// `sync_threads()`).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// if let Some(val) = output.read(row * n + col) {
+    ///     // use val
+    /// }
+    /// ```
+    #[inline]
+    pub fn read(&self, idx: usize) -> Option<T>
+    where
+        T: Copy,
+    {
+        if idx < self.len {
+            // SAFETY: bounds check passed above.
+            Some(unsafe { core::ptr::read(self.ptr.add(idx)) })
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a, T, IS: IndexFormula> DisjointSlice<'a, T, IS> {

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -364,6 +364,12 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     ///
     /// # Safety
     ///
+    /// - The slot must already be **initialized**. This reads by value, so a
+    ///   slot that was never written holds an indeterminate bit pattern, and
+    ///   producing a `T` from it is undefined behaviour for any `T` whose
+    ///   values are not all bit patterns (`bool`, `char`, enums, references).
+    ///   Buffers from `DeviceBuffer::zeroed` or `from_host` are initialized;
+    ///   those from `uninitialized_async` are not until written.
     /// - No thread may write to the same index while this read occurs.
     /// - If this index was written by another thread, explicit synchronization
     ///   (e.g., `sync_threads()`) must separate the write from this read.


### PR DESCRIPTION
`DisjointSlice` has two access paths with a gap between them:

| today | proof required | bounds checked |
|---|---|---|
| `get_mut(ThreadIndex)` | a `ThreadIndex` | yes |
| `get_unchecked_mut(usize)` | none | **no** |

An algorithm whose write uniqueness comes from somewhere *other* than a `ThreadIndex` — a warp reduction where only lane 0 writes, a scatter with known-unique destinations, a manually clipped tile — has no `ThreadIndex` to offer and must drop all the way to `get_unchecked_mut`, losing the bounds check along with the proof.

```rust
pub unsafe fn write(&mut self, idx: usize, value: T) -> bool where T: Copy;
pub unsafe fn read(&self, idx: usize) -> Option<T> where T: Copy;
```

```rust
// only lane 0 writes, so uniqueness holds without a ThreadIndex
if warp::lane_id() == 0 {
    unsafe { slice.write(out_idx, total) };
}
```

---

# API decisions, and the alternatives rejected

## 1. `unsafe fn`, despite the bounds check

**Chosen:** `unsafe`, with the bounds check inside.

**Alternative:** safe, since it is checked.

The bounds check does not discharge the obligation that matters. What makes a `DisjointSlice` write sound is that **no two threads target the same index**, and that no read races a write without an intervening barrier — neither of which an index comparison can see. Making these safe would be claiming a guarantee the check does not provide. The `unsafe` marks exactly the residual obligation, and the docs say explicitly that the returned `bool` is not a safety signal.

## 2. `bool` from `write`, `Option<T>` from `read`

**Chosen:** `-> bool` and `-> Option<T>`, both `#[must_use]`.

**Alternatives:** `Result<(), OutOfBounds>`; or `-> ()` with a debug assert.

`Result` implies a recoverable error with a reason, and there is only one reason. Device code also has no error-reporting path, so a `Result` would mostly be `.ok()`-ed at the call site. `-> ()` with a debug assert was tempting for symmetry with `get_unchecked_mut`, but then a release build silently drops the write — the failure this method exists to prevent. `#[must_use]` is what stops the `bool` being ignored, which would reintroduce exactly that.

The asymmetry is deliberate: a failed `write` has nothing to return, a failed `read` has no value to give, so `bool` and `Option<T>` are each the smallest honest type.

## 3. `T: Copy` on both

**Chosen:** bound both methods on `T: Copy`.

**Alternative:** allow any `T` and use `ptr::write`, which does not drop the old value.

Without `Copy`, `write` overwrites a slot whose previous occupant is never dropped — a leak for any `T` with a destructor, and silent. `Copy` makes that impossible to express. Device buffers hold plain data, so in practice this costs nothing; the bound is documented as a leak-prevention measure rather than an arbitrary restriction. `read` carries it for the same reason a bitwise copy out is only sound for `Copy`.

## 4. `write`/`read` rather than `set`/`get` or `store`/`load`

**Chosen:** `write`/`read`.

`get`/`set` would sit confusingly beside the existing `get_mut`, which has entirely different (proof-carrying) semantics. `store`/`load` implies atomics or explicit ordering, which these are not. `write`/`read` matches `ptr::write`/`ptr::read`, whose obligations are the closest analogue.

## 5. What I did *not* build: a second proof type

The principled fix is a proof type for "uniqueness established by other means" — something like a `UniqueWrite` witness that lane-0 patterns could construct — so these could be safe. I did not, for two reasons: it is a design question about what evidence such a witness would carry (and #515's rejection upstream shows a *per-call* witness cannot carry a slice-lifetime property), and it would still need this bounds-checked primitive underneath. This PR is the primitive; the witness is a separate conversation.

## 6. Relationship to `get_mut` — not a competitor

`get_mut` is strictly better wherever a `ThreadIndex` exists, and nothing here relaxes, wraps or duplicates it. These serve the cases where no such index exists, and the honest alternative today is `get_unchecked_mut`, which is worse on every axis than a bounds-checked `unsafe fn`. If you would rather the crate not grow a middle tier at all, the reasonable response is to reject this and keep users on `get_unchecked_mut` — I would want that stated in the docs, since right now nothing points them there.

---

# Soundness: what these methods do and do not put at risk

Since both are `unsafe fn` added to a type whose whole purpose is disciplined aliasing, here is the argument in full rather than by assertion.

## The obligations are a strict subset of `get_unchecked_mut`'s

This is the core claim, and it is checkable against the existing docs. `get_unchecked_mut` documents three obligations:

1. `idx < self.len()`
2. no two threads write the same index simultaneously
3. the uniqueness guarantee comes from the algorithm

`write` requires only **(2)** and **(3)**. Obligation (1) is discharged by the bounds check, which returns `false` instead of reaching for the pointer. So:

> every program that is sound using `get_unchecked_mut` remains sound if it uses `write`, and `write` additionally rejects the out-of-bounds case that would have been UB.

That makes this a **monotonic** change to the crate's safety surface: it adds no new *kind* of obligation, and strictly weakens the preconditions of the path callers use today. Rejecting this PR does not make anything safer — it leaves those callers on `get_unchecked_mut` with obligation (1) still live.

## Memory safety, per operation

**Bounds.** `idx < self.len` guards `self.ptr.add(idx)`. `len` is the element count the view was constructed with, so `idx < len` puts the offset inside the allocation — the same condition `<[T]>::get` relies on. The byte offset `idx * size_of::<T>()` cannot overflow `isize`, because an allocation of `len * size_of::<T>()` bytes exists, which already implies that product is representable.

**Alignment.** `ptr` originates from `DeviceBuffer<T>` or `from_mut_slice`, so it is aligned for `T`; `add` advances by whole elements, which preserves alignment. Neither method can produce a misaligned access from an aligned view.

**Provenance.** Both derive from the view's own pointer via `add`, staying within the provenance the view was created with. No integer-to-pointer casts, no pointer synthesised from an index.

**No wrap-to-alias.** Because the comparison is `idx < len` on the *element* index rather than arithmetic on a byte address, there is no route by which an offset wraps and lands back inside the allocation — the failure mode that `get_block_mut` needs `checked_add` for, since it validates `start + N`.

## Type safety

**`T: Copy` is load-bearing twice.** For `write`, `ptr::write` does not drop the overwritten value; with a `Drop` type that is a silent leak, so the bound makes the leak unrepresentable rather than merely undocumented. For `read`, a by-value bitwise copy out of the slice is only a valid way to produce a `T` when `T` has no ownership semantics.

**No transmutation, no lifetime laundering.** Neither method casts `T`, and neither returns a reference — `write` consumes a `T` by value, `read` produces one by value. So there is no borrow whose lifetime could outlive the view, and none of the `&mut [T; N]`-style aliasing questions that `get_block_mut` has to answer.

**Initialization.** `read` copying by value means a never-written slot yields an indeterminate bit pattern, which is UB for any `T` whose values are not all bit patterns (`bool`, `char`, enums, references). That obligation was **missing from the `# Safety` section** and this PR now documents it; it is reachable today via `DeviceBuffer::uninitialized_async`. `write` has no such requirement — it is what makes a slot initialized.

## What is deliberately *not* proven, and why the `unsafe` is honest

The data-race freedom is **not** established by these methods and cannot be. `&mut self` on `write` does not help: the entire design of `DisjointSlice` is that every thread holds its own view over the same buffer, so a per-thread `&mut` says nothing about the other threads. That is the pre-existing model of the type, inherited unchanged.

So the residual obligation is exactly:

- no two threads target the same index, and
- no read races a write without an intervening barrier.

Neither is visible to an index comparison, which is why the bounds check does not earn a safe signature and why the docs state plainly that the returned `bool` is not a safety signal.

## ZSTs

Unguarded, and safely so. For `size_of::<T>() == 0`, `add` is a no-op and `ptr::write` touches zero bytes, so even two threads "writing the same slot" writes nothing. This differs from `get_block_mut`, which guards ZSTs explicitly because it hands out `&mut [T; N]` and the aliasing question becomes real there. Worth stating so the asymmetry does not read as an oversight.

# Gates

fmt, clippy `--workspace --all-targets -D warnings`, rustdoc `-D warnings`, tests and doctests clean on `nightly-2026-04-03`. +97/−0 against `main`.
