### PR TITLE
fix(mir-importer): materialize bare enum-array constants

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5119,13 +5119,10 @@ fn translate_array_value_constant(
         array_ty.element_type()
     };
 
-    // Keep bare array value constants on the same element contract as the
-    // byte lowering this path replaced: primitive scalars, tuples with
-    // supported fields, or nested arrays of those. Bare arrays whose
-    // elements are structs or enums are still not materialized as constants
-    // (arrays of structs nested inside struct constants remain supported,
-    // as before); admitting them here would silently widen that documented
-    // boundary.
+    // Bare array values support primitive scalars, enums, tuples with supported
+    // fields, or nested arrays of those. Struct elements remain outside this
+    // entry point; arrays nested inside struct constants have their own
+    // layout-aware aggregate path.
     validate_array_value_element_type(ctx, element_ty, &loc)?;
 
     let rust_array_ty = constant.const_.ty();
@@ -9239,14 +9236,11 @@ fn translate_struct_constant_from_alloc(
 /// Element kinds admitted by a bare array value constant
 /// (`translate_array_value_constant`).
 ///
-/// The alloc-based path replaced a byte-only lowering that supported
-/// primitive scalar, tuple, and nested-array elements at this entry, and the
-/// supported-features appendix documents that arrays of structs are not
-/// materialized as constants. Nested arrays are walked recursively, exactly
-/// like the old byte lowering did, so an unsupported leaf cannot hide behind
-/// nesting. Arrays that sit inside a struct or tuple constant are dispatched
-/// through [`translate_constant_value_from_alloc`] instead and keep their
-/// wider, pre-existing element support.
+/// Primitive scalars, enums, tuples, and nested arrays are supported at this
+/// entry point. Arrays of structs are not materialized here. Nested arrays are
+/// walked recursively so an unsupported leaf cannot hide behind nesting.
+/// Arrays inside struct or tuple constants are dispatched through
+/// [`translate_constant_value_from_alloc`] and are not governed by this gate.
 fn validate_array_value_element_type(
     ctx: &Context,
     element_ty: TypeHandle,
@@ -9259,6 +9253,7 @@ fn validate_array_value_element_type(
             || elem_obj.is::<FP32Type>()
             || elem_obj.is::<FP64Type>()
             || elem_obj.is::<dialect_mir::types::MirTupleType>()
+            || elem_obj.is::<dialect_mir::types::MirEnumType>()
         {
             return Ok(());
         }
@@ -9267,8 +9262,8 @@ fn validate_array_value_element_type(
                 loc.clone(),
                 TranslationErr::unsupported(format!(
                     "Array constant element type is not supported: {:?}. Supported array \
-                     constants are primitive scalars, tuples with supported fields, or \
-                     nested arrays of those.",
+                     constants are primitive scalars, enums, tuples with supported fields, \
+                     or nested arrays of those.",
                     elem_obj
                 ))
             );
@@ -10025,7 +10020,9 @@ mod aggregate_relocation_tests {
         provenance_starts_in_range, relocation_offsets_overlapping_range,
         validate_array_value_element_type,
     };
-    use dialect_mir::types::{MirArrayType, MirPtrType, MirStructType, MirTupleType};
+    use dialect_mir::types::{
+        EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
+    };
     use pliron::builtin::types::{IntegerType, Signedness};
     use pliron::context::Context;
     use pliron::location::Location;
@@ -10170,7 +10167,7 @@ mod aggregate_relocation_tests {
     }
 
     #[test]
-    fn bare_array_elements_stay_on_the_documented_contract() {
+    fn bare_array_elements_follow_the_documented_contract() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
 
@@ -10185,11 +10182,35 @@ mod aggregate_relocation_tests {
             validate_array_value_element_type(&ctx, tuple_ty, &Location::Unknown).is_ok(),
             "tuple elements remain supported"
         );
-
         let nested_array_ty: TypeHandle = MirArrayType::get(&mut ctx, u32_ty, 4).into();
         assert!(
             validate_array_value_element_type(&ctx, nested_array_ty, &Location::Unknown).is_ok(),
             "nested array elements remain supported"
+        );
+
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let enum_ty: TypeHandle = MirEnumType::get_with_layout(
+            &mut ctx,
+            "Side".into(),
+            u8_ty,
+            vec![2, 5],
+            vec![
+                EnumVariant::unit("Low".into()),
+                EnumVariant::unit("High".into()),
+            ],
+            0,
+            1,
+            1,
+        )
+        .into();
+        assert!(
+            validate_array_value_element_type(&ctx, enum_ty, &Location::Unknown).is_ok(),
+            "bare enum-array elements are supported"
+        );
+        let nested_enum_array: TypeHandle = MirArrayType::get(&mut ctx, enum_ty, 2).into();
+        assert!(
+            validate_array_value_element_type(&ctx, nested_enum_array, &Location::Unknown).is_ok(),
+            "nesting preserves supported enum leaves"
         );
 
         let struct_ty: TypeHandle = MirStructType::get(

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5306,8 +5306,10 @@ fn build_array_op_from_bytes(
                 loc,
                 TranslationErr::unsupported(format!(
                     "Array constant element type is not supported by byte lowering: {:?}. \
-                     Supported array constants are primitive scalars, tuples with supported \
-                     fields, or nested arrays of those.",
+                     Byte lowering handles primitive scalars, tuples with supported fields, \
+                     or nested arrays of those. Enum elements decode from a constant \
+                     allocation instead, so an enum array that reaches byte lowering (e.g. \
+                     one with a zero-sized element) cannot be materialized here.",
                     elem_obj
                 ))
             );

--- a/crates/rustc-codegen-cuda/examples/array_constants/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/array_constants/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 
 # Regression coverage for MIR import of array constants:
 # - bare `[T; N]` constants indexed by runtime value,
+# - bare arrays of direct-tag enums,
 # - nested `[[T; M]; N]` constants,
 # - existing pointer-to-array constants (`&[T; N]`).
 #

--- a/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
@@ -7,6 +7,7 @@
 //!
 //! Covered shapes:
 //! - bare `[T; N]` constants indexed by a runtime value,
+//! - bare arrays of direct-tag enum constants,
 //! - nested `[[T; M]; N]` constants,
 //! - arrays of padded tuple constants containing no-payload enums,
 //! - nested tuples with zero-sized fields,
@@ -37,6 +38,15 @@ const TUPLE_TABLE: [(bool, Side); 6] = [
     (false, Side::LowZ),
     (true, Side::HighZ),
 ];
+const BARE_ENUM_TABLE: [Side; 6] = [
+    Side::LowX,
+    Side::HighZ,
+    Side::HighY,
+    Side::HighX,
+    Side::LowZ,
+    Side::LowY,
+];
+const EXPECTED_BARE_ENUM: [u32; 6] = [1, 6, 4, 2, 5, 3];
 const NESTED_TUPLE_TABLE: [((u8, ()), u32); 2] = [((3, ()), 17), ((5, ()), 29)];
 const ALL_ZST_TUPLE_TABLE: [(((), ()), u32); 2] = [(((), ()), 59), (((), ()), 61)];
 
@@ -100,6 +110,11 @@ mod kernels {
     }
 
     #[inline(never)]
+    fn bare_enum_array_value(i: usize) -> u32 {
+        BARE_ENUM_TABLE[i % BARE_ENUM_TABLE.len()] as u32
+    }
+
+    #[inline(never)]
     fn nested_tuple_array_value(i: usize) -> u32 {
         let ((tag, ()), value) = NESTED_TUPLE_TABLE[i & 1];
         tag as u32 + value
@@ -143,7 +158,11 @@ mod kernels {
     }
 
     #[kernel]
-    pub fn check_array_constants(mut out_f32: DisjointSlice<f32>, mut out_u32: DisjointSlice<u32>) {
+    pub fn check_array_constants(
+        mut out_f32: DisjointSlice<f32>,
+        mut out_u32: DisjointSlice<u32>,
+        mut out_enum: DisjointSlice<u32>,
+    ) {
         let tid = thread::index_1d();
         let i = tid.get();
 
@@ -181,6 +200,11 @@ mod kernels {
                 .wrapping_add(reordered)
                 .wrapping_mul(257)
                 .wrapping_add(overaligned_zst);
+        }
+
+        let tid_enum = thread::index_1d();
+        if let Some(slot) = out_enum.get_mut(tid_enum) {
+            *slot = bare_enum_array_value(i);
         }
     }
 }
@@ -249,6 +273,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     const N: usize = 24;
     let mut out_f32 = DeviceBuffer::<f32>::zeroed(&stream, N)?;
     let mut out_u32 = DeviceBuffer::<u32>::zeroed(&stream, N)?;
+    let mut out_enum = DeviceBuffer::<u32>::zeroed(&stream, N)?;
 
     // SAFETY: this is a 1D launch and the kernel bounds-checks each output
     // access against the corresponding slice length.
@@ -258,11 +283,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             LaunchConfig::for_num_elems(N as u32),
             &mut out_f32,
             &mut out_u32,
+            &mut out_enum,
         )
     }?;
 
     let got_f32 = out_f32.to_host_vec(&stream)?;
     let got_u32 = out_u32.to_host_vec(&stream)?;
+    let got_enum = out_enum.to_host_vec(&stream)?;
 
     let mut failures = 0usize;
     for i in 0..N {
@@ -283,11 +310,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             failures += 1;
         }
+
+        let want_enum = EXPECTED_BARE_ENUM[i % EXPECTED_BARE_ENUM.len()];
+        if got_enum[i] != want_enum {
+            println!(
+                "FAIL bare enum array tid={i}: got={} expected={want_enum}",
+                got_enum[i]
+            );
+            failures += 1;
+        }
     }
 
     if failures == 0 {
         println!(
-            "array_constants: PASS ({N} threads; primitive, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, pointer-to-array, and tuple-array static-pointer constants)"
+            "array_constants: PASS ({N} threads; primitive, enum, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, pointer-to-array, and tuple-array static-pointer constants)"
         );
         Ok(())
     } else {

--- a/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
@@ -102,6 +102,27 @@ require_shape \
     "padded tuple-array enum value in LLVM slot 2" \
     'insertvalue \{ i1, \[3 x i8\], \{ i32 \} \} .* \{ i32 \} .* 2'
 
+bare_enum_symbol='array_constants__kernels__bare_enum_array_value'
+
+# A bare enum array must be constructed as six direct-tag values and indexed
+# dynamically. This distinguishes it from the already-covered enum nested in a
+# tuple array and prevents optimization-only success from hiding importer
+# coverage.
+for discriminant in 1 2 3 4 5 6; do
+    require_symbol_shape "${llvm_ir}" llvm "${bare_enum_symbol}" \
+        "bare enum-array discriminant ${discriminant}" \
+        "insertvalue \\{ i32 \\} undef, i32 ${discriminant}, 0"
+done
+require_symbol_shape "${llvm_ir}" llvm "${bare_enum_symbol}" \
+    "complete six-element enum array" \
+    'insertvalue \[6 x \{ i32 \}\] .* \{ i32 \} .* 5'
+require_symbol_shape "${llvm_ir}" llvm "${bare_enum_symbol}" \
+    "runtime enum-array index" \
+    'urem i64 .*, 6'
+require_symbol_shape "${llvm_ir}" llvm "${bare_enum_symbol}" \
+    "runtime enum-array element load" \
+    'load \{ i32 \},'
+
 pointer_tuple_symbol='array_constants__kernels__pointer_tuple_array_value'
 
 # Device globals use backend-generated internal symbols, so source-level static


### PR DESCRIPTION
Closes #615.

## Summary

Bare array constants rejected enum elements before reaching cuda-oxide's
existing layout-aware enum constant decoder. This change admits enum elements
at the bare-array boundary and routes each element through that existing
decoder, allowing runtime-indexed fieldless enum tables while retaining the
existing fail-closed rules for unsupported aggregate and provenance-bearing
constants.

Before:

```text
Unsupported construct: Array constant element type is not supported: MirEnumType { name: "Side", ... }
```

After: a runtime-indexed `const SIDES: [Side; 6]` executes with the expected
results for all 24 threads.

## What changed

### Reuse the authoritative enum constant decoder

- Admit `MirEnumType` in `validate_array_value_element_type`, including when
  it is reached recursively through a nested array. This is the only logic
  change: each admitted element flows through the existing alloc-based
  per-element decoder chain, so discriminants, carrier widths, layout kinds,
  field offsets, and inhabited variants stay owned by the existing enum
  decoder rather than being re-derived in array lowering.
- State the present array contract in comments and diagnostics: primitive
  scalars, enums, supported tuples, and nested arrays are accepted here;
  structs are handled only by their separate layout-aware aggregate path.
- (Maintainer follow-up, `444df9fd`.) Align the byte-lowering rejection
  message with the widened gate: enum elements decode from a constant
  allocation, so an enum array that reaches byte lowering (for example one
  with a zero-sized element) still fails closed, now with a message that says
  why instead of claiming enums are unsupported outright.

### Focused coverage and related paths

- Extend the repo-native `array_constants` example with a bare
  `#[repr(u32)] [Side; 6]` constant. It uses six explicit discriminants in a
  shuffled order and selects an element by runtime thread index.
- Assert the exact result independently from the example's existing
  enum-inside-tuple coverage. Code-shape checks require all six constructed
  direct tags, the completed array aggregate, runtime modulo, and dynamic
  element load.
- Extend the bare-array contract unit test with direct and nested enum
  leaves, keeping the retained struct and pointer rejections asserted.
- PR #595 (merged as `600d61a5`) addresses pointer provenance inside enum
  constants. This patch is independent for relocation-free enum arrays and
  does not duplicate its allocation-aware decoding; arrays containing its
  supported pointer-bearing enums can continue through the same shared enum
  decoder as follow-up work.

## Known separate limitations

- Enum elements whose allocation range contains pointer relocations remain
  fail-closed on this branch.
- Bare arrays of structs, initialized unions, and direct pointer elements
  remain outside the admission contract.
- Pointer-to-array constants intentionally retain their narrower primitive
  element boundary; this change applies only to bare array values.
- Multi-artifact loading and unrelated constant/provenance changes are
  deliberately outside this patch.

## Testing

- Upstream red, based on `upstream/main` at
  `bead880cd7461c67a14bc69d10fa7def538f3394`:
  `scripts/smoketest.sh --only '^array_constants$' --no-color --keep-logs`
  failed 0/1 with cargo exit 101 because the admission gate rejected the
  direct `Side` enum element.
- Patched green: the same command passed 1/1 on an NVIDIA GeForce RTX 3080
  (sm_86), validating exact direct-tag enum-array results for all 24 threads
  and the LLVM code-shape assertions. Independently re-verified by a
  maintainer on an RTX 5090 (sm_120).
- `cargo test -p mir-importer translator::rvalue::aggregate_relocation_tests::bare_array_elements_follow_the_documented_contract -- --exact --nocapture`
  passed.
- `cargo test -p mir-importer --lib` passed all 892 tests.
- `cargo clippy -p mir-importer --all-targets -- -D warnings` passed.
- `cargo clippy --manifest-path crates/rustc-codegen-cuda/examples/array_constants/Cargo.toml --all-targets -- -D warnings`
  passed.
- Root and standalone-example formatting checks,
  `crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh`,
  and `git diff --check` passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
