### PR TITLE
ci(naming-guard): guard every reserved symbol prefix, not three of them

### DIFF
--- a/.github/workflows/naming-guard.yml
+++ b/.github/workflows/naming-guard.yml
@@ -30,10 +30,15 @@ jobs:
       # route through that crate's constants, builders, and predicates.
       #
       # The alternation below covers all ten symbol constants that crate
-      # exports: `kernel` covers KERNEL_PREFIX, LEGACY_KERNEL_PREFIX and
-      # KERNEL_SCOPE_LOCAL; `device` covers DEVICE_PREFIX,
-      # LEGACY_DEVICE_PREFIX and DEVICE_EXTERN_PREFIX; and `instantiate`,
-      # `const`, `artifact_anchor` and `ptx_merge_required` cover one each.
+      # exports: `kernel` covers LEGACY_KERNEL_PREFIX and
+      # KERNEL_SCOPE_LOCAL; `device` covers LEGACY_DEVICE_PREFIX and
+      # DEVICE_EXTERN_PREFIX; `instantiate`, `const`, `artifact_anchor`
+      # and `ptx_merge_required` cover one each; and `codegen_v1` covers
+      # the modern KERNEL_PREFIX and DEVICE_PREFIX. The last one matters
+      # because the pattern is anchored to the opening quote: a hardcoded
+      # full modern prefix starts with `cuda_oxide_codegen_v1_`, so its
+      # embedded `cuda_oxide_kernel_` segment sits mid-string where the
+      # quote-anchored `kernel` family can never match it.
       #
       # It deliberately does NOT match bare `cuda_oxide_`. That word-space
       # also holds things this crate does not own and must not police:
@@ -65,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          pattern='"cuda_oxide_(kernel|device|instantiate|const|artifact_anchor|ptx_merge_required)_'
+          pattern='"cuda_oxide_(kernel|device|instantiate|const|artifact_anchor|ptx_merge_required|codegen_v1)_'
 
           # Self-test. The failure mode this guard has to survive is
           # "silently stops matching anything", so require it to prove it

--- a/.github/workflows/naming-guard.yml
+++ b/.github/workflows/naming-guard.yml
@@ -24,10 +24,24 @@ jobs:
         uses: actions/checkout@v4
 
       # Reject any Rust source line (outside the canonical
-      # `reserved-oxide-symbols` crate) that hardcodes a `cuda_oxide_*`
+      # `reserved-oxide-symbols` crate) that hardcodes a reserved *symbol*
       # prefix as a string literal. The single source of truth for these
       # prefixes is `crates/reserved-oxide-symbols/`; everything else must
       # route through that crate's constants, builders, and predicates.
+      #
+      # The alternation below covers all ten symbol constants that crate
+      # exports: `kernel` covers KERNEL_PREFIX, LEGACY_KERNEL_PREFIX and
+      # KERNEL_SCOPE_LOCAL; `device` covers DEVICE_PREFIX,
+      # LEGACY_DEVICE_PREFIX and DEVICE_EXTERN_PREFIX; and `instantiate`,
+      # `const`, `artifact_anchor` and `ptx_merge_required` cover one each.
+      #
+      # It deliberately does NOT match bare `cuda_oxide_`. That word-space
+      # also holds things this crate does not own and must not police:
+      # pliron op-attribute keys (`cuda_oxide_asm_kind`,
+      # `cuda_oxide_debug_local_*`), rustc `--cfg` names
+      # (`cuda_oxide_internal_backend_identity`), dlopen probe symbols
+      # (`cuda_oxide_probe`), and unique temp-directory names. Those are
+      # legitimate local constants, not reserved link symbols.
       #
       # The pipeline is three-step:
       #   1. a self-test proves the search still matches a known violation.
@@ -51,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          pattern='"cuda_oxide_(kernel|device|instantiate)_'
+          pattern='"cuda_oxide_(kernel|device|instantiate|const|artifact_anchor|ptx_merge_required)_'
 
           # Self-test. The failure mode this guard has to survive is
           # "silently stops matching anything", so require it to prove it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "cuda-macros",
  "half",
  "oxide-artifacts",
+ "reserved-oxide-symbols",
  "trybuild",
 ]
 

--- a/crates/cuda-core/Cargo.toml
+++ b/crates/cuda-core/Cargo.toml
@@ -16,4 +16,7 @@ oxide-artifacts = { workspace = true, features = ["object-read"] }
 
 [dev-dependencies]
 oxide-artifacts = { workspace = true, features = ["object-write"] }
+# Test-only: the embedded-artifact round trip builds a link-anchor symbol,
+# whose spelling is owned by reserved-oxide-symbols rather than restated here.
+reserved-oxide-symbols = { workspace = true }
 trybuild = "1"

--- a/crates/cuda-core/src/embedded.rs
+++ b/crates/cuda-core/src/embedded.rs
@@ -230,12 +230,10 @@ mod tests {
         // Mirror production: the backend always defines a link-anchor
         // symbol in the artifact object. The linked-executable round trip
         // must keep working with that symbol present.
-        let object = build_host_object_for_target(
-            &blob,
-            "x86_64-unknown-linux-gnu",
-            Some("cuda_oxide_artifact_anchor_246e25db_linked_0_0_0"),
-        )
-        .unwrap();
+        let anchor = reserved_oxide_symbols::artifact_anchor_symbol("linked", "0.0.0");
+        let object =
+            build_host_object_for_target(&blob, "x86_64-unknown-linux-gnu", Some(anchor.as_str()))
+                .unwrap();
         std::fs::write(&source_path, "fn main() {}\n").unwrap();
         std::fs::write(&object_path, object).unwrap();
 


### PR DESCRIPTION
Fixes #645. This is the separate discussion you suggested when approving #644.

## What was wrong

`naming-guard`'s comment says it rejects any hardcoded reserved prefix and that `reserved-oxide-symbols` is their single source of truth, but the pattern matched only `kernel|device|instantiate`. Four of the crate's ten exported symbol constants were unguarded, and now that the guard actually executes, that gap hid exactly one live violation:

```text
crates/cuda-core/src/embedded.rs:236:            Some("cuda_oxide_artifact_anchor_246e25db_linked_0_0_0"),
```

Coverage before and after:

| Constant(s) | Segment | Before | After |
|---|---|---|---|
| `KERNEL_PREFIX`, `LEGACY_KERNEL_PREFIX`, `KERNEL_SCOPE_LOCAL` | `cuda_oxide_kernel_` | yes | yes |
| `DEVICE_PREFIX`, `LEGACY_DEVICE_PREFIX`, `DEVICE_EXTERN_PREFIX` | `cuda_oxide_device_` | yes | yes |
| `INSTANTIATE_PREFIX` | `cuda_oxide_instantiate_` | yes | yes |
| `CONSTANT_PREFIX` | `cuda_oxide_const_` | **no** | yes |
| `ARTIFACT_ANCHOR_PREFIX` | `cuda_oxide_artifact_anchor_` | **no** | yes |
| `PTX_MERGE_REQUIRED_PREFIX` | `cuda_oxide_ptx_merge_required_` | **no** | yes |

## Why six families and not bare `cuda_oxide_`

The obvious simplification is to drop the list and match `RESERVED_ROOT` outright. I measured it: that hits **58** literals, and ~57 belong to a namespace this crate does not own and must not police —

- pliron op-attribute keys: `cuda_oxide_asm_kind`, `cuda_oxide_debug_local_*`, `cuda_oxide_op_alignment`, `cuda_oxide_gep_inbounds`
- rustc `--cfg` names: `cuda_oxide_internal_backend_identity`, `cuda_oxide_internal_codegen_env`
- `dlopen` probe symbols: `cuda_oxide_probe`
- unique temp-directory names: `cuda_oxide_stale_artifacts_*`, `cuda_oxide_clean_cache_*`
- the generated marker attribute: `cuda_oxide_intrinsic_marker`

Widening that far would mean ~57 false positives and a pointless refactor. The six symbol families cover all ten constants and produce exactly the one real hit. I put that reasoning in the step comment so the boundary does not have to be re-derived next time.

## The dev-dependency

The violation is inside `#[cfg(test)] mod tests`, so `reserved-oxide-symbols` goes in `[dev-dependencies]` and stays out of the shipped `cuda-core` library. It is already a workspace dependency of `llvm-export`, `cargo-oxide`, and `mir-lower`, so this adds no licensing surface and the `Cargo.lock` delta is one line.

## Verification

CPU-only, no GPU. Guard step extracted from the YAML and run directly:

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | Widened guard, `embedded.rs` fixed | pass | exit 0 |
| 2 | Widened guard, violation restored | fail | exit 1, names file and line |
| 3 | Old 3-family pattern vs. that same violation | — | 0 matches, confirms the blind spot |
| 4 | Synthetic violation for each of the six families | fail | all six caught |
| 5 | `cuda_oxide_asm_kind` / `..._internal_backend_identity` / `..._probe` | pass | not flagged |

The rebuilt symbol is byte-identical — I temporarily added `assert_eq!(anchor, "cuda_oxide_artifact_anchor_246e25db_linked_0_0_0")` to the test, confirmed it passed, then removed it. `artifact_bundles_from_binary_path_reads_linked_executable` also links a real executable carrying the anchor and reads it back, and still passes.

`cargo test -p cuda-core --lib`: 26 passed / 0 failed. `reserved-oxide-symbols`: 13 unit + 17 doc tests pass. `cargo clippy -p cuda-core --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.

## One unrelated thing I noticed, not touched here

Checking whether CONTRIBUTING's "update `dependency-licenses.csv` when adding a dependency" applied, I found the CSV lists 11 first-party workspace crates while the workspace has 23 members. Missing: `cuda-intrinsics`, `cuda-intrinsics-gen`, `cuda-artifact-finalizer`, `cuda-oxide-codegen`, `mir-transforms`, `nvvm-transforms`, `cargo-oxide`, `oxide-artifacts`, `cuda-async`, `libnvvm-sys`, `nvjitlink-sys`, `reserved-oxide-symbols`, `fuzzer`. That predates this change; say the word and I'll file it separately.
