### PR TITLE
fix(examples): gate future_apis on the floor of the PTX it emits

### DIFF
--- a/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
@@ -244,10 +244,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
 
-    // The mbarrier APIs exercised below require sm_80 (Ampere) or later.
+    // The mbarrier APIs themselves are sm_80, but the PTX generated for them is
+    // not: `ManagedBarrier::init` pairs every `mbarrier.init` with a
+    // `fence.proxy.async.shared::cta`, and `ptxas` rejects that `.async`
+    // modifier below sm_90 ("Modifier '.async' requires .target sm_90 or
+    // higher"). Gating on the API floor let sm_80..sm_89 devices through to a
+    // `DriverError(218)` from the PTX JIT, before any kernel ran. Gate on the
+    // floor of the code we actually emit.
     let (major, minor) = ctx.compute_capability()?;
-    if major < 8 {
-        println!("skipping: mbarrier requires sm_80+ (device is sm_{major}{minor})");
+    if major < 9 {
+        println!(
+            "skipping: ManagedBarrier emits fence.proxy.async, which requires \
+             sm_90+ (device is sm_{major}{minor})"
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
## Problem

`future_apis` self-gates on compute capability, but at the floor of the mbarrier
*API* rather than the floor of the PTX cuda-oxide emits for it:

```rust
// The mbarrier APIs exercised below require sm_80 (Ampere) or later.
let (major, minor) = ctx.compute_capability()?;
if major < 8 {
    println!("skipping: mbarrier requires sm_80+ (device is sm_{major}{minor})");
```

`ManagedBarrier::init` pairs every `mbarrier.init` with a proxy fence
(`crates/cuda-device/src/barrier.rs:417`), which is visible in the generated PTX:

```text
mbarrier.init.shared.b64 	[__shared_mem_0], %r2;
// begin inline asm
fence.proxy.async.shared::cta;
// end inline asm
```

`ptxas` rejects that `.async` modifier below sm_90, so on sm_80..sm_89 the gate
passes and the example goes on to fail in the driver, which rejects the whole
module before any kernel starts:

```text
Error: DriverError(218, "a PTX JIT compilation failed")
```

It was the only failure in an otherwise-green 185-example run on an A10G
(sm_86), where it reported `[85/185] future_apis ... FAIL (exit=1)`.

### Reproduction

The floor needs no GPU — rewrite only the `.target` line of the generated PTX
and ask `ptxas` where it stops being valid:

```bash
cargo oxide build future_apis
cd crates/rustc-codegen-cuda/examples/future_apis
for arch in sm_86 sm_90; do
  sed "s/^\.target .*/.target $arch/" future_apis.ptx > /tmp/fa_$arch.ptx
  printf '%-8s : ' "$arch"; ptxas -arch=$arch /tmp/fa_$arch.ptx -o /dev/null 2>&1 | head -1; echo
done
```

```text
sm_86    : ptxas fatal   : Modifier '.async' requires .target sm_90 or higher
sm_90    :
```

## Fix

Gate on sm_90, so sub-floor devices take `verdict_standard`'s `skipping:` path
and report `PASS (skipped)` — the same graceful opt-out `cluster` already uses
for pre-Hopper. The comment now records *why* the floor is sm_90 rather than the
sm_80 the APIs suggest, so the next reader does not "correct" it back.

## Verification on hardware

`NVIDIA A10G (sm_86), 23028 MiB, driver 595.71.05, nvcc 13.2` — `cargo oxide run future_apis`

With this change, the same device that previously failed now skips cleanly:

```text
     Running `target/release/future_apis`
=== Future APIs Test (Unified) ===

skipping: ManagedBarrier emits fence.proxy.async, which requires sm_90+ (device is sm_86)

--- result ---
exit code  : 0
```

`verdict_standard` matches that `skipping:` line and reports `PASS (skipped)`.

Before the change, on the same box: `Error: DriverError(218, "a PTX JIT
compilation failed")`, exit 1, counted as `FAIL (exit=1)` by the suite.

I have not been able to execute the sm_90+ path — I have no Hopper or Blackwell
hardware — so this PR verifies the skip, not the run. The gate's upper side is
unchanged in shape from the sm_80 version it replaces, and `cluster` uses the
same `major < 9` comparison for the same reason.

## Scope

This corrects the gate, not the emission, and deliberately so.

The fence is emitted for every `ManagedBarrier::init` regardless of `Kind`, and
its purpose is to make generic-proxy writes visible to the *async* proxy. A
`ManagedBarrier<_, GeneralBarrier>` that never feeds an async copy may not need
it, and the typestate already distinguishes `GeneralBarrier` from `TmaBarrier`.
If the fence can be predicated on `Kind`, plain barriers would keep working on
Ampere exactly as the old sm_80 comment intended, instead of the whole API being
Hopper+. That is a memory-model question I did not want to answer by inference,
so it is raised in #676 rather than guessed at here. Happy to implement it if
you confirm the ordering requirement.

Refs #676
