### PR TITLE
fix(mir-lower): support nested shared-pointer enum payloads

### DIFF
--- a/crates/mir-lower/src/convert/enum_payload_storage.rs
+++ b/crates/mir-lower/src/convert/enum_payload_storage.rs
@@ -1,0 +1,309 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Target-stable physical storage for enum payload values.
+//!
+//! Rust treats CUDA pointers as one logical pointer-sized value, while modern
+//! NVVM uses a 32-bit physical representation for address-space-3 pointers.
+//! Enum storage therefore cannot retain a semantic shared pointer directly.
+//! Direct and struct/tuple-nested shared pointers are represented as CUDA
+//! generic pointers in the enum and converted at construction/extraction
+//! boundaries. Rust `bool` leaves are represented by canonical `i8` bytes at
+//! the same boundary.
+//!
+//! Arrays and vectors containing shared pointers remain fail-closed. Rebuilding
+//! an array creates one operation sequence per element, while pointer vectors
+//! have separate ABI and address-space-cast semantics. Those shapes need their
+//! own bounded/code-shape design rather than being accepted implicitly here.
+
+use llvm_export::op_interfaces::{CastOpInterface, CastOpWithNNegInterface};
+use llvm_export::ops as llvm;
+use llvm_export::types as llvm_types;
+use llvm_export::types::PointerTypeExt;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::Context;
+use pliron::irbuild::dialect_conversion::DialectConversionRewriter;
+use pliron::irbuild::inserter::Inserter;
+use pliron::op::Op;
+use pliron::result::Result;
+use pliron::r#type::{TypeHandle, Typed};
+use pliron::value::Value;
+
+#[derive(Clone)]
+struct StorageRewrite {
+    ty: TypeHandle,
+    rewrote_shared_pointer: bool,
+}
+
+enum TypeShape {
+    Bool,
+    Pointer(u32),
+    Array(TypeHandle, u64),
+    Vector(TypeHandle),
+    Struct(Vec<TypeHandle>),
+    Identity,
+}
+
+/// Return the physical LLVM type used to store one semantic enum payload.
+///
+/// The transformation is recursive through LLVM structs, which cover MIR
+/// structs and tuples after ordinary type conversion:
+///
+/// - `ptr addrspace(3)` becomes a CUDA generic pointer;
+/// - `i1` becomes the canonical one-byte `i8` memory representation;
+/// - structs are rebuilt field by field;
+/// - bool-only arrays are rebuilt recursively;
+/// - arrays/vectors containing shared pointers are rejected.
+pub(crate) fn enum_payload_storage_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+) -> std::result::Result<TypeHandle, anyhow::Error> {
+    Ok(rewrite_storage_type(ctx, semantic_ty)?.ty)
+}
+
+fn rewrite_storage_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+) -> std::result::Result<StorageRewrite, anyhow::Error> {
+    let shape = {
+        let ty_ref = semantic_ty.deref(ctx);
+        if ty_ref
+            .downcast_ref::<IntegerType>()
+            .is_some_and(|integer| integer.width() == 1)
+        {
+            TypeShape::Bool
+        } else if let Some(pointer) = ty_ref.downcast_ref::<llvm_types::PointerType>() {
+            TypeShape::Pointer(pointer.address_space())
+        } else if let Some(array) = ty_ref.downcast_ref::<llvm_types::ArrayType>() {
+            TypeShape::Array(array.elem_type(), array.size())
+        } else if let Some(vector) = ty_ref.downcast_ref::<llvm_types::VectorType>() {
+            TypeShape::Vector(vector.elem_type())
+        } else if let Some(struct_ty) = ty_ref.downcast_ref::<llvm_types::StructType>() {
+            TypeShape::Struct(struct_ty.fields().collect())
+        } else {
+            TypeShape::Identity
+        }
+    };
+
+    match shape {
+        TypeShape::Bool => Ok(StorageRewrite {
+            ty: IntegerType::get(ctx, 8, Signedness::Signless).into(),
+            rewrote_shared_pointer: false,
+        }),
+        TypeShape::Pointer(address_space) if address_space == llvm_types::address_space::SHARED => {
+            Ok(StorageRewrite {
+                ty: llvm_types::PointerType::get_generic(ctx).into(),
+                rewrote_shared_pointer: true,
+            })
+        }
+        TypeShape::Pointer(_) | TypeShape::Identity => Ok(StorageRewrite {
+            ty: semantic_ty,
+            rewrote_shared_pointer: false,
+        }),
+        TypeShape::Array(element_ty, count) => {
+            let element = rewrite_storage_type(ctx, element_ty)?;
+            if element.rewrote_shared_pointer {
+                return Err(anyhow::anyhow!(
+                    "enum payload storage: arrays containing shared-memory pointers are not supported; recursive target-stable storage currently supports direct pointers and struct/tuple nesting"
+                ));
+            }
+            let ty = if element.ty == element_ty {
+                semantic_ty
+            } else {
+                llvm_types::ArrayType::get(ctx, element.ty, count).into()
+            };
+            Ok(StorageRewrite {
+                ty,
+                rewrote_shared_pointer: false,
+            })
+        }
+        TypeShape::Vector(element_ty) => {
+            let element = rewrite_storage_type(ctx, element_ty)?;
+            if element.ty != element_ty || element.rewrote_shared_pointer {
+                return Err(anyhow::anyhow!(
+                    "enum payload storage: vectors containing bool or shared-memory pointer elements are not supported"
+                ));
+            }
+            Ok(StorageRewrite {
+                ty: semantic_ty,
+                rewrote_shared_pointer: false,
+            })
+        }
+        TypeShape::Struct(fields) => {
+            let mut storage_fields = Vec::with_capacity(fields.len());
+            let mut changed = false;
+            let mut rewrote_shared_pointer = false;
+            for field in fields {
+                let storage = rewrite_storage_type(ctx, field)?;
+                changed |= storage.ty != field;
+                rewrote_shared_pointer |= storage.rewrote_shared_pointer;
+                storage_fields.push(storage.ty);
+            }
+            let ty = if changed {
+                llvm_types::StructType::get_unnamed(ctx, storage_fields).into()
+            } else {
+                semantic_ty
+            };
+            Ok(StorageRewrite {
+                ty,
+                rewrote_shared_pointer,
+            })
+        }
+    }
+}
+
+enum ValueCoercion {
+    BoolToByte,
+    ByteToBool,
+    SharedToGeneric,
+    GenericToShared,
+    Array {
+        target_element: TypeHandle,
+        count: u64,
+    },
+    Struct(Vec<TypeHandle>),
+    Unsupported,
+}
+
+/// Convert an enum payload value between its semantic and physical types.
+///
+/// This is the value-level counterpart of [`enum_payload_storage_type`]. It
+/// recursively rebuilds structs/tuples, inserts the required address-space
+/// casts for shared pointer leaves, and canonicalizes/decanonicalizes bool
+/// bytes. The conversion is symmetric and is used both when constructing an
+/// enum and when extracting its payload.
+pub(crate) fn coerce_enum_payload_value(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    value: Value,
+    target_ty: TypeHandle,
+) -> Result<Value> {
+    let source_ty = value.get_type(ctx);
+    if source_ty == target_ty {
+        return Ok(value);
+    }
+
+    let coercion = {
+        let source_ref = source_ty.deref(ctx);
+        let target_ref = target_ty.deref(ctx);
+
+        let source_integer = source_ref
+            .downcast_ref::<IntegerType>()
+            .map(IntegerType::width);
+        let target_integer = target_ref
+            .downcast_ref::<IntegerType>()
+            .map(IntegerType::width);
+        if source_integer == Some(1) && target_integer == Some(8) {
+            ValueCoercion::BoolToByte
+        } else if source_integer == Some(8) && target_integer == Some(1) {
+            ValueCoercion::ByteToBool
+        } else if let (Some(source_pointer), Some(target_pointer)) = (
+            source_ref.downcast_ref::<llvm_types::PointerType>(),
+            target_ref.downcast_ref::<llvm_types::PointerType>(),
+        ) {
+            match (
+                source_pointer.address_space(),
+                target_pointer.address_space(),
+            ) {
+                (llvm_types::address_space::SHARED, llvm_types::address_space::GENERIC) => {
+                    ValueCoercion::SharedToGeneric
+                }
+                (llvm_types::address_space::GENERIC, llvm_types::address_space::SHARED) => {
+                    ValueCoercion::GenericToShared
+                }
+                _ => ValueCoercion::Unsupported,
+            }
+        } else if let (Some(source_array), Some(target_array)) = (
+            source_ref.downcast_ref::<llvm_types::ArrayType>(),
+            target_ref.downcast_ref::<llvm_types::ArrayType>(),
+        ) {
+            if source_array.size() == target_array.size() {
+                ValueCoercion::Array {
+                    target_element: target_array.elem_type(),
+                    count: source_array.size(),
+                }
+            } else {
+                ValueCoercion::Unsupported
+            }
+        } else if let (Some(source_struct), Some(target_struct)) = (
+            source_ref.downcast_ref::<llvm_types::StructType>(),
+            target_ref.downcast_ref::<llvm_types::StructType>(),
+        ) {
+            if source_struct.num_fields() == target_struct.num_fields() {
+                ValueCoercion::Struct(target_struct.fields().collect())
+            } else {
+                ValueCoercion::Unsupported
+            }
+        } else {
+            ValueCoercion::Unsupported
+        }
+    };
+
+    match coercion {
+        ValueCoercion::BoolToByte => {
+            let zext = llvm::ZExtOp::new_with_nneg(ctx, value, target_ty, false);
+            rewriter.insert_operation(ctx, zext.get_operation());
+            Ok(zext.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::ByteToBool => {
+            let trunc = llvm::TruncOp::new(ctx, value, target_ty);
+            rewriter.insert_operation(ctx, trunc.get_operation());
+            Ok(trunc.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::SharedToGeneric | ValueCoercion::GenericToShared => {
+            let cast = llvm::AddrSpaceCastOp::new(ctx, value, target_ty);
+            rewriter.insert_operation(ctx, cast.get_operation());
+            Ok(cast.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::Array {
+            target_element,
+            count,
+        } => {
+            let undef = llvm::UndefOp::new(ctx, target_ty);
+            rewriter.insert_operation(ctx, undef.get_operation());
+            let mut current = undef.get_operation().deref(ctx).get_result(0);
+            for index in 0..count {
+                let index = u32::try_from(index).map_err(|_| {
+                    pliron::input_error_noloc!(
+                        "enum payload storage array has more than u32::MAX elements"
+                    )
+                })?;
+                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
+                rewriter.insert_operation(ctx, extract.get_operation());
+                let element = extract.get_operation().deref(ctx).get_result(0);
+                let converted = coerce_enum_payload_value(ctx, rewriter, element, target_element)?;
+                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
+                rewriter.insert_operation(ctx, insert.get_operation());
+                current = insert.get_operation().deref(ctx).get_result(0);
+            }
+            Ok(current)
+        }
+        ValueCoercion::Struct(fields) => {
+            let undef = llvm::UndefOp::new(ctx, target_ty);
+            rewriter.insert_operation(ctx, undef.get_operation());
+            let mut current = undef.get_operation().deref(ctx).get_result(0);
+            for (index, target_field) in fields.into_iter().enumerate() {
+                let index = u32::try_from(index).map_err(|_| {
+                    pliron::input_error_noloc!(
+                        "enum payload storage struct has more than u32::MAX fields"
+                    )
+                })?;
+                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
+                rewriter.insert_operation(ctx, extract.get_operation());
+                let field = extract.get_operation().deref(ctx).get_result(0);
+                let converted = coerce_enum_payload_value(ctx, rewriter, field, target_field)?;
+                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
+                rewriter.insert_operation(ctx, insert.get_operation());
+                current = insert.get_operation().deref(ctx).get_result(0);
+            }
+            Ok(current)
+        }
+        ValueCoercion::Unsupported => pliron::input_err_noloc!(
+            "enum payload storage type mismatch: {} cannot be adapted to {}",
+            source_ty.deref(ctx).disp(ctx),
+            target_ty.deref(ctx).disp(ctx)
+        ),
+    }
+}

--- a/crates/mir-lower/src/convert/mod.rs
+++ b/crates/mir-lower/src/convert/mod.rs
@@ -26,6 +26,7 @@
 //! 2. Write a `pub(crate) fn convert_*` function in the relevant submodule.
 //! 3. Add an `#[op_interface_impl]` block in [`interface_impls`].
 
+pub(crate) mod enum_payload_storage;
 mod generated_intrinsics;
 pub mod interface_impls;
 pub mod intrinsics;

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -36,6 +36,7 @@
 //! instead uses rustc's wrapping `niche_start + variant_offset` encoding and
 //! introduces no extra tag.
 
+use crate::convert::enum_payload_storage::{coerce_enum_payload_value, enum_payload_storage_type};
 use crate::convert::types::{
     EnumSlotMap, StructLayoutInfo, StructSlotMap, build_enum_slot_map, build_struct_slot_map,
     build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
@@ -895,43 +896,18 @@ fn canonicalize_bool_value_bytes(
     Ok(current)
 }
 
-/// Adapt a semantic enum payload pointer to or from its physical storage
-/// address space.
+/// Adapt a semantic enum payload value to or from its physical storage type.
 ///
-/// Direct shared-pointer payloads use a generic pointer slot so their enum
-/// representation remains 64-bit under both legacy PTX and modern NVVM. All
-/// other type mismatches remain errors; rebuilding nested pointer-bearing
-/// aggregates is deliberately outside this narrow boundary conversion.
-fn coerce_enum_payload_pointer(
+/// Shared pointer leaves are converted through CUDA generic space recursively
+/// through struct/tuple payloads. Bool leaves are canonicalized separately on
+/// construction and narrowed recursively on extraction.
+fn coerce_enum_payload_storage(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     value: Value,
     target_ty: TypeHandle,
 ) -> Result<Value> {
-    let source_ty = value.get_type(ctx);
-    if source_ty == target_ty {
-        return Ok(value);
-    }
-
-    let source_address_space = source_ty
-        .deref(ctx)
-        .downcast_ref::<llvm_types::PointerType>()
-        .map(|pointer| pointer.address_space());
-    let target_address_space = target_ty
-        .deref(ctx)
-        .downcast_ref::<llvm_types::PointerType>()
-        .map(|pointer| pointer.address_space());
-    if source_address_space.is_none() || target_address_space.is_none() {
-        return pliron::input_err_noloc!(
-            "enum payload storage type mismatch: {} cannot be adapted to {}",
-            source_ty.deref(ctx).disp(ctx),
-            target_ty.deref(ctx).disp(ctx)
-        );
-    }
-
-    let cast = llvm::AddrSpaceCastOp::new(ctx, value, target_ty);
-    rewriter.insert_operation(ctx, cast.get_operation());
-    Ok(cast.get_operation().deref(ctx).get_result(0))
+    coerce_enum_payload_value(ctx, rewriter, value, target_ty)
 }
 
 /// Convert `mir.construct_enum` (e.g. `E::A(x)`) to LLVM operations.
@@ -1046,7 +1022,7 @@ pub(crate) fn convert_construct_enum(
                     storage_struct.field_type(storage_slot)
                 };
                 let stored_operand =
-                    coerce_enum_payload_pointer(ctx, rewriter, operand, storage_ty)?;
+                    coerce_enum_payload_storage(ctx, rewriter, operand, storage_ty)?;
                 let insert_op =
                     llvm::InsertValueOp::new(ctx, current_struct, stored_operand, vec![*slot]);
                 rewriter.insert_operation(ctx, insert_op.get_operation());
@@ -1080,7 +1056,11 @@ pub(crate) fn convert_construct_enum(
         // bool-bearing payload (scalar i8 byte, or an aggregate with each
         // i1 leaf widened to i8), so canonicalize the stored value to that
         // twin: every physical bool byte becomes an unambiguous 0 or 1.
-        let stored_operand = canonicalize_bool_value_bytes(ctx, rewriter, operand)?;
+        let semantic_ty = slot_map.field_llvm_types[flat];
+        let storage_ty = enum_payload_storage_type(ctx, semantic_ty).map_err(anyhow_to_pliron)?;
+        let canonical_operand = canonicalize_bool_value_bytes(ctx, rewriter, operand)?;
+        let stored_operand =
+            coerce_enum_payload_storage(ctx, rewriter, canonical_operand, storage_ty)?;
         let store_op = llvm::StoreOp::new(ctx, stored_operand, field_ptr);
         rewriter.insert_operation(ctx, store_op.get_operation());
     }
@@ -1404,7 +1384,7 @@ pub(crate) fn convert_enum_payload(
             let extract_op = llvm::ExtractValueOp::new(ctx, enum_val, vec![slot])?;
             rewriter.insert_operation(ctx, extract_op.get_operation());
             let extracted = extract_op.get_operation().deref(ctx).get_result(0);
-            let semantic_value = coerce_enum_payload_pointer(
+            let semantic_value = coerce_enum_payload_storage(
                 ctx,
                 rewriter,
                 extracted,
@@ -1421,9 +1401,14 @@ pub(crate) fn convert_enum_payload(
             let slot_ptr =
                 spill_enum_value(ctx, rewriter, enum_val, slot_map.llvm_struct_ty, abi_align);
             let field_ptr = enum_byte_gep(ctx, rewriter, slot_ptr, slot_map.field_offsets[flat]);
-            let load_op = llvm::LoadOp::new(ctx, field_ptr, slot_map.field_llvm_types[flat]);
+            let semantic_ty = slot_map.field_llvm_types[flat];
+            let storage_ty =
+                enum_payload_storage_type(ctx, semantic_ty).map_err(anyhow_to_pliron)?;
+            let load_op = llvm::LoadOp::new(ctx, field_ptr, storage_ty);
             rewriter.insert_operation(ctx, load_op.get_operation());
-            rewriter.replace_operation(ctx, op, load_op.get_operation());
+            let stored = load_op.get_operation().deref(ctx).get_result(0);
+            let semantic = coerce_enum_payload_storage(ctx, rewriter, stored, semantic_ty)?;
+            rewriter.replace_operation_with_values(ctx, op, vec![semantic]);
         }
     }
 
@@ -2558,6 +2543,97 @@ mod tests {
             count_ops::<llvm::PtrToIntOp>(&ctx, &body),
             1,
             "niche discrimination must inspect the generic pointer carrier"
+        );
+        assert_eq!(count_ops::<MirConstructEnumOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<MirEnumPayloadOp>(&ctx, &body), 0);
+    }
+
+    #[test]
+    fn nested_shared_pointer_payload_round_trips_through_recursive_storage() {
+        let mut ctx = make_ctx();
+        let logical: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, true).into();
+        let inner: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "SharedPointerInner".into(),
+            vec!["pointer".into(), "cookie".into()],
+            vec![shared, logical],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "SharedPointerOuter".into(),
+            vec!["inner".into(), "guard".into()],
+            vec![inner, logical],
+            vec![0, 1],
+            vec![0, 16],
+            24,
+            8,
+        )
+        .into();
+        let enum_ty: TypeHandle = MirEnumType::get_with_encoding(
+            &mut ctx,
+            "NestedSharedPointer".into(),
+            logical,
+            vec![0, 1],
+            vec![
+                EnumVariant::unit("None".into()),
+                EnumVariant::new_with_layout("Some".into(), vec![outer], vec![8], vec![24]),
+            ],
+            EnumEncoding {
+                tag_offset: 0,
+                total_size: 32,
+                abi_align: 8,
+                layout_kind: EnumLayoutKind::Direct,
+                carrier_kind: EnumCarrierKind::Integer,
+                carrier_width: 32,
+                variant_inhabited: vec![1, 1],
+                ..EnumEncoding::default()
+            },
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![outer], vec![outer]);
+        let wrapper = block.deref(&ctx).get_argument(0);
+        let construct = Operation::new(
+            &mut ctx,
+            MirConstructEnumOp::get_concrete_op_info(),
+            vec![enum_ty],
+            vec![wrapper],
+            vec![],
+            0,
+        );
+        MirConstructEnumOp::new(construct)
+            .set_attr_construct_enum_variant_index(&ctx, VariantIndexAttr(1));
+        construct.insert_at_back(block, &ctx);
+        let option = construct.deref(&ctx).get_result(0);
+
+        let payload = Operation::new(
+            &mut ctx,
+            MirEnumPayloadOp::get_concrete_op_info(),
+            vec![outer],
+            vec![option],
+            vec![],
+            0,
+        );
+        let payload_op = MirEnumPayloadOp::new(payload);
+        payload_op.set_attr_payload_variant_index(&ctx, VariantIndexAttr(1));
+        payload_op.set_attr_payload_field_index(&ctx, FieldIndexAttr(0));
+        payload.insert_at_back(block, &ctx);
+        let result = payload.deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, block, vec![result]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module).expect("lowering failed");
+        let body = kernel_blocks(&ctx, module);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            2,
+            "construction and extraction must cast the nested shared pointer leaf"
         );
         assert_eq!(count_ops::<MirConstructEnumOp>(&ctx, &body), 0);
         assert_eq!(count_ops::<MirEnumPayloadOp>(&ctx, &body), 0);

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -110,6 +110,7 @@ use pliron::context::{Context, Ptr};
 use pliron::operation::Operation;
 use pliron::r#type::{TypeHandle, type_cast};
 
+use super::enum_payload_storage::enum_payload_storage_type;
 use crate::type_conversion_interface::MirTypeConversion;
 
 // =============================================================================
@@ -1454,36 +1455,14 @@ pub(crate) fn build_enum_slot_map(
             continue;
         }
         let llvm_ty = field_llvm_types[flat];
-        let is_direct_shared_pointer = llvm_ty
-            .deref(ctx)
-            .downcast_ref::<llvm_types::PointerType>()
-            .is_some_and(|pointer| pointer.address_space() == llvm_types::address_space::SHARED);
-        if !is_direct_shared_pointer
-            && llvm_type_contains_pointer_in_address_space(
-                ctx,
-                llvm_ty,
-                llvm_types::address_space::SHARED,
-            )
-        {
-            return Err(anyhow::anyhow!(
-                "enum slot map: `{}` field {} contains a nested shared-memory pointer whose size is target-mode dependent (64-bit PTX/legacy, 32-bit modern NVVM); refusing target-agnostic enum lowering",
-                name,
-                flat
-            ));
-        }
-        // A raw shared pointer is 32-bit in modern NVVM but Rust's logical
-        // pointer layout is 64-bit. Store it in the enum as a CUDA generic
-        // pointer, whose representation includes the memory-space identity
-        // and is 64-bit in every supported target mode. Enum construction
-        // and payload extraction insert the address-space casts at the value
-        // boundary. Nested aggregates still fail closed above because their
-        // pointer leaves cannot be retagged without rebuilding the aggregate.
-        let physical_ty: TypeHandle = if is_direct_shared_pointer {
-            llvm_types::PointerType::get_generic(ctx).into()
-        } else {
-            llvm_ty
-        };
-        let (size, align) = llvm_type_size_align(ctx, physical_ty).ok_or_else(|| {
+        // Enum payload storage uses one target-stable physical view. Shared
+        // pointer leaves become generic pointers recursively through LLVM
+        // structs (MIR structs/tuples), while bool leaves become canonical i8
+        // bytes. Unsupported pointer arrays/vectors fail closed here.
+        let storage_ty = enum_payload_storage_type(ctx, llvm_ty).map_err(|error| {
+            anyhow::anyhow!("enum slot map: `{}` field {}: {error}", name, flat)
+        })?;
+        let (size, align) = llvm_type_size_align(ctx, storage_ty).ok_or_else(|| {
             anyhow::anyhow!(
                 "enum slot map: `{}` field {} has unsupported LLVM size/alignment",
                 name,
@@ -1582,18 +1561,11 @@ pub(crate) fn build_enum_slot_map(
         // construction canonicalizes the value and writes it at its byte
         // offset; extraction re-loads the original type from the canonical
         // bytes, exactly like the scalar-bool path above.
-        let storage_ty = if llvm_type_contains_i1(ctx, llvm_ty) {
-            llvm_byte_faithful_twin(ctx, llvm_ty).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "enum slot map: `{}` field {} contains bool storage in a shape (e.g. an i1 vector) whose memory bytes cannot be canonicalized",
-                    name,
-                    flat
-                )
-            })?
-        } else {
-            physical_ty
-        };
-        let field_gets_slot = storage_ty == llvm_ty || is_direct_shared_pointer;
+        // Bool-bearing aggregates remain slotless so their canonical byte view
+        // continues through the established spill path. Pointer-only nested
+        // aggregates may own a slot because construction/extraction now rebuild
+        // them recursively at the semantic/physical boundary.
+        let field_gets_slot = !llvm_type_contains_i1(ctx, llvm_ty);
 
         // Another variant already placed the same storage type at the same
         // position? Then both fields can simply use that claim: variants
@@ -3276,7 +3248,7 @@ mod tests {
     }
 
     #[test]
-    fn enum_slot_map_still_rejects_nested_shared_pointer_payload() {
+    fn enum_slot_map_genericizes_nested_shared_pointer_payload() {
         let mut ctx = make_ctx();
         let discr = mir_uint(&mut ctx, 32);
         let u32_ty = mir_uint(&mut ctx, 32);
@@ -3314,11 +3286,77 @@ mod tests {
         )
         .into();
 
+        let map = build_enum_slot_map(&mut ctx, enum_ty)
+            .expect("a struct-nested shared pointer should use generic physical storage");
+        let field_slot = map.field_slots[0].expect("nested payload should own a slot");
+        let stored_ty = map
+            .llvm_struct_ty
+            .deref(&ctx)
+            .downcast_ref::<llvm_types::StructType>()
+            .map(|struct_ty| struct_ty.field_type(field_slot as usize))
+            .expect("field slot must exist");
+        assert!(
+            llvm_type_contains_pointer_in_address_space(
+                &ctx,
+                stored_ty,
+                llvm_types::address_space::GENERIC
+            ),
+            "physical nested payload must contain a generic pointer"
+        );
+        assert!(
+            !llvm_type_contains_pointer_in_address_space(
+                &ctx,
+                stored_ty,
+                llvm_types::address_space::SHARED
+            ),
+            "physical nested payload must not retain the target-dependent AS3 pointer"
+        );
+        assert!(
+            llvm_type_contains_pointer_in_address_space(
+                &ctx,
+                map.field_llvm_types[0],
+                llvm_types::address_space::SHARED
+            ),
+            "semantic payload type must retain shared address-space semantics"
+        );
+    }
+
+    #[test]
+    fn enum_slot_map_rejects_shared_pointer_array_payload() {
+        let mut ctx = make_ctx();
+        let discr = mir_uint(&mut ctx, 32);
+        let u32_ty = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, u32_ty, false).into();
+        let pointers: TypeHandle = MirArrayType::get(&mut ctx, shared, 2).into();
+        let enum_ty: TypeHandle = MirEnumType::get_with_encoding(
+            &mut ctx,
+            "SharedPointerArrayPayload".into(),
+            discr,
+            vec![0, 1],
+            vec![
+                EnumVariant::unit("Unit".into()),
+                EnumVariant::new_with_layout("Pointers".into(), vec![pointers], vec![8], vec![16]),
+            ],
+            EnumEncoding {
+                tag_offset: 0,
+                total_size: 24,
+                abi_align: 8,
+                layout_kind: EnumLayoutKind::Direct,
+                carrier_kind: EnumCarrierKind::Integer,
+                carrier_width: 32,
+                variant_inhabited: vec![1, 1],
+                ..EnumEncoding::default()
+            },
+        )
+        .into();
+
         let error = build_enum_slot_map(&mut ctx, enum_ty)
             .err()
-            .expect("nested shared-pointer payloads remain target-mode dependent");
+            .expect("arrays of shared pointers remain an explicit boundary");
         assert!(
-            error.to_string().contains("nested shared-memory pointer"),
+            error
+                .to_string()
+                .contains("arrays containing shared-memory pointers are not supported"),
             "{error}"
         );
     }

--- a/crates/rustc-codegen-cuda/STATUS.md
+++ b/crates/rustc-codegen-cuda/STATUS.md
@@ -15,7 +15,7 @@ Run `scripts/check-error-example-status.sh` to verify both are in sync.
 | :------------------------------------ | :------------------ | :---------------------------------- |
 | `error`                               | diagnostics-fixture | `core::fmt` reachable from device   |
 | `error_enum_pointer_overlap`          | support-gap         | Overlaid pointer/integer payload    |
-| `error_enum_shared_pointer_layout`    | support-gap         | Nested AS3 pointer representation   |
+| `error_enum_shared_pointer_layout`    | support-gap         | AS3 pointer arrays/vectors in enums |
 | `error_generated_intrinsic_abi`       | diagnostics-fixture | Unsupported raw intrinsic ABI       |
 | `error_generated_intrinsic_callable`  | diagnostics-fixture | Raw intrinsic passed through `Fn`   |
 | `error_generated_intrinsic_fn_pointer`| diagnostics-fixture | Raw intrinsic made into `fn` pointer|
@@ -40,12 +40,10 @@ a drop is either proven unobservable or its call is emitted.
 The remaining enum storage fixtures deliberately fail closed. Pointer and
 integer payloads cannot share one lowered slot without erasing LLVM pointer
 provenance. Shared-memory pointers are 64 bits in PTX and legacy NVVM output
-but 32 bits in modern NVVM output. A direct enum payload can use a target-stable
-generic pointer slot, but a pointer nested inside an aggregate would require
-recursively rebuilding that aggregate at construction and extraction
-boundaries. Accepting the nested case without that conversion would risk
-generating wrong code, so it remains rejected. (Bools nested in aggregate
-payloads are no longer in this list: enum storage claims each payload's
-byte-faithful twin and construction zero-extends every `i1` leaf into its
-canonical memory byte, so `Option<struct { u32, bool }>` and related layouts
-are supported.)
+but 32 bits in modern NVVM output. Direct fields and pointer leaves nested
+through structs/tuples use target-stable generic physical storage, with
+recursive reconstruction at enum construction and extraction boundaries.
+Arrays and vectors containing shared pointers remain rejected: arrays need an
+explicit expansion bound and code-shape contract, while pointer vectors need
+separate ABI and address-space-cast semantics. (Bool leaves use canonical i8
+physical bytes and are converted recursively at the same boundary.)

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -226,9 +226,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
     if (result[2] - 1.0).abs() >= f32::EPSILON {
-        eprintln!(
-            "FAIL addressof_sharedarray: nested shared pointer enum did not round-trip"
-        );
+        eprintln!("FAIL addressof_sharedarray: nested shared pointer enum did not round-trip");
         std::process::exit(1);
     }
     if (result[3] - 1.0).abs() >= f32::EPSILON {

--- a/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/addressof_sharedarray/src/main.rs
@@ -20,9 +20,10 @@
 //! back into the shared space through the generic space, so the
 //! expose/recover round trip stores through the recovered pointer.
 //!
-//! It also constructs and matches a direct enum payload containing that shared
-//! pointer. The enum's physical storage must stay 64-bit even when modern NVVM
-//! uses a 32-bit representation for semantic shared-space pointers.
+//! It also constructs and matches an enum payload containing a shared pointer
+//! nested through two ordinary Rust structs. The enum's physical storage must
+//! recursively replace the semantic shared pointer leaf with a target-stable
+//! generic pointer, then restore address space 3 when extracting the payload.
 //!
 //! Finally the kernel validates `SharedArray::as_raw_mut_ptr`: 32 threads
 //! derive pointers from one raw shared-array address, write disjoint elements,
@@ -43,9 +44,19 @@ use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, SharedArray, device, kernel, thread};
 use cuda_host::{cuda_module, ltoir};
 
+struct SharedPointerInner {
+    pointer: *mut SharedArray<f32, 1>,
+    cookie: usize,
+}
+
+struct SharedPointerOuter {
+    inner: SharedPointerInner,
+    guard: u32,
+}
+
 enum SharedPointerPayload {
     Empty,
-    Pointer(*mut SharedArray<f32, 1>),
+    Pointer(SharedPointerOuter),
 }
 
 #[cuda_module]
@@ -53,19 +64,32 @@ mod kernels {
     use super::*;
 
     const THREADS: usize = 32;
+    const ENUM_COOKIE: usize = 0xC0DE;
+    const ENUM_GUARD: u32 = 0xA55A;
 
     #[inline(never)]
     #[device]
     fn shared_pointer_enum_address(use_pointer: bool, pointer: *mut SharedArray<f32, 1>) -> usize {
         let payload = if use_pointer {
-            SharedPointerPayload::Pointer(pointer)
+            SharedPointerPayload::Pointer(SharedPointerOuter {
+                inner: SharedPointerInner {
+                    pointer,
+                    cookie: ENUM_COOKIE,
+                },
+                guard: ENUM_GUARD,
+            })
         } else {
             SharedPointerPayload::Empty
         };
 
         match payload {
             SharedPointerPayload::Empty => 0,
-            SharedPointerPayload::Pointer(extracted) => extracted.addr(),
+            SharedPointerPayload::Pointer(extracted)
+                if extracted.inner.cookie == ENUM_COOKIE && extracted.guard == ENUM_GUARD =>
+            {
+                extracted.inner.pointer.addr()
+            }
+            SharedPointerPayload::Pointer(_) => 0,
         }
     }
 
@@ -92,9 +116,10 @@ mod kernels {
                     1.0
                 };
 
-                // A direct enum payload keeps the pointer's shared-space
-                // semantics while using target-stable generic physical
-                // storage. The runtime condition keeps construction,
+                // The enum payload nests the shared pointer through two
+                // structs. Lowering recursively rebuilds the payload with a
+                // generic physical pointer, then restores shared space during
+                // extraction. The runtime condition keeps construction,
                 // discriminant inspection, and extraction observable.
                 let enum_address = shared_pointer_enum_address(seed != 0.0, raw);
                 *out.get_unchecked_mut(2) = if enum_address == raw_address {
@@ -201,7 +226,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
     if (result[2] - 1.0).abs() >= f32::EPSILON {
-        eprintln!("FAIL addressof_sharedarray: shared pointer enum did not round-trip");
+        eprintln!(
+            "FAIL addressof_sharedarray: nested shared pointer enum did not round-trip"
+        );
         std::process::exit(1);
     }
     if (result[3] - 1.0).abs() >= f32::EPSILON {
@@ -211,7 +238,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
     println!(
-        "PASS addressof_sharedarray: seed={seed}, result={}, shared address is non-null, shared pointer enum round-tripped, integer address cast back to the shared pointer",
+        "PASS addressof_sharedarray: seed={seed}, result={}, shared address is non-null, nested shared pointer enum round-tripped, integer address cast back to the shared pointer",
         result[0]
     );
 

--- a/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/README.md
+++ b/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/README.md
@@ -1,16 +1,16 @@
 # `error_enum_shared_pointer_layout`
 
-Negative test for `Option<SharedPointerWrapper>`, where the wrapper contains a
-`&SharedArray<...>`.
+Negative test for `Option<SharedPointerArrayWrapper>`, where the wrapper contains
+an array of two `&SharedArray<...>` values.
 
-Shared-memory pointers use different LLVM storage widths depending on output
-mode: 64 bits in the ordinary PTX and legacy NVVM layouts, but 32 bits in the
-modern NVVM layout. A direct enum pointer field can use generic physical
-storage, but a nested aggregate would have to be rebuilt recursively to replace
-its semantic shared pointer with that target-stable representation.
+Direct shared-pointer enum fields and shared pointers nested through ordinary
+structs/tuples use target-stable CUDA generic physical storage. Arrays remain a
+separate boundary because value conversion would emit one extraction, address-
+space cast, and insertion sequence per element. That expansion needs an explicit
+bound and code-shape contract before it can be accepted safely.
 
-The compiler must reject this nested shape instead of silently leaving half of
-its payload undefined:
+The compiler must reject the array shape instead of retaining target-dependent
+address-space-3 pointer storage:
 
 ```bash
 cargo oxide build error_enum_shared_pointer_layout
@@ -21,5 +21,5 @@ cargo oxide build error_enum_shared_pointer_layout --emit-nvvm-ir --arch sm_100
 Expected diagnostic:
 
 ```text
-contains a nested shared-memory pointer whose size is target-mode dependent
+arrays containing shared-memory pointers are not supported
 ```

--- a/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/error_enum_shared_pointer_layout/src/main.rs
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Negative test: enum storage containing a shared-memory pointer nested in an
-//! aggregate must fail closed until lowering can rebuild that aggregate with a
-//! target-stable physical pointer representation.
+//! Negative test: enum storage containing an array of shared-memory pointers
+//! must fail closed until lowering has a bounded, code-shape-reviewed array
+//! reconstruction strategy.
 
 use cuda_device::{SharedArray, kernel};
 
 static mut SHARED: SharedArray<u32, 1> = SharedArray::UNINIT;
 
-struct SharedPointerWrapper {
-    pointer: &'static SharedArray<u32, 1>,
+struct SharedPointerArrayWrapper {
+    pointers: [&'static SharedArray<u32, 1>; 2],
 }
 
 #[inline(never)]
-fn pointer_bits(value: Option<SharedPointerWrapper>) -> u64 {
+fn pointer_bits(value: Option<SharedPointerArrayWrapper>) -> u64 {
     value.map_or(0, |wrapper| {
-        wrapper.pointer as *const SharedArray<u32, 1> as u64
+        wrapper.pointers[0] as *const SharedArray<u32, 1> as u64
     })
 }
 
@@ -31,7 +31,9 @@ pub unsafe fn shared_pointer_enum(out: *mut u64) {
     let shared_ptr: *const SharedArray<u32, 1> = &raw const SHARED;
     let shared: &'static SharedArray<u32, 1> = unsafe { &*shared_ptr };
     unsafe {
-        *out = pointer_bits(Some(SharedPointerWrapper { pointer: shared }));
+        *out = pointer_bits(Some(SharedPointerArrayWrapper {
+            pointers: [shared, shared],
+        }));
     }
 }
 

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -363,8 +363,8 @@ verdict_error() {
             fi
             ;;
         error_enum_shared_pointer_layout)
-            if ! grep -Fq 'contains a nested shared-memory pointer whose size is target-mode dependent' "${log}"; then
-                echo "FAIL (missing nested shared-pointer layout diagnostic)"
+            if ! grep -Fq 'arrays containing shared-memory pointers are not supported' "${log}"; then
+                echo "FAIL (missing shared-pointer array layout diagnostic)"
                 return 1
             fi
             ;;


### PR DESCRIPTION
Closes #641

## What this fixes

Wrapping a shared-memory pointer inside a struct or tuple before putting it in an enum made the kernel fail device codegen:

```rust
struct Cursor {
    data: SharedPtr<f32>,   // pointer into CUDA shared memory
    offset: u32,
}

let direct: Option<SharedPtr<f32>> = Some(ptr);              // worked before
let nested: Option<Cursor> = Some(Cursor { data: ptr, offset: 4 });  // failed before, works now
```

This is an ordinary pattern: any handle struct that groups a shared pointer with a length, index, or flag, made optional or put in a state enum, hit this.

## Why it happens

- A shared-memory pointer does not have one fixed physical width across our output modes:
  - PTX and legacy NVVM: 64-bit
  - modern NVVM: 32-bit (`ptr addrspace(3)`)
- Enum payload storage must have one stable layout regardless of output mode, so shared pointers cannot sit in enum storage as themselves.
- The existing code substituted a target-stable storage type, but only when the pointer **was** the payload directly. One level of nesting fell into the unsupported path:

```text
Before this PR: the substitution only looked at the payload's top level.

  Option<SharedPtr<f32>>              Option<Cursor>
  =====================              ==============
  payload = SharedPtr<f32>           payload = struct Cursor
      |                                  |
      | top level IS a shared            | top level is a struct, and the
      | pointer, special case            | walker did not look inside it
      v fires                            v
  stored as a generic ptr            no storage type found
      |                                  |
      v                                  v
     OK                              kernel REJECTED

After this PR: the walk recurses through struct/tuple nesting.

  Option<Cursor>
  ==============
  payload = struct Cursor
      |-- data:   SharedPtr<f32>  -> stored as generic ptr
      |                              (addrspacecast on construct/extract)
      |-- offset: u32             -> unchanged
      v
  same size, alignment, offsets, padding as rustc's recorded layout
      |
      v
     OK in all three output modes
```

## The fix, in plain terms

- When computing an enum payload's storage type, walk the payload recursively:
  - shared pointer leaf: store it as a generic pointer (64-bit in every mode)
  - struct field or tuple element: recurse
  - bool leaf: keep the existing byte-faithful `i8` handling
  - other scalars: unchanged
- When a payload is **constructed**, convert each shared-pointer leaf to its storage form; when it is **extracted**, convert back. Both directions are plain `addrspacecast` ops, no `ptrtoint`/`inttoptr` round trip.
- This is layout-safe for structs and tuples because rustc's recorded layout already gives every pointer field a 64-bit slot: field offsets, padding, size, and alignment are unchanged by the substitution.

## The one shape still rejected, and why

Arrays (and vectors) of shared pointers inside a payload remain unsupported. For example:

```rust
struct Table {
    // an ARRAY of shared pointers, not a single one
    pointers: [&'static SharedArray<u32, 128>; 2],
}

let slot: Option<Table> = Some(Table { pointers: [a, b] });  // rejected
```

This now fails with a precise diagnostic instead of a generic failure:

```text
enum payload storage: arrays containing shared-memory pointers are not
supported; recursive target-stable storage currently supports direct
pointers and struct/tuple nesting
```

The reason it fails closed rather than recursing:

- A struct has a fixed, named list of fields, so the construct/extract coercions are a bounded set of per-field casts at known offsets.
- An array is indexed dynamically at runtime, and swapping the element type changes the element stride in the mode where the two pointer widths differ. Converting values would require per-element work at every dynamic access site, not a bounded set of casts.
- Until that is designed properly, a loud, specific error is safer than a layout that silently disagrees between output modes.

## Tests

- Unit coverage: recursive storage-type conversion, construction and extraction through nested structs, symmetric shared-to-generic and generic-to-shared casts, slot maps with nested shared-pointer leaves, rejection of arrays and of vectors.
- `addressof_sharedarray` example: runtime round-trip of the nested shape on GPU.
- New error-category example locks in the array diagnostic, wired into the smoketest.

## Validation

```text
cargo fmt --all -- --check
cargo test -p mir-lower
cargo test -p cuda-oxide-codegen
cargo clippy -p mir-lower -p cuda-oxide-codegen --all-targets -- -D warnings
scripts/check-error-example-status.sh
```
