### PR TITLE
feat(cuda-device): expose raw shared-array pointer

### DIFF
--- a/crates/cuda-device/src/shared.rs
+++ b/crates/cuda-device/src/shared.rs
@@ -192,6 +192,34 @@ impl<T, const N: usize, const ALIGN: usize> SharedArray<T, N, ALIGN> {
     pub fn as_mut_ptr(&mut self) -> *mut T {
         unreachable!("SharedArray::as_mut_ptr called outside CUDA kernel context")
     }
+
+    /// Returns a mutable raw pointer to the shared memory array without
+    /// creating a Rust reference to the complete allocation.
+    ///
+    /// This is the appropriate entry point when multiple CUDA threads derive
+    /// disjoint raw pointers from one `static mut SharedArray`. Unlike
+    /// [`Self::as_mut_ptr`], the raw receiver does not require each thread to
+    /// create an overlapping `&mut SharedArray`.
+    ///
+    /// # Safety
+    ///
+    /// `shared` must point to a `static mut SharedArray` in the current CUDA
+    /// kernel, normally obtained with `&raw mut`. The returned pointer is valid
+    /// only within that kernel. Callers must keep concurrent accesses disjoint
+    /// and use the CUDA synchronization required before reading data written by
+    /// another thread.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// static mut SCRATCH: SharedArray<f32, 256> = SharedArray::UNINIT;
+    /// let scratch = unsafe { SharedArray::as_raw_mut_ptr(&raw mut SCRATCH) };
+    /// ```
+    #[inline(never)]
+    pub unsafe fn as_raw_mut_ptr(shared: *mut Self) -> *mut T {
+        let _ = shared;
+        unreachable!("SharedArray::as_raw_mut_ptr called outside CUDA kernel context")
+    }
 }
 
 impl<T, const N: usize, const ALIGN: usize> Index<usize> for SharedArray<T, N, ALIGN> {

--- a/crates/mir-importer/src/translator/mod.rs
+++ b/crates/mir-importer/src/translator/mod.rs
@@ -64,6 +64,38 @@ use pliron::operation::Operation;
 use rustc_public::mir;
 use rustc_public::mir::mono;
 
+/// Public `SharedArray` methods whose compiler expansion returns a generic
+/// pointer to the underlying shared allocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SharedArrayPointerMethod {
+    /// `SharedArray::as_ptr(&self)`.
+    BorrowedConst,
+    /// `SharedArray::as_mut_ptr(&mut self)`.
+    BorrowedMut,
+    /// `SharedArray::as_raw_mut_ptr(*mut Self)`.
+    RawMut,
+}
+
+/// Recognize exactly the three public `SharedArray` pointer conversions.
+///
+/// Intrinsic dispatch and destination address-space classification both use
+/// this helper so adding a method cannot update one compiler path without the
+/// other.
+pub(crate) fn shared_array_pointer_method(path: &str) -> Option<SharedArrayPointerMethod> {
+    if !path.starts_with("cuda_device::")
+        || !path.split("::").any(|component| component == "SharedArray")
+    {
+        return None;
+    }
+
+    match path.rsplit("::").next() {
+        Some("as_ptr") => Some(SharedArrayPointerMethod::BorrowedConst),
+        Some("as_mut_ptr") => Some(SharedArrayPointerMethod::BorrowedMut),
+        Some("as_raw_mut_ptr") => Some(SharedArrayPointerMethod::RawMut),
+        _ => None,
+    }
+}
+
 /// Registers all dialects needed for translation.
 ///
 /// Registers `dialect-mir` (our MIR modelling dialect), `dialect-nvvm`
@@ -157,4 +189,42 @@ pub fn translate_function(
     func_op.insert_at_front(module_block, ctx);
 
     Ok(module_op)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SharedArrayPointerMethod, shared_array_pointer_method};
+
+    #[test]
+    fn shared_array_pointer_recognition_is_exact_and_centralized() {
+        for (path, expected) in [
+            (
+                "cuda_device::shared::SharedArray::as_ptr",
+                SharedArrayPointerMethod::BorrowedConst,
+            ),
+            (
+                "cuda_device::shared::SharedArray::as_mut_ptr",
+                SharedArrayPointerMethod::BorrowedMut,
+            ),
+            (
+                "cuda_device::shared::SharedArray::as_raw_mut_ptr",
+                SharedArrayPointerMethod::RawMut,
+            ),
+        ] {
+            assert_eq!(shared_array_pointer_method(path), Some(expected), "{path}");
+        }
+
+        for near_match in [
+            "cuda_device::shared::DynamicSharedArray::as_ptr",
+            "cuda_device::shared::SharedArrayHelper::as_ptr",
+            "cuda_device::shared::SharedArray::as_raw_mut_ptr_extra",
+            "other_crate::SharedArray::as_raw_mut_ptr",
+        ] {
+            assert_eq!(
+                shared_array_pointer_method(near_match),
+                None,
+                "{near_match}"
+            );
+        }
+    }
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -626,14 +626,15 @@ pub fn emit_shared_array_index(
     )
 }
 
-/// Emits `SharedArray::as_ptr` or `as_mut_ptr` - returns pointer to shared memory.
+/// Emits a public `SharedArray` pointer conversion.
 ///
 /// This converts the shared memory address (addrspace 3) to a generic pointer (addrspace 0)
 /// following LLVM's opaque pointer model where generic pointers can hold any address space.
 ///
 /// # Arguments
 ///
-/// - `args[0]`: `&SharedArray<T, N>` - Reference to the shared memory array
+/// - `args[0]`: `&SharedArray<T, N>`, `&mut SharedArray<T, N>`, or
+///   `*mut SharedArray<T, N>` - pointer to the shared memory array
 ///
 /// # Returns
 ///
@@ -657,7 +658,7 @@ pub fn emit_shared_array_as_ptr(
         return input_err!(
             loc.clone(),
             TranslationErr::unsupported(
-                "SharedArray::as_ptr expects 1 argument (self), got 0".to_string(),
+                "SharedArray pointer conversion expects 1 argument, got 0".to_string(),
             )
         );
     }
@@ -684,7 +685,7 @@ pub fn emit_shared_array_as_ptr(
             return input_err!(
                 loc.clone(),
                 TranslationErr::unsupported(format!(
-                    "SharedArray::as_ptr: expected MirPtrType, got {:?}",
+                    "SharedArray pointer conversion: expected MirPtrType, got {:?}",
                     shared_ptr_obj
                 ))
             );
@@ -725,7 +726,7 @@ pub fn emit_shared_array_as_ptr(
         value_map,
         block_map,
         loc,
-        "SharedArray::as_ptr call without target block",
+        "SharedArray pointer conversion call without target block",
     )
 }
 

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3021,22 +3021,10 @@ fn try_dispatch_intrinsic(
             }
         }
 
-        // SharedArray::as_ptr and as_mut_ptr - convert shared memory pointer to generic
-        path if path.contains("SharedArray") && path.contains("as_ptr") => {
-            Ok(Some(intrinsics::memory::emit_shared_array_as_ptr(
-                ctx,
-                body,
-                args,
-                destination,
-                target,
-                block_ptr,
-                prev_op,
-                value_map,
-                block_map,
-                loc,
-            )?))
-        }
-        path if path.contains("SharedArray") && path.contains("as_mut_ptr") => {
+        // Public SharedArray pointer conversions all narrow the shared-memory
+        // base to a generic pointer. Recognition is shared with destination
+        // address-space classification in translator::values.
+        path if super::shared_array_pointer_method(path).is_some() => {
             Ok(Some(intrinsics::memory::emit_shared_array_as_ptr(
                 ctx,
                 body,

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -610,10 +610,10 @@ fn classify_call(func: &mir::Operand) -> WriteClass {
 
     // --- explicit narrow to generic -----------------------------------------
     //
-    // `SharedArray::as_ptr` / `as_mut_ptr` deliberately `cvta.shared` the
+    // Public SharedArray pointer conversions deliberately `cvta.shared` the
     // base pointer into the generic address space, so the callee sees
-    // `addrspace(0)`.
-    if path.contains("SharedArray") && (path.contains("as_ptr") || path.contains("as_mut_ptr")) {
+    // `addrspace(0)`. Keep recognition shared with intrinsic dispatch.
+    if super::shared_array_pointer_method(&path).is_some() {
         return WriteClass::Classified(address_space::GENERIC);
     }
 

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -13,6 +13,10 @@
 //! addressof's block, the GEP referenced a `%vN` no instruction defined and
 //! libNVVM rejected the IR.
 //!
+//! The same kernel also validates `SharedArray::as_raw_mut_ptr`: 32 threads
+//! derive pointers from one raw shared-array address, write disjoint elements,
+//! synchronize, and let thread 0 verify the complete allocation.
+//!
 //! This example launches the kernel through `cuda_host::ltoir::load_kernel_module`,
 //! which compiles the cuda-oxide-emitted NVVM IR via libNVVM and links the
 //! cubin via nvJitLink. A dangling SSA reference in the `.ll` would fail at
@@ -32,9 +36,12 @@ use cuda_host::{cuda_module, ltoir};
 mod kernels {
     use super::*;
 
+    const THREADS: usize = 32;
+
     #[kernel]
     pub fn sharedarray_late_use(seed: f32, mut out: DisjointSlice<f32>) {
         static mut OUTPUT_NORM: SharedArray<f32, 1> = SharedArray::UNINIT;
+        static mut SCRATCH: SharedArray<u32, THREADS> = SharedArray::UNINIT;
 
         if thread::index_1d().get() == 0 {
             unsafe {
@@ -44,6 +51,24 @@ mod kernels {
                 OUTPUT_NORM[0] = OUTPUT_NORM[0] * weight;
                 *out.get_unchecked_mut(0) = OUTPUT_NORM[0];
             }
+        }
+
+        // Every thread starts from the raw address of one shared allocation,
+        // then writes only its own element. No thread constructs an
+        // `&mut SharedArray` spanning elements owned by other threads.
+        let lane = thread::threadIdx_x() as usize;
+        let scratch = unsafe { SharedArray::as_raw_mut_ptr(&raw mut SCRATCH) };
+        if lane < THREADS {
+            unsafe { scratch.add(lane).write((lane + 1) as u32) };
+        }
+        thread::sync_threads();
+
+        if lane == 0 {
+            let mut sum = 0_u32;
+            for index in 0..THREADS {
+                sum += unsafe { scratch.add(index).read() };
+            }
+            unsafe { *out.get_unchecked_mut(1) = sum as f32 };
         }
     }
 
@@ -65,22 +90,46 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw_module = ltoir::load_kernel_module(&ctx, "addressof_sharedarray")?;
     let module = kernels::from_module(raw_module).expect("typed module init failed");
 
-    let cfg = LaunchConfig::for_num_elems(1);
-    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 1)?;
+    let cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 2)?;
     let seed: f32 = 7.0;
 
-    // SAFETY: one thread is launched, matching the kernel's single-element
-    // output access and fixed shared-memory use.
+    // SAFETY: one 32-thread block writes 32 distinct shared elements, then
+    // thread 0 reads them after a block-wide barrier. Only thread 0 writes the
+    // two output elements.
     unsafe { module.sharedarray_late_use(stream.as_ref(), cfg, seed, &mut out) }?;
 
-    let result = out.to_host_vec(&stream)?[0];
+    let result = out.to_host_vec(&stream)?;
     let expected: f32 = 21.0; // seed * repro_weight() == 7.0 * 3.0
 
-    if (result - expected).abs() < f32::EPSILON {
-        println!("PASS addressof_sharedarray: seed={seed}, result={result}");
-        Ok(())
+    if (result[0] - expected).abs() < f32::EPSILON {
+        println!(
+            "PASS addressof_sharedarray: seed={seed}, result={}",
+            result[0]
+        );
     } else {
-        eprintln!("FAIL addressof_sharedarray: got {result}, expected {expected}");
+        eprintln!(
+            "FAIL addressof_sharedarray: got {}, expected {expected}",
+            result[0]
+        );
         std::process::exit(1);
     }
+
+    let raw_expected = (1_u32..=32).sum::<u32>() as f32;
+    if (result[1] - raw_expected).abs() > f32::EPSILON {
+        eprintln!(
+            "FAIL addressof_sharedarray raw receiver: got {}, expected {raw_expected}",
+            result[1]
+        );
+        std::process::exit(1);
+    }
+    println!(
+        "PASS addressof_sharedarray raw receiver: result={}",
+        result[1]
+    );
+    Ok(())
 }


### PR DESCRIPTION
Closes #623.

## Summary

`SharedArray::as_mut_ptr` forces callers to create a whole-allocation mutable
reference before multiple CUDA threads can derive disjoint element pointers.
This adds an unsafe `as_raw_mut_ptr(*mut Self)` entry point and lowers it through
the same shared-to-generic conversion as the borrowed pointer methods. The
caller retains responsibility for disjoint accesses and CUDA synchronization,
while the API no longer requires an overlapping `&mut SharedArray`.

## What changed

### Raw receiver and lowering rule

- Added `SharedArray::as_raw_mut_ptr`, with safety documentation centered on
  raw `static mut` provenance, per-thread disjointness, kernel lifetime, and
  synchronization.
- Kept the returned pointer in generic address space 0, matching `as_ptr` and
  `as_mut_ptr` after their explicit conversion from shared address space 3.
- Generalized the existing pointer-conversion emitter diagnostics so all three
  public entry points share the same lowering implementation.

### Coverage and related paths

- Replaced duplicated substring dispatch with one typed recognizer used by
  both intrinsic dispatch and call-result address-space classification.
- Anchored recognition to the `cuda_device` crate, an exact `SharedArray` path
  component, and exact method names; unit tests cover canonical names and
  nearby false matches.
- Extended the existing `addressof_sharedarray` regression without introducing
  another artifact: one 32-thread kernel writes distinct shared elements from
  the raw receiver, synchronizes, and checks their sum while retaining the
  original issue-54 behavior.

## Known separate limitations

- This is an unsafe escape hatch, not a safe ownership witness. Callers must
  prove that concurrent accesses are disjoint and place the required CUDA
  barriers. A higher-level safe partitioning API is separate work.
- The focused LTOIR smoke on current `upstream/main` is independently blocked
  on CUDA 12.8 by cubin validation requiring generic ELF `e_version == 1`;
  nvJitLink emits the CUDA format value `0x80`. The raw-pointer branch remains
  independent of that validator fix. Its PTX route passes directly, and the
  LTOIR route passes when tested with only that validator correction stacked
  transiently.
- Dynamic shared-memory APIs and multi-artifact module lookup are unchanged.

## Testing

- Upstream-red: with only the GPU regression added to
  `bead880cd7461c67a14bc69d10fa7def538f3394`,
  `scripts/smoketest.sh --only '^addressof_sharedarray$' --no-color` failed
  during device compilation with Rust error E0599 because
  `SharedArray::as_raw_mut_ptr` did not exist.
- Patched-green on an RTX 3080 (sm_86):
  `cargo oxide run addressof_sharedarray --arch=sm_86` preserved the original
  result (`21`) and produced the 32-thread raw-pointer sum (`528`).
- LTOIR integration: with only the separate CUDA-ELF validator condition
  applied transiently,
  `scripts/smoketest.sh --only '^addressof_sharedarray$' --no-color` passed
  1/1. Removing that unrelated condition reproduces `Finalizer(InvalidCubin)`
  after nvJitLink has produced a valid 5,152-byte CUDA ELF.
- `cargo test -p mir-importer -p cuda-device --all-targets` passed
  (892 mir-importer tests, 76 cuda-device unit tests, the config extension
  test, and all 25 thread-index trybuild cases).
- `cargo clippy -p mir-importer -p cuda-device --all-targets -- -D warnings`
  passed.
- Example `cargo clippy --all-targets -- -D warnings`, workspace and example
  formatting checks, and `git diff --check` passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.
