### PR TITLE
fix(mir): lower dead uninhabited-enum paths to typed undef

### DIFF
--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -1333,3 +1333,90 @@ fn test_mir_enum_payload_rejects_uninhabited_variant() {
     payload.set_attr_payload_field_index(&ctx, FieldIndexAttr(0));
     assert!(payload.verify(&ctx).is_err());
 }
+
+/// Reachable-but-dead MIR (e.g. the residual arms of `array::try_from_fn`)
+/// can name uninhabited variants. The importer must lower such reads and
+/// constructions to typed undefs; if it ever emits the real ops again, these
+/// verifiers are the loud stop.
+#[test]
+fn test_uninhabited_enum_construct_and_discriminant_fail_verification() {
+    use dialect_mir::types::{EnumCarrierKind, EnumEncoding, EnumLayoutKind};
+
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+    let i8_ty = IntegerType::get(&ctx, 8, Signedness::Unsigned);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Unsigned);
+
+    // Constructing an uninhabited variant must fail verification.
+    let partial = MirEnumType::get_with_encoding(
+        &mut ctx,
+        "HasImpossibleVariant".into(),
+        i8_ty.into(),
+        vec![0, 1],
+        vec![
+            EnumVariant::unit("Live".into()),
+            EnumVariant::new_with_layout(
+                "Impossible".into(),
+                vec![i32_ty.into()],
+                vec![0],
+                vec![4],
+            ),
+        ],
+        EnumEncoding {
+            tag_offset: 0,
+            total_size: 8,
+            abi_align: 4,
+            layout_kind: EnumLayoutKind::Direct,
+            carrier_kind: EnumCarrierKind::Integer,
+            carrier_width: 8,
+            variant_inhabited: vec![1, 0],
+            ..EnumEncoding::default()
+        },
+    );
+    let block = BasicBlock::new(&mut ctx, None, vec![i32_ty.into()]);
+    let field = block.deref(&ctx).get_argument(0);
+    let construct = Operation::new(
+        &mut ctx,
+        MirConstructEnumOp::get_concrete_op_info(),
+        vec![partial.into()],
+        vec![field],
+        vec![],
+        0,
+    );
+    let construct = MirConstructEnumOp::new(construct);
+    construct.set_attr_construct_enum_variant_index(&ctx, VariantIndexAttr(1));
+    assert!(construct.verify(&ctx).is_err());
+
+    // Reading the discriminant of a fully uninhabited enum must fail
+    // verification.
+    let never = MirEnumType::get_with_encoding(
+        &mut ctx,
+        "Never".into(),
+        i8_ty.into(),
+        vec![],
+        vec![],
+        EnumEncoding {
+            tag_offset: 0,
+            total_size: 0,
+            abi_align: 1,
+            layout_kind: EnumLayoutKind::Empty,
+            carrier_kind: EnumCarrierKind::None,
+            carrier_width: 0,
+            variant_inhabited: vec![],
+            ..EnumEncoding::default()
+        },
+    );
+    assert!(never.verify(&ctx).is_ok());
+    let never_block = BasicBlock::new(&mut ctx, None, vec![never.into()]);
+    let never_value = never_block.deref(&ctx).get_argument(0);
+    let get_discriminant = Operation::new(
+        &mut ctx,
+        MirGetDiscriminantOp::get_concrete_op_info(),
+        vec![i8_ty.into()],
+        vec![never_value],
+        vec![],
+        0,
+    );
+    let get_discriminant = MirGetDiscriminantOp::new(get_discriminant);
+    assert!(get_discriminant.verify(&ctx).is_err());
+}

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -734,9 +734,12 @@ impl<'a> ModuleExportState<'a> {
                     let op_obj = Operation::get_op_dyn(op, self.ctx);
                     let op_dyn = op_obj.as_ref();
 
-                    // Skip ops that don't produce named results (UndefOp is handled specially)
-                    if op_dyn.downcast_ref::<ops::UndefOp>().is_some() {
-                        // UndefOp result will be named "undef"
+                    // PHIs can reference an undef defined in a block that is
+                    // printed later. Register its literal spelling during the
+                    // pre-pass just like constants.
+                    if let Some(undef_op) = op_dyn.downcast_ref::<ops::UndefOp>() {
+                        let result = undef_op.get_operation().deref(self.ctx).get_result(0);
+                        value_names.insert(result, "undef".to_string());
                         continue;
                     }
 

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -17,7 +17,7 @@ use llvm_export::{
         DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourcePosition, DebugSourceScope,
         DebugSourceScopeLocation, DebugSourceScopeMap, DebugValueOp, FuncOp, GepIndex,
         GetElementPtrOp, GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp, LoadOp,
-        ReturnOp, SelectOp, StoreOp, encode_global_initializer_relocations,
+        ReturnOp, SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
     },
     types::{ArrayType, FuncType, HalfType, PointerType, StructType, VoidType},
 };
@@ -484,6 +484,74 @@ fn exporter_deduplicates_identical_values_on_duplicate_conditional_edges() {
         .find(|line| line.contains(" = phi i32 "))
         .expect("destination block must contain a PHI");
     assert_eq!(phi.matches("%entry").count(), 1, "{phi}");
+}
+
+#[test]
+fn phi_can_reference_undef_from_a_later_block() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "later_undef_phi".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+    let i1_ty = IntegerType::get(&ctx, 1, Signedness::Signless);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let func_ty = FuncType::get(
+        &ctx,
+        i32_ty.into(),
+        vec![i1_ty.into(), i32_ty.into()],
+        false,
+    );
+    let func = FuncOp::new(&mut ctx, "choose_undef".try_into().unwrap(), func_ty);
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    let condition = entry.deref(&ctx).get_argument(0);
+    let fallback = entry.deref(&ctx).get_argument(1);
+    let region = func.get_operation().deref(&ctx).get_region(0);
+
+    // The join precedes both predecessors in print order, so its PHI depends
+    // on the exporter's whole-function value-name pre-pass.
+    let join = BasicBlock::new(&mut ctx, None, vec![i32_ty.into()]);
+    join.insert_at_back(region, &ctx);
+    let undef_block = BasicBlock::new(&mut ctx, None, vec![]);
+    undef_block.insert_at_back(region, &ctx);
+    let value_block = BasicBlock::new(&mut ctx, None, vec![]);
+    value_block.insert_at_back(region, &ctx);
+
+    CondBrOp::new(
+        &mut ctx,
+        condition,
+        undef_block,
+        vec![],
+        value_block,
+        vec![],
+    )
+    .get_operation()
+    .insert_at_back(entry, &ctx);
+
+    let undef = UndefOp::new(&mut ctx, i32_ty.into());
+    let undef_value = undef.get_operation().deref(&ctx).get_result(0);
+    undef.get_operation().insert_at_back(undef_block, &ctx);
+    BrOp::new(&mut ctx, join, vec![undef_value])
+        .get_operation()
+        .insert_at_back(undef_block, &ctx);
+    BrOp::new(&mut ctx, join, vec![fallback])
+        .get_operation()
+        .insert_at_back(value_block, &ctx);
+
+    let result = join.deref(&ctx).get_argument(0);
+    ReturnOp::new(&mut ctx, Some(result))
+        .get_operation()
+        .insert_at_back(join, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let ir = export_module_to_string_with_config(
+        &ctx,
+        &module,
+        &NvvmExportConfig::new(NvvmIrDialect::LegacyLlvm7),
+    )
+    .expect("later-block undef must be available while exporting an earlier PHI");
+    assert!(
+        ir.lines()
+            .any(|line| line.contains(" = phi i32 ") && line.contains("[ undef,")),
+        "{ir}"
+    );
 }
 
 #[test]

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -1098,6 +1098,26 @@ pub fn translate_rvalue(
                             // (e.g., enum Foo { A = 0, B = 2, C = 6 } has indices 0,1,2 but discriminants 0,2,6)
                             let variant_index_val: usize = variant_idx.to_index();
 
+                            // A value inhabiting this variant cannot exist,
+                            // so this construction sits on a dynamically dead
+                            // path rustc keeps in MIR (e.g. building
+                            // `ControlFlow::Break(NeverShortCircuitResidual)`
+                            // inside `array::try_from_fn`).
+                            // `mir.construct_enum` refuses uninhabited
+                            // variants by verification, so keep the dead path
+                            // representable with a typed undef instead.
+                            let variant_is_uninhabited = adt_ty
+                                .deref(ctx)
+                                .downcast_ref::<dialect_mir::types::MirEnumType>()
+                                .and_then(|enum_ty| enum_ty.variant_is_inhabited(variant_index_val))
+                                .is_some_and(|inhabited| !inhabited);
+                            if variant_is_uninhabited {
+                                let undef = MirUndefOp::new(ctx, adt_ty).get_operation();
+                                undef.deref_mut(ctx).set_loc(loc);
+                                let result = undef.deref(ctx).get_result(0);
+                                return Ok((Some(undef), result, current_prev_op));
+                            }
+
                             // Cast field values to expected types (address space normalization)
                             // This handles cases where field values have specific address spaces
                             // (e.g., addrspace:3 for shared memory) but the enum type expects
@@ -1551,10 +1571,14 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let enum_ty = enum_val.get_type(ctx);
-            let native_tag_ty = {
+            let (native_tag_ty, enum_is_uninhabited) = {
                 let enum_ty_obj = enum_ty.deref(ctx);
                 if let Some(enum_type) = enum_ty_obj.downcast_ref::<MirEnumType>() {
-                    enum_type.discriminant_type()
+                    let uninhabited = !enum_type
+                        .variant_inhabited
+                        .iter()
+                        .any(|inhabited| *inhabited != 0);
+                    (enum_type.discriminant_type(), uninhabited)
                 } else {
                     return input_err!(
                         loc,
@@ -1565,6 +1589,28 @@ pub fn translate_rvalue(
                     );
                 }
             };
+
+            // No value of an uninhabited enum can exist, so this read sits
+            // on a dynamically dead path rustc keeps in MIR (e.g. matching
+            // the residual `ControlFlow<Infallible, NeverShortCircuitResidual>`
+            // inside `array::try_from_fn`). `mir.get_discriminant` refuses
+            // uninhabited enums by verification, so keep the dead path
+            // representable with a typed undef of the declared discriminant
+            // type instead.
+            if enum_is_uninhabited {
+                let declared_discr_ty = place
+                    .ty(body.locals())
+                    .ok()
+                    .and_then(|place_ty| place_ty.kind().discriminant_ty());
+                let undef_ty = match declared_discr_ty {
+                    Some(ty) => super::types::translate_type(ctx, &ty)?,
+                    None => native_tag_ty,
+                };
+                let undef = MirUndefOp::new(ctx, undef_ty).get_operation();
+                undef.deref_mut(ctx).set_loc(loc);
+                let result = undef.deref(ctx).get_result(0);
+                return Ok((Some(undef), result, prev_op_after));
+            }
 
             let get_disc_op = Operation::new(
                 ctx,
@@ -3762,6 +3808,48 @@ fn apply_enum_field_projection(
 
     let field_type = types::translate_type(ctx, field_ty)?;
 
+    // Get the variant index
+    // NOTE: variant_idx IS the index (0, 1, 2, ...), NOT the discriminant!
+    // We just need to validate it's an ADT type, then use the index directly.
+    let variant_idx_val: usize = match enum_rust_ty.kind() {
+        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(_adt_def, _)) => {
+            variant_idx.to_index()
+        }
+        _ => {
+            return input_err!(
+                loc.clone(),
+                TranslationErr::unsupported(format!(
+                    "Downcast on non-ADT type: {:?}",
+                    enum_rust_ty
+                ))
+            );
+        }
+    };
+
+    // A value inhabiting this variant cannot exist, so the read sits on a
+    // dynamically dead path that rustc nevertheless keeps in MIR (e.g. the
+    // `ControlFlow::Break(NeverShortCircuitResidual)` arm inside
+    // `array::try_from_fn`). `mir.enum_payload` refuses uninhabited
+    // variants by verification, so keep the dead path representable with a
+    // typed undef instead — the same treatment `[T; 0]` extraction gets.
+    let variant_is_uninhabited = {
+        let enum_ty = enum_value.get_type(ctx);
+        enum_ty
+            .deref(ctx)
+            .downcast_ref::<dialect_mir::types::MirEnumType>()
+            .and_then(|enum_ty| enum_ty.variant_is_inhabited(variant_idx_val))
+            .is_some_and(|inhabited| !inhabited)
+    };
+    if variant_is_uninhabited {
+        let undef = MirUndefOp::new(ctx, field_type).get_operation();
+        undef.deref_mut(ctx).set_loc(loc);
+        match prev_op {
+            Some(prev) => undef.insert_after(ctx, prev),
+            None => undef.insert_at_front(block_ptr, ctx),
+        }
+        return Ok((undef.deref(ctx).get_result(0), Some(undef)));
+    }
+
     let op = Operation::new(
         ctx,
         MirEnumPayloadOp::get_concrete_op_info(),
@@ -3773,24 +3861,6 @@ fn apply_enum_field_projection(
     op.deref_mut(ctx).set_loc(loc.clone());
 
     let payload_op = MirEnumPayloadOp::new(op);
-
-    // Get the variant index
-    // NOTE: variant_idx IS the index (0, 1, 2, ...), NOT the discriminant!
-    // We just need to validate it's an ADT type, then use the index directly.
-    let variant_idx_val: usize = match enum_rust_ty.kind() {
-        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(_adt_def, _)) => {
-            variant_idx.to_index()
-        }
-        _ => {
-            return input_err!(
-                loc,
-                TranslationErr::unsupported(format!(
-                    "Downcast on non-ADT type: {:?}",
-                    enum_rust_ty
-                ))
-            );
-        }
-    };
 
     payload_op.set_attr_payload_variant_index(
         ctx,

--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -20,8 +20,9 @@
 //!   `drop_in_place` calls.
 //!
 //! Two kernels cover the shapes from the issue: a `for` loop over a
-//! plain `[u32; 4]` and one over an array of Copy structs. Both sums are
-//! verified on the host.
+//! plain `[u32; 4]` and one over an array of Copy structs. A third kernel
+//! covers the reachable-but-dead uninhabited-enum paths retained by
+//! `array::from_fn` and `array::map`. All results are verified on the host.
 //!
 //! Run: cargo oxide run array_for_loop
 
@@ -74,6 +75,19 @@ mod kernels {
             *out_elem = acc;
         }
     }
+
+    /// `array::from_fn` and `array::map` retain impossible residual-enum
+    /// branches in MIR even though these infallible helpers cannot take them.
+    #[kernel]
+    pub fn map_generated_array(mut out: DisjointSlice<u32>) {
+        let tid = thread::index_1d();
+        let t = tid.get() as u32;
+        if let Some(out_elem) = out.get_mut(tid) {
+            let generated: [u32; 4] = core::array::from_fn(|index| t + index as u32);
+            let mapped = generated.map(|value| value * 3 + 1);
+            *out_elem = mapped.into_iter().sum();
+        }
+    }
 }
 
 fn main() {
@@ -110,6 +124,13 @@ fn main() {
         .expect("launch sum_point_array");
     let got_pts = d_pts.to_host_vec(&stream).unwrap();
 
+    let mut d_mapped = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
+    // SAFETY: the 32-thread 1D block matches the kernel's indexing model and
+    // the 32-element output allocation.
+    unsafe { module.map_generated_array(stream.as_ref(), cfg, &mut d_mapped) }
+        .expect("launch map_generated_array");
+    let got_mapped = d_mapped.to_host_vec(&stream).unwrap();
+
     let mut failures = 0usize;
     for tid in 0..N {
         let t = tid as u32;
@@ -117,6 +138,8 @@ fn main() {
         let want_u32 = 4 * t + 6;
         // t*1 + (t+1)*2 + (t+2)*3 + (t+3)*4
         let want_pts = t + (t + 1) * 2 + (t + 2) * 3 + (t + 3) * 4;
+        // sum([t, t+1, t+2, t+3].map(|value| value * 3 + 1))
+        let want_mapped = 12 * t + 22;
         if got_u32[tid] != want_u32 {
             println!(
                 "FAIL tid={tid}: sum_u32_array={} expected={want_u32}",
@@ -131,10 +154,17 @@ fn main() {
             );
             failures += 1;
         }
+        if got_mapped[tid] != want_mapped {
+            println!(
+                "FAIL tid={tid}: map_generated_array={} expected={want_mapped}",
+                got_mapped[tid]
+            );
+            failures += 1;
+        }
     }
 
     if failures == 0 {
-        println!("array_for_loop: PASS ({N} threads, both array for-loops summed correctly)");
+        println!("array_for_loop: PASS ({N} threads, array loops and infallible helpers agree)");
     } else {
         println!("array_for_loop: FAIL ({failures} mismatches)");
         std::process::exit(1);


### PR DESCRIPTION
Closes #607.

## Summary

Rustc retains impossible residual-enum arms in the MIR for infallible
fixed-array helpers. The importer was emitting real enum operations for those
dead paths, which the MIR dialect correctly rejected. This change represents
dead construction, discriminant, and payload paths with typed `mir.undef`
values, preserving strict verification while allowing `array::from_fn` and
`array::map` to compile and execute on the device.

Before:

```text
MirEnumPayloadOp cannot extract a field from uninhabited variant 1
```

After: the focused GPU regression computes and validates the mapped array for
all 32 launched threads.

## What changed

### Preserve dead uninhabited-enum paths without weakening verification

- Inspect the authoritative `MirEnumType::variant_inhabited` layout facts at
  enum construction, discriminant-read, and payload-read lowering sites.
- Emit a `MirUndefOp` with the operation's declared result type when rustc's
  MIR names an enum or variant that cannot be inhabited.
- Leave `MirConstructEnumOp`, `MirGetDiscriminantOp`, and
  `MirEnumPayloadOp` verification unchanged. Unit coverage confirms those
  operations still reject uninhabited inputs.

### Make undef values available to later-block PHIs

- Register an undef result's literal LLVM spelling during the exporter's
  whole-function value-name pre-pass.
- Cover a join block printed before both predecessors, with a PHI incoming
  value defined by `undef` in a later-printed block.

### Focused end-to-end coverage

- Extend `array_for_loop` with a `[u32; 4]` kernel that composes
  `core::array::from_fn` and `array::map` and checks the exact host result.
- The regression uses ordinary scalar arrays and is independent of
  over-aligned union storage and bare enum-array constants.
- This extracts the enabling correctness fix previously carried inside draft
  PR #398. That PR is on hold over its always-on array-optimization pipeline;
  this branch contains none of that optimization, unrolling, or SSA
  scalarization work.

## Known separate limitations

- This only substitutes undef when imported `MirEnumType` layout facts prove
  an enum or variant uninhabited. Unsupported or malformed inhabited enum
  operations continue to fail verification.
- The upstream-main smoke reaches the payload verifier failure first, so that
  one run does not independently demonstrate red failures for construction and
  discriminant lowering. Focused tests cover all three paths, and the patched
  generated IR exercises undefined discriminants flowing through PHIs.
- Empty-enum layout reconstruction, over-aligned union storage, bare
  enum-array constants, and multi-artifact loading are deliberately outside
  this patch.
- The regression exercises current rustc MIR for `array::from_fn` and
  `array::map`; it does not attempt to generalize unrelated dead-code
  elimination.

## Testing

- Upstream red, based on `upstream/main` at
  `bead880cd7461c67a14bc69d10fa7def538f3394`:
  `scripts/smoketest.sh --only '^array_for_loop$' --no-color --keep-logs`
  failed with cargo exit 101 because `MirEnumPayloadOp` attempted to extract
  uninhabited variant 1 inside `core::array::try_from_fn`.
- Patched green: the same command passed 1/1 on an NVIDIA GeForce RTX 3080
  (sm_86), including exact results for all 32 threads.
- `cargo test -p dialect-mir test_uninhabited_enum_construct_and_discriminant_fail_verification`
  passed.
- `cargo test -p llvm-export phi_can_reference_undef_from_a_later_block`
  passed.
- `cargo test -p mir-importer --lib` passed all 891 tests.
- `cargo clippy -p dialect-mir -p llvm-export -p mir-importer --all-targets -- -D warnings`
  passed.
- Root and standalone-example formatting checks and `git diff --check`
  passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
