### PR TITLE
test(reserved-oxide-symbols): pin the constants two hygiene fixtures depend on

### DIFF
--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -9717,4 +9717,33 @@ mod tests {
             "minimum blocks affects device occupancy metadata, not the host launch contract",
         );
     }
+
+    /// The two hygiene regressions for the injected launch-context scope spell
+    /// `KERNEL_SCOPE_LOCAL`-derived names as *identifiers*, so no compiler
+    /// check ties them back to the constant. Rename the constant and both
+    /// fixtures quietly stop colliding with the generated bindings: they keep
+    /// passing while testing nothing, because there is no longer anything to
+    /// collide with. Pin the coupling so a rename fails here and names the
+    /// fixtures that have to move with it.
+    #[test]
+    fn hygiene_fixtures_still_collide_with_the_generated_scope_names() {
+        let storage = format!("{KERNEL_SCOPE_LOCAL}_storage");
+
+        let launch_context = include_str!("../tests/pass/kernel_launch_context_api.rs");
+        assert!(
+            launch_context.contains(&storage),
+            "tests/pass/kernel_launch_context_api.rs must bind `{storage}` so \
+             `generated_storage_name_is_hygienic` exercises the mixed-site \
+             hygiene of the generated storage binding"
+        );
+
+        let const_generic =
+            include_str!("../../rustc-codegen-cuda/examples/const_generic/src/main.rs");
+        assert!(
+            const_generic.contains(KERNEL_SCOPE_LOCAL),
+            "examples/const_generic must declare a const generic named \
+             `{KERNEL_SCOPE_LOCAL}` so `call_site_ident_avoiding_item` is \
+             forced down its rename path"
+        );
+    }
 }

--- a/crates/reserved-oxide-symbols/src/lib.rs
+++ b/crates/reserved-oxide-symbols/src/lib.rs
@@ -585,12 +585,31 @@ mod tests {
             PTX_MERGE_REQUIRED_PREFIX,
             "cuda_oxide_ptx_merge_required_246e25db_"
         );
+        assert_eq!(
+            ARTIFACT_ANCHOR_PREFIX,
+            "cuda_oxide_artifact_anchor_246e25db_"
+        );
+        // `KERNEL_SCOPE_LOCAL` is not a link symbol, but renaming it silently
+        // disarms two hygiene regressions that spell it as an *identifier*,
+        // where no compiler check ties them back to this constant:
+        //
+        //   * crates/cuda-macros/tests/pass/kernel_launch_context_api.rs
+        //     declares a binding named `{KERNEL_SCOPE_LOCAL}_storage` so the
+        //     mixed-site storage binding must survive the collision.
+        //   * crates/rustc-codegen-cuda/examples/const_generic/src/main.rs
+        //     declares a const generic named `KERNEL_SCOPE_LOCAL` so
+        //     `call_site_ident_avoiding_item` must take its rename path.
+        //
+        // Both keep passing once renamed, because there is simply nothing left
+        // to collide with. Update them together with this constant.
+        assert_eq!(KERNEL_SCOPE_LOCAL, "cuda_oxide_kernel_scope_246e25db");
     }
 
-    /// Every prefix shares the reserved root. The macro guard checks
+    /// Every reserved name shares the reserved root. The macro guard checks
     /// for `RESERVED_ROOT` and rejects user-defined names that start
     /// with it; this test ensures the reserved root remains a true
-    /// prefix of all four mangled categories.
+    /// prefix of every mangled category this crate hands out, including the
+    /// artifact anchor and the injected scope local.
     #[test]
     fn all_prefixes_share_reserved_root() {
         for p in [
@@ -602,6 +621,8 @@ mod tests {
             INSTANTIATE_PREFIX,
             CONSTANT_PREFIX,
             PTX_MERGE_REQUIRED_PREFIX,
+            ARTIFACT_ANCHOR_PREFIX,
+            KERNEL_SCOPE_LOCAL,
         ] {
             assert!(
                 p.starts_with(RESERVED_ROOT),


### PR DESCRIPTION
Fixes #647. Branched from `main` and touches only two files, so it does not overlap #646.

## What was wrong

Two hygiene regressions spell `KERNEL_SCOPE_LOCAL`'s value as a Rust **identifier**, and nothing tied either back to the constant:

| Fixture | Declares | Proves |
|---|---|---|
| `crates/cuda-macros/tests/pass/kernel_launch_context_api.rs:27` | parameter `cuda_oxide_kernel_scope_246e25db_storage` | the `Span::mixed_site()` storage binding (`lib.rs:4609`) survives a same-text user binding |
| `crates/rustc-codegen-cuda/examples/const_generic/src/main.rs:55` | const generic `cuda_oxide_kernel_scope_246e25db` | `call_site_ident_avoiding_item` (`lib.rs:4547`) takes its rename path |

Their whole point is to *collide*. Rename the constant and they become ordinary unrelated names — the hygiene goes unexercised, and everything stays green:

```diff
-pub const KERNEL_SCOPE_LOCAL: &str = "cuda_oxide_kernel_scope_246e25db";
+pub const KERNEL_SCOPE_LOCAL: &str = "cuda_oxide_kernel_scope_deadbeef";
```

```console
$ cargo test -p reserved-oxide-symbols --all-targets
test result: ok. 13 passed; 0 failed
$ cargo test -p cuda-macros --all-targets
test result: ok. 91 passed; 0 failed     # lib
test result: ok. 1 passed; 0 failed      # trybuild pass suite, incl. the hygiene fixture
...
```

The contributing cause: `hash_value_is_pinned` — whose doc comment says changing these "must be done deliberately" — asserted 8 of the crate's 10 constants, and `all_prefixes_share_reserved_root` enumerated the same 8. `KERNEL_SCOPE_LOCAL` and `ARTIFACT_ANCHOR_PREFIX` were absent. `ARTIFACT_ANCHOR_PREFIX` at least had an indirect backstop via the exact-output asserts in `artifact_anchor_symbol_is_sanitized_and_reserved`; `KERNEL_SCOPE_LOCAL` had none anywhere in the workspace.

Worth noting the contrast inside that same fixture: lines 36–40 also spell `KERNEL_PREFIX` as identifiers, but those are *referenced*, so a rename breaks the build. The hygiene bindings are only *declared*, so they fail open.

## What this changes

1. Pin `KERNEL_SCOPE_LOCAL` and `ARTIFACT_ANCHOR_PREFIX` in `hash_value_is_pinned`, with a comment naming both fixtures so a rename says what must move with it.
2. Enumerate both in `all_prefixes_share_reserved_root`, so the test named "all prefixes" covers all ten.
3. Add `hygiene_fixtures_still_collide_with_the_generated_scope_names` to `cuda-macros`, which reads both fixtures via `include_str!` and asserts they still spell the `KERNEL_SCOPE_LOCAL`-derived names. This makes the coupling machine-checked instead of relying on memory, and is the part that would have caught this on day one.

## Verification

CPU-only, no GPU.

With the constant intact: `reserved-oxide-symbols` 13 unit + 17 doc pass; `cuda-macros` 92 lib (91 + the new test) plus all four trybuild suites pass.

With the constant renamed to `..._deadbeef`, both new checks now fail loudly:

```text
test tests::hash_value_is_pinned ... FAILED
  assertion `left == right` failed  (reserved-oxide-symbols/src/lib.rs:605)

test tests::hygiene_fixtures_still_collide_with_the_generated_scope_names ... FAILED
  tests/pass/kernel_launch_context_api.rs must bind
  `cuda_oxide_kernel_scope_deadbeef_storage` so `generated_storage_name_is_hygienic`
  exercises the mixed-site hygiene of the generated storage binding
```

`cargo clippy -p reserved-oxide-symbols -p cuda-macros --all-targets -- -D warnings` and `cargo fmt --all --check` are clean. No new dependencies, so `Cargo.lock` is untouched.

## Two notes for review

**The cross-crate `include_str!`.** One half of (3) reads `crates/rustc-codegen-cuda/examples/const_generic/src/main.rs` from `cuda-macros`. It sits inside `#[cfg(test)]`, so it is stripped from non-test builds — confirmed with `cargo build -p cuda-macros` — and both files are git-tracked, so they exist in any CI checkout. If you would rather not have that coupling, dropping just that assertion still leaves (1) failing on a rename and naming the example explicitly.

**Guard compatibility.** The new literals live in `crates/reserved-oxide-symbols/`, which `naming-guard` excludes, so this is clean under both the current pattern and #646's widened one — I checked both.
