### PR TITLE
feat: Mir pass registry

### DIFF
--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -121,6 +121,7 @@ pub struct CompileOptions {
     debug_info: DebugInfo,
     verbose: bool,
     linking: Linking,
+    mir_pass_pipeline: Option<String>,
 }
 
 impl CompileOptions {
@@ -133,6 +134,7 @@ impl CompileOptions {
             debug_info: DebugInfo::None,
             verbose: false,
             linking: Linking::SelfContained,
+            mir_pass_pipeline: None,
         }
     }
 
@@ -165,6 +167,12 @@ impl CompileOptions {
     /// perform that link.
     pub fn with_linking(mut self, linking: Linking) -> Self {
         self.linking = linking;
+        self
+    }
+
+    /// Select an optional post-preparation MIR pass pipeline.
+    pub fn with_mir_pass_pipeline(mut self, pipeline: impl Into<String>) -> Self {
+        self.mir_pass_pipeline = Some(pipeline.into());
         self
     }
 
@@ -202,6 +210,11 @@ impl CompileOptions {
     /// Requested libdevice linking policy.
     pub fn linking(&self) -> Linking {
         self.linking
+    }
+
+    /// Requested optional post-preparation MIR pass pipeline.
+    pub fn mir_pass_pipeline(&self) -> Option<&str> {
+        self.mir_pass_pipeline.as_deref()
     }
 
     /// Whether progress and tool-selection diagnostics were requested.
@@ -661,6 +674,7 @@ impl Compiler {
             verbose: options.verbose,
             llc_override: None,
             opt_override: None,
+            mir_pass_pipeline: options.mir_pass_pipeline.clone(),
         };
         let request = ModulePipelineRequest::for_standalone_ptx(
             &backend_options,
@@ -979,6 +993,7 @@ impl CompileError {
 impl From<PipelineError> for CompileError {
     fn from(error: PipelineError) -> Self {
         match error {
+            PipelineError::InvalidMirPassPipeline(message) => Self::InvalidOptions { message },
             PipelineError::Verification {
                 message, operation, ..
             } => Self::Verification { message, operation },
@@ -1003,6 +1018,26 @@ impl From<PipelineError> for CompileError {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod mir_pass_tests {
+    use super::*;
+
+    #[test]
+    fn mir_pass_pipeline_is_a_typed_compile_option() {
+        let options = CompileOptions::new(Target::parse("sm_90").unwrap())
+            .with_mir_pass_pipeline("future-pass");
+        assert_eq!(options.mir_pass_pipeline(), Some("future-pass"));
+    }
+
+    #[test]
+    fn invalid_mir_pass_pipeline_is_an_input_error() {
+        let error = CompileError::from(PipelineError::InvalidMirPassPipeline(
+            "bad pass".to_string(),
+        ));
+        assert_eq!(error.stage(), CompilationStage::Input);
     }
 }
 

--- a/crates/cuda-oxide-codegen/src/api.rs
+++ b/crates/cuda-oxide-codegen/src/api.rs
@@ -170,7 +170,7 @@ impl CompileOptions {
         self
     }
 
-    /// Select an optional post-preparation MIR pass pipeline.
+    /// Select an optional staged MIR pass pipeline.
     pub fn with_mir_pass_pipeline(mut self, pipeline: impl Into<String>) -> Self {
         self.mir_pass_pipeline = Some(pipeline.into());
         self
@@ -212,7 +212,7 @@ impl CompileOptions {
         self.linking
     }
 
-    /// Requested optional post-preparation MIR pass pipeline.
+    /// Requested optional staged MIR pass pipeline.
     pub fn mir_pass_pipeline(&self) -> Option<&str> {
         self.mir_pass_pipeline.as_deref()
     }

--- a/crates/cuda-oxide-codegen/src/error.rs
+++ b/crates/cuda-oxide-codegen/src/error.rs
@@ -7,6 +7,8 @@
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub enum PipelineError {
+    /// The requested MIR pass pipeline is invalid for this compilation.
+    InvalidMirPassPipeline(String),
     /// Function has no MIR body (shouldn't happen for collected functions).
     NoBody(String),
     /// MIR→Pliron IR translation failed.
@@ -45,6 +47,9 @@ pub enum PipelineError {
 impl std::fmt::Display for PipelineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InvalidMirPassPipeline(message) => {
+                write!(f, "invalid MIR pass pipeline: {message}")
+            }
             Self::NoBody(name) => write!(f, "Function '{}' has no MIR body", name),
             Self::Translation(msg) => write!(f, "Translation failed: {}", msg),
             Self::Verification {

--- a/crates/cuda-oxide-codegen/src/lib.rs
+++ b/crates/cuda-oxide-codegen/src/lib.rs
@@ -23,6 +23,7 @@ mod generated;
 mod generated_intrinsic_targets;
 mod llvm_tools;
 mod lower;
+mod mir_pass_registry;
 mod options;
 mod pipeline;
 mod prep;

--- a/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
+++ b/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
@@ -32,18 +32,13 @@ pub enum MirPassStage {
     /// Runs after scalar promotion, while loop structure is still intact.
     PostMem2Reg,
     PostPreparation,
-    /// A late backend transformation over generated PTX. It is selected and
-    /// validated together with MIR passes, but has no dialect-MIR instance.
-    /// No in-tree pass currently registers at this stage.
-    #[allow(dead_code)]
-    PostPtx,
 }
 
 #[derive(Clone, Copy)]
 struct OptEntry {
     name: &'static str,
     stage: MirPassStage,
-    build: Option<OptCtor>,
+    build: OptCtor,
 }
 
 /// A fully validated optional pass selection.
@@ -52,6 +47,15 @@ struct OptEntry {
 /// then request the pipeline for each stage in compiler order.
 pub struct SelectedMirPasses(Vec<OptEntry>);
 
+impl SelectedMirPasses {
+    /// Whether any selected pass is declared for `stage`. Lets the driver skip
+    /// a stage entirely (no pass-manager run, no extra module verification)
+    /// when nothing was selected for it.
+    pub fn has_stage(&self, stage: MirPassStage) -> bool {
+        self.0.iter().any(|entry| entry.stage == stage)
+    }
+}
+
 /// Errors from selecting a MIR pass pipeline.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum MirPassPipelineError {
@@ -59,6 +63,8 @@ pub enum MirPassPipelineError {
     EmptyName,
     #[error("unknown MIR pass \"{name}\"; available passes: {available}")]
     UnknownName { name: String, available: String },
+    #[error("MIR pass \"{name}\" selected more than once in pipeline")]
+    DuplicateName { name: String },
 }
 
 /// The cuda-oxide-owned registry of staged optional MIR passes.
@@ -87,6 +93,19 @@ impl MirPassRegistry {
             .map(|name| self.lookup(name))
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
+        // A pass name may appear at most once. Running the same pass twice is
+        // never what the user meant; reject the spec instead of guessing.
+        for (position, entry) in entries.iter().enumerate() {
+            if entries[..position]
+                .iter()
+                .any(|seen| seen.name == entry.name)
+            {
+                return Err(MirPassPipelineError::DuplicateName {
+                    name: entry.name.to_owned(),
+                });
+            }
+        }
+
         Ok(SelectedMirPasses(entries))
     }
 
@@ -98,9 +117,7 @@ impl MirPassRegistry {
     ) -> Passes {
         let mut passes = Passes::default();
         for entry in selected.0.iter().filter(|entry| entry.stage == stage) {
-            if let Some(build) = entry.build {
-                passes.add_pass(BoxedPass(build()));
-            }
+            passes.add_pass(BoxedPass((entry.build)()));
         }
         passes
     }
@@ -209,22 +226,22 @@ mod tests {
                 OptEntry {
                     name: "first",
                     stage: MirPassStage::PostPreparation,
-                    build: Some(first),
+                    build: first,
                 },
                 OptEntry {
                     name: "second",
                     stage: MirPassStage::PostPreparation,
-                    build: Some(second),
+                    build: second,
                 },
                 OptEntry {
                     name: "early",
                     stage: MirPassStage::PrePreparation,
-                    build: Some(early),
+                    build: early,
                 },
                 OptEntry {
                     name: "middle",
                     stage: MirPassStage::PostMem2Reg,
-                    build: Some(middle),
+                    build: middle,
                 },
             ],
         }
@@ -260,6 +277,23 @@ mod tests {
             Err(MirPassPipelineError::EmptyName)
         ));
         assert!(RUNS.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn duplicate_pass_name_is_rejected() {
+        assert!(matches!(
+            registry_with_test_passes().select("first,second,first"),
+            Err(MirPassPipelineError::DuplicateName { name }) if name == "first"
+        ));
+    }
+
+    #[test]
+    fn has_stage_reports_only_selected_stages() {
+        let registry = registry_with_test_passes();
+        let selected = registry.select("first,middle").unwrap();
+        assert!(selected.has_stage(MirPassStage::PostPreparation));
+        assert!(selected.has_stage(MirPassStage::PostMem2Reg));
+        assert!(!selected.has_stage(MirPassStage::PrePreparation));
     }
 
     #[test]

--- a/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
+++ b/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
@@ -64,7 +64,7 @@ pub enum MirPassPipelineError {
     #[error("unknown MIR pass \"{name}\"; available passes: {available}")]
     UnknownName { name: String, available: String },
     #[error("MIR pass \"{name}\" selected more than once in pipeline")]
-    DuplicateName { name: String },
+    Duplicate { name: String },
 }
 
 /// The cuda-oxide-owned registry of staged optional MIR passes.
@@ -100,7 +100,7 @@ impl MirPassRegistry {
                 .iter()
                 .any(|seen| seen.name == entry.name)
             {
-                return Err(MirPassPipelineError::DuplicateName {
+                return Err(MirPassPipelineError::Duplicate {
                     name: entry.name.to_owned(),
                 });
             }
@@ -283,7 +283,7 @@ mod tests {
     fn duplicate_pass_name_is_rejected() {
         assert!(matches!(
             registry_with_test_passes().select("first,second,first"),
-            Err(MirPassPipelineError::DuplicateName { name }) if name == "first"
+            Err(MirPassPipelineError::Duplicate { name }) if name == "first"
         ));
     }
 

--- a/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
+++ b/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
@@ -5,10 +5,10 @@
 
 //! Optional MIR passes selected by `CUDA_OXIDE_MIR_PASSES`.
 //!
-//! This registry runs after the standard MIR preparation passes. Add only
-//! workload-specific passes that are safe at that point; defaults belong in
-//! the normal pipeline instead. New entries need correctness coverage and a
-//! measured workload benefit.
+//! Entries declare the earliest compiler stage at which their IR contract is
+//! valid. The driver validates the selected names once, then invokes the
+//! selected entries at each declared stage. This deliberately keeps an early
+//! formation pass separate from late MIR peepholes.
 
 use pliron::{
     context::{Context, Ptr},
@@ -20,10 +20,37 @@ use thiserror::Error;
 
 type OptCtor = fn() -> Box<dyn Pass>;
 
+/// Extension points in the dialect-MIR preparation pipeline.
+///
+/// `PrePreparation` sees imported MIR before mem2reg and annotated-loop
+/// unrolling. It is the earliest existing hook for passes that require source
+/// loop and local-allocation structure. `PostPreparation` is for ordinary SSA
+/// cleanups after those standard transformations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MirPassStage {
+    PrePreparation,
+    /// Runs after scalar promotion, while loop structure is still intact.
+    PostMem2Reg,
+    PostPreparation,
+    /// A late backend transformation over generated PTX. It is selected and
+    /// validated together with MIR passes, but has no dialect-MIR instance.
+    /// No in-tree pass currently registers at this stage.
+    #[allow(dead_code)]
+    PostPtx,
+}
+
+#[derive(Clone, Copy)]
 struct OptEntry {
     name: &'static str,
-    build: OptCtor,
+    stage: MirPassStage,
+    build: Option<OptCtor>,
 }
+
+/// A fully validated optional pass selection.
+///
+/// Keep this opaque: callers must select once before any transformation runs,
+/// then request the pipeline for each stage in compiler order.
+pub struct SelectedMirPasses(Vec<OptEntry>);
 
 /// Errors from selecting a MIR pass pipeline.
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -34,40 +61,58 @@ pub enum MirPassPipelineError {
     UnknownName { name: String, available: String },
 }
 
-/// The cuda-oxide-owned registry of post-preparation MIR passes.
+/// The cuda-oxide-owned registry of staged optional MIR passes.
 #[derive(Default)]
 pub struct MirPassRegistry {
     entries: Vec<OptEntry>,
 }
 
 impl MirPassRegistry {
-    /// Build a comma-separated pipeline. Empty specs select no passes.
-    pub fn build_pipeline(&self, spec: &str) -> std::result::Result<Passes, MirPassPipelineError> {
+    /// Validate a comma-separated pipeline. Empty specs select no passes.
+    ///
+    /// The textual order is preserved among entries at the same stage. Stages
+    /// themselves always execute in compiler order, regardless of where names
+    /// appear in `spec`.
+    pub fn select(
+        &self,
+        spec: &str,
+    ) -> std::result::Result<SelectedMirPasses, MirPassPipelineError> {
         let spec = spec.trim();
         if spec.is_empty() {
-            return Ok(Passes::default());
+            return Ok(SelectedMirPasses(Vec::new()));
         }
-        let constructors = spec
+        let entries = spec
             .split(',')
             .map(str::trim)
             .map(|name| self.lookup(name))
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        let mut passes = Passes::default();
-        for build in constructors {
-            passes.add_pass(BoxedPass(build()));
-        }
-        Ok(passes)
+        Ok(SelectedMirPasses(entries))
     }
 
-    fn lookup(&self, name: &str) -> std::result::Result<OptCtor, MirPassPipelineError> {
+    /// Build the selected pipeline for one compiler stage.
+    pub fn build_stage_pipeline(
+        &self,
+        selected: &SelectedMirPasses,
+        stage: MirPassStage,
+    ) -> Passes {
+        let mut passes = Passes::default();
+        for entry in selected.0.iter().filter(|entry| entry.stage == stage) {
+            if let Some(build) = entry.build {
+                passes.add_pass(BoxedPass(build()));
+            }
+        }
+        passes
+    }
+
+    fn lookup(&self, name: &str) -> std::result::Result<OptEntry, MirPassPipelineError> {
         if name.is_empty() {
             return Err(MirPassPipelineError::EmptyName);
         }
         self.entries
             .iter()
             .find(|entry| entry.name == name)
-            .map(|entry| entry.build)
+            .copied()
             .ok_or_else(|| MirPassPipelineError::UnknownName {
                 name: name.to_owned(),
                 available: self
@@ -82,7 +127,7 @@ impl MirPassRegistry {
 
 /// Build the registry of supported optional CUDA Oxide MIR passes.
 pub fn registry() -> MirPassRegistry {
-    MirPassRegistry::default()
+    MirPassRegistry { entries: vec![] }
 }
 
 struct BoxedPass(Box<dyn Pass>);
@@ -110,6 +155,7 @@ mod tests {
     use std::sync::Mutex;
 
     static RUNS: Mutex<Vec<&str>> = Mutex::new(Vec::new());
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     struct TestPass(&'static str);
 
@@ -137,6 +183,14 @@ mod tests {
         Box::new(TestPass("second"))
     }
 
+    fn early() -> Box<dyn Pass> {
+        Box::new(TestPass("early"))
+    }
+
+    fn middle() -> Box<dyn Pass> {
+        Box::new(TestPass("middle"))
+    }
+
     fn run(passes: &mut Passes) {
         let mut ctx = Context::new();
         let module = ModuleOp::new(&mut ctx, "test".try_into().unwrap());
@@ -154,45 +208,55 @@ mod tests {
             entries: vec![
                 OptEntry {
                     name: "first",
-                    build: first,
+                    stage: MirPassStage::PostPreparation,
+                    build: Some(first),
                 },
                 OptEntry {
                     name: "second",
-                    build: second,
+                    stage: MirPassStage::PostPreparation,
+                    build: Some(second),
+                },
+                OptEntry {
+                    name: "early",
+                    stage: MirPassStage::PrePreparation,
+                    build: Some(early),
+                },
+                OptEntry {
+                    name: "middle",
+                    stage: MirPassStage::PostMem2Reg,
+                    build: Some(middle),
                 },
             ],
         }
     }
 
     #[test]
-    fn default_registry_is_empty() {
-        assert!(registry().build_pipeline("").is_ok());
+    fn empty_registry_accepts_only_the_empty_pipeline() {
+        assert!(registry().select("").is_ok());
         assert!(matches!(
-            registry().build_pipeline("first"),
+            registry().select("first"),
             Err(MirPassPipelineError::UnknownName { .. })
         ));
     }
 
     #[test]
     fn selected_passes_run_in_order() {
+        let _serial = TEST_LOCK.lock().unwrap();
         RUNS.lock().unwrap().clear();
-        let mut passes = registry_with_test_passes()
-            .build_pipeline("first,second")
-            .unwrap();
+        let registry = registry_with_test_passes();
+        let selected = registry.select("first,second").unwrap();
+        let mut passes = registry.build_stage_pipeline(&selected, MirPassStage::PostPreparation);
         run(&mut passes);
         assert_eq!(*RUNS.lock().unwrap(), ["first", "second"]);
     }
 
     #[test]
     fn invalid_pipeline_does_not_run_a_prefix() {
+        let _serial = TEST_LOCK.lock().unwrap();
         RUNS.lock().unwrap().clear();
-        assert!(
-            registry_with_test_passes()
-                .build_pipeline("first,missing")
-                .is_err()
-        );
+        assert!(registry_with_test_passes().select("first,missing").is_err());
         assert!(matches!(
-            registry_with_test_passes().build_pipeline("first,"),
+            registry_with_test_passes().select("first,"),
             Err(MirPassPipelineError::EmptyName)
         ));
         assert!(RUNS.lock().unwrap().is_empty());
@@ -200,9 +264,32 @@ mod tests {
 
     #[test]
     fn empty_pipeline_runs_nothing() {
+        let _serial = TEST_LOCK.lock().unwrap();
         RUNS.lock().unwrap().clear();
-        let mut passes = registry_with_test_passes().build_pipeline("").unwrap();
+        let registry = registry_with_test_passes();
+        let selected = registry.select("").unwrap();
+        let mut passes = registry.build_stage_pipeline(&selected, MirPassStage::PostPreparation);
         run(&mut passes);
         assert!(RUNS.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn selection_runs_only_entries_declared_for_each_stage() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        RUNS.lock().unwrap().clear();
+        let registry = registry_with_test_passes();
+        let selected = registry.select("first,early,middle,second").unwrap();
+
+        let mut pre = registry.build_stage_pipeline(&selected, MirPassStage::PrePreparation);
+        run(&mut pre);
+        let mut middle = registry.build_stage_pipeline(&selected, MirPassStage::PostMem2Reg);
+        run(&mut middle);
+        let mut post = registry.build_stage_pipeline(&selected, MirPassStage::PostPreparation);
+        run(&mut post);
+
+        assert_eq!(
+            *RUNS.lock().unwrap(),
+            ["early", "middle", "first", "second"]
+        );
     }
 }

--- a/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
+++ b/crates/cuda-oxide-codegen/src/mir_pass_registry.rs
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Optional MIR passes selected by `CUDA_OXIDE_MIR_PASSES`.
+//!
+//! This registry runs after the standard MIR preparation passes. Add only
+//! workload-specific passes that are safe at that point; defaults belong in
+//! the normal pipeline instead. New entries need correctness coverage and a
+//! measured workload benefit.
+
+use pliron::{
+    context::{Context, Ptr},
+    operation::Operation,
+    pass::{AnalysisManager, Pass, PassResult, Passes},
+    result::Result,
+};
+use thiserror::Error;
+
+type OptCtor = fn() -> Box<dyn Pass>;
+
+struct OptEntry {
+    name: &'static str,
+    build: OptCtor,
+}
+
+/// Errors from selecting a MIR pass pipeline.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum MirPassPipelineError {
+    #[error("empty opt name in pipeline")]
+    EmptyName,
+    #[error("unknown MIR pass \"{name}\"; available passes: {available}")]
+    UnknownName { name: String, available: String },
+}
+
+/// The cuda-oxide-owned registry of post-preparation MIR passes.
+#[derive(Default)]
+pub struct MirPassRegistry {
+    entries: Vec<OptEntry>,
+}
+
+impl MirPassRegistry {
+    /// Build a comma-separated pipeline. Empty specs select no passes.
+    pub fn build_pipeline(&self, spec: &str) -> std::result::Result<Passes, MirPassPipelineError> {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return Ok(Passes::default());
+        }
+        let constructors = spec
+            .split(',')
+            .map(str::trim)
+            .map(|name| self.lookup(name))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let mut passes = Passes::default();
+        for build in constructors {
+            passes.add_pass(BoxedPass(build()));
+        }
+        Ok(passes)
+    }
+
+    fn lookup(&self, name: &str) -> std::result::Result<OptCtor, MirPassPipelineError> {
+        if name.is_empty() {
+            return Err(MirPassPipelineError::EmptyName);
+        }
+        self.entries
+            .iter()
+            .find(|entry| entry.name == name)
+            .map(|entry| entry.build)
+            .ok_or_else(|| MirPassPipelineError::UnknownName {
+                name: name.to_owned(),
+                available: self
+                    .entries
+                    .iter()
+                    .map(|entry| entry.name)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            })
+    }
+}
+
+/// Build the registry of supported optional CUDA Oxide MIR passes.
+pub fn registry() -> MirPassRegistry {
+    MirPassRegistry::default()
+}
+
+struct BoxedPass(Box<dyn Pass>);
+
+impl Pass for BoxedPass {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn run(
+        &mut self,
+        operation: Ptr<Operation>,
+        ctx: &mut Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<PassResult> {
+        self.0.run(operation, ctx, analyses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pliron::builtin::ops::ModuleOp;
+    use pliron::op::Op;
+    use std::sync::Mutex;
+
+    static RUNS: Mutex<Vec<&str>> = Mutex::new(Vec::new());
+
+    struct TestPass(&'static str);
+
+    impl Pass for TestPass {
+        fn name(&self) -> &str {
+            self.0
+        }
+
+        fn run(
+            &mut self,
+            _operation: Ptr<Operation>,
+            _ctx: &mut Context,
+            _analyses: &mut AnalysisManager,
+        ) -> Result<PassResult> {
+            RUNS.lock().unwrap().push(self.0);
+            Ok(PassResult::default())
+        }
+    }
+
+    fn first() -> Box<dyn Pass> {
+        Box::new(TestPass("first"))
+    }
+
+    fn second() -> Box<dyn Pass> {
+        Box::new(TestPass("second"))
+    }
+
+    fn run(passes: &mut Passes) {
+        let mut ctx = Context::new();
+        let module = ModuleOp::new(&mut ctx, "test".try_into().unwrap());
+        passes
+            .run(
+                module.get_operation(),
+                &mut ctx,
+                &mut AnalysisManager::default(),
+            )
+            .unwrap();
+    }
+
+    fn registry_with_test_passes() -> MirPassRegistry {
+        MirPassRegistry {
+            entries: vec![
+                OptEntry {
+                    name: "first",
+                    build: first,
+                },
+                OptEntry {
+                    name: "second",
+                    build: second,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn default_registry_is_empty() {
+        assert!(registry().build_pipeline("").is_ok());
+        assert!(matches!(
+            registry().build_pipeline("first"),
+            Err(MirPassPipelineError::UnknownName { .. })
+        ));
+    }
+
+    #[test]
+    fn selected_passes_run_in_order() {
+        RUNS.lock().unwrap().clear();
+        let mut passes = registry_with_test_passes()
+            .build_pipeline("first,second")
+            .unwrap();
+        run(&mut passes);
+        assert_eq!(*RUNS.lock().unwrap(), ["first", "second"]);
+    }
+
+    #[test]
+    fn invalid_pipeline_does_not_run_a_prefix() {
+        RUNS.lock().unwrap().clear();
+        assert!(
+            registry_with_test_passes()
+                .build_pipeline("first,missing")
+                .is_err()
+        );
+        assert!(matches!(
+            registry_with_test_passes().build_pipeline("first,"),
+            Err(MirPassPipelineError::EmptyName)
+        ));
+        assert!(RUNS.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_pipeline_runs_nothing() {
+        RUNS.lock().unwrap().clear();
+        let mut passes = registry_with_test_passes().build_pipeline("").unwrap();
+        run(&mut passes);
+        assert!(RUNS.lock().unwrap().is_empty());
+    }
+}

--- a/crates/cuda-oxide-codegen/src/options.rs
+++ b/crates/cuda-oxide-codegen/src/options.rs
@@ -34,6 +34,11 @@ pub struct BackendOptions {
     pub llc_override: Option<PathBuf>,
     /// Explicit `opt` binary (was `CUDA_OXIDE_OPT`).
     pub opt_override: Option<PathBuf>,
+    /// Optional dialect-mir pass pipeline (`CUDA_OXIDE_MIR_PASSES`).
+    ///
+    /// Empty or `None` preserves the default pipeline. The available names
+    /// are defined by the cuda-oxide-owned optimization registry.
+    pub mir_pass_pipeline: Option<String>,
 }
 
 impl Default for BackendOptions {
@@ -47,6 +52,7 @@ impl Default for BackendOptions {
             verbose: false,
             llc_override: None,
             opt_override: None,
+            mir_pass_pipeline: None,
         }
     }
 }
@@ -66,6 +72,7 @@ impl BackendOptions {
             verbose: std::env::var("CUDA_OXIDE_VERBOSE").is_ok(),
             llc_override: std::env::var("CUDA_OXIDE_LLC").ok().map(PathBuf::from),
             opt_override: std::env::var("CUDA_OXIDE_OPT").ok().map(PathBuf::from),
+            mir_pass_pipeline: std::env::var("CUDA_OXIDE_MIR_PASSES").ok(),
         }
     }
 }

--- a/crates/cuda-oxide-codegen/src/options.rs
+++ b/crates/cuda-oxide-codegen/src/options.rs
@@ -34,10 +34,11 @@ pub struct BackendOptions {
     pub llc_override: Option<PathBuf>,
     /// Explicit `opt` binary (was `CUDA_OXIDE_OPT`).
     pub opt_override: Option<PathBuf>,
-    /// Optional dialect-mir pass pipeline (`CUDA_OXIDE_MIR_PASSES`).
+    /// Optional staged dialect-mir pass pipeline (`CUDA_OXIDE_MIR_PASSES`).
     ///
     /// Empty or `None` preserves the default pipeline. The available names
-    /// are defined by the cuda-oxide-owned optimization registry.
+    /// are defined by the cuda-oxide-owned optimization registry. Each entry
+    /// declares whether it runs before or after standard MIR preparation.
     pub mir_pass_pipeline: Option<String>,
 }
 

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -199,6 +199,7 @@ pub fn compile_translated_module(
         MirPreparation {
             promote_and_unroll,
             verbose: request.trace.verbose,
+            mir_pass_pipeline: request.backend.mir_pass_pipeline.as_deref(),
         },
     )?;
     if request.trace.verbose {

--- a/crates/cuda-oxide-codegen/src/prep.rs
+++ b/crates/cuda-oxide-codegen/src/prep.rs
@@ -60,7 +60,6 @@ pub fn prepare_mir_module(
         MirPassStage::PrePreparation,
         &mut analyses,
     )?;
-    verify_operation(ctx, module, "module post-preparation-formation-passes")?;
 
     // A by-value aggregate argument initially lives in a MIR alloca. Read-only
     // field/index projections make that alloca non-promotable even though the
@@ -95,7 +94,6 @@ pub fn prepare_mir_module(
         MirPassStage::PostMem2Reg,
         &mut analyses,
     )?;
-    verify_operation(ctx, module, "module post-mem2reg-formation-passes")?;
 
     // An immutable aggregate pointer argument in an always-inline helper can
     // still retain dynamic field/array pointer chains after mem2reg. Recover
@@ -139,6 +137,12 @@ fn run_optional_mir_passes(
     stage: MirPassStage,
     analyses: &mut pliron::pass::AnalysisManager,
 ) -> Result<(), PipelineError> {
+    // Nothing selected for this stage: skip the pass-manager run and the extra
+    // module verification so a default build pays nothing for the hooks.
+    if !selected.has_stage(stage) {
+        return Ok(());
+    }
+
     let mut passes = crate::mir_pass_registry::registry().build_stage_pipeline(selected, stage);
 
     <pliron::pass::Passes as pliron::pass::PassManager>::run_pass(

--- a/crates/cuda-oxide-codegen/src/prep.rs
+++ b/crates/cuda-oxide-codegen/src/prep.rs
@@ -12,7 +12,7 @@ use pliron::printable::Printable;
 /// Controls the reusable dialect-mir preparation stage.
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MirPreparation {
+pub struct MirPreparation<'a> {
     /// Promote stack slots to SSA and run annotation-driven loop unrolling.
     pub promote_and_unroll: bool,
     /// Print preparation-pass progress notes to stderr. Threaded from the
@@ -20,6 +20,8 @@ pub struct MirPreparation {
     /// instead of the environment (loop unrolling still checks
     /// `CUDA_OXIDE_VERBOSE` on its own).
     pub verbose: bool,
+    /// Optional pass pipeline; `None` or empty preserves the defaults.
+    pub mir_pass_pipeline: Option<&'a str>,
 }
 
 /// Verify and prepare a dialect-mir module before LLVM lowering.
@@ -30,10 +32,18 @@ pub struct MirPreparation {
 pub fn prepare_mir_module(
     ctx: &mut Context,
     module: Ptr<Operation>,
-    preparation: MirPreparation,
+    preparation: MirPreparation<'_>,
 ) -> Result<(), PipelineError> {
     verify_operation(ctx, module, "module")?;
+    let has_pass_pipeline = preparation
+        .mir_pass_pipeline
+        .is_some_and(|pipeline| !pipeline.trim().is_empty());
     if !preparation.promote_and_unroll {
+        if has_pass_pipeline {
+            return Err(PipelineError::InvalidMirPassPipeline(
+                "optional MIR passes are unavailable with full variable debug info".to_string(),
+            ));
+        }
         return Ok(());
     }
 
@@ -80,5 +90,62 @@ pub fn prepare_mir_module(
             operation: None,
         },
     )?;
-    verify_operation(ctx, module, "module post-unroll")
+    verify_operation(ctx, module, "module post-unroll")?;
+
+    run_optional_mir_passes(ctx, module, preparation.mir_pass_pipeline, &mut analyses)
+}
+
+fn run_optional_mir_passes(
+    ctx: &mut Context,
+    module: Ptr<Operation>,
+    spec: Option<&str>,
+    analyses: &mut pliron::pass::AnalysisManager,
+) -> Result<(), PipelineError> {
+    let Some(spec) = spec.map(str::trim).filter(|spec| !spec.is_empty()) else {
+        return Ok(());
+    };
+
+    // Construct the full pipeline before running anything, so malformed input
+    // cannot leave a half-optimized module behind.
+    let mut passes = crate::mir_pass_registry::registry()
+        .build_pipeline(spec)
+        .map_err(|error| PipelineError::InvalidMirPassPipeline(error.to_string()))?;
+
+    <pliron::pass::Passes as pliron::pass::PassManager>::run_pass(
+        &mut passes,
+        module,
+        ctx,
+        analyses,
+    )
+    .map_err(|error| PipelineError::Verification {
+        name: "optional MIR passes".to_string(),
+        message: error.disp(ctx).to_string(),
+        operation: None,
+    })?;
+
+    verify_operation(ctx, module, "module post-optional-mir-passes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pliron::builtin::ops::ModuleOp;
+    use pliron::op::Op;
+
+    #[test]
+    fn debug_mode_rejects_requested_mir_passes() {
+        let mut ctx = Context::new();
+        let module = ModuleOp::new(&mut ctx, "test".try_into().unwrap());
+        let error = prepare_mir_module(
+            &mut ctx,
+            module.get_operation(),
+            MirPreparation {
+                promote_and_unroll: false,
+                verbose: false,
+                mir_pass_pipeline: Some("future-pass"),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, PipelineError::InvalidMirPassPipeline(_)));
+    }
 }

--- a/crates/cuda-oxide-codegen/src/prep.rs
+++ b/crates/cuda-oxide-codegen/src/prep.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::error::PipelineError;
+use crate::mir_pass_registry::{MirPassStage, SelectedMirPasses};
 use crate::verify::verify_operation;
 use pliron::context::{Context, Ptr};
 use pliron::operation::Operation;
@@ -47,6 +48,20 @@ pub fn prepare_mir_module(
         return Ok(());
     }
 
+    // Validate every requested pass before any transformation runs. This keeps
+    // an invalid later-stage name from leaving a module partially transformed.
+    let selected_passes = select_optional_mir_passes(preparation.mir_pass_pipeline)?;
+
+    let mut analyses = pliron::pass::AnalysisManager::default();
+    run_optional_mir_passes(
+        ctx,
+        module,
+        &selected_passes,
+        MirPassStage::PrePreparation,
+        &mut analyses,
+    )?;
+    verify_operation(ctx, module, "module post-preparation-formation-passes")?;
+
     // A by-value aggregate argument initially lives in a MIR alloca. Read-only
     // field/index projections make that alloca non-promotable even though the
     // original entry-block argument is already an SSA value. Canonicalize the
@@ -61,8 +76,6 @@ pub fn prepare_mir_module(
         module,
         "module post-borrowed-aggregate-read-canonicalization",
     )?;
-
-    let mut analyses = pliron::pass::AnalysisManager::default();
     pliron::opts::mem2reg::mem2reg(module, ctx, &mut analyses).map_err(|error| {
         PipelineError::Verification {
             name: "mem2reg".to_string(),
@@ -71,6 +84,18 @@ pub fn prepare_mir_module(
         }
     })?;
     verify_operation(ctx, module, "module post-mem2reg")?;
+
+    // Formation passes that need promoted SSA values but must still see the
+    // original loop CFG run here. In particular, a reduction formation pass
+    // cannot safely infer a source loop once generic unrolling has cloned it.
+    run_optional_mir_passes(
+        ctx,
+        module,
+        &selected_passes,
+        MirPassStage::PostMem2Reg,
+        &mut analyses,
+    )?;
+    verify_operation(ctx, module, "module post-mem2reg-formation-passes")?;
 
     // An immutable aggregate pointer argument in an always-inline helper can
     // still retain dynamic field/array pointer chains after mem2reg. Recover
@@ -92,24 +117,29 @@ pub fn prepare_mir_module(
     )?;
     verify_operation(ctx, module, "module post-unroll")?;
 
-    run_optional_mir_passes(ctx, module, preparation.mir_pass_pipeline, &mut analyses)
+    run_optional_mir_passes(
+        ctx,
+        module,
+        &selected_passes,
+        MirPassStage::PostPreparation,
+        &mut analyses,
+    )
+}
+
+fn select_optional_mir_passes(spec: Option<&str>) -> Result<SelectedMirPasses, PipelineError> {
+    crate::mir_pass_registry::registry()
+        .select(spec.unwrap_or_default())
+        .map_err(|error| PipelineError::InvalidMirPassPipeline(error.to_string()))
 }
 
 fn run_optional_mir_passes(
     ctx: &mut Context,
     module: Ptr<Operation>,
-    spec: Option<&str>,
+    selected: &SelectedMirPasses,
+    stage: MirPassStage,
     analyses: &mut pliron::pass::AnalysisManager,
 ) -> Result<(), PipelineError> {
-    let Some(spec) = spec.map(str::trim).filter(|spec| !spec.is_empty()) else {
-        return Ok(());
-    };
-
-    // Construct the full pipeline before running anything, so malformed input
-    // cannot leave a half-optimized module behind.
-    let mut passes = crate::mir_pass_registry::registry()
-        .build_pipeline(spec)
-        .map_err(|error| PipelineError::InvalidMirPassPipeline(error.to_string()))?;
+    let mut passes = crate::mir_pass_registry::registry().build_stage_pipeline(selected, stage);
 
     <pliron::pass::Passes as pliron::pass::PassManager>::run_pass(
         &mut passes,
@@ -118,12 +148,16 @@ fn run_optional_mir_passes(
         analyses,
     )
     .map_err(|error| PipelineError::Verification {
-        name: "optional MIR passes".to_string(),
+        name: format!("optional MIR passes ({stage:?})"),
         message: error.disp(ctx).to_string(),
         operation: None,
     })?;
 
-    verify_operation(ctx, module, "module post-optional-mir-passes")
+    verify_operation(
+        ctx,
+        module,
+        &format!("module post-optional-mir-passes ({stage:?})"),
+    )
 }
 
 #[cfg(test)]
@@ -143,6 +177,23 @@ mod tests {
                 promote_and_unroll: false,
                 verbose: false,
                 mir_pass_pipeline: Some("future-pass"),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, PipelineError::InvalidMirPassPipeline(_)));
+    }
+
+    #[test]
+    fn invalid_staged_pipeline_is_rejected_before_preparation() {
+        let mut ctx = Context::new();
+        let module = ModuleOp::new(&mut ctx, "test".try_into().unwrap());
+        let error = prepare_mir_module(
+            &mut ctx,
+            module.get_operation(),
+            MirPreparation {
+                promote_and_unroll: true,
+                verbose: false,
+                mir_pass_pipeline: Some("missing-pass"),
             },
         )
         .unwrap_err();


### PR DESCRIPTION
this pr adds an opt-in staged MIR pass registry to cuda-oxide.

the goal is to give MIR optimizations one owned, validated entry point instead of adding ad-hoc environment checks and pipeline hooks for each pass.

- adds `CUDA_OXIDE_MIR_PASSES` plus a typed `CompileOptions::with_mir_pass_pipeline(...)` API
- parses and validates the complete comma-separated selection before any transformation runs, so an invalid later pass cannot leave a module partially transformed
- runs selected passes at explicit compiler stages: `PrePreparation`, `PostMem2Reg`, and `PostPreparation`
- preserves the requested order for passes in the same stage while keeping stage execution in compiler order
- reports invalid selections as input errors
- adds registry and preparation tests for ordering, empty/invalid pipelines, and debug-mode rejection

this intentionally adds the registry infrastructure without enabling an in-tree optimization yet. follow-up optimization branches can register a pass at the stage whose IR contract they need, without changing the public option or orchestration plumbing again.

this pr is based off the discussions in #398 and #636. both were adding opt-in compiler optimizations, and the question kept coming up how each pass should be selected and where it should run. instead of having every follow-up add another env option and more pipeline plumbing, this puts that in a small registry and lets each pass pick its stage.

### running tests

```bash
cargo test -p cuda-oxide-codegen --lib mir_pass_registry::
```

outputs

```
running 5 tests
test mir_pass_registry::tests::empty_registry_accepts_only_the_empty_pipeline ... ok
test mir_pass_registry::tests::empty_pipeline_runs_nothing ... ok
test mir_pass_registry::tests::invalid_pipeline_does_not_run_a_prefix ... ok
test mir_pass_registry::tests::selection_runs_only_entries_declared_for_each_stage ... ok
test mir_pass_registry::tests::selected_passes_run_in_order ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 146 filtered out; finished in 0.01s
```

and

```bash
cargo test -p cuda-oxide-codegen --lib prep::
```

outputs

```
running 2 tests
test prep::tests::debug_mode_rejects_requested_mir_passes ... ok
test prep::tests::invalid_staged_pipeline_is_rejected_before_preparation ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 149 filtered out; finished in 0.00s
```

### implementation notes

this pr does not add any new optimization passes so the registry can be reviewed independently of any specific optimization. the first follow up is https://github.com/drbh/cuda-oxide/pull/1, which adds `warp-aggregate-constant-fp-atomics`: an explicitly opt-in `PostMem2Reg` pass for coalescing eligible contended f16/f32 atomic adds within a warp. on a RTX 4090 the `atomic_f16` benchmark, improves the highest-contention f32 case from 5.68 ms to 0.18 ms (31.4x). if/when the pass registry lands, i'll re open the pr to this repo to serve as the first example of an optional workload specific pass.


please let me know if the approach should be updated, split differently, or if there is a better direction for the registry and stage plumbing - happy to adjust anything accordingly, thanks!
