### PR TITLE
feat(mir-importer): support ConstantIndex from_end on arrays

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -3306,17 +3306,9 @@ fn translate_place_value_fallback(
                     // `MirConstantOp` + `MirArrayElementAddrOp` and load.
                     // `mem2reg` collapses the resulting load-after-store pairs
                     // back into SSA extracts for promotable arrays.
-
-                    let index = if *from_end {
-                        return input_err!(
-                            loc,
-                            TranslationErr::unsupported(
-                                "ConstantIndex with from_end=true not yet supported"
-                            )
-                        );
-                    } else {
-                        *offset as usize
-                    };
+                    //
+                    // `from_end` resolves via [`resolve_constant_index`] using
+                    // the known `MirArrayType` length.
 
                     // Load the current array value if we don't have a slot (ZST/edge case)
                     // so that we fall back to the SSA extract-field behaviour.
@@ -3340,12 +3332,12 @@ fn translate_place_value_fallback(
                         let anchor = prev_op_after_base.or(prev_op);
 
                         let array_ty = array_value.get_type(ctx);
-                        let element_ty = {
+                        let (element_ty, sequence_len) = {
                             let array_ty_ref = array_ty.deref(ctx);
                             if let Some(arr_ty) =
                                 array_ty_ref.downcast_ref::<dialect_mir::types::MirArrayType>()
                             {
-                                arr_ty.element_type()
+                                (arr_ty.element_type(), arr_ty.size())
                             } else {
                                 return input_err!(
                                     loc,
@@ -3356,6 +3348,8 @@ fn translate_place_value_fallback(
                                 );
                             }
                         };
+                        let index =
+                            resolve_constant_index(*offset, *from_end, sequence_len, &loc)?;
 
                         let op = Operation::new(
                             ctx,
@@ -3386,7 +3380,7 @@ fn translate_place_value_fallback(
                     // Slot-backed path: GEP + load from the slot.
                     let mut current_prev = prev_op;
 
-                    let (element_ty, address_space) = {
+                    let (element_ty, address_space, sequence_len) = {
                         let arr_ptr_ty = arr_ptr.get_type(ctx);
                         let arr_ptr_ty_ref = arr_ptr_ty.deref(ctx);
                         let mir_ptr_ty = arr_ptr_ty_ref
@@ -3401,16 +3395,16 @@ fn translate_place_value_fallback(
                                 )
                             })?;
                         let array_ty_ref = mir_ptr_ty.pointee.deref(ctx);
-                        let elem_ty = array_ty_ref
+                        let arr_ty = array_ty_ref
                             .downcast_ref::<dialect_mir::types::MirArrayType>()
                             .ok_or_else(|| {
                                 input_error_noloc!(TranslationErr::unsupported(
                                     "ConstantIndex base slot pointee is not MirArrayType"
                                 ))
-                            })?
-                            .element_type();
-                        (elem_ty, mir_ptr_ty.address_space)
+                            })?;
+                        (arr_ty.element_type(), mir_ptr_ty.address_space, arr_ty.size())
                     };
+                    let index = resolve_constant_index(*offset, *from_end, sequence_len, &loc)?;
 
                     use dialect_mir::ops::MirConstantOp;
                     use pliron::builtin::attributes::IntegerAttr;
@@ -3821,14 +3815,55 @@ pub(crate) fn translate_place_address(
     )
 }
 
+/// Resolve a MIR `ConstantIndex` into a 0-based element offset.
+///
+/// Rustc semantics: if `from_end` then index = `sequence_len - offset`, else
+/// `offset`. Callers must supply a known sequence length (typically
+/// [`MirArrayType::size`]); slices / unknown lengths must be rejected before
+/// invoking this so we never silently wrong-index.
+pub(crate) fn resolve_constant_index(
+    offset: u64,
+    from_end: bool,
+    sequence_len: u64,
+    loc: &Location,
+) -> TranslationResult<usize> {
+    if from_end {
+        if offset > sequence_len {
+            return input_err!(
+                loc.clone(),
+                TranslationErr::unsupported(format!(
+                    "ConstantIndex from_end offset {offset} exceeds sequence length {sequence_len}"
+                ))
+            );
+        }
+        Ok((sequence_len - offset) as usize)
+    } else {
+        Ok(offset as usize)
+    }
+}
+
+/// Length of the `[T; N]` pointee behind `ptr`, if any.
+fn mir_ptr_array_len(ctx: &Context, ptr: Value) -> Option<u64> {
+    let ptr_ty = ptr.get_type(ctx);
+    let ptr_ty_ref = ptr_ty.deref(ctx);
+    let mir_ptr = ptr_ty_ref.downcast_ref::<dialect_mir::types::MirPtrType>()?;
+    let pointee = mir_ptr.pointee;
+    pointee
+        .deref(ctx)
+        .downcast_ref::<dialect_mir::types::MirArrayType>()
+        .map(|arr| arr.size())
+}
+
 /// Compute the in-memory address of `place` starting from its alloca `slot`.
 ///
 /// Walks the projection chain and emits the correct pliron ops for each
 /// element:
 ///
 /// - `Field(idx, _)`   → [`MirFieldAddrOp`]
-/// - `ConstantIndex {offset, from_end: false, ..}` → `MirConstantOp` + [`MirArrayElementAddrOp`]
-///   (array pointee) or `MirConstantOp` + [`MirPtrOffsetOp`] (slice data pointer)
+/// - `ConstantIndex {offset, from_end, ..}` → `MirConstantOp` + [`MirArrayElementAddrOp`]
+///   (array pointee; `from_end` resolves via [`resolve_constant_index`] using
+///   the known array length) or `MirConstantOp` + [`MirPtrOffsetOp`] (slice
+///   data pointer; forward indices only)
 /// - `Index(local)`    → `load_local(local)` + [`MirArrayElementAddrOp`]
 ///   (array pointee) or `load_local(local)` + [`MirPtrOffsetOp`] (slice data pointer)
 /// - `Deref`           → `MirLoadOp` of the pointer (the loaded pointer IS
@@ -3839,9 +3874,10 @@ pub(crate) fn translate_place_address(
 ///   so the walk continues against the ORIGINAL elements, while a trailing
 ///   fat deref (`&*s` reborrow) is just a load of the fat value.
 ///
-/// `Downcast` (enum payload addressing; issues #131/#146), `Subslice` and
-/// from-end `ConstantIndex` are NOT handled; the walker punts on them
-/// (returns `Ok(None)`).
+/// `Downcast` (enum payload addressing; issues #131/#146) and `Subslice` are
+/// NOT handled; the walker punts on them (returns `Ok(None)`). From-end
+/// `ConstantIndex` on non-array pointees (e.g. slice data pointers) also
+/// punts — only known-length arrays can resolve `from_end`.
 ///
 /// Returns `Ok(Some((addr, last_op)))` on success, `Ok(None)` if the
 /// projection chain contains an element this helper doesn't know how to
@@ -4158,9 +4194,6 @@ fn translate_place_addr_from_slot(
                 min_length: _,
                 from_end,
             } => {
-                if *from_end {
-                    return Ok(None);
-                }
                 let (mut pointee_kind, addr_space) = match pointer_pointee_kind(ctx, current) {
                     Some(kind) => kind,
                     None => return Ok(None),
@@ -4169,8 +4202,20 @@ fn translate_place_addr_from_slot(
                     pointee_kind = PointeeKind::Direct;
                 }
 
+                // from_end needs a known array length. Slice data pointers
+                // (Direct) have no compile-time length — punt rather than
+                // silently wrong-index.
+                let index = if *from_end {
+                    let Some(seq_len) = mir_ptr_array_len(ctx, current) else {
+                        return Ok(None);
+                    };
+                    resolve_constant_index(*offset, true, seq_len, &loc)?
+                } else {
+                    *offset as usize
+                };
+
                 let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
-                let index_apint = APInt::from_i64(*offset as i64, NonZeroUsize::new(64).unwrap());
+                let index_apint = APInt::from_i64(index as i64, NonZeroUsize::new(64).unwrap());
                 let const_attr = pliron::builtin::attributes::IntegerAttr::new(i64_ty, index_apint);
                 let const_op_ptr = Operation::new(
                     ctx,
@@ -4257,10 +4302,11 @@ fn translate_place_addr_from_slot(
             // value copy and mutable borrows fail loudly at the caller.
             mir::ProjectionElem::Downcast(_) => return Ok(None),
 
-            // Remaining projection kinds (Subslice, from-end ConstantIndex,
-            // ...) aren't lowered to addresses here yet. Punt to the caller,
-            // which decides between a value fallback (shared borrows) and a
-            // hard error (mutable borrows).
+            // Remaining projection kinds (Subslice, ...) aren't lowered to
+            // addresses here yet. Punt to the caller, which decides between a
+            // value fallback (shared borrows) and a hard error (mutable
+            // borrows). From-end ConstantIndex on non-array pointees is
+            // handled above (returns Ok(None)).
             _ => return Ok(None),
         }
     }
@@ -4707,25 +4753,19 @@ pub fn translate_place_iterative(
                 min_length: _,
                 from_end,
             } => {
-                if *from_end {
-                    return input_err!(
-                        loc,
-                        TranslationErr::unsupported(
-                            "ConstantIndex with from_end=true not yet supported"
-                        )
-                    );
-                }
-                let index = *offset as usize;
-
                 // Determine indexable kind upfront so we drop the immutable borrow
                 // before creating operations (which need &mut ctx).
                 enum ConstIndexKind {
                     Array {
                         element_ty: TypeHandle,
+                        sequence_len: u64,
                     },
                     Ptr {
                         element_ty: TypeHandle,
                         ptr_ty: TypeHandle,
+                        /// Known length when pointee is `[T; N]`; `None` for
+                        /// slice data pointers / other pointees.
+                        array_len: Option<u64>,
                     },
                 }
 
@@ -4737,13 +4777,20 @@ pub fn translate_place_iterative(
                     {
                         Ok(ConstIndexKind::Array {
                             element_ty: arr_ty.element_type(),
+                            sequence_len: arr_ty.size(),
                         })
                     } else if let Some(ptr_ty) =
                         cur_ty_ref.downcast_ref::<dialect_mir::types::MirPtrType>()
                     {
+                        let array_len = ptr_ty
+                            .pointee
+                            .deref(ctx)
+                            .downcast_ref::<dialect_mir::types::MirArrayType>()
+                            .map(|arr| arr.size());
                         Ok(ConstIndexKind::Ptr {
                             element_ty: ptr_ty.pointee,
                             ptr_ty: cur_ty,
+                            array_len,
                         })
                     } else {
                         let ty_dbg = format!("{:?}", cur_ty_ref);
@@ -4752,7 +4799,12 @@ pub fn translate_place_iterative(
                 };
 
                 match kind {
-                    Ok(ConstIndexKind::Array { element_ty }) => {
+                    Ok(ConstIndexKind::Array {
+                        element_ty,
+                        sequence_len,
+                    }) => {
+                        let index =
+                            resolve_constant_index(*offset, *from_end, sequence_len, &loc)?;
                         let op = Operation::new(
                             ctx,
                             MirExtractFieldOp::get_concrete_op_info(),
@@ -4777,69 +4829,173 @@ pub fn translate_place_iterative(
                         current_value = extract_op.get_operation().deref(ctx).get_result(0);
                         current_prev_op = Some(extract_op.get_operation());
                     }
-                    Ok(ConstIndexKind::Ptr { element_ty, ptr_ty }) => {
-                        // Create constant index value
-                        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
-                        let apint = APInt::from_u32(index as u32, NonZeroUsize::new(32).unwrap());
-                        let index_attr =
-                            pliron::builtin::attributes::IntegerAttr::new(i32_ty, apint);
+                    Ok(ConstIndexKind::Ptr {
+                        element_ty,
+                        ptr_ty,
+                        array_len,
+                    }) => {
                         use dialect_mir::ops::MirConstantOp;
-                        let const_op = Operation::new(
-                            ctx,
-                            MirConstantOp::get_concrete_op_info(),
-                            vec![i32_ty.into()],
-                            vec![],
-                            vec![],
-                            0,
-                        );
-                        const_op.deref_mut(ctx).set_loc(loc.clone());
-                        let const_mir = MirConstantOp::new(const_op);
-                        const_mir.set_attr_value(ctx, index_attr);
-                        if let Some(prev) = current_prev_op {
-                            const_mir.get_operation().insert_after(ctx, prev);
-                        } else {
-                            const_mir.get_operation().insert_at_front(block_ptr, ctx);
-                        }
-                        current_prev_op = Some(const_mir.get_operation());
-                        let index_value = const_mir.get_operation().deref(ctx).get_result(0);
 
-                        // Pointer offset
-                        let offset_op = Operation::new(
-                            ctx,
-                            MirPtrOffsetOp::get_concrete_op_info(),
-                            vec![ptr_ty],
-                            vec![current_value, index_value],
-                            vec![],
-                            0,
-                        );
-                        offset_op.deref_mut(ctx).set_loc(loc.clone());
-                        if let Some(prev) = current_prev_op {
-                            offset_op.insert_after(ctx, prev);
-                        } else {
-                            offset_op.insert_at_front(block_ptr, ctx);
-                        }
-                        current_prev_op = Some(offset_op);
-                        let offset_ptr = offset_op.deref(ctx).get_result(0);
+                        // from_end on a pointer requires a known-length array
+                        // pointee; slice data pointers have no compile-time len.
+                        if *from_end {
+                            let Some(seq_len) = array_len else {
+                                return input_err!(
+                                    loc,
+                                    TranslationErr::unsupported(
+                                        "ConstantIndex with from_end=true requires a \
+                                         known-length array (got pointer to non-array)"
+                                    )
+                                );
+                            };
+                            let index = resolve_constant_index(*offset, true, seq_len, &loc)?;
+                            // `element_ty` here is the MirArrayType pointee; GEP
+                            // into it and load the scalar element.
+                            let arr_elem_ty = element_ty
+                                .deref(ctx)
+                                .downcast_ref::<dialect_mir::types::MirArrayType>()
+                                .map(|arr| arr.element_type())
+                                .ok_or_else(|| {
+                                    input_error_noloc!(TranslationErr::unsupported(
+                                        "ConstantIndex from_end array_len set but \
+                                         pointee is not MirArrayType"
+                                    ))
+                                })?;
+                            let addr_space = ptr_ty
+                                .deref(ctx)
+                                .downcast_ref::<dialect_mir::types::MirPtrType>()
+                                .map(|p| p.address_space)
+                                .unwrap_or(0);
 
-                        // Load element
-                        let load_op = Operation::new(
-                            ctx,
-                            MirLoadOp::get_concrete_op_info(),
-                            vec![element_ty],
-                            vec![offset_ptr],
-                            vec![],
-                            0,
-                        );
-                        load_op.deref_mut(ctx).set_loc(loc.clone());
-                        let load = MirLoadOp::new(load_op);
-                        if let Some(prev) = current_prev_op {
-                            load.get_operation().insert_after(ctx, prev);
-                        } else {
-                            load.get_operation().insert_at_front(block_ptr, ctx);
-                        }
+                            let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+                            let index_apint =
+                                APInt::from_i64(index as i64, NonZeroUsize::new(64).unwrap());
+                            let index_attr = pliron::builtin::attributes::IntegerAttr::new(
+                                i64_ty, index_apint,
+                            );
+                            let const_op = Operation::new(
+                                ctx,
+                                MirConstantOp::get_concrete_op_info(),
+                                vec![i64_ty.into()],
+                                vec![],
+                                vec![],
+                                0,
+                            );
+                            const_op.deref_mut(ctx).set_loc(loc.clone());
+                            MirConstantOp::new(const_op).set_attr_value(ctx, index_attr);
+                            if let Some(prev) = current_prev_op {
+                                const_op.insert_after(ctx, prev);
+                            } else {
+                                const_op.insert_at_front(block_ptr, ctx);
+                            }
+                            current_prev_op = Some(const_op);
+                            let index_value = const_op.deref(ctx).get_result(0);
 
-                        current_value = load.get_operation().deref(ctx).get_result(0);
-                        current_prev_op = Some(load.get_operation());
+                            use dialect_mir::ops::MirArrayElementAddrOp;
+                            let elem_ptr_ty = dialect_mir::types::MirPtrType::get(
+                                ctx, arr_elem_ty, false, addr_space,
+                            )
+                            .into();
+                            let addr_op = Operation::new(
+                                ctx,
+                                MirArrayElementAddrOp::get_concrete_op_info(),
+                                vec![elem_ptr_ty],
+                                vec![current_value, index_value],
+                                vec![],
+                                0,
+                            );
+                            addr_op.deref_mut(ctx).set_loc(loc.clone());
+                            if let Some(prev) = current_prev_op {
+                                addr_op.insert_after(ctx, prev);
+                            } else {
+                                addr_op.insert_at_front(block_ptr, ctx);
+                            }
+                            current_prev_op = Some(addr_op);
+                            let elem_ptr = addr_op.deref(ctx).get_result(0);
+
+                            let load_op = Operation::new(
+                                ctx,
+                                MirLoadOp::get_concrete_op_info(),
+                                vec![arr_elem_ty],
+                                vec![elem_ptr],
+                                vec![],
+                                0,
+                            );
+                            load_op.deref_mut(ctx).set_loc(loc.clone());
+                            if let Some(prev) = current_prev_op {
+                                load_op.insert_after(ctx, prev);
+                            } else {
+                                load_op.insert_at_front(block_ptr, ctx);
+                            }
+                            current_value = load_op.deref(ctx).get_result(0);
+                            current_prev_op = Some(load_op);
+                        } else {
+                            let index = *offset as usize;
+
+                            // Create constant index value
+                            let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+                            let apint =
+                                APInt::from_u32(index as u32, NonZeroUsize::new(32).unwrap());
+                            let index_attr =
+                                pliron::builtin::attributes::IntegerAttr::new(i32_ty, apint);
+                            let const_op = Operation::new(
+                                ctx,
+                                MirConstantOp::get_concrete_op_info(),
+                                vec![i32_ty.into()],
+                                vec![],
+                                vec![],
+                                0,
+                            );
+                            const_op.deref_mut(ctx).set_loc(loc.clone());
+                            let const_mir = MirConstantOp::new(const_op);
+                            const_mir.set_attr_value(ctx, index_attr);
+                            if let Some(prev) = current_prev_op {
+                                const_mir.get_operation().insert_after(ctx, prev);
+                            } else {
+                                const_mir.get_operation().insert_at_front(block_ptr, ctx);
+                            }
+                            current_prev_op = Some(const_mir.get_operation());
+                            let index_value =
+                                const_mir.get_operation().deref(ctx).get_result(0);
+
+                            // Pointer offset
+                            let offset_op = Operation::new(
+                                ctx,
+                                MirPtrOffsetOp::get_concrete_op_info(),
+                                vec![ptr_ty],
+                                vec![current_value, index_value],
+                                vec![],
+                                0,
+                            );
+                            offset_op.deref_mut(ctx).set_loc(loc.clone());
+                            if let Some(prev) = current_prev_op {
+                                offset_op.insert_after(ctx, prev);
+                            } else {
+                                offset_op.insert_at_front(block_ptr, ctx);
+                            }
+                            current_prev_op = Some(offset_op);
+                            let offset_ptr = offset_op.deref(ctx).get_result(0);
+
+                            // Load element
+                            let load_op = Operation::new(
+                                ctx,
+                                MirLoadOp::get_concrete_op_info(),
+                                vec![element_ty],
+                                vec![offset_ptr],
+                                vec![],
+                                0,
+                            );
+                            load_op.deref_mut(ctx).set_loc(loc.clone());
+                            let load = MirLoadOp::new(load_op);
+                            if let Some(prev) = current_prev_op {
+                                load.get_operation().insert_after(ctx, prev);
+                            } else {
+                                load.get_operation().insert_at_front(block_ptr, ctx);
+                            }
+
+                            current_value = load.get_operation().deref(ctx).get_result(0);
+                            current_prev_op = Some(load.get_operation());
+                        }
                     }
                     Err(ty_dbg) => {
                         return input_err!(
@@ -4848,14 +5004,15 @@ pub fn translate_place_iterative(
                                 "ConstantIndex projection on unsupported type.\n\
                                  \n  pliron type: {}\n\
                                  \n  display    : {}\n\
-                                 \n  index      : {}\n\
+                                 \n  offset     : {} (from_end={})\n\
                                  \n\
                                  \nConstantIndex handles MirArrayType (extractvalue) and MirPtrType\n\
                                  (pointer offset + load, e.g. after Deref on a slice). The type above\n\
                                  matched neither. A new handler may need to be added.",
                                 ty_dbg,
                                 cur_ty.disp(ctx),
-                                index
+                                offset,
+                                from_end
                             ))
                         );
                     }
@@ -9057,6 +9214,43 @@ mod tests {
             Operation::get_op::<MirCastOp>(cast_op, &ctx).is_some(),
             "normalization must insert mir.cast"
         );
+    }
+}
+
+#[cfg(test)]
+mod constant_index_tests {
+    use super::resolve_constant_index;
+    use pliron::location::Location;
+
+    #[test]
+    fn resolve_constant_index_from_start() {
+        assert_eq!(
+            resolve_constant_index(2, false, 4, &Location::Unknown).unwrap(),
+            2
+        );
+        assert_eq!(
+            resolve_constant_index(0, false, 4, &Location::Unknown).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn resolve_constant_index_from_end() {
+        // `let [.., last] = [T; 4]` → offset=1, from_end → index 3
+        assert_eq!(
+            resolve_constant_index(1, true, 4, &Location::Unknown).unwrap(),
+            3
+        );
+        // offset == len → index 0
+        assert_eq!(
+            resolve_constant_index(4, true, 4, &Location::Unknown).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn resolve_constant_index_from_end_offset_exceeds_len() {
+        assert!(resolve_constant_index(5, true, 4, &Location::Unknown).is_err());
     }
 }
 

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -291,15 +291,9 @@ pub fn translate_statement(
                         // Alloca model: locate the element via
                         // `MirConstantOp` + `MirArrayElementAddrOp` from the
                         // local's slot and emit `mir.store`.
-
-                        if *from_end {
-                            return input_err!(
-                                loc,
-                                TranslationErr::unsupported(
-                                    "ConstantIndex with from_end=true not yet supported for writes"
-                                )
-                            );
-                        }
+                        // `from_end` resolves via
+                        // [`rvalue::resolve_constant_index`] using the known
+                        // array length.
 
                         let mut current_prev = prev_op;
                         if let Some(rvalue_op) = rvalue_op_opt {
@@ -318,7 +312,6 @@ pub fn translate_statement(
                         }
 
                         let local = place.local;
-                        let index = *offset as usize;
                         let Some(arr_ptr) = value_map.get_slot(local) else {
                             return input_err!(
                                 loc,
@@ -329,8 +322,14 @@ pub fn translate_statement(
                             );
                         };
 
-                        let (element_ty, address_space) =
+                        let (element_ty, address_space, sequence_len) =
                             slot_array_element_ty(ctx, arr_ptr, &loc)?;
+                        let index = rvalue::resolve_constant_index(
+                            *offset,
+                            *from_end,
+                            sequence_len,
+                            &loc,
+                        )?;
 
                         use dialect_mir::ops::MirConstantOp;
                         use pliron::builtin::attributes::IntegerAttr;
@@ -421,7 +420,7 @@ pub fn translate_statement(
                         )?;
                         current_prev = prev_op_after_index;
 
-                        let (element_ty, address_space) =
+                        let (element_ty, address_space, _) =
                             slot_array_element_ty(ctx, arr_ptr, &loc)?;
 
                         let store_op = emit_array_element_store(
@@ -1071,18 +1070,18 @@ fn store_through_place_address(
     Ok(Some(store_op))
 }
 
-/// Extract the element type and address space from a pointer that points
-/// to an array.
+/// Extract the element type, address space, and array length from a pointer
+/// that points to an array.
 ///
 /// Used by the statement-level element write helpers. Returns a structured
 /// error when the pointer's pointee isn't a [`MirArrayType`], which signals
 /// a structural mismatch (most likely the wrong MIR projection reaching
-/// this path).
+/// this path). The length is used for `ConstantIndex { from_end: true }`.
 fn slot_array_element_ty(
     ctx: &pliron::context::Context,
     arr_ptr: Value,
     loc: &Location,
-) -> TranslationResult<(pliron::r#type::TypeHandle, u32)> {
+) -> TranslationResult<(pliron::r#type::TypeHandle, u32, u64)> {
     let arr_ptr_ty = arr_ptr.get_type(ctx);
     let arr_ptr_ty_ref = arr_ptr_ty.deref(ctx);
     let mir_ptr_ty = arr_ptr_ty_ref
@@ -1095,16 +1094,15 @@ fn slot_array_element_ty(
         })?;
     let address_space = mir_ptr_ty.address_space;
     let pointee_ref = mir_ptr_ty.pointee.deref(ctx);
-    let element_ty = pointee_ref
+    let arr_ty = pointee_ref
         .downcast_ref::<dialect_mir::types::MirArrayType>()
         .ok_or_else(|| {
             pliron::input_error!(
                 loc.clone(),
                 TranslationErr::unsupported("Array-index slot pointee is not MirArrayType",)
             )
-        })?
-        .element_type();
-    Ok((element_ty, address_space))
+        })?;
+    Ok((arr_ty.element_type(), address_space, arr_ty.size()))
 }
 
 /// Emit `mir.array_element_addr` + `mir.store` to assign `value` into

--- a/crates/rustc-codegen-cuda/examples/constant_index_from_end/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/constant_index_from_end/Cargo.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "constant_index_from_end"
+version = "0.1.0"
+edition = "2024"
+authors = ["Ayush7614 <ayushknj3@gmail.com>"]
+license = "Apache-2.0"
+
+# Mark as standalone crate (not part of parent workspace)
+[workspace]
+
+# Exercises ProjectionElem::ConstantIndex { from_end: true } on fixed-length
+# arrays (e.g. `let [.., last] = arr`).
+#
+# Build and run with:
+#   cargo oxide run constant_index_from_end
+
+[dependencies]
+cuda-device = { path = "../../../cuda-device" }
+cuda-host = { path = "../../../cuda-host" }
+cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/constant_index_from_end/LICENSE
+++ b/crates/rustc-codegen-cuda/examples/constant_index_from_end/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2026 NVIDIA CORPORATION
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/rustc-codegen-cuda/examples/constant_index_from_end/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/constant_index_from_end/src/main.rs
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! ConstantIndex `from_end` smoke test.
+//!
+//! Forces rustc to emit `ProjectionElem::ConstantIndex { from_end: true }`
+//! via rest patterns on fixed-length arrays (`let [.., last] = arr` and
+//! `let [.., ref mut last] = arr`). Before support landed, these rejected
+//! with "ConstantIndex with from_end=true not yet supported".
+//!
+//! Run: cargo oxide run constant_index_from_end
+
+use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
+
+#[cuda_module]
+mod kernels {
+    use super::*;
+
+    /// Read the last element via `let [.., last] = arr`.
+    #[kernel]
+    pub fn read_last(mut out: DisjointSlice<u32>) {
+        let idx = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let arr: [u32; 4] = [10, 20, 30, 40];
+            let [.., last] = arr;
+            *out_elem = last;
+        }
+    }
+
+    /// Write through a from-end mutable binding, then read last + first.
+    #[kernel]
+    pub fn write_last(val: u32, mut out: DisjointSlice<u32>) {
+        let idx = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let mut arr: [u32; 4] = [1, 2, 3, 4];
+            let [.., ref mut last] = arr;
+            *last = val;
+            *out_elem = arr[0] + arr[3];
+        }
+    }
+}
+
+fn main() {
+    const N: usize = 64;
+
+    let ctx = CudaContext::new(0).expect("CUDA context");
+    let stream = ctx.default_stream();
+    let module = kernels::load(&ctx).expect("load module");
+
+    // --- read_last ---
+    let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.read_last(&stream, LaunchConfig::for_num_elems(N as u32), &mut out_dev)
+    }
+    .expect("read_last launch");
+    let out = out_dev.to_host_vec(&stream).unwrap();
+    let mut errors = 0usize;
+    for (i, &val) in out.iter().enumerate() {
+        if val != 40 {
+            if errors < 5 {
+                eprintln!("  FAIL read_last[{}]: got {} want 40", i, val);
+            }
+            errors += 1;
+        }
+    }
+
+    // --- write_last ---
+    let val: u32 = 99;
+    let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    unsafe {
+        module.write_last(
+            &stream,
+            LaunchConfig::for_num_elems(N as u32),
+            val,
+            &mut out_dev,
+        )
+    }
+    .expect("write_last launch");
+    let out = out_dev.to_host_vec(&stream).unwrap();
+    let expected = 1 + val; // arr[0] + arr[3]
+    for (i, &got) in out.iter().enumerate() {
+        if got != expected {
+            if errors < 5 {
+                eprintln!("  FAIL write_last[{}]: got {} want {}", i, got, expected);
+            }
+            errors += 1;
+        }
+    }
+
+    if errors == 0 {
+        println!("PASS: constant_index_from_end (read + write)");
+    } else {
+        eprintln!("FAIL: {} errors", errors);
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve `ProjectionElem::ConstantIndex { from_end: true }` as `len - offset` for known-length arrays across place loads, SSA extracts, address walks, and element writes.
- Slices / unknown-length bases still get a clear unsupported or punt path (no silent wrong index).
- Adds unit tests for the resolver and a `constant_index_from_end` example using `let [.., last] = arr` / `let [.., ref mut last] = arr`.

## Test plan

- [x] `cargo test -p mir-importer` (883 passed + 1 ignored doctest), including `resolve_constant_index_*` unit tests
- [x] `cargo check -p mir-importer`
- [ ] `cargo oxide run constant_index_from_end` (needs GPU / toolkit)