### PR TITLE
test(codegen): validate spill-free 32-value WGMMA carrier

### DIFF
--- a/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
@@ -1,0 +1,354 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Proves that the codegen pipeline can carry thirty-two tied `f32` values
+//! through one inline-PTX operation and produce spill-free `sm_90a` code.
+
+#![cfg(unix)]
+
+use cuda_oxide_codegen::experimental::{CodegenModule, CompileOptions, Compiler, Target};
+use dialect_mir::{
+    ops::{MirConstantOp, MirFuncOp, MirPtrOffsetOp, MirReturnOp, MirStoreOp},
+    types::MirPtrType,
+};
+use dialect_nvvm::ops::InlinePtxOp;
+use pliron::builtin::attributes::IntegerAttr;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        attributes::TypeAttr,
+        op_interfaces::SymbolOpInterface,
+        types::{FP32Type, FunctionType},
+    },
+    linked_list::ContainsLinkedList,
+    op::Op,
+    operation::Operation,
+    utils::apint::APInt,
+};
+use std::num::NonZeroUsize;
+
+const ACCUMULATOR_LEN: usize = 32;
+
+fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
+    module.edit(|ctx, module| {
+        let module_region = module.get_operation().deref(ctx).get_region(0);
+        let module_block = module_region
+            .deref(ctx)
+            .iter(ctx)
+            .next()
+            .expect("codegen module must contain its top-level block");
+
+        let f32_ty = FP32Type::get(ctx);
+        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+        let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+        let output_ptr_ty = MirPtrType::get_global(ctx, f32_ty.into(), true);
+
+        // Kernel signature:
+        //
+        // wgmma_value_carrier_kernel(
+        //     output: *mut f32,
+        //     acc0: f32,
+        //     ...
+        //     acc31: f32,
+        //     desc_a: u64,
+        //     desc_b: u64,
+        // )
+        let mut argument_types: Vec<pliron::r#type::TypeHandle> =
+            Vec::with_capacity(3 + ACCUMULATOR_LEN);
+
+        argument_types.push(output_ptr_ty.into());
+
+        let accumulator_types: Vec<pliron::r#type::TypeHandle> =
+            vec![f32_ty.into(); ACCUMULATOR_LEN];
+
+        argument_types.extend(accumulator_types);
+        argument_types.push(u64_ty.into());
+        argument_types.push(u64_ty.into());
+
+        let function_type = FunctionType::get(ctx, argument_types.clone(), vec![]);
+        let function_op = Operation::new(
+            ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let function = MirFuncOp::new(ctx, function_op, TypeAttr::new(function_type.into()));
+        function.set_symbol_name(ctx, "wgmma_value_carrier_kernel".try_into().unwrap());
+
+        let function_region = function.get_operation().deref(ctx).get_region(0);
+        let entry = BasicBlock::new(ctx, None, argument_types);
+        entry.insert_at_back(function_region, ctx);
+
+        let output = entry.deref(ctx).get_argument(0);
+        let accumulator_inputs = (0..ACCUMULATOR_LEN)
+            .map(|index| entry.deref(ctx).get_argument(index + 1))
+            .collect::<Vec<_>>();
+
+        let desc_a = entry.deref(ctx).get_argument(1 + ACCUMULATOR_LEN);
+        let desc_b = entry.deref(ctx).get_argument(2 + ACCUMULATOR_LEN);
+
+        // Each output is tied to the corresponding accumulator input through
+        // constraints 0..31. The WGMMA instruction references all thirty-two
+        // output operands as one accumulator register tuple.
+        let accumulator_registers = (0..ACCUMULATOR_LEN)
+            .map(|index| format!("${index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        const DESC_A_OPERAND: usize = ACCUMULATOR_LEN * 2;
+        const DESC_B_OPERAND: usize = DESC_A_OPERAND + 1;
+
+        let template = format!(
+            "{{\n\
+             \x20   wgmma.fence.sync.aligned;\n\
+             \x20   wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+             {{{accumulator_registers}}}, \
+             ${DESC_A_OPERAND}, ${DESC_B_OPERAND}, 1, 1, 1, 0, 0;\n\
+             \x20   wgmma.commit_group.sync.aligned;\n\
+             \x20   wgmma.wait_group.sync.aligned 0;\n\
+             }}"
+        );
+
+        let mut constraints = vec!["=f".to_owned(); ACCUMULATOR_LEN];
+
+        constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
+
+        constraints.extend(["l".to_owned(), "l".to_owned(), "~{memory}".to_owned()]);
+
+        let constraints = constraints.join(",");
+
+        let mut asm_inputs = accumulator_inputs;
+        asm_inputs.push(desc_a);
+        asm_inputs.push(desc_b);
+
+        let inline_ptx = InlinePtxOp::build(
+            ctx,
+            vec![f32_ty.into(); ACCUMULATOR_LEN],
+            asm_inputs,
+            &template,
+            &constraints,
+            true,
+            true,
+        );
+
+        let accumulator_results = (0..ACCUMULATOR_LEN)
+            .map(|index| inline_ptx.deref(ctx).get_result(index))
+            .collect::<Vec<_>>();
+
+        inline_ptx.insert_at_back(entry, ctx);
+
+        // Keep every result observably live across the inline-PTX boundary.
+        //
+        // Immediately after the asm, all thirty-two values must remain available.
+        // Each value is then written to output[index], preventing the backend from
+        // discarding unused outputs or shortening the probe to one live result.
+        for (index, result) in accumulator_results.into_iter().enumerate() {
+            let index_op = Operation::new(
+                ctx,
+                MirConstantOp::get_concrete_op_info(),
+                vec![i32_ty.into()],
+                vec![],
+                vec![],
+                0,
+            );
+
+            MirConstantOp::new(index_op).set_attr_value(
+                ctx,
+                IntegerAttr::new(
+                    i32_ty,
+                    APInt::from_u32(index as u32, NonZeroUsize::new(32).unwrap()),
+                ),
+            );
+
+            let index_value = index_op.deref(ctx).get_result(0);
+            index_op.insert_at_back(entry, ctx);
+
+            let output_element_op = Operation::new(
+                ctx,
+                MirPtrOffsetOp::get_concrete_op_info(),
+                vec![output_ptr_ty.into()],
+                vec![output, index_value],
+                vec![],
+                0,
+            );
+
+            let output_element = output_element_op.deref(ctx).get_result(0);
+
+            output_element_op.insert_at_back(entry, ctx);
+
+            Operation::new(
+                ctx,
+                MirStoreOp::get_concrete_op_info(),
+                vec![],
+                vec![output_element, result],
+                vec![],
+                0,
+            )
+            .insert_at_back(entry, ctx);
+        }
+
+        Operation::new(
+            ctx,
+            MirReturnOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        )
+        .insert_at_back(entry, ctx);
+
+        function.get_operation().insert_at_back(module_block, ctx);
+    });
+
+    module
+        .mark_kernel_entry("wgmma_value_carrier_kernel")
+        .expect("kernel entry must be marked");
+}
+
+fn find_ptxas() -> std::path::PathBuf {
+    ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
+        .iter()
+        .filter_map(|variable| std::env::var(variable).ok())
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| std::path::PathBuf::from(root).join("bin/ptxas"))
+        .chain(std::iter::once(std::path::PathBuf::from(
+            "/usr/local/cuda/bin/ptxas",
+        )))
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("ptxas"))
+}
+
+fn used_register_count(ptxas_stderr: &str) -> Option<u32> {
+    ptxas_stderr.lines().find_map(|line| {
+        let start = line.find("Used ")? + "Used ".len();
+        let remainder = &line[start..];
+        let end = remainder.find(" registers")?;
+        remainder[..end].trim().parse().ok()
+    })
+}
+
+#[test]
+fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
+    let mut module = CodegenModule::new("wgmma_value_carrier").unwrap();
+    build_wgmma_value_carrier_kernel(&mut module);
+
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
+    let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
+
+    let ptx = compiler
+        .compile(&mut module, &options)
+        .expect("32-value carrier must compile to PTX")
+        .into_ptx();
+
+    let text = String::from_utf8(ptx.clone()).expect("PTX must be UTF-8");
+
+    assert!(
+        text.contains(".visible .entry"),
+        "kernel entry is missing:\n{text}",
+    );
+    assert!(
+        text.contains(".target sm_90a"),
+        "PTX must target sm_90a:\n{text}",
+    );
+    assert!(
+        text.contains("wgmma_value_carrier_kernel"),
+        "carrier kernel is missing:\n{text}",
+    );
+    assert_eq!(
+        text.matches("wgmma.fence.sync.aligned").count(),
+        1,
+        "the WGMMA carrier must contain exactly one fence:\n{text}",
+    );
+
+    assert_eq!(
+        text.matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
+            .count(),
+        1,
+        "the WGMMA carrier must contain exactly one BF16 MMA:\n{text}",
+    );
+
+    assert_eq!(
+        text.matches("wgmma.commit_group.sync.aligned").count(),
+        1,
+        "the WGMMA carrier must contain exactly one commit:\n{text}",
+    );
+
+    assert_eq!(
+        text.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1,
+        "the WGMMA carrier must fully drain the group:\n{text}",
+    );
+    assert!(
+        !text.contains(".local") && !text.contains("ld.local") && !text.contains("st.local"),
+        "the carrier unexpectedly materializes local memory:\n{text}",
+    );
+
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+
+    let directory = std::env::temp_dir().join(format!(
+        "wgmma_value_carrier_ptx_{}_{}",
+        std::process::id(),
+        unique,
+    ));
+
+    std::fs::create_dir_all(&directory).unwrap();
+
+    let ptx_path = directory.join("carrier.ptx");
+    let cubin_path = directory.join("carrier.cubin");
+    std::fs::write(&ptx_path, &ptx).unwrap();
+
+    let ptxas = find_ptxas();
+    let ptxas_result = std::process::Command::new(&ptxas)
+        .arg("-arch=sm_90a")
+        .arg("--compile-only")
+        .arg("-v")
+        .arg(&ptx_path)
+        .arg("-o")
+        .arg(&cubin_path)
+        .output();
+
+    let _ = std::fs::remove_dir_all(&directory);
+
+    let output = ptxas_result.unwrap_or_else(|error| {
+        panic!(
+            "could not run {}: {error}\n\
+             Set CUDA_TOOLKIT_PATH or CUDA_HOME, or put ptxas on PATH.",
+            ptxas.display(),
+        )
+    });
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "ptxas rejected the 32-value carrier:\n{stderr}\n\nPTX:\n{text}",
+    );
+    assert!(
+        stderr.contains("0 bytes spill stores"),
+        "ptxas reported spill stores:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("0 bytes spill loads"),
+        "ptxas reported spill loads:\n{stderr}",
+    );
+
+    let used_registers =
+        used_register_count(&stderr).expect("ptxas output must report register usage");
+
+    assert!(
+        used_registers >= ACCUMULATOR_LEN as u32,
+        "the probe did not keep all 32 accumulator values live: \
+     ptxas used only {used_registers} registers\n{stderr}",
+    );
+
+    eprintln!("{stderr}");
+}

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -2949,6 +2949,126 @@ fn test_multi_result_inline_ptx_lowers_to_struct_asm_and_extractvalues() -> Resu
 }
 
 #[test]
+fn test_inline_ptx_supports_thirty_two_tied_f32_results() -> Result<(), anyhow::Error> {
+    use llvm_export::types as llvm_types;
+    use pliron::builtin::types::FP32Type;
+    use pliron::r#type::Typed;
+
+    const ACCUMULATOR_LEN: usize = 32;
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![f32_ty.into(); ACCUMULATOR_LEN]);
+
+    let inputs = (0..ACCUMULATOR_LEN)
+        .map(|index| entry.deref(&ctx).get_argument(index))
+        .collect::<Vec<_>>();
+
+    let template = (0..ACCUMULATOR_LEN)
+        .map(|index| format!("mov.f32 ${index}, ${index};"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut constraints = vec!["=f".to_string(); ACCUMULATOR_LEN];
+    constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
+    let constraints = constraints.join(",");
+
+    let inline_ptx = nvvm::InlinePtxOp::build(
+        &mut ctx,
+        vec![f32_ty.into(); ACCUMULATOR_LEN],
+        inputs,
+        &template,
+        &constraints,
+        true,
+        true,
+    );
+    inline_ptx.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let mut asm_result = None;
+    let mut extract_indices = Vec::new();
+
+    for op in lowered_kernel_body(&ctx, module_ptr) {
+        if let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(op, &ctx) {
+            assert_eq!(
+                inline_asm
+                    .get_attr_inline_asm_template(&ctx)
+                    .map(|value| String::from((*value).clone()))
+                    .as_deref(),
+                Some(template.as_str()),
+            );
+
+            assert_eq!(
+                inline_asm
+                    .get_attr_inline_asm_constraints(&ctx)
+                    .map(|value| String::from((*value).clone()))
+                    .as_deref(),
+                Some(constraints.as_str()),
+            );
+
+            let result = inline_asm.get_operation().deref(&ctx).get_result(0);
+            let result_ty = result.get_type(&ctx);
+            let result_ty = result_ty.deref(&ctx);
+
+            let struct_ty = result_ty
+                .downcast_ref::<llvm_types::StructType>()
+                .expect("32-output inline PTX must return an LLVM struct");
+
+            assert_eq!(
+                struct_ty.num_fields(),
+                ACCUMULATOR_LEN,
+                "inline PTX must return exactly 32 accumulator values",
+            );
+
+            for index in 0..ACCUMULATOR_LEN {
+                assert!(
+                    struct_ty
+                        .field_type(index)
+                        .deref(&ctx)
+                        .downcast_ref::<FP32Type>()
+                        .is_some(),
+                    "inline PTX result field {index} must remain f32",
+                );
+            }
+
+            assert!(
+                asm_result.replace(result).is_none(),
+                "expected exactly one inline PTX operation",
+            );
+        } else if let Some(extract) = Operation::get_op::<llvm::ExtractValueOp>(op, &ctx) {
+            let aggregate = extract.get_operation().deref(&ctx).get_operand(0);
+
+            assert_eq!(
+                Some(aggregate),
+                asm_result,
+                "extractvalue must consume the struct-returning asm result",
+            );
+
+            extract_indices.push(extract.indices(&ctx));
+        }
+    }
+
+    assert!(
+        asm_result.is_some(),
+        "expected a struct-returning inline PTX asm operation",
+    );
+
+    let expected_indices = (0..ACCUMULATOR_LEN)
+        .map(|index| vec![index as u32])
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        extract_indices, expected_indices,
+        "each accumulator output must be extracted exactly once and in constraint order",
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_cluster_grid_compatibility_ops_keep_original_lowering() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};
 


### PR DESCRIPTION
This PR is the first of six planned PRs that incrementally implement #605.

## Summary

Add feasibility coverage for carrying the 32 per-thread f32 accumulator
values of BF16 m64n64k16 WGMMA through one convergent inline-PTX region.

The tests verify that:

- `nvvm.inline_ptx` accepts 32 tied f32 inputs and 32 f32 results;
- MIR lowering represents the outputs as an LLVM aggregate followed by
  32 `extractvalue` operations;
- a real `wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16`
  sequence compiles for `sm_90a`;
- all 32 results remain observable after `wait_group 0`;
- PTX contains no local-memory materialization;
- `ptxas -v` reports zero stack frame, zero spill stores, and zero spill
  loads.

Observed locally:

    Used 58 registers
    0 bytes stack frame
    0 bytes spill stores
    0 bytes spill loads

## Motivation

This isolates the primary backend feasibility question for #605 before
introducing a production value-form WGMMA operation or changing the
existing pointer-based deferred fallback.

## Scope

This PR adds tests only. It does not:

- change the public WGMMA API;
- change the existing deferred accumulator lowering;
- implement K-loop fusion;
- implement partial waits;
- claim runtime numerical validation on Hopper hardware.
