### PR TITLE
codegen: opt-in libdevice linking for the standalone PTX API

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -96,6 +96,21 @@ pub enum DebugInfo {
     Full,
 }
 
+/// Whether compilation may resolve libdevice calls at the LLVM IR level.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Linking {
+    /// Reject every unresolved external symbol. The generated PTX is
+    /// self-contained and the CUDA driver can load it with no further step.
+    #[default]
+    SelfContained,
+    /// Link `libdevice.10.bc` into the module at the LLVM IR level, resolving
+    /// `__nv_*` calls before `llc` runs. Unresolved symbols that are not
+    /// libdevice are still rejected, and the output is still a single
+    /// self-contained PTX artifact.
+    Libdevice,
+}
+
 /// Typed options for one standalone PTX compilation.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -105,6 +120,7 @@ pub struct CompileOptions {
     fma_contraction: bool,
     debug_info: DebugInfo,
     verbose: bool,
+    linking: Linking,
 }
 
 impl CompileOptions {
@@ -116,6 +132,7 @@ impl CompileOptions {
             fma_contraction: true,
             debug_info: DebugInfo::None,
             verbose: false,
+            linking: Linking::SelfContained,
         }
     }
 
@@ -136,6 +153,16 @@ impl CompileOptions {
     /// [`DebugInfo::Full`] must be paired with [`Optimization::None`].
     pub fn with_debug_info(mut self, debug_info: DebugInfo) -> Self {
         self.debug_info = debug_info;
+        self
+    }
+
+    /// Select whether libdevice calls may be resolved by an IR-level link.
+    ///
+    /// [`Linking::SelfContained`], the default, rejects any unresolved
+    /// external symbol. [`Linking::Libdevice`] resolves `__nv_*` calls
+    /// against `libdevice.10.bc`.
+    pub fn with_linking(mut self, linking: Linking) -> Self {
+        self.linking = linking;
         self
     }
 
@@ -168,6 +195,11 @@ impl CompileOptions {
     /// Requested device debug-information tier.
     pub fn debug_info(&self) -> DebugInfo {
         self.debug_info
+    }
+
+    /// Requested libdevice linking policy.
+    pub fn linking(&self) -> Linking {
+        self.linking
     }
 
     /// Whether progress and tool-selection diagnostics were requested.
@@ -632,6 +664,7 @@ impl Compiler {
             &backend_options,
             debug_kind,
             &self.toolchain.inner,
+            options.linking == Linking::Libdevice,
             OutputFiles {
                 llvm_ir: &ll_path,
                 ptx: &ptx_path,
@@ -977,6 +1010,17 @@ mod tests {
         assert!(
             cloned.try_deref(&module.context).is_err(),
             "the cloned operation should be erased even though the guarded closure panicked"
+        );
+    }
+
+    #[test]
+    fn linking_defaults_to_self_contained() {
+        let options = CompileOptions::new(Target::parse("sm_90").unwrap());
+        assert_eq!(options.linking(), Linking::SelfContained);
+        assert_eq!(Linking::default(), Linking::SelfContained);
+        assert_eq!(
+            options.with_linking(Linking::Libdevice).linking(),
+            Linking::Libdevice
         );
     }
 }

--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -677,7 +677,15 @@ impl Compiler {
         (|| {
             let generated =
                 compile_translated_module(ctx, module, &request).map_err(CompileError::from)?;
-            debug_assert_eq!(generated.artifact_kind, ModuleArtifactKind::Ptx);
+            if generated.artifact_kind != ModuleArtifactKind::Ptx {
+                return Err(CompileError::Codegen {
+                    message: format!(
+                        "the standalone pipeline produced {:?} where PTX was required; \
+                         this path never emits NVVM IR",
+                        generated.artifact_kind
+                    ),
+                });
+            }
             let ptx = std::fs::read(&ptx_path).map_err(|source| CompileError::Io {
                 action: "read generated PTX",
                 path: ptx_path.clone(),

--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -160,7 +160,9 @@ impl CompileOptions {
     ///
     /// [`Linking::SelfContained`], the default, rejects any unresolved
     /// external symbol. [`Linking::Libdevice`] resolves `__nv_*` calls
-    /// against `libdevice.10.bc`.
+    /// against `libdevice.10.bc` and fails with
+    /// [`CompileError::LibdeviceUnavailable`] when the toolchain cannot
+    /// perform that link.
     pub fn with_linking(mut self, linking: Linking) -> Self {
         self.linking = linking;
         self
@@ -901,6 +903,13 @@ pub enum CompileError {
         /// Sorted, deduplicated unresolved symbol names.
         symbols: Vec<String>,
     },
+    /// Libdevice linking was requested, but the toolchain cannot perform it.
+    #[error("libdevice linking is unavailable: {message}")]
+    LibdeviceUnavailable {
+        /// Which piece is missing: `libdevice.10.bc`, or a same-major
+        /// `llvm-link`.
+        message: String,
+    },
     /// LLVM text export failed.
     #[error("LLVM IR export failed: {message}")]
     Export {
@@ -941,7 +950,9 @@ impl CompileError {
             }
             Self::Verification { .. } => CompilationStage::MirPreparation,
             Self::Lowering { .. } | Self::LoweredVerification { .. } => CompilationStage::Lowering,
-            Self::UnsupportedLinking { .. } => CompilationStage::Linking,
+            Self::UnsupportedLinking { .. } | Self::LibdeviceUnavailable { .. } => {
+                CompilationStage::Linking
+            }
             Self::Export { .. } => CompilationStage::Export,
             Self::Codegen { .. } | Self::Io { .. } => CompilationStage::Codegen,
         }
@@ -968,6 +979,9 @@ impl From<PipelineError> for CompileError {
                 Self::LoweredVerification { message, operation }
             }
             PipelineError::UnsupportedLinking { symbols } => Self::UnsupportedLinking { symbols },
+            PipelineError::LibdeviceUnavailable { message } => {
+                Self::LibdeviceUnavailable { message }
+            }
             PipelineError::Export(message) => Self::Export { message },
             PipelineError::TargetSelection { target, reason } => {
                 Self::TargetSelection { target, reason }

--- a/crates/cuda-oxide-codegen/src/error.rs
+++ b/crates/cuda-oxide-codegen/src/error.rs
@@ -26,6 +26,8 @@ pub enum PipelineError {
     },
     /// Standalone PTX contains declarations that require a link step.
     UnsupportedLinking { symbols: Vec<String> },
+    /// Libdevice linking was requested, but the toolchain cannot perform it.
+    LibdeviceUnavailable { message: String },
     /// LLVM IR export failed.
     Export(String),
     /// The requested CUDA target could not be parsed, or cannot lower a
@@ -70,6 +72,9 @@ impl std::fmt::Display for PipelineError {
                 f,
                 "standalone PTX cannot resolve external symbols: {symbols:?}"
             ),
+            Self::LibdeviceUnavailable { message } => {
+                write!(f, "libdevice linking is unavailable: {message}")
+            }
             Self::Export(msg) => write!(f, "Export failed: {}", msg),
             Self::TargetSelection { reason, .. } => write!(f, "{reason}"),
             Self::PtxGeneration(msg) => write!(f, "PTX generation failed: {}", msg),

--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -348,6 +348,14 @@ pub fn module_uses_libdevice(ctx: &Context, module_op_ptr: Ptr<Operation>) -> bo
     op_uses_libdevice(ctx, module_op_ptr)
 }
 
+/// Whether `name` is a CUDA libdevice entry point.
+///
+/// The unresolved-symbol filter and the libdevice detector both read this, so
+/// the `__nv_` spelling has one definition in the crate.
+pub(crate) fn is_libdevice_symbol(name: &str) -> bool {
+    name.starts_with("__nv_")
+}
+
 /// Return unresolved non-intrinsic LLVM function declarations.
 ///
 /// Standalone PTX has no link step. LLVM intrinsics are resolved by `llc`, but
@@ -392,14 +400,14 @@ fn collect_unresolved_external_symbols(
 /// Recursively scan for declared or called CUDA libdevice functions.
 fn op_uses_libdevice(ctx: &Context, op_ptr: Ptr<Operation>) -> bool {
     if let Some(func) = Operation::get_op::<llvm_export::ops::FuncOp>(op_ptr, ctx)
-        && func.get_symbol_name(ctx).starts_with("__nv_")
+        && is_libdevice_symbol(&func.get_symbol_name(ctx))
     {
         return true;
     }
 
     if let Some(call) = Operation::get_op::<llvm_export::ops::CallOp>(op_ptr, ctx)
         && let CallOpCallable::Direct(callee) = call.callee(ctx)
-        && callee.to_string().starts_with("__nv_")
+        && is_libdevice_symbol(&callee.to_string())
     {
         return true;
     }

--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -356,6 +356,59 @@ pub(crate) fn is_libdevice_symbol(name: &str) -> bool {
     name.starts_with("__nv_")
 }
 
+/// Whether `c` can appear in a PTX identifier (`followsym`).
+fn is_ptx_identifier_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '$'
+}
+
+/// Names of `.extern .func` declarations in `ptx` that name a CUDA libdevice
+/// (`__nv_*`) symbol.
+///
+/// `llc` prints an unresolved callee as `.extern .func __nv_foo(` when it
+/// returns void, or `.extern .func  (.param .b32 func_retval0) __nv_foo(`
+/// when it returns a value, the same two shapes the `.visible .func` scan in
+/// `ptx.rs`'s tests already parses for exported and unreferenced libdevice
+/// symbols.
+///
+/// `llvm-link --only-needed` resolves whatever `__nv_*` symbols it finds in
+/// `libdevice.10.bc` and stays silent about the rest, so a `__nv_*` symbol
+/// libdevice does not define survives as an unresolved declaration all the
+/// way through `opt` and `llc`, both of which exit 0, into PTX that `ptxas`
+/// also accepts. The failure then surfaces only at `cuModuleLoad` on the
+/// device, with no diagnostic. This scan is what catches it at compile time
+/// for the self-contained output policy, where no later link step exists to
+/// resolve it.
+pub(crate) fn unresolved_libdevice_ptx_declarations(ptx: &str) -> Vec<String> {
+    let mut declared: Vec<String> = Vec::new();
+    for line in ptx.lines() {
+        let Some(rest) = line.trim_start().strip_prefix(".extern") else {
+            continue;
+        };
+        let Some(idx) = rest.find(".func") else {
+            continue;
+        };
+        let mut rest = rest[idx + ".func".len()..].trim_start();
+        // Skip the `(.param .b32 func_retval0)` clause of a value-returning
+        // declaration, matching `exported_nv_functions` in `ptx.rs`.
+        if let Some(after_open) = rest.strip_prefix('(') {
+            let Some(close) = after_open.find(')') else {
+                continue;
+            };
+            rest = after_open[close + 1..].trim_start();
+        }
+        let name: String = rest
+            .chars()
+            .take_while(|c| is_ptx_identifier_char(*c))
+            .collect();
+        if is_libdevice_symbol(&name) {
+            declared.push(name);
+        }
+    }
+    declared.sort();
+    declared.dedup();
+    declared
+}
+
 /// Return unresolved non-intrinsic LLVM function declarations.
 ///
 /// Standalone PTX has no link step. LLVM intrinsics are resolved by `llc`, but
@@ -777,5 +830,30 @@ mod tests {
             module_uses_libdevice(&ctx, module_ptr),
             "direct call to a `__nv_*` symbol must be detected"
         );
+    }
+
+    #[test]
+    fn unresolved_libdevice_ptx_declarations_finds_void_and_value_returning_externs() {
+        let ptx = "\
+.visible .entry kernel(
+.extern .func __nv_void_helper(
+.extern .func  (.param .b32 func_retval0) __nv_totally_not_real(
+.extern .func vprintf(
+.func  (.param .b32 func_retval0) __nv_internal_only(
+";
+        assert_eq!(
+            unresolved_libdevice_ptx_declarations(ptx),
+            ["__nv_totally_not_real", "__nv_void_helper"]
+        );
+    }
+
+    #[test]
+    fn unresolved_libdevice_ptx_declarations_ignores_a_fully_linked_module() {
+        let ptx = "\
+.visible .entry kernel(
+.visible .func __nv_helper(
+\tcall.uni __nv_helper, (param0);
+";
+        assert!(unresolved_libdevice_ptx_declarations(ptx).is_empty());
     }
 }

--- a/crates/cuda-oxide-codegen/src/lib.rs
+++ b/crates/cuda-oxide-codegen/src/lib.rs
@@ -93,7 +93,7 @@ mod verify;
 pub mod experimental {
     pub use crate::api::{
         CodegenModule, Compilation, CompilationStage, CompileError, CompileOptions, Compiler,
-        DebugInfo, Diagnostic, DiagnosticLevel, Optimization, Target, Toolchain,
+        DebugInfo, Diagnostic, DiagnosticLevel, Linking, Optimization, Target, Toolchain,
     };
 }
 

--- a/crates/cuda-oxide-codegen/src/lib.rs
+++ b/crates/cuda-oxide-codegen/src/lib.rs
@@ -47,9 +47,15 @@ mod verify;
 /// lowering pipeline. Kernel entries are top-level
 /// [`dialect_mir::ops::MirFuncOp`] values whose symbols are marked through
 /// [`CodegenModule::mark_kernel_entry`](experimental::CodegenModule::mark_kernel_entry).
-/// The v1 PTX output must be self-contained: libdevice calls and other
-/// unresolved functions return
+/// The v1 PTX output is self-contained. By default any libdevice call or
+/// other unresolved function returns
 /// [`CompileError::UnsupportedLinking`](experimental::CompileError::UnsupportedLinking).
+/// [`Linking::Libdevice`](experimental::Linking::Libdevice) opts into
+/// resolving `__nv_*` calls against `libdevice.10.bc` at the LLVM IR level,
+/// which keeps the output a single self-contained PTX artifact. Unresolved
+/// symbols that are not libdevice stay rejected under that option, and a
+/// toolchain that cannot perform the link returns
+/// [`CompileError::LibdeviceUnavailable`](experimental::CompileError::LibdeviceUnavailable).
 ///
 /// # Minimal flow
 ///

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -68,8 +68,18 @@ impl PipelineTrace {
 
 #[derive(Clone, Copy, Debug)]
 enum OutputPolicy {
-    SelfContainedPtx,
-    ExternalLinkAllowed { request_nvvm_ir: bool },
+    SelfContainedPtx {
+        /// Not yet consulted: the unresolved-symbol check does not read this
+        /// field yet, so it is write-only until a later change threads it in.
+        #[expect(
+            dead_code,
+            reason = "not yet consulted; write-only until the libdevice filter reads it"
+        )]
+        allow_libdevice: bool,
+    },
+    ExternalLinkAllowed {
+        request_nvvm_ir: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -118,11 +128,12 @@ impl<'a> ModulePipelineRequest<'a> {
         backend: &'a BackendOptions,
         debug_kind: DebugKind,
         toolchain: &'a LlvmToolchain,
+        allow_libdevice: bool,
         files: OutputFiles<'a>,
     ) -> Self {
         Self {
             device_externs: &[],
-            output_policy: OutputPolicy::SelfContainedPtx,
+            output_policy: OutputPolicy::SelfContainedPtx { allow_libdevice },
             backend,
             debug_kind,
             toolchain: ToolchainPolicy::Explicit(toolchain),
@@ -361,7 +372,7 @@ pub fn compile_translated_module(
         request.trace.emit("LLVM dialect verification successful ✓");
     }
 
-    if matches!(request.output_policy, OutputPolicy::SelfContainedPtx) {
+    if matches!(request.output_policy, OutputPolicy::SelfContainedPtx { .. }) {
         let symbols = unresolved_external_symbols(ctx, module);
         if !symbols.is_empty() {
             return Err(PipelineError::UnsupportedLinking { symbols });
@@ -584,7 +595,7 @@ fn should_emit_nvvm_ir(
     can_ir_link_libdevice: bool,
 ) -> bool {
     match policy {
-        OutputPolicy::SelfContainedPtx => false,
+        OutputPolicy::SelfContainedPtx { .. } => false,
         OutputPolicy::ExternalLinkAllowed { request_nvvm_ir } => {
             if request_nvvm_ir {
                 return true;
@@ -673,16 +684,22 @@ mod tests {
 
     #[test]
     fn standalone_never_silently_switches_to_a_linkable_artifact() {
-        assert!(!should_emit_nvvm_ir(
-            OutputPolicy::SelfContainedPtx,
-            false,
-            false
-        ));
-        assert!(!should_emit_nvvm_ir(
-            OutputPolicy::SelfContainedPtx,
-            true,
-            false
-        ));
+        // Opting into libdevice must not open the NVVM IR route: the standalone
+        // surface promises one artifact kind out, whatever the linking policy.
+        for allow_libdevice in [false, true] {
+            let policy = OutputPolicy::SelfContainedPtx { allow_libdevice };
+            for uses_strict_libdevice in [false, true] {
+                for can_ir_link_libdevice in [false, true] {
+                    assert!(
+                        !should_emit_nvvm_ir(policy, uses_strict_libdevice, can_ir_link_libdevice),
+                        "self-contained PTX emitted NVVM IR for \
+                         allow_libdevice={allow_libdevice}, \
+                         uses_strict_libdevice={uses_strict_libdevice}, \
+                         can_ir_link_libdevice={can_ir_link_libdevice}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -938,8 +955,14 @@ mod tests {
         assert!(nvvm.emit_nvvm_ir);
         assert_eq!(nvvm.intrinsic_backend, mir_lower::IntrinsicBackend::LibNvvm);
 
-        let standalone =
-            select_pre_lowering_backend(&ctx, ordinary, OutputPolicy::SelfContainedPtx, false);
+        let standalone = select_pre_lowering_backend(
+            &ctx,
+            ordinary,
+            OutputPolicy::SelfContainedPtx {
+                allow_libdevice: false,
+            },
+            false,
+        );
         assert!(!standalone.emit_nvvm_ir);
         assert_eq!(
             standalone.intrinsic_backend,

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -368,6 +368,14 @@ pub fn compile_translated_module(
     }
 
     if let OutputPolicy::SelfContainedPtx { allow_libdevice } = request.output_policy {
+        if let Some(error) = libdevice_availability_error(
+            allow_libdevice,
+            needs_libdevice,
+            can_ir_link_libdevice,
+            libdevice_path.is_some(),
+        ) {
+            return Err(error);
+        }
         let symbols = unlinkable_symbols(unresolved_external_symbols(ctx, module), allow_libdevice);
         if !symbols.is_empty() {
             return Err(PipelineError::UnsupportedLinking { symbols });
@@ -613,6 +621,35 @@ fn unlinkable_symbols(mut symbols: Vec<String>, allow_libdevice: bool) -> Vec<St
         symbols.retain(|symbol| !crate::export::is_libdevice_symbol(symbol));
     }
     symbols
+}
+
+/// Whether a compilation that opted into libdevice can be completed.
+///
+/// Returns the failure to report, or `None` when compilation may continue.
+/// Factored out of `compile_translated_module` so the decision is testable
+/// with no module, no toolchain, and no CUDA installation.
+///
+/// `can_ir_link_libdevice` is false when either piece is missing, so
+/// `libdevice_found` is what separates a missing CUDA toolkit from an
+/// incomplete LLVM toolchain. Neither is a defect in the caller's module,
+/// and the two have different fixes, so the message names which one it is.
+fn libdevice_availability_error(
+    allow_libdevice: bool,
+    needs_libdevice: bool,
+    can_ir_link_libdevice: bool,
+    libdevice_found: bool,
+) -> Option<PipelineError> {
+    if !allow_libdevice || !needs_libdevice || can_ir_link_libdevice {
+        return None;
+    }
+    let message = if libdevice_found {
+        "no `llvm-link` sharing the selected `llc`'s LLVM major was found"
+    } else {
+        "`libdevice.10.bc` was not found in any CUDA installation"
+    };
+    Some(PipelineError::LibdeviceUnavailable {
+        message: message.to_string(),
+    })
 }
 
 fn as_lowered_verification(error: PipelineError) -> PipelineError {
@@ -1034,5 +1071,36 @@ mod tests {
         assert!(!crate::export::is_libdevice_symbol("__nvvm_thing"));
         assert!(!crate::export::is_libdevice_symbol("nv_sqrtf"));
         assert!(!crate::export::is_libdevice_symbol("my___nv_sqrtf"));
+    }
+
+    #[test]
+    fn libdevice_availability_names_the_missing_piece() {
+        // Missing bitcode: the CUDA toolkit was not found.
+        let error = libdevice_availability_error(true, true, false, false)
+            .expect("an unlinkable libdevice module must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("libdevice.10.bc"),
+            "message names the missing bitcode: {message}"
+        );
+
+        // Bitcode present, linker absent: the LLVM toolchain is incomplete.
+        let error = libdevice_availability_error(true, true, false, true)
+            .expect("an unlinkable libdevice module must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("llvm-link"),
+            "message names the missing linker: {message}"
+        );
+    }
+
+    #[test]
+    fn libdevice_availability_permits_every_compilable_case() {
+        // Not opted in: the ordinary unresolved-symbol rejection handles it.
+        assert!(libdevice_availability_error(false, true, false, false).is_none());
+        // Opted in but the module needs no libdevice: nothing to link.
+        assert!(libdevice_availability_error(true, false, false, false).is_none());
+        // Opted in, needed, and linkable: the ordinary path proceeds.
+        assert!(libdevice_availability_error(true, true, true, true).is_none());
     }
 }

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -12,7 +12,8 @@
 use crate::error::PipelineError;
 use crate::export::{
     DeviceExternDecl, export_llvm_ir, module_uses_libdevice, render_llvm_ir,
-    resolve_nvvm_target_with_generated, unresolved_external_symbols, validate_nvvm_debug_support,
+    resolve_nvvm_target_with_generated, unresolved_external_symbols,
+    unresolved_libdevice_ptx_declarations, validate_nvvm_debug_support,
 };
 use crate::generated::{
     GeneratedMarkerPolicy, collect_generated_intrinsic_requirements_for_backend,
@@ -456,6 +457,30 @@ pub fn compile_translated_module(
             ptx_libdevice,
         )?,
     };
+    // Self-contained PTX promises a single artifact the CUDA driver can load
+    // with no further step, so an unresolved `__nv_*` symbol here is a
+    // compile-time failure: `llvm-link --only-needed` resolves whatever it
+    // finds in libdevice.10.bc and stays silent about the rest, and `opt` and
+    // `llc` both exit 0 on what remains, so the alternative is PTX that fails
+    // only at `cuModuleLoad` on the device, with no diagnostic. Under
+    // `ExternalLinkAllowed` (the rustc frontend) an unresolved `__nv_*` stays
+    // legitimate: that consumer owns a later libNVVM/nvJitLink step and
+    // resolves it there, so this check must not run for that policy.
+    if matches!(request.output_policy, OutputPolicy::SelfContainedPtx { .. }) {
+        let ptx_text = std::fs::read_to_string(request.files.ptx).map_err(|error| {
+            PipelineError::PtxGeneration(format!(
+                "failed to read generated PTX to check for unresolved libdevice symbols ({}): {error}",
+                request.files.ptx.display()
+            ))
+        })?;
+        let unresolved = unresolved_libdevice_ptx_declarations(&ptx_text);
+        if !unresolved.is_empty() {
+            return Err(PipelineError::UnsupportedLinking {
+                symbols: unresolved,
+            });
+        }
+    }
+
     if request.trace.verbose {
         request.trace.emit(format!(
             "✓ PTX written to {} (target: {})",

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -69,12 +69,7 @@ impl PipelineTrace {
 #[derive(Clone, Copy, Debug)]
 enum OutputPolicy {
     SelfContainedPtx {
-        /// Not yet consulted: the unresolved-symbol check does not read this
-        /// field yet, so it is write-only until a later change threads it in.
-        #[expect(
-            dead_code,
-            reason = "not yet consulted; write-only until the libdevice filter reads it"
-        )]
+        /// Whether `__nv_*` symbols may be left for the IR-level libdevice link.
         allow_libdevice: bool,
     },
     ExternalLinkAllowed {
@@ -372,8 +367,8 @@ pub fn compile_translated_module(
         request.trace.emit("LLVM dialect verification successful ✓");
     }
 
-    if matches!(request.output_policy, OutputPolicy::SelfContainedPtx { .. }) {
-        let symbols = unresolved_external_symbols(ctx, module);
+    if let OutputPolicy::SelfContainedPtx { allow_libdevice } = request.output_policy {
+        let symbols = unlinkable_symbols(unresolved_external_symbols(ctx, module), allow_libdevice);
         if !symbols.is_empty() {
             return Err(PipelineError::UnsupportedLinking { symbols });
         }
@@ -605,6 +600,19 @@ fn should_emit_nvvm_ir(
             uses_strict_libdevice && !can_ir_link_libdevice
         }
     }
+}
+
+/// Narrow collected unresolved symbols to those the artifact cannot resolve.
+///
+/// Under `allow_libdevice`, `__nv_*` entry points are dropped: the IR-level
+/// `llvm-link` step further down resolves them against `libdevice.10.bc`.
+/// Every other unresolved symbol still fails the compilation, so
+/// `UnsupportedLinking` keeps its meaning for device externs.
+fn unlinkable_symbols(mut symbols: Vec<String>, allow_libdevice: bool) -> Vec<String> {
+    if allow_libdevice {
+        symbols.retain(|symbol| !crate::export::is_libdevice_symbol(symbol));
+    }
+    symbols
 }
 
 fn as_lowered_verification(error: PipelineError) -> PipelineError {
@@ -982,5 +990,49 @@ mod tests {
             PipelineError::LoweredVerification { message, operation }
                 if message == "invalid lowered op" && operation.as_deref() == Some("llvm.bad")
         ));
+    }
+
+    #[test]
+    fn self_contained_linking_rejects_every_unresolved_symbol() {
+        let symbols = vec![
+            "__nv_sqrtf".to_string(),
+            "vprintf".to_string(),
+            "my_device_extern".to_string(),
+        ];
+        assert_eq!(
+            unlinkable_symbols(symbols.clone(), false),
+            symbols,
+            "without the libdevice opt-in nothing is filtered"
+        );
+    }
+
+    #[test]
+    fn libdevice_linking_drops_only_libdevice_symbols() {
+        let symbols = vec![
+            "__nv_erff".to_string(),
+            "__nv_sqrtf".to_string(),
+            "my_device_extern".to_string(),
+            "vprintf".to_string(),
+        ];
+        assert_eq!(
+            unlinkable_symbols(symbols, true),
+            vec!["my_device_extern".to_string(), "vprintf".to_string()],
+            "device externs still fail the compilation"
+        );
+    }
+
+    #[test]
+    fn libdevice_linking_accepts_a_purely_libdevice_module() {
+        let symbols = vec!["__nv_sqrtf".to_string(), "__nv_expf".to_string()];
+        assert!(unlinkable_symbols(symbols, true).is_empty());
+    }
+
+    #[test]
+    fn libdevice_symbol_predicate_matches_the_nv_prefix_only() {
+        assert!(crate::export::is_libdevice_symbol("__nv_sqrtf"));
+        assert!(crate::export::is_libdevice_symbol("__nv_"));
+        assert!(!crate::export::is_libdevice_symbol("__nvvm_thing"));
+        assert!(!crate::export::is_libdevice_symbol("nv_sqrtf"));
+        assert!(!crate::export::is_libdevice_symbol("my___nv_sqrtf"));
     }
 }

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -510,8 +510,8 @@ fn generate_ptx_impl(
     // `__CUDA_FTZ` is left unset deliberately: nvcc defaults `-ftz=false`,
     // which 0 already matches.
     //
-    // Not every libdevice build branches division on `__CUDA_PREC_DIV`; the
-    // toolkit on this machine defines no such reflect name, so here the
+    // Not every libdevice build branches division on `__CUDA_PREC_DIV`;
+    // current libdevice builds define no such reflect name, so here the
     // argument matches no `__nvvm_reflect` call and has no effect. It stays
     // because `NVVMReflectPass` silently drops a name absent from the
     // module, emitting neither a warning nor a failure, and any libdevice
@@ -986,7 +986,7 @@ mod tests {
     /// nvcc defaults `-prec-sqrt=true`. Without the reflect arguments on `llc`,
     /// a `sqrt` kernel silently compiles to `sqrt.approx.f32`.
     #[test]
-    fn linked_libdevice_honours_nvcc_precision_defaults() {
+    fn linked_libdevice_honors_nvcc_precision_defaults() {
         let opts = BackendOptions {
             target_arch: Some("sm_80".to_string()),
             ..BackendOptions::default()

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -501,6 +501,27 @@ fn generate_ptx_impl(
     if !opts.no_fma {
         llc_cmd.arg("-fp-contract=fast");
     }
+    // Match nvcc's precision defaults when libdevice is in the module.
+    // libdevice selects between correctly-rounded and approximate
+    // implementations by reading these through `__nvvm_reflect`, and LLVM
+    // resolves an unset reflect variable to 0, which is the approximate
+    // branch. nvcc defaults `-prec-sqrt=true` and `-prec-div=true`, so 0
+    // diverges from it silently and in the direction of lower accuracy.
+    // `__CUDA_FTZ` is left unset deliberately: nvcc defaults `-ftz=false`,
+    // which 0 already matches.
+    //
+    // Not every libdevice build branches division on `__CUDA_PREC_DIV`; the
+    // toolkit on this machine defines no such reflect name, so here the
+    // argument matches no `__nvvm_reflect` call and has no effect. It stays
+    // because `NVVMReflectPass` silently drops a name absent from the
+    // module, emitting neither a warning nor a failure, and any libdevice
+    // build that does branch on `__CUDA_PREC_DIV` needs the same
+    // nvcc-matching value.
+    if linked.is_some() {
+        llc_cmd
+            .arg("--nvvm-reflect-add=__CUDA_PREC_SQRT=1")
+            .arg("--nvvm-reflect-add=__CUDA_PREC_DIV=1");
+    }
     let result = llc_cmd.arg(llc_input).arg("-o").arg(module.output).output();
 
     match result {
@@ -956,6 +977,81 @@ mod tests {
             ptx.lines().count()
         );
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Regression test for libdevice reflect defaults: `libdevice.10.bc`
+    /// selects between a correctly-rounded and an approximate implementation
+    /// by reading `__CUDA_PREC_SQRT` through `__nvvm_reflect`. LLVM resolves an
+    /// unset reflect variable to 0 and so picks the approximate branch, while
+    /// nvcc defaults `-prec-sqrt=true`. Without the reflect arguments on `llc`,
+    /// a `sqrt` kernel silently compiles to `sqrt.approx.f32`.
+    #[test]
+    fn linked_libdevice_honours_nvcc_precision_defaults() {
+        let opts = BackendOptions {
+            target_arch: Some("sm_80".to_string()),
+            ..BackendOptions::default()
+        };
+        let Some(toolchain) = LlvmToolchain::resolve(&opts) else {
+            return;
+        };
+        if toolchain.opt.is_none() || toolchain.llvm_link.is_none() {
+            return;
+        }
+        let Ok(libdevice) = libnvvm_sys::find_libdevice() else {
+            return;
+        };
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_libdevice_prec_{}_{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let ll_path = root.join("kernel.ll");
+        let ptx_path = root.join("kernel.ptx");
+        std::fs::write(
+            &ll_path,
+            "target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\"\n\
+             target triple = \"nvptx64-nvidia-cuda\"\n\
+             \n\
+             declare float @__nv_sqrtf(float)\n\
+             \n\
+             define ptx_kernel void @kernel(ptr %out, float %x) {\n\
+               %s = call float @__nv_sqrtf(float %x)\n\
+               store float %s, ptr %out\n\
+               ret void\n\
+             }\n",
+        )
+        .unwrap();
+
+        generate_ptx_with_toolchain(
+            PtxModule {
+                llvm_ir: &ll_path,
+                output: &ptx_path,
+                public_symbols: &["kernel".to_string()],
+            },
+            DebugKind::Off,
+            &opts,
+            &toolchain,
+            &GeneratedModuleRequirements::default(),
+            Some(&libdevice),
+        )
+        .unwrap();
+
+        let ptx = std::fs::read_to_string(&ptx_path).unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(
+            ptx.contains("sqrt.rn.f32"),
+            "libdevice sqrt must resolve to the correctly-rounded instruction, \
+             matching nvcc's -prec-sqrt=true default:\n{ptx}"
+        );
+        assert!(
+            !ptx.contains("sqrt.approx"),
+            "no approximate sqrt may survive:\n{ptx}"
+        );
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -1,0 +1,274 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Proof that the standalone API can compile a module whose float intrinsics
+//! lower to libdevice, and that opting in changes nothing else.
+//!
+//! Two routes reach libdevice and both are covered here:
+//!
+//!   1. A Rust intrinsic placeholder (`sqrtf32`), which `mir-lower` maps to
+//!      `__nv_sqrtf` through `libdevice_name`. This is what a frontend gets
+//!      for free by emitting the placeholder callee.
+//!   2. A `__nv_*` symbol the frontend names itself. Several libdevice
+//!      functions have no Rust intrinsic and so no placeholder to reach them
+//!      through; `__nv_erff` is one. Lowering self-declares the symbol at
+//!      `mir-lower/src/convert/ops/call.rs:697`, and the pre-lowering scan in
+//!      `typed_mir_uses_libdevice` sees the same callee, so the two libdevice
+//!      detectors agree and the consistency refusal does not fire.
+
+use cuda_oxide_codegen::experimental::{
+    CodegenModule, CompileError, CompileOptions, Compiler, Linking, Target,
+};
+
+use dialect_mir::ops::{MirCallOp, MirFuncOp, MirLoadOp, MirPtrOffsetOp, MirReturnOp, MirStoreOp};
+use dialect_mir::types::MirPtrType;
+use dialect_nvvm::ops::ReadPtxSregTidXOp;
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        attributes::{StringAttr, TypeAttr},
+        op_interfaces::SymbolOpInterface,
+        types::{FP32Type, FunctionType, IntegerType, Signedness},
+    },
+    context::Context,
+    linked_list::ContainsLinkedList,
+    op::Op,
+    operation::Operation,
+};
+
+/// Build `kernel(a: *const f32, out: *mut f32) { out[tid] = callee(a[tid]) }`.
+///
+/// `callee` is a `mir.call` target, either a Rust intrinsic placeholder such
+/// as `dialect_mir::rust_intrinsics::CALLEE_SQRT_F32` or a bare `__nv_*`
+/// symbol. Indexing is by `tid.x` alone, which keeps the kernel to the
+/// smallest shape that still produces a real load, a real call and a real
+/// store.
+fn build_unary_call_kernel(module: &mut CodegenModule, callee: &str) {
+    module.edit(|ctx, module| {
+        let module_op = module.get_operation();
+        let module_region = module_op.deref(ctx).get_region(0);
+        let module_block = {
+            let existing = {
+                let region = module_region.deref(ctx);
+                region.iter(ctx).next()
+            };
+            if let Some(block) = existing {
+                block
+            } else {
+                let block = BasicBlock::new(ctx, None, vec![]);
+                block.insert_at_back(module_region, ctx);
+                block
+            }
+        };
+
+        let f32_ty = FP32Type::get(ctx);
+        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+        let in_ptr_ty = MirPtrType::get_global(ctx, f32_ty.into(), false);
+        let out_ptr_ty = MirPtrType::get_global(ctx, f32_ty.into(), true);
+
+        let func_type = FunctionType::get(ctx, vec![in_ptr_ty.into(), out_ptr_ty.into()], vec![]);
+        let func = {
+            let op = Operation::new(
+                ctx,
+                MirFuncOp::get_concrete_op_info(),
+                vec![],
+                vec![],
+                vec![],
+                1,
+            );
+            let func = MirFuncOp::new(ctx, op, TypeAttr::new(func_type.into()));
+            func.set_symbol_name(ctx, "unary_kernel".try_into().unwrap());
+            func
+        };
+
+        let entry = BasicBlock::new(ctx, None, vec![in_ptr_ty.into(), out_ptr_ty.into()]);
+        let func_region = func.get_operation().deref(ctx).get_region(0);
+        entry.insert_at_front(func_region, ctx);
+
+        let a = entry.deref(ctx).get_argument(0);
+        let out = entry.deref(ctx).get_argument(1);
+
+        let emit = |ctx: &mut Context,
+                    info: (
+            fn(pliron::context::Ptr<Operation>) -> pliron::op::OpObj,
+            std::any::TypeId,
+        ),
+                    results: Vec<pliron::r#type::TypeHandle>,
+                    operands: Vec<pliron::value::Value>|
+         -> Option<pliron::value::Value> {
+            let op = Operation::new(ctx, info, results.clone(), operands, vec![], 0);
+            let res = if results.is_empty() {
+                None
+            } else {
+                Some(op.deref(ctx).get_result(0))
+            };
+            op.insert_at_back(entry, ctx);
+            res
+        };
+
+        let i = emit(
+            ctx,
+            ReadPtxSregTidXOp::get_concrete_op_info(),
+            vec![i32_ty.into()],
+            vec![],
+        )
+        .unwrap();
+
+        let a_ptr = emit(
+            ctx,
+            MirPtrOffsetOp::get_concrete_op_info(),
+            vec![in_ptr_ty.into()],
+            vec![a, i],
+        )
+        .unwrap();
+        let a_val = emit(
+            ctx,
+            MirLoadOp::get_concrete_op_info(),
+            vec![f32_ty.into()],
+            vec![a_ptr],
+        )
+        .unwrap();
+
+        // The call carries its signature through the operation's own operand
+        // and result types; `MirCallOp` verifies only that a callee attribute
+        // is present.
+        let call_op = Operation::new(
+            ctx,
+            MirCallOp::get_concrete_op_info(),
+            vec![f32_ty.into()],
+            vec![a_val],
+            vec![],
+            0,
+        );
+        let call = MirCallOp::new(call_op);
+        call.set_attr_callee(ctx, StringAttr::new(callee.to_string()));
+        call_op.insert_at_back(entry, ctx);
+        let result = call_op.deref(ctx).get_result(0);
+
+        let out_ptr = emit(
+            ctx,
+            MirPtrOffsetOp::get_concrete_op_info(),
+            vec![out_ptr_ty.into()],
+            vec![out, i],
+        )
+        .unwrap();
+        emit(
+            ctx,
+            MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![out_ptr, result],
+        );
+        emit(ctx, MirReturnOp::get_concrete_op_info(), vec![], vec![]);
+
+        func.get_operation().insert_at_back(module_block, ctx);
+    });
+    module.mark_kernel_entry("unary_kernel").unwrap();
+}
+
+/// Locate `ptxas`, matching `tests/spine_kernel_ptx.rs`.
+fn find_ptxas() -> std::path::PathBuf {
+    ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
+        .iter()
+        .filter_map(|var| std::env::var(var).ok())
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| std::path::PathBuf::from(root).join("bin/ptxas"))
+        .chain(std::iter::once(std::path::PathBuf::from(
+            "/usr/local/cuda/bin/ptxas",
+        )))
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("ptxas"))
+}
+
+/// Write `ptx` to a scratch file and require `ptxas -arch=sm_120` to accept it.
+fn assert_ptxas_accepts(ptx: &[u8], label: &str) {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "libdevice_linking_{label}_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let ptx_path = dir.join("kernel.ptx");
+    let cubin_path = dir.join("kernel.cubin");
+    std::fs::write(&ptx_path, ptx).unwrap();
+
+    let ptxas = find_ptxas();
+    let result = std::process::Command::new(&ptxas)
+        .arg("-arch=sm_120")
+        .arg("--compile-only")
+        .arg(&ptx_path)
+        .arg("-o")
+        .arg(&cubin_path)
+        .output();
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let out = result.unwrap_or_else(|error| {
+        panic!(
+            "could not run {}: {error}\nThis test needs `ptxas` from a CUDA \
+             toolkit (no GPU required). Point CUDA_TOOLKIT_PATH or CUDA_HOME \
+             at the install root, or put `ptxas` on PATH.",
+            ptxas.display()
+        )
+    });
+    assert!(
+        out.status.success(),
+        "ptxas rejected the {label} PTX:\nstderr:\n{}\n\nPTX:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(ptx)
+    );
+}
+
+#[test]
+fn self_contained_linking_still_rejects_a_libdevice_kernel() {
+    let mut module = CodegenModule::new("sqrt_module").unwrap();
+    build_unary_call_kernel(&mut module, dialect_mir::rust_intrinsics::CALLEE_SQRT_F32);
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+    let options = CompileOptions::new(Target::parse("sm_120").unwrap());
+
+    let error = compiler
+        .compile(&mut module, &options)
+        .expect_err("the default policy has no link step");
+    match error {
+        CompileError::UnsupportedLinking { symbols } => assert!(
+            symbols.iter().any(|symbol| symbol == "__nv_sqrtf"),
+            "the rejection names the unresolved libdevice symbol: {symbols:?}"
+        ),
+        other => panic!("expected UnsupportedLinking, got {other}"),
+    }
+}
+
+#[test]
+fn libdevice_linking_resolves_a_rust_intrinsic_kernel() {
+    let mut module = CodegenModule::new("sqrt_module").unwrap();
+    build_unary_call_kernel(&mut module, dialect_mir::rust_intrinsics::CALLEE_SQRT_F32);
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+    let options =
+        CompileOptions::new(Target::parse("sm_120").unwrap()).with_linking(Linking::Libdevice);
+
+    let ptx = compiler
+        .compile(&mut module, &options)
+        .expect("libdevice linking resolves __nv_sqrtf")
+        .into_ptx();
+    let text = String::from_utf8(ptx.clone()).expect("PTX is utf-8");
+
+    assert!(
+        text.contains(".visible .entry"),
+        "kernel entry present:\n{text}"
+    );
+    assert!(
+        text.contains("sqrt.rn.f32"),
+        "libdevice sqrt was inlined to a native PTX instruction:\n{text}"
+    );
+    assert!(
+        !text.contains(".extern .func __nv_"),
+        "no unresolved libdevice declaration survives into the artifact:\n{text}"
+    );
+
+    assert_ptxas_accepts(&ptx, "sqrt");
+}

--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -296,7 +296,7 @@ fn libdevice_linking_resolves_a_frontend_declared_symbol() {
     );
     assert!(
         !text.contains(".extern .func __nv_"),
-        "the declared symbol was resolved, not left extern:\n{text}"
+        "the declared symbol resolved to a definition:\n{text}"
     );
     // erff is a polynomial evaluation in libdevice, so the linked body
     // arrives as real arithmetic rather than a single instruction.
@@ -340,8 +340,7 @@ fn libdevice_linking_rejects_a_symbol_libdevice_does_not_define() {
 
 /// Return the sole top-level block of `module`, creating it if the module is
 /// still empty. Mirrors `module_block` in `tests/compile_to_ptx.rs`; kept
-/// separate here rather than lifted out of `build_unary_call_kernel`, which
-/// stays as Task 6 left it.
+/// separate here rather than lifted out of `build_unary_call_kernel`.
 fn module_block(
     ctx: &mut Context,
     module: &pliron::builtin::ops::ModuleOp,
@@ -361,8 +360,8 @@ fn module_block(
 /// Insert a body-less LLVM-dialect function declaration named `name` into
 /// `module`. Mirrors `add_llvm_declaration` in `tests/compile_to_ptx.rs`.
 ///
-/// This is the only way to place a genuinely unresolved external symbol into
-/// a standalone-API module: MIR lowering self-declares a callee only when it
+/// This is the only way to place an unresolved external symbol into a
+/// standalone-API module: MIR lowering self-declares a callee only when it
 /// resolves to a `__nv_*` name, so a `mir.call` to any other bare symbol has
 /// no matching declaration and fails LLVM-dialect verification before the
 /// unresolved-symbol scan that `UnsupportedLinking` comes from ever runs.

--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -272,3 +272,104 @@ fn libdevice_linking_resolves_a_rust_intrinsic_kernel() {
 
     assert_ptxas_accepts(&ptx, "sqrt");
 }
+
+#[test]
+fn libdevice_linking_resolves_a_frontend_declared_symbol() {
+    // `__nv_erff` has no Rust intrinsic and so no placeholder callee. A
+    // frontend reaches it by naming the symbol, which is the route the
+    // `__nv_` prefix filter admits.
+    let mut module = CodegenModule::new("erf_module").unwrap();
+    build_unary_call_kernel(&mut module, "__nv_erff");
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+    let options =
+        CompileOptions::new(Target::parse("sm_120").unwrap()).with_linking(Linking::Libdevice);
+
+    let ptx = compiler
+        .compile(&mut module, &options)
+        .expect("libdevice linking resolves a frontend-declared __nv_ symbol")
+        .into_ptx();
+    let text = String::from_utf8(ptx.clone()).expect("PTX is utf-8");
+
+    assert!(
+        text.contains(".visible .entry"),
+        "kernel entry present:\n{text}"
+    );
+    assert!(
+        !text.contains(".extern .func __nv_"),
+        "the declared symbol was resolved, not left extern:\n{text}"
+    );
+    // erff is a polynomial evaluation in libdevice, so the linked body
+    // arrives as real arithmetic rather than a single instruction.
+    assert!(
+        text.contains("fma.rn.f32") || text.contains("mul.f32"),
+        "the linked erff body is present:\n{text}"
+    );
+
+    assert_ptxas_accepts(&ptx, "erf");
+}
+
+/// Return the sole top-level block of `module`, creating it if the module is
+/// still empty. Mirrors `module_block` in `tests/compile_to_ptx.rs`; kept
+/// separate here rather than lifted out of `build_unary_call_kernel`, which
+/// stays as Task 6 left it.
+fn module_block(
+    ctx: &mut Context,
+    module: &pliron::builtin::ops::ModuleOp,
+) -> pliron::context::Ptr<BasicBlock> {
+    let module_region = module.get_operation().deref(ctx).get_region(0);
+    let existing = {
+        let region = module_region.deref(ctx);
+        region.iter(ctx).next()
+    };
+    existing.unwrap_or_else(|| {
+        let block = BasicBlock::new(ctx, None, vec![]);
+        block.insert_at_back(module_region, ctx);
+        block
+    })
+}
+
+/// Insert a body-less LLVM-dialect function declaration named `name` into
+/// `module`. Mirrors `add_llvm_declaration` in `tests/compile_to_ptx.rs`.
+///
+/// This is the only way to place a genuinely unresolved external symbol into
+/// a standalone-API module: MIR lowering self-declares a callee only when it
+/// resolves to a `__nv_*` name, so a `mir.call` to any other bare symbol has
+/// no matching declaration and fails LLVM-dialect verification before the
+/// unresolved-symbol scan that `UnsupportedLinking` comes from ever runs.
+/// Declaring the symbol directly, with no call site at all, is what
+/// `standalone_v1_rejects_libdevice_and_other_externs` already relies on to
+/// reach that scan for `user_device_external`.
+fn add_llvm_declaration(module: &mut CodegenModule, name: &str) {
+    module.edit(|ctx, module| {
+        use llvm_export::{ops::FuncOp, types::FuncType};
+
+        let block = module_block(ctx, module);
+        let i32_type = IntegerType::get(ctx, 32, Signedness::Signless);
+        let function_type = FuncType::get(ctx, i32_type.into(), vec![i32_type.into()], false);
+        let function = FuncOp::new(ctx, name.try_into().unwrap(), function_type);
+        function.get_operation().insert_at_back(block, ctx);
+    });
+}
+
+#[test]
+fn libdevice_linking_still_rejects_a_device_extern() {
+    // The opt-in narrows the rejection to symbols that are not libdevice. A
+    // module carrying both kinds must lose only the libdevice one, or
+    // `UnsupportedLinking` would stop meaning anything for device externs.
+    let mut module = CodegenModule::new("extern_module").unwrap();
+    add_llvm_declaration(&mut module, "__nv_erff");
+    add_llvm_declaration(&mut module, "my_device_extern");
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+    let options =
+        CompileOptions::new(Target::parse("sm_120").unwrap()).with_linking(Linking::Libdevice);
+
+    let error = compiler
+        .compile(&mut module, &options)
+        .expect_err("a non-libdevice extern is still unresolvable");
+    match error {
+        CompileError::UnsupportedLinking { symbols } => {
+            assert_eq!(symbols, ["my_device_extern"]);
+        }
+        other => panic!("expected UnsupportedLinking, got {other}"),
+    }
+}

--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -308,6 +308,36 @@ fn libdevice_linking_resolves_a_frontend_declared_symbol() {
     assert_ptxas_accepts(&ptx, "erf");
 }
 
+#[test]
+fn libdevice_linking_rejects_a_symbol_libdevice_does_not_define() {
+    // `__nv_totally_not_real` is shaped like a libdevice entry point but
+    // libdevice.10.bc defines no such symbol -- the version-skew case where a
+    // frontend targets a newer CUDA toolkit than the installed libdevice.
+    // `llvm-link --only-needed` resolves what it has and stays silent about
+    // the rest, and `opt` and `llc` both exit 0 on what remains, so without a
+    // compile-time check this would produce PTX carrying an unresolved
+    // `.extern .func __nv_totally_not_real` that only fails at `cuModuleLoad`
+    // on the device, with no diagnostic.
+    let mut module = CodegenModule::new("skew_module").unwrap();
+    build_unary_call_kernel(&mut module, "__nv_totally_not_real");
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+    let options =
+        CompileOptions::new(Target::parse("sm_120").unwrap()).with_linking(Linking::Libdevice);
+
+    let error = compiler
+        .compile(&mut module, &options)
+        .expect_err("a __nv_* symbol libdevice does not define must not produce PTX");
+    match error {
+        CompileError::UnsupportedLinking { symbols } => assert!(
+            symbols
+                .iter()
+                .any(|symbol| symbol == "__nv_totally_not_real"),
+            "the rejection names the unresolved symbol: {symbols:?}"
+        ),
+        other => panic!("expected UnsupportedLinking, got {other}"),
+    }
+}
+
 /// Return the sole top-level block of `module`, creating it if the module is
 /// still empty. Mirrors `module_block` in `tests/compile_to_ptx.rs`; kept
 /// separate here rather than lifted out of `build_unary_call_kernel`, which
@@ -372,4 +402,62 @@ fn libdevice_linking_still_rejects_a_device_extern() {
         }
         other => panic!("expected UnsupportedLinking, got {other}"),
     }
+}
+
+/// Sentinel env var telling this test it is running inside the child process
+/// spawned by `libdevice_linking_reports_unavailable_when_llvm_link_cannot_run`,
+/// so it should run the check itself instead of spawning another child.
+const LIBDEVICE_UNAVAILABLE_CHILD_ENV: &str = "CUDA_OXIDE_CODEGEN_LIBDEVICE_UNAVAILABLE_CHILD";
+
+#[test]
+fn libdevice_linking_reports_unavailable_when_llvm_link_cannot_run() {
+    // `Toolchain::discover()` reads `CUDA_OXIDE_LLVM_LINK` straight from the
+    // process environment (`llvm_tools::resolve_sibling_tool`), and `cargo
+    // test` runs every test in this binary concurrently by default. Every
+    // other test here calls `Compiler::discover()` expecting a working
+    // `llvm-link`, so setting that variable in this process would race them.
+    // Re-exec this one test, filtered to itself, in a fresh child process
+    // instead: the child gets its own environment block, so the broken value
+    // never reaches this process or any sibling test.
+    if std::env::var_os(LIBDEVICE_UNAVAILABLE_CHILD_ENV).is_some() {
+        let mut module = CodegenModule::new("unavailable_module").unwrap();
+        build_unary_call_kernel(&mut module, dialect_mir::rust_intrinsics::CALLEE_SQRT_F32);
+        let compiler = Compiler::discover().expect("LLVM 21+ llc/opt are installed");
+        let options =
+            CompileOptions::new(Target::parse("sm_120").unwrap()).with_linking(Linking::Libdevice);
+
+        let error = compiler
+            .compile(&mut module, &options)
+            .expect_err("a broken CUDA_OXIDE_LLVM_LINK must not silently produce PTX");
+        match error {
+            CompileError::LibdeviceUnavailable { message } => {
+                assert!(
+                    message.contains("llvm-link"),
+                    "message names llvm-link: {message}"
+                );
+            }
+            other => panic!("expected LibdeviceUnavailable, got {other}"),
+        }
+        return;
+    }
+
+    let exe = std::env::current_exe().expect("the running test binary has a path");
+    let output = std::process::Command::new(exe)
+        .arg("--exact")
+        .arg("libdevice_linking_reports_unavailable_when_llvm_link_cannot_run")
+        .arg("--nocapture")
+        .env(LIBDEVICE_UNAVAILABLE_CHILD_ENV, "1")
+        .env(
+            "CUDA_OXIDE_LLVM_LINK",
+            "/nonexistent/cuda-oxide-test/llvm-link",
+        )
+        .output()
+        .expect("failed to re-exec this test in a child process");
+
+    assert!(
+        output.status.success(),
+        "child process check failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
Closes #485.

A frontend driving `cuda_oxide_codegen::experimental` stops at the first `sqrt`. Float intrinsics lower to libdevice `__nv_*` calls, and v1 rejects every unresolved external symbol. The rejection at `pipeline.rs:364` sits directly above the IR-level libdevice link at `pipeline.rs:417`, so a module is refused for symbols the step below it would have resolved.

```rust
pub enum Linking { SelfContained, Libdevice }

impl CompileOptions {
    pub fn with_linking(self, linking: Linking) -> Self;
    pub fn linking(&self) -> Linking;
}
```

`Linking::SelfContained` is the default and changes no compilation that succeeds today: no link runs, and the symbol filter is the identity.

## Design decisions and rejected alternatives

### 1. The option belongs in experimental v1

**Chosen:** a default-off option on the existing surface.

**Alternative:** hold it for a v2 that redesigns linking properly.

No existing consumer changes, and a v2 stays free to supersede it. It is the smallest shape that unblocks an out-of-tree frontend and the cheapest to withdraw.

### 2. A `CompileOptions` field

**Chosen:** a field, with discovery inside the pipeline.

**Alternative:** the caller passes a path to `libdevice.10.bc`.

Discovery reuses the `libnvvm_sys::find_libdevice()` call `compile_translated_module` already makes on this path, so the API gains no filesystem search it did not already perform. A caller-supplied path adds a parameter that duplicates work already done.

### 3. No NVVM IR fallback for standalone callers

**Chosen:** one path in, one artifact kind out.

**Alternative:** fall back to NVVM IR when the link is unavailable, as `ExternalLinkAllowed` does.

`should_emit_nvvm_ir` returns `false` for `SelfContainedPtx` whatever the flag holds, and a test loops all eight combinations of the flag, strict-libdevice use and link availability to pin it. When the link is needed and unavailable, compilation fails with a new `CompileError::LibdeviceUnavailable` naming which piece is missing, since an absent `libdevice.10.bc` and an absent `llvm-link` have different fixes.

## What the filter admits

Symbols beginning `__nv_`. The predicate sits beside `unresolved_external_symbols`, so the libdevice detector, the surviving-declaration scan and the filter read one definition. Unresolved symbols that are not libdevice are still rejected, and a module carrying both loses only the libdevice half.

This admits any `__nv_*` symbol, including one a frontend names itself. Several libdevice functions have no Rust intrinsic and so no placeholder callee for `mir-lower` to recognise, `__nv_erff` and `__nv_rhypotf` among them. The alternative for such a frontend is a polynomial approximation, which gives up bit-exactness against nvcc for a function CUDA already ships. Both routes have tests.

## Fixing a precision defect

The first test asserting which instruction libdevice produces failed. libdevice selects an implementation by reading reflect variables, and `NVVMReflectPass` resolves an unset one to 0.

| reflect variable | unset | nvcc default | this PR |
|---|---|---|---|
| `__CUDA_PREC_SQRT` | 0, selects `sqrt.approx.f32` | `-prec-sqrt=true` | passes 1 |
| `__CUDA_FTZ` | 0 | `-ftz=false`, already matches | leaves unset |
| `__CUDA_ARCH` | resolved from `-mcpu` | | leaves unset |

Nothing in the tree passed a reflect variable to `llc`, so every `sqrt` reaching libdevice compiled to `sqrt.approx.f32` where nvcc produces `sqrt.rn.f32`.

**This reaches the rustc frontend too.** The arguments are keyed on a link having happened rather than on the output policy, and `sqrt` has no entry in `llvm_intrinsic_name`, so any kernel calling `f32::sqrt` moves to `sqrt.rn.f32` wherever IR-level linking is available. That is the result Rust specifies for `f32::sqrt` and the one nvcc produces by default, and it removes a disagreement between this path and the libNVVM fallback. Callers wanting the fast path have `cuda_device::float::sqrt_approx_f32`. Nothing in the tree asserts `sqrt.approx.f32` as a libdevice-path output, and `rustc-codegen-cuda` is a separate workspace with no PTX assertions, so no written expectation changes.

Happy to split this into its own pull request if you would rather judge it on numerics. It touches only `ptx.rs` and applies cleanly to `main`.

## A caveat

**`llvm-link --only-needed` resolves what it has and stays silent about the rest.** A `__nv_*` name libdevice does not define survived into the PTX as `.extern .func` and failed at `cuModuleLoad`; `ptxas` accepts such PTX, so nothing downstream caught it. The pipeline now scans for surviving `__nv_*` declarations after linking and reports them through `UnsupportedLinking`.

That scan is scoped to `SelfContainedPtx`. `can_ir_link_libdevice` is computed from tool availability alone, so `ExternalLinkAllowed { request_nvvm_ir: false }` can also reach the direct-PTX-with-linked-libdevice route on a machine holding both pieces, and the same class of unresolved symbol stays reachable there. That predates this branch and is untouched by it.

## Verification and testing

160 tests across 6 suites, debug and release. fmt, clippy `--workspace --all-targets -D warnings` and rustdoc clean. +915/−26 against `main`, seven files.

`ptxas -arch=sm_120` accepts every generated artifact. On device (RTX 5060 Laptop, sm_120) the `sqrt` kernel is bit-exact against `f32::sqrt` over 256 values; before the precision fix it computed the approximate result.

The integration tests require `llvm-link` and a discoverable `libdevice.10.bc`, which are new requirements for this crate. The `cuda-oxide-codegen` job sets `needs_cuda: true` and `rust-toolchain.toml` includes `llvm-tools`, so CI has both.
