### PR TITLE
ci(naming-guard): make the reserved-prefix guard actually run

### DIFF
--- a/.github/workflows/naming-guard.yml
+++ b/.github/workflows/naming-guard.yml
@@ -29,26 +29,62 @@ jobs:
       # prefixes is `crates/reserved-oxide-symbols/`; everything else must
       # route through that crate's constants, builders, and predicates.
       #
-      # The pipeline is two-step:
-      #   1. ripgrep finds candidate lines containing `"cuda_oxide_*_`.
-      #   2. grep -v drops lines whose content (after `file:lineno:`)
-      #      starts with optional whitespace then `//` — i.e. pure
-      #      comment lines, which are free to mention the legacy
-      #      prefix forms in prose.
+      # The pipeline is three-step:
+      #   1. a self-test proves the search still matches a known violation.
+      #   2. grep finds candidate lines containing `"cuda_oxide_*_`.
+      #   3. grep -v drops the canonical crate, then drops lines whose
+      #      content (after `file:lineno:`) starts with optional whitespace
+      #      then `//` — i.e. pure comment lines, which are free to mention
+      #      the legacy prefix forms in prose.
       #
-      # We avoid PCRE2 negative-lookahead because some ripgrep builds
+      # This step used to search with ripgrep, which `ubuntu-latest` does
+      # not ship. `rg ... || true` turned the resulting "command not found"
+      # into an empty result set, so the guard reported OK on every commit
+      # without ever reading a file. `grep` is in the runner's base image,
+      # and the self-test plus the exit-status check below make a search
+      # that cannot run fail the job instead of passing it.
+      #
+      # We avoid PCRE2 negative-lookahead because some regex engines
       # tickle catastrophic backtracking on `.*"…"` patterns over the
       # full repo.
       - name: Search for hardcoded reserved-prefix literals
         run: |
           set -euo pipefail
-          matches="$(rg --type rust -n \
-              '"cuda_oxide_(kernel|device|instantiate)_' \
-              crates \
-              -g '!crates/reserved-oxide-symbols/**' \
-              -g '!**/target/**' \
+
+          pattern='"cuda_oxide_(kernel|device|instantiate)_'
+
+          # Self-test. The failure mode this guard has to survive is
+          # "silently stops matching anything", so require it to prove it
+          # can still match before a clean result is believed.
+          canary="$(mktemp -d)"
+          trap 'rm -rf "${canary}"' EXIT
+          mkdir -p "${canary}/crates"
+          printf 'const CANARY: &str = %s;\n' \
+              '"cuda_oxide_kernel_246e25db_canary"' \
+              >"${canary}/crates/canary.rs"
+          if ! grep -rEn --include='*.rs' "${pattern}" "${canary}/crates" \
+              >/dev/null; then
+              echo "::error::reserved-prefix guard self-test failed: the search did not match a known violation"
+              exit 1
+          fi
+
+          # grep exits 0 with matches, 1 with none, and >=2 on error. Only 1
+          # means clean; anything higher must fail the job rather than be
+          # mistaken for an empty result.
+          set +e
+          matches="$(grep -rEn --include='*.rs' "${pattern}" crates \
+              --exclude-dir=target)"
+          status=$?
+          set -e
+          if [ "${status}" -gt 1 ]; then
+              echo "::error::reserved-prefix search failed (grep exit ${status})"
+              exit 1
+          fi
+
+          violations="$(printf '%s\n' "${matches}" \
+              | grep -v '^crates/reserved-oxide-symbols/' \
+              | grep -vE ':[0-9]+:[[:space:]]*//' \
               || true)"
-          violations="$(echo "$matches" | grep -vE ':[0-9]+:[[:space:]]*//' || true)"
           if [ -n "$violations" ]; then
               echo "::error::Hardcoded cuda_oxide_* prefix literals found outside reserved-oxide-symbols:"
               echo "$violations"

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -1387,11 +1387,13 @@ fn ptx_export_records_standalone_device_function_roots_for_internalization() {
     let module = ModuleOp::new(&mut ctx, "ptx_device_root".try_into().unwrap());
     let module_block = module_top_block(&mut ctx, &module);
     let func_ty = FuncType::get(&ctx, VoidType::get(&ctx).into(), vec![], false);
+    let prefixed_name = format!(
+        "{}standalone_export",
+        reserved_oxide_symbols::LEGACY_DEVICE_PREFIX
+    );
     let func = FuncOp::new(
         &mut ctx,
-        "cuda_oxide_device_246e25db_standalone_export"
-            .try_into()
-            .unwrap(),
+        prefixed_name.as_str().try_into().unwrap(),
         func_ty,
     );
     let entry = func.get_or_create_entry_block(&mut ctx);


### PR DESCRIPTION
Fixes #643.

## What was wrong

The `naming-guard` step searches with `rg`, which the `ubuntu-latest` image does not ship. `rg ... || true` turned the resulting `command not found` into an empty result set, so the guard printed `OK` and exited 0 on every commit since `fc0aae62` (2026-05-03) without ever reading a file.

From the latest `main` run ([30748062109](https://github.com/NVlabs/cuda-oxide/actions/runs/30748062109), conclusion `success`):

```text
/home/runner/work/_temp/fb92a9b1-....sh: line 7: rg: command not found
OK: no hardcoded reserved-prefix literals outside reserved-oxide-symbols.
```

The step also finishes in ~6s, which is about what a search that reads nothing costs.

## What this changes

**Search with `grep`.** It is in the runner's base image, so the tool cannot go missing. This is also why the diff does not just `apt-get install ripgrep`: that keeps the dependency and adds ~15s per run, and the `|| true` would still hide a future failure.

**Fail closed.** `grep` exits 0 with matches, 1 with none, and >= 2 on error. Only 1 is treated as clean, so a search that cannot run fails the job rather than being mistaken for an empty result.

**Self-test.** This guard's failure mode is silently matching nothing, so before a clean result is believed it must match a known violation in a throwaway fixture. That is the part that would have caught the original bug on the day it was introduced.

**One real violation, now fixed.** With a working search, the guard's own pattern finds:

```text
crates/llvm-export/tests/export_test.rs:1392:        "cuda_oxide_device_246e25db_standalone_export"
```

That is `LEGACY_DEVICE_PREFIX` plus a base name, built by hand. Line 810 of the same file already does it the sanctioned way, so this now uses `reserved_oxide_symbols::LEGACY_DEVICE_PREFIX`. The constructed symbol is byte-identical and the test still asserts the prefix is stripped to `standalone_export`.

## Verification

CPU-only; no CUDA toolkit or GPU. I extracted the step's `run:` block from the YAML and exercised it six ways:

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | Reworked guard, violation fixed | pass | exit 0 |
| 2 | Reworked guard, violation restored | fail | exit 1, names file and line |
| 3 | **Current** guard, violation present, `rg` absent | — | exit 0, reproduces the bug with CI's two log lines |
| 4 | Reworked guard, search tool absent | fail | exit 1 via the self-test |
| 5 | Reworked guard, fresh violation in a new file | fail | exit 1 |
| 6 | Reworked guard, prefix only in `//` and `///` comments | pass | exit 0, exemption preserved |

`cargo test -p llvm-export --all-targets`: 100 passed, 0 failed. `cargo clippy -p llvm-export --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean.

The `reserved-oxide-symbols literal guard` check on this PR is the real signal: it should now take longer than 6s and still pass.

## One open question, deliberately not bundled here

The step comment says it rejects any hardcoded `cuda_oxide_*` prefix, but the pattern matches only `kernel|device|instantiate`. The crate also owns `CONSTANT_PREFIX`, `ARTIFACT_ANCHOR_PREFIX`, and `PTX_MERGE_REQUIRED_PREFIX`. Widening the alternation surfaces one more hit:

```text
crates/cuda-core/src/embedded.rs:236:            Some("cuda_oxide_artifact_anchor_246e25db_linked_0_0_0"),
```

`artifact_anchor_symbol("linked", "0.0.0")` produces exactly that string, but `cuda-core` does not currently depend on `reserved-oxide-symbols`, so fixing it adds a dev-dependency edge. That is a policy call rather than a bug, so I left it out. Happy to add it here or in a follow-up, whichever you prefer.
