### PR TITLE
test(mir-lower): assert the whole-aggregate payload move as a property

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -2497,36 +2497,68 @@ mod tests {
             2,
             "construction should reload the enum and extraction should load the tuple payload"
         );
-        // The niche carrier claims the pointer at byte 8, and the 8 bytes below
-        // it are 8-aligned inside an 8-aligned enum, so they lower to one `i64`
-        // filler. That makes the enum's physical storage `{i64, ptr}` -- the
-        // *same interned type* as the lowered payload tuple. So all three stores
-        // counted above (two enum spills plus the payload write) now carry
-        // `lowered_tuple`, and a type filter can no longer tell them apart;
-        // before the filler was widened only the payload write did. The property
-        // that matters -- whole-aggregate moves, never field-by-field -- stays
-        // pinned by the total store/load counts asserted above.
-        assert_eq!(
-            find_all::<llvm::StoreOp>(&ctx, &body)
-                .iter()
-                .filter(|store| store.get_operand_value(&ctx).get_type(&ctx) == lowered_tuple)
-                .count(),
-            3,
-            "every whole-aggregate store here must move a complete {{i64, ptr}}"
+        // What this test is about is that the payload moves as one unit, never
+        // field by field. Assert that property directly instead of counting
+        // whole-aggregate accesses.
+        //
+        // Counting was the fragile form. The enum's physical storage here is
+        // `{i64, ptr}` -- the *same interned type* as the lowered payload tuple,
+        // since the niche carrier claims the pointer at byte 8 and the 8 bytes
+        // below it become one `i64` filler. So a count of `lowered_tuple`-typed
+        // accesses cannot separate the payload write from the enum spill, and
+        // the expected numbers move whenever that coincidence appears or
+        // disappears -- which has nothing to do with the property under test.
+        //
+        // A lowering that decomposed the payload is recognisable by what it
+        // emits instead: traffic in the tuple's *field* types. Look for that,
+        // and the assertion holds whatever the enum storage type happens to be.
+        let field_tys: Vec<TypeHandle> = lowered_tuple
+            .deref(&ctx)
+            .downcast_ref::<llvm_types::StructType>()
+            .expect("the lowered tuple is an LLVM struct")
+            .fields()
+            .collect();
+
+        let store_tys: Vec<TypeHandle> = find_all::<llvm::StoreOp>(&ctx, &body)
+            .iter()
+            .map(|store| store.get_operand_value(&ctx).get_type(&ctx))
+            .collect();
+        let load_tys: Vec<TypeHandle> = find_all::<llvm::LoadOp>(&ctx, &body)
+            .iter()
+            .map(|load| {
+                load.get_operation()
+                    .deref(&ctx)
+                    .get_result(0)
+                    .get_type(&ctx)
+            })
+            .collect();
+
+        let describe = |tys: &[TypeHandle]| -> Vec<String> {
+            tys.iter()
+                .filter(|ty| field_tys.contains(ty))
+                .map(|ty| ty.deref(&ctx).disp(&ctx).to_string())
+                .collect()
+        };
+        assert!(
+            describe(&store_tys).is_empty(),
+            "the payload must be stored whole, but these field-typed stores appear: {:?}",
+            describe(&store_tys)
         );
-        assert_eq!(
-            find_all::<llvm::LoadOp>(&ctx, &body)
-                .iter()
-                .filter(|load| {
-                    load.get_operation()
-                        .deref(&ctx)
-                        .get_result(0)
-                        .get_type(&ctx)
-                        == lowered_tuple
-                })
-                .count(),
-            2,
-            "the enum reload and the payload extraction must both read a complete {{i64, ptr}}"
+        assert!(
+            describe(&load_tys).is_empty(),
+            "the payload must be read whole, but these field-typed loads appear: {:?}",
+            describe(&load_tys)
+        );
+
+        // And it must actually be moved: without this the checks above would
+        // also pass a lowering that emitted no payload traffic at all.
+        assert!(
+            store_tys.contains(&lowered_tuple),
+            "at least one store must move the complete {{i64, ptr}} payload"
+        );
+        assert!(
+            load_tys.contains(&lowered_tuple),
+            "at least one load must read the complete {{i64, ptr}} payload"
         );
     }
 


### PR DESCRIPTION
The test restructure you said was welcome as a follow-up on #675.

> the weakened type-discrimination in the nested-niche test is fine as-is;
> the restructure you offered is welcome as a follow-up.

Single commit on top of `main` (`981b9eb0`), one file, test-only. Replaces #678,
which carried a stale "stacked on #675" description and a force-push from before
that PR merged; this branch is cut fresh so there is nothing to read around.

## What was weak

The test pinned its central property — an enum payload moves as one unit, never
field by field — by counting accesses whose type equalled the lowered payload
tuple. That count is not a property of the lowering under test. It depends on
whether the enum's physical storage type happens to coincide with the payload's.

For `Option<(i64, &T)>` it now does: the niche carrier claims the pointer at byte
8, the 8 bytes below it become one `i64` filler, and the storage is `{i64, ptr}`
— the same interned type as the payload tuple. So every whole-aggregate access
carries that type, the expected counts had to move from 1 and 1 to 3 and 2, and a
type filter stopped being able to separate the payload write from the enum spill.

## What it asserts now

A lowering that decomposed the payload is recognisable by what it *emits*:
traffic in the tuple's field types. So the test now requires that no store or
load moves a bare `i64` or a bare `ptr`, with two non-vacuity checks that the
complete tuple really is moved at least once each way — without those, a lowering
that emitted no payload traffic at all would pass.

The field types are read out of `lowered_tuple` rather than hardcoded, so the
assertion follows the tuple if its shape changes.

## Why this is the right shape

I ran the same assertion on both sides of the filler widening. The field-typed
count is zero either way; only the tuple-typed counts differ:

| | stores | loads |
|---|---|---|
| before #675 | `{[8 x i8],ptr}`, `{i64,ptr}`, `{[8 x i8],ptr}` | `{[8 x i8],ptr}`, `{i64,ptr}` |
| after #675 (now `main`) | `{i64,ptr}` ×3 | `{i64,ptr}` ×2 |

`field_tys` is `[i64, ptr]` in both cases and nothing matches it in either, so the
new assertion holds unchanged across the change that broke the old one — which is
the point of making it. Verified by applying only this test change to the
pre-#675 tree and running it there, as well as on `main`.

## Gates

Local, on the pinned toolchain: `cargo fmt --check` and
`cargo test -p mir-lower --lib` (167 tests) both pass, plus `clippy -D warnings`
and the `llvm-export` / `dialect-mir` / `dialect-nvvm` test crates.

The full workflow set also ran green on my fork for this same commit, which
covers what I cannot run locally (`cuda-host` and `cuda-macros` need the CUDA
driver): `unit-tests / cargo test -p mir-lower`, `mir-importer`, `cuda-device`,
`cuda-intrinsics`, `cuda-async`, the generated-intrinsics ABI check, plus `fmt`,
`naming-guard`, `status-guard`, `docs` and `cargo-deny`. Those are my runners
rather than an upstream run — the runs here need approving to go green.

No GPU is needed for any of this: the test is hardware-free.

Refs #675
