### PR TITLE
Write a canonical-storage enum payload by rebuilding the enum

### DIFF
--- a/crates/mir-importer/src/translator/mod.rs
+++ b/crates/mir-importer/src/translator/mod.rs
@@ -47,6 +47,7 @@ pub mod block;
 pub mod body;
 pub(crate) mod layout;
 pub(crate) mod location;
+pub(crate) mod payload_store;
 pub mod rvalue;
 pub mod statement;
 pub mod terminator;

--- a/crates/mir-importer/src/translator/payload_store.rs
+++ b/crates/mir-importer/src/translator/payload_store.rs
@@ -1,0 +1,288 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Writing an enum payload whose bytes use canonical storage.
+//!
+//! Enum storage keeps two payload kinds in a converted form: a `bool` occupies
+//! a full `i8` byte, and a shared-memory pointer is stored generic. The value
+//! paths coerce at that boundary. A raw payload address cannot, because the
+//! address escapes and the loads and stores made through it elsewhere are
+//! typed with the SEMANTIC type, so mir-lower refuses to hand one out.
+//!
+//! `(_flag as On).0 = value`, which is what
+//! `if let Flag::On(b) = &mut flag { *b = value }` becomes once the borrow
+//! folds into its use, took that address and met the refusal. The write needs
+//! no address: the enum can be rebuilt around the new payload, which is what
+//! the value paths already do for a whole-enum assignment.
+//!
+//! ```text
+//!   (_flag as On).0 = v   ->   _e  = load _flag
+//!                              _e' = construct_enum On(v)
+//!                              store _e' -> _flag
+//! ```
+//!
+//! `construct_enum` coerces each payload to its canonical storage on the way
+//! in, which is the coercion the address could not carry. Valid MIR assigns to
+//! a variant's field only when the enum already holds that variant, so
+//! rebuilding with the same variant leaves the discriminant where it was.
+//!
+//! A variant of several fields keeps the others as they stand: each is read
+//! back out of the loaded value and passed through unchanged.
+
+use pliron::basic_block::BasicBlock;
+use pliron::context::{Context, Ptr};
+use pliron::location::{Located, Location};
+use pliron::op::Op;
+use pliron::operation::Operation;
+use pliron::r#type::TypeHandle;
+use pliron::value::Value;
+use rustc_public::mir;
+use rustc_public_bridge::IndexedVal;
+
+use crate::error::{TranslationErr, TranslationResult};
+use crate::translator::rvalue;
+use crate::translator::types;
+use crate::translator::values::ValueMap;
+
+/// The enum place, variant and field an assignment destination names, when it
+/// ends in a payload whose bytes use canonical storage.
+pub(crate) struct CanonicalPayloadStore {
+    /// The enum place: the destination without its `Downcast` and `Field`.
+    pub(crate) enum_place: mir::Place,
+    /// The enum's Rust type.
+    pub(crate) enum_rust_ty: rustc_public::ty::Ty,
+    /// Variant named by the `Downcast`.
+    pub(crate) variant: usize,
+    /// Field within that variant.
+    pub(crate) field: usize,
+}
+
+/// Classify an assignment destination.
+///
+/// `None` for every destination the ordinary address path still owns: a
+/// payload whose storage equals its semantic type, a place that names no
+/// payload, or an enum type this importer cannot resolve.
+pub(crate) fn classify(
+    ctx: &mut Context,
+    body: &mir::Body,
+    place: &mir::Place,
+) -> TranslationResult<Option<CanonicalPayloadStore>> {
+    let projection = &place.projection;
+    if projection.len() < 2 {
+        return Ok(None);
+    }
+    let (mir::ProjectionElem::Downcast(variant), mir::ProjectionElem::Field(field, field_ty)) = (
+        &projection[projection.len() - 2],
+        &projection[projection.len() - 1],
+    ) else {
+        return Ok(None);
+    };
+
+    let enum_place = mir::Place {
+        local: place.local,
+        projection: projection[..projection.len() - 2].to_vec(),
+    };
+    let Ok(enum_rust_ty) = enum_place.ty(body.locals()) else {
+        return Ok(None);
+    };
+    let enum_ty = types::translate_type(ctx, &enum_rust_ty)?;
+    if !enum_ty.deref(ctx).is::<dialect_mir::types::MirEnumType>() {
+        return Ok(None);
+    }
+
+    let field_type = types::translate_type(ctx, field_ty)?;
+    if !rvalue::enum_payload_needs_storage_coercion_pub(ctx, field_type) {
+        return Ok(None);
+    }
+
+    Ok(Some(CanonicalPayloadStore {
+        enum_place,
+        enum_rust_ty,
+        variant: IndexedVal::to_index(variant),
+        field: *field,
+    }))
+}
+
+/// Rebuild the enum around `new_value` and store it back.
+///
+/// `Ok(None)` when the enum place has no address to load from and store to,
+/// which leaves the caller on its existing path and its loud refusal.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rebuild_and_store(
+    ctx: &mut Context,
+    body: &mir::Body,
+    value_map: &ValueMap,
+    store: &CanonicalPayloadStore,
+    new_value: Value,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<Option<Option<Ptr<Operation>>>> {
+    let enum_ty = types::translate_type(ctx, &store.enum_rust_ty)?;
+
+    let Some((enum_ptr, prev)) = rvalue::translate_place_address(
+        ctx,
+        body,
+        value_map,
+        &store.enum_place,
+        /* is_mutable */ true,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let (load_op, enum_value) = emit_load(ctx, enum_ptr, enum_ty, block_ptr, prev, loc.clone());
+    let mut prev = Some(load_op);
+
+    let field_count = {
+        let ty_obj = enum_ty.deref(ctx);
+        let enum_ty_ref = ty_obj
+            .downcast_ref::<dialect_mir::types::MirEnumType>()
+            .expect("classify resolved this enum type");
+        match enum_ty_ref.get_variant(store.variant) {
+            Some(variant) => variant.field_types.len(),
+            None => {
+                return pliron::input_err!(
+                    loc,
+                    TranslationErr::unsupported(format!(
+                        "payload store: variant {} is out of bounds for the enum",
+                        store.variant
+                    ))
+                );
+            }
+        }
+    };
+
+    // Every field of the variant, with the assigned one replaced.
+    let mut payload_values = Vec::with_capacity(field_count);
+    for field in 0..field_count {
+        if field == store.field {
+            payload_values.push(new_value);
+            continue;
+        }
+        let field_rust_ty = payload_field_type(&store.enum_rust_ty, store.variant, field, &loc)?;
+        let (value, next) = rvalue::apply_enum_field_projection_pub(
+            ctx,
+            enum_value,
+            &store.enum_rust_ty,
+            IndexedVal::to_val(store.variant),
+            field,
+            &field_rust_ty,
+            block_ptr,
+            prev,
+            loc.clone(),
+        )?;
+        payload_values.push(value);
+        prev = next;
+    }
+
+    let construct = Operation::new(
+        ctx,
+        dialect_mir::ops::MirConstructEnumOp::get_concrete_op_info(),
+        vec![enum_ty],
+        payload_values,
+        vec![],
+        0,
+    );
+    construct.deref_mut(ctx).set_loc(loc.clone());
+    dialect_mir::ops::MirConstructEnumOp::new(construct).set_attr_construct_enum_variant_index(
+        ctx,
+        dialect_mir::attributes::VariantIndexAttr(store.variant as u32),
+    );
+    match prev {
+        Some(p) => construct.insert_after(ctx, p),
+        None => construct.insert_at_front(block_ptr, ctx),
+    }
+    let rebuilt = construct.deref(ctx).get_result(0);
+
+    let store_op = emit_store(ctx, rebuilt, enum_ptr, block_ptr, Some(construct), loc);
+    Ok(Some(Some(store_op)))
+}
+
+/// The Rust type of one payload field, read from the enum's own definition.
+fn payload_field_type(
+    enum_rust_ty: &rustc_public::ty::Ty,
+    variant: usize,
+    field: usize,
+    loc: &Location,
+) -> TranslationResult<rustc_public::ty::Ty> {
+    use rustc_public::ty::{RigidTy, TyKind};
+
+    let TyKind::RigidTy(RigidTy::Adt(adt_def, args)) = enum_rust_ty.kind() else {
+        return pliron::input_err!(
+            loc.clone(),
+            TranslationErr::unsupported("payload store: the destination is not an ADT".to_string())
+        );
+    };
+    let variants = adt_def.variants();
+    let Some(variant_def) = variants.get(variant) else {
+        return pliron::input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "payload store: variant {variant} is out of bounds"
+            ))
+        );
+    };
+    let fields = variant_def.fields();
+    let Some(field_def) = fields.get(field) else {
+        return pliron::input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!("payload store: field {field} is out of bounds"))
+        );
+    };
+    Ok(field_def.ty_with_args(&args))
+}
+
+fn emit_store(
+    ctx: &mut Context,
+    value: Value,
+    slot: Value,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> Ptr<Operation> {
+    let op = Operation::new(
+        ctx,
+        dialect_mir::ops::MirStoreOp::get_concrete_op_info(),
+        vec![],
+        vec![slot, value],
+        vec![],
+        0,
+    );
+    op.deref_mut(ctx).set_loc(loc);
+    match prev_op {
+        Some(p) => op.insert_after(ctx, p),
+        None => op.insert_at_front(block_ptr, ctx),
+    }
+    op
+}
+
+fn emit_load(
+    ctx: &mut Context,
+    slot: Value,
+    pointee: TypeHandle,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> (Ptr<Operation>, Value) {
+    let op = Operation::new(
+        ctx,
+        dialect_mir::ops::MirLoadOp::get_concrete_op_info(),
+        vec![pointee],
+        vec![slot],
+        vec![],
+        0,
+    );
+    op.deref_mut(ctx).set_loc(loc);
+    match prev_op {
+        Some(p) => op.insert_after(ctx, p),
+        None => op.insert_at_front(block_ptr, ctx),
+    }
+    let value = op.deref(ctx).get_result(0);
+    (op, value)
+}

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -3793,6 +3793,31 @@ fn apply_field_projection(
 }
 
 /// Apply a Field projection on an enum variant (after Downcast).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_enum_field_projection_pub(
+    ctx: &mut Context,
+    enum_value: Value,
+    enum_rust_ty: &rustc_public::ty::Ty,
+    variant_idx: rustc_public::ty::VariantIdx,
+    field_idx: mir::FieldIdx,
+    field_ty: &rustc_public::ty::Ty,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
+    apply_enum_field_projection(
+        ctx,
+        enum_value,
+        enum_rust_ty,
+        variant_idx,
+        field_idx,
+        field_ty,
+        block_ptr,
+        prev_op,
+        loc,
+    )
+}
+
 fn apply_enum_field_projection(
     ctx: &mut Context,
     enum_value: Value,
@@ -3946,6 +3971,10 @@ pub(crate) fn translate_place_address(
 /// shared borrow and stays sound. mir-lower's canonical-storage gate on
 /// `mir.field_addr` remains the fail-closed authority, so a miss here still
 /// errors loudly instead of miscompiling.
+pub(crate) fn enum_payload_needs_storage_coercion_pub(ctx: &Context, ty: TypeHandle) -> bool {
+    enum_payload_needs_storage_coercion(ctx, ty)
+}
+
 fn enum_payload_needs_storage_coercion(ctx: &Context, ty: TypeHandle) -> bool {
     // Bool leaf: semantic i1, canonical i8 byte in enum storage.
     if let Some(integer) = ty.deref(ctx).downcast_ref::<IntegerType>() {

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -37,6 +37,7 @@
 use super::types;
 use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::location::span_to_location;
+use crate::translator::payload_store;
 use crate::translator::rvalue;
 use crate::translator::values::ValueMap;
 use dialect_mir::ops::{
@@ -1069,6 +1070,26 @@ fn store_through_place_address(
         current_prev = Some(rvalue_op);
     } else if let Some(prev) = last_inserted {
         current_prev = Some(prev);
+    }
+
+    // A payload whose bytes use canonical storage has no address to write
+    // through: bool payloads occupy a full byte and shared-memory pointers
+    // are stored generic, while a store through an escaped address carries
+    // the semantic type. Rebuild the enum around the new payload instead,
+    // which coerces on the way in exactly as a whole-enum assignment does.
+    if let Some(payload_store) = payload_store::classify(ctx, body, place)?
+        && let Some(result) = payload_store::rebuild_and_store(
+            ctx,
+            body,
+            value_map,
+            &payload_store,
+            result_value,
+            block_ptr,
+            current_prev,
+            loc.clone(),
+        )?
+    {
+        return Ok(result);
     }
 
     // The destination is written through, so request a mutable address.

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -1633,7 +1633,7 @@ pub(crate) fn convert_field_addr(
         let storage_ty = enum_payload_storage_type(ctx, semantic_ty).map_err(anyhow_to_pliron)?;
         if storage_ty != semantic_ty {
             return pliron::input_err_noloc!(
-                "field_addr: cannot hand out the in-place address of payload field {} of enum `{}`: its bytes use canonical storage type {} while its semantic type is {}, and loads or stores made through an escaped payload address are typed with the semantic type, which the canonical bytes cannot honor; shared reads of such payloads are compiled through a value copy automatically, and in-place mutation of bool or shared-pointer enum payloads is not supported",
+                "field_addr: cannot hand out the in-place address of payload field {} of enum `{}`: its bytes use canonical storage type {} while its semantic type is {}, and loads or stores made through an escaped payload address are typed with the semantic type, which the canonical bytes cannot honor; shared reads of such payloads are compiled through a value copy automatically, and a write that stays inside its function is compiled by rebuilding the enum around the new payload; a borrow that escapes into a call keeps no such rewrite and is refused here",
                 field_index,
                 enum_name,
                 storage_ty.deref(ctx).disp(ctx),

--- a/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
@@ -63,6 +63,13 @@ mod kernels {
         Off,
     }
 
+    /// A variant of two fields, one of them canonical storage. Rebuilding
+    /// around the bool has to carry the `f32` through untouched.
+    pub enum Pair {
+        Both(bool, f32),
+        Neither,
+    }
+
     /// Scale a borrowed payload. Taking `&mut f32` across a call boundary
     /// keeps the borrow from folding into a plain store.
     #[device]
@@ -197,6 +204,63 @@ mod kernels {
         }
     }
 
+    /// Write a bool payload without the borrow leaving the kernel.
+    ///
+    /// The borrow folds into a store to the payload place, which has no
+    /// address to write through: the byte is canonical `i8` storage while the
+    /// value is `i1`. The importer rebuilds the enum around the new payload
+    /// instead, so the write lands in the enum itself. Each input maps to a
+    /// distinct output, so a dropped write shows up as an unchanged element.
+    #[kernel]
+    pub fn mutate_bool_payload(input: &[f32], mut out: DisjointSlice<f32>) {
+        let index = thread::index_1d();
+        let i = index.get();
+        if i >= input.len() {
+            return;
+        }
+        let mut flag = Flag::On(false);
+        if let Flag::On(value) = &mut flag {
+            *value = true;
+        }
+        let result = match flag {
+            // Only the written value gives the expected element, so a write
+            // that landed in a copy reports a mismatch.
+            Flag::On(true) => input[i] * 2.0,
+            Flag::On(false) => -input[i],
+            Flag::Off => f32::NAN,
+        };
+        if let Some(cell) = out.get_mut(index) {
+            *cell = result;
+        }
+    }
+
+    /// Write one field of a two-field variant, where the other must survive.
+    ///
+    /// The rebuild reads the sibling `f32` back out of the current value and
+    /// passes it through, so a rebuild that dropped it would return the
+    /// variant's default rather than the input.
+    #[kernel]
+    pub fn mutate_multi_field_payload(input: &[f32], mut out: DisjointSlice<f32>) {
+        let index = thread::index_1d();
+        let i = index.get();
+        if i >= input.len() {
+            return;
+        }
+        let mut pair = Pair::Both(false, input[i] * 2.0);
+        if let Pair::Both(flag, _) = &mut pair {
+            *flag = true;
+        }
+        let result = match pair {
+            // The bool must have been written and the f32 must have survived.
+            Pair::Both(true, carried) => carried,
+            Pair::Both(false, _) => f32::NAN,
+            Pair::Neither => f32::NAN,
+        };
+        if let Some(cell) = out.get_mut(index) {
+            *cell = result;
+        }
+    }
+
     /// The workaround this replaces: rebuild the enum from a matched copy.
     #[kernel]
     pub fn rebuild_payload(input: &[f32], mut out: DisjointSlice<f32>) {
@@ -271,6 +335,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
     check("shared_bytes_no_slot", &|out| unsafe {
         module.shared_bytes_no_slot(&stream, config, &input, out)
+    })?;
+    check("mutate_bool_payload", &|out| unsafe {
+        module.mutate_bool_payload(&stream, config, &input, out)
+    })?;
+    check("mutate_multi_field_payload", &|out| unsafe {
+        module.mutate_multi_field_payload(&stream, config, &input, out)
     })?;
     check("rebuild_payload", &|out| unsafe {
         module.rebuild_payload(&stream, config, &input, out)

--- a/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
@@ -67,6 +67,7 @@ mod kernels {
     /// around the bool has to carry the `f32` through untouched.
     pub enum Pair {
         Both(bool, f32),
+        #[allow(dead_code)]
         Neither,
     }
 

--- a/crates/rustc-codegen-cuda/examples/error_enum_bool_payload_addr/README.md
+++ b/crates/rustc-codegen-cuda/examples/error_enum_bool_payload_addr/README.md
@@ -22,7 +22,7 @@ Expected: the build FAILS, and the smoketest checks the log for this
 exact diagnostic:
 
 ```text
-in-place mutation of bool or shared-pointer enum payloads is not supported
+a write that stays inside its function is compiled by rebuilding the enum around the new payload; a borrow that escapes into a call keeps no such rewrite and is refused here
 ```
 
 together with the `canonical storage type` explanation from the

--- a/crates/rustc-codegen-cuda/examples/error_enum_bool_payload_addr/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/error_enum_bool_payload_addr/src/main.rs
@@ -11,9 +11,14 @@
 //! an `i1` store through it would leave the byte's upper seven bits undefined
 //! for every `i8` reader, including a niche tag sharing the byte. Shared
 //! borrows of such payloads compile through a sound value copy (see the
-//! `shared_borrow_bool_payload` kernel in `enum_payload_addr`), but a mutable
-//! borrow cannot use a copy (writes would be lost), so the compiler must
-//! reject it loudly instead of miscompiling.
+//! `shared_borrow_bool_payload` kernel in `enum_payload_addr`), and a write
+//! that stays inside its own function compiles by rebuilding the enum around
+//! the new payload (see `mutate_bool_payload` there).
+//!
+//! Neither route reaches the borrow below. It crosses a `#[device]` call, so
+//! the address genuinely escapes and no rewrite at the store site can stand in
+//! for it. A copy would lose the write, so the compiler must reject it loudly
+//! instead of miscompiling.
 
 use cuda_device::{device, kernel};
 

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -366,7 +366,7 @@ verdict_error() {
     case "${ex}" in
         error_enum_bool_payload_addr)
             if ! grep -Fq 'canonical storage type' "${log}" \
-                || ! grep -Fq 'in-place mutation of bool or shared-pointer enum payloads is not supported' "${log}"; then
+                || ! grep -Fq 'a borrow that escapes into a call keeps no such rewrite and is refused here' "${log}"; then
                 echo "FAIL (missing canonical-storage payload-address diagnostic)"
                 return 1
             fi


### PR DESCRIPTION
Mutating a `bool` enum payload has no lowering, even when the write never leaves the function it is written in.

## What

Enum storage keeps two payload kinds in a converted form: a `bool` occupies a full `i8` byte and a shared-memory pointer is stored generic. A raw payload address cannot carry that conversion, because the address escapes and the loads and stores made through it elsewhere are typed with the semantic type. #652 therefore refused to hand one out, which left this with no lowering at all:

```rust
if let Flag::On(value) = &mut flag {
    *value = input[i] > 0.0;
}
```

## How

The borrow in that shape does not survive to the importer. Optimisation folds it into a store to the payload place:

```text
((_9 as On).0: bool) = Gt(move _12, const 0f32)
```

It is that store which asks for the address, so the write needs none. The enum is rebuilt around the new payload and stored whole, which is what a whole-enum assignment already does, and `construct_enum` coerces each payload to its canonical storage on the way in.

```text
(_flag as On).0 = v   ->   _e  = load _flag
                           _e' = construct_enum On(v)
                           store _e' -> _flag
```

Valid MIR assigns to a variant's field only when the enum already holds that variant, so rebuilding with the same variant leaves the discriminant where it was. A variant of several fields keeps the others as they stand: each is read back out of the loaded value and passed through unchanged.

A borrow that escapes, into a `#[device]` call for instance, reaches no store site and keeps the refusal. The diagnostic now names which of the two cases it is.

## Testing

On an RTX 5060 (sm_120):

- `enum_payload_addr` gains `mutate_bool_payload`, whose match arms differ so a write landing in a copy reports a mismatch rather than passing, and `mutate_multi_field_payload`, where the sibling `f32` of a two-field variant has to survive the rebuild. Both exact over 1048576 elements.
- Removing the write from the first kernel fails it at element 1, so the check discriminates.
- `error_enum_bool_payload_addr` still fails closed on the escaping borrow, and the smoketest verdict matches the updated diagnostic.
- The other six kernels of `enum_payload_addr` are unchanged, in-place over rebuild 1.070.
- `cargo test --workspace` and `cargo clippy --workspace --all-targets` clean.

Follow-up to #652.
