### PR TITLE
test(mir-lower): assert the whole-aggregate payload move as a property

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -2497,36 +2497,68 @@ mod tests {
             2,
             "construction should reload the enum and extraction should load the tuple payload"
         );
-        // The niche carrier claims the pointer at byte 8, and the 8 bytes below
-        // it are 8-aligned inside an 8-aligned enum, so they lower to one `i64`
-        // filler. That makes the enum's physical storage `{i64, ptr}` -- the
-        // *same interned type* as the lowered payload tuple. So all three stores
-        // counted above (two enum spills plus the payload write) now carry
-        // `lowered_tuple`, and a type filter can no longer tell them apart;
-        // before the filler was widened only the payload write did. The property
-        // that matters -- whole-aggregate moves, never field-by-field -- stays
-        // pinned by the total store/load counts asserted above.
-        assert_eq!(
-            find_all::<llvm::StoreOp>(&ctx, &body)
-                .iter()
-                .filter(|store| store.get_operand_value(&ctx).get_type(&ctx) == lowered_tuple)
-                .count(),
-            3,
-            "every whole-aggregate store here must move a complete {{i64, ptr}}"
+        // What this test is about is that the payload moves as one unit, never
+        // field by field. Assert that property directly instead of counting
+        // whole-aggregate accesses.
+        //
+        // Counting was the fragile form. The enum's physical storage here is
+        // `{i64, ptr}` -- the *same interned type* as the lowered payload tuple,
+        // since the niche carrier claims the pointer at byte 8 and the 8 bytes
+        // below it become one `i64` filler. So a count of `lowered_tuple`-typed
+        // accesses cannot separate the payload write from the enum spill, and
+        // the expected numbers move whenever that coincidence appears or
+        // disappears -- which has nothing to do with the property under test.
+        //
+        // A lowering that decomposed the payload is recognisable by what it
+        // emits instead: traffic in the tuple's *field* types. Look for that,
+        // and the assertion holds whatever the enum storage type happens to be.
+        let field_tys: Vec<TypeHandle> = lowered_tuple
+            .deref(&ctx)
+            .downcast_ref::<llvm_types::StructType>()
+            .expect("the lowered tuple is an LLVM struct")
+            .fields()
+            .collect();
+
+        let store_tys: Vec<TypeHandle> = find_all::<llvm::StoreOp>(&ctx, &body)
+            .iter()
+            .map(|store| store.get_operand_value(&ctx).get_type(&ctx))
+            .collect();
+        let load_tys: Vec<TypeHandle> = find_all::<llvm::LoadOp>(&ctx, &body)
+            .iter()
+            .map(|load| {
+                load.get_operation()
+                    .deref(&ctx)
+                    .get_result(0)
+                    .get_type(&ctx)
+            })
+            .collect();
+
+        let describe = |tys: &[TypeHandle]| -> Vec<String> {
+            tys.iter()
+                .filter(|ty| field_tys.contains(ty))
+                .map(|ty| ty.deref(&ctx).disp(&ctx).to_string())
+                .collect()
+        };
+        assert!(
+            describe(&store_tys).is_empty(),
+            "the payload must be stored whole, but these field-typed stores appear: {:?}",
+            describe(&store_tys)
         );
-        assert_eq!(
-            find_all::<llvm::LoadOp>(&ctx, &body)
-                .iter()
-                .filter(|load| {
-                    load.get_operation()
-                        .deref(&ctx)
-                        .get_result(0)
-                        .get_type(&ctx)
-                        == lowered_tuple
-                })
-                .count(),
-            2,
-            "the enum reload and the payload extraction must both read a complete {{i64, ptr}}"
+        assert!(
+            describe(&load_tys).is_empty(),
+            "the payload must be read whole, but these field-typed loads appear: {:?}",
+            describe(&load_tys)
+        );
+
+        // And it must actually be moved: without this the checks above would
+        // also pass a lowering that emitted no payload traffic at all.
+        assert!(
+            store_tys.contains(&lowered_tuple),
+            "at least one store must move the complete {{i64, ptr}} payload"
+        );
+        assert!(
+            load_tys.contains(&lowered_tuple),
+            "at least one load must read the complete {{i64, ptr}} payload"
         );
     }
 


### PR DESCRIPTION
The test restructure you said was welcome as a follow-up on #675.

> the weakened type-discrimination in the nested-niche test is fine as-is;
> the restructure you offered is welcome as a follow-up.

#675 has merged, so this is now rebased onto `main` as a **single commit**
(`35558a85`) — the stacking note that was here is obsolete.

## What was weak

The test pinned its central property — an enum payload moves as one unit, never
field by field — by counting accesses whose type equalled the lowered payload
tuple. That count is not a property of the lowering under test. It depends on
whether the enum's physical storage type happens to coincide with the payload's.

For `Option<(i64, &T)>` it now does: the niche carrier claims the pointer at byte
8, the 8 bytes below it become one `i64` filler, and the storage is `{i64, ptr}`
— the same interned type as the payload tuple. So every whole-aggregate access
carries that type, the expected counts had to move from 1 and 1 to 3 and 2, and a
type filter stopped being able to separate the payload write from the enum spill.

## What it asserts now

A lowering that decomposed the payload is recognisable by what it *emits*:
traffic in the tuple's field types. So the test now requires that no store or
load moves a bare `i64` or a bare `ptr`, with two non-vacuity checks that the
complete tuple really is moved at least once each way — without those, a lowering
that emitted no payload traffic at all would pass.

The field types are taken from `lowered_tuple` rather than hardcoded, so the
assertion follows the tuple if its shape changes.

## Why this is the right shape

I ran the same assertion on both sides of the filler widening. The field-typed
count is zero either way; only the tuple-typed counts differ:

| | stores | loads |
|---|---|---|
| at `upstream/main` | `{[8 x i8],ptr}`, `{i64,ptr}`, `{[8 x i8],ptr}` | `{[8 x i8],ptr}`, `{i64,ptr}` |
| with #675 (now on `main`) | `{i64,ptr}` ×3 | `{i64,ptr}` ×2 |

`field_tys` is `[i64, ptr]` in both cases, and nothing matches it in either. So
the new assertion holds unchanged across the change that broke the old one —
which is the whole point of making it.

Verified by applying only this test change to `upstream/main` (without the
widening) and running it there, as well as on top of the widening.

## Gates

- `cargo fmt --check` — pass
- `cargo test -p mir-lower -p llvm-export -p dialect-mir -p dialect-nvvm --lib --tests` — pass (165 `mir-lower` tests, 88 `llvm-export`)

`cuda-host` and `cuda-macros` could not run on that machine — `cuda-bindings`
needs the CUDA driver — so I ran the full workflow set on my fork instead; see the
comment below. No GPU is needed for any of this: the test is hardware-free.

Refs #675


