### PR TITLE
docs(examples): tma_multicast does run on consumer Blackwell

### DIFF
--- a/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
@@ -13,8 +13,9 @@
 //! the shared memory of ALL CTAs in a thread block cluster.
 //!
 //! Requirements:
-//! - Blackwell datacenter GPU (sm_100a): B100, B200, GB200
-//! - NOT supported on consumer Blackwell (sm_120) or Hopper (sm_90)
+//! - Blackwell (sm_100a or later): datacenter B100/B200/GB200, and reported to
+//!   load and run on consumer sm_120 as well
+//! - Not supported on Hopper (sm_90) or earlier
 //!
 //! Build and run with:
 //!   cargo oxide run tma_multicast
@@ -183,8 +184,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // example can verify off-hopper datacenter.
             println!("\nskipping: TMA multicast requires sm_100a");
             println!("  driver reported: {}", e);
-            println!("  TMA multicast requires sm_100a (Blackwell datacenter: B100/B200/GB200).");
-            println!("  Consumer Blackwell (sm_120) does NOT support multicast.");
+            println!("  TMA multicast requires sm_100a or later (B100/B200/GB200, and sm_120).");
             println!("  For basic TMA tests, use: cargo oxide run tma_copy");
         }
     }


### PR DESCRIPTION
The follow-up you flagged reviewing #658.

`tma_multicast` claimed in two places that TMA multicast is **"NOT supported on consumer Blackwell (sm_120)"** — once in the module header, once in the runtime message printed when the module fails to load. Your measurement says otherwise:

> the sm_100a `tma_multicast` PTX JIT-loads and passes on an RTX 5090, so the "consumer Blackwell does not support TMA multicast" fallback text is outdated

## The change

Both places now state the floor rather than enumerate what supposedly does not work:

```
//! - Blackwell (sm_100a or later): datacenter B100/B200/GB200, and reported to
//!   load and run on consumer sm_120 as well
//! - Not supported on Hopper (sm_90) or earlier
```

The Hopper-and-earlier half was accurate and is kept.

**I have no Blackwell hardware, so the positive claim is attributed, not re-measured** — the header says sm_120 is *reported* to load and run, and the runtime message simply names the floor rather than asserting anything about a device I have not tested. If you would rather it state the sm_120 result flatly on the strength of your measurement, say so and I will tighten the wording.

The `major < 10` guard is unchanged and correct: on sm_120 it does not fire, so the example runs its real path — which is exactly how you observed it passing.

Docs and one `println!` only; no behaviour change. `cargo fmt --check` clean.