### PR TITLE
fix(mir-importer): support ConstantIndex to Index assignments

### DIFF
--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -670,40 +670,24 @@ pub fn translate_statement(
                         )
                     }
                     (
-                        mir::ProjectionElem::Index(_outer_index_local),
-                        mir::ProjectionElem::Index(_inner_index_local),
+                        mir::ProjectionElem::Index(_) | mir::ProjectionElem::ConstantIndex { .. },
+                        mir::ProjectionElem::Index(_) | mir::ProjectionElem::ConstantIndex { .. },
                     ) => {
-                        // `_local[i][j] = value` for nested arrays. The shared
-                        // walk-and-store path already handles chained runtime
-                        // indexes, so delegate to it instead of re-deriving the
-                        // address here. That keeps this 2-level arm from drifting
-                        // from the (Deref, Index) arm above and the N-projection
-                        // fallback below, which use the same helper. The store
-                        // target of an assignment is always a mutable place, so
-                        // the helper's mutable-address request is correct here.
-                        store_through_place_address(
-                            ctx,
-                            body,
-                            value_map,
-                            place,
-                            result_value,
-                            rvalue_op_opt,
-                            last_inserted,
-                            prev_op,
-                            block_ptr,
-                            loc,
-                        )
-                    }
-                    (
-                        mir::ProjectionElem::ConstantIndex {
-                            from_end: false, ..
-                        },
-                        mir::ProjectionElem::Index(_),
-                    ) => {
-                        // `_local[CONST][j] = value` for nested arrays. The shared
-                        // address walker already handles a forward constant index
-                        // followed by a runtime index, so delegate the complete
-                        // destination place instead of duplicating address logic.
+                        // Nested array element assignment with any mix of
+                        // runtime and constant indexes: `_local[i][j]`,
+                        // `_local[CONST][j]`, `_local[i][CONST]`, or
+                        // `_local[CONST][CONST]` (the last two arise when GVN
+                        // or user code fixes one level). The shared
+                        // walk-and-store path already handles chained indexes
+                        // of either kind, so delegate to it instead of
+                        // re-deriving the address here. That keeps this
+                        // 2-level arm from drifting from the (Deref, Index)
+                        // arm above and the N-projection fallback below,
+                        // which use the same helper. The store target of an
+                        // assignment is always a mutable place, so the
+                        // helper's mutable-address request is correct here.
+                        // `ConstantIndex { from_end: true, .. }` is rejected
+                        // loudly by the walker itself.
                         store_through_place_address(
                             ctx,
                             body,

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -695,6 +695,29 @@ pub fn translate_statement(
                         )
                     }
                     (
+                        mir::ProjectionElem::ConstantIndex {
+                            from_end: false, ..
+                        },
+                        mir::ProjectionElem::Index(_),
+                    ) => {
+                        // `_local[CONST][j] = value` for nested arrays. The shared
+                        // address walker already handles a forward constant index
+                        // followed by a runtime index, so delegate the complete
+                        // destination place instead of duplicating address logic.
+                        store_through_place_address(
+                            ctx,
+                            body,
+                            value_map,
+                            place,
+                            result_value,
+                            rvalue_op_opt,
+                            last_inserted,
+                            prev_op,
+                            block_ptr,
+                            loc,
+                        )
+                    }
+                    (
                         mir::ProjectionElem::Field(_, _),
                         mir::ProjectionElem::ConstantIndex { .. } | mir::ProjectionElem::Index(_),
                     ) => {

--- a/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
@@ -6,10 +6,11 @@
 //! Regression tests for assigning through nested array indexes.
 //!
 //! MIR represents `local[i][j] = value` as a two-level `Index, Index`
-//! projection. A constant outer index followed by a runtime inner index uses
-//! `ConstantIndex, Index`. The statement translator must lower both chains to
-//! an address and store through it instead of rejecting the assignment before
-//! the generic projection walker can handle it.
+//! projection. Fixing either level at a constant produces `ConstantIndex,
+//! Index`, `Index, ConstantIndex`, or `ConstantIndex, ConstantIndex`. The
+//! statement translator must lower every combination to an address and store
+//! through it instead of rejecting the assignment before the generic
+//! projection walker can handle it.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, cuda_module, kernel};
@@ -47,15 +48,37 @@ mod kernels {
     }
 
     #[kernel]
-    pub fn nested_constant_runtime_index_assignment_kernel(
-        j: usize,
-        mut out: DisjointSlice<u32>,
-    ) {
+    pub fn nested_constant_runtime_index_assignment_kernel(j: usize, mut out: DisjointSlice<u32>) {
         let mut values = [[0u32; 3]; 5];
         values[4][j] = 0x6b00_0000 | j as u32;
 
         if let Some((slot, _idx)) = out.get_mut_indexed() {
             *slot = values[4][j];
+        }
+    }
+
+    // Runtime outer row followed by a constant inner column: the mirrored
+    // `Index, ConstantIndex` projection pair.
+    #[kernel]
+    pub fn nested_runtime_constant_index_assignment_kernel(i: usize, mut out: DisjointSlice<u32>) {
+        let mut values = [[0u32; 3]; 5];
+        values[i][2] = 0x7c00_0000 | i as u32;
+
+        if let Some((slot, _idx)) = out.get_mut_indexed() {
+            *slot = values[i][2];
+        }
+    }
+
+    // Both indexes constant. rustc usually keeps this as a
+    // `ConstantIndex, ConstantIndex` projection pair in optimized MIR, so it
+    // exercises the remaining combination of the merged translator arm.
+    #[kernel]
+    pub fn nested_constant_constant_index_assignment_kernel(mut out: DisjointSlice<u32>) {
+        let mut values = [[0u32; 3]; 5];
+        values[1][2] = 0x8d00_0102;
+
+        if let Some((slot, _idx)) = out.get_mut_indexed() {
+            *slot = values[1][2];
         }
     }
 }
@@ -115,7 +138,41 @@ fn main() {
         vec![0x6b00_0002],
     );
 
+    // Runtime outer row followed by a constant inner column: write [3][2].
+    let mut out_runtime_constant = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
+    // SAFETY: one thread is launched, the output contains one element, and i=3
+    // is within the outer array's length of 5.
+    unsafe {
+        module.nested_runtime_constant_index_assignment_kernel(
+            &stream,
+            LaunchConfig::for_num_elems(1),
+            3usize,
+            &mut out_runtime_constant,
+        )
+    }
+    .expect("Runtime/constant nested-index kernel launch failed");
+    assert_eq!(
+        out_runtime_constant.to_host_vec(&stream).unwrap(),
+        vec![0x7c00_0003],
+    );
+
+    // Both indexes constant: write [1][2].
+    let mut out_constant_constant = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
+    // SAFETY: one thread is launched and the output contains one element.
+    unsafe {
+        module.nested_constant_constant_index_assignment_kernel(
+            &stream,
+            LaunchConfig::for_num_elems(1),
+            &mut out_constant_constant,
+        )
+    }
+    .expect("Constant/constant nested-index kernel launch failed");
+    assert_eq!(
+        out_constant_constant.to_host_vec(&stream).unwrap(),
+        vec![0x8d00_0102],
+    );
+
     println!(
-        "PASS: nested Index->Index and ConstantIndex->Index assignments wrote and read back correctly"
+        "PASS: nested index assignments (runtime and constant, in every combination) wrote and read back correctly"
     );
 }

--- a/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/nested_index_assignment/src/main.rs
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Regression test for assigning through nested runtime array indexes.
+//! Regression tests for assigning through nested array indexes.
 //!
 //! MIR represents `local[i][j] = value` as a two-level `Index, Index`
-//! projection. The statement translator must lower that chained projection to
+//! projection. A constant outer index followed by a runtime inner index uses
+//! `ConstantIndex, Index`. The statement translator must lower both chains to
 //! an address and store through it instead of rejecting the assignment before
 //! the generic projection walker can handle it.
 
@@ -42,6 +43,19 @@ mod kernels {
 
         if let Some((slot, _idx)) = out.get_mut_indexed() {
             *slot = values[i][j];
+        }
+    }
+
+    #[kernel]
+    pub fn nested_constant_runtime_index_assignment_kernel(
+        j: usize,
+        mut out: DisjointSlice<u32>,
+    ) {
+        let mut values = [[0u32; 3]; 5];
+        values[4][j] = 0x6b00_0000 | j as u32;
+
+        if let Some((slot, _idx)) = out.get_mut_indexed() {
+            *slot = values[4][j];
         }
     }
 }
@@ -83,5 +97,25 @@ fn main() {
     .expect("Non-square kernel launch failed");
     assert_eq!(out_ns.to_host_vec(&stream).unwrap(), vec![0x5a00_0402]);
 
-    println!("PASS: nested runtime indexes assigned and read back correctly (square + non-square)");
+    // Constant outer row followed by a runtime inner column: write [4][2].
+    let mut out_constant_runtime = DeviceBuffer::<u32>::zeroed(&stream, 1).unwrap();
+    // SAFETY: one thread is launched, the output contains one element, and j=2
+    // is within the inner array's length of 3.
+    unsafe {
+        module.nested_constant_runtime_index_assignment_kernel(
+            &stream,
+            LaunchConfig::for_num_elems(1),
+            2usize,
+            &mut out_constant_runtime,
+        )
+    }
+    .expect("Constant/runtime nested-index kernel launch failed");
+    assert_eq!(
+        out_constant_runtime.to_host_vec(&stream).unwrap(),
+        vec![0x6b00_0002],
+    );
+
+    println!(
+        "PASS: nested Index->Index and ConstantIndex->Index assignments wrote and read back correctly"
+    );
 }


### PR DESCRIPTION
Fixes #639 

## Summary

Support nested assignments whose destination place contains a forward `ConstantIndex` projection followed by a runtime `Index` projection.

This fixes device code generation for assignments such as:

```rust
values[4][j] = value;
```

## Problem

The MIR generated for the assignment above contains this two-level destination projection:

```text
ConstantIndex {
    offset: 4,
    min_length: 5,
    from_end: false,
} -> Index(1)
```

The assignment projection dispatcher did not contain an arm for this combination, causing the MIR importer to report:

```text
Unsupported construct: 2-level projection
ConstantIndex { offset: 4, min_length: 5, from_end: false }
-> Index(1)
not yet implemented for assignment
```

## Implementation

Add an assignment projection arm matching:

```rust
(
    mir::ProjectionElem::ConstantIndex {
        from_end: false, ..
    },
    mir::ProjectionElem::Index(_),
)
```

The arm delegates the complete destination place to `store_through_place_address`.

The shared projected-place address walker already supports a forward constant index followed by a runtime index, so this avoids duplicating address-calculation logic and keeps assignment handling consistent with the existing projection cases.

## Regression coverage

Extend the `nested_index_assignment` example with a kernel that:

1. Creates a nested local array.
2. Assigns through `values[4][j]`.
3. Reads the same location back.
4. Writes the result to host-visible output.

The example now validates both:

* `Index -> Index`
* `ConstantIndex -> Index`

Without the importer change, the new kernel fails during device code generation with exit status 101.

With the importer change, the example compiles and runs successfully on the GPU.

## Validation

The following checks pass:

```text
cargo fmt --all -- --check
cargo check -p mir-importer --all-targets
cargo test -p mir-importer
cargo clippy -p mir-importer --all-targets -- -D warnings
cargo oxide run nested_index_assignment
scripts/smoketest.sh --compile-only --no-color
```

Results:

```text
mir-importer unit tests: 893 passed, 0 failed
nested_index_assignment: PASS
smoketest: 178 passed, 0 failed
```
