### PR TITLE
docs(examples): vectorization misdescribes what f32x4_view_copy emits

### DIFF
--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -272,7 +272,16 @@ fn main() {
             Some(line) => println!("f32x4_view_copy: {line}"),
             None => {
                 errors += 1;
-                println!("  !! f32x4_view_copy has no 128-bit {dir}.global vector op");
+                // Deliberately not "has no 128-bit vector op": measured on
+                // sm_86, this path does reach 128 bits, as a generic `LD.E.128`
+                // / `ST.E.128` rather than the `LDG.E.128` / `STG.E.128` the
+                // direct path gets, and pays four extra `LDL.64`/`STL.64`
+                // local accesses on the way. What is missing is the *global*
+                // window, not the width. See #657.
+                println!(
+                    "  !! f32x4_view_copy: no 128-bit {dir}.global vector op \
+                     (the 128-bit access is there, but in the generic window)"
+                );
             }
         }
     }

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -272,12 +272,15 @@ fn main() {
             Some(line) => println!("f32x4_view_copy: {line}"),
             None => {
                 errors += 1;
-                // Deliberately not "has no 128-bit vector op": measured on
-                // sm_86, this path does reach 128 bits, as a generic `LD.E.128`
-                // / `ST.E.128` rather than the `LDG.E.128` / `STG.E.128` the
-                // direct path gets, and pays four extra `LDL.64`/`STL.64`
-                // local accesses on the way. What is missing is the *global*
-                // window, not the width. See #657.
+                // Deliberately not "has no 128-bit vector op". When this fires,
+                // the likely state is not a scalarized transaction but a
+                // widened one that lost its state space: measured on sm_86
+                // while #657 was open, the view path did reach 128 bits, as a
+                // generic `LD.E.128` / `ST.E.128` rather than the `LDG.E.128` /
+                // `STG.E.128` the direct path gets, and paid four extra
+                // `LDL.64`/`STL.64` local accesses on the way. What was missing
+                // was the *global* window, not the width. Say that, so whoever
+                // sees this next looks at the address space first.
                 println!(
                     "  !! f32x4_view_copy: no 128-bit {dir}.global vector op \
                      (the 128-bit access is there, but in the generic window)"


### PR DESCRIPTION
Split out of #657 as the part that needs no decision from you.

The failure message reads as though the transaction had been scalarized:

```
!! f32x4_view_copy has no 128-bit ld.global vector op
```

SASS on sm_86 says otherwise:

| | `f32x4` (direct) | `f32x4_view_copy` |
|---|---|---|
| global | `LDG.E.128` x1, `STG.E.128` x1 | — |
| generic | — | `LD.E.128` x1, `ST.E.128` x1 |
| local | — | `LDL.64` x2, `STL.64` x2 |
| **total** | **2** | **6** |

The 128-bit access **is** there. What is missing is the *global window*: the view path addresses through the generic one and pays four local-memory accesses, plus 37 `PRMT` byte-permutes, on the way.

## What this changes

The message and its comment only. **The check is untouched and still fails** — the pessimization it detects is real, and this PR does not paper over it. #657 remains open for the codegen question.

I am sending it separately because it is correct either way: if the codegen is fixed the message never prints, and if it is not, anyone who hits it currently gets pointed at the wrong thing. I spent a while chasing a scalarization that was never happening because I believed this string.

`cargo fmt --check` clean; no behaviour change.