### PR TITLE
feat(disjoint): predicate derived tiles against the slice extent

### DIFF
--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -679,17 +679,26 @@ mod tiling_algebra_tests {
     #[test]
     fn a_period_below_grid_span_collides() {
         let (grid, n) = (4usize, 1usize);
-        let bad_period = 2; // G·N would be 4.
-        // (k=0, t=2) and (k=1, t=0) both land on element 2.
-        let a = 0 * bad_period + 2 * n;
-        let b = 1 * bad_period + 0 * n;
-        assert_eq!(a, b, "the counterexample must actually collide");
 
-        // The derived period keeps them apart.
+        // `phi` with the period supplied rather than derived, so a wrong period
+        // can be expressed at all. Written as a call so the (k, t) digit pair
+        // stays visible at each use.
+        fn at(k: usize, t: usize, period: usize, n: usize) -> usize {
+            k * period + t * n
+        }
+
+        let bad_period = 2; // G·N would be 4.
+        assert_eq!(
+            at(0, 2, bad_period, n),
+            at(1, 0, bad_period, n),
+            "with a period below G·N, (k=0,t=2) and (k=1,t=0) must collide"
+        );
+
+        // The derived period keeps the same two apart.
         let good_period = grid * n;
         assert_ne!(
-            0 * good_period + 2 * n,
-            1 * good_period + 0 * n,
+            at(0, 2, good_period, n),
+            at(1, 0, good_period, n),
             "period G·N must separate the pass and thread digits"
         );
     }

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -258,9 +258,22 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     /// ```
     ///
     /// Returning `&mut [T; N]` rather than `&mut [T]` is deliberate: the length
-    /// is static, so this is also the shape the codegen can fuse into a single
-    /// wide access when `[T; N]` carries the matching alignment (see the
-    /// `vectorization` example).
+    /// is static, so the tile is a value the caller can assign in one statement.
+    ///
+    /// It does **not** widen the access, and it is worth being explicit about
+    /// that. Measured on sm_86, whether an access becomes `LDG.E.128` /
+    /// `STG.E.128` is decided by the *alignment of the element type*, not by the
+    /// static length: a 16-byte-aligned aggregate fuses, the same payload at
+    /// 4-byte alignment does not. Since `T` here is the element type of a
+    /// `DisjointSlice<T>`, a `DisjointSlice<f32>` yields `&mut [f32; N]` with
+    /// 4-byte alignment, which stays scalar.
+    ///
+    /// To get wide accesses, make the element type aligned and use
+    /// [`Self::get_mut`] on a `DisjointSlice<F32x4>` where
+    /// `#[repr(C, align(16))] struct F32x4([f32; 4])`. That path emits one
+    /// `LDG.E.128` plus one `STG.E.128` with no `unsafe` and no inline PTX; see
+    /// the `vectorization` example. This method is about the disjointness proof
+    /// for multi-element access, not about access width.
     ///
     /// # Soundness
     ///

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -904,13 +904,13 @@ mod predication_tests {
         while start < buf {
             match clip(start, n, logical, buf) {
                 Clip::Full => {
-                    for i in start..start + n {
-                        claims[i] += 1;
+                    for c in &mut claims[start..start + n] {
+                        *c += 1;
                     }
                 }
                 Clip::Partial(len) => {
-                    for i in start..start + len {
-                        claims[i] += 1;
+                    for c in &mut claims[start..start + len] {
+                        *c += 1;
                     }
                 }
                 Clip::None => {}

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -292,6 +292,75 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
         Some(unsafe { &mut *self.ptr.add(start).cast::<[T; N]>() })
     }
 
+    /// Visit each of the `K` tiles a thread owns, exactly once.
+    ///
+    /// Takes the grid-stride proof from [`DisjointBlock::repeat`] and hands the
+    /// closure one `&mut [T; N]` per pass, with the pass number. Returns how many
+    /// tiles were visited, which is `K` unless the buffer ran out first.
+    ///
+    /// ```rust,ignore
+    /// let tiling = thread::index_1d().scale::<4>().repeat::<4>();
+    /// let done = output.for_each_tile(tiling, |k, tile| {
+    ///     *tile = compute_stripe(k);
+    /// });
+    /// ```
+    ///
+    /// # Why a callback rather than an accessor
+    ///
+    /// A `get_tile_mut(&mut self, k)` taking `k` at runtime could be called
+    /// twice with the same `k`, producing two live `&mut` to the same elements -
+    /// the disjointness proof covers *different* threads and *different* passes,
+    /// not repeated access to one pass. Driving the loop here is what keeps each
+    /// tile handed out once, so the guarantee is structural rather than a rule
+    /// the caller has to follow.
+    ///
+    /// # Soundness
+    ///
+    /// Tiles are pairwise disjoint across both threads and passes, by the
+    /// mixed-radix injectivity argument on [`DisjointBlock::repeat`]. Each is
+    /// bounds-checked before the closure sees it, and iteration stops at the
+    /// first tile that does not fit, so a partially covering launch truncates
+    /// instead of writing past the end.
+    #[inline]
+    pub fn for_each_tile<'kernel, const N: usize, const K: usize>(
+        &mut self,
+        tiling: crate::thread::DisjointTiling<'kernel, N, K>,
+        mut f: impl FnMut(usize, &mut [T; N]),
+    ) -> usize {
+        if size_of::<T>() == 0 || !tiling.is_valid() {
+            return 0;
+        }
+        let (base, period) = (tiling.start(), tiling.period());
+        let mut visited = 0;
+        for k in 0..K {
+            // Checked throughout: a pass whose offset or end wraps must stop the
+            // loop, not fold into a passing bounds test.
+            let Some(offset) = period.checked_mul(k) else {
+                break;
+            };
+            let Some(start) = base.checked_add(offset) else {
+                break;
+            };
+            let Some(end) = start.checked_add(N) else {
+                break;
+            };
+            if end > self.len {
+                break;
+            }
+            // SAFETY:
+            // - The bounds check above proves `start .. start + N` is in range.
+            // - Distinct threads decode to distinct `t` digits and distinct
+            //   passes to distinct `k` digits, so this tile overlaps no other
+            //   tile handed out anywhere in the launch.
+            // - `k` is visited once per loop, so the closure cannot receive two
+            //   references to this tile.
+            // - `[T; N]` has the layout of `N` consecutive `T`.
+            f(k, unsafe { &mut *self.ptr.add(start).cast::<[T; N]>() });
+            visited += 1;
+        }
+        visited
+    }
+
     #[inline]
     pub fn get_mut<'kernel>(&mut self, idx: ThreadIndex<'kernel, IndexSpace>) -> Option<&mut T> {
         let i = idx.get();
@@ -522,5 +591,114 @@ mod block_tests {
         assert!(tile(16, 4).unwrap().1 > len);
         // And the wrapping case is rejected outright.
         assert_eq!(usize::MAX.checked_add(4), None);
+    }
+}
+
+#[cfg(test)]
+mod tiling_algebra_tests {
+    //! Tests for the mixed-radix argument behind `DisjointBlock::repeat`.
+    //!
+    //! `repeat` reads the grid extent from hardware registers, so these exercise
+    //! the arithmetic directly: `phi` below is the same index expression, and the
+    //! properties asserted are the ones the safety of `for_each_tile` rests on.
+
+    /// The index expression: `k·(G·N) + t·N + c`.
+    fn phi(k: usize, t: usize, c: usize, grid: usize, n: usize) -> usize {
+        k * (grid * n) + t * n + c
+    }
+
+    /// The claimed inverse: recover each digit by division and remainder.
+    fn decode(index: usize, grid: usize, n: usize) -> (usize, usize, usize) {
+        (index / (grid * n), (index / n) % grid, index % n)
+    }
+
+    /// `phi` is injective on the digit domain, which is the whole proof: an index
+    /// determines the thread it came from, so two threads cannot share one.
+    #[test]
+    fn index_expression_is_injective() {
+        for &(grid, n, k_max) in &[(4usize, 1usize, 3usize), (4, 4, 3), (8, 2, 4), (3, 5, 2)] {
+            for k in 0..k_max {
+                for t in 0..grid {
+                    for c in 0..n {
+                        let v = phi(k, t, c, grid, n);
+                        assert_eq!(
+                            decode(v, grid, n),
+                            (k, t, c),
+                            "decode failed for k={k} t={t} c={c} (G={grid}, N={n})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// The consequence used by `for_each_tile`: tiles belonging to different
+    /// threads never overlap, across every pass.
+    #[test]
+    fn tiles_of_distinct_threads_never_overlap() {
+        let (grid, n, passes) = (8usize, 4usize, 3usize);
+        let mut owner = [usize::MAX; 8 * 4 * 3];
+        for k in 0..passes {
+            for t in 0..grid {
+                for c in 0..n {
+                    let v = phi(k, t, c, grid, n);
+                    assert_eq!(
+                        owner[v],
+                        usize::MAX,
+                        "element {v} claimed twice: by thread {} and thread {t}",
+                        owner[v]
+                    );
+                    owner[v] = t;
+                }
+            }
+        }
+        // Every element in the covered span has exactly one owner.
+        assert!(
+            owner.iter().all(|&o| o != usize::MAX),
+            "grid-stride passes must tile the span with no gaps"
+        );
+    }
+
+    /// The reason the period is derived rather than supplied. With a period
+    /// smaller than `G·N` the thread and pass digits overlap and two threads
+    /// collide on the same element - so a `repeat_with_stride` taking a
+    /// caller-chosen value would be unsound.
+    #[test]
+    fn a_period_below_grid_span_collides() {
+        let (grid, n) = (4usize, 1usize);
+        let bad_period = 2; // G·N would be 4.
+        // (k=0, t=2) and (k=1, t=0) both land on element 2.
+        let a = 0 * bad_period + 2 * n;
+        let b = 1 * bad_period + 0 * n;
+        assert_eq!(a, b, "the counterexample must actually collide");
+
+        // The derived period keeps them apart.
+        let good_period = grid * n;
+        assert_ne!(
+            0 * good_period + 2 * n,
+            1 * good_period + 0 * n,
+            "period G·N must separate the pass and thread digits"
+        );
+    }
+
+    /// A period larger than `G·N` stays injective but leaves gaps, so it is
+    /// sound yet wasteful. Recorded to show the derived period is the tight
+    /// choice, not merely a safe one.
+    #[test]
+    fn a_period_above_grid_span_is_injective_but_leaves_gaps() {
+        let (grid, n, passes) = (4usize, 1usize, 2usize);
+        let period = grid * n + 1;
+        let mut seen = [false; 16];
+        for k in 0..passes {
+            for t in 0..grid {
+                let v = k * period + t * n;
+                assert!(!seen[v], "still injective");
+                seen[v] = true;
+            }
+        }
+        let covered = seen.iter().filter(|&&s| s).count();
+        assert_eq!(covered, grid * passes);
+        // Element 4 falls in the gap: no (k, t) reaches it.
+        assert!(!seen[4], "an oversized period must leave the span gapped");
     }
 }

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -100,6 +100,60 @@ pub struct DisjointSlice<'a, T, IndexSpace = Index1D> {
     _space: PhantomData<fn() -> IndexSpace>,
 }
 
+/// A thread's tile, once clipped to a logical extent.
+///
+/// Returned by
+/// [`DisjointSlice::get_block_clipped_mut`](DisjointSlice::get_block_clipped_mut).
+/// The two cases are separate variants on purpose: a boundary tile has a
+/// different length from an interior one, and collapsing both into `&mut [T]`
+/// would cost the interior case its fixed-size type for no benefit, while
+/// silently letting a caller treat a short tile as whole.
+pub enum Tile<'a, T, const N: usize> {
+    /// The tile lies wholly inside the logical extent: all `N` elements valid.
+    Full(&'a mut [T; N]),
+    /// The tile straddles the end of the logical extent. Length is in `1..N`.
+    Partial(&'a mut [T]),
+}
+
+impl<'a, T, const N: usize> Tile<'a, T, N> {
+    /// Valid elements in this tile: `N` when full, fewer when partial.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Tile::Full(_) => N,
+            Tile::Partial(s) => s.len(),
+        }
+    }
+
+    /// Whether every element of the tile is valid.
+    #[inline]
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        matches!(self, Tile::Full(_))
+    }
+
+    /// Never true: a tile with no valid elements is reported as `None` rather
+    /// than as an empty `Partial`.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The valid elements, whichever case this is.
+    ///
+    /// Use when the work is uniform per element and the distinction does not
+    /// matter; match on the variant when the full case has a faster path.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        match self {
+            Tile::Full(a) => &mut a[..],
+            Tile::Partial(s) => s,
+        }
+    }
+}
+
 mod launch_contract_sealed {
     pub trait Sealed {}
 }
@@ -303,6 +357,80 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
         // - `[T; N]` has the same layout as `N` consecutive `T`, so the cast is
         //   valid for a region this long.
         Some(unsafe { &mut *self.ptr.add(start).cast::<[T; N]>() })
+    }
+
+    /// This thread's tile, clipped to a logical extent smaller than the buffer.
+    ///
+    /// A tile shape rarely divides the problem. Tensor-core work pads to a tile
+    /// boundary - `M = 9` against a 16-row MMA tile is the shape this fork
+    /// actually runs - so the buffer is 16 rows while only 9 carry data. Bounds
+    /// checking against the buffer accepts all 16, and the last 7 are padding
+    /// the kernel must not treat as real.
+    ///
+    /// `logical_len` is that smaller extent. The return distinguishes the two
+    /// cases rather than flattening them:
+    ///
+    /// - [`Tile::Full`] carries `&mut [T; N]`, so the common path keeps the
+    ///   fixed-size type and whatever codegen depends on it.
+    /// - [`Tile::Partial`] carries a shorter slice, so a boundary tile cannot be
+    ///   mistaken for a whole one.
+    /// - `None` means the tile starts at or past `logical_len` and has no valid
+    ///   elements at all.
+    ///
+    /// ```rust,ignore
+    /// // 9 valid rows in a buffer padded to a 16-row tile boundary.
+    /// match output.get_block_clipped_mut(block, 9) {
+    ///     Some(Tile::Full(row)) => *row = [a, b, c, d],
+    ///     Some(Tile::Partial(head)) => for (i, slot) in head.iter_mut().enumerate() {
+    ///         *slot = value(i);
+    ///     },
+    ///     None => {}
+    /// }
+    /// ```
+    ///
+    /// # Soundness
+    ///
+    /// Clipping cannot introduce aliasing. It only ever *removes* elements from
+    /// a pattern that Law 1 already proved disjoint, and a subset of disjoint
+    /// sets is disjoint. So predication composes with any witness this module
+    /// accepts, and needs no separate argument.
+    ///
+    /// `logical_len` is additionally clamped to the buffer length, so passing a
+    /// value larger than the allocation cannot widen the access.
+    #[inline]
+    pub fn get_block_clipped_mut<'kernel, const N: usize>(
+        &mut self,
+        block: DisjointBlock<'kernel, N, IndexSpace>,
+        logical_len: usize,
+    ) -> Option<Tile<'_, T, N>> {
+        if size_of::<T>() == 0 || !block.is_valid() {
+            return None;
+        }
+        // A caller-supplied extent must never exceed the real allocation.
+        let limit = if logical_len < self.len {
+            logical_len
+        } else {
+            self.len
+        };
+        let start = block.start();
+        if start >= limit {
+            return None;
+        }
+        let end = start.checked_add(N)?;
+        if end <= limit {
+            // SAFETY: as `get_block_mut`; the tile lies wholly inside `limit`,
+            // which is itself within the allocation.
+            return Some(Tile::Full(unsafe {
+                &mut *self.ptr.add(start).cast::<[T; N]>()
+            }));
+        }
+        // `start < limit <= end`, so this length is in `1..N`.
+        let valid = limit - start;
+        // SAFETY: `start + valid == limit <= self.len`, so the slice is in
+        // bounds, and it is a subset of this thread's already-disjoint tile.
+        Some(Tile::Partial(unsafe {
+            core::slice::from_raw_parts_mut(self.ptr.add(start), valid)
+        }))
     }
 
     /// Visit each of the `K` tiles a thread owns, exactly once.
@@ -722,5 +850,121 @@ mod tiling_algebra_tests {
         assert_eq!(covered, grid * passes);
         // Element 4 falls in the gap: no (k, t) reaches it.
         assert!(!seen[4], "an oversized period must leave the span gapped");
+    }
+}
+
+#[cfg(test)]
+mod predication_tests {
+    //! Clipping logic for partial tiles.
+    //!
+    //! `get_block_clipped_mut` needs a real `DisjointBlock`, which needs a launch
+    //! context, so these model the clip arithmetic directly. `clip` below is the
+    //! same decision the method makes.
+
+    /// What the method decides for one thread: `None`, a full tile, or a partial
+    /// tile of the given length.
+    #[derive(Debug, PartialEq)]
+    enum Clip {
+        None,
+        Full,
+        Partial(usize),
+    }
+
+    fn clip(start: usize, n: usize, logical: usize, buf: usize) -> Clip {
+        let limit = if logical < buf { logical } else { buf };
+        if start >= limit {
+            return Clip::None;
+        }
+        match start.checked_add(n) {
+            Some(end) if end <= limit => Clip::Full,
+            _ => Clip::Partial(limit - start),
+        }
+    }
+
+    /// The shape this fork actually runs: 9 valid rows against a 16-row tile.
+    /// With one row per thread and N = 4, threads 0 and 1 are whole, thread 2
+    /// straddles the boundary, and thread 3 is entirely padding.
+    #[test]
+    fn nine_valid_rows_against_a_sixteen_row_tile() {
+        let (n, logical, buf) = (4usize, 9usize, 16usize);
+        assert_eq!(clip(0, n, logical, buf), Clip::Full);
+        assert_eq!(clip(4, n, logical, buf), Clip::Full);
+        assert_eq!(clip(8, n, logical, buf), Clip::Partial(1), "row 8 only");
+        assert_eq!(clip(12, n, logical, buf), Clip::None, "all padding");
+    }
+
+    /// Every valid element is claimed exactly once, and no padding element is
+    /// ever handed out. This is the property predication has to preserve: it may
+    /// remove elements from a disjoint pattern, never add or duplicate them.
+    #[test]
+    fn clipping_covers_the_logical_extent_exactly_once() {
+        let (n, logical, buf) = (4usize, 9usize, 16usize);
+        let mut claims = [0u8; 16];
+        let mut start = 0;
+        while start < buf {
+            match clip(start, n, logical, buf) {
+                Clip::Full => {
+                    for i in start..start + n {
+                        claims[i] += 1;
+                    }
+                }
+                Clip::Partial(len) => {
+                    for i in start..start + len {
+                        claims[i] += 1;
+                    }
+                }
+                Clip::None => {}
+            }
+            start += n;
+        }
+        for (i, &c) in claims.iter().enumerate() {
+            if i < logical {
+                assert_eq!(c, 1, "valid element {i} must be claimed exactly once");
+            } else {
+                assert_eq!(c, 0, "padding element {i} must never be claimed");
+            }
+        }
+    }
+
+    /// A logical extent beyond the allocation must not widen the access. The
+    /// buffer length is the hard limit; `logical_len` can only narrow.
+    #[test]
+    fn logical_extent_cannot_exceed_the_buffer() {
+        // Buffer of 8, caller claims 99 valid elements.
+        assert_eq!(clip(0, 4, 99, 8), Clip::Full);
+        assert_eq!(clip(4, 4, 99, 8), Clip::Full);
+        assert_eq!(clip(8, 4, 99, 8), Clip::None, "past the allocation");
+        // A tile straddling the buffer end clips to the buffer, not to 99.
+        assert_eq!(clip(6, 4, 99, 8), Clip::Partial(2));
+    }
+
+    /// A tile boundary landing exactly on the extent is full, not partial. Off
+    /// by one here would either drop a valid element or expose padding.
+    #[test]
+    fn exact_boundary_is_full_not_partial() {
+        assert_eq!(clip(4, 4, 8, 16), Clip::Full, "4..8 with extent 8");
+        assert_eq!(clip(4, 4, 7, 16), Clip::Partial(3), "4..7 with extent 7");
+        assert_eq!(clip(4, 4, 5, 16), Clip::Partial(1));
+        assert_eq!(clip(4, 4, 4, 16), Clip::None, "starts at the extent");
+    }
+
+    /// A partial tile always has between 1 and N-1 elements. Zero would mean the
+    /// method should have returned `None`; N would mean it should have been full.
+    #[test]
+    fn partial_length_is_strictly_between_zero_and_n() {
+        for n in [2usize, 4, 8, 16] {
+            for logical in 1..(3 * n) {
+                let mut start = 0;
+                while start < 3 * n {
+                    if let Clip::Partial(len) = clip(start, n, logical, 4 * n) {
+                        assert!(
+                            len >= 1 && len < n,
+                            "partial length {len} out of range for N={n}, logical={logical}"
+                        );
+                    }
+                    start += n;
+                }
+            }
+        }
     }
 }

--- a/crates/cuda-device/src/disjoint.rs
+++ b/crates/cuda-device/src/disjoint.rs
@@ -36,7 +36,7 @@
 //! raw launch is unsafe and leaves that proof to the caller. Constructing a
 //! `DisjointSlice` from raw memory is also unsafe.
 
-use crate::thread::{Index1D, IndexFormula, LaunchContext, ThreadIndex};
+use crate::thread::{DisjointBlock, Index1D, IndexFormula, LaunchContext, ThreadIndex};
 use crate::view::{LinearTiles, RowMajorTiles, RuntimeRowMajorTiles};
 use core::marker::PhantomData;
 use core::mem::size_of;
@@ -241,6 +241,57 @@ impl<'a, T, IndexSpace> DisjointSlice<'a, T, IndexSpace> {
     ///     *elem = a[i] + b[i];
     /// }
     /// ```
+    /// Bounds-checked access to the `N` consecutive elements a thread owns.
+    ///
+    /// Takes the tile proof from [`ThreadIndex::scale`] and returns that thread's
+    /// elements as a fixed-size array, or `None` if the tile does not fit.
+    ///
+    /// This is the safe form of the multi-element write that otherwise needs
+    /// `get_unchecked_mut` plus a hand-discharged bounds argument. Writing four
+    /// elements per thread becomes:
+    ///
+    /// ```rust,ignore
+    /// let block = thread::index_1d().scale::<4>();
+    /// if let Some(row) = output.get_block_mut(block) {
+    ///     *row = [o0, o1, o2, o3];
+    /// }
+    /// ```
+    ///
+    /// Returning `&mut [T; N]` rather than `&mut [T]` is deliberate: the length
+    /// is static, so this is also the shape the codegen can fuse into a single
+    /// wide access when `[T; N]` carries the matching alignment (see the
+    /// `vectorization` example).
+    ///
+    /// # Soundness
+    ///
+    /// Two threads cannot obtain overlapping tiles. Distinct `ThreadIndex`
+    /// values scale to distinct `N`-sized tiles that partition the space, and
+    /// [`DisjointBlock`] is neither `Copy` nor `Clone`, so one thread cannot
+    /// hold two proofs covering the same elements.
+    #[inline]
+    pub fn get_block_mut<'kernel, const N: usize>(
+        &mut self,
+        block: DisjointBlock<'kernel, N, IndexSpace>,
+    ) -> Option<&mut [T; N]> {
+        if size_of::<T>() == 0 || !block.is_valid() {
+            return None;
+        }
+        let start = block.start();
+        // Checked so a tile straddling the end of the address space cannot wrap
+        // into a passing bounds test.
+        if start.checked_add(N)? > self.len {
+            return None;
+        }
+        // SAFETY:
+        // - The bounds check above proves `start .. start + N` is in range.
+        // - `block` came from scaling a `ThreadIndex`, so this thread's tile is
+        //   disjoint from every other thread's, and the proof is not
+        //   duplicable.
+        // - `[T; N]` has the same layout as `N` consecutive `T`, so the cast is
+        //   valid for a region this long.
+        Some(unsafe { &mut *self.ptr.add(start).cast::<[T; N]>() })
+    }
+
     #[inline]
     pub fn get_mut<'kernel>(&mut self, idx: ThreadIndex<'kernel, IndexSpace>) -> Option<&mut T> {
         let i = idx.get();
@@ -388,3 +439,88 @@ unsafe impl<'a, T: Send, IndexSpace> Send for DisjointSlice<'a, T, IndexSpace> {
 //         different element. Sharing &DisjointSlice across threads would allow
 //         multiple threads to call get_mut() on the same struct, which
 //         would produce aliasing &mut T references — unsound.
+
+#[cfg(test)]
+mod block_tests {
+    /// `DisjointBlock` can only come from a `ThreadIndex`, which needs a launch
+    /// context, so these tests exercise the arithmetic and bounds logic through
+    /// a locally constructed block instead of a real launch.
+    ///
+    /// `scale` is a pure function of `raw` and `N`, so the tiling property below
+    /// is the same one the real witness relies on.
+    fn tile(raw: usize, n: usize) -> Option<(usize, usize)> {
+        // Mirrors `ThreadIndex::scale`: invalid on N == 0 or overflow.
+        if n == 0 {
+            return None;
+        }
+        let start = raw.checked_mul(n)?;
+        if start == usize::MAX {
+            return None;
+        }
+        Some((start, start + n))
+    }
+
+    /// The soundness claim: distinct thread indices scale to non-overlapping
+    /// ranges. This is what lets `get_block_mut` hand out `&mut [T; N]` to every
+    /// thread at once.
+    #[test]
+    fn distinct_indices_produce_non_overlapping_tiles() {
+        for n in [1usize, 2, 4, 8, 16] {
+            let mut ranges = [(0usize, 0usize); 64];
+            for (slot, raw) in (0..64).enumerate() {
+                ranges[slot] = tile(raw, n).expect("small tiles must be valid");
+            }
+            for i in 0..ranges.len() {
+                for j in (i + 1)..ranges.len() {
+                    let (a_lo, a_hi) = ranges[i];
+                    let (b_lo, b_hi) = ranges[j];
+                    assert!(
+                        a_hi <= b_lo || b_hi <= a_lo,
+                        "tiles for raw={i} and raw={j} overlap at N={n}: \
+                         [{a_lo},{a_hi}) vs [{b_lo},{b_hi})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Tiles must also be gapless, otherwise scaling would silently skip
+    /// elements rather than partition the range.
+    #[test]
+    fn tiles_are_contiguous_and_gapless() {
+        let n = 4;
+        let mut expected_start = 0;
+        for raw in 0..32 {
+            let (start, end) = tile(raw, n).unwrap();
+            assert_eq!(start, expected_start, "gap before raw={raw}");
+            assert_eq!(end - start, n);
+            expected_start = end;
+        }
+    }
+
+    /// A multiplication that overflows must invalidate the witness rather than
+    /// wrap into a small, passing start offset.
+    #[test]
+    fn overflowing_scale_is_rejected() {
+        assert_eq!(tile(usize::MAX / 2, 4), None);
+        assert_eq!(tile(usize::MAX, 2), None);
+        // N == 0 would map every thread to start 0.
+        assert_eq!(tile(7, 0), None);
+    }
+
+    /// `start + N` must be checked, so a tile straddling the end of the address
+    /// space cannot wrap into a passing bounds test.
+    #[test]
+    fn bounds_test_uses_checked_addition() {
+        let len = 64usize;
+        // Well inside.
+        assert!(tile(0, 4).unwrap().1 <= len);
+        assert!(tile(15, 4).unwrap().1 <= len);
+        // Exactly at the end is still in range.
+        assert_eq!(tile(15, 4).unwrap().1, len);
+        // One tile past the end must not fit.
+        assert!(tile(16, 4).unwrap().1 > len);
+        // And the wrapping case is rejected outright.
+        assert_eq!(usize::MAX.checked_add(4), None);
+    }
+}

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -414,6 +414,161 @@ impl<'kernel, const N: usize, IndexSpace> DisjointBlock<'kernel, N, IndexSpace> 
     }
 }
 
+impl<'kernel, const N: usize> DisjointBlock<'kernel, N, Index1D> {
+    /// Extend one tile into `K` tiles, one per pass of the grid over the buffer.
+    ///
+    /// This is the grid-stride form: a thread handles element ranges
+    /// `[tN, tN+N)`, then `[tN + P, tN + P + N)`, and so on, where the period
+    /// `P` is the whole grid's span `G·N`. It covers the strided families the
+    /// single-tile form cannot, such as four stripes at `tid*4 + k*1024` under
+    /// 256 threads - there `G·N = 256·4 = 1024`, so the literal `1024` is not a
+    /// magic number but the period this method derives.
+    ///
+    /// # Why the period is derived and not a parameter
+    ///
+    /// Write the element index as a numeral with three digits:
+    ///
+    /// ```text
+    ///     index  =  k·(G·N)  +  t·N  +  c
+    ///                  ^          ^      ^
+    ///                 pass      thread  within-tile
+    ///
+    ///     digit   range      place value
+    ///     c       [0, N)     1
+    ///     t       [0, G)     N
+    ///     k       [0, K)     G·N
+    /// ```
+    ///
+    /// Each place value is exactly the product of the ranges of all lower
+    /// digits: `1`, then `1·N = N`, then `N·G = G·N`. That is precisely the
+    /// condition for a mixed-radix positional system to be uniquely decodable,
+    /// so the map `(k, t, c) -> index` is injective, with the inverse
+    ///
+    /// ```text
+    ///     c = index mod N
+    ///     t = (index div N) mod G
+    ///     k = index div (G·N)
+    /// ```
+    ///
+    /// Injectivity is the disjointness proof: if `t != t'`, every index from
+    /// thread `t` decodes to `t` and every index from `t'` decodes to `t'`, so
+    /// no index can belong to both. The tiles of distinct threads are therefore
+    /// pairwise disjoint, for every `k`.
+    ///
+    /// A caller-chosen period would break exactly this. Taking `S < G·N` makes
+    /// the `t` and `k` digit ranges overlap, and injectivity fails - with
+    /// `N = 1`, `G = 4`, `S = 2`:
+    ///
+    /// ```text
+    ///     (k=0, t=2)  ->  0·2 + 2  =  2
+    ///     (k=1, t=0)  ->  1·2 + 0  =  2      collision
+    /// ```
+    ///
+    /// Two threads would then hold `&mut` to the same element while each
+    /// pattern looked disjoint in isolation. Deriving `P = G·N` from the launch
+    /// geometry is what rules that out, which is why there is no
+    /// `repeat_with_stride`.
+    ///
+    /// # Scope
+    ///
+    /// Only available for [`Index1D`], where the grid extent is
+    /// `gridDim.x * blockDim.x`. Overflow in `G·N` yields an invalid witness.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Four stripes per thread, period derived from the launch.
+    /// let tiling = thread::index_1d().scale::<4>().repeat::<4>();
+    /// output.for_each_tile(tiling, |k, tile| {
+    ///     *tile = compute_stripe(k);
+    /// });
+    /// ```
+    #[inline(always)]
+    #[must_use]
+    pub fn repeat<const K: usize>(self) -> DisjointTiling<'kernel, N, K> {
+        // G = gridDim.x * blockDim.x, the number of distinct `t` digits.
+        let grid_extent = (gridDim_x() as usize).checked_mul(blockDim_x() as usize);
+        let period = match grid_extent {
+            Some(g) if self.is_valid() && K != 0 => match g.checked_mul(N) {
+                Some(period) if period != 0 && period != usize::MAX => period,
+                _ => usize::MAX,
+            },
+            _ => usize::MAX,
+        };
+        DisjointTiling {
+            start: if period == usize::MAX {
+                usize::MAX
+            } else {
+                self.start
+            },
+            period,
+            _kernel: PhantomData,
+            _not_send_sync: PhantomData,
+        }
+    }
+}
+
+/// Proof that a thread exclusively owns `K` tiles of `N` elements, one per pass
+/// of the grid.
+///
+/// Produced by [`DisjointBlock::repeat`] and consumed by
+/// [`DisjointSlice::for_each_tile`](crate::DisjointSlice::for_each_tile). The
+/// disjointness argument, including why the period is derived rather than
+/// supplied, is on [`DisjointBlock::repeat`].
+///
+/// `!Copy` and `!Clone` for the same reason as [`DisjointBlock`]: duplicating it
+/// would let one thread take the same tile twice.
+pub struct DisjointTiling<'kernel, const N: usize, const K: usize> {
+    /// First element of pass 0, i.e. `t·N`. `usize::MAX` when invalid.
+    start: usize,
+    /// Distance between passes, `G·N`. `usize::MAX` when invalid.
+    period: usize,
+    _kernel: PhantomData<fn(&'kernel mut ()) -> &'kernel mut ()>,
+    _not_send_sync: PhantomData<*mut ()>,
+}
+
+impl<'kernel, const N: usize, const K: usize> DisjointTiling<'kernel, N, K> {
+    /// First element of pass 0.
+    #[inline(always)]
+    #[must_use]
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Distance between consecutive passes, `G·N`.
+    #[inline(always)]
+    #[must_use]
+    pub fn period(&self) -> usize {
+        self.period
+    }
+
+    /// Number of passes. Always `K`.
+    #[inline(always)]
+    #[must_use]
+    pub const fn passes(&self) -> usize {
+        K
+    }
+
+    /// Whether the originating witness was valid and the period is usable.
+    #[inline(always)]
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.start != usize::MAX && self.period != usize::MAX && N != 0 && K != 0
+    }
+}
+
+impl<const N: usize, const K: usize> core::fmt::Debug for DisjointTiling<'_, N, K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DisjointTiling")
+            .field("start", &self.start)
+            .field("period", &self.period)
+            .field("tile_len", &N)
+            .field("passes", &K)
+            .field("valid", &self.is_valid())
+            .finish()
+    }
+}
+
 impl<const N: usize, IndexSpace> core::fmt::Debug for DisjointBlock<'_, N, IndexSpace> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DisjointBlock")

--- a/crates/cuda-device/src/thread.rs
+++ b/crates/cuda-device/src/thread.rs
@@ -288,12 +288,137 @@ impl<'kernel, IndexSpace> ThreadIndex<'kernel, IndexSpace> {
     pub fn in_bounds(&self, len: usize) -> bool {
         self.is_valid() && self.raw < len
     }
+
+    /// Trade this one-element witness for one covering `N` consecutive elements.
+    ///
+    /// A [`ThreadIndex`] proves only that this thread's index differs from every
+    /// other thread's, which is a proof about a single element. Processing `N`
+    /// elements per thread is the usual way to stop wasting bandwidth, and there
+    /// was previously no way to say "index `raw * N` through `raw * N + N - 1`,
+    /// still disjoint" - so those writes went through `get_unchecked_mut` and an
+    /// `unsafe` block with the bounds argument discharged by hand.
+    ///
+    /// The proof carries because scaling *tiles* the space: if every `raw` is
+    /// distinct, the half-open ranges `[raw * N, raw * N + N)` are pairwise
+    /// disjoint. Feed the result to
+    /// [`DisjointSlice::get_block_mut`](crate::DisjointSlice::get_block_mut) for
+    /// a bounds-checked `&mut [T; N]`.
+    ///
+    /// This consumes the witness, which is what keeps it sound. [`ThreadIndex`]
+    /// is deliberately not `Copy`, so a thread cannot hold both this block proof
+    /// and the original single-element proof, or two differently scaled blocks,
+    /// and end up with two live references to the same slot.
+    ///
+    /// `N == 0` and any multiplication that overflows yield an invalid witness
+    /// rather than a wrong one.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Four elements per thread, no unsafe, no manual bounds proof.
+    /// let block = thread::index_1d().scale::<4>();
+    /// if let Some(row) = output.get_block_mut(block) {
+    ///     *row = [o0, o1, o2, o3];
+    /// }
+    /// ```
+    #[inline(always)]
+    #[must_use]
+    pub fn scale<const N: usize>(self) -> DisjointBlock<'kernel, N, IndexSpace> {
+        let start = if self.is_valid() && N != 0 {
+            match self.raw.checked_mul(N) {
+                // `usize::MAX` is the reserved invalid encoding, so a legitimate
+                // start landing exactly there is conservatively rejected.
+                Some(start) if start != usize::MAX => start,
+                _ => usize::MAX,
+            }
+        } else {
+            usize::MAX
+        };
+        DisjointBlock {
+            start,
+            _kernel: PhantomData,
+            _space: PhantomData,
+            _not_send_sync: PhantomData,
+        }
+    }
 }
 
 impl<'kernel, IndexSpace> fmt::Debug for ThreadIndex<'kernel, IndexSpace> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ThreadIndex")
             .field("raw", &self.raw)
+            .field("valid", &self.is_valid())
+            .finish()
+    }
+}
+
+/// Proof that a thread exclusively owns `N` consecutive elements.
+///
+/// Produced by [`ThreadIndex::scale`] and consumed by
+/// [`DisjointSlice::get_block_mut`](crate::DisjointSlice::get_block_mut). Where
+/// a [`ThreadIndex`] proves "this element is mine", this proves "these `N`
+/// elements, starting at `start`, are mine".
+///
+/// # Why the proof holds
+///
+/// The disjointness argument is tiling. [`ThreadIndex`] guarantees each thread's
+/// `raw` is distinct within its index space. Scaling maps `raw` to the half-open
+/// range `[raw * N, raw * N + N)`, and distinct `raw` values give ranges that
+/// cannot overlap: if `a != b` then `[a*N, a*N+N)` and `[b*N, b*N+N)` are
+/// disjoint, because the ranges partition the space into `N`-sized tiles.
+///
+/// Only *scaling* is offered, and that is deliberate. A general affine
+/// `raw * S + K` with a caller-chosen stride does not tile unless `S == N`, so
+/// two such families over one buffer could overlap while each looked disjoint
+/// on its own. Scaling is the case where the proof is unconditional.
+///
+/// Like [`ThreadIndex`], this is deliberately `!Copy`, `!Clone`, `!Send`, and
+/// `!Sync`: duplicating it would let one thread hold two live references to the
+/// same elements.
+pub struct DisjointBlock<'kernel, const N: usize, IndexSpace = Index1D> {
+    /// First element of this thread's tile, or `usize::MAX` when invalid.
+    start: usize,
+    _kernel: PhantomData<fn(&'kernel mut ()) -> &'kernel mut ()>,
+    _space: PhantomData<fn() -> IndexSpace>,
+    _not_send_sync: PhantomData<*mut ()>,
+}
+
+impl<'kernel, const N: usize, IndexSpace> DisjointBlock<'kernel, N, IndexSpace> {
+    /// First element index of this thread's tile.
+    #[inline(always)]
+    #[must_use]
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Number of elements in the tile. Always `N`.
+    #[inline(always)]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        N
+    }
+
+    /// Whether the tile is empty, i.e. `N == 0`.
+    #[inline(always)]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        N == 0
+    }
+
+    /// Whether the originating witness was valid and the scaling did not
+    /// overflow.
+    #[inline(always)]
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.start != usize::MAX && N != 0
+    }
+}
+
+impl<const N: usize, IndexSpace> core::fmt::Debug for DisjointBlock<'_, N, IndexSpace> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DisjointBlock")
+            .field("start", &self.start)
+            .field("len", &N)
             .field("valid", &self.is_valid())
             .finish()
     }


### PR DESCRIPTION
**Stacked on #571** — its diff includes that PR's commits. Review #571 first; this adds the last 244 lines.

A derived index proof covers the case where the extent divides the launch. Real launches round up, so the last block owns a partial run, and today the only way to handle that is to abandon the proof and index manually.

This adds the predicated forms:

```rust
pub enum Tile<'a, T, const N: usize> { Full(&'a mut [T; N]), Partial(&'a mut [T]) }

slice.get_block_clipped_mut(block)      // -> Tile: Full when it fits, Partial at the tail
slice.for_each_tile::<N, K>(tiling, |tile| ...)
```

`Tile` makes the tail a type-level distinction rather than a runtime `if`: `Full` hands back `&mut [T; N]`, which keeps the fixed-size array the arithmetic wants, and `Partial` degrades to a slice only where it must. `len`, `is_full`, `is_empty` and `as_mut_slice` cover the uniform cases.

The disjointness argument is unchanged by clipping: intersecting each thread's run with the slice extent can only shrink runs that were already pairwise disjoint, so no clipped run can overlap another. That is why this is a safe method rather than an `unsafe` one — the proof survives the clip.

## Why it is stacked rather than standalone

`get_block_clipped_mut` takes a `DisjointBlock`, so it cannot compile without #571. Splitting them would mean inventing a second, weaker parameter type to be replaced immediately. Happy to squash both into one PR if you would rather review them together.

## Gates

fmt, clippy `--workspace --all-targets -D warnings`, rustdoc `-D warnings`, tests and doctests clean on `nightly-2026-04-03`. Own content +244/−0 on top of #571.
