### PR TITLE
docs(view): by-value readers must document the initialization obligation

### DIFF
--- a/crates/cuda-device/src/view.rs
+++ b/crates/cuda-device/src/view.rs
@@ -18,6 +18,24 @@
 //! The pointer fields are private. Safe code can obtain a view only through a
 //! checked slice constructor or a `DisjointSlice` method that consumes a
 //! thread-unique [`crate::thread::ThreadIndex32`].
+//!
+//! # Initialization
+//!
+//! The by-value readers ([`InBounds32::read`], [`InBoundsMut32::read`],
+//! [`RowView32::get`], [`ColView32::get`], [`RowViewIter32::next`],
+//! [`ColViewIter32::next`] and [`ZipView32::next`]) copy the element out of
+//! the underlying buffer, so every slot they touch must already be
+//! **initialized**. Reading a slot that was never written is undefined
+//! behavior for any element type: Rust treats even integers and floats read
+//! from uninitialized memory as invalid. Beyond being written at all, the
+//! slot must hold a valid value of the type, which zeroed memory does not
+//! guarantee for types with invalid bit patterns such as references or enums
+//! without a zero variant.
+//!
+//! In practice: buffers from `DeviceBuffer::zeroed` or
+//! `DeviceBuffer::from_host` arrive fully initialized, while one from
+//! `DeviceBuffer::uninitialized_async` must not be read until a kernel or
+//! copy has written it, exactly as that constructor's safety contract says.
 
 use crate::DisjointSlice;
 use crate::thread::{Index1D, ThreadCoord2D32, ThreadIndex32};
@@ -131,12 +149,8 @@ impl<'a, T> InBounds32<'a, T> {
 
     /// Load a `Copy` value from the proven element.
     ///
-    /// The element must already be **initialized**. This copies the value out,
-    /// so a slot that was never written holds an indeterminate bit pattern, and
-    /// producing a `T` from it is undefined behaviour for any `T` whose values
-    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
-    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
-    /// `uninitialized_async` are not until written.
+    /// The element must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     pub fn read(&self) -> T
     where
@@ -183,12 +197,8 @@ impl<'a, T> InBoundsMut32<'a, T> {
 
     /// Load a `Copy` value from the proven element.
     ///
-    /// The element must already be **initialized**. This copies the value out,
-    /// so a slot that was never written holds an indeterminate bit pattern, and
-    /// producing a `T` from it is undefined behaviour for any `T` whose values
-    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
-    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
-    /// `uninitialized_async` are not until written.
+    /// The element must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     pub fn read(&self) -> T
     where
@@ -660,12 +670,8 @@ impl<'a, T> RowView32<'a, T> {
 
     /// Load element `i` with a single bounds compare.
     ///
-    /// The element must already be **initialized**. This copies the value out,
-    /// so a slot that was never written holds an indeterminate bit pattern, and
-    /// producing a `T` from it is undefined behaviour for any `T` whose values
-    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
-    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
-    /// `uninitialized_async` are not until written.
+    /// The element must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     pub fn get(&self, i: u32) -> Option<T>
     where
@@ -773,12 +779,8 @@ impl<'a, T> ColView32<'a, T> {
     /// Load element `i` (flat offset `i * stride`) with a single bounds
     /// compare.
     ///
-    /// The element must already be **initialized**. This copies the value out,
-    /// so a slot that was never written holds an indeterminate bit pattern, and
-    /// producing a `T` from it is undefined behaviour for any `T` whose values
-    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
-    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
-    /// `uninitialized_async` are not until written.
+    /// The element must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     pub fn get(&self, i: u32) -> Option<T>
     where
@@ -845,6 +847,8 @@ pub struct RowViewIter32<'a, T> {
 impl<'a, T: Copy> Iterator for RowViewIter32<'a, T> {
     type Item = T;
 
+    /// Every element yielded must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     fn next(&mut self) -> Option<T> {
         if self.next < self.len {
@@ -874,6 +878,8 @@ pub struct ColViewIter32<'a, T> {
 impl<'a, T: Copy> Iterator for ColViewIter32<'a, T> {
     type Item = T;
 
+    /// Every element yielded must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     fn next(&mut self) -> Option<T> {
         if self.next < self.len {
@@ -909,6 +915,8 @@ pub struct ZipView32<'a, T> {
 impl<'a, T: Copy> Iterator for ZipView32<'a, T> {
     type Item = (T, T);
 
+    /// Every element of both bands must already be initialized; see
+    /// [Initialization](self#initialization) in the module docs.
     #[inline(always)]
     fn next(&mut self) -> Option<(T, T)> {
         if self.next < self.len {

--- a/crates/cuda-device/src/view.rs
+++ b/crates/cuda-device/src/view.rs
@@ -130,6 +130,13 @@ impl<'a, T> InBounds32<'a, T> {
     }
 
     /// Load a `Copy` value from the proven element.
+    ///
+    /// The element must already be **initialized**. This copies the value out,
+    /// so a slot that was never written holds an indeterminate bit pattern, and
+    /// producing a `T` from it is undefined behaviour for any `T` whose values
+    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
+    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
+    /// `uninitialized_async` are not until written.
     #[inline(always)]
     pub fn read(&self) -> T
     where
@@ -175,6 +182,13 @@ impl<'a, T> InBoundsMut32<'a, T> {
     }
 
     /// Load a `Copy` value from the proven element.
+    ///
+    /// The element must already be **initialized**. This copies the value out,
+    /// so a slot that was never written holds an indeterminate bit pattern, and
+    /// producing a `T` from it is undefined behaviour for any `T` whose values
+    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
+    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
+    /// `uninitialized_async` are not until written.
     #[inline(always)]
     pub fn read(&self) -> T
     where
@@ -645,6 +659,13 @@ impl<'a, T> RowView32<'a, T> {
     }
 
     /// Load element `i` with a single bounds compare.
+    ///
+    /// The element must already be **initialized**. This copies the value out,
+    /// so a slot that was never written holds an indeterminate bit pattern, and
+    /// producing a `T` from it is undefined behaviour for any `T` whose values
+    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
+    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
+    /// `uninitialized_async` are not until written.
     #[inline(always)]
     pub fn get(&self, i: u32) -> Option<T>
     where
@@ -751,6 +772,13 @@ impl<'a, T> ColView32<'a, T> {
 
     /// Load element `i` (flat offset `i * stride`) with a single bounds
     /// compare.
+    ///
+    /// The element must already be **initialized**. This copies the value out,
+    /// so a slot that was never written holds an indeterminate bit pattern, and
+    /// producing a `T` from it is undefined behaviour for any `T` whose values
+    /// are not all bit patterns (`bool`, `char`, enums, references). Buffers
+    /// from `DeviceBuffer::zeroed` or `from_host` are initialized; those from
+    /// `uninitialized_async` are not until written.
     #[inline(always)]
     pub fn get(&self, i: u32) -> Option<T>
     where


### PR DESCRIPTION
Four methods in `view.rs` copy their element out **by value**, and none documents that the element must already be initialized:

| method | signature |
|---|---|
| `InBounds32::read` | `fn read(&self) -> T where T: Copy` |
| `InBoundsMut32::read` | `fn read(&self) -> T where T: Copy` |
| `RowView32::get` | `fn get(&self, i: u32) -> Option<T> where T: Copy` |
| `ColView32::get` | `fn get(&self, i: u32) -> Option<T> where T: Copy` |

A slot that was never written holds an indeterminate bit pattern, so producing a `T` from it is undefined behaviour for any `T` whose values are not all bit patterns — `bool`, `char`, enums, references. `T: Copy` does not help: `bool` is `Copy`.

## Why this is reachable, not theoretical

`DeviceBuffer::zeroed` and `from_host` produce initialized memory, but `uninitialized_async` does not until written. Nothing in these four doc comments points at that distinction, so a caller who allocates with `uninitialized_async` and reads before writing has no signal that the read is the problem. Searching `view.rs` for "initiali" returns zero hits today.

## Scope

Docs only, +28 lines in one file, no signature or behaviour change.

Deliberately **not** touched: `InBounds32::get` and `InBoundsMut32::get_mut` hand back a reference rather than a copy, so they carry no such requirement — the asymmetry is the point, and conflating them would overstate the obligation. `DisjointSlice::get_unchecked_mut` likewise returns `&mut T`.

## How it was found

Writing out a per-operation soundness argument for a (now closed) PR that added by-value `read`/`write` to `DisjointSlice`. The obligation applied to the *existing* by-value readers too, which is the part worth keeping regardless of what happens to that API.

## Gates

fmt, clippy `--workspace --all-targets -D warnings`, rustdoc `-D warnings`, tests and doctests clean on `nightly-2026-04-03`.
