### PR TITLE
test(examples): check the smoketest contract a new example cannot see

### DIFF
--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -25,3 +25,20 @@ jobs:
 
       - name: Verify error* examples are in STATUS.md and smoketest.sh
         run: bash scripts/check-error-example-status.sh
+
+  # Both of the things this checks are otherwise only visible when the suite
+  # runs on a GPU: the compile-only lane collapses every category into
+  # verdict_compile, so it never exercises classify() or the standard-category
+  # success marker. 981b9eb0 is the precedent -- a new example landed with no
+  # marker and needed a follow-up commit on main to stop reporting FAIL.
+  example-smoketest-contract:
+    name: smoketest example contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # Reads sources only: no cargo, no CUDA toolkit, no LLVM.
+      - name: Verify smoketest categories and standard-example success markers
+        run: bash scripts/check-example-smoketest-contract.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,12 @@ third-party files must keep their upstream license and copyright notices.
   correct behavior.
 - Dialect changes should include appropriate tests in the crate's `tests/`
   directory.
+- A new example must print a `SUCCESS`/`PASS`/`Complete` marker once it has
+  verified its results, or `scripts/smoketest.sh` reports it as
+  `FAIL (no success marker)`. `scripts/check-example-smoketest-contract.sh`
+  checks that without a GPU, along with the `*_EXAMPLES` arrays in
+  `smoketest.sh`; CI runs it as the `status-guard / smoketest example contract`
+  job.
 
 #### Running the driver-linked crates without a GPU
 

--- a/scripts/check-example-smoketest-contract.sh
+++ b/scripts/check-example-smoketest-contract.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Verify the two things scripts/smoketest.sh assumes about the examples, both
+# of which are otherwise only discoverable by running the suite on a GPU:
+#
+#   1. Every name in a *_EXAMPLES array is a real example directory.  These
+#      arrays drive classify(), so a typo or a renamed example does not fail
+#      loudly -- the entry simply matches nothing and the example silently
+#      falls through to the `standard` category and the wrong verdict rules.
+#
+#   2. Every `standard` example can actually report success.  That category's
+#      verdict requires a SUCCESS/PASS/Complete marker in the output, and an
+#      example that verifies its results but never prints one is reported as
+#      `FAIL (no success marker)`.  That is a false failure, and it has landed
+#      before: 981b9eb0 had to add a marker to disjoint_from_raw_parts after
+#      #670 (the new example) and #665 (stricter verdicts) merged in one batch.
+#
+# Neither check needs a GPU, and neither is reachable from the compile-only CI
+# lane, which collapses every category into verdict_compile.
+#
+# Run this after adding an example or editing a *_EXAMPLES array.
+set -euo pipefail
+
+export LC_ALL=C
+
+cd "$(dirname "$0")/.."
+
+SMOKETEST=scripts/smoketest.sh
+EXAMPLES_ROOT=crates/rustc-codegen-cuda/examples
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: python3 is required to verify the smoketest example contract" >&2
+    echo "       refusing to report success from a check that cannot run" >&2
+    exit 1
+fi
+
+test -s "${SMOKETEST}"
+
+# The marker and skip patterns below duplicate verdict_standard's greps.  Pin
+# that coupling: if the verdict changes its patterns, this guard is stale and
+# must say so rather than keep checking the old contract.
+if ! grep -Fq "'SUCCESS|PASS|Complete'" "${SMOKETEST}"; then
+    echo "error: ${SMOKETEST} no longer greps 'SUCCESS|PASS|Complete' for success" >&2
+    echo "       verdict_standard's contract changed; update this guard" >&2
+    exit 1
+fi
+if ! grep -Fq "'^[[:space:]]*(skipping:|pass \\(skipped\\))'" "${SMOKETEST}"; then
+    echo "error: ${SMOKETEST} no longer greps the skip declaration this guard expects" >&2
+    echo "       verdict_standard's contract changed; update this guard" >&2
+    exit 1
+fi
+
+python3 - "${SMOKETEST}" "${EXAMPLES_ROOT}" <<'PY'
+import glob
+import os
+import re
+import sys
+
+smoketest, examples_root = sys.argv[1], sys.argv[2]
+source = open(smoketest, encoding="utf-8").read()
+
+# Same two patterns verdict_standard applies to the run log.
+MARKER = re.compile(r"SUCCESS|PASS|Complete")
+SKIP = re.compile(r"^[ \t]*(skipping:|pass \(skipped\))", re.IGNORECASE)
+
+lists = re.findall(r"^([A-Z0-9_]+_EXAMPLES)=\(([^)]*)\)", source, re.M)
+on_disk = sorted(
+    os.path.basename(os.path.dirname(path))
+    for path in glob.glob(os.path.join(examples_root, "*", "Cargo.toml"))
+)
+
+# Parse self-tests: a guard whose failure mode is "matched nothing" has to
+# prove it still reads both inputs before a clean result is believed.
+if len(lists) < 8:
+    sys.exit(f"parse self-test failed: found {len(lists)} *_EXAMPLES arrays in {smoketest}")
+if len(on_disk) < 100:
+    sys.exit(f"parse self-test failed: found {len(on_disk)} examples under {examples_root}")
+
+failures = []
+
+known = set(on_disk)
+for name, body in lists:
+    phantom = [entry for entry in body.split() if entry not in known]
+    if phantom:
+        failures.append(
+            f"{name} names {len(phantom)} example(s) that do not exist: " + " ".join(phantom)
+        )
+
+# classify() returns `standard` for anything not claimed by a category array.
+# NVVM_VERIFY / NOINLINE_MIR / NO_LAUNCH / NO_OPT_SHAPE are modifiers, not
+# categories, so their members stay `standard` and still need a marker.
+CATEGORY_LISTS = (
+    "TCGEN05_EXAMPLES",
+    "WGMMA_EXAMPLES",
+    "LTOIR_EXAMPLES",
+    "LTOIR_MODERN_EXAMPLES",
+    "AUTO_NVVM_EXAMPLES",
+    "BLACKWELL_COMPILE_EXAMPLES",
+    "ERROR_EXAMPLES",
+)
+by_name = dict(lists)
+missing_arrays = [name for name in CATEGORY_LISTS if name not in by_name]
+if missing_arrays:
+    sys.exit(
+        "parse self-test failed: classify() arrays not found in "
+        f"{smoketest}: " + " ".join(missing_arrays)
+    )
+
+categorised = {
+    entry for name in CATEGORY_LISTS for entry in by_name[name].split()
+}
+
+unmarked = []
+for example in on_disk:
+    if example in categorised:
+        continue
+    pattern = os.path.join(examples_root, example, "src", "**", "*.rs")
+    has_marker = False
+    for path in glob.glob(pattern, recursive=True):
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if line.lstrip().startswith("//"):
+                    continue
+                if MARKER.search(line) and not SKIP.search(line):
+                    has_marker = True
+                    break
+        if has_marker:
+            break
+    if not has_marker:
+        unmarked.append(example)
+
+if unmarked:
+    failures.append(
+        "these `standard` examples print no SUCCESS/PASS/Complete marker, so "
+        "smoketest reports FAIL (no success marker):\n  "
+        + "\n  ".join(unmarked)
+    )
+
+if failures:
+    print("error: smoketest example contract violated", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    sys.exit(1)
+
+standard = len(on_disk) - len(categorised)
+print(
+    f"OK: {len(lists)} *_EXAMPLES arrays name only real examples, and all "
+    f"{standard} standard examples print a success marker."
+)
+PY


### PR DESCRIPTION
Fixes #682. Three files, no overlap with #679, #680, or #681.

## Why

`smoketest.sh` assumes two things about the examples that nothing verified, and neither is reachable without a GPU — the compile-only lane collapses every category into `verdict_compile`, so it exercises neither `classify()` nor the standard-category success marker.

**A `standard` example that prints no marker is a false FAIL.** `verdict_standard` requires `SUCCESS`/`PASS`/`Complete`; an example that launches kernels, verifies against exact expectations and returns is reported `FAIL (no success marker)`. That landed two days ago — `981b9eb0` added a marker to `disjoint_from_raw_parts` on `main`:

> Merging #670 (new example) and #665 (stricter smoketest verdicts) in the same batch left this example failing the standard-category check: both kernels verify to exact match but nothing prints SUCCESS/PASS/Complete, and the stricter harness rightly no longer rescues such a log.

A new example is where this bites: nothing in its own directory says a marker is required, and its author cannot see the consequence without hardware.

**A typo in a `*_EXAMPLES` array silently mis-categorises.** `classify()` falls through to `standard` for anything its seven arrays do not claim, so a misspelled or renamed entry does not fail — it matches nothing and the example gets the wrong verdict rules. For a `tcgen05`/`wgmma` example that loses the "PTX compiled on non-Hopper" path and starts reporting `FAIL` on hardware it was never meant to run on. All 45 entries across the 11 arrays are valid today, so this half is preventive; it is included because it is the same shape and free to check alongside.

## What this adds

`scripts/check-example-smoketest-contract.sh`, run from `status-guard.yml` as a second job — next to the existing guard that keeps `ERROR_EXAMPLES` and `STATUS.md` in step, which exists for exactly this class. Sources only: no cargo, no toolkit, no LLVM.

The guard duplicates two of `verdict_standard`'s greps, so it **pins that coupling**: if `smoketest.sh` stops grepping `SUCCESS|PASS|Complete`, or changes the skip pattern, the guard fails with *"verdict_standard's contract changed; update this guard"* rather than quietly checking a contract that no longer exists. Same trick as #648, where two hygiene fixtures had silently decoupled from the constant they pinned.

## Verification

CPU-only, no GPU.

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Current `main` | pass | exit 0 — "11 arrays name only real examples, and all 159 standard examples print a success marker" |
| 2 | Revert `981b9eb0`'s marker line | fail | exit 1, names `disjoint_from_raw_parts` |
| 3 | Typo entry added to `WGMMA_EXAMPLES` | fail | exit 1, names the phantom entry |
| 4 | Both restored | pass | exit 0 |
| 5 | `verdict_standard`'s success pattern changed | fail | exit 1, "update this guard" |
| 6 | Its skip pattern changed | fail | exit 1, same |
| 7 | `*_EXAMPLES` arrays removed | fail | exit 1 via parse self-test |
| 8 | `python3` absent from `PATH` | fail | exit 1, "refusing to report success from a check that cannot run" |
| 9 | Control: all tools present | pass | exit 0 |

Row 2 is the one that matters: it reproduces the real regression and names the same example you had to patch.

5–8 follow #643, where a guard reported success for three months because `rg ... || true` turned a missing binary into an empty result set.

## One thing worth knowing about how this was built

The counts the guard reports (11 arrays, 159 standard examples) match an independent scan I ran separately, and that cross-check earned its keep: my first attempt used a quote-pairing regex to extract string literals, which silently captured only 8 of `generated_ldmatrix`'s literals and produced **11 bogus "missing marker" hits** — including that example, which visibly prints `PASS: all …`. The shipped version is line-based for that reason. Given the guard's whole job is to not be silently wrong, it seemed worth saying that the first draft was.

`scripts/check-error-example-status.sh` and both halves of `check-dependency-licenses.sh` still pass on this branch. `bash -n` is clean and the workflow YAML parses.
