### PR TITLE
ci: test oxide-artifacts with the object features its consumers enable

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,12 @@ jobs:
           - package: mir-lower
           - package: mir-transforms
           - package: nvvm-transforms
+          # `default = []`, but every consumer turns the object features on:
+          # rustc-codegen-cuda and cuda-core take `object-write`, cuda-core
+          # also `object-read`. Testing the default set alone skips the eight
+          # ELF emit/extract tests that cover the configuration actually built.
           - package: oxide-artifacts
+            test_args: --all-targets --features object
           - package: reserved-oxide-symbols
           # launch_requires_unsafe trybuild fixture dev-depends on
           # cuda-host/cuda-core, which transitively pull cuda-bindings


### PR DESCRIPTION
## Summary

Fixes #634. `oxide-artifacts` declares `default = []` and the unit-tests matrix
runs it with defaults, so eight tests never execute:

```
cargo test -p oxide-artifacts --all-targets                     14 passed
cargo test -p oxide-artifacts --all-targets --features object   22 passed
```

The eight cover the ELF emit/extract paths:

```
host_object_round_trips_section_on_supported_formats
host_object_defines_requested_anchor_symbol
host_object_rejects_non_cuda_host_targets
host_object_without_anchor_has_no_symbols
target_anchor_object_also_defines_weak_legacy_alias
weak_legacy_alias_extracts_artifact_from_static_archive
anchor_only_object_defines_symbol_without_artifact_section
anchor_only_object_rejects_empty_symbol
```

## The untested configuration is the one that ships

```
crates/rustc-codegen-cuda/Cargo.toml:26  features = ["object-write"]
crates/cuda-core/Cargo.toml:15           features = ["object-read"]
crates/cuda-core/Cargo.toml:18           features = ["object-write"]   # dev
```

The codegen backend takes `object-write`, `cuda-core` takes `object-read`.
Nothing in the workspace builds `default = []` — it is only what CI measures.

The machinery is not dead code either: `examples-compile.yml` reads the emitted
section back with `objcopy --dump-section ".oxart=..."`, so it is exercised end
to end in CI while its unit tests are skipped.

Root cause of the blind spot:

```
$ grep -rn "\-\-features\|--all-features\|--no-default-features" .github/workflows/ Justfile
$
```

No workflow passes any feature flag, so no non-default feature is built anywhere
in CI.

## Change

One key. The matrix already supports per-entry overrides — `cuda-core` uses
`test_args: --lib` — and `object = ["object-read", "object-write"]`, so a single
entry covers every feature any consumer turns on.

```yaml
- package: oxide-artifacts
  test_args: --all-targets --features object
```

## Validation

Nothing here was broken; the tests simply were not running. I ran the exact
command the workflow will now execute:

| target | result |
| :-- | :-- |
| `oxide-artifacts --all-targets` (before) | 14 passed |
| `oxide-artifacts --all-targets --features object` (after) | **22 passed, 0 failed** |
| `--features object-read` | 22 passed |
| `--features object-write` | 22 passed |

I also swept the rest of the feature space while I was here — `cuda-macros
--features async` (98 passed) and `cuda-host --features async` (compiles) — so
this PR is not hiding a second failure.

No YAML parser was available locally, so I verified the entry structurally
instead: the new `test_args` key sits at the same 12-space indentation as the
existing `cuda-core` one, and the diff adds only that key plus a comment.

No GPU required.

## Not included

`cuda-macros` has async-gated codegen — `cfg!(feature = "async")` at
`src/lib.rs:948`, `983`, `1097`, `1396`, plus `#[cfg(feature = "async")]` items —
and its own dev-dependency enables `cuda-host/async`, yet CI never builds that
configuration.

Covering it needs a *second* matrix entry rather than a flag on the existing one:
two integration tests are deliberately `#[cfg(not(feature = "async"))]`
("trybuild's generated crate does not mirror feature flags onto the separate
cuda-host dev dependency"), so switching the existing entry would trade coverage
rather than add it. A second entry also yields two jobs with the same display
name, since the job name is `cargo test -p ${{ matrix.package }}`.

That is a structural choice about the matrix, so I left it out rather than
deciding it. Happy to add it, with or without a name suffix.
