### PR TITLE
fix(mir-lower): genericize named-space pointer values

### DIFF
--- a/crates/cuda-device/src/shared.rs
+++ b/crates/cuda-device/src/shared.rs
@@ -497,7 +497,7 @@ impl<T, const ALIGN: usize> DynamicSharedArray<T, ALIGN> {
 
 /// Convert a generic-address pointer into its raw `.shared` window offset.
 ///
-/// The CUDA C++ `__cvta_generic_to_shared` analog (PTX `cvta.to.shared`).
+/// The CUDA C++ `__cvta_generic_to_shared_offset` analog (PTX `cvta.to.shared`).
 /// Rust-visible pointer addresses (`ptr as usize`, `ptr::addr`) are CUDA
 /// generic addresses; hardware SMEM descriptors (WGMMA and tcgen05 matrix
 /// descriptors, whose low bits encode `(start_address >> 4) & 0x3FFF`) are
@@ -506,7 +506,7 @@ impl<T, const ALIGN: usize> DynamicSharedArray<T, ALIGN> {
 ///
 /// ```rust,ignore
 /// static mut SMEM_A: SharedArray<f16, 2048> = SharedArray::UNINIT;
-/// let base = unsafe { cvta_generic_to_shared(&raw const SMEM_A as *const u8) };
+/// let base = unsafe { cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8) };
 /// let desc = build_smem_descriptor(base, LBO_BYTES, SBO_BYTES, SWIZZLE_NONE);
 /// ```
 ///
@@ -517,13 +517,13 @@ impl<T, const ALIGN: usize> DynamicSharedArray<T, ALIGN> {
 /// point into shared memory yields an unspecified offset.
 //
 // The importer intercepts calls by the exact rendered def-path
-// `cuda_device::shared::cvta_generic_to_shared`. A `pub use` at the crate
+// `cuda_device::shared::cvta_generic_to_shared_offset`. A `pub use` at the crate
 // root would change rustc's visible path for this item and silently break
 // interception, so import it through this module.
 #[inline(never)]
-pub unsafe fn cvta_generic_to_shared(ptr: *const u8) -> u64 {
+pub unsafe fn cvta_generic_to_shared_offset(ptr: *const u8) -> u64 {
     let _ = ptr;
-    unreachable!("cvta_generic_to_shared called outside CUDA kernel context")
+    unreachable!("cvta_generic_to_shared_offset called outside CUDA kernel context")
 }
 
 include!("generated/shared_sreg.rs");

--- a/crates/cuda-device/src/shared.rs
+++ b/crates/cuda-device/src/shared.rs
@@ -467,4 +467,30 @@ impl<T, const ALIGN: usize> DynamicSharedArray<T, ALIGN> {
     }
 }
 
+/// Convert a generic-address pointer into its raw `.shared` window offset.
+///
+/// The CUDA C++ `__cvta_generic_to_shared` analog (PTX `cvta.to.shared`).
+/// Rust-visible pointer addresses (`ptr as usize`, `ptr::addr`) are CUDA
+/// generic addresses; hardware SMEM descriptors (WGMMA and tcgen05 matrix
+/// descriptors, whose low bits encode `(start_address >> 4) & 0x3FFF`) are
+/// defined on the space-local shared offset instead. Use this to derive
+/// descriptor base addresses; do not pass a raw `ptr as u64` there.
+///
+/// ```rust,ignore
+/// static mut SMEM_A: SharedArray<f16, 2048> = SharedArray::UNINIT;
+/// let base = unsafe { cvta_generic_to_shared(&raw const SMEM_A as *const u8) };
+/// let desc = build_smem_descriptor(base, LBO_BYTES, SBO_BYTES, SWIZZLE_NONE);
+/// ```
+///
+/// # Safety
+///
+/// `ptr` must be a generic pointer to shared memory (for example one
+/// derived from a `SharedArray` static). Converting a pointer that does not
+/// point into shared memory yields an unspecified offset.
+#[inline(never)]
+pub unsafe fn cvta_generic_to_shared(ptr: *const u8) -> u64 {
+    let _ = ptr;
+    unreachable!("cvta_generic_to_shared called outside CUDA kernel context")
+}
+
 include!("generated/shared_sreg.rs");

--- a/crates/cuda-device/src/shared.rs
+++ b/crates/cuda-device/src/shared.rs
@@ -487,6 +487,11 @@ impl<T, const ALIGN: usize> DynamicSharedArray<T, ALIGN> {
 /// `ptr` must be a generic pointer to shared memory (for example one
 /// derived from a `SharedArray` static). Converting a pointer that does not
 /// point into shared memory yields an unspecified offset.
+//
+// The importer intercepts calls by the exact rendered def-path
+// `cuda_device::shared::cvta_generic_to_shared`. A `pub use` at the crate
+// root would change rustc's visible path for this item and silently break
+// interception, so import it through this module.
 #[inline(never)]
 pub unsafe fn cvta_generic_to_shared(ptr: *const u8) -> u64 {
     let _ = ptr;

--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -864,9 +864,9 @@ pub enum Tcgen05SwizzleMode {
 /// ```rust,ignore
 /// // For 128×16 f16 matrix A in K-major tiled layout. The descriptor's
 /// // address bits encode the raw .shared offset, so derive it with
-/// // cvta_generic_to_shared rather than `ptr as u64` (which is the
+/// // cvta_generic_to_shared_offset rather than `ptr as u64` (which is the
 /// // CUDA generic address).
-/// let smem_a_addr = cvta_generic_to_shared(smem_a_ptr as *const u8);
+/// let smem_a_addr = cvta_generic_to_shared_offset(smem_a_ptr as *const u8);
 /// let desc = Tcgen05SmemDescriptor::for_k_major(
 ///     smem_a_addr,
 ///     128,  // M dimension
@@ -915,7 +915,7 @@ impl Tcgen05SmemDescriptor {
     /// # Example
     ///
     /// ```rust,ignore
-    /// // 128×16 f16 matrix (smem_addr from cvta_generic_to_shared)
+    /// // 128×16 f16 matrix (smem_addr from cvta_generic_to_shared_offset)
     /// let desc = Tcgen05SmemDescriptor::for_k_major(
     ///     smem_addr, 128, 16, 2, Tcgen05SwizzleMode::None
     /// );

--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -862,9 +862,13 @@ pub enum Tcgen05SwizzleMode {
 /// # Example
 ///
 /// ```rust,ignore
-/// // For 128×16 f16 matrix A in K-major tiled layout:
+/// // For 128×16 f16 matrix A in K-major tiled layout. The descriptor's
+/// // address bits encode the raw .shared offset, so derive it with
+/// // cvta_generic_to_shared rather than `ptr as u64` (which is the
+/// // CUDA generic address).
+/// let smem_a_addr = cvta_generic_to_shared(smem_a_ptr as *const u8);
 /// let desc = Tcgen05SmemDescriptor::for_k_major(
-///     smem_a_ptr as u64,
+///     smem_a_addr,
 ///     128,  // M dimension
 ///     16,   // K dimension
 ///     2,    // f16 = 2 bytes per element
@@ -911,9 +915,9 @@ impl Tcgen05SmemDescriptor {
     /// # Example
     ///
     /// ```rust,ignore
-    /// // 128×16 f16 matrix
+    /// // 128×16 f16 matrix (smem_addr from cvta_generic_to_shared)
     /// let desc = Tcgen05SmemDescriptor::for_k_major(
-    ///     smem_ptr as u64, 128, 16, 2, Tcgen05SwizzleMode::None
+    ///     smem_addr, 128, 16, 2, Tcgen05SwizzleMode::None
     /// );
     /// // SBO = 8*8*2 = 128 bytes
     /// // LBO = (128/8)*8*8*2 = 16*64*2 = 2048 bytes

--- a/crates/dialect-nvvm/src/ops/memory.rs
+++ b/crates/dialect-nvvm/src/ops/memory.rs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Memory address-space conversion operations.
+//!
+//! CUDA source-level pointers are generic; hardware instruction descriptors
+//! (WGMMA/tcgen05 SMEM descriptors, `ldmatrix`/`stmatrix` operands) consume
+//! raw space-local offsets instead. These operations expose that conversion
+//! as a first-class step, mirroring CUDA C++'s `__cvta_generic_to_shared`.
+
+use dialect_mir::types::{MirPtrType, address_space};
+use pliron::{
+    builtin::{
+        op_interfaces::{NOpdsInterface, NResultsInterface},
+        types::{IntegerType, Signedness},
+    },
+    common_traits::Verify,
+    context::{Context, Ptr},
+    location::Located,
+    op::Op,
+    operation::Operation,
+    result::Error,
+    r#type::Typed,
+    verify_err,
+};
+use pliron_derive::pliron_op;
+
+/// Convert a generic-address pointer into its raw `.shared` window offset.
+///
+/// The operand is a pointer in the generic (or already shared) address
+/// space; the result is the space-local shared offset as `u64`, the value
+/// hardware SMEM descriptors encode. Lowered as `addrspacecast` to
+/// `addrspace(3)` followed by `ptrtoint`, which `llc` selects as
+/// `cvta.to.shared`.
+#[pliron_op(
+    name = "nvvm.cvta_generic_to_shared",
+    format,
+    interfaces = [NOpdsInterface<1>, NResultsInterface<1>],
+)]
+pub struct CvtaGenericToSharedOp;
+
+impl CvtaGenericToSharedOp {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        CvtaGenericToSharedOp { op }
+    }
+}
+
+fn is_u64(ctx: &Context, ty: pliron::r#type::TypeHandle) -> bool {
+    ty.deref(ctx)
+        .downcast_ref::<IntegerType>()
+        .is_some_and(|integer| {
+            integer.width() == 64 && integer.signedness() == Signedness::Unsigned
+        })
+}
+
+impl Verify for CvtaGenericToSharedOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        if op.get_num_operands() != 1 || op.get_num_results() != 1 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.cvta_generic_to_shared requires one operand and one result"
+            );
+        }
+        let pointer_ty = op.get_operand(0).get_type(ctx);
+        let pointer_ty_obj = pointer_ty.deref(ctx);
+        let Some(pointer_ty) = pointer_ty_obj.downcast_ref::<MirPtrType>() else {
+            return verify_err!(
+                op.loc(),
+                "nvvm.cvta_generic_to_shared operand must be a MIR pointer"
+            );
+        };
+        if !matches!(
+            pointer_ty.address_space,
+            address_space::GENERIC | address_space::SHARED
+        ) {
+            return verify_err!(
+                op.loc(),
+                "nvvm.cvta_generic_to_shared operand must point to generic or shared memory"
+            );
+        }
+        if !is_u64(ctx, op.get_result(0).get_type(ctx)) {
+            return verify_err!(op.loc(), "nvvm.cvta_generic_to_shared result must be u64");
+        }
+        Ok(())
+    }
+}

--- a/crates/dialect-nvvm/src/ops/memory.rs
+++ b/crates/dialect-nvvm/src/ops/memory.rs
@@ -8,7 +8,7 @@
 //! CUDA source-level pointers are generic; hardware instruction descriptors
 //! (WGMMA/tcgen05 SMEM descriptors, `ldmatrix`/`stmatrix` operands) consume
 //! raw space-local offsets instead. These operations expose that conversion
-//! as a first-class step, mirroring CUDA C++'s `__cvta_generic_to_shared`.
+//! as a first-class step, mirroring CUDA C++'s `__cvta_generic_to_shared_offset`.
 
 use dialect_mir::types::{MirPtrType, address_space};
 use pliron::{
@@ -35,16 +35,16 @@ use pliron_derive::pliron_op;
 /// `addrspace(3)` followed by `ptrtoint`, which `llc` selects as
 /// `cvta.to.shared`.
 #[pliron_op(
-    name = "nvvm.cvta_generic_to_shared",
+    name = "nvvm.cvta_generic_to_shared_offset",
     format,
     interfaces = [NOpdsInterface<1>, NResultsInterface<1>],
 )]
-pub struct CvtaGenericToSharedOp;
+pub struct CvtaGenericToSharedOffsetOp;
 
-impl CvtaGenericToSharedOp {
+impl CvtaGenericToSharedOffsetOp {
     /// Wrap an existing operation pointer.
     pub fn new(op: Ptr<Operation>) -> Self {
-        CvtaGenericToSharedOp { op }
+        CvtaGenericToSharedOffsetOp { op }
     }
 }
 
@@ -56,13 +56,13 @@ fn is_u64(ctx: &Context, ty: pliron::r#type::TypeHandle) -> bool {
         })
 }
 
-impl Verify for CvtaGenericToSharedOp {
+impl Verify for CvtaGenericToSharedOffsetOp {
     fn verify(&self, ctx: &Context) -> Result<(), Error> {
         let op = self.get_operation().deref(ctx);
         if op.get_num_operands() != 1 || op.get_num_results() != 1 {
             return verify_err!(
                 op.loc(),
-                "nvvm.cvta_generic_to_shared requires one operand and one result"
+                "nvvm.cvta_generic_to_shared_offset requires one operand and one result"
             );
         }
         let pointer_ty = op.get_operand(0).get_type(ctx);
@@ -70,7 +70,7 @@ impl Verify for CvtaGenericToSharedOp {
         let Some(pointer_ty) = pointer_ty_obj.downcast_ref::<MirPtrType>() else {
             return verify_err!(
                 op.loc(),
-                "nvvm.cvta_generic_to_shared operand must be a MIR pointer"
+                "nvvm.cvta_generic_to_shared_offset operand must be a MIR pointer"
             );
         };
         if !matches!(
@@ -79,11 +79,14 @@ impl Verify for CvtaGenericToSharedOp {
         ) {
             return verify_err!(
                 op.loc(),
-                "nvvm.cvta_generic_to_shared operand must point to generic or shared memory"
+                "nvvm.cvta_generic_to_shared_offset operand must point to generic or shared memory"
             );
         }
         if !is_u64(ctx, op.get_result(0).get_type(ctx)) {
-            return verify_err!(op.loc(), "nvvm.cvta_generic_to_shared result must be u64");
+            return verify_err!(
+                op.loc(),
+                "nvvm.cvta_generic_to_shared_offset result must be u64"
+            );
         }
         Ok(())
     }

--- a/crates/dialect-nvvm/src/ops/mod.rs
+++ b/crates/dialect-nvvm/src/ops/mod.rs
@@ -25,6 +25,7 @@ mod cluster;
 mod debug;
 mod generated;
 mod grid;
+mod memory;
 mod wgmma;
 
 use pliron::context::Context;
@@ -36,6 +37,7 @@ pub use cluster::*;
 pub use debug::*;
 pub use generated::*;
 pub use grid::*;
+pub use memory::*;
 pub use wgmma::*;
 
 /// Register all NVVM dialect operations with the context.

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -8,16 +8,16 @@ use dialect_nvvm::ops::{
     ActiveMaskOp, AssertFailOp, AtomicOrdering, AtomicRmwKind, AtomicScope, BarWarpSyncOp,
     Barrier0Op, ClusterBarrierModeAttr, ClusterBarrierOp, CpAsyncCa4Op, CpAsyncCaZfill4Op,
     CpAsyncMbarrierArriveNoIncOp, CpAsyncMbarrierArriveNoIncSharedOp, CpAsyncMbarrierArriveOp,
-    CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, Dp2aS32Op, Dp2aU32Op, Dp4aS32Op, Dp4aU32Op,
-    ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr, LdmatrixLayoutAttr,
-    LdmatrixMultiplicityAttr, LdmatrixOp, LdmatrixShapeAttr, LdmatrixStateSpaceAttr, LdmatrixX1Op,
-    LdmatrixX1TransOp, LdmatrixX2Op, LdmatrixX2TransOp, LdmatrixX4Op, LdmatrixX4TransOp,
-    MatchAllSyncI32Op, MatchAllSyncI64Op, MatchAnySyncI32Op, MatchAnySyncI64Op,
-    MbarrierArriveSharedOp, MbarrierInitSharedOp, MbarrierInvalSharedOp, MbarrierTestWaitSharedOp,
-    MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op, MmaM16N8K16F32F16Op,
-    MmaM16N8K32S32S8Op, MovmatrixTransB16Op, NvvmAtomAddBf16x2Op, NvvmAtomAddF16x2Op,
-    NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, PackedAtomicAddOp,
-    PackedAtomicAtomicityAttr, PackedAtomicFormatAttr, PackedAtomicOrderingAttr,
+    CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, CvtaGenericToSharedOp, Dp2aS32Op, Dp2aU32Op,
+    Dp4aS32Op, Dp4aU32Op, ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr,
+    LdmatrixLayoutAttr, LdmatrixMultiplicityAttr, LdmatrixOp, LdmatrixShapeAttr,
+    LdmatrixStateSpaceAttr, LdmatrixX1Op, LdmatrixX1TransOp, LdmatrixX2Op, LdmatrixX2TransOp,
+    LdmatrixX4Op, LdmatrixX4TransOp, MatchAllSyncI32Op, MatchAllSyncI64Op, MatchAnySyncI32Op,
+    MatchAnySyncI64Op, MbarrierArriveSharedOp, MbarrierInitSharedOp, MbarrierInvalSharedOp,
+    MbarrierTestWaitSharedOp, MmaM8N8K4F64Op, MmaM16N8K8F32Tf32Op, MmaM16N8K16F32Bf16Op,
+    MmaM16N8K16F32F16Op, MmaM16N8K32S32S8Op, MovmatrixTransB16Op, NvvmAtomAddBf16x2Op,
+    NvvmAtomAddF16x2Op, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp,
+    PackedAtomicAddOp, PackedAtomicAtomicityAttr, PackedAtomicFormatAttr, PackedAtomicOrderingAttr,
     PackedAtomicRoundingAttr, PackedAtomicScopeAttr, PackedAtomicStateSpaceAttr,
     PackedAtomicSubnormalAttr, ReadPtxSregClusterIdxOp, ReadPtxSregDynamicSmemSizeOp,
     ReadPtxSregGridIdOp, ReadPtxSregLaneIdOp, ReadPtxSregLanemaskEqOp, ReadPtxSregLanemaskGeOp,
@@ -83,6 +83,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("debug.rs", "AssertFailOp"),
         ("debug.rs", "VprintfOp"),
         ("grid.rs", "GridSyncOp"),
+        ("memory.rs", "CvtaGenericToSharedOp"),
         ("wgmma.rs", "WgmmaMakeSmemDescOp"),
         ("wgmma.rs", "WgmmaMmaM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupM64N64K16F32Bf16Op"),
@@ -4394,6 +4395,36 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
             0,
         );
         assert!(WgmmaMakeSmemDescOp::new(invalid).verify(&ctx).is_err());
+    }
+
+    let cvta = Operation::new(
+        &mut ctx,
+        CvtaGenericToSharedOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![pointer],
+        vec![],
+        0,
+    );
+    assert!(CvtaGenericToSharedOp::new(cvta).verify(&ctx).is_ok());
+    for (operands, results) in [
+        // Operand must be a MIR pointer.
+        (vec![u32_value], vec![u64_ty.into()]),
+        // Operand must point to generic or shared memory.
+        (vec![global_pointer], vec![u64_ty.into()]),
+        // Result must be u64.
+        (vec![pointer], vec![u32_ty.into()]),
+        // Exact arity is required.
+        (vec![], vec![u64_ty.into()]),
+    ] {
+        let invalid = Operation::new(
+            &mut ctx,
+            CvtaGenericToSharedOp::get_concrete_op_info(),
+            results,
+            operands,
+            vec![],
+            0,
+        );
+        assert!(CvtaGenericToSharedOp::new(invalid).verify(&ctx).is_err());
     }
 
     let mma = Operation::new(

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -8,8 +8,8 @@ use dialect_nvvm::ops::{
     ActiveMaskOp, AssertFailOp, AtomicOrdering, AtomicRmwKind, AtomicScope, BarWarpSyncOp,
     Barrier0Op, ClusterBarrierModeAttr, ClusterBarrierOp, CpAsyncCa4Op, CpAsyncCaZfill4Op,
     CpAsyncMbarrierArriveNoIncOp, CpAsyncMbarrierArriveNoIncSharedOp, CpAsyncMbarrierArriveOp,
-    CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, CvtaGenericToSharedOp, Dp2aS32Op, Dp2aU32Op,
-    Dp4aS32Op, Dp4aU32Op, ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr,
+    CpAsyncMbarrierArriveSharedOp, CpAsyncWaitGroupOp, CvtaGenericToSharedOffsetOp, Dp2aS32Op,
+    Dp2aU32Op, Dp4aS32Op, Dp4aU32Op, ElectSyncOp, FmaBf16x2Op, InlinePtxOp, LdmatrixElementAttr,
     LdmatrixLayoutAttr, LdmatrixMultiplicityAttr, LdmatrixOp, LdmatrixShapeAttr,
     LdmatrixStateSpaceAttr, LdmatrixX1Op, LdmatrixX1TransOp, LdmatrixX2Op, LdmatrixX2TransOp,
     LdmatrixX4Op, LdmatrixX4TransOp, MatchAllSyncI32Op, MatchAllSyncI64Op, MatchAnySyncI32Op,
@@ -83,7 +83,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("debug.rs", "AssertFailOp"),
         ("debug.rs", "VprintfOp"),
         ("grid.rs", "GridSyncOp"),
-        ("memory.rs", "CvtaGenericToSharedOp"),
+        ("memory.rs", "CvtaGenericToSharedOffsetOp"),
         ("wgmma.rs", "WgmmaMakeSmemDescOp"),
         ("wgmma.rs", "WgmmaMmaM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupM64N64K16F32Bf16Op"),
@@ -4399,13 +4399,13 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
 
     let cvta = Operation::new(
         &mut ctx,
-        CvtaGenericToSharedOp::get_concrete_op_info(),
+        CvtaGenericToSharedOffsetOp::get_concrete_op_info(),
         vec![u64_ty.into()],
         vec![pointer],
         vec![],
         0,
     );
-    assert!(CvtaGenericToSharedOp::new(cvta).verify(&ctx).is_ok());
+    assert!(CvtaGenericToSharedOffsetOp::new(cvta).verify(&ctx).is_ok());
     for (operands, results) in [
         // Operand must be a MIR pointer.
         (vec![u32_value], vec![u64_ty.into()]),
@@ -4418,13 +4418,17 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     ] {
         let invalid = Operation::new(
             &mut ctx,
-            CvtaGenericToSharedOp::get_concrete_op_info(),
+            CvtaGenericToSharedOffsetOp::get_concrete_op_info(),
             results,
             operands,
             vec![],
             0,
         );
-        assert!(CvtaGenericToSharedOp::new(invalid).verify(&ctx).is_err());
+        assert!(
+            CvtaGenericToSharedOffsetOp::new(invalid)
+                .verify(&ctx)
+                .is_err()
+        );
     }
 
     let mma = Operation::new(

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -992,3 +992,77 @@ pub fn emit_dynamic_shared_offset(
         "DynamicSharedArray::offset call without target block",
     )
 }
+
+/// Emit `cuda_device::shared::cvta_generic_to_shared(ptr) -> u64`.
+///
+/// Converts a generic-address pointer into its raw `.shared` window offset,
+/// the value hardware SMEM descriptors (WGMMA/tcgen05) encode. Mirrors CUDA
+/// C++'s `__cvta_generic_to_shared`: the Rust-visible pointer stays generic,
+/// and this intrinsic is the explicit step into the space-local offset.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_cvta_generic_to_shared(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    use dialect_nvvm::ops::CvtaGenericToSharedOp;
+    use pliron::builtin::types::Signedness;
+
+    if args.len() != 1 {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "cvta_generic_to_shared expects 1 argument, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    let (ptr_val, last_op) = rvalue::translate_operand(
+        ctx,
+        body,
+        &args[0],
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
+
+    let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+    let cvta_op = Operation::new(
+        ctx,
+        CvtaGenericToSharedOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![ptr_val],
+        vec![],
+        0,
+    );
+    cvta_op.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = last_op {
+        cvta_op.insert_after(ctx, prev);
+    } else {
+        cvta_op.insert_at_front(block_ptr, ctx);
+    }
+
+    let result_value = cvta_op.deref(ctx).get_result(0);
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        result_value,
+        target,
+        block_ptr,
+        cvta_op,
+        value_map,
+        block_map,
+        loc,
+        "cvta_generic_to_shared call without target block",
+    )
+}

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -1086,14 +1086,14 @@ pub fn emit_dynamic_shared_offset(
     )
 }
 
-/// Emit `cuda_device::shared::cvta_generic_to_shared(ptr) -> u64`.
+/// Emit `cuda_device::shared::cvta_generic_to_shared_offset(ptr) -> u64`.
 ///
 /// Converts a generic-address pointer into its raw `.shared` window offset,
 /// the value hardware SMEM descriptors (WGMMA/tcgen05) encode. Mirrors CUDA
-/// C++'s `__cvta_generic_to_shared`: the Rust-visible pointer stays generic,
+/// C++'s `__cvta_generic_to_shared_offset`: the Rust-visible pointer stays generic,
 /// and this intrinsic is the explicit step into the space-local offset.
 #[allow(clippy::too_many_arguments)]
-pub fn emit_cvta_generic_to_shared(
+pub fn emit_cvta_generic_to_shared_offset(
     ctx: &mut Context,
     body: &mir::Body,
     args: &[mir::Operand],
@@ -1105,14 +1105,14 @@ pub fn emit_cvta_generic_to_shared(
     block_map: &[Ptr<BasicBlock>],
     loc: Location,
 ) -> TranslationResult<Ptr<Operation>> {
-    use dialect_nvvm::ops::CvtaGenericToSharedOp;
+    use dialect_nvvm::ops::CvtaGenericToSharedOffsetOp;
     use pliron::builtin::types::Signedness;
 
     if args.len() != 1 {
         return input_err!(
             loc.clone(),
             TranslationErr::unsupported(format!(
-                "cvta_generic_to_shared expects 1 argument, got {}",
+                "cvta_generic_to_shared_offset expects 1 argument, got {}",
                 args.len()
             ))
         );
@@ -1131,7 +1131,7 @@ pub fn emit_cvta_generic_to_shared(
     let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
     let cvta_op = Operation::new(
         ctx,
-        CvtaGenericToSharedOp::get_concrete_op_info(),
+        CvtaGenericToSharedOffsetOp::get_concrete_op_info(),
         vec![u64_ty.into()],
         vec![ptr_val],
         vec![],
@@ -1156,6 +1156,6 @@ pub fn emit_cvta_generic_to_shared(
         value_map,
         block_map,
         loc,
-        "cvta_generic_to_shared call without target block",
+        "cvta_generic_to_shared_offset call without target block",
     )
 }

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3037,9 +3037,9 @@ fn try_dispatch_intrinsic(
         }
 
         // Explicit generic-to-shared address conversion for hardware SMEM
-        // descriptors (the CUDA C++ `__cvta_generic_to_shared` analog).
-        "cuda_device::shared::cvta_generic_to_shared" => {
-            Ok(Some(intrinsics::memory::emit_cvta_generic_to_shared(
+        // descriptors (the CUDA C++ `__cvta_generic_to_shared_offset` analog).
+        "cuda_device::shared::cvta_generic_to_shared_offset" => Ok(Some(
+            intrinsics::memory::emit_cvta_generic_to_shared_offset(
                 ctx,
                 body,
                 args,
@@ -3050,8 +3050,8 @@ fn try_dispatch_intrinsic(
                 value_map,
                 block_map,
                 loc,
-            )?))
-        }
+            )?,
+        )),
 
         // Public SharedArray pointer conversions all narrow the shared-memory
         // base to a generic pointer. Recognition is shared with destination

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3021,6 +3021,23 @@ fn try_dispatch_intrinsic(
             }
         }
 
+        // Explicit generic-to-shared address conversion for hardware SMEM
+        // descriptors (the CUDA C++ `__cvta_generic_to_shared` analog).
+        "cuda_device::shared::cvta_generic_to_shared" => {
+            Ok(Some(intrinsics::memory::emit_cvta_generic_to_shared(
+                ctx,
+                body,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+            )?))
+        }
+
         // SharedArray::as_ptr and as_mut_ptr - convert shared memory pointer to generic
         path if path.contains("SharedArray") && path.contains("as_ptr") => {
             Ok(Some(intrinsics::memory::emit_shared_array_as_ptr(

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -36,9 +36,9 @@ use dialect_mir::ops::{
     MirStorageLiveOp, MirStoreOp, MirSubOp, MirUndefOp, MirUnreachableOp, MirUnrollHintOp,
 };
 use dialect_nvvm::ops::{
-    AssertFailOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp, NvvmAtomicRmwOp,
-    NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp, VprintfOp,
-    WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
+    AssertFailOp, CvtaGenericToSharedOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
+    NvvmAtomicRmwOp, NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp,
+    VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -975,6 +975,25 @@ impl MirToLlvmConversion for ReadPtxSregNclusterIdOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::cluster::convert_num_clusters(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+// ---- NVVM memory ops -------------------------------------------------------
+
+#[op_interface_impl]
+impl MirToLlvmConversion for CvtaGenericToSharedOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::memory::convert_cvta_generic_to_shared(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -36,7 +36,7 @@ use dialect_mir::ops::{
     MirStorageLiveOp, MirStoreOp, MirSubOp, MirUndefOp, MirUnreachableOp, MirUnrollHintOp,
 };
 use dialect_nvvm::ops::{
-    AssertFailOp, CvtaGenericToSharedOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
+    AssertFailOp, CvtaGenericToSharedOffsetOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
     NvvmAtomicRmwOp, NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp,
     VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
 };
@@ -986,14 +986,14 @@ impl MirToLlvmConversion for ReadPtxSregNclusterIdOp {
 // ---- NVVM memory ops -------------------------------------------------------
 
 #[op_interface_impl]
-impl MirToLlvmConversion for CvtaGenericToSharedOp {
+impl MirToLlvmConversion for CvtaGenericToSharedOffsetOp {
     fn convert(
         &self,
         ctx: &mut Context,
         rewriter: &mut DialectConversionRewriter,
         operands_info: &OperandsInfo,
     ) -> Result<()> {
-        super::intrinsics::memory::convert_cvta_generic_to_shared(
+        super::intrinsics::memory::convert_cvta_generic_to_shared_offset(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/memory.rs
+++ b/crates/mir-lower/src/convert/intrinsics/memory.rs
@@ -5,7 +5,7 @@
 
 //! Memory address-space conversion intrinsics.
 //!
-//! `nvvm.cvta_generic_to_shared` lowers without inline PTX: an
+//! `nvvm.cvta_generic_to_shared_offset` lowers without inline PTX: an
 //! `addrspacecast` into `addrspace(3)` followed by `ptrtoint`, which `llc`
 //! selects as `cvta.to.shared`. The `ptrtoint` here deliberately reads the
 //! space-local shared offset; it is a hardware-descriptor boundary, not a
@@ -24,8 +24,8 @@ use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
 
-/// Convert `nvvm.cvta_generic_to_shared` to `addrspacecast` + `ptrtoint`.
-pub(crate) fn convert_cvta_generic_to_shared(
+/// Convert `nvvm.cvta_generic_to_shared_offset` to `addrspacecast` + `ptrtoint`.
+pub(crate) fn convert_cvta_generic_to_shared_offset(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
@@ -33,7 +33,7 @@ pub(crate) fn convert_cvta_generic_to_shared(
 ) -> Result<()> {
     let operands: Vec<_> = op.deref(ctx).operands().collect();
     if operands.is_empty() {
-        return pliron::input_err_noloc!("cvta_generic_to_shared requires an operand");
+        return pliron::input_err_noloc!("cvta_generic_to_shared_offset requires an operand");
     }
     let shared_ptr = cast_to_shared_addrspace(ctx, rewriter, operands[0]);
 

--- a/crates/mir-lower/src/convert/intrinsics/memory.rs
+++ b/crates/mir-lower/src/convert/intrinsics/memory.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Memory address-space conversion intrinsics.
+//!
+//! `nvvm.cvta_generic_to_shared` lowers without inline PTX: an
+//! `addrspacecast` into `addrspace(3)` followed by `ptrtoint`, which `llc`
+//! selects as `cvta.to.shared`. The `ptrtoint` here deliberately reads the
+//! space-local shared offset; it is a hardware-descriptor boundary, not a
+//! Rust pointer-address observation (those genericize first, see
+//! `convert/ops/cast.rs`).
+
+use crate::convert::intrinsics::common::cast_to_shared_addrspace;
+use llvm_export::op_interfaces::CastOpInterface;
+use llvm_export::ops as llvm;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::{Context, Ptr};
+use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::inserter::Inserter;
+use pliron::irbuild::rewriter::Rewriter;
+use pliron::op::Op;
+use pliron::operation::Operation;
+use pliron::result::Result;
+
+/// Convert `nvvm.cvta_generic_to_shared` to `addrspacecast` + `ptrtoint`.
+pub(crate) fn convert_cvta_generic_to_shared(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+    if operands.is_empty() {
+        return pliron::input_err_noloc!("cvta_generic_to_shared requires an operand");
+    }
+    let shared_ptr = cast_to_shared_addrspace(ctx, rewriter, operands[0]);
+
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);
+    let ptr_to_int = llvm::PtrToIntOp::new(ctx, shared_ptr, i64_ty.into());
+    rewriter.insert_operation(ctx, ptr_to_int.get_operation());
+    rewriter.replace_operation(ctx, op, ptr_to_int.get_operation());
+    Ok(())
+}

--- a/crates/mir-lower/src/convert/intrinsics/mod.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mod.rs
@@ -82,6 +82,7 @@ pub mod dotprod;
 pub mod extended_minmax;
 pub mod ldmatrix;
 pub mod mbarrier;
+pub mod memory;
 pub mod packed;
 pub mod prmt;
 pub mod scalar_arithmetic;

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -895,6 +895,45 @@ fn canonicalize_bool_value_bytes(
     Ok(current)
 }
 
+/// Adapt a semantic enum payload pointer to or from its physical storage
+/// address space.
+///
+/// Direct shared-pointer payloads use a generic pointer slot so their enum
+/// representation remains 64-bit under both legacy PTX and modern NVVM. All
+/// other type mismatches remain errors; rebuilding nested pointer-bearing
+/// aggregates is deliberately outside this narrow boundary conversion.
+fn coerce_enum_payload_pointer(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    value: Value,
+    target_ty: TypeHandle,
+) -> Result<Value> {
+    let source_ty = value.get_type(ctx);
+    if source_ty == target_ty {
+        return Ok(value);
+    }
+
+    let source_address_space = source_ty
+        .deref(ctx)
+        .downcast_ref::<llvm_types::PointerType>()
+        .map(|pointer| pointer.address_space());
+    let target_address_space = target_ty
+        .deref(ctx)
+        .downcast_ref::<llvm_types::PointerType>()
+        .map(|pointer| pointer.address_space());
+    if source_address_space.is_none() || target_address_space.is_none() {
+        return pliron::input_err_noloc!(
+            "enum payload storage type mismatch: {} cannot be adapted to {}",
+            source_ty.deref(ctx).disp(ctx),
+            target_ty.deref(ctx).disp(ctx)
+        );
+    }
+
+    let cast = llvm::AddrSpaceCastOp::new(ctx, value, target_ty);
+    rewriter.insert_operation(ctx, cast.get_operation());
+    Ok(cast.get_operation().deref(ctx).get_result(0))
+}
+
 /// Convert `mir.construct_enum` (e.g. `E::A(x)`) to LLVM operations.
 ///
 /// Builds the enum value slot by slot, taking every index from
@@ -988,7 +1027,28 @@ pub(crate) fn convert_construct_enum(
         };
         match slot {
             Some(slot) => {
-                let insert_op = llvm::InsertValueOp::new(ctx, current_struct, operand, vec![*slot]);
+                let storage_ty = {
+                    let storage_type = llvm_struct_ty.deref(ctx);
+                    let storage_struct = storage_type
+                        .downcast_ref::<llvm_types::StructType>()
+                        .ok_or_else(|| {
+                            pliron::input_error_noloc!(
+                                "MirConstructEnumOp physical storage is not an LLVM struct"
+                            )
+                        })?;
+                    let storage_slot = *slot as usize;
+                    if storage_slot >= storage_struct.num_fields() {
+                        return pliron::input_err_noloc!(
+                            "MirConstructEnumOp physical field slot {} is out of range",
+                            slot
+                        );
+                    }
+                    storage_struct.field_type(storage_slot)
+                };
+                let stored_operand =
+                    coerce_enum_payload_pointer(ctx, rewriter, operand, storage_ty)?;
+                let insert_op =
+                    llvm::InsertValueOp::new(ctx, current_struct, stored_operand, vec![*slot]);
                 rewriter.insert_operation(ctx, insert_op.get_operation());
                 current_struct = insert_op.get_operation().deref(ctx).get_result(0);
                 last_op = insert_op.get_operation();
@@ -1343,7 +1403,14 @@ pub(crate) fn convert_enum_payload(
         Some(slot) => {
             let extract_op = llvm::ExtractValueOp::new(ctx, enum_val, vec![slot])?;
             rewriter.insert_operation(ctx, extract_op.get_operation());
-            rewriter.replace_operation(ctx, op, extract_op.get_operation());
+            let extracted = extract_op.get_operation().deref(ctx).get_result(0);
+            let semantic_value = coerce_enum_payload_pointer(
+                ctx,
+                rewriter,
+                extracted,
+                slot_map.field_llvm_types[flat],
+            )?;
+            rewriter.replace_operation_with_values(ctx, op, vec![semantic_value]);
         }
         None if is_zero_sized_type(ctx, slot_map.field_llvm_types[flat]) => {
             let undef_op = llvm::UndefOp::new(ctx, slot_map.field_llvm_types[flat]);
@@ -2405,6 +2472,95 @@ mod tests {
             error.to_string().contains("target-mode dependent"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn shared_pointer_niche_payload_round_trips_through_generic_storage() {
+        let mut ctx = make_ctx();
+        let logical: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, true).into();
+        let enum_ty: TypeHandle = MirEnumType::get_with_encoding(
+            &mut ctx,
+            "OptionShared".into(),
+            logical,
+            vec![0, 1],
+            vec![
+                EnumVariant::unit("None".into()),
+                EnumVariant::new_with_layout("Some".into(), vec![shared], vec![0], vec![8]),
+            ],
+            EnumEncoding {
+                tag_offset: 0,
+                total_size: 8,
+                abi_align: 8,
+                layout_kind: EnumLayoutKind::Niche,
+                carrier_kind: EnumCarrierKind::Pointer,
+                carrier_width: 64,
+                carrier_address_space: llvm_types::address_space::GENERIC,
+                niche_start: 0,
+                niche_variant_start: 0,
+                niche_variant_end: 0,
+                untagged_variant: 1,
+                variant_inhabited: vec![1, 1],
+                ..EnumEncoding::default()
+            },
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![shared], vec![shared]);
+        let pointer = block.deref(&ctx).get_argument(0);
+        let construct = Operation::new(
+            &mut ctx,
+            MirConstructEnumOp::get_concrete_op_info(),
+            vec![enum_ty],
+            vec![pointer],
+            vec![],
+            0,
+        );
+        MirConstructEnumOp::new(construct)
+            .set_attr_construct_enum_variant_index(&ctx, VariantIndexAttr(1));
+        construct.insert_at_back(block, &ctx);
+        let option = construct.deref(&ctx).get_result(0);
+
+        let discriminant = Operation::new(
+            &mut ctx,
+            mir::MirGetDiscriminantOp::get_concrete_op_info(),
+            vec![logical],
+            vec![option],
+            vec![],
+            0,
+        );
+        discriminant.insert_at_back(block, &ctx);
+
+        let payload = Operation::new(
+            &mut ctx,
+            MirEnumPayloadOp::get_concrete_op_info(),
+            vec![shared],
+            vec![option],
+            vec![],
+            0,
+        );
+        let payload_op = MirEnumPayloadOp::new(payload);
+        payload_op.set_attr_payload_variant_index(&ctx, VariantIndexAttr(1));
+        payload_op.set_attr_payload_field_index(&ctx, FieldIndexAttr(0));
+        payload.insert_at_back(block, &ctx);
+        let result = payload.deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, block, vec![result]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            2,
+            "construction must genericize the pointer and extraction must restore shared space"
+        );
+        assert_eq!(
+            count_ops::<llvm::PtrToIntOp>(&ctx, &body),
+            1,
+            "niche discrimination must inspect the generic pointer carrier"
+        );
+        assert_eq!(count_ops::<MirConstructEnumOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<MirEnumPayloadOp>(&ctx, &body), 0);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -23,7 +23,7 @@
 //! | PtrToPtr / FnPtrToPtr          | `emit_pointer_cast` (see below)                        |
 //! | PointerCoercionUnsize          | `emit_unsize_cast` → `emit_pointer_cast` (see below)   |
 //! | PointerCoercion* (other)       | `emit_pointer_cast` (see below)                        |
-//! | PointerExposeAddress           | `ptrtoint`                                             |
+//! | PointerExposeAddress           | genericize named-space pointers, then `ptrtoint`       |
 //! | PointerWithExposedProvenance   | `inttoptr`                                             |
 //!
 //! ## `emit_unsize_cast` handles array→slice unsizing:
@@ -36,8 +36,8 @@
 //! | Source → Dest                                  | LLVM Operation                              |
 //! |------------------------------------------------|---------------------------------------------|
 //! | struct → ptr (fat→thin)                        | `extractvalue` field 0                      |
-//! | ptr → struct (thin→fat)                        | `insertvalue` into undef                    |
-//! | ptr → integer                                  | `ptrtoint`                                  |
+//! | ptr → struct (thin→fat, no niche)              | `insertvalue` into undef                    |
+//! | ptr → integer                                  | genericize named-space pointers, `ptrtoint` |
 //! | integer → ptr                                  | `inttoptr`                                  |
 //! | struct → struct (transmute)                    | `alloca` + `store` + `load`                 |
 //! | ptr → ptr (diff addrspace)                     | `addrspacecast`                             |
@@ -61,7 +61,7 @@ use dialect_mir::ops::MirCastOp;
 use dialect_mir::types::{MirArrayType, MirPtrType};
 use llvm_export::op_interfaces::{CastOpInterface, CastOpWithNNegInterface};
 use llvm_export::ops as llvm;
-use llvm_export::types::FuncType;
+use llvm_export::types::{FuncType, PointerType, PointerTypeExt};
 use pliron::builtin::op_interfaces::CallOpCallable;
 use pliron::builtin::type_interfaces::FloatTypeInterface;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -156,7 +156,7 @@ pub fn convert(
         | MirCastKindAttr::Subtype => emit_pointer_cast(ctx, rewriter, op, val, val_ty, llvm_ty)?,
 
         MirCastKindAttr::PointerExposeAddress => {
-            llvm::PtrToIntOp::new(ctx, val, llvm_ty).get_operation()
+            emit_ptr_to_int(ctx, rewriter, val, val_ty, llvm_ty)
         }
 
         MirCastKindAttr::PointerWithExposedProvenance => {
@@ -477,7 +477,7 @@ fn emit_pointer_cast(
         let undef_val = undef.get_operation().deref(ctx).get_result(0);
         Ok(llvm::InsertValueOp::new(ctx, undef_val, val, vec![0]).get_operation())
     } else if src_is_ptr && llvm_ty.deref(ctx).is::<IntegerType>() {
-        Ok(llvm::PtrToIntOp::new(ctx, val, llvm_ty).get_operation())
+        Ok(emit_ptr_to_int(ctx, rewriter, val, val_ty, llvm_ty))
     } else if src_is_int && dst_is_ptr {
         Ok(llvm::IntToPtrOp::new(ctx, val, llvm_ty).get_operation())
     } else if src_is_struct && dst_is_struct {
@@ -516,6 +516,28 @@ fn emit_transmute(
     val_ty: pliron::r#type::TypeHandle,
     llvm_ty: pliron::r#type::TypeHandle,
 ) -> Result<Ptr<Operation>> {
+    let src_ptr_as = val_ty
+        .deref(ctx)
+        .downcast_ref::<PointerType>()
+        .map(PointerType::address_space);
+    let dst_ptr_as = llvm_ty
+        .deref(ctx)
+        .downcast_ref::<PointerType>()
+        .map(PointerType::address_space);
+    let src_is_int = val_ty.deref(ctx).is::<IntegerType>();
+    let dst_is_int = llvm_ty.deref(ctx).is::<IntegerType>();
+
+    // `ptr::addr()` is implemented in the sysroot as a pointer-to-usize
+    // transmute. For a named CUDA address space, Rust's logical address is
+    // the generic CUDA address rather than the local offset in that space:
+    // static shared memory can validly have offset zero without being null.
+    // Genericize before ptrtoint so the memory-space identity participates in
+    // the integer value. This also gives modern NVVM's 32-bit shared pointer
+    // the 64-bit Rust `usize` representation expected by the MIR.
+    if src_ptr_as.is_some() && dst_is_int {
+        return Ok(emit_ptr_to_int(ctx, rewriter, val, val_ty, llvm_ty));
+    }
+
     // Lowering runs before the exporter chooses its target data layout.
     // Shared pointers are 64-bit in PTX/legacy mode but 32-bit in modern
     // NVVM (`p3:32`). A transmute observes the physical pointer bytes, so the
@@ -592,17 +614,6 @@ fn emit_transmute(
         return emit_transmute_via_memory(ctx, rewriter, val, val_ty, llvm_ty);
     }
 
-    let src_ptr_as = val_ty
-        .deref(ctx)
-        .downcast_ref::<llvm_export::types::PointerType>()
-        .map(|ty| ty.address_space());
-    let dst_ptr_as = llvm_ty
-        .deref(ctx)
-        .downcast_ref::<llvm_export::types::PointerType>()
-        .map(|ty| ty.address_space());
-    let src_is_int = val_ty.deref(ctx).is::<IntegerType>();
-    let dst_is_int = llvm_ty.deref(ctx).is::<IntegerType>();
-
     match (src_ptr_as, dst_ptr_as) {
         (Some(source), Some(destination)) if source != destination => {
             Ok(llvm::AddrSpaceCastOp::new(ctx, val, llvm_ty).get_operation())
@@ -647,6 +658,45 @@ fn scalar_bit_width(ctx: &Context, ty: pliron::r#type::TypeHandle) -> Option<u32
     }
     drop(ty_ref);
     llvm_type_size_align(ctx, ty).and_then(|(bytes, _)| u32::try_from(bytes.checked_mul(8)?).ok())
+}
+
+/// Expose a pointer's CUDA generic address as an integer.
+///
+/// Named CUDA address spaces use offsets local to that space. In particular,
+/// a valid static shared-memory allocation may have shared offset zero. Rust
+/// raw-pointer APIs treat that allocation as non-null, so exposing the named
+/// offset directly would make `ptr::is_null` and `ptr::as_mut` misclassify it.
+/// Convert through the generic address space first, where CUDA encodes the
+/// memory-space identity as part of the pointer value.
+///
+/// This is the Rust pointer-address boundary. Target intrinsics that explicitly
+/// consume native shared offsets (for example, inline-PTX `ldmatrix`) keep
+/// their direct address-space-specific conversion.
+fn emit_ptr_to_int(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    val: pliron::value::Value,
+    val_ty: pliron::r#type::TypeHandle,
+    int_ty: pliron::r#type::TypeHandle,
+) -> Ptr<Operation> {
+    let Some(address_space) = val_ty
+        .deref(ctx)
+        .downcast_ref::<PointerType>()
+        .map(PointerType::address_space)
+    else {
+        return llvm::PtrToIntOp::new(ctx, val, int_ty).get_operation();
+    };
+
+    let val = if address_space == 0 {
+        val
+    } else {
+        let generic_ptr_ty = PointerType::get_generic(ctx);
+        let cast = llvm::AddrSpaceCastOp::new(ctx, val, generic_ptr_ty.into());
+        rewriter.insert_operation(ctx, cast.get_operation());
+        cast.get_operation().deref(ctx).get_result(0)
+    };
+
+    llvm::PtrToIntOp::new(ctx, val, int_ty).get_operation()
 }
 
 fn const_i64(
@@ -1144,45 +1194,64 @@ mod tests {
     }
 
     #[test]
-    fn transmute_involving_shared_pointer_rejects_target_dependent_width() {
-        for wrap_pointer in [false, true] {
-            for pointer_is_source in [false, true] {
-                let mut ctx = make_ctx();
-                let pointee = int_ty(&mut ctx, 32, Signedness::Unsigned);
-                let shared_pointer: TypeHandle =
-                    MirPtrType::get(&mut ctx, pointee, false, 3).into();
-                let pointer_shape = if wrap_pointer {
-                    MirStructType::get_with_full_layout(
-                        &mut ctx,
-                        "SharedPointerWrapper".into(),
-                        vec!["pointer".into()],
-                        vec![shared_pointer],
-                        vec![0],
-                        vec![0],
-                        8,
-                        8,
-                    )
-                    .into()
-                } else {
-                    shared_pointer
-                };
-                let bits = int_ty(&mut ctx, 64, Signedness::Unsigned);
-                let (source, destination) = if pointer_is_source {
-                    (pointer_shape, bits)
-                } else {
-                    (bits, pointer_shape)
-                };
-                let module =
-                    build_single_cast(&mut ctx, source, destination, MirCastKindAttr::Transmute);
+    fn unsupported_shared_pointer_transmutes_reject_target_dependent_width() {
+        for (wrap_pointer, pointer_is_source) in [(false, false), (true, false), (true, true)] {
+            let mut ctx = make_ctx();
+            let pointee = int_ty(&mut ctx, 32, Signedness::Unsigned);
+            let shared_pointer: TypeHandle = MirPtrType::get(&mut ctx, pointee, false, 3).into();
+            let pointer_shape = if wrap_pointer {
+                MirStructType::get_with_full_layout(
+                    &mut ctx,
+                    "SharedPointerWrapper".into(),
+                    vec!["pointer".into()],
+                    vec![shared_pointer],
+                    vec![0],
+                    vec![0],
+                    8,
+                    8,
+                )
+                .into()
+            } else {
+                shared_pointer
+            };
+            let bits = int_ty(&mut ctx, 64, Signedness::Unsigned);
+            let (source, destination) = if pointer_is_source {
+                (pointer_shape, bits)
+            } else {
+                (bits, pointer_shape)
+            };
+            let module =
+                build_single_cast(&mut ctx, source, destination, MirCastKindAttr::Transmute);
 
-                let error = crate::lower_mir_to_llvm(&mut ctx, module)
-                    .expect_err("shared-pointer transmute must fail before target mode is known");
-                assert!(
-                    error.to_string().contains("target-mode dependent"),
-                    "unexpected diagnostic: {error}"
-                );
-            }
+            let error = crate::lower_mir_to_llvm(&mut ctx, module)
+                .expect_err("shared-pointer transmute must fail before target mode is known");
+            assert!(
+                error.to_string().contains("target-mode dependent"),
+                "unexpected diagnostic: {error}"
+            );
         }
+    }
+
+    #[test]
+    fn shared_pointer_to_integer_transmute_genericizes_before_ptr_to_int() {
+        let mut ctx = make_ctx();
+        let pointee = int_ty(&mut ctx, 32, Signedness::Unsigned);
+        let shared_pointer: TypeHandle = MirPtrType::get(&mut ctx, pointee, false, 3).into();
+        let usize_ty = int_ty(&mut ctx, 64, Signedness::Unsigned);
+
+        let module = lower_single_cast(
+            &mut ctx,
+            shared_pointer,
+            usize_ty,
+            MirCastKindAttr::Transmute,
+        );
+
+        assert_cast_lowered_to::<llvm::PtrToIntOp>(&ctx, module, "llvm.ptrtoint");
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &kernel_blocks(&ctx, module)),
+            1,
+            "shared pointers must become generic before ptr::addr() observes them"
+        );
     }
 
     #[test]
@@ -1261,6 +1330,41 @@ mod tests {
         );
 
         assert_cast_lowered_to::<llvm::PtrToIntOp>(&ctx, module_ptr, "llvm.ptrtoint");
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &kernel_blocks(&ctx, module_ptr)),
+            0,
+            "generic pointers need no address-space conversion"
+        );
+    }
+
+    #[test]
+    fn named_space_pointer_expose_address_genericizes_before_ptr_to_int() {
+        for address_space in [
+            llvm_export::types::address_space::GLOBAL,
+            llvm_export::types::address_space::SHARED,
+            llvm_export::types::address_space::CONSTANT,
+            llvm_export::types::address_space::LOCAL,
+        ] {
+            let mut ctx = make_ctx();
+            let pointee_ty = int_ty(&mut ctx, 32, Signedness::Signless);
+            let ptr_ty: TypeHandle =
+                MirPtrType::get(&mut ctx, pointee_ty, false, address_space).into();
+            let usize_ty = int_ty(&mut ctx, 64, Signedness::Unsigned);
+
+            let module_ptr = lower_single_cast(
+                &mut ctx,
+                ptr_ty,
+                usize_ty,
+                MirCastKindAttr::PointerExposeAddress,
+            );
+
+            assert_cast_lowered_to::<llvm::PtrToIntOp>(&ctx, module_ptr, "llvm.ptrtoint");
+            assert_eq!(
+                count_ops::<llvm::AddrSpaceCastOp>(&ctx, &kernel_blocks(&ctx, module_ptr)),
+                1,
+                "address space {address_space} must become generic before exposing its address"
+            );
+        }
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -160,7 +160,7 @@ pub fn convert(
         }
 
         MirCastKindAttr::PointerWithExposedProvenance => {
-            llvm::IntToPtrOp::new(ctx, val, llvm_ty).get_operation()
+            emit_int_to_ptr(ctx, rewriter, val, llvm_ty)
         }
     };
 
@@ -479,7 +479,7 @@ fn emit_pointer_cast(
     } else if src_is_ptr && llvm_ty.deref(ctx).is::<IntegerType>() {
         Ok(emit_ptr_to_int(ctx, rewriter, val, val_ty, llvm_ty))
     } else if src_is_int && dst_is_ptr {
-        Ok(llvm::IntToPtrOp::new(ctx, val, llvm_ty).get_operation())
+        Ok(emit_int_to_ptr(ctx, rewriter, val, llvm_ty))
     } else if src_is_struct && dst_is_struct {
         emit_transmute_via_memory(ctx, rewriter, val, val_ty, llvm_ty)
     } else if let (Some(s), Some(d)) = (src_as, dst_as) {
@@ -622,9 +622,7 @@ fn emit_transmute(
         (Some(_), None) if dst_is_int => {
             Ok(llvm::PtrToIntOp::new(ctx, val, llvm_ty).get_operation())
         }
-        (None, Some(_)) if src_is_int => {
-            Ok(llvm::IntToPtrOp::new(ctx, val, llvm_ty).get_operation())
-        }
+        (None, Some(_)) if src_is_int => Ok(emit_int_to_ptr(ctx, rewriter, val, llvm_ty)),
         (Some(_), None) => {
             let integer_ty: pliron::r#type::TypeHandle =
                 IntegerType::get(ctx, src_bits, Signedness::Signless).into();
@@ -639,7 +637,7 @@ fn emit_transmute(
             let bitcast = llvm::BitcastOp::new(ctx, val, integer_ty);
             rewriter.insert_operation(ctx, bitcast.get_operation());
             let integer = bitcast.get_operation().deref(ctx).get_result(0);
-            Ok(llvm::IntToPtrOp::new(ctx, integer, llvm_ty).get_operation())
+            Ok(emit_int_to_ptr(ctx, rewriter, integer, llvm_ty))
         }
         (None, None) => Ok(llvm::BitcastOp::new(ctx, val, llvm_ty).get_operation()),
     }
@@ -697,6 +695,37 @@ fn emit_ptr_to_int(
     };
 
     llvm::PtrToIntOp::new(ctx, val, int_ty).get_operation()
+}
+
+/// Materialize an integer as a pointer, entering named address spaces
+/// through the CUDA generic space.
+///
+/// The inverse boundary of [`emit_ptr_to_int`]: an exposed pointer address
+/// is the CUDA generic address, so an integer cast back into a named
+/// address space must `inttoptr` to generic first and then `addrspacecast`
+/// into that space. A bare `inttoptr` into a named space would reinterpret
+/// the generic address as a space-local offset and break the
+/// expose/with-exposed-provenance round trip.
+fn emit_int_to_ptr(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    val: pliron::value::Value,
+    ptr_ty: pliron::r#type::TypeHandle,
+) -> Ptr<Operation> {
+    let address_space = ptr_ty
+        .deref(ctx)
+        .downcast_ref::<PointerType>()
+        .map(PointerType::address_space);
+    match address_space {
+        None | Some(0) => llvm::IntToPtrOp::new(ctx, val, ptr_ty).get_operation(),
+        Some(_) => {
+            let generic_ptr_ty = PointerType::get_generic(ctx);
+            let to_generic = llvm::IntToPtrOp::new(ctx, val, generic_ptr_ty.into());
+            rewriter.insert_operation(ctx, to_generic.get_operation());
+            let generic = to_generic.get_operation().deref(ctx).get_result(0);
+            llvm::AddrSpaceCastOp::new(ctx, generic, ptr_ty).get_operation()
+        }
+    }
 }
 
 fn const_i64(
@@ -1443,6 +1472,58 @@ mod tests {
         );
 
         assert_cast_lowered_to::<llvm::IntToPtrOp>(&ctx, module_ptr, "llvm.inttoptr");
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &kernel_blocks(&ctx, module_ptr)),
+            0,
+            "generic pointers need no address-space conversion"
+        );
+    }
+
+    #[test]
+    fn named_space_pointer_with_exposed_provenance_enters_through_generic() {
+        for address_space in [
+            llvm_export::types::address_space::GLOBAL,
+            llvm_export::types::address_space::SHARED,
+            llvm_export::types::address_space::CONSTANT,
+            llvm_export::types::address_space::LOCAL,
+        ] {
+            let mut ctx = make_ctx();
+            let usize_ty = int_ty(&mut ctx, 64, Signedness::Unsigned);
+            let pointee_ty = int_ty(&mut ctx, 32, Signedness::Signless);
+            let ptr_ty: TypeHandle =
+                MirPtrType::get(&mut ctx, pointee_ty, false, address_space).into();
+
+            let module_ptr = lower_single_cast(
+                &mut ctx,
+                usize_ty,
+                ptr_ty,
+                MirCastKindAttr::PointerWithExposedProvenance,
+            );
+
+            // The exposed integer is a generic address, so re-entry must be
+            // inttoptr-to-generic followed by addrspacecast into the space,
+            // mirroring the PointerExposeAddress direction.
+            assert_cast_lowered_to::<llvm::AddrSpaceCastOp>(&ctx, module_ptr, "llvm.addrspacecast");
+            assert_eq!(
+                count_ops::<llvm::IntToPtrOp>(&ctx, &kernel_blocks(&ctx, module_ptr)),
+                1,
+                "address space {address_space} must re-enter through a generic inttoptr"
+            );
+            let casts = find_all::<llvm::AddrSpaceCastOp>(&ctx, &kernel_blocks(&ctx, module_ptr));
+            let [cast] = casts.as_slice() else {
+                panic!("expected exactly one llvm.addrspacecast");
+            };
+            let result_ty = cast
+                .get_operation()
+                .deref(&ctx)
+                .get_result(0)
+                .get_type(&ctx);
+            assert_eq!(
+                pointer_addrspace(&ctx, result_ty),
+                address_space,
+                "the addrspacecast must land in the destination space"
+            );
+        }
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -1154,8 +1154,9 @@ pub(crate) fn llvm_type_size_align(ctx: &Context, ty: TypeHandle) -> Option<(u64
     if ty_ref.is::<llvm_types::PointerType>() {
         // Lowering runs before the exporter chooses the minimal, legacy, or
         // modern NVPTX data layout. The first two use 64-bit pointers in all
-        // address spaces; modern NVVM alone uses p3:32. Enum storage rejects
-        // shared pointers below because no one target-agnostic size is sound.
+        // address spaces; modern NVVM alone uses p3:32. Callers that expose
+        // physical shared-pointer width must either genericize a direct
+        // pointer first or reject the target-dependent representation.
         return Some((8, 8));
     }
     if let Some(arr_ty) = ty_ref.downcast_ref::<llvm_types::ArrayType>() {
@@ -1458,18 +1459,36 @@ pub(crate) fn build_enum_slot_map(
             continue;
         }
         let llvm_ty = field_llvm_types[flat];
-        if llvm_type_contains_pointer_in_address_space(
-            ctx,
-            llvm_ty,
-            llvm_types::address_space::SHARED,
-        ) {
+        let is_direct_shared_pointer = llvm_ty
+            .deref(ctx)
+            .downcast_ref::<llvm_types::PointerType>()
+            .is_some_and(|pointer| pointer.address_space() == llvm_types::address_space::SHARED);
+        if !is_direct_shared_pointer
+            && llvm_type_contains_pointer_in_address_space(
+                ctx,
+                llvm_ty,
+                llvm_types::address_space::SHARED,
+            )
+        {
             return Err(anyhow::anyhow!(
-                "enum slot map: `{}` field {} contains a shared-memory pointer whose size is target-mode dependent (64-bit PTX/legacy, 32-bit modern NVVM); refusing target-agnostic enum lowering",
+                "enum slot map: `{}` field {} contains a nested shared-memory pointer whose size is target-mode dependent (64-bit PTX/legacy, 32-bit modern NVVM); refusing target-agnostic enum lowering",
                 name,
                 flat
             ));
         }
-        let (size, align) = llvm_type_size_align(ctx, llvm_ty).ok_or_else(|| {
+        // A raw shared pointer is 32-bit in modern NVVM but Rust's logical
+        // pointer layout is 64-bit. Store it in the enum as a CUDA generic
+        // pointer, whose representation includes the memory-space identity
+        // and is 64-bit in every supported target mode. Enum construction
+        // and payload extraction insert the address-space casts at the value
+        // boundary. Nested aggregates still fail closed above because their
+        // pointer leaves cannot be retagged without rebuilding the aggregate.
+        let physical_ty: TypeHandle = if is_direct_shared_pointer {
+            llvm_types::PointerType::get_generic(ctx).into()
+        } else {
+            llvm_ty
+        };
+        let (size, align) = llvm_type_size_align(ctx, physical_ty).ok_or_else(|| {
             anyhow::anyhow!(
                 "enum slot map: `{}` field {} has unsupported LLVM size/alignment",
                 name,
@@ -1577,9 +1596,9 @@ pub(crate) fn build_enum_slot_map(
                 )
             })?
         } else {
-            llvm_ty
+            physical_ty
         };
-        let field_gets_slot = storage_ty == llvm_ty;
+        let field_gets_slot = storage_ty == llvm_ty || is_direct_shared_pointer;
 
         // Another variant already placed the same storage type at the same
         // position? Then both fields can simply use that claim: variants
@@ -3206,7 +3225,7 @@ mod tests {
     }
 
     #[test]
-    fn enum_slot_map_rejects_nonoverlapping_shared_pointer_payload() {
+    fn enum_slot_map_genericizes_nonoverlapping_shared_pointer_payload() {
         let mut ctx = make_ctx();
         let discr = mir_uint(&mut ctx, 32);
         let u32_ty = mir_uint(&mut ctx, 32);
@@ -3232,10 +3251,81 @@ mod tests {
             },
         )
         .into();
+        let map = build_enum_slot_map(&mut ctx, enum_ty)
+            .expect("a direct shared-pointer payload should use generic physical storage");
+        let field_slot = map.field_slots[0].expect("shared pointer field should own a slot");
+        let stored_ty = map
+            .llvm_struct_ty
+            .deref(&ctx)
+            .downcast_ref::<llvm_types::StructType>()
+            .map(|struct_ty| struct_ty.field_type(field_slot as usize))
+            .expect("field slot must exist");
+        assert_eq!(
+            stored_ty
+                .deref(&ctx)
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("shared pointer storage must remain a pointer")
+                .address_space(),
+            llvm_types::address_space::GENERIC,
+            "enum storage must use a target-stable generic pointer"
+        );
+        assert_eq!(
+            map.field_llvm_types[0]
+                .deref(&ctx)
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("semantic field must remain a pointer")
+                .address_space(),
+            llvm_types::address_space::SHARED,
+            "payload operations must retain the semantic shared address space"
+        );
+    }
+
+    #[test]
+    fn enum_slot_map_still_rejects_nested_shared_pointer_payload() {
+        let mut ctx = make_ctx();
+        let discr = mir_uint(&mut ctx, 32);
+        let u32_ty = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, u32_ty, false).into();
+        let wrapper: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "SharedPointerWrapper".into(),
+            vec!["pointer".into()],
+            vec![shared],
+            vec![0],
+            vec![0],
+            8,
+            8,
+        )
+        .into();
+        let enum_ty: TypeHandle = MirEnumType::get_with_encoding(
+            &mut ctx,
+            "NestedSharedPointerPayload".into(),
+            discr,
+            vec![0, 1],
+            vec![
+                EnumVariant::unit("Unit".into()),
+                EnumVariant::new_with_layout("Ptr".into(), vec![wrapper], vec![8], vec![8]),
+            ],
+            EnumEncoding {
+                tag_offset: 0,
+                total_size: 16,
+                abi_align: 8,
+                layout_kind: EnumLayoutKind::Direct,
+                carrier_kind: EnumCarrierKind::Integer,
+                carrier_width: 32,
+                variant_inhabited: vec![1, 1],
+                ..EnumEncoding::default()
+            },
+        )
+        .into();
+
         let error = build_enum_slot_map(&mut ctx, enum_ty)
             .err()
-            .expect("shared pointer enum payload must reject");
-        assert!(error.to_string().contains("target-mode dependent"));
+            .expect("nested shared-pointer payloads remain target-mode dependent");
+        assert!(
+            error.to_string().contains("nested shared-memory pointer"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/STATUS.md
+++ b/crates/rustc-codegen-cuda/STATUS.md
@@ -15,7 +15,7 @@ Run `scripts/check-error-example-status.sh` to verify both are in sync.
 | :------------------------------------ | :------------------ | :---------------------------------- |
 | `error`                               | diagnostics-fixture | `core::fmt` reachable from device   |
 | `error_enum_pointer_overlap`          | support-gap         | Overlaid pointer/integer payload    |
-| `error_enum_shared_pointer_layout`    | support-gap         | Mode-dependent AS3 pointer width    |
+| `error_enum_shared_pointer_layout`    | support-gap         | Nested AS3 pointer representation   |
 | `error_generated_intrinsic_abi`       | diagnostics-fixture | Unsupported raw intrinsic ABI       |
 | `error_generated_intrinsic_callable`  | diagnostics-fixture | Raw intrinsic passed through `Fn`   |
 | `error_generated_intrinsic_fn_pointer`| diagnostics-fixture | Raw intrinsic made into `fn` pointer|
@@ -40,10 +40,12 @@ a drop is either proven unobservable or its call is emitted.
 The remaining enum storage fixtures deliberately fail closed. Pointer and
 integer payloads cannot share one lowered slot without erasing LLVM pointer
 provenance. Shared-memory pointers are 64 bits in PTX and legacy NVVM output
-but 32 bits in modern NVVM output, while MIR lowering does not yet know which
-exporter mode will be selected. Accepting either case would risk generating
-wrong code, so both remain rejected until their information can be preserved
-through lowering. (Bools nested in aggregate payloads are no longer in this
-list: enum storage claims each payload's byte-faithful twin and construction
-zero-extends every `i1` leaf into its canonical memory byte, so
-`Option<struct { u32, bool }>` and related layouts are supported.)
+but 32 bits in modern NVVM output. A direct enum payload can use a target-stable
+generic pointer slot, but a pointer nested inside an aggregate would require
+recursively rebuilding that aggregate at construction and extraction
+boundaries. Accepting the nested case without that conversion would risk
+generating wrong code, so it remains rejected. (Bools nested in aggregate
+payloads are no longer in this list: enum storage claims each payload's
+byte-faithful twin and construction zero-extends every `i1` leaf into its
+canonical memory byte, so `Option<struct { u32, bool }>` and related layouts
+are supported.)

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -13,6 +13,15 @@
 //! addressof's block, the GEP referenced a `%vN` no instruction defined and
 //! libNVVM rejected the IR.
 //!
+//! The same kernel verifies that exposing the address of the first static
+//! shared allocation does not turn its valid shared-space offset zero into a
+//! null Rust address. Named-space pointers must become CUDA generic pointers
+//! before pointer-to-integer conversion.
+//!
+//! It also constructs and matches a direct enum payload containing that shared
+//! pointer. The enum's physical storage must stay 64-bit even when modern NVVM
+//! uses a 32-bit representation for semantic shared-space pointers.
+//!
 //! This example launches the kernel through `cuda_host::ltoir::load_kernel_module`,
 //! which compiles the cuda-oxide-emitted NVVM IR via libNVVM and links the
 //! cubin via nvJitLink. A dangling SSA reference in the `.ll` would fail at
@@ -28,9 +37,29 @@ use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, SharedArray, device, kernel, thread};
 use cuda_host::{cuda_module, ltoir};
 
+enum SharedPointerPayload {
+    Empty,
+    Pointer(*mut SharedArray<f32, 1>),
+}
+
 #[cuda_module]
 mod kernels {
     use super::*;
+
+    #[inline(never)]
+    #[device]
+    fn shared_pointer_enum_address(use_pointer: bool, pointer: *mut SharedArray<f32, 1>) -> usize {
+        let payload = if use_pointer {
+            SharedPointerPayload::Pointer(pointer)
+        } else {
+            SharedPointerPayload::Empty
+        };
+
+        match payload {
+            SharedPointerPayload::Empty => 0,
+            SharedPointerPayload::Pointer(extracted) => extracted.addr(),
+        }
+    }
 
     #[kernel]
     pub fn sharedarray_late_use(seed: f32, mut out: DisjointSlice<f32>) {
@@ -43,6 +72,27 @@ mod kernels {
                 // Issue #54 repro shape: load addressof[0], multiply, store.
                 OUTPUT_NORM[0] = OUTPUT_NORM[0] * weight;
                 *out.get_unchecked_mut(0) = OUTPUT_NORM[0];
+
+                // The first static shared allocation has local shared offset
+                // zero, but its CUDA generic address must not be null.
+                let raw = &raw mut OUTPUT_NORM;
+                let raw_address = raw.addr();
+                *out.get_unchecked_mut(1) = if raw.is_null() || raw_address == 0 {
+                    0.0
+                } else {
+                    1.0
+                };
+
+                // A direct enum payload keeps the pointer's shared-space
+                // semantics while using target-stable generic physical
+                // storage. The runtime condition keeps construction,
+                // discriminant inspection, and extraction observable.
+                let enum_address = shared_pointer_enum_address(seed != 0.0, raw);
+                *out.get_unchecked_mut(2) = if enum_address == raw_address {
+                    1.0
+                } else {
+                    0.0
+                };
             }
         }
     }
@@ -66,21 +116,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module = kernels::from_module(raw_module).expect("typed module init failed");
 
     let cfg = LaunchConfig::for_num_elems(1);
-    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 1)?;
+    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 3)?;
     let seed: f32 = 7.0;
 
-    // SAFETY: one thread is launched, matching the kernel's single-element
-    // output access and fixed shared-memory use.
+    // SAFETY: one thread is launched, matching the kernel's three-element output
+    // access and fixed shared-memory use.
     unsafe { module.sharedarray_late_use(stream.as_ref(), cfg, seed, &mut out) }?;
 
-    let result = out.to_host_vec(&stream)?[0];
+    let result = out.to_host_vec(&stream)?;
     let expected: f32 = 21.0; // seed * repro_weight() == 7.0 * 3.0
 
-    if (result - expected).abs() < f32::EPSILON {
-        println!("PASS addressof_sharedarray: seed={seed}, result={result}");
-        Ok(())
-    } else {
-        eprintln!("FAIL addressof_sharedarray: got {result}, expected {expected}");
+    if (result[0] - expected).abs() >= f32::EPSILON {
+        eprintln!(
+            "FAIL addressof_sharedarray: got {}, expected {expected}",
+            result[0]
+        );
         std::process::exit(1);
     }
+    if (result[1] - 1.0).abs() >= f32::EPSILON {
+        eprintln!("FAIL addressof_sharedarray: shared offset zero exposed as null");
+        std::process::exit(1);
+    }
+    if (result[2] - 1.0).abs() >= f32::EPSILON {
+        eprintln!("FAIL addressof_sharedarray: shared pointer enum did not round-trip");
+        std::process::exit(1);
+    }
+    println!(
+        "PASS addressof_sharedarray: seed={seed}, result={}, shared address is non-null, shared pointer enum round-tripped",
+        result[0]
+    );
+    Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -16,7 +16,9 @@
 //! The same kernel verifies that exposing the address of the first static
 //! shared allocation does not turn its valid shared-space offset zero into a
 //! null Rust address. Named-space pointers must become CUDA generic pointers
-//! before pointer-to-integer conversion.
+//! before pointer-to-integer conversion, and the exposed integer must cast
+//! back into the shared space through the generic space, so the
+//! expose/recover round trip stores through the recovered pointer.
 //!
 //! It also constructs and matches a direct enum payload containing that shared
 //! pointer. The enum's physical storage must stay 64-bit even when modern NVVM
@@ -93,6 +95,25 @@ mod kernels {
                 } else {
                     0.0
                 };
+
+                // The exposed integer is a generic address, so casting it
+                // back into the shared space must recover the original
+                // pointer (inttoptr to generic, then cvta back to shared).
+                // Write through the recovered pointer and observe the store
+                // through the original allocation.
+                // The recovered pointer must equal the original as a value,
+                // not merely reach the same memory: hardware masks the
+                // shared-window base out of st.shared addresses, so a wrong
+                // pointer value can still store to the right slot.
+                let round_trip = recover_shared_pointer(raw_address);
+                (&mut (*round_trip))[0] = OUTPUT_NORM[0] + 1.0;
+                *out.get_unchecked_mut(3) = if core::ptr::eq(round_trip, raw)
+                    && OUTPUT_NORM[0] == seed * repro_weight() + 1.0
+                {
+                    1.0
+                } else {
+                    0.0
+                };
             }
         }
     }
@@ -101,6 +122,18 @@ mod kernels {
     #[device]
     fn repro_weight() -> f32 {
         3.0
+    }
+
+    /// Recover a shared pointer from its exposed integer address.
+    ///
+    /// `#[inline(never)]` keeps the `inttoptr` in a function that cannot
+    /// see the matching `ptrtoint`, so LLVM's InferAddressSpaces cannot
+    /// fold the pair away and the lowering's own re-entry rule is what
+    /// executes.
+    #[inline(never)]
+    #[device]
+    fn recover_shared_pointer(address: usize) -> *mut SharedArray<f32, 1> {
+        address as *mut SharedArray<f32, 1>
     }
 }
 
@@ -116,7 +149,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module = kernels::from_module(raw_module).expect("typed module init failed");
 
     let cfg = LaunchConfig::for_num_elems(1);
-    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 3)?;
+    let mut out = DeviceBuffer::<f32>::zeroed(&stream, 4)?;
     let seed: f32 = 7.0;
 
     // SAFETY: one thread is launched, matching the kernel's three-element output
@@ -141,8 +174,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("FAIL addressof_sharedarray: shared pointer enum did not round-trip");
         std::process::exit(1);
     }
+    if (result[3] - 1.0).abs() >= f32::EPSILON {
+        eprintln!(
+            "FAIL addressof_sharedarray: integer address did not cast back to the shared pointer"
+        );
+        std::process::exit(1);
+    }
     println!(
-        "PASS addressof_sharedarray: seed={seed}, result={}, shared address is non-null, shared pointer enum round-tripped",
+        "PASS addressof_sharedarray: seed={seed}, result={}, shared address is non-null, shared pointer enum round-tripped, integer address cast back to the shared pointer",
         result[0]
     );
     Ok(())

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -17,6 +17,7 @@
 //! Run: cargo oxide run compiler_features
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
+use cuda_device::shared::cvta_generic_to_shared;
 use cuda_device::{DisjointSlice, SharedArray, kernel, thread};
 use cuda_host::cuda_module;
 
@@ -202,7 +203,7 @@ mod kernels {
         }
     }
 
-    /// Test Via *const u8 (current approach - has cvta round-trip)
+    /// Test Via *const u8 (must agree with the direct cast)
     #[kernel]
     pub unsafe fn test_smem_addr_via_ptr_u8(mut out: DisjointSlice<u64>) {
         static mut SMEM: SharedArray<u8, 256, 128> = SharedArray::UNINIT;
@@ -211,6 +212,18 @@ mod kernels {
         if let Some(out_elem) = out.get_mut(idx) {
             let addr = &raw const SMEM as *const u8 as u64;
             *out_elem = addr;
+        }
+    }
+
+    /// Test the explicit raw `.shared` offset path for hardware descriptors
+    #[kernel]
+    pub unsafe fn test_smem_addr_shared_offset(mut out: DisjointSlice<u64>) {
+        static mut SMEM: SharedArray<u8, 256, 128> = SharedArray::UNINIT;
+
+        let idx = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let offset = unsafe { cvta_generic_to_shared(&raw const SMEM as *const u8) };
+            *out_elem = offset;
         }
     }
 
@@ -865,16 +878,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n-----------------------------------------");
     println!("SHARED MEMORY ADDRESS CASTING TESTS");
     println!("-----------------------------------------");
-    println!("Comparing: &raw const SMEM as u64  vs  &raw const SMEM as *const u8 as u64");
-    println!();
 
     let mut smem_direct_ok = true;
 
-    // Test 1: DIRECT cast - &raw const SMEM as u64.
-    // This is a real pass/fail test: the direct cast must keep the address
-    // in the shared address space (small value, no cvta round-trip).
-    println!("Testing: test_smem_addr_direct_u64 (&raw const SMEM as u64)");
-    {
+    // Rust-observed pointer addresses are CUDA generic addresses (the nvcc
+    // model): `ptr as u64` must yield the same nonzero generic address
+    // whether or not an intermediate `*const u8` cast is involved. The raw
+    // `.shared` window offset is available only through the explicit
+    // `cvta_generic_to_shared` intrinsic, which hardware SMEM descriptors
+    // consume.
+    println!("Testing: generic-address contract for shared statics");
+    let direct = {
         let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, 1)?;
         unsafe {
             module.test_smem_addr_direct_u64(
@@ -883,24 +897,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &mut out_dev,
             )
         }?;
-        let result = out_dev.to_host_vec(&stream)?;
-        println!("  DIRECT addr: 0x{:016x}", result[0]);
-        if result[0] < 0x100000 {
-            println!("  ✓ SMALL value = likely shared address (what we want!)");
-        } else {
-            println!("  ✗ FAILED: LARGE value = generic address (cvta happened)");
-            smem_direct_ok = false;
-        }
-    }
-
-    // Test 2: Via *const u8 (informational, documents known limitation).
-    // The intermediate `*const u8` cast currently triggers a cvta round-trip;
-    // we print the observed address but don't fail on it. Whenever this lights
-    // up as "SMALL value" we know the upstream codegen quirk is gone and we
-    // can promote it to a real assertion.
-    println!("\nInfo: test_smem_addr_via_ptr_u8 (&raw const SMEM as *const u8 as u64)");
-    println!("  (known: today's lowering inserts a cvta round-trip here)");
-    {
+        out_dev.to_host_vec(&stream)?[0]
+    };
+    let via_ptr = {
         let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, 1)?;
         unsafe {
             module.test_smem_addr_via_ptr_u8(
@@ -909,17 +908,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &mut out_dev,
             )
         }?;
-        let result = out_dev.to_host_vec(&stream)?;
-        println!("  VIA PTR addr: 0x{:016x}", result[0]);
-        if result[0] < 0x100000 {
-            println!("  (small value — cvta round-trip elided)");
-        } else {
-            println!("  (large value — cvta round-trip present, as documented)");
-        }
-    }
+        out_dev.to_host_vec(&stream)?[0]
+    };
+    let shared_offset = {
+        let mut out_dev = DeviceBuffer::<u64>::zeroed(&stream, 1)?;
+        unsafe {
+            module.test_smem_addr_shared_offset(
+                (stream).as_ref(),
+                LaunchConfig::for_num_elems(1),
+                &mut out_dev,
+            )
+        }?;
+        out_dev.to_host_vec(&stream)?[0]
+    };
 
-    println!("\n-----------------------------------------");
-    println!("Check PTX for 'cvta' in each test function.");
+    println!("  DIRECT addr:   0x{direct:016x}");
+    println!("  VIA PTR addr:  0x{via_ptr:016x}");
+    println!("  SHARED offset: 0x{shared_offset:016x}");
+    if direct == 0 {
+        println!("  ✗ FAILED: generic address of a valid shared static is null");
+        smem_direct_ok = false;
+    }
+    if direct != via_ptr {
+        println!("  ✗ FAILED: the two Rust-level casts disagree on the address");
+        smem_direct_ok = false;
+    }
+    if shared_offset >= 0x100000 {
+        println!("  ✗ FAILED: cvta_generic_to_shared must yield the raw .shared offset");
+        smem_direct_ok = false;
+    }
+    if shared_offset % 128 != 0 {
+        println!("  ✗ FAILED: shared offset ignores the array's 128-byte alignment");
+        smem_direct_ok = false;
+    }
+    if smem_direct_ok {
+        println!("  ✓ generic addresses agree and are non-null; raw offset via intrinsic");
+    }
 
     if !smem_direct_ok {
         println!("\n=== FAILED: at least one test did not pass ===");

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -17,7 +17,7 @@
 //! Run: cargo oxide run compiler_features
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::shared::cvta_generic_to_shared;
+use cuda_device::shared::cvta_generic_to_shared_offset;
 use cuda_device::{DisjointSlice, SharedArray, kernel, thread};
 use cuda_host::cuda_module;
 
@@ -222,7 +222,7 @@ mod kernels {
 
         let idx = thread::index_1d();
         if let Some(out_elem) = out.get_mut(idx) {
-            let offset = unsafe { cvta_generic_to_shared(&raw const SMEM as *const u8) };
+            let offset = unsafe { cvta_generic_to_shared_offset(&raw const SMEM as *const u8) };
             *out_elem = offset;
         }
     }
@@ -885,7 +885,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // model): `ptr as u64` must yield the same nonzero generic address
     // whether or not an intermediate `*const u8` cast is involved. The raw
     // `.shared` window offset is available only through the explicit
-    // `cvta_generic_to_shared` intrinsic, which hardware SMEM descriptors
+    // `cvta_generic_to_shared_offset` intrinsic, which hardware SMEM descriptors
     // consume.
     println!("Testing: generic-address contract for shared statics");
     let direct = {
@@ -934,7 +934,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         smem_direct_ok = false;
     }
     if shared_offset >= 0x100000 {
-        println!("  ✗ FAILED: cvta_generic_to_shared must yield the raw .shared offset");
+        println!("  ✗ FAILED: cvta_generic_to_shared_offset must yield the raw .shared offset");
         smem_direct_ok = false;
     }
     if shared_offset % 128 != 0 {

--- a/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/README.md
+++ b/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/README.md
@@ -1,14 +1,16 @@
 # `error_enum_shared_pointer_layout`
 
-Negative test for `Option<&SharedArray<...>>`.
+Negative test for `Option<SharedPointerWrapper>`, where the wrapper contains a
+`&SharedArray<...>`.
 
 Shared-memory pointers use different LLVM storage widths depending on output
 mode: 64 bits in the ordinary PTX and legacy NVVM layouts, but 32 bits in the
-modern NVVM layout. MIR-to-LLVM lowering currently runs before that mode is
-known, so it cannot choose one byte-faithful enum representation.
+modern NVVM layout. A direct enum pointer field can use generic physical
+storage, but a nested aggregate would have to be rebuilt recursively to replace
+its semantic shared pointer with that target-stable representation.
 
-The compiler must reject this enum instead of silently leaving half of its
-carrier undefined:
+The compiler must reject this nested shape instead of silently leaving half of
+its payload undefined:
 
 ```bash
 cargo oxide build error_enum_shared_pointer_layout
@@ -19,5 +21,5 @@ cargo oxide build error_enum_shared_pointer_layout --emit-nvvm-ir --arch sm_100
 Expected diagnostic:
 
 ```text
-contains a shared-memory pointer whose size is target-mode dependent
+contains a nested shared-memory pointer whose size is target-mode dependent
 ```

--- a/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/src/main.rs
@@ -3,16 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Negative test: enum storage containing a shared-memory pointer must fail
-//! closed until MIR lowering knows which exporter data layout was selected.
+//! Negative test: enum storage containing a shared-memory pointer nested in an
+//! aggregate must fail closed until lowering can rebuild that aggregate with a
+//! target-stable physical pointer representation.
 
 use cuda_device::{SharedArray, kernel};
 
 static mut SHARED: SharedArray<u32, 1> = SharedArray::UNINIT;
 
+struct SharedPointerWrapper {
+    pointer: &'static SharedArray<u32, 1>,
+}
+
 #[inline(never)]
-fn pointer_bits(value: Option<&'static SharedArray<u32, 1>>) -> u64 {
-    value.map_or(0, |pointer| pointer as *const SharedArray<u32, 1> as u64)
+fn pointer_bits(value: Option<SharedPointerWrapper>) -> u64 {
+    value.map_or(0, |wrapper| {
+        wrapper.pointer as *const SharedArray<u32, 1> as u64
+    })
 }
 
 /// # Safety
@@ -24,7 +31,7 @@ pub unsafe fn shared_pointer_enum(out: *mut u64) {
     let shared_ptr: *const SharedArray<u32, 1> = &raw const SHARED;
     let shared: &'static SharedArray<u32, 1> = unsafe { &*shared_ptr };
     unsafe {
-        *out = pointer_bits(Some(shared));
+        *out = pointer_bits(Some(SharedPointerWrapper { pointer: shared }));
     }
 }
 

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
@@ -50,7 +50,7 @@ use cuda_device::clc::{
     clc_query_get_first_ctaid_x, clc_query_is_canceled, clc_try_cancel, clc_try_cancel_multicast,
 };
 use cuda_device::cluster;
-use cuda_device::shared::SharedArray;
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
     cvt_f32x2_bf16x2, stmatrix_m8n8_x2, tcgen05_alloc, tcgen05_alloc_cg2,
@@ -421,8 +421,8 @@ mod kernels {
                 //   j=2: K-groups 4,5 (K=32..47)  — base offset =  8192
                 //   j=3: K-groups 6,7 (K=48..63)  — base offset = 12288
                 if is_thread0 {
-                    let smem_a_base = &raw const SMEM_A as u64;
-                    let smem_b_base = &raw const SMEM_B as u64;
+                    let smem_a_base = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
+                    let smem_b_base = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
 
                     let mut j: u32 = 0;
                     while j < 4 {
@@ -693,8 +693,8 @@ mod kernels {
                 //   j=2: byte offset 64 (K=32..47)
                 //   j=3: byte offset 96 (K=48..63)
                 if is_thread0 {
-                    let smem_a_base = &raw const SMEM_A as u64;
-                    let smem_b_base = &raw const SMEM_B as u64;
+                    let smem_a_base = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
+                    let smem_b_base = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
 
                     let mut j: u32 = 0;
                     while j < 4 {

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
@@ -50,7 +50,7 @@ use cuda_device::clc::{
     clc_query_get_first_ctaid_x, clc_query_is_canceled, clc_try_cancel, clc_try_cancel_multicast,
 };
 use cuda_device::cluster;
-use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
     cvt_f32x2_bf16x2, stmatrix_m8n8_x2, tcgen05_alloc, tcgen05_alloc_cg2,
@@ -421,8 +421,8 @@ mod kernels {
                 //   j=2: K-groups 4,5 (K=32..47)  — base offset =  8192
                 //   j=3: K-groups 6,7 (K=48..63)  — base offset = 12288
                 if is_thread0 {
-                    let smem_a_base = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
-                    let smem_b_base = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
+                    let smem_a_base = cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8);
+                    let smem_b_base = cvta_generic_to_shared_offset(&raw const SMEM_B as *const u8);
 
                     let mut j: u32 = 0;
                     while j < 4 {
@@ -693,8 +693,8 @@ mod kernels {
                 //   j=2: byte offset 64 (K=32..47)
                 //   j=3: byte offset 96 (K=48..63)
                 if is_thread0 {
-                    let smem_a_base = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
-                    let smem_b_base = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
+                    let smem_a_base = cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8);
+                    let smem_b_base = cvta_generic_to_shared_offset(&raw const SMEM_B as *const u8);
 
                     let mut j: u32 = 0;
                     while j < 4 {
@@ -950,14 +950,14 @@ mod kernels {
                 // Step 2: Issue MMA on current buffer (async → tensor core)
                 if is_thread0 {
                     let smem_a_base = if buf == 0 {
-                        &raw const SMEM_A0 as u64
+                        cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8)
                     } else {
-                        &raw const SMEM_A1 as u64
+                        cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8)
                     };
                     let smem_b_base = if buf == 0 {
-                        &raw const SMEM_B0 as u64
+                        cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8)
                     } else {
-                        &raw const SMEM_B1 as u64
+                        cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8)
                     };
 
                     let mut j: u32 = 0;
@@ -1327,14 +1327,14 @@ mod kernels {
                     // Issue 4 MMAs on this buffer
                     if is_lane0 {
                         let smem_a_base = if stage == 0 {
-                            &raw const SMEM_A0 as u64
+                            cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8)
                         } else {
-                            &raw const SMEM_A1 as u64
+                            cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8)
                         };
                         let smem_b_base = if stage == 0 {
-                            &raw const SMEM_B0 as u64
+                            cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8)
                         } else {
-                            &raw const SMEM_B1 as u64
+                            cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8)
                         };
 
                         let mut j: u32 = 0;
@@ -1758,14 +1758,14 @@ mod kernels {
 
                         if is_lane0 {
                             let smem_a_base = if stage == 0 {
-                                &raw const SMEM_A0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8)
                             } else {
-                                &raw const SMEM_A1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8)
                             };
                             let smem_b_base = if stage == 0 {
-                                &raw const SMEM_B0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8)
                             } else {
-                                &raw const SMEM_B1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8)
                             };
 
                             let mut j: u32 = 0;
@@ -2356,14 +2356,14 @@ mod kernels {
 
                         if is_lane0 {
                             let smem_a_base = if stage == 0 {
-                                &raw const SMEM_A0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8)
                             } else {
-                                &raw const SMEM_A1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8)
                             };
                             let smem_b_base = if stage == 0 {
-                                &raw const SMEM_B0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8)
                             } else {
-                                &raw const SMEM_B1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8)
                             };
 
                             let mut j: u32 = 0;
@@ -2678,9 +2678,18 @@ mod kernels {
 
             // map_shared_rank translates a local SMEM pointer to the address in rank 0's
             // shared memory, for use with mbarrier_arrive_cluster (cross-CTA barrier arrive).
-            let rank0_mcast_bar0_addr = cluster::map_shared_rank(&raw const MCAST_BAR0, 0) as u64;
-            let rank0_mcast_bar1_addr = cluster::map_shared_rank(&raw const MCAST_BAR1, 0) as u64;
-            let rank0_clc_ready_addr = cluster::map_shared_rank(&raw const CLC_READY, 0) as u64;
+            let rank0_mcast_bar0_addr = cvta_generic_to_shared_offset(cluster::map_shared_rank(
+                &raw const MCAST_BAR0,
+                0,
+            ) as *const u8);
+            let rank0_mcast_bar1_addr = cvta_generic_to_shared_offset(cluster::map_shared_rank(
+                &raw const MCAST_BAR1,
+                0,
+            ) as *const u8);
+            let rank0_clc_ready_addr = cvta_generic_to_shared_offset(cluster::map_shared_rank(
+                &raw const CLC_READY,
+                0,
+            ) as *const u8);
 
             // Pre-arrive MMA_BARs so TMA can proceed on the first K-iteration
             if tid == 0 {
@@ -3029,14 +3038,14 @@ mod kernels {
 
                         if is_lane0 {
                             let smem_a_base = if stage == 0 {
-                                &raw const SMEM_A0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8)
                             } else {
-                                &raw const SMEM_A1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8)
                             };
                             let smem_b_base = if stage == 0 {
-                                &raw const SMEM_B0 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8)
                             } else {
-                                &raw const SMEM_B1 as u64
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8)
                             };
 
                             let mut j: u32 = 0;
@@ -3700,26 +3709,26 @@ mod kernels {
                             *mut Barrier,
                         ) = match stage {
                             0 => (
-                                &raw const SMEM_A0 as u64,
-                                &raw const SMEM_B0 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8),
                                 &raw const TMA_BAR0 as *const Barrier,
                                 &raw mut MMA_BAR0 as *mut Barrier,
                             ),
                             1 => (
-                                &raw const SMEM_A1 as u64,
-                                &raw const SMEM_B1 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8),
                                 &raw const TMA_BAR1 as *const Barrier,
                                 &raw mut MMA_BAR1 as *mut Barrier,
                             ),
                             2 => (
-                                &raw const SMEM_A2 as u64,
-                                &raw const SMEM_B2 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A2 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B2 as *const u8),
                                 &raw const TMA_BAR2 as *const Barrier,
                                 &raw mut MMA_BAR2 as *mut Barrier,
                             ),
                             _ => (
-                                &raw const SMEM_A3 as u64,
-                                &raw const SMEM_B3 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A3 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B3 as *const u8),
                                 &raw const TMA_BAR3 as *const Barrier,
                                 &raw mut MMA_BAR3 as *mut Barrier,
                             ),
@@ -3796,10 +3805,12 @@ mod kernels {
                 let mut epi_tile_iter: u32 = 0;
                 let mut tile_parity: u32 = 0;
 
-                let leader_accum_empty0_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as u64;
-                let leader_accum_empty1_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as u64;
+                let leader_accum_empty0_addr = cvta_generic_to_shared_offset(
+                    cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as *const u8,
+                );
+                let leader_accum_empty1_addr = cvta_generic_to_shared_offset(
+                    cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as *const u8,
+                );
 
                 const TILE_N: usize = 128;
                 let warp_row_base = (warp_id * 32) as usize;

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/kernels.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/kernels.rs
@@ -370,26 +370,26 @@ mod kernels {
                             *mut Barrier,
                         ) = match stage {
                             0 => (
-                                &raw const SMEM_A0 as u64,
-                                &raw const SMEM_B0 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8),
                                 &raw const TMA_BAR0 as *const Barrier,
                                 &raw mut MMA_BAR0 as *mut Barrier,
                             ),
                             1 => (
-                                &raw const SMEM_A1 as u64,
-                                &raw const SMEM_B1 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8),
                                 &raw const TMA_BAR1 as *const Barrier,
                                 &raw mut MMA_BAR1 as *mut Barrier,
                             ),
                             2 => (
-                                &raw const SMEM_A2 as u64,
-                                &raw const SMEM_B2 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A2 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B2 as *const u8),
                                 &raw const TMA_BAR2 as *const Barrier,
                                 &raw mut MMA_BAR2 as *mut Barrier,
                             ),
                             _ => (
-                                &raw const SMEM_A3 as u64,
-                                &raw const SMEM_B3 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A3 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B3 as *const u8),
                                 &raw const TMA_BAR3 as *const Barrier,
                                 &raw mut MMA_BAR3 as *mut Barrier,
                             ),
@@ -467,9 +467,9 @@ mod kernels {
                 let mut tile_parity: u32 = 0;
 
                 let leader_accum_empty0_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as u64;
+                    cvta_generic_to_shared_offset(cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as *const u8);
                 let leader_accum_empty1_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as u64;
+                    cvta_generic_to_shared_offset(cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as *const u8);
 
                 const TILE_N: usize = 256;
                 let warp_row_base = (warp_id * 32) as usize;
@@ -986,26 +986,26 @@ mod kernels {
                             *mut Barrier,
                         ) = match stage {
                             0 => (
-                                &raw const SMEM_A0 as u64,
-                                &raw const SMEM_B0 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A0 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B0 as *const u8),
                                 &raw const TMA_BAR0 as *const Barrier,
                                 &raw mut MMA_BAR0 as *mut Barrier,
                             ),
                             1 => (
-                                &raw const SMEM_A1 as u64,
-                                &raw const SMEM_B1 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A1 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B1 as *const u8),
                                 &raw const TMA_BAR1 as *const Barrier,
                                 &raw mut MMA_BAR1 as *mut Barrier,
                             ),
                             2 => (
-                                &raw const SMEM_A2 as u64,
-                                &raw const SMEM_B2 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A2 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B2 as *const u8),
                                 &raw const TMA_BAR2 as *const Barrier,
                                 &raw mut MMA_BAR2 as *mut Barrier,
                             ),
                             _ => (
-                                &raw const SMEM_A3 as u64,
-                                &raw const SMEM_B3 as u64,
+                                cvta_generic_to_shared_offset(&raw const SMEM_A3 as *const u8),
+                                cvta_generic_to_shared_offset(&raw const SMEM_B3 as *const u8),
                                 &raw const TMA_BAR3 as *const Barrier,
                                 &raw mut MMA_BAR3 as *mut Barrier,
                             ),
@@ -1118,9 +1118,9 @@ mod kernels {
                 let mut tile_parity: u32 = 0;
 
                 let leader_accum_empty0_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as u64;
+                    cvta_generic_to_shared_offset(cluster::map_shared_rank(&raw const ACCUM_EMPTY0, 0) as *const u8);
                 let leader_accum_empty1_addr =
-                    cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as u64;
+                    cvta_generic_to_shared_offset(cluster::map_shared_rank(&raw const ACCUM_EMPTY1, 0) as *const u8);
 
                 const SCRATCH_BF16_COLS: usize = 128;
                 const SCRATCH_U32_COLS: usize = SCRATCH_BF16_COLS / 2;

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
@@ -31,7 +31,7 @@ use cuda_device::clc::{
     clc_query_get_first_ctaid_x, clc_query_is_canceled, clc_try_cancel_multicast,
 };
 use cuda_device::cluster;
-use cuda_device::shared::SharedArray;
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
     cvt_f32x2_bf16x2, stmatrix_m8n8_x2, tcgen05_alloc_cg2, tcgen05_commit_multicast_cg2,

--- a/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
@@ -19,6 +19,7 @@ use cuda_device::barrier::{
     mbarrier_try_wait_parity, nanosleep,
 };
 use cuda_device::cluster;
+use cuda_device::shared::cvta_generic_to_shared_offset;
 use cuda_device::{DisjointSlice, cluster_launch, kernel, thread};
 use cuda_host::cuda_module;
 
@@ -48,8 +49,14 @@ mod kernels {
             }
             thread::sync_threads();
 
-            let rank0_bar0_addr = cluster::map_shared_rank(&raw const MCAST_BAR0, 0) as u64;
-            let rank0_bar1_addr = cluster::map_shared_rank(&raw const MCAST_BAR1, 0) as u64;
+            let rank0_bar0_addr = cvta_generic_to_shared_offset(cluster::map_shared_rank(
+                &raw const MCAST_BAR0,
+                0,
+            ) as *const u8);
+            let rank0_bar1_addr = cvta_generic_to_shared_offset(cluster::map_shared_rank(
+                &raw const MCAST_BAR1,
+                0,
+            ) as *const u8);
 
             let is_rank0 = my_rank == 0;
 

--- a/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
@@ -31,7 +31,7 @@
 
 use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig, sys};
 use cuda_device::barrier::Barrier;
-use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     self, Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor,
     Tcgen05MmaShape, Tcgen05SmemDescriptor, Tcgen05SwizzleMode, tcgen05_alloc, tcgen05_alloc_cg2,
@@ -62,7 +62,7 @@ mod kernels {
             let gid = thread::index_1d();
 
             // Test SMEM descriptor builder (single-thread)
-            let smem_addr = cvta_generic_to_shared(&raw const SMEM as *const u8);
+            let smem_addr = cvta_generic_to_shared_offset(&raw const SMEM as *const u8);
             let desc = Tcgen05SmemDescriptor::builder()
                 .address(smem_addr)
                 .leading_dim_bytes(128)
@@ -133,7 +133,7 @@ mod kernels {
             }
             thread::sync_threads();
 
-            let smem_addr = cvta_generic_to_shared(&raw const SMEM as *const u8);
+            let smem_addr = cvta_generic_to_shared_offset(&raw const SMEM as *const u8);
             let desc = Tcgen05SmemDescriptor::builder()
                 .address(smem_addr)
                 .leading_dim_bytes(128)
@@ -191,7 +191,7 @@ mod kernels {
 
             // Step 3: Copy A from SMEM to TMEM
             if tid == 0 {
-                let smem_a_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
+                let smem_a_addr = cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8);
                 let a_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_a_addr)
                     .leading_dim_bytes(1024)
@@ -206,7 +206,7 @@ mod kernels {
 
             // Step 4: Issue MMA
             if tid == 0 {
-                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
+                let smem_b_addr = cvta_generic_to_shared_offset(&raw const SMEM_B as *const u8);
                 let b_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_b_addr)
                     .leading_dim_bytes(1024)
@@ -688,7 +688,7 @@ mod kernels {
             let tmem_addr = *(&raw const TMEM_ADDR as *const u32);
 
             if tid == 0 && block_rank == 0 {
-                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
+                let smem_b_addr = cvta_generic_to_shared_offset(&raw const SMEM_B as *const u8);
                 let b_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_b_addr)
                     .leading_dim_bytes(1024)
@@ -704,7 +704,7 @@ mod kernels {
                     .build()
                     .raw();
 
-                let a_smem_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
+                let a_smem_addr = cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8);
                 let a_desc = Tcgen05SmemDescriptor::builder()
                     .address(a_smem_addr)
                     .leading_dim_bytes(1024)

--- a/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
@@ -31,7 +31,7 @@
 
 use cuda_core::{CudaContext, CudaStream, DeviceBuffer, LaunchConfig, sys};
 use cuda_device::barrier::Barrier;
-use cuda_device::shared::SharedArray;
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
 use cuda_device::tcgen05::{
     self, Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor,
     Tcgen05MmaShape, Tcgen05SmemDescriptor, Tcgen05SwizzleMode, tcgen05_alloc, tcgen05_alloc_cg2,
@@ -62,7 +62,7 @@ mod kernels {
             let gid = thread::index_1d();
 
             // Test SMEM descriptor builder (single-thread)
-            let smem_addr = &raw const SMEM as *const u8 as u64;
+            let smem_addr = cvta_generic_to_shared(&raw const SMEM as *const u8);
             let desc = Tcgen05SmemDescriptor::builder()
                 .address(smem_addr)
                 .leading_dim_bytes(128)
@@ -133,7 +133,7 @@ mod kernels {
             }
             thread::sync_threads();
 
-            let smem_addr = &raw const SMEM as *const u8 as u64;
+            let smem_addr = cvta_generic_to_shared(&raw const SMEM as *const u8);
             let desc = Tcgen05SmemDescriptor::builder()
                 .address(smem_addr)
                 .leading_dim_bytes(128)
@@ -191,7 +191,7 @@ mod kernels {
 
             // Step 3: Copy A from SMEM to TMEM
             if tid == 0 {
-                let smem_a_addr = &raw const SMEM_A as *const u8 as u64;
+                let smem_a_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
                 let a_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_a_addr)
                     .leading_dim_bytes(1024)
@@ -206,7 +206,7 @@ mod kernels {
 
             // Step 4: Issue MMA
             if tid == 0 {
-                let smem_b_addr = &raw const SMEM_B as *const u8 as u64;
+                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
                 let b_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_b_addr)
                     .leading_dim_bytes(1024)
@@ -688,7 +688,7 @@ mod kernels {
             let tmem_addr = *(&raw const TMEM_ADDR as *const u32);
 
             if tid == 0 && block_rank == 0 {
-                let smem_b_addr = &raw const SMEM_B as *const u8 as u64;
+                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
                 let b_desc = Tcgen05SmemDescriptor::builder()
                     .address(smem_b_addr)
                     .leading_dim_bytes(1024)
@@ -704,7 +704,7 @@ mod kernels {
                     .build()
                     .raw();
 
-                let a_smem_addr = &raw const SMEM_A as *const u8 as u64;
+                let a_smem_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
                 let a_desc = Tcgen05SmemDescriptor::builder()
                     .address(a_smem_addr)
                     .leading_dim_bytes(1024)

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
@@ -24,7 +24,7 @@ use cuda_device::barrier::{
     Barrier, fence_proxy_async_shared_cta, mbarrier_arrive_expect_tx, mbarrier_init,
     mbarrier_inval, mbarrier_try_wait, mbarrier_try_wait_parity,
 };
-use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
     cvt_f32x2_bf16x2, stmatrix_m8n8_x2, tcgen05_alloc, tcgen05_commit_shared_cluster,
@@ -135,8 +135,8 @@ mod kernels {
 
             // PHASE 4: Build SMEM descriptors and execute MMA
             if is_thread0 {
-                let smem_a_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
-                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
+                let smem_a_addr = cvta_generic_to_shared_offset(&raw const SMEM_A as *const u8);
+                let smem_b_addr = cvta_generic_to_shared_offset(&raw const SMEM_B as *const u8);
 
                 const SBO_BYTES: u32 = 128; // 64 elements × 2 bytes
                 const LBO_BYTES: u32 = 2048; // 16 tiles × 64 elements × 2 bytes

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
@@ -24,7 +24,7 @@ use cuda_device::barrier::{
     Barrier, fence_proxy_async_shared_cta, mbarrier_arrive_expect_tx, mbarrier_init,
     mbarrier_inval, mbarrier_try_wait, mbarrier_try_wait_parity,
 };
-use cuda_device::shared::SharedArray;
+use cuda_device::shared::{SharedArray, cvta_generic_to_shared};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
     cvt_f32x2_bf16x2, stmatrix_m8n8_x2, tcgen05_alloc, tcgen05_commit_shared_cluster,
@@ -135,8 +135,8 @@ mod kernels {
 
             // PHASE 4: Build SMEM descriptors and execute MMA
             if is_thread0 {
-                let smem_a_addr = &raw const SMEM_A as u64;
-                let smem_b_addr = &raw const SMEM_B as u64;
+                let smem_a_addr = cvta_generic_to_shared(&raw const SMEM_A as *const u8);
+                let smem_b_addr = cvta_generic_to_shared(&raw const SMEM_B as *const u8);
 
                 const SBO_BYTES: u32 = 128; // 64 elements × 2 bytes
                 const LBO_BYTES: u32 = 2048; // 16 tiles × 64 elements × 2 bytes

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -363,8 +363,8 @@ verdict_error() {
             fi
             ;;
         error_enum_shared_pointer_layout)
-            if ! grep -Fq 'contains a shared-memory pointer whose size is target-mode dependent' "${log}"; then
-                echo "FAIL (missing target-dependent shared-pointer layout diagnostic)"
+            if ! grep -Fq 'contains a nested shared-memory pointer whose size is target-mode dependent' "${log}"; then
+                echo "FAIL (missing nested shared-pointer layout diagnostic)"
                 return 1
             fi
             ;;


### PR DESCRIPTION
Closes #625.

## Summary

CUDA named-space pointers are offsets within a memory space, while Rust
pointer-address operations and aggregate layout require one stable logical
pointer representation. This change casts named-space pointers to CUDA generic
space before exposing them as integers and stores direct shared-pointer enum
payloads in generic pointer slots. A valid shared allocation at local offset
zero is therefore non-null, and enum storage remains 64-bit in both legacy PTX
and modern NVVM modes.

## What changed

### Central pointer-address representation

- Added one `emit_ptr_to_int` boundary used by `PointerExposeAddress`,
  pointer-to-integer semantic casts, and the pointer-to-integer transmute that
  implements `ptr::addr` in core.
- Generic pointers continue directly to `ptrtoint`. Every nonzero CUDA address
  space first receives `addrspacecast` to generic space, so the integer
  contains both the address and memory-space identity.
- Audited the remaining direct `ptrtoint` sites. `ldmatrix` intentionally
  consumes a native 32-bit shared offset, while enum niche discrimination
  reads a carrier that is already stored as a generic pointer; neither is a
  Rust pointer-address exposure boundary.
- Kept pointer-bearing aggregate transmutes rejected because lowering still
  lacks target-mode-specific physical width at that boundary. (Maintainer
  follow-up: the reverse integer-to-pointer `as`-cast boundary is now
  handled rather than left as a bare `inttoptr`; see below.)

### Target-stable enum storage

- `build_enum_slot_map` now distinguishes a direct shared-pointer field from
  an aggregate that merely contains one. A direct field claims a generic
  physical pointer slot, while `field_llvm_types` retains its semantic shared
  type.
- Enum construction and payload extraction use one narrow pointer coercion
  helper to cross between semantic and physical address spaces.
- Niche discrimination reads the generic physical carrier, so direct shared
  payload construction, discriminant inspection, and extraction round-trip
  through two explicit address-space casts.
- Extended the repo-native `addressof_sharedarray` example with a noinline
  Rust function that conditionally constructs a direct shared-pointer enum,
  matches its discriminant, extracts the pointer, and compares its address
  with the original. The same kernel now observes both `ptr::addr()` and
  `is_null()`.
- Unit coverage checks the address-exposure boundary for global, shared,
  constant, and local pointers, plus the no-op generic-pointer case.
- Focused tests retain fail-closed behavior for nested shared-pointer fields,
  shared-pointer niche carriers, shared-pointer vectors, and unsupported
  reverse or aggregate transmutes. The existing shared-pointer error example
  now protects the unsupported nested-aggregate boundary instead of expecting
  direct pointer fields to fail.

## Known separate limitations

- Only direct pointer fields receive the representation boundary. Rebuilding
  arbitrary nested pointer-bearing aggregates would need a recursive,
  layout-aware conversion and remains deliberately unsupported.
- A niche carrier that is itself declared in shared address space remains
  target-mode dependent and is rejected; the supported niche shape uses a
  generic physical carrier with a semantic direct shared-pointer payload.
- (Resolved since filing.) Runtime LTOIR smoke on CUDA 12.8 was independently
  blocked by the cubin `e_version` validation; that fix landed separately in
  #622, so the runtime LTOIR route is unblocked on current main.
- Raw shared-array API design and multi-artifact module lookup are unchanged.

## Maintainer follow-ups on this branch

Four commits stacked during review and landing, so the branch as merged is
the author's fix plus:

- `d515c07e` -- the reverse boundary. `usize as *mut SharedArray<T, N>`
  lowered as a bare `inttoptr`, reinterpreting the now-generic exposed
  integer as a space-local offset. `emit_int_to_ptr` mirrors this PR's
  `emit_ptr_to_int` (enter named spaces through generic), wired into
  `PointerWithExposedProvenance`, the pointer-cast int arm, and the
  transmute int arms. Unit tests cover all four named spaces, and the
  `addressof_sharedarray` kernel now recovers a pointer from its exposed
  integer through a noinline function and compares pointer values (a wrong
  value can still store to the right slot because hardware masks the
  shared-window base, so the value comparison is the real check).
- `fce395d5` + rename in `32882d26` -- `cvta_generic_to_shared_offset`, a
  first-class intrinsic (device stub, `nvvm.cvta_generic_to_shared_offset`
  op, exact importer recognizer, PTX-free lowering: `addrspacecast` to
  `addrspace(3)` + `ptrtoint`). Hardware SMEM descriptors encode
  `(start_address >> 4) & 0x3FFF` over the raw `.shared` offset, so
  descriptor bases must not be derived from `ptr as u64` (a generic address)
  once this PR lands. All raw-address exposure sites now route through it:
  gemm_sol (28 per-stage descriptor bases + 5 `cluster::map_shared_rank`
  barrier addresses feeding `mbarrier_arrive_cluster`, whose PTX consumes a
  raw `shared::cluster` address), gemm_sol_final (16 + 4),
  tcgen05/tcgen05_matmul (8), and mcast_barrier_test (2). Emitted PTX
  verified register-pure for both classes.
- `c1322d55` -- `compiler_features` asserted the pre-PR semantics (a direct
  `as u64` had to yield the small raw offset) and failed at runtime under
  the new contract. It now asserts the generic-address contract and
  executes the new intrinsic on GPU (generic `0x..00000400` vs raw offset
  `0x400`).
- `3700dcd5` -- merge with main resolving the two textual conflicts with
  #624 (the exact SharedArray recognizer and the shared example, whose
  kernels collided on one output slot; both extensions kept).

Maintainer validation: full executing smoketest 177/177 on an RTX 5090
(sm_120, CUDA 13.3), 1270 tests across the four touched crates, the
reverse-boundary regression red on the branch as submitted and green with
the fix, and per-example `cargo fmt --check` clean.

## Testing

- Upstream-red: with the address and enum regression source applied to
  `bead880cd7461c67a14bc69d10fa7def538f3394`,
  `cargo oxide run addressof_sharedarray --arch=sm_86` failed with cargo exit
  101 because `SharedPointerPayload` contained a target-dependent shared
  pointer. The earlier address-only form of the same command failed at the
  pointer-to-integer transmute boundary.
- Patched-green: the exact same command passed on an RTX 3080 (sm_86),
  preserving the original issue-54 result (`21`), observing `is_null() ==
  false` and a nonzero address, and round-tripping the direct enum payload.
- Modern NVVM/LTOIR:
  `cargo oxide emit-ltoir addressof_sharedarray --arch=sm_100` passed on the
  clean branch and produced a 4,900-byte compute_100 LTOIR artifact. The
  unoptimized IR records `p3:32`, stores the enum as `{ i64, ptr }`, casts the
  shared pointer to generic on construction, restores shared space on
  extraction, and genericizes again before `ptrtoint`.
- LTOIR integration: with only the separate CUDA-ELF validator condition
  applied transiently,
  `scripts/smoketest.sh --only '^addressof_sharedarray$' --no-color` passed
  1/1 on the RTX 3080 and observed the same address and enum runtime results.
  Without that condition, the clean branch reaches host execution and fails
  solely with `Finalizer(InvalidCubin)`. The unrelated edit was reverted before
  commit.
- `cargo test -p mir-lower --all-targets` passed all 149 unit tests and 76
  lowering integration tests.
- `scripts/smoketest.sh --compile-only --no-color --keep-logs` passed all
  178 examples, including real-libNVVM verification lanes and the repurposed
  nested shared-pointer expected-failure fixture.
- `scripts/check-error-example-status.sh` passed.
- `cargo clippy --workspace --all-targets -- -D warnings`, both changed-example
  clippy checks, workspace and example formatting checks, and
  `git diff --check` passed.

## Checklist

- [x] The branch is based on current upstream `main`, or its dependency is explicit.
- [x] The regression fails on upstream `main` and passes on this branch.
- [x] Relevant sibling paths and edge cases are covered or called out above.
- [x] Formatting, focused tests, and relevant broader checks pass.
- [x] Commits include DCO signoff and new files have required headers.

