### PR TITLE
fix(codegen): rescan module requirements after optimization

### DIFF
--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -8,11 +8,12 @@ use crate::generated::GeneratedModuleRequirements;
 use crate::llvm_tools::LlvmToolchain;
 use crate::options::BackendOptions;
 use crate::target::{
-    detect_module_requirements_in_llvm_file, merge_generated_module_requirements,
-    merge_generated_module_requirements_for_target, required_ptx_feature,
-    resolve_ptx_target_with_generated, validate_ptx_isa_for_llvm_major,
-    validate_target_for_llvm_major,
+    ModuleRequirements, detect_module_requirements_in_llvm_file,
+    merge_generated_module_requirements, merge_generated_module_requirements_for_target,
+    required_ptx_feature, resolve_ptx_target_with_generated, validate_ptx_isa_for_llvm_major,
+    validate_target_features, validate_target_for_llvm_major,
 };
+use libnvvm_sys::CudaArch;
 use llvm_export::export::DebugKind;
 use std::path::{Path, PathBuf};
 
@@ -406,8 +407,6 @@ fn generate_ptx_impl(
 
     validate_target_for_llvm_major(&target, toolchain.llc_major)
         .map_err(PipelineError::PtxGeneration)?;
-    validate_ptx_isa_for_llvm_major(requirements.ptx_isa, toolchain.llc_major)
-        .map_err(PipelineError::PtxGeneration)?;
 
     // Link libdevice at the IR level when the kernel uses `__nv_*` calls.
     // This resolves (and later inlines) CUDA math functions without forcing
@@ -425,9 +424,11 @@ fn generate_ptx_impl(
     };
     let post_link_input: &Path = linked.as_deref().unwrap_or(module.llvm_ir);
 
-    // Run the LLVM middle-end (opt -O2) before llc. Feature detection above
-    // intentionally reads the original (pre-opt) IR so the target is determined
-    // by what the source actually needs, not what opt elides.
+    // Run the LLVM middle-end (opt -O2) before llc. Source requirements are
+    // detected above so target selection cannot lose a source-level contract
+    // merely because optimization elides it. Requirements are detected again
+    // from the exact llc input below because linking and optimization can also
+    // introduce backend intrinsics (notably llvm.stacksave/stackrestore).
     //
     // Full-debug is a `-G`-style build: it keeps every local in memory and
     // describes it with `llvm.dbg.declare`. Running `opt -O2` would promote
@@ -458,6 +459,28 @@ fn generate_ptx_impl(
         optimized
     };
     let llc_input: &Path = optimized.as_deref().unwrap_or(post_link_input);
+    let llc_requirements = detect_module_requirements_in_llvm_file(llc_input)?;
+    let requirements = merge_module_requirements(requirements, llc_requirements);
+    let requirements =
+        merge_generated_module_requirements_for_target(requirements, generated, &target)
+            .map_err(PipelineError::PtxGeneration)?;
+    let parsed_target =
+        target
+            .parse::<CudaArch>()
+            .map_err(|error| PipelineError::TargetSelection {
+                target: target.clone(),
+                reason: format!(
+                    "{error} (while validating requirements from the final LLVM input)"
+                ),
+            })?;
+    validate_target_features(&parsed_target, requirements.features).map_err(|reason| {
+        PipelineError::TargetSelection {
+            target: target.clone(),
+            reason: format!("{reason} (requirements from the final LLVM input)"),
+        }
+    })?;
+    validate_ptx_isa_for_llvm_major(requirements.ptx_isa, toolchain.llc_major)
+        .map_err(PipelineError::PtxGeneration)?;
 
     let llc_desc = if toolchain.llc_from_env {
         format!("llc_override ({})", toolchain.llc_path)
@@ -527,6 +550,16 @@ fn generate_ptx_impl(
             String::from_utf8_lossy(&output.stderr).trim()
         ))),
         Err(e) => Err(PipelineError::PtxGeneration(format!("{llc_desc}: {e}"))),
+    }
+}
+
+fn merge_module_requirements(
+    source: ModuleRequirements,
+    llc_input: ModuleRequirements,
+) -> ModuleRequirements {
+    ModuleRequirements {
+        features: source.features | llc_input.features,
+        ptx_isa: source.ptx_isa.max(llc_input.ptx_isa),
     }
 }
 
@@ -665,6 +698,31 @@ mod tests {
     #[test]
     fn modules_without_public_roots_keep_the_existing_optimization_pipeline() {
         assert_eq!(optimization_args(&[]).unwrap(), ["-O2"]);
+    }
+
+    #[test]
+    fn final_llc_input_requirements_are_unioned_with_source_requirements() {
+        use crate::target::{DetectedFeatures, PtxIsaRequirement};
+
+        let source = ModuleRequirements {
+            features: DetectedFeatures::Sm80,
+            ptx_isa: PtxIsaRequirement::Ptx70,
+        };
+        let llc_input = ModuleRequirements {
+            features: DetectedFeatures::DynamicStack,
+            ptx_isa: PtxIsaRequirement::Ptx73,
+        };
+
+        let merged = merge_module_requirements(source, llc_input);
+        assert_eq!(
+            merged.features,
+            DetectedFeatures::Sm80 | DetectedFeatures::DynamicStack
+        );
+        assert_eq!(merged.ptx_isa, PtxIsaRequirement::Ptx73);
+        assert_eq!(
+            required_ptx_feature("sm_80", merged.ptx_isa),
+            Some("+ptx73")
+        );
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/src/target.rs
+++ b/crates/cuda-oxide-codegen/src/target.rs
@@ -606,6 +606,91 @@ fn contains_cluster_ptx80_features(contents: &str) -> bool {
     })
 }
 
+/// Detect a direct LLVM intrinsic call, including its opaque-pointer overload.
+///
+/// Opaque-pointer LLVM IR spells the dynamic-stack intrinsics as
+/// `llvm.stacksave.p0` and `llvm.stackrestore.p0`, while typed-pointer IR can
+/// use the unsuffixed names. Keep the boundary strict so similarly named user
+/// functions do not raise the module's target requirements. Only call
+/// instructions count: declarations, comments, and quoted metadata or string
+/// contents do not reach the backend.
+fn contains_llvm_pointer_intrinsic_call(contents: &str, intrinsic: &str) -> bool {
+    contents.lines().any(|line| {
+        if !line.contains(intrinsic) {
+            return false;
+        }
+        let code = llvm_code_without_comments_or_strings(line);
+        code.match_indices(intrinsic).any(|(start, _)| {
+            if !contains_llvm_keyword(&code[..start], "call") {
+                return false;
+            }
+
+            let suffix = &code[start + intrinsic.len()..];
+            if suffix.starts_with('(') {
+                return true;
+            }
+            let Some(overload) = suffix.strip_prefix(".p") else {
+                return false;
+            };
+            let digits = overload.bytes().take_while(u8::is_ascii_digit).count();
+            digits != 0 && overload[digits..].starts_with('(')
+        })
+    })
+}
+
+fn llvm_code_without_comments_or_strings(line: &str) -> String {
+    let mut code = String::with_capacity(line.len());
+    let mut chars = line.chars();
+    let mut in_string = false;
+
+    while let Some(character) = chars.next() {
+        if in_string {
+            match character {
+                '\\' => {
+                    code.push(' ');
+                    if chars.next().is_some() {
+                        code.push(' ');
+                    }
+                }
+                '"' => {
+                    code.push(' ');
+                    in_string = false;
+                }
+                _ => code.push(' '),
+            }
+        } else {
+            match character {
+                ';' => break,
+                '"' => {
+                    code.push(' ');
+                    in_string = true;
+                }
+                _ => code.push(character),
+            }
+        }
+    }
+
+    code
+}
+
+fn contains_llvm_keyword(contents: &str, keyword: &str) -> bool {
+    contents.match_indices(keyword).any(|(start, _)| {
+        let before = contents[..start].bytes().next_back();
+        let after = contents[start + keyword.len()..].bytes().next();
+        before.is_none_or(|byte| !is_llvm_identifier_byte(byte))
+            && after.is_none_or(|byte| !is_llvm_identifier_byte(byte))
+    })
+}
+
+fn is_llvm_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'$' | b'.' | b'_')
+}
+
+fn contains_dynamic_stack_features(contents: &str) -> bool {
+    contains_llvm_pointer_intrinsic_call(contents, "@llvm.stacksave")
+        || contains_llvm_pointer_intrinsic_call(contents, "@llvm.stackrestore")
+}
+
 /// GPU feature requirements detected in one LLVM module.
 ///
 /// This is a set rather than a single "strongest" feature: architecture
@@ -654,8 +739,10 @@ impl DetectedFeatures {
     pub(crate) const ReduxF32: Self = Self(1 << 15);
     /// FP8 / f16-accumulator multimem forms on supported Blackwell families.
     pub(crate) const MultimemFp8: Self = Self(1 << 16);
+    /// Dynamic stack save/restore, supported by LLVM NVPTX on sm_52+.
+    pub(crate) const DynamicStack: Self = Self(1 << 18);
 
-    const ALL: [Self; 18] = [
+    const ALL: [Self; 19] = [
         Self::Blackwell,
         Self::TmaCtaGroup,
         Self::BlackwellAccelerated,
@@ -673,6 +760,7 @@ impl DetectedFeatures {
         Self::Movmatrix,
         Self::Ldmatrix,
         Self::Sm100,
+        Self::DynamicStack,
         Self::Basic,
     ];
 
@@ -713,6 +801,7 @@ impl DetectedFeatures {
             Self::BlackwellAccelerated => "BlackwellAccelerated",
             Self::ReduxF32 => "ReduxF32",
             Self::MultimemFp8 => "MultimemFp8",
+            Self::DynamicStack => "DynamicStack",
             Self::Basic => "Basic",
             _ => "Unknown",
         }
@@ -752,6 +841,7 @@ pub enum PtxIsaRequirement {
     Ptx65,
     Ptx70,
     Ptx71,
+    Ptx73,
     Ptx78,
     Ptx80,
     Ptx86,
@@ -857,7 +947,8 @@ fn ptx_isa_requirement_for_floor(
         63..=65 => Ok(PtxIsaRequirement::Ptx65),
         66..=70 => Ok(PtxIsaRequirement::Ptx70),
         71 => Ok(PtxIsaRequirement::Ptx71),
-        72..=78 => Ok(PtxIsaRequirement::Ptx78),
+        72..=73 => Ok(PtxIsaRequirement::Ptx73),
+        74..=78 => Ok(PtxIsaRequirement::Ptx78),
         79..=80 => Ok(PtxIsaRequirement::Ptx80),
         81..=86 => Ok(PtxIsaRequirement::Ptx86),
         87 => Ok(PtxIsaRequirement::Ptx87),
@@ -973,6 +1064,10 @@ pub fn detect_features_in_llvm_text(contents: &str) -> DetectedFeatures {
             contains_tma_sm100_features(contents) || contains_clc_features(contents),
             DetectedFeatures::Sm100,
         ),
+        (
+            contains_dynamic_stack_features(contents),
+            DetectedFeatures::DynamicStack,
+        ),
     ] {
         if present {
             features.insert(feature);
@@ -1012,6 +1107,9 @@ fn detect_module_requirements_in_llvm_text(contents: &str) -> ModuleRequirements
     }
     if contains_b1_and_mma_features(contents) {
         ptx_isa = ptx_isa.max(PtxIsaRequirement::Ptx71);
+    }
+    if contains_dynamic_stack_features(contents) {
+        ptx_isa = ptx_isa.max(PtxIsaRequirement::Ptx73);
     }
     if contains_movmatrix_features(contents)
         || contains_stmatrix_features(contents)
@@ -1495,6 +1593,7 @@ fn arch_satisfies_feature(
         DetectedFeatures::Sm75 | DetectedFeatures::Movmatrix | DetectedFeatures::Ldmatrix => {
             capability >= 75
         }
+        DetectedFeatures::DynamicStack => capability >= 52,
         // Basic kernels are supported on the project's Volta+ floor. The
         // cross-compilation default remains sm_80, but a detected sm_70/sm_75
         // GPU is a valid and more useful target for `cargo oxide run`.
@@ -1665,6 +1764,7 @@ pub fn required_ptx_feature(target: &str, requirement: PtxIsaRequirement) -> Opt
         PtxIsaRequirement::Ptx65 => 65,
         PtxIsaRequirement::Ptx70 => 70,
         PtxIsaRequirement::Ptx71 => 71,
+        PtxIsaRequirement::Ptx73 => 73,
         PtxIsaRequirement::Ptx78 => 78,
         PtxIsaRequirement::Ptx80 => 80,
         PtxIsaRequirement::Ptx86 => 86,
@@ -1681,6 +1781,7 @@ pub fn required_ptx_feature(target: &str, requirement: PtxIsaRequirement) -> Opt
         PtxIsaRequirement::Ptx65 => Some("+ptx65"),
         PtxIsaRequirement::Ptx70 => Some("+ptx70"),
         PtxIsaRequirement::Ptx71 => Some("+ptx71"),
+        PtxIsaRequirement::Ptx73 => Some("+ptx73"),
         PtxIsaRequirement::Ptx78 => Some("+ptx78"),
         PtxIsaRequirement::Ptx80 => Some("+ptx80"),
         PtxIsaRequirement::Ptx86 => Some("+ptx86"),
@@ -2056,6 +2157,126 @@ mod tests {
                 "{error}"
             );
         }
+    }
+
+    #[test]
+    fn dynamic_stack_calls_require_ptx73_and_sm52() {
+        for llvm in [
+            "%saved = call ptr @llvm.stacksave.p0()\n",
+            "%saved = tail call ptr addrspace(12) @llvm.stacksave.p12()\n",
+            "call void @llvm.stackrestore.p3(ptr addrspace(3) %saved)\n",
+            "%saved = call i8* @llvm.stacksave()\n",
+            "call void @llvm.stackrestore(i8* %saved)\n",
+        ] {
+            let requirements = detect_module_requirements_in_llvm_text(llvm);
+            assert!(
+                requirements
+                    .features
+                    .contains(DetectedFeatures::DynamicStack),
+                "{llvm}"
+            );
+            assert_eq!(requirements.ptx_isa, PtxIsaRequirement::Ptx73, "{llvm}");
+        }
+
+        for near_match in [
+            "%saved = call ptr @llvm.stacksavex.p0()\n",
+            "%saved = call ptr @llvm.stacksave_extra.p0()\n",
+            "%saved = call ptr @llvm.stacksave.p()\n",
+            "%saved = call ptr @llvm.stacksave.p0x()\n",
+            "%saved = call ptr @llvm.stacksave.p0.extra()\n",
+            "call void @llvm.stackrestorex.p0(ptr %saved)\n",
+            "call void @llvm.stackrestore.p0_extra(ptr %saved)\n",
+            "%saved = call ptr @llvm.stacksave.p0\n",
+        ] {
+            let requirements = detect_module_requirements_in_llvm_text(near_match);
+            assert_eq!(
+                requirements.features,
+                DetectedFeatures::Basic,
+                "{near_match}"
+            );
+            assert_eq!(
+                requirements.ptx_isa,
+                PtxIsaRequirement::Default,
+                "{near_match}"
+            );
+        }
+
+        assert!(!arch_satisfies_feature(
+            50,
+            None,
+            DetectedFeatures::DynamicStack
+        ));
+        assert!(arch_satisfies_feature(
+            52,
+            None,
+            DetectedFeatures::DynamicStack
+        ));
+        for target in ["sm_70", "sm_86"] {
+            let parsed = target.parse::<CudaArch>().unwrap();
+            assert!(
+                validate_target_features(&parsed, DetectedFeatures::DynamicStack).is_ok(),
+                "{target}"
+            );
+        }
+        let sm_50 = "sm_50".parse::<CudaArch>().unwrap();
+        let error = validate_target_features(&sm_50, DetectedFeatures::DynamicStack).unwrap_err();
+        assert!(error.contains("DynamicStack"), "{error}");
+    }
+
+    #[test]
+    fn dynamic_stack_mentions_without_calls_do_not_raise_requirements() {
+        let non_calls = [
+            "declare ptr @llvm.stacksave.p0()\n",
+            "declare void @llvm.stackrestore.p0(ptr)\n",
+            "; %saved = call ptr @llvm.stacksave.p0()\n",
+            "!0 = !{!\"call ptr @llvm.stacksave.p0()\"}\n",
+            "@message = private constant [39 x i8] c\"call ptr @llvm.stacksave.p0()\\00\"\n",
+            "!1 = !{ptr @llvm.stacksave.p0}\n",
+            "declare ptr @llvm.stacksave.p0 ; call ptr @llvm.stacksave.p0()\n",
+        ];
+
+        for llvm in non_calls {
+            let requirements = detect_module_requirements_in_llvm_text(llvm);
+            assert_eq!(requirements.features, DetectedFeatures::Basic, "{llvm}");
+            assert_eq!(requirements.ptx_isa, PtxIsaRequirement::Default, "{llvm}");
+        }
+
+        let call_after_quoted_semicolon = concat!(
+            "@message = private constant [2 x i8] c\";\\00\"\n",
+            "%saved = call ptr @llvm.stacksave.p0() ; ignored comment\n",
+        );
+        assert!(
+            detect_module_requirements_in_llvm_text(call_after_quoted_semicolon)
+                .features
+                .contains(DetectedFeatures::DynamicStack)
+        );
+    }
+
+    #[test]
+    fn ptx73_feature_is_requested_only_when_the_target_default_is_older() {
+        assert_eq!(
+            ptx_isa_requirement_for_floor(72, "test", "test").unwrap(),
+            PtxIsaRequirement::Ptx73
+        );
+        assert_eq!(
+            ptx_isa_requirement_for_floor(73, "test", "test").unwrap(),
+            PtxIsaRequirement::Ptx73
+        );
+        assert_eq!(
+            ptx_isa_requirement_for_floor(74, "test", "test").unwrap(),
+            PtxIsaRequirement::Ptx78
+        );
+        for target in ["sm_70", "sm_80", "sm_86"] {
+            assert_eq!(
+                required_ptx_feature(target, PtxIsaRequirement::Ptx73),
+                Some("+ptx73"),
+                "{target}"
+            );
+        }
+        assert_eq!(
+            required_ptx_feature("sm_87", PtxIsaRequirement::Ptx73),
+            None
+        );
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/compile_to_ptx.rs
@@ -98,6 +98,105 @@ cp "$input" "$out"
         }
     }
 
+    fn post_opt_dynamic_stack() -> Self {
+        let guard = FAKE_TOOLS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let root = unique_test_dir("post_opt_dynamic_stack");
+        let llc = write_tool(
+            &root,
+            "llc",
+            r#"#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "LLVM version 21.0.0"
+  exit 0
+fi
+out=""
+input=""
+target="sm_80"
+ptx73=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -mcpu=*) target="${1#-mcpu=}" ;;
+    -mattr=+ptx73) ptx73=1 ;;
+    -o) shift; out="$1" ;;
+    -*) ;;
+    *) input="$1" ;;
+  esac
+  shift
+done
+grep -F -q 'call ptr addrspace(3) @llvm.stacksave.p3()' "$input" || {
+  echo "fake opt output did not reach llc" >&2
+  exit 11
+}
+grep -F -q 'call void @llvm.stackrestore.p3(ptr addrspace(3) %post_opt_saved_stack)' "$input" || {
+  echo "fake opt output did not contain the reachable stack restore" >&2
+  exit 14
+}
+[ "$ptx73" -eq 1 ] || {
+  echo "final llc input did not request +ptx73" >&2
+  exit 12
+}
+printf '.version 7.3\n.target %s\n.address_size 64\n.visible .entry fake() { ret; }\n' "$target" > "$out"
+"#,
+        );
+        let opt = Some(write_tool(
+            &root,
+            "opt",
+            r#"#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "LLVM version 21.0.0"
+  exit 0
+fi
+input=""
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; out="$1" ;;
+    -*) ;;
+    *) input="$1" ;;
+  esac
+  shift
+done
+if grep -F -q '@llvm.stacksave' "$input"; then
+  echo "source unexpectedly required a dynamic stack" >&2
+  exit 13
+fi
+awk '
+  /^define .*@empty\(/ {
+    in_empty = 1
+  }
+  in_empty && /^[[:space:]]*ret void/ {
+    print "  %post_opt_saved_stack = call ptr addrspace(3) @llvm.stacksave.p3()"
+    print "  call void @llvm.stackrestore.p3(ptr addrspace(3) %post_opt_saved_stack)"
+    introduced = 1
+  }
+  {
+    print
+  }
+  in_empty && /^}/ {
+    in_empty = 0
+  }
+  END {
+    if (!introduced) {
+      exit 1
+    }
+  }
+' "$input" > "$out" || {
+  echo "fake opt could not add calls to the exported kernel" >&2
+  exit 15
+}
+printf '\ndeclare ptr addrspace(3) @llvm.stacksave.p3()\ndeclare void @llvm.stackrestore.p3(ptr addrspace(3))\n' >> "$out"
+"#,
+        ));
+        Self {
+            _guard: guard,
+            root,
+            llc,
+            opt,
+        }
+    }
+
     fn failing_llc() -> Self {
         let guard = FAKE_TOOLS_LOCK
             .lock()
@@ -596,6 +695,24 @@ fn requested_optimization_requires_opt() {
         CompileError::OptimizationUnavailable { .. }
     ));
     assert_eq!(error.stage(), CompilationStage::Optimization);
+}
+
+#[test]
+fn requirements_introduced_by_opt_reach_llc() {
+    let tools = FakeTools::post_opt_dynamic_stack();
+    let compiler = tools.compiler();
+    let mut module = CodegenModule::new("post_opt_dynamic_stack").unwrap();
+    add_empty_function(&mut module, true);
+
+    let compilation = compiler
+        .compile(
+            &mut module,
+            &CompileOptions::new(Target::parse("sm_80").unwrap()),
+        )
+        .unwrap();
+
+    assert_eq!(compilation.target(), &Target::parse("sm_80").unwrap());
+    assert!(compilation.ptx().starts_with(b".version 7.3\n"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #617.

# fix(codegen): rescan module requirements after optimization

## Summary

The PTX pipeline now derives final backend requirements from both the exported
source module and the exact post-link/post-optimization LLVM module passed to
`llc`. This allows LLVM-introduced dynamic-stack intrinsics to request PTX 7.3
while preserving any stronger source-level feature or ISA requirement, without
raising requirements for declarations or textual mentions that cannot execute.

## What changed

### Validate the exact `llc` input

- Kept the initial source scan as the basis for target selection, so
  optimization cannot erase a source-level compilation contract.
- Rescanned the final LLVM path after optional libdevice linking and `opt`.
- Unioned detected feature bits and retained the maximum PTX ISA requirement.
- Reapplied target-specific generated requirements, then validated the chosen
  target and LLVM/PTX compatibility immediately before constructing the `llc`
  command.
- A newly introduced feature that the already selected target cannot lower now
  fails with a final-input-specific target diagnostic instead of reaching
  `llc` with inconsistent options.

### Model dynamic-stack requirements precisely

- Added exact direct-call detection for unsuffixed
  `llvm.stacksave`/`llvm.stackrestore` and opaque-pointer overloads ending in
  `.pN`.
- Ignored unused declarations, LLVM comments, quoted metadata/string contents,
  and near matches such as longer function names, missing address-space
  digits, extra suffixes, and names without an invocation.
- Modeled dynamic stack operations as PTX 7.3 with an sm_52 hardware floor.
- Added the discrete `+ptx73` spelling and used it for generated PTX floors
  7.2–7.3, without forcing it on targets whose default ISA is already newer.
- Added a fake-tool end-to-end test: fake `opt` inserts reachable `.p3`
  stack-save and stack-restore calls into the exported kernel, and fake `llc`
  rejects the invocation unless it receives both calls and `-mattr=+ptx73`.

## Known separate limitations

- Closed PR #290 globally selected a PTX ISA from the SM target in the older
  MIR-importer path. This change does not revive that approach: it requests the
  minimum ISA derived from requirements in the shared codegen pipeline.
- This patch does not change multi-artifact architecture, partitioning, or
  module ownership.
- Target resolution still happens from source requirements. If a
  transformation introduces a hardware feature incompatible with that chosen
  target, compilation fails clearly rather than silently selecting a different
  deployment target.
- Dynamic-stack recognition is a focused LLVM-text detector, not a call-graph
  analysis. It ignores declarations and non-code text, but conservatively
  retains a real call in an otherwise unreferenced function until LLVM removes
  that function from the scanned module.

## Testing

- Upstream-red evidence at `bead880c`: in a detached worktree with only the
  detector/model and strengthened regression applied, while retaining the
  upstream pipeline order,
  `cargo test -p cuda-oxide-codegen --test compile_to_ptx requirements_introduced_by_opt_reach_llc -- --exact`
  failed because fake `llc` reported
  `final llc input did not request +ptx73`.
- Patch-green evidence: the same command passed after the exact final LLVM
  input was rescanned and unioned with source requirements.
- Real-LLVM evidence with Ubuntu LLVM 21.1.8: a minimized `alwaysinline` helper
  containing a dynamic alloca was inlined by `opt-21 -O2` into a reachable
  `ptx_kernel`, producing direct `.p0` stacksave/stackrestore calls. Piping that
  output to `llc-21 -march=nvptx64 -mcpu=sm_80` exited 1 with the expected PTX
  7.3/sm_52 diagnostics; adding `-mattr=+ptx73` exited 0.
- `cargo test -p cuda-oxide-codegen --all-targets` — 127 unit tests, 16
  standalone compiler tests, 1 concurrency test, 1 real LLVM/ptxas spine test,
  and 4 target-provenance tests passed.
- `cargo clippy -p cuda-oxide-codegen --all-targets -- -D warnings` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
