### PR TITLE
test(smoketest): stop reporting a skipped or never-launched example as a full PASS

### DIFF
--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -60,6 +60,15 @@ ERROR_EXAMPLES=(error error_set_discriminant_uninhabited error_enum_bool_payload
 # Examples that pin RUSTFLAGS=-Zinline-mir=no (verdict rules are unaffected)
 NOINLINE_MIR_EXAMPLES=(disjoint_slice_len)
 
+# Examples whose `main` deliberately never launches a kernel: they exist to
+# prove the device code compiles, and say so in their module docs
+# ("compilation and PTX generation only. Do not launch this kernel."). They
+# still belong to the `standard` category because the build and the host
+# binary must both succeed, but reporting a bare `PASS` would make them
+# indistinguishable in the summary from an example that launched kernels and
+# verified results.
+NO_LAUNCH_EXAMPLES=(wgmma_mma_bf16)
+
 # Examples whose verify-code-shape.sh asserts on `#[inline(never)]` marker
 # symbols. Those markers are private, so once the middle end inlines them into
 # their single caller it deletes them, and they survive only in the
@@ -83,6 +92,14 @@ classify() {
 verify_nvvm_in_compile_only() {
     local ex="$1" candidate
     for candidate in "${NVVM_VERIFY_EXAMPLES[@]}"; do
+        [[ "$ex" == "$candidate" ]] && return 0
+    done
+    return 1
+}
+
+example_never_launches() {
+    local ex="$1" candidate
+    for candidate in "${NO_LAUNCH_EXAMPLES[@]}"; do
         [[ "$ex" == "$candidate" ]] && return 0
     done
     return 1
@@ -319,7 +336,7 @@ fi
 # They never run cargo themselves; that is the caller's job.
 
 verdict_standard() {
-    local log="$1" ec="$2"
+    local log="$1" ec="$2" ex="${3:-}"
     if [[ ${ec} -gt 128 ]]; then echo "FAIL (crashed, signal $((ec - 128)))"; return 1; fi
     if [[ ${ec} -ne 0 ]]; then   echo "FAIL (exit=${ec})";                    return 1; fi
     if grep_failure_markers "${log}"; then
@@ -330,11 +347,28 @@ verdict_standard() {
     # pre-Hopper, mathdx_ffi_test with no MathDx SDK). Accept it as PASS so
     # standard-category examples can gate themselves on hardware/SDK presence
     # without having to fake a success marker.
-    if grep -qE '^[[:space:]]*skipping:' "${log}"; then
+    #
+    # This has to recognise the declaration in every spelling the examples
+    # use, because the success-marker check below matches `SUCCESS|PASS|
+    # Complete` anywhere in the log and skip messages routinely contain those
+    # words. Missing a skip here therefore does not merely lose the
+    # "(skipped)" annotation: it promotes the example to a full execution
+    # PASS, indistinguishable from one that launched kernels and checked
+    # results. That is how `Skipping: ... -- PASS (skipped)` used to report a
+    # clean PASS, and `generated_ldmatrix` still prints the
+    # `PASS (skipped): ...` form below sm_75.
+    if grep -qiE '^[[:space:]]*(skipping:|pass \(skipped\))' "${log}"; then
         echo "PASS (skipped)"
         return 0
     fi
-    if grep -qE 'SUCCESS|PASS|Complete' "${log}"; then echo "PASS"; return 0; fi
+    if grep -qE 'SUCCESS|PASS|Complete' "${log}"; then
+        if example_never_launches "${ex}"; then
+            echo "PASS (compiled, no launch)"
+        else
+            echo "PASS"
+        fi
+        return 0
+    fi
     echo "FAIL (no success marker)"
     return 1
 }
@@ -1526,7 +1560,7 @@ for ex in "${selected[@]}"; do
             ltoir)       verdict="$(verdict_ltoir       "${ex}" "${log}" "${ec}")" && status=0 || status=$? ;;
             ltoir-modern) verdict="$(verdict_ltoir_modern "${ex}" "${log}" "${ec}")" && status=0 || status=$? ;;
             auto-nvvm)   verdict="$(verdict_ltoir       "${ex}" "${log}" "${ec}")" && status=0 || status=$? ;;
-            standard)    verdict="$(verdict_standard    "${log}" "${ec}")"        && status=0 || status=$? ;;
+            standard)    verdict="$(verdict_standard    "${log}" "${ec}" "${ex}")" && status=0 || status=$? ;;
             *)           verdict="FAIL (unknown category: ${cat})"; status=1 ;;
         esac
     fi


### PR DESCRIPTION
Fixes #656. This is the `smoketest.sh` half of that issue; #658 fixed the example-side half and deliberately left the script untouched.

Touches one file, so it does not overlap #664.

## What was wrong

`verdict_standard` decides a bare `PASS` from `grep -qE 'SUCCESS|PASS|Complete'` over the whole log. Skip declarations routinely contain those words, so a skip the function fails to recognise is not merely missing its `(skipped)` annotation — it is **promoted to a full execution PASS**, indistinguishable in the summary from an example that launched kernels and verified results.

Three cases all reported a clean `PASS`:

| case | why | live? |
|---|---|---|
| `wgmma_mma_bf16` never launches | its `main` only prints; module doc says *"compilation and PTX generation only. Do not launch this kernel."* Yet it is in `standard`, whose contract is that execution succeeds | **yes, on every GPU run** |
| `generated_ldmatrix` prints `PASS (skipped): …` | the skip check matched only a leading lowercase `skipping:`, so the line fell through to the success grep, which matched its own `PASS` | only below sm_75 |
| a capitalised `Skipping:` | same fall-through | no — #658 reworded the two examples that hit it |

I am being explicit about the third row: nothing triggers it today, so matching case-insensitively is purely defensive. It is included because it is the same fall-through that produced two of the original false passes in #656, and the next example to capitalise the word would silently get a full PASS again.

## What this changes

- Recognise the skip declaration in both spellings the examples use, case-insensitively, **before** the success-marker check.
- Add `NO_LAUNCH_EXAMPLES=(wgmma_mma_bf16)` and report `PASS (compiled, no launch)` for it, mirroring the existing `verify_nvvm_in_compile_only` helper shape.
- Pass `${ex}` into `verdict_standard`, as the dispatch already does for `verdict_error`.

`wgmma_mma_bf16` stays in `standard` on purpose. It cannot move to `WGMMA_EXAMPLES` — `verdict_wgmma`'s gate patterns (`WARNING: WGMMA requires`, `PTX load failed (expected on non-Hopper)`, …) match none of its output, so it would land on `FAIL (wgmma, no success marker)`. And `blackwell-compile`, the existing always-compile-only category, carries a bespoke dual-route `run_cargo` branch specific to `generated_intrinsics_blackwell`. The build and host binary genuinely must succeed here; only the *label* was wrong.

## Verification

No GPU was used, and none is needed: the `verdict_*` functions are pure by design — "Each `verdict_*` function consumes a log file + exit code … They never run cargo themselves". I extracted the real `verdict_standard`, `grep_failure_markers`, and `example_never_launches` from the script and drove them with synthetic logs.

| scenario | before | after |
|---|---|---|
| real execution pass | `PASS` | `PASS` |
| lowercase `skipping:` | `PASS (skipped)` | `PASS (skipped)` |
| capitalised `Skipping: … -- PASS (skipped)` | **`PASS`** | `PASS (skipped)` |
| `PASS (skipped): ldmatrix… requires sm_75+` | **`PASS`** | `PASS (skipped)` |
| `wgmma_mma_bf16` no-launch output | **`PASS`** | `PASS (compiled, no launch)` |
| no marker at all | `FAIL (no success marker)` | unchanged |
| failure marker (`panicked at`) | `FAIL (failure marker in output)` | unchanged |
| exit code 1 | `FAIL (exit=1)` | unchanged |
| signal 11 | `FAIL (crashed, signal 11)` | unchanged |

The three bold rows are the fix; the other six confirm nothing else moved.

I also checked that no other example is reclassified: of the 14 self-gating message forms across the examples, 13 already use lowercase `skipping:` and only `generated_ldmatrix` uses the `PASS (skipped)` spelling. No example prints a capitalised `Skipping:` any more.

The summary tallies on the verdict function's **return code**, not on parsing the label, so the new string changes no counts. `bash -n` is clean, and both sibling guards (`check-error-example-status.sh`, which parses `ERROR_EXAMPLES` out of this same file, and `check-dependency-licenses.sh`) still pass.

## Scope note on CI

Compile-only runs collapse every category into `verdict_compile`, so the GPU-less `examples-compile` lane never reaches `verdict_standard`. This change affects real-GPU runs only, which is also why it cannot be exercised by upstream CI.

One maintenance note: if `wgmma_mma_bf16` ever starts launching, its `NO_LAUNCH_EXAMPLES` entry should go. The failure mode of forgetting is understating a genuine execution pass as `PASS (compiled, no launch)`, not a false pass.
