### PR TITLE
test(smoketest): pin the diagnostic for three error fixtures

### DIFF
--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -394,6 +394,30 @@ verdict_error() {
                 return 1
             fi
             ;;
+        # These three pin an exact diagnostic in their own source or README
+        # ("Expected: the build FAILS with this exact diagnostic (pinned)"),
+        # so an unrelated compile error must not satisfy them either.
+        error_heap_alloc)
+            if ! grep -Fq 'heap allocation is not supported in kernels' "${log}"; then
+                echo "FAIL (missing heap-allocation diagnostic)"
+                return 1
+            fi
+            ;;
+        error_missing_device_attr)
+            if ! grep -Fq 'only works inside `#[kernel]` / `#[device]`' "${log}"; then
+                echo "FAIL (missing host-only-stub diagnostic)"
+                return 1
+            fi
+            ;;
+        error_set_discriminant_uninhabited)
+            if ! grep -Fq 'cannot select uninhabited variant' "${log}"; then
+                echo "FAIL (missing uninhabited-variant diagnostic)"
+                return 1
+            fi
+            ;;
+        # `error` stays on the generic check below: unlike the fixtures above it
+        # pins no single message, carrying two kernels to show that a valid one
+        # still compiles while `core::fmt` machinery is refused.
     esac
 
     if grep -qE 'Device codegen failed|Translation failed|Compilation error|Unsupported construct' "${log}"; then


### PR DESCRIPTION
## Summary

Fixes #601. `verdict_error` asserted an exact diagnostic for six of the ten
`error*` fixtures and let the other four fall through to a generic "did it fail to
compile" check. Three of those four pin an exact message in their own source or
README, so **any** unrelated compile error satisfied them.

## Demonstration

Feeding `verdict_error` a log whose only error is an unresolved import:

```
$ cat unrelated.log
error[E0432]: unresolved import `foo::bar`
error: could not compile `error_heap_alloc` (bin "error_heap_alloc") due to 1 previous error

error_heap_alloc                       PASS (expected compile failure, exit=101)
error_missing_device_attr              PASS (expected compile failure, exit=101)
error_set_discriminant_uninhabited     PASS (expected compile failure, exit=101)
```

The six pinned fixtures reject that same log — that asymmetry is the bug:

```
error_enum_pointer_overlap             FAIL (missing overlapping enum pointer-provenance diagnostic)
error_generated_intrinsic_abi          FAIL (missing intrinsic ABI-v2 diagnostic)
error_generated_intrinsic_callable     FAIL (missing direct-call-only intrinsic diagnostic)
```

So an example that stopped compiling for an unrelated reason — a dependency bump,
a renamed API, a typo in the fixture — kept reporting PASS while the diagnostic it
exists to protect went unexercised.

That matters most for these three specifically: `error_missing_device_attr` and
`error_heap_alloc` exist *because* the previous behaviour was an opaque unrelated
error ("the user got an inscrutable const-translation error spanned into
`alloc/src/boxed.rs`"). A regression to that state is exactly what the check could
not tell apart from success.

## Change

The script already stated the principle for the six:

```sh
# The generated-intrinsic fixtures protect fail-closed compiler contracts,
# so merely observing an unrelated compile error is not enough.
```

This extends it to the three whose own docs pin a message:

| fixture | pins, per its own source/README | asserted substring |
| :-- | :-- | :-- |
| `error_heap_alloc` | "the build FAILS with this exact diagnostic (pinned)" | `heap allocation is not supported in kernels` |
| `error_missing_device_attr` | same wording | ``only works inside `#[kernel]` / `#[device]` `` |
| `error_set_discriminant_uninhabited` | "The build must fail with" | `cannot select uninhabited variant` |

Substrings come from the real format strings in
`crates/rustc-codegen-cuda/src/collector.rs` and
`crates/mir-importer/src/translator/statement.rs` — not from the doc comments,
which are line-wrapped. Both `only works inside` call sites (collector.rs:2183
and :2372) wrap the literal at different points but render the same single line,
so one substring covers both.

`error` deliberately stays on the generic path: unlike the others it pins no
single message — it carries two kernels to show a valid one still compiles while
`core::fmt` machinery is refused — so there is no exact string to assert without
inventing one. A comment records that, so the omission reads as deliberate rather
than forgotten.

## Validation

Shell-only — no Rust code, no GPU, no toolchain build. I exercised
`verdict_error` directly against synthetic logs.

| log | before | after |
| :-- | :-- | :-- |
| unrelated `error[E0432]`, all three fixtures | **PASS** (wrong) | FAIL, each naming its missing diagnostic |
| genuine `heap allocation is not supported in kernels …` | PASS | PASS |
| genuine ``\`thread::index_1d\` only works inside …`` | PASS | PASS |
| genuine `SetDiscriminant cannot select uninhabited variant 1` | PASS | PASS |
| unrelated error, `error` fixture | PASS | PASS (unchanged by design) |

Also: `bash -n scripts/smoketest.sh` clean, `scripts/check-error-example-status.sh`
still reports OK, and `smoketest.sh --help` unchanged.

I could not run the full smoketest end to end — it builds the backend and every
example — so the guarantee here is over `verdict_error`'s logic and the substrings
being real format-string text, verified against the compiler sources rather than
the wrapped doc comments.

## Relationship to #600

Independent and disjoint: #600 touches
`crates/cuda-oxide-codegen/tests/libdevice_linking.rs`, this touches
`scripts/smoketest.sh`. Same theme, though — a check that reports green without
verifying what it claims.
