### PR TITLE
fix(mir): preserve wrapping pointer-offset semantics

### DIFF
--- a/crates/dialect-mir/src/ops/memory.rs
+++ b/crates/dialect-mir/src/ops/memory.rs
@@ -9,13 +9,14 @@
 
 use pliron::{
     builtin::{
-        attributes::IntegerAttr,
+        attributes::{BoolAttr, IntegerAttr},
         op_interfaces::{NOpdsInterface, NResultsInterface, OneOpdInterface, OneResultInterface},
         types::IntegerType,
     },
     common_traits::Verify,
     context::{Context, Ptr},
     derive::op_interface_impl,
+    identifier::Identifier,
     irbuild::{inserter::Inserter, rewriter::Rewriter},
     location::Located,
     op::Op,
@@ -732,10 +733,38 @@ impl Verify for MirRefOp {
 )]
 pub struct MirPtrOffsetOp;
 
+const PTR_OFFSET_INBOUNDS_KEY: &str = "mir_ptr_offset_inbounds";
+
 impl MirPtrOffsetOp {
     /// Create a new MirPtrOffsetOp wrapper.
     pub fn new(op: Ptr<Operation>) -> Self {
         MirPtrOffsetOp { op }
+    }
+
+    /// Set whether this offset carries Rust's in-bounds pointer-arithmetic
+    /// promise. Wrapping offsets must set this to false.
+    pub fn set_inbounds(&self, ctx: &mut Context, inbounds: bool) {
+        let key = Identifier::try_new(PTR_OFFSET_INBOUNDS_KEY.to_string())
+            .expect("valid ptr-offset attribute key");
+        self.get_operation()
+            .deref_mut(ctx)
+            .attributes
+            .set(key, BoolAttr::new(inbounds));
+    }
+
+    /// Return whether this offset may lower to LLVM `getelementptr inbounds`.
+    ///
+    /// Pointer offsets without an explicit attribute carry Rust's ordinary
+    /// in-bounds contract, so absence defaults to true.
+    pub fn is_inbounds(&self, ctx: &Context) -> bool {
+        let key = Identifier::try_new(PTR_OFFSET_INBOUNDS_KEY.to_string())
+            .expect("valid ptr-offset attribute key");
+        self.get_operation()
+            .deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&key)
+            .map(|attr| bool::from(attr.clone()))
+            .unwrap_or(true)
     }
 }
 

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -305,6 +305,15 @@ fn test_mir_ptr_offset_verify() {
     );
     let offset_op = MirPtrOffsetOp::new(op);
     assert!(offset_op.verify(&ctx).is_ok(), "Valid MirPtrOffsetOp");
+    assert!(
+        offset_op.is_inbounds(&ctx),
+        "ordinary pointer offsets default to inbounds"
+    );
+    offset_op.set_inbounds(&mut ctx, false);
+    assert!(
+        !offset_op.is_inbounds(&ctx),
+        "wrapping pointer offsets retain their explicit semantics"
+    );
 
     let block2 = BasicBlock::new(&mut ctx, None, vec![i32_ty.into(), usize_ty.into()]);
     let i32_val = block2.deref(&ctx).get_argument(0);

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -874,7 +874,11 @@ impl<'a> ModuleExportState<'a> {
             res_name.clone()
         };
 
-        write!(output, "  {gep_name} = getelementptr inbounds ").unwrap();
+        write!(output, "  {gep_name} = getelementptr").unwrap();
+        if ops::gep_inbounds(self.ctx, op.get_operation()) {
+            write!(output, " inbounds").unwrap();
+        }
+        write!(output, " ").unwrap();
         self.export_type(elem_ty, output)?;
         write!(output, ", ").unwrap();
         if self.legacy_typed_pointers() {

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -271,6 +271,10 @@ pub mod ops {
     /// and emitted as `align N` during export.
     const OP_ALIGNMENT_KEY: &str = "cuda_oxide_op_alignment";
 
+    /// Op-attribute key controlling whether a GEP is emitted with LLVM's
+    /// `inbounds` promise. Absence denotes an in-bounds GEP.
+    const GEP_INBOUNDS_KEY: &str = "cuda_oxide_gep_inbounds";
+
     /// Op-attribute key controlling whether an inline asm op is emitted with
     /// LLVM's `sideeffect` marker. Absent means true, matching the conservative
     /// default for user-authored inline PTX.
@@ -293,6 +297,24 @@ pub mod ops {
             .get::<BoolAttr>(&key)
             .map(|attr| bool::from((*attr).clone()))
             .unwrap_or(false)
+    }
+
+    /// Stamp the source pointer arithmetic contract onto an LLVM GEP.
+    pub fn set_gep_inbounds(ctx: &mut Context, op: Ptr<Operation>, inbounds: bool) {
+        let key = Identifier::try_new(GEP_INBOUNDS_KEY.to_string()).expect("valid identifier");
+        op.deref_mut(ctx)
+            .attributes
+            .set(key, BoolAttr::new(inbounds));
+    }
+
+    /// Return whether an LLVM GEP carries the `inbounds` promise.
+    pub fn gep_inbounds(ctx: &Context, op: Ptr<Operation>) -> bool {
+        let key = Identifier::try_new(GEP_INBOUNDS_KEY.to_string()).expect("valid identifier");
+        op.deref(ctx)
+            .attributes
+            .get::<BoolAttr>(&key)
+            .map(|attr| bool::from(attr.clone()))
+            .unwrap_or(true)
     }
 
     /// Debug type metadata for a local variable described by `llvm.dbg.declare`.

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -305,6 +305,46 @@ fn legacy_gep_rejects_a_result_address_space_different_from_its_base() {
 }
 
 #[test]
+fn gep_inbounds_marker_controls_exported_pointer_semantics() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "gep_semantics".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let pointer = PointerType::get(&ctx, 0);
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.into(), vec![pointer.into()], false);
+    let func = FuncOp::new(&mut ctx, "offsets".try_into().unwrap(), func_ty);
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    let base = entry.deref(&ctx).get_argument(0);
+
+    let ordinary = GetElementPtrOp::new(&mut ctx, base, vec![GepIndex::Constant(1)], i32_ty.into());
+    ordinary.get_operation().insert_at_back(entry, &ctx);
+
+    let wrapping = GetElementPtrOp::new(&mut ctx, base, vec![GepIndex::Constant(2)], i32_ty.into());
+    llvm_export::ops::set_gep_inbounds(&mut ctx, wrapping.get_operation(), false);
+    wrapping.get_operation().insert_at_back(entry, &ctx);
+
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let ir = export_module_to_string(&ctx, &module).expect("GEP export succeeds");
+    let gep_lines: Vec<_> = ir
+        .lines()
+        .filter(|line| line.contains("getelementptr"))
+        .collect();
+    assert_eq!(gep_lines.len(), 2, "{ir}");
+    assert!(gep_lines[0].contains("getelementptr inbounds"), "{ir}");
+    assert!(
+        gep_lines[1].contains("getelementptr i32")
+            && !gep_lines[1].contains("getelementptr inbounds"),
+        "{ir}"
+    );
+}
+
+#[test]
 fn legacy_pointer_select_keeps_one_canonical_type() {
     let mut ctx = Context::new();
     let module = ModuleOp::new(&mut ctx, "legacy_pointer_select".try_into().unwrap());

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -199,6 +199,98 @@ pub fn emit_volatile_store(
     }
 }
 
+/// Emits `core::intrinsics::arith_offset::<T>(ptr, count) -> *const T`.
+///
+/// This intrinsic backs the safe wrapping raw-pointer offset methods. The
+/// explicit non-inbounds marker preserves wrapping semantics through LLVM
+/// lowering while retaining the source pointer's pointee type and address
+/// space.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_arith_offset(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    use dialect_mir::ops::MirPtrOffsetOp;
+    use dialect_mir::types::MirPtrType;
+
+    if args.len() != 2 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "arith_offset expects 2 arguments (ptr, count), got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (ptr, op_after_ptr) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+    let ptr_type = ptr.get_type(ctx);
+    if ptr_type.deref(ctx).downcast_ref::<MirPtrType>().is_none() {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "arith_offset: expected pointer operand, got {:?}",
+                ptr_type.deref(ctx)
+            ))
+        );
+    }
+
+    let (count, op_after_count) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[1],
+        value_map,
+        block_ptr,
+        op_after_ptr,
+        loc.clone(),
+    )?;
+    let offset = Operation::new(
+        ctx,
+        MirPtrOffsetOp::get_concrete_op_info(),
+        vec![ptr_type],
+        vec![ptr, count],
+        vec![],
+        0,
+    );
+    offset.deref_mut(ctx).set_loc(loc.clone());
+    MirPtrOffsetOp::new(offset).set_inbounds(ctx, false);
+    if let Some(prev) = op_after_count {
+        offset.insert_after(ctx, prev);
+    } else {
+        offset.insert_at_front(block_ptr, ctx);
+    }
+
+    let result = offset.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result,
+        target,
+        block_ptr,
+        offset,
+        value_map,
+        block_map,
+        loc,
+        "arith_offset call without target block",
+    )
+}
+
 #[derive(Clone, Copy)]
 enum PtrOffsetFromResult {
     Signed,

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -2670,6 +2670,21 @@ fn try_dispatch_intrinsic(
             )?))
         }
 
+        "core::intrinsics::arith_offset" | "std::intrinsics::arith_offset" => {
+            Ok(Some(intrinsics::memory::emit_arith_offset(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+
         "core::intrinsics::ptr_offset_from" | "std::intrinsics::ptr_offset_from" => {
             Ok(Some(intrinsics::memory::emit_ptr_offset_from(
                 ctx,

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -503,6 +503,8 @@ pub(crate) fn convert_ptr_offset(
         vec![llvm_export::ops::GepIndex::Value(offset)],
         elem_ty,
     );
+    let inbounds = dialect_mir::ops::MirPtrOffsetOp::new(op).is_inbounds(ctx);
+    llvm::set_gep_inbounds(ctx, llvm_gep.get_operation(), inbounds);
     rewriter.insert_operation(ctx, llvm_gep.get_operation());
     rewriter.replace_operation(ctx, op, llvm_gep.get_operation());
 
@@ -1576,6 +1578,43 @@ mod tests {
             .downcast_ref::<IntegerType>()
             .expect("gep src_elem_type should be IntegerType");
         assert_eq!(int_ty.width(), 32, "gep elem type must be i32 (pointee)");
+        assert!(
+            llvm::gep_inbounds(&ctx, gep.get_operation()),
+            "ordinary pointer offsets retain the in-bounds contract"
+        );
+    }
+
+    #[test]
+    fn convert_wrapping_ptr_offset_lowers_to_non_inbounds_gep() {
+        let mut ctx = make_ctx();
+        let i32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
+        let i64_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+        let mir_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, false);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![mir_ptr_ty.into(), i64_ty], vec![]);
+        let ptr_val = block.deref(&ctx).get_argument(0);
+        let off_val = block.deref(&ctx).get_argument(1);
+
+        let off_op = Operation::new(
+            &mut ctx,
+            mir::MirPtrOffsetOp::get_concrete_op_info(),
+            vec![mir_ptr_ty.into()],
+            vec![ptr_val, off_val],
+            vec![],
+            0,
+        );
+        mir::MirPtrOffsetOp::new(off_op).set_inbounds(&mut ctx, false);
+        off_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let gep = find_first::<llvm::GetElementPtrOp>(&ctx, &body).expect("expected one llvm.gep");
+        assert!(
+            !llvm::gep_inbounds(&ctx, gep.get_operation()),
+            "wrapping pointer offsets must not promise in-bounds arithmetic"
+        );
     }
 
     // =========================================================================

--- a/crates/rustc-codegen-cuda/examples/ptr_offset_from/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/ptr_offset_from/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 # - `ptr_offset_from_unsigned::<T>` via `offset_from_unsigned`
 # - `ptr_offset_from::<T>` via `offset_from`
 # - byte-oriented wrappers via `byte_offset_from*`
+# - `arith_offset::<T>` via safe wrapping pointer offsets
 #
 # Build and run with:
 #   cargo oxide run ptr_offset_from

--- a/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
@@ -1,13 +1,14 @@
 // Copyright (c) 2024-2026 NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Regression coverage for raw pointer distance intrinsics.
+//! Regression coverage for raw pointer distance and wrapping-offset intrinsics.
 //!
 //! The stable raw pointer methods lower through rustc intrinsics in MIR:
 //! `offset_from_unsigned` uses `ptr_offset_from_unsigned`, while
 //! `offset_from` and the byte-oriented wrappers use `ptr_offset_from`.
-//! cuda-oxide must compute the byte address difference and divide by the
-//! pointee size, preserving signed results for negative distances.
+//! Safe `wrapping_offset`/`wrapping_add` use `arith_offset`. cuda-oxide must
+//! preserve signed distances, scale offsets by the pointee type, retain pointer
+//! mutability through libcore's cast, and leave zero-sized pointees stationary.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
@@ -16,8 +17,19 @@ use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
 mod kernels {
     use super::*;
 
+    #[inline(always)]
+    fn wrapping_offset<T>(pointer: *const T, count: isize) -> *const T {
+        pointer.wrapping_offset(count)
+    }
+
     #[kernel]
-    pub fn pointer_distances(values: &[u32], lo: usize, hi: usize, mut out: DisjointSlice<i64>) {
+    pub fn pointer_offsets(
+        values: &[u32],
+        lo: usize,
+        hi: usize,
+        extreme: isize,
+        mut out: DisjointSlice<i64>,
+    ) {
         if thread::index_1d().get() == 0 {
             let base = values.as_ptr();
             unsafe {
@@ -28,12 +40,25 @@ mod kernels {
                 *out.get_unchecked_mut(1) = lo_ptr.offset_from(hi_ptr) as i64;
                 *out.get_unchecked_mut(2) = hi_ptr.byte_offset_from(lo_ptr) as i64;
                 *out.get_unchecked_mut(3) = hi_ptr.byte_offset_from_unsigned(lo_ptr) as i64;
+                *out.get_unchecked_mut(4) = *base.wrapping_add(hi) as i64;
+                *out.get_unchecked_mut(5) = *hi_ptr.wrapping_offset(-((hi - lo) as isize)) as i64;
+                *out.get_unchecked_mut(6) =
+                    *base.cast::<[u32; 3]>().wrapping_add(2).cast::<u32>() as i64;
+                *out.get_unchecked_mut(7) = *(base as *mut u32).wrapping_add(lo) as i64;
+                *out.get_unchecked_mut(8) =
+                    (wrapping_offset(base.cast::<()>(), hi as isize) == base.cast::<()>()) as i64;
+                let wrapped = base.wrapping_offset(extreme).addr();
+                let byte_delta = wrapped.wrapping_sub(base.addr());
+                let expected_delta = (extreme as usize).wrapping_mul(core::mem::size_of::<u32>());
+                *out.get_unchecked_mut(9) = (byte_delta == expected_delta) as i64;
+                *out.get_unchecked_mut(10) =
+                    (wrapping_offset(base.cast::<()>(), extreme) == base.cast::<()>()) as i64;
             }
         }
     }
 }
 
-const SLOTS: usize = 4;
+const SLOTS: usize = 11;
 
 fn main() {
     let ctx = CudaContext::new(0).expect("ctx");
@@ -43,22 +68,24 @@ fn main() {
     let values: Vec<u32> = (0..16).map(|v| v * 11).collect();
     let lo = 3usize;
     let hi = 9usize;
+    let extreme = isize::MAX;
 
     let values_dev = DeviceBuffer::from_host(&stream, &values).unwrap();
     let mut out_dev = DeviceBuffer::<i64>::zeroed(&stream, SLOTS).unwrap();
 
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe {
-        module.pointer_distances(
+        module.pointer_offsets(
             &stream,
             LaunchConfig::for_num_elems(1),
             &values_dev,
             lo,
             hi,
+            extreme,
             &mut out_dev,
         )
     }
-    .expect("launch pointer_distances");
+    .expect("launch pointer_offsets");
 
     let got = out_dev.to_host_vec(&stream).unwrap();
     let element_distance = (hi - lo) as i64;
@@ -68,6 +95,13 @@ fn main() {
         -element_distance,
         byte_distance,
         byte_distance,
+        values[hi] as i64,
+        values[lo] as i64,
+        values[6] as i64,
+        values[lo] as i64,
+        1,
+        1,
+        1,
     ];
 
     let mut errors = 0;
@@ -79,9 +113,9 @@ fn main() {
     }
 
     if errors == 0 {
-        println!("SUCCESS: pointer distances are correct");
+        println!("SUCCESS: pointer distances and wrapping offsets are correct");
     } else {
-        println!("FAILURE: {errors} pointer distance mismatches");
+        println!("FAILURE: {errors} pointer offset mismatches");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Closes #611.

# fix(mir): preserve wrapping pointer-offset semantics

## Summary

Safe raw-pointer wrapping methods previously failed device compilation because
rustc's `arith_offset` intrinsic was unsupported. This change carries the
source pointer-arithmetic contract through MIR and LLVM lowering: ordinary
offsets remain `getelementptr inbounds`, while wrapping offsets become plain
`getelementptr`, preserving Rust's permitted address wrapping without adding
LLVM poison semantics.

```text
Before: wrapping_offset -> unsupported arith_offset
After:  wrapping_offset -> mir.ptr_offset(non-inbounds) -> getelementptr
```

## What changed

### Pointer-arithmetic contract

- Adds an `inbounds` semantic marker to `MirPtrOffsetOp`. Absence defaults to
  `true`, preserving every existing producer's behavior.
- Imports both rustc spellings of `arith_offset` through one focused importer
  path and stamps those operations as non-inbounds.
- Propagates the marker to the LLVM GEP operation and makes textual export emit
  `inbounds` conditionally.
- Continues to obtain element scaling from the MIR pointer's authoritative
  pointee type rather than reconstructing it from the call name or result.

### Coverage and related paths

- Dialect, lowering, and exporter tests assert both sides of the contract:
  default ordinary offsets are in-bounds and explicit wrapping offsets are not.
- Extends the existing `ptr_offset_from` example so one GPU run checks positive
  and negative wrapping offsets, aggregate scaling, const and mutable pointers,
  zero-sized pointees, and `isize::MAX` address wrapping.
- The extreme and out-of-allocation cases are compared as addresses only. They
  are never dereferenced.
- Merged PR #206 added pointer-distance intrinsics; those paths remain
  unchanged. Open PR #398's `DeferredGep` and small-array scalarization changes
  are deliberately absent from this branch.

## Known separate limitations

- A wrapped pointer may be dereferenced only when the resulting pointer is
  valid for that access under Rust's normal rules.
- This does not change exposed-provenance reconstruction or pointer/integer
  cast semantics.
- The compatibility default on operations without the marker is in-bounds.
  New wrapping producers must set the marker explicitly.
- This change adds no array scalarization, speculative memory access, or
  optimization-pipeline policy.

## Testing

- Upstream red at `bead880c` with only the regression present:
  `scripts/smoketest.sh --only '^ptr_offset_from$' --no-color` failed
  (`exit=101`) because `std::intrinsics::arith_offset` was unsupported.
- Prepared branch:
  `scripts/smoketest.sh --only '^ptr_offset_from$' --no-color` passed on an
  RTX 3080 (`sm_86`), 1/1 example.
- Focused regressions passed:
  `test_mir_ptr_offset_verify`,
  `gep_inbounds_marker_controls_exported_pointer_semantics`, and
  `convert_wrapping_ptr_offset_lowers_to_non_inbounds_gep`.
- `cargo test -p dialect-mir -p llvm-export -p mir-importer -p mir-lower
  --all-targets` passed, including 891 importer tests, 146 mir-lower unit
  tests, and 76 mir-lower integration tests.
- `cargo clippy -p dialect-mir -p llvm-export -p mir-importer -p mir-lower
  --all-targets -- -D warnings` passed.
- The standalone example passes `cargo fmt --check` and
  `cargo clippy --all-targets -- -D warnings`; repository formatting and
  `git diff --check` pass.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
