### PR TITLE
docs: record the libcuda stub needed to test driver-linked crates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,31 @@ third-party files must keep their upstream license and copyright notices.
 - Dialect changes should include appropriate tests in the crate's `tests/`
   directory.
 
+#### Running the driver-linked crates without a GPU
+
+Most crates test on a machine with no GPU and no NVIDIA driver. `cuda-core`,
+`cuda-host`, and `cuda-async` link the CUDA driver, so their test binaries need
+`libcuda.so.1` at load time even when no test calls the driver:
+
+```text
+error while loading shared libraries: libcuda.so.1: cannot open shared object file
+```
+
+The toolkit ships only the link-time stub `libcuda.so`, with no `libcuda.so.1`
+alias, while the linker stamps that SONAME into the binary. Point the loader at a
+directory that supplies the name:
+
+```bash
+mkdir -p /tmp/libcuda-stub
+ln -sf "$CUDA_TOOLKIT_PATH/lib64/stubs/libcuda.so" /tmp/libcuda-stub/libcuda.so.1
+export LD_LIBRARY_PATH="/tmp/libcuda-stub:$LD_LIBRARY_PATH"
+```
+
+The stub only satisfies the loader; tests that need a real driver are already
+`#[ignore]`d, so the suites run unchanged. `.github/workflows/unit-tests.yml`
+does the same thing for CI and remains the source of truth for how those jobs
+are configured.
+
 ### Dependencies
 
 - New dependencies must use permissive licenses (MIT, Apache-2.0, BSD, ISC,


### PR DESCRIPTION
## Summary

Fixes #628. `cuda-core`, `cuda-host`, and `cuda-async` link the CUDA driver, so
their test binaries need `libcuda.so.1` at load time even when no test calls the
driver. On a machine with a toolkit but no driver they fail before running a
single test:

```
$ cargo test -p cuda-host --lib
/…/deps/cuda_host-a974f4370f0a63b2: error while loading shared libraries:
libcuda.so.1: cannot open shared object file: No such file or directory
error: test failed, to rerun pass `-p cuda-host --lib`
```

Nothing in `CONTRIBUTING.md`, the book, or the root `README.md` mentions
`libcuda.so.1`.

## Why CI is fine and a checkout is not

`.github/workflows/unit-tests.yml` already diagnoses this exactly and fixes it —
the linker stamps the stub's SONAME (`libcuda.so.1`) into the binary, the toolkit
ships only a link-time `libcuda.so` with no such alias, so CI builds a shadow
directory supplying the name and prepends it to `LD_LIBRARY_PATH`. That reasoning
lives only in a workflow comment.

`crates/cuda-bindings/README.md` documents the *link-time* side ("The script
links against `libcuda.so` (the driver stub)"), which is why this is easy to
miss: the build succeeds and only the test binaries fail to start.

## Change

A short subsection under Code Requirements → Testing giving the error, the
one-line cause, and the three commands:

```bash
mkdir -p /tmp/libcuda-stub
ln -sf "$CUDA_TOOLKIT_PATH/lib64/stubs/libcuda.so" /tmp/libcuda-stub/libcuda.so.1
export LD_LIBRARY_PATH="/tmp/libcuda-stub:$LD_LIBRARY_PATH"
```

It points at `unit-tests.yml` as the source of truth for how those jobs are
configured rather than restating their setup, so the two cannot drift in
substance.

## Validation

Verified on a GPU-less machine (no NVIDIA driver) with a redistributable toolkit
layout where `lib64` is a symlink to `lib`, so the `lib64/stubs` path CI uses
resolves there too:

| | before | after |
| :-- | :-- | :-- |
| `cuda-core --lib` | fails to load | 15 passed |
| `cuda-async --lib` | fails to load | 26 passed |
| `cuda-host --lib` | fails to load | 58 passed, 1 ignored |

Driver-dependent tests are already `#[ignore]`d, so the suites run unchanged —
the stub only satisfies the loader.

Docs only: one file, no code, no GPU, and no effect on CI.

## Why this is worth a doc

GPU-less development is a first-class scenario here — the whole `unit-tests.yml`
matrix runs without a live GPU, and `cargo-oxide`'s entry exists specifically to
prove the toolkit-free path. Three crates in that matrix are unrunnable locally
until you reverse-engineer a CI comment, and the loader error gives no hint. Same
shape as #549, where the install docs omitted `llvm-tools` and left a
doctor-failing toolchain.

## Relationship to #627

Independent and disjoint — #627 touches `intrinsics/overlay/movmatrix.toml`, the
two `cuda-intrinsics-gen` recipe sites, `llvm-export/src/lib.rs`, and the
regenerated catalog. This touches only `CONTRIBUTING.md`. Merge in either order.
