### PR TITLE
fix(mir-lower): preserve over-aligned union size and stride

### DIFF
--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -1012,7 +1012,7 @@ mod tests {
     use super::*;
     use crate::convert::ops::test_util::*;
     use dialect_mir::ops as mir;
-    use dialect_mir::types::{MirArrayType, MirPtrType, MirStructType, MirTupleType};
+    use dialect_mir::types::{MirArrayType, MirPtrType, MirStructType, MirTupleType, MirUnionType};
     use llvm_export::op_interfaces::PointerTypeResult;
     use llvm_export::ops as llvm;
     use llvm_export::types::{PointerType, address_space as llvm_addr};
@@ -1540,6 +1540,70 @@ mod tests {
             llvm_export::ops::op_alignment(&ctx, store.get_operation()),
             Some(32)
         );
+    }
+
+    #[test]
+    fn convert_ref_preserves_over_aligned_union_array_layout_and_alignment() {
+        for abi_align in [32, 64] {
+            let mut ctx = make_ctx();
+            let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+            let union_ty: TypeHandle = MirUnionType::get(
+                &mut ctx,
+                format!("Align{abi_align}Union"),
+                vec!["word".into()],
+                vec![u32_ty],
+                abi_align,
+                abi_align,
+            )
+            .into();
+            let array_ty: TypeHandle = MirArrayType::get(&mut ctx, union_ty, 3).into();
+            let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, array_ty, false);
+            let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+            let undef = mir::MirUndefOp::new(&mut ctx, array_ty);
+            undef.get_operation().insert_at_back(block, &ctx);
+            let value = undef.get_operation().deref(&ctx).get_result(0);
+            let ref_op = Operation::new(
+                &mut ctx,
+                mir::MirRefOp::get_concrete_op_info(),
+                vec![mir_ptr_ty.into()],
+                vec![value],
+                vec![],
+                0,
+            );
+            mir::MirRefOp::new(ref_op).set_mutable(&mut ctx, false);
+            ref_op.insert_at_back(block, &ctx);
+            append_mir_return(&mut ctx, block, vec![]);
+
+            crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+            let body = kernel_blocks(&ctx, module_ptr);
+            let alloca = find_first::<llvm::AllocaOp>(&ctx, &body).expect("expected llvm.alloca");
+            let store = find_first::<llvm::StoreOp>(&ctx, &body).expect("expected llvm.store");
+            let llvm_array_ty = alloca.result_pointee_type(&ctx);
+            let llvm_array_data = llvm_array_ty.deref(&ctx);
+            let llvm_array = llvm_array_data
+                .downcast_ref::<ArrayType>()
+                .expect("over-aligned union array must remain an LLVM array");
+
+            assert_eq!(llvm_array.size(), 3);
+            assert_eq!(
+                crate::convert::types::llvm_type_size_align(&ctx, llvm_array.elem_type()),
+                Some((abi_align, 16))
+            );
+            assert_eq!(
+                crate::convert::types::llvm_type_size_align(&ctx, llvm_array_ty),
+                Some((abi_align * 3, 16))
+            );
+            assert_eq!(
+                llvm_export::ops::op_alignment(&ctx, alloca.get_operation()),
+                Some(abi_align as u32)
+            );
+            assert_eq!(
+                llvm_export::ops::op_alignment(&ctx, store.get_operation()),
+                Some(abi_align as u32)
+            );
+        }
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -581,9 +581,10 @@ fn make_padding_type(ctx: &mut Context, size: u64) -> TypeHandle {
 /// alignment without consuming storage. Pointer-bearing fields are preferred
 /// so an ordinary union copy keeps LLVM pointer provenance.
 ///
-/// NVPTX gives scalar integers natural alignments up to 16 bytes. Reject a
-/// more strongly aligned union instead of silently emitting a by-value type
-/// with a weaker ABI alignment.
+/// NVPTX gives scalar integers natural alignments up to 16 bytes. Stronger
+/// Rust alignment is carried explicitly on memory operations because LLVM
+/// aggregate types cannot encode over-alignment; the storage type still keeps
+/// the union's exact size and therefore its array stride.
 pub(crate) fn build_union_storage_type(
     ctx: &mut Context,
     union_ty: &MirUnionType,
@@ -593,13 +594,6 @@ pub(crate) fn build_union_storage_type(
     if align == 0 || !align.is_power_of_two() {
         return Err(anyhow::anyhow!(
             "union `{}` has invalid ABI alignment {}",
-            union_ty.name(),
-            align
-        ));
-    }
-    if align > 16 {
-        return Err(anyhow::anyhow!(
-            "union `{}` requires {}-byte alignment; cuda-oxide currently supports union alignments up to 16 bytes",
             union_ty.name(),
             align
         ));
@@ -658,7 +652,8 @@ pub(crate) fn build_union_storage_type(
         fields.push((llvm_field_ty, field_size, field_align, contains_pointer));
     }
 
-    let anchor_int = IntegerType::get(ctx, (align * 8) as u32, Signedness::Signless);
+    let storage_align = align.min(16);
+    let anchor_int = IntegerType::get(ctx, (storage_align * 8) as u32, Signedness::Signless);
     let anchor: TypeHandle = llvm_types::ArrayType::get(ctx, anchor_int.into(), 0).into();
     let mut storage_fields = vec![anchor];
     if size > 0 {
@@ -695,9 +690,9 @@ pub(crate) fn build_union_storage_type(
             union_ty.name()
         )
     })?;
-    if llvm_size != size || llvm_align != align {
+    if llvm_size != size || llvm_align > align {
         return Err(anyhow::anyhow!(
-            "union `{}` storage lowered to size/alignment {}/{} but rustc requires {}/{}",
+            "union `{}` storage lowered to incompatible size/alignment {}/{} but rustc requires {}/{}",
             union_ty.name(),
             llvm_size,
             llvm_align,
@@ -3349,7 +3344,7 @@ mod tests {
     }
 
     #[test]
-    fn union_storage_rejects_unrepresentable_over_alignment() {
+    fn union_storage_preserves_over_aligned_size_and_stride() {
         let mut ctx = make_ctx();
         let u32_ty = mir_uint(&mut ctx, 32);
         let union_ty = MirUnionType::get(
@@ -3361,8 +3356,13 @@ mod tests {
             32,
         );
         let union_data = union_ty.deref(&ctx).clone();
-        let err = build_union_storage_type(&mut ctx, &union_data).unwrap_err();
-        assert!(err.to_string().contains("up to 16 bytes"));
+        let storage = build_union_storage_type(&mut ctx, &union_data).unwrap();
+        assert_eq!(llvm_type_size_align(&ctx, storage), Some((32, 16)));
+
+        let union_handle: TypeHandle = union_ty.into();
+        let array: TypeHandle = MirArrayType::get(&mut ctx, union_handle, 3).into();
+        let llvm_array = convert_type(&mut ctx, array).unwrap();
+        assert_eq!(llvm_type_size_align(&ctx, llvm_array), Some((96, 16)));
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/examples/union_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/union_aggregate/src/main.rs
@@ -8,7 +8,8 @@
 //! Every field of a Rust union is a different typed view of the same bytes.
 //! This example checks construction through either field, cross-field reads,
 //! unequal field sizes, arrays, nested structs, generic fields, pointers, and
-//! passing a union through an ordinary device function.
+//! passing a union through an ordinary device function. It also checks that
+//! an over-aligned union keeps its size and array stride.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
@@ -94,6 +95,12 @@ union AlignedZeroUnion {
 union TupleBytes {
     value: (u8, u64),
     bytes: [u8; 16],
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, align(32))]
+union OverAlignedWord {
+    word: u32,
 }
 
 struct Wrapper {
@@ -315,6 +322,16 @@ mod kernels {
                 // A synthetic value for a void-lowered call result must retain
                 // the union's 16-byte address requirement.
                 20 => aligned_zero_address(&make_aligned_zero()),
+                // Storage for an over-aligned union retains the 32-byte Rust
+                // size, so consecutive array elements use the same stride.
+                21 => {
+                    let values = [
+                        OverAlignedWord { word: 0x11 },
+                        OverAlignedWord { word: 0x22 },
+                        OverAlignedWord { word: 0x33 },
+                    ];
+                    unsafe { values[0].word | (values[1].word << 8) | (values[2].word << 16) }
+                }
                 _ => 0,
             };
         }
@@ -332,7 +349,7 @@ mod kernels {
 }
 
 fn main() {
-    const EXPECTED: [u32; 21] = [
+    const EXPECTED: [u32; 22] = [
         0,
         0x1122_3344,
         0x5566_7788,
@@ -354,6 +371,7 @@ fn main() {
         0x1818,
         0x2222,
         0,
+        0x0033_2211,
     ];
     const N: usize = EXPECTED.len();
 


### PR DESCRIPTION
Closes #609.

## Summary

Over-aligned Rust unions were rejected solely because LLVM/NVPTX aggregate
types have no natural alignment above 16 bytes. The actual correctness rule is
that the storage carrier must preserve Rust's byte size and array stride while
memory operations carry the stronger ABI alignment explicitly. This change
uses a 16-byte natural-alignment anchor for over-aligned carriers, preserves
the exact Rust size, and admits representable `#[repr(C, align(32))]` unions.

Before:

```text
union `OverAlignedWord` requires 32-byte alignment; cuda-oxide currently supports union alignments up to 16 bytes
```

After: hardware-free MIR-to-LLVM lowering tests preserve the carrier size,
array stride, and explicit memory-operation alignment for both 32- and
64-byte-aligned unions. The direct GPU regression also compiles and returns the
expected values from all three 32-byte-stride elements.

## What changed

### Preserve authoritative Rust size and stride

- Continue using `MirUnionType::total_size` and `abi_align`, which come from
  rustc layout, instead of deriving layout from the declared fields.
- Cap only the LLVM carrier's natural-alignment anchor at 16 bytes, the
  strongest scalar alignment available for this NVPTX representation.
- Require the lowered carrier size to equal rustc's union size exactly and
  reject a carrier whose natural alignment exceeds the Rust ABI alignment.
- Keep the existing requirement that a non-empty union's size be a multiple
  of its Rust ABI alignment. Arrays therefore inherit the exact Rust stride.

### Focused coverage and related paths

- Replace the old blanket-rejection unit test with exact layout assertions:
  `Some((32, 16))` for the union carrier and `Some((96, 16))` for a
  three-element array.
- Add a full MIR-to-LLVM code-shape regression for 32- and 64-byte-aligned
  unions. It asserts three-element LLVM carrier sizes of 96 and 192 bytes,
  32- and 64-byte element strides, and matching explicit alignment on the
  resulting `llvm.alloca` and `llvm.store`.
- Extend `union_aggregate` with a direct
  `#[repr(C, align(32))] union OverAlignedWord` array and validate distinct
  values from all three elements at runtime.
- Existing pointer-carrier selection, incompatible-address-space rejection,
  non-byte-faithful carrier rejection, and ordinary union layout tests are
  unchanged and pass.
- Draft PR #398 carried an earlier form of this enabling fix alongside an
  on-hold, always-on array optimization. Its maintainer review explicitly
  identified union over-alignment as independently valuable; this branch
  extracts only that layout correction.

## Known separate limitations

- LLVM storage still has at most 16-byte natural alignment. Correct
  over-alignment relies on the existing explicit rustc-derived alignment on
  allocations and memory accesses; this patch does not add a new LLVM type
  alignment mechanism.
- Union shapes that lose pointer provenance, mix incompatible pointer
  representations, have invalid size/alignment relationships, or otherwise
  lack a byte-faithful carrier remain rejected.
- Empty-enum lowering, `array::map`, uninhabited-enum paths, enum-array
  constants, and multi-artifact loading are deliberately outside this patch.

## Testing

- Upstream red, based on `upstream/main` at
  `bead880cd7461c67a14bc69d10fa7def538f3394`:
  `cargo test -p mir-lower
  convert_ref_preserves_over_aligned_union_array_layout_and_alignment`
  failed during lowering with the 32-byte union alignment-limit diagnostic.
- Upstream GPU red at the same revision:
  `scripts/smoketest.sh --only '^union_aggregate$' --no-color --keep-logs`
  failed with cargo exit 101 and the 32-byte union alignment-limit diagnostic.
- Patched hardware-free green: the focused lowering/code-shape test passed for
  both 32- and 64-byte alignment.
- Patched GPU green: the same smoke command passed 1/1 on an NVIDIA GeForce RTX 3080
  (sm_86), including the three-element over-aligned union result.
- `cargo test -p mir-lower union_storage_preserves_over_aligned_size_and_stride`
  passed with exact `Some((32, 16))` and `Some((96, 16))` assertions.
- `cargo test -p mir-lower --all-targets` passed all 222 tests.
- `cargo clippy -p mir-lower --all-targets -- -D warnings` passed.
- Standalone-example clippy, root and standalone-example formatting checks,
  and `git diff --check` passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
