### PR TITLE
fix(examples): future_apis needs sm_90, not sm_80

### DIFF
--- a/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
@@ -244,10 +244,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
 
-    // The mbarrier APIs exercised below require sm_80 (Ampere) or later.
+    // sm_100, not sm_80. The mbarrier calls here would run on Ampere, but the
+    // kernels also construct `ManagedBarrier<_, TmaBarrier>`, and the backend
+    // detects that as a TMA feature: building for anything lower is refused
+    // with "CUDA target sm_86 cannot lower detected feature Tma + Sm80;
+    // cuda-oxide requires a target compatible with sm_100 for this module".
+    // Under an auto-detected target the build instead succeeds at sm_100 and
+    // the module then fails to load, so a lower floor here reads as
+    // DriverError(218) on every pre-Blackwell device.
     let (major, minor) = ctx.compute_capability()?;
-    if major < 8 {
-        println!("skipping: mbarrier requires sm_80+ (device is sm_{major}{minor})");
+    if major < 10 {
+        println!("skipping: TMA-typed barriers require sm_100+ (device is sm_{major}{minor})");
         return Ok(());
     }
 

--- a/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
@@ -244,17 +244,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
 
-    // sm_100, not sm_80. The mbarrier calls here would run on Ampere, but the
-    // kernels also construct `ManagedBarrier<_, TmaBarrier>`, and the backend
-    // detects that as a TMA feature: building for anything lower is refused
-    // with "CUDA target sm_86 cannot lower detected feature Tma + Sm80;
-    // cuda-oxide requires a target compatible with sm_100 for this module".
-    // Under an auto-detected target the build instead succeeds at sm_100 and
-    // the module then fails to load, so a lower floor here reads as
-    // DriverError(218) on every pre-Blackwell device.
+    // sm_90, not sm_80. `ManagedBarrier::init_by` emits `fence.proxy.async`
+    // for every barrier kind (the TmaBarrier typestate parameter is inert
+    // PhantomData and detects nothing), and per the PTX ISA that fence needs
+    // sm_90 or newer: ptxas rejects it below that with "Modifier '.async'
+    // requires .target sm_90 or higher". The backend's feature scan classifies
+    // the fence as Tma; with a device hint the target resolves to the device
+    // (a Hopper box builds and runs this example at sm_90), while a hint-less
+    // cross-compile defaults the module to sm_100 and a pre-Hopper device then
+    // fails to load it with DriverError(218). Skip below sm_90 so the example
+    // exercises real hardware everywhere it can actually run.
     let (major, minor) = ctx.compute_capability()?;
-    if major < 10 {
-        println!("skipping: TMA-typed barriers require sm_100+ (device is sm_{major}{minor})");
+    if major < 9 {
+        println!(
+            "skipping: fence.proxy.async (emitted by ManagedBarrier::init_by) requires sm_90+ (device is sm_{major}{minor})"
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
Follow-up to #658, which I got wrong for this one example.

## What was wrong

#658 gated `future_apis` at sm_80, reasoning from its `mbarrier_{init,arrive,test_wait,inval}` calls. Those really are sm_80 instructions and they are the only arch-sensitive ones the emitted PTX contains — but the kernels also construct `ManagedBarrier<_, TmaBarrier>`, and the backend detects that as a TMA feature. Asking for anything lower is refused outright:

```
error: [rustc_codegen_cuda] Device codegen failed: PTX generation failed:
CUDA target sm_86 cannot lower detected feature Tma + Sm80; cuda-oxide
requires a target compatible with sm_100 for this module
```

Under an auto-detected target the build instead succeeds at `.target sm_100`, and the module then fails to load. So the too-low floor did not present as a clean skip — it presented as `DriverError(218, "a PTX JIT compilation failed")` on **every pre-Blackwell device**, Ampere and Hopper alike, not merely the pre-Ampere hardware #658 was aimed at.

Both compiler behaviours are the designed ones: fail closed on an explicit low `--arch`, raise the target when it is auto-detected. Only the floor in the example was wrong.

## The change

`major < 8` → `major < 10`, matching `clc` and `tma_multicast`, with the compiler's own diagnostic quoted in the comment so the floor is not re-derived from the visible instructions next time. That was exactly my mistake: the instructions in the PTX say sm_80, and they are not what sets the requirement.

## Verification

NVIDIA A10G (`compute_cap 8.6`):

```
[ 1/ 2] future_apis                      ... PASS (skipped)
[ 2/ 2] vecadd                           ... PASS
Pass:    2 / 2
```

```
=== Future APIs Test (Unified) ===

skipping: TMA-typed barriers require sm_100+ (device is sm_86)
```

Before this change, the same example on the same device failed with `DriverError(218)` — including after `touch crates/*/src/lib.rs` to force a full backend rebuild, so it was not a stale-artifact effect. `cargo fmt --check` clean.

## How this went unnoticed in #658

@nihalpasham validated #658 on CC 12.0, where sm_100 ≤ the device and the example runs its real path correctly — so nothing there could have shown it. I validated on sm_75, where the guard fires and the example skips, which also hides it. The failure only appears in the band between the two, on Ampere and Hopper, and that is where I found it: running the full suite on an A10G, which sits inside the documented `sm_80+` support floor.

Worth noting for the target-selection discussion in #656: `Tma + Sm80` resolving to a requirement of sm_100 rather than sm_90 is the part I do not understand, since TMA itself is Hopper. I have not investigated whether that mapping is intentional and am not proposing a change to it here — this PR only corrects the example's floor to match whatever the backend requires today.
