### PR TITLE
perf(mir-lower): type an enum's unclaimed bytes as one integer

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -2331,13 +2331,22 @@ mod tests {
             2,
             "construction should reload the enum and extraction should load the tuple payload"
         );
+        // The niche carrier claims the pointer at byte 8, and the 8 bytes below
+        // it are 8-aligned inside an 8-aligned enum, so they lower to one `i64`
+        // filler. That makes the enum's physical storage `{i64, ptr}` -- the
+        // *same interned type* as the lowered payload tuple. So all three stores
+        // counted above (two enum spills plus the payload write) now carry
+        // `lowered_tuple`, and a type filter can no longer tell them apart;
+        // before the filler was widened only the payload write did. The property
+        // that matters -- whole-aggregate moves, never field-by-field -- stays
+        // pinned by the total store/load counts asserted above.
         assert_eq!(
             find_all::<llvm::StoreOp>(&ctx, &body)
                 .iter()
                 .filter(|store| store.get_operand_value(&ctx).get_type(&ctx) == lowered_tuple)
                 .count(),
-            1,
-            "the complete {{i64, ptr}} payload must be written into the enum storage"
+            3,
+            "every whole-aggregate store here must move a complete {{i64, ptr}}"
         );
         assert_eq!(
             find_all::<llvm::LoadOp>(&ctx, &body)
@@ -2350,8 +2359,8 @@ mod tests {
                         == lowered_tuple
                 })
                 .count(),
-            1,
-            "payload extraction must read the complete {{i64, ptr}} tuple back"
+            2,
+            "the enum reload and the payload extraction must both read a complete {{i64, ptr}}"
         );
     }
 

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -590,6 +590,45 @@ fn make_padding_type(ctx: &mut Context, size: u64) -> TypeHandle {
     llvm_types::ArrayType::get(ctx, i8_ty.into(), size).into()
 }
 
+/// Storage for `size` bytes of enum filler at byte `offset`: bytes the payload
+/// occupies that no typed slot claims.
+///
+/// `[N x i8]` is byte-exact but costs one leaf *per byte* everywhere a payload
+/// value is built, merged, or taken apart. `Option<&[T]>` is the shape that
+/// shows it: the niche carrier claims the pointer, the length is left to an
+/// 8-byte filler, and building the value then decomposes that length into
+/// eight `i8` `insertvalue`s, every block merge carries eight `phi i8`, and
+/// reading it back is a chain of `prmt` byte permutes with the aggregate
+/// spilled to `.local` in between. Measured on sm_86, it costs the *pointer*
+/// too: it rides through the same byte soup, `InferAddressSpaces` can no
+/// longer follow it, and the access lands in the generic window (`ld.v2.b64`)
+/// instead of `ld.global.v2.b64`.
+///
+/// One integer of the same width is the same bytes in one leaf. It is only
+/// legal where it moves nothing:
+///
+/// - the width is 2, 4 or 8 bytes, so the integer is byte-faithful (a multiple
+///   of 8 bits, hence no padding of its own). 16 is deliberately excluded:
+///   `i128` is legal LLVM but lowers to register pairs on NVPTX, so widening
+///   that far trades one win for another cost and wants its own measurement;
+/// - `offset` is a multiple of the width, so LLVM inserts no gap ahead of the
+///   field and every later field keeps its byte offset;
+/// - the width does not exceed the enum's alignment, or the struct's natural
+///   alignment would rise above rustc's.
+///
+/// Anything else keeps the byte array. The filler is a *vehicle*, not a claim:
+/// nothing reads it field-wise, because a payload that has no typed slot
+/// round-trips through memory as a whole aggregate, and both ends of that
+/// round trip are byte-exact. `build_enum_slot_map`'s own size and alignment
+/// assertions — hard errors, not debug checks — backstop all three conditions.
+fn make_enum_filler_type(ctx: &mut Context, offset: u64, size: u64, abi_align: u64) -> TypeHandle {
+    if matches!(size, 2 | 4 | 8) && offset.is_multiple_of(size) && size <= abi_align.max(1) {
+        let width = u32::try_from(size * 8).expect("size is at most 8, so width is at most 64");
+        return IntegerType::get(ctx, width, Signedness::Signless).into();
+    }
+    make_padding_type(ctx, size)
+}
+
 /// Build byte-exact LLVM storage for a Rust union.
 ///
 /// A union cannot be represented as an LLVM struct containing every declared
@@ -1661,7 +1700,8 @@ pub(crate) fn build_enum_slot_map(
     }
 
     // Phase 2: lay the slots down in byte order, filling every gap (and
-    // the tail) with [N x i8] so the struct's size is exactly rustc's.
+    // the tail) so the struct's size is exactly rustc's. One integer per gap
+    // where that is layout-neutral, else [N x i8]; see `make_enum_filler_type`.
     let mut emit_order: Vec<usize> = (0..claims.len()).collect();
     emit_order.sort_by_key(|&ci| claims[ci].0);
     let mut llvm_fields: Vec<TypeHandle> = Vec::new();
@@ -1670,7 +1710,9 @@ pub(crate) fn build_enum_slot_map(
     for &ci in &emit_order {
         let (offset, size, llvm_ty) = claims[ci];
         if current_offset < offset {
-            llvm_fields.push(make_padding_type(ctx, offset - current_offset));
+            let filler =
+                make_enum_filler_type(ctx, current_offset, offset - current_offset, abi_align);
+            llvm_fields.push(filler);
             current_offset = offset;
         }
         slot_of_claim[ci] = llvm_fields.len() as u32;
@@ -1678,7 +1720,9 @@ pub(crate) fn build_enum_slot_map(
         current_offset += size;
     }
     if current_offset < total_size {
-        llvm_fields.push(make_padding_type(ctx, total_size - current_offset));
+        let filler =
+            make_enum_filler_type(ctx, current_offset, total_size - current_offset, abi_align);
+        llvm_fields.push(filler);
     }
 
     // Sanity: the struct we just built must be exactly rustc's size.
@@ -2823,14 +2867,16 @@ mod tests {
         .into();
         // The pointer at byte 0 never shares bytes with the integer niche
         // carrier at byte 8, so it is representable: it gets its own `ptr` slot
-        // and the carrier stays an integer slot. `{ptr@0, i32@8, pad}`.
+        // and the carrier stays an integer slot. `{ptr@0, i32@8, i32 filler}`
+        // -- the trailing 4 bytes are 4-aligned inside an 8-aligned enum, so
+        // they lower to one `i32` rather than `[4 x i8]`.
         let map = build_enum_slot_map(&mut ctx, enum_ty).unwrap();
         assert_eq!(map.field_slots, vec![None]);
         let lowered_pointer = convert_type(&mut ctx, pointer).unwrap();
         let carrier: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
         assert_eq!(
             struct_fields(&ctx, map.llvm_struct_ty),
-            vec![lowered_pointer, carrier, pad(&mut ctx, 4)]
+            vec![lowered_pointer, carrier, llvm_int(&mut ctx, 32)]
         );
         assert_eq!(
             llvm_type_size_align(&ctx, map.llvm_struct_ty),
@@ -2922,11 +2968,13 @@ mod tests {
                 Some((16, 8))
             );
             let lowered_pointer = convert_type(&mut ctx, pointer).unwrap();
-            let padding = pad(&mut ctx, 8);
+            // The 8 bytes the pointer slot does not claim are 8-aligned inside
+            // an 8-aligned enum, so they lower to one `i64`, not `[8 x i8]`.
+            let filler = llvm_int(&mut ctx, 64);
             let expected = if pointer_first {
-                vec![lowered_pointer, padding]
+                vec![lowered_pointer, filler]
             } else {
-                vec![padding, lowered_pointer]
+                vec![filler, lowered_pointer]
             };
             assert_eq!(struct_fields(&ctx, map.llvm_struct_ty), expected);
         }
@@ -3043,14 +3091,15 @@ mod tests {
         let map = build_enum_slot_map(&mut ctx, enum_ty).unwrap();
         assert_eq!(map.field_slots, vec![None]);
         let lowered_pointer = convert_type(&mut ctx, pointer).unwrap();
+        // Each slice's length sits in the 8 bytes after its pointer, 8-aligned
+        // inside an 8-aligned enum, so both lower to one `i64`. This is the
+        // `split_at_mut_checked` shape, and the whole point of the widening:
+        // `{ptr, i64, ptr, i64}` moves two lengths as two values, where
+        // `{ptr, [8 x i8], ptr, [8 x i8]}` moved them as sixteen separate bytes.
+        let filler = llvm_int(&mut ctx, 64);
         assert_eq!(
             struct_fields(&ctx, map.llvm_struct_ty),
-            vec![
-                lowered_pointer,
-                pad(&mut ctx, 8),
-                lowered_pointer,
-                pad(&mut ctx, 8),
-            ]
+            vec![lowered_pointer, filler, lowered_pointer, filler]
         );
         assert_eq!(
             llvm_type_size_align(&ctx, map.llvm_struct_ty),


### PR DESCRIPTION
## Problem

`Option<&[T]>` lowers to `{ ptr, [8 x i8] }`. The niche carrier claims the pointer, the slice length falls into an 8-byte filler, and that filler is typed as a byte array — eight separate SSA values.

So every construct, merge and destructure of the payload becomes eight `i8` `insertvalue`/`extractvalue` pairs and eight `phi i8`, plus an `alloca` round trip purely to retype `{ptr, i64}` into `{ptr, [8 x i8]}`:

```llvm
; from vectorization.ll; symbol abridged, chain elided at the ellipses
define { ptr, [8 x i8] } @as_vectors(ptr %v0, i64 %v1) {
  ...
  %v41 = alloca { ptr, [8 x i8] }, align 8
  store { ptr, [8 x i8] } undef, ptr %v41, align 8
  %v42 = getelementptr inbounds i8, ptr %v41, i64 0
  store { ptr, i64 } %v40, ptr %v42, align 8   ; store type != load type
  %v43 = load { ptr, [8 x i8] }, ptr %v41, align 8
  %v45 = extractvalue { ptr, [8 x i8] } %v43, 1, 0
  %v46 = extractvalue { ptr, [8 x i8] } %v43, 1, 1
  ...                                    1, 2 … 1, 6
  %v52 = extractvalue { ptr, [8 x i8] } %v43, 1, 7
  %v81 = phi i8 [ %v45, %bb5 ], ...          ; ×8, at every merge
```

`[8 x i8]` occurs **134 times** in the NVVM IR of one small example.

The pointer rides through that same aggregate, so `InferAddressSpaces` can no longer prove it global and the access falls out of the global window into the generic one. In PTX, the width is right and the address space is not:

```
st.local.v2.b32  [%rd34+8], {%r33, %r29}   ; 32-byte .local depot
ld.local.b64     %rd5,  [%rd34+8]
ld.v2.b64        {%rd54, %rd55}, [%rd53]   ; generic, not .global
st.v2.b64        [%rd56], {%rd54, %rd55}
```

This is #657. That issue's open question was whether the fix belonged in lowering or in the example's expectation, and it named `as_mut_ptr` and `from_raw_parts` as the suspects. It belongs in lowering, and neither suspect is involved — it is the filler type.

### Reproduction

```
cargo oxide run vectorization     # the f32x4_view_copy assertion fails
```

## Fix

Emit one integer for the filler where doing so moves nothing:

- width 2, 4 or 8 bytes, so the integer is byte-faithful (a multiple of 8 bits, no padding of its own). 16 is deliberately excluded: `i128` is legal LLVM but lowers to register pairs on NVPTX, so widening that far trades one win for another cost and wants its own measurement.
- `offset` a multiple of the width, so LLVM inserts no gap ahead of the field and every later field keeps its byte offset.
- width no greater than the enum's alignment, or the struct's natural alignment would rise above rustc's.

Anything else keeps `[N x i8]` — the 7-byte and 3-byte fillers in the existing tests are untouched.

The filler is a *vehicle*, not a claim: a payload with no typed slot round-trips through memory as a whole aggregate, and both ends of that round trip are byte-exact, so nothing ever reads the filler field-wise. `build_enum_slot_map`'s existing size and alignment assertions are hard errors rather than debug checks, and they backstop all three conditions.

`{ ptr, [8 x i8] }` becomes `{ ptr, i64 }`, which makes the store and load types match, so the `alloca` round trip folds away entirely.

## Verification on hardware

`NVIDIA A10G (sm_86), 23028 MiB, driver 595.71.05, nvcc 13.2` — `cargo oxide run vectorization`

The example inspects the PTX it just launched and asserts the shape, so this is the #657 assertion itself, executing:

```
f32x4       float4           16    16  ld.global.v2.b64       yes
f64x2       double2          16    16  ld.global.v2.b64       yes
f64x4       double4          32    16  ld.global.v2.b64       yes
f64x4_a32   double4_32a      32    32  ld.global.v2.b64       yes
f32x4_view_copy: ld.global.v2.b64 	{%rd42, %rd43}, [%rd41];
f32x4_view_copy: st.global.v2.b64 	[%rd44], {%rd42, %rd43};

✓ SUCCESS: 26 CUDA vector types -- layout, copy, and codegen all correct

--- result ---
exit code  : 0
```

Before this change the same two lines read `!! f32x4_view_copy has no 128-bit ld.global vector op` / `... st.global ...` and the example exited 1.

The full 185-example suite was also run on this device: **184 pass**. The one failure, `future_apis`, is pre-existing and unrelated — its PTX declares `.target sm_100` while the device is sm_86, so the driver rejects the module before a kernel runs (`DriverError(218)`). I confirmed that by rebuilding this same tree with the change reverted and observing the identical failure, rather than inferring it. Worth its own issue; nothing in filler lowering can set `.target`.

### Measured effect

A flat-buffer `f32x4` copy taken through `vector::as_vectors`, against the equivalent hand-written direct path over **the same device allocation** (reinterpreted between phases, so neither can win on placement). 128 MiB read + 128 MiB written per launch, 100 timed launches after 20 warmup:

| kernel | µs before | µs after | GB/s before | GB/s after |
|---|---|---|---|---|
| `copy_view` | 810.5 | **552.8** | 331.2 | **485.6** |
| `copy_direct` *(control)* | 552.4 | 552.5 | 486.0 | 485.9 |
| `copy_scalar` *(control)* | 546.4 | 546.7 | 491.3 | 491.0 |

The view path goes from 68.2% of the direct path to 99.9% of it — **+46.6% bandwidth, 1.47× faster**. Both controls move by under 0.06%, which is what makes the `copy_view` row meaningful. 486 GB/s is ~81% of the A10G's 600 GB/s spec peak, the ordinary achieved fraction for a read-plus-write streaming copy.

Codegen for that kernel:

| metric | before | after |
|---|---|---|
| `[8 x i8]` in NVVM IR | 134 | **0** |
| PTX instructions | 149 | **68** |
| `prmt` byte permutes | 26 | **0** |
| local-memory accesses | 4 | **0** |
| `ptxas` stack frame | 32 B | **0 B** |
| `ld/st.global.v*` | 0 | **2** |
| generic `ld/st.v*` | 2 | **0** |
| registers (`ptxas`) | 17 | 20 |

Three more registers is the cost of keeping the value in registers instead of a stack frame; `ptxas` reports zero spill stores and zero spill loads either way, and at 20 registers the kernel still reaches full occupancy on sm_86.

The measurement harness is a small example (`view_bandwidth`) that I have kept out of this PR to keep the diff to the fix — `vectorization` already guards the codegen shape as an in-tree regression test. Happy to send it as a follow-up if a standing benchmark is wanted.

## Test expectations

Four `mir-lower` unit tests pinned the old lowered struct type as a golden expectation and are updated. In each, that same test's own size-and-alignment assertion still passes unchanged, which is the invariant that matters: the bytes did not move.

One is worth calling out. In `Option<(i64, &T)>` the storage becomes `{i64, ptr}` — the *same interned type* as its own payload tuple — so `nested_pointer_niche_tuple_construct_extract_and_discriminant_lower` could no longer separate the payload store from the enum spill by type, and its two type-filtered counts go from 1 to 2. The property that matters (whole-aggregate moves, never field-by-field) stays pinned by the total store/load counts asserted immediately above. If you would rather that test keep its discrimination, I am happy to restructure it to assert that no *field*-typed store targets the enum.

## Upstream gates

All run on the A10G box against this branch, all green:

| gate | result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets --lib --tests -- -D warnings` | pass |
| `cargo test -p cuda-host -p cuda-macros -p llvm-export -p dialect-mir -p dialect-nvvm -p mir-lower --lib --tests` | pass |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` | pass |
| `cargo test --doc --workspace --exclude cuda-bindings` | pass |
| `scripts/smoketest.sh` (all 185 examples) | 184 pass, 1 pre-existing failure described above |

`-p mir-lower` is not in the CI unit-test set; I added it because it is the crate this change touches. Its 165 tests pass.

No `error*` example changed, so `STATUS.md` and `check-error-example-status.sh` are not implicated.

## Not in scope

The union tail filler and ordinary struct padding have the same shape and would take the same widening, but I have no measurement for either and folding them in would turn a contained diff into a risky one. Happy to follow up.

Closes #657
