### PR TITLE
test(smoketest): run every example's verify-code-shape.sh

### DIFF
--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -60,6 +60,14 @@ ERROR_EXAMPLES=(error error_set_discriminant_uninhabited error_enum_pointer_over
 # Examples that pin RUSTFLAGS=-Zinline-mir=no (verdict rules are unaffected)
 NOINLINE_MIR_EXAMPLES=(disjoint_slice_len)
 
+# Examples whose verify-code-shape.sh asserts on `#[inline(never)]` marker
+# symbols. Those markers are private, so once the middle end inlines them into
+# their single caller it deletes them, and they survive only in the
+# unoptimized IR. The optimized build still runs and still decides the verdict;
+# these get one extra CUDA_OXIDE_NO_OPT=1 build afterwards purely to produce
+# artifacts the shape check can read.
+NO_OPT_SHAPE_EXAMPLES=(const_bool_dead_branch)
+
 classify() {
     local ex="$1" cat
     for cat in "${TCGEN05_EXAMPLES[@]}";     do [[ "$ex" == "$cat" ]] && { echo tcgen05;     return; }; done
@@ -1332,10 +1340,31 @@ run_cargo() {
         invoke_cargo_oxide "${args[@]}" >"${log}" 2>&1
         CARGO_EC=$?
     fi
-    if [[ ${CARGO_EC} -eq 0 && "${ex}" == "array_constants" ]]; then
-        local shape_check="crates/rustc-codegen-cuda/examples/${ex}/verify-code-shape.sh"
-        if ! "${shape_check}" >>"${log}" 2>&1; then
-            printf 'array_constants failed its exact unoptimized LLVM, optimized LLVM, or PTX shape assertions\n' >>"${log}"
+    # Any example may ship a verify-code-shape.sh; running whichever exist keeps
+    # a new one from being added and then silently never executed. Presence, not
+    # the executable bit, is the trigger -- a script committed without +x would
+    # otherwise be skipped in exactly the silence this is meant to remove -- so
+    # it runs through `bash` rather than being executed directly.
+    local shape_check="crates/rustc-codegen-cuda/examples/${ex}/verify-code-shape.sh"
+    if [[ ${CARGO_EC} -eq 0 && -f "${shape_check}" ]]; then
+        local no_opt_shape
+        for no_opt_shape in "${NO_OPT_SHAPE_EXAMPLES[@]}"; do
+            if [[ "${ex}" == "${no_opt_shape}" ]]; then
+                # Re-emit unoptimized artifacts for the check, reusing this
+                # example's own flags so the rebuild differs from the build
+                # above only in optimization. The optimized build already ran
+                # and already set CARGO_EC.
+                local -a no_opt_args=("${args[@]}")
+                no_opt_args[0]="build"
+                CUDA_OXIDE_NO_OPT=1 invoke_cargo_oxide "${no_opt_args[@]}" >>"${log}" 2>&1 \
+                    || CARGO_EC=$?
+                break
+            fi
+        done
+    fi
+    if [[ ${CARGO_EC} -eq 0 && -f "${shape_check}" ]]; then
+        if ! bash "${shape_check}" >>"${log}" 2>&1; then
+            printf '%s failed its verify-code-shape.sh assertions\n' "${ex}" >>"${log}"
             CARGO_EC=1
         fi
     fi


### PR DESCRIPTION
## Summary

Fixes #632. Two examples ship a `verify-code-shape.sh`; the smoketest ran one.
The call site was hardcoded:

```sh
if [[ ${CARGO_EC} -eq 0 && "${ex}" == "array_constants" ]]; then
```

So `const_bool_dead_branch`'s check — 120 lines, ~20 assertions — had never been
executed by anything automated. Its README presents it as a manual command, so it
did not look dead; it just never ran.

What went unchecked is not cosmetic. It asserts that const-dead hook symbols are
absent and live ones present, that const-selected functions carry no `br i1`
while the dynamic control keeps exactly one, that **a const-dead dynamic-shared
arm does not contaminate the address space inferred for the live global-pointer
arm**, and that **a runtime-selected global pointer is not narrowed to
`addrspace(3)`**. The last two are the miscompile the example exists to catch.

## Why the one-line fix does not work

Generalizing the guard alone breaks CI. Against the smoketest's optimized build
the check exits 1 — silently, because `set -e` trips on a bare `grep -q`:

| artifact | live hook symbols |
| :-- | :-- |
| `const_bool_dead_branch.ll` | present (3) |
| `const_bool_dead_branch.opt.ll` | absent |
| `const_bool_dead_branch.ptx` | absent |

The hooks are `#[inline(never)]` but private, so the middle end inlines each into
its single caller and deletes it — the behaviour the `helper_fn` block in this
same file already describes ("private, so the middle-end internalizes, inlines,
and deletes them from the optimized PTX"). They survive only in unoptimized IR,
which is why the example's README builds a second time with `CUDA_OXIDE_NO_OPT=1`.
Rebuilt that way, the check passes.

I found this by building the example and running the script rather than assuming
the guard was the whole problem.

## Change

1. Run whichever examples ship a `verify-code-shape.sh` instead of naming one, so
   the next added script cannot be silently ignored.
2. Add `NO_OPT_SHAPE_EXAMPLES`, alongside the existing `NOINLINE_MIR_EXAMPLES`
   precedent for per-example build tweaks, giving those examples one extra
   `CUDA_OXIDE_NO_OPT=1` build before the check.

The optimized build still runs and still decides the verdict. I deliberately did
not switch the example to unoptimized: its address-space assertions are exactly
the kind of property that could differ under optimization, so that compile should
stay in the matrix. The cost is one extra ~2s build for one example.

## Validation

All CPU-only, no GPU — run through `scripts/smoketest.sh --compile-only`, the
same entry point `examples-compile.yml` uses.

| check | result |
| :-- | :-- |
| `array_constants` + `const_bool_dead_branch` | 2/2 PASS |
| shape checks actually executed | `code shape: PASS` present in **both** logs |
| failure propagates | injected `exit 1` in the script → `const_bool_dead_branch FAIL (exit=1)` |
| examples without a shape check unaffected | 7/7 PASS (array_constants, async_vecadd, const_bool_dead_branch, disjoint_slice_len, drop_glue, helper_fn, vecadd) |
| `bash -n scripts/smoketest.sh` | clean |

The "actually executed" row is the one that matters: a green example proves
nothing if the check was skipped, so I grepped each log for the script's own PASS
line rather than trusting the verdict.

## Not included

`array_constants` keeps its current behaviour — it reads `.opt.ll` and wants the
optimized artifacts, so it is not in the new list.

I also left the script's own silent-exit behaviour alone. `set -euo pipefail`
with bare `grep -q`/`test -s` means a failure prints nothing, which is what made
this hard to diagnose; adding messages would be a reasonable follow-up but is a
change to the example's script rather than to the harness.
