### PR TITLE
test(cuda-oxide-codegen): make the libdevice re-exec check prove it ran

### DIFF
--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -227,18 +227,20 @@ fn assert_ptxas_accepts(ptx: &[u8], label: &str) {
 /// Extra guidance for a `LibdeviceUnavailable` a caller did not expect.
 ///
 /// `Toolchain::discover()` honours `CUDA_OXIDE_LLVM_LINK` straight from the
-/// environment, so an exported override pointing at a missing binary -- or at
-/// one whose LLVM major differs from the selected `llc`'s -- turns every
-/// libdevice test in this file into `LibdeviceUnavailable`. The error names
-/// neither the variable nor the override, so the tests do, the same way
-/// `assert_ptxas_accepts` points at `CUDA_TOOLKIT_PATH`. Empty for every other
-/// error, where the variable is irrelevant.
+/// environment, so an exported override pointing at a missing or unrunnable
+/// binary turns every libdevice test in this file into
+/// `LibdeviceUnavailable`. (A runnable override is trusted as-is; an LLVM
+/// major mismatch surfaces later as a link error, not as this variant.) The
+/// error names neither the variable nor the override, so the tests do, the
+/// same way `assert_ptxas_accepts` points at `CUDA_TOOLKIT_PATH`. Empty for
+/// every other error, where the variable is irrelevant.
 fn libdevice_unavailable_hint(error: &CompileError) -> &'static str {
     match error {
         CompileError::LibdeviceUnavailable { .. } => {
-            "\nThis needs an `llvm-link` whose LLVM major matches the selected \
-             `llc`. `Toolchain::discover()` honours CUDA_OXIDE_LLVM_LINK, so an \
-             exported override pointing at a missing or mismatched binary \
+            "\nThis needs a runnable `llvm-link` (auto-discovery only accepts \
+             one sharing the selected `llc`'s LLVM major). \
+             `Toolchain::discover()` honours CUDA_OXIDE_LLVM_LINK, so an \
+             exported override pointing at a missing or unrunnable binary \
              produces exactly this error: unset it, or point it at the \
              `llvm-link` beside your `llc`."
         }

--- a/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
+++ b/crates/cuda-oxide-codegen/tests/libdevice_linking.rs
@@ -224,6 +224,28 @@ fn assert_ptxas_accepts(ptx: &[u8], label: &str) {
     );
 }
 
+/// Extra guidance for a `LibdeviceUnavailable` a caller did not expect.
+///
+/// `Toolchain::discover()` honours `CUDA_OXIDE_LLVM_LINK` straight from the
+/// environment, so an exported override pointing at a missing binary -- or at
+/// one whose LLVM major differs from the selected `llc`'s -- turns every
+/// libdevice test in this file into `LibdeviceUnavailable`. The error names
+/// neither the variable nor the override, so the tests do, the same way
+/// `assert_ptxas_accepts` points at `CUDA_TOOLKIT_PATH`. Empty for every other
+/// error, where the variable is irrelevant.
+fn libdevice_unavailable_hint(error: &CompileError) -> &'static str {
+    match error {
+        CompileError::LibdeviceUnavailable { .. } => {
+            "\nThis needs an `llvm-link` whose LLVM major matches the selected \
+             `llc`. `Toolchain::discover()` honours CUDA_OXIDE_LLVM_LINK, so an \
+             exported override pointing at a missing or mismatched binary \
+             produces exactly this error: unset it, or point it at the \
+             `llvm-link` beside your `llc`."
+        }
+        _ => "",
+    }
+}
+
 #[test]
 fn self_contained_linking_still_rejects_a_libdevice_kernel() {
     let mut module = CodegenModule::new("sqrt_module").unwrap();
@@ -253,7 +275,12 @@ fn libdevice_linking_resolves_a_rust_intrinsic_kernel() {
 
     let ptx = compiler
         .compile(&mut module, &options)
-        .expect("libdevice linking resolves __nv_sqrtf")
+        .unwrap_or_else(|error| {
+            panic!(
+                "libdevice linking resolves __nv_sqrtf: {error}{}",
+                libdevice_unavailable_hint(&error)
+            )
+        })
         .into_ptx();
     let text = String::from_utf8(ptx.clone()).expect("PTX is utf-8");
 
@@ -286,7 +313,12 @@ fn libdevice_linking_resolves_a_frontend_declared_symbol() {
 
     let ptx = compiler
         .compile(&mut module, &options)
-        .expect("libdevice linking resolves a frontend-declared __nv_ symbol")
+        .unwrap_or_else(|error| {
+            panic!(
+                "libdevice linking resolves a frontend-declared __nv_ symbol: {error}{}",
+                libdevice_unavailable_hint(&error)
+            )
+        })
         .into_ptx();
     let text = String::from_utf8(ptx.clone()).expect("PTX is utf-8");
 
@@ -334,7 +366,10 @@ fn libdevice_linking_rejects_a_symbol_libdevice_does_not_define() {
                 .any(|symbol| symbol == "__nv_totally_not_real"),
             "the rejection names the unresolved symbol: {symbols:?}"
         ),
-        other => panic!("expected UnsupportedLinking, got {other}"),
+        other => panic!(
+            "expected UnsupportedLinking, got {other}{}",
+            libdevice_unavailable_hint(&other)
+        ),
     }
 }
 
@@ -399,7 +434,10 @@ fn libdevice_linking_still_rejects_a_device_extern() {
         CompileError::UnsupportedLinking { symbols } => {
             assert_eq!(symbols, ["my_device_extern"]);
         }
-        other => panic!("expected UnsupportedLinking, got {other}"),
+        other => panic!(
+            "expected UnsupportedLinking, got {other}{}",
+            libdevice_unavailable_hint(&other)
+        ),
     }
 }
 
@@ -407,6 +445,15 @@ fn libdevice_linking_still_rejects_a_device_extern() {
 /// spawned by `libdevice_linking_reports_unavailable_when_llvm_link_cannot_run`,
 /// so it should run the check itself instead of spawning another child.
 const LIBDEVICE_UNAVAILABLE_CHILD_ENV: &str = "CUDA_OXIDE_CODEGEN_LIBDEVICE_UNAVAILABLE_CHILD";
+
+/// Printed by the child once the check has actually run.
+///
+/// libtest exits 0 when a filter matches nothing ("running 0 tests"), so the
+/// child's exit status alone does not distinguish "the check passed" from "the
+/// check never ran". Renaming this test, or letting the `--exact` argument drift
+/// out of sync with its name, would otherwise leave a green test that verifies
+/// nothing. The parent asserts on this sentinel instead.
+const LIBDEVICE_UNAVAILABLE_CHECK_RAN: &str = "libdevice-unavailable-check-ran";
 
 #[test]
 fn libdevice_linking_reports_unavailable_when_llvm_link_cannot_run() {
@@ -437,6 +484,7 @@ fn libdevice_linking_reports_unavailable_when_llvm_link_cannot_run() {
             }
             other => panic!("expected LibdeviceUnavailable, got {other}"),
         }
+        println!("{LIBDEVICE_UNAVAILABLE_CHECK_RAN}");
         return;
     }
 
@@ -453,10 +501,18 @@ fn libdevice_linking_reports_unavailable_when_llvm_link_cannot_run() {
         .output()
         .expect("failed to re-exec this test in a child process");
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
-        "child process check failed:\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
+        "child process check failed:\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Exit status alone is not enough: a filter that matches nothing also exits
+    // 0, which would make this test green while checking nothing.
+    assert!(
+        stdout.contains(LIBDEVICE_UNAVAILABLE_CHECK_RAN),
+        "the child exited 0 but never ran the check -- the `--exact` filter above \
+         no longer matches this test's name:\nstdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## Summary

Fixes #599. Two ways `crates/cuda-oxide-codegen/tests/libdevice_linking.rs` (new
in #596) misleads its reader. The libdevice feature itself is fine — this is
test-only, no production code, no behaviour change, no GPU.

## 1. The re-exec guard could verify nothing

`libdevice_linking_reports_unavailable_when_llvm_link_cannot_run` re-execs itself
in a child so a broken `CUDA_OXIDE_LLVM_LINK` cannot race its siblings. Good
isolation — but the parent asserted only on the child's exit status, and libtest
exits 0 when a filter matches nothing:

```
$ ./libdevice_linking-<hash> --exact this_test_does_not_exist --nocapture
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out
$ echo $?
0
```

The `--exact` literal and the function name were coupled only by convention.
Rename the test, or mistype the literal, and the child runs nothing, exits 0, the
parent asserts success, and the suite stays green — with the only check that a
broken `llvm-link` cannot silently emit PTX no longer running.

The child now prints a sentinel once the check has actually executed, and the
parent asserts on that too.

**Verified**: pointing the `--exact` argument at a name that does not exist now
fails with

```
the child exited 0 but never ran the check -- the `--exact` filter above no
longer matches this test's name
```

where before it passed.

## 2. A `CUDA_OXIDE_LLVM_LINK` failure did not name `CUDA_OXIDE_LLVM_LINK`

`Toolchain::discover()` reads that variable from the environment — the file's own
comment says so. Exporting it (the documented way to point at an `llvm-link` that
is not a sibling of `llc`) at a missing or major-mismatched binary fails four
tests:

```
$ CUDA_OXIDE_LLVM_LINK=/nonexistent/llvm-link cargo test -p cuda-oxide-codegen
libdevice_linking_resolves_a_rust_intrinsic_kernel            FAILED
libdevice_linking_resolves_a_frontend_declared_symbol         FAILED
libdevice_linking_rejects_a_symbol_libdevice_does_not_define   FAILED
libdevice_linking_still_rejects_a_device_extern               FAILED

libdevice linking resolves __nv_sqrtf: LibdeviceUnavailable { message:
  "no `llvm-link` sharing the selected `llc`'s LLVM major was found" }
```

Nothing pointed at the override. The file already handles the other external tool
well (`assert_ptxas_accepts` says "Point CUDA_TOOLKIT_PATH or CUDA_HOME at the
install root, or put `ptxas` on PATH"), so `llvm-link` now gets the same
treatment via `libdevice_unavailable_hint`, used at the two `expect` sites and the
two `other =>` arms. It returns nothing for any other error, so unrelated
failures gain no noise.

After:

```
libdevice linking resolves __nv_sqrtf: libdevice linking is unavailable: no
`llvm-link` sharing the selected `llc`'s LLVM major was found
This needs an `llvm-link` whose LLVM major matches the selected `llc`.
`Toolchain::discover()` honours CUDA_OXIDE_LLVM_LINK, so an exported override
pointing at a missing or mismatched binary produces exactly this error: unset it,
or point it at the `llvm-link` beside your `llc`.
```

To be explicit about severity: an override aimed at a broken tool **should** fail,
and still does. The fix is only that the failure now says which knob to turn. The
realistic case is a machine with several LLVMs, where the override is valid for
the user's own builds but its major does not match the pinned `llc`.

Side effect worth noting: the two `expect` sites become `unwrap_or_else`, which
renders the error through `Display` instead of `Debug` — hence
`libdevice linking is unavailable: ...` rather than
`LibdeviceUnavailable { message: ... }`.

## Validation

All CPU-only; no GPU and no driver.

- `cargo test -p cuda-oxide-codegen --test libdevice_linking`: 6 passed, 0 failed
- Drifted-filter experiment: fails before the fix would have passed (above)
- `CUDA_OXIDE_LLVM_LINK=/nonexistent/llvm-link`: the four failures now name the variable
- `cargo clippy -p cuda-oxide-codegen --all-targets --locked -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cuda-intrinsics-gen check`: generated outputs current (untouched)
- 18-crate CPU matrix: **3017 passed, 0 failed**

## How I found it

Sweeping the suite against every `CUDA_OXIDE_*` / toolkit variable the repo reads.
`CUDA_OXIDE_LLVM_LINK` was the only one that broke anything — the rest
(`CUDA_OXIDE_LLC`, `_OPT`, `_LIBDEVICE`, `_DUMP_LLVM`, `_DUMP_MIR`,
`_SHOW_RUSTC_MIR`, `_DEVICE_CODEGEN_CRATE`, `_DEBUG_CONST`, `CUDA_PATH`) are
clean, which is what led me into this file and then to the re-exec guard.
