### PR TITLE
feat(wgmma): add 32-value SSA accumulator carrier

### DIFF
--- a/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
@@ -6,6 +6,10 @@
 
 //! Proves that the codegen pipeline can carry thirty-two tied `f32` values
 //! through one inline-PTX operation and produce spill-free `sm_90a` code.
+//!
+//! The probe covers both group shapes the value-form lowering emits: a
+//! single `wgmma.mma_async` and a chain of several under one
+//! fence/commit/wait sequence in the same asm region.
 
 #![cfg(unix)]
 
@@ -33,7 +37,7 @@ use std::num::NonZeroUsize;
 
 const ACCUMULATOR_LEN: usize = 32;
 
-fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
+fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule, mma_count: usize) {
     module.edit(|ctx, module| {
         let module_region = module.get_operation().deref(ctx).get_region(0);
         let module_block = module_region
@@ -47,6 +51,8 @@ fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
         let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
         let output_ptr_ty = MirPtrType::get_global(ctx, f32_ty.into(), true);
 
+        let descriptor_count = mma_count * 2;
+
         // Kernel signature:
         //
         // wgmma_value_carrier_kernel(
@@ -54,11 +60,12 @@ fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
         //     acc0: f32,
         //     ...
         //     acc31: f32,
-        //     desc_a: u64,
-        //     desc_b: u64,
+        //     desc_a0: u64,
+        //     desc_b0: u64,
+        //     ...              // one descriptor pair per chained MMA
         // )
         let mut argument_types: Vec<pliron::r#type::TypeHandle> =
-            Vec::with_capacity(3 + ACCUMULATOR_LEN);
+            Vec::with_capacity(1 + ACCUMULATOR_LEN + descriptor_count);
 
         argument_types.push(output_ptr_ty.into());
 
@@ -66,8 +73,10 @@ fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
             vec![f32_ty.into(); ACCUMULATOR_LEN];
 
         argument_types.extend(accumulator_types);
-        argument_types.push(u64_ty.into());
-        argument_types.push(u64_ty.into());
+
+        for _ in 0..descriptor_count {
+            argument_types.push(u64_ty.into());
+        }
 
         let function_type = FunctionType::get(ctx, argument_types.clone(), vec![]);
         let function_op = Operation::new(
@@ -90,42 +99,47 @@ fn build_wgmma_value_carrier_kernel(module: &mut CodegenModule) {
             .map(|index| entry.deref(ctx).get_argument(index + 1))
             .collect::<Vec<_>>();
 
-        let desc_a = entry.deref(ctx).get_argument(1 + ACCUMULATOR_LEN);
-        let desc_b = entry.deref(ctx).get_argument(2 + ACCUMULATOR_LEN);
+        let descriptors = (0..descriptor_count)
+            .map(|index| entry.deref(ctx).get_argument(1 + ACCUMULATOR_LEN + index))
+            .collect::<Vec<_>>();
 
         // Each output is tied to the corresponding accumulator input through
-        // constraints 0..31. The WGMMA instruction references all thirty-two
-        // output operands as one accumulator register tuple.
+        // constraints 0..31. Every chained WGMMA instruction references all
+        // thirty-two output operands as one accumulator register tuple, the
+        // same shape the value-form lowering template emits.
         let accumulator_registers = (0..ACCUMULATOR_LEN)
             .map(|index| format!("${index}"))
             .collect::<Vec<_>>()
             .join(", ");
 
-        const DESC_A_OPERAND: usize = ACCUMULATOR_LEN * 2;
-        const DESC_B_OPERAND: usize = DESC_A_OPERAND + 1;
+        const DESC_OPERAND_BASE: usize = ACCUMULATOR_LEN * 2;
 
-        let template = format!(
-            "{{\n\
-             \x20   wgmma.fence.sync.aligned;\n\
-             \x20   wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
-             {{{accumulator_registers}}}, \
-             ${DESC_A_OPERAND}, ${DESC_B_OPERAND}, 1, 1, 1, 0, 0;\n\
-             \x20   wgmma.commit_group.sync.aligned;\n\
-             \x20   wgmma.wait_group.sync.aligned 0;\n\
-             }}"
-        );
+        let mut template = String::from("{\n    wgmma.fence.sync.aligned;\n");
+
+        for mma_index in 0..mma_count {
+            let desc_a = DESC_OPERAND_BASE + mma_index * 2;
+            let desc_b = desc_a + 1;
+            template.push_str(&format!(
+                "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+                 {{{accumulator_registers}}}, ${desc_a}, ${desc_b}, 1, 1, 1, 0, 0;\n"
+            ));
+        }
+
+        template.push_str("    wgmma.commit_group.sync.aligned;\n");
+        template.push_str("    wgmma.wait_group.sync.aligned 0;\n");
+        template.push('}');
 
         let mut constraints = vec!["=f".to_owned(); ACCUMULATOR_LEN];
 
         constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
 
-        constraints.extend(["l".to_owned(), "l".to_owned(), "~{memory}".to_owned()]);
+        constraints.extend((0..descriptor_count).map(|_| "l".to_owned()));
+        constraints.push("~{memory}".to_owned());
 
         let constraints = constraints.join(",");
 
         let mut asm_inputs = accumulator_inputs;
-        asm_inputs.push(desc_a);
-        asm_inputs.push(desc_b);
+        asm_inputs.extend(descriptors);
 
         let inline_ptx = InlinePtxOp::build(
             ctx,
@@ -233,10 +247,9 @@ fn used_register_count(ptxas_stderr: &str) -> Option<u32> {
     })
 }
 
-#[test]
-fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
+fn assert_spill_free_value_carrier(mma_count: usize) {
     let mut module = CodegenModule::new("wgmma_value_carrier").unwrap();
-    build_wgmma_value_carrier_kernel(&mut module);
+    build_wgmma_value_carrier_kernel(&mut module, mma_count);
 
     let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
     let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
@@ -269,8 +282,8 @@ fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
     assert_eq!(
         text.matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
             .count(),
-        1,
-        "the WGMMA carrier must contain exactly one BF16 MMA:\n{text}",
+        mma_count,
+        "the WGMMA carrier must chain exactly {mma_count} BF16 MMAs:\n{text}",
     );
 
     assert_eq!(
@@ -295,7 +308,8 @@ fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
         .unwrap_or(0);
 
     let directory = std::env::temp_dir().join(format!(
-        "wgmma_value_carrier_ptx_{}_{}",
+        "wgmma_value_carrier_ptx_{}_{}_{}",
+        mma_count,
         std::process::id(),
         unique,
     ));
@@ -351,4 +365,14 @@ fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
     );
 
     eprintln!("{stderr}");
+}
+
+#[test]
+fn bf16_wgmma_uses_thirty_two_tied_f32_values_without_spills() {
+    assert_spill_free_value_carrier(1);
+}
+
+#[test]
+fn bf16_wgmma_chains_two_mma_async_under_one_commit_without_spills() {
+    assert_spill_free_value_carrier(2);
 }

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -13,12 +13,17 @@
 //! fence/MMA/commit/wait sequence and replaces it with a deferred group
 //! operation. The deferred group keeps all 32 per-thread accumulator values in
 //! one inline-PTX scope until `wait_group<0>` completes.
+//!
+//! The internal value-form group represents those same 32 accumulator values
+//! explicitly as SSA operands/results. It is the register-resident carrier used
+//! by value-threaded WGMMA lowering; the pointer-form group remains available as
+//! the deferred fallback.
 
 use dialect_mir::types::{MirPtrType, address_space};
 use pliron::{
     builtin::{
         op_interfaces::{NOpdsInterface, NResultsInterface},
-        types::{IntegerType, Signedness},
+        types::{FP32Type, IntegerType, Signedness},
     },
     common_traits::Verify,
     context::{Context, Ptr},
@@ -31,6 +36,8 @@ use pliron::{
     verify_err,
 };
 use pliron_derive::pliron_op;
+
+const WGMMA_M64N64_F32_ACCUMULATOR_COUNT: usize = 32;
 
 // =============================================================================
 // Descriptor Operations
@@ -57,6 +64,10 @@ fn is_u64(ctx: &Context, ty: pliron::r#type::TypeHandle) -> bool {
         .is_some_and(|integer| {
             integer.width() == 64 && integer.signedness() == Signedness::Unsigned
         })
+}
+
+fn is_f32(ctx: &Context, ty: pliron::r#type::TypeHandle) -> bool {
+    ty.deref(ctx).downcast_ref::<FP32Type>().is_some()
 }
 
 fn is_supported_wgmma_accumulator(ctx: &Context, value: Value) -> bool {
@@ -216,9 +227,116 @@ impl Verify for WgmmaMmaGroupM64N64K16F32Bf16Op {
     }
 }
 
+/// Value-form BF16 WGMMA group with 32 SSA accumulator values.
+///
+/// Operand layout:
+///
+/// ```text
+/// [acc_0, ..., acc_31, desc_a_0, desc_b_0, ..., desc_a_n, desc_b_n]
+/// ```
+///
+/// Result layout:
+///
+/// ```text
+/// [acc_0', ..., acc_31']
+/// ```
+///
+/// The operation represents one complete register lifetime scope containing an
+/// implicit fence, one or more MMA instructions, one commit, and
+/// `wait_group<0>`. Unlike the deferred pointer-form group, it does not
+/// materialize the accumulator through memory at either boundary.
+#[pliron_op(name = "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16", format)]
+pub struct WgmmaMmaGroupValuesM64N64K16F32Bf16Op;
+
+impl WgmmaMmaGroupValuesM64N64K16F32Bf16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+
+    /// Build a value-form group from 32 accumulator values and descriptor pairs.
+    pub fn build(
+        ctx: &mut Context,
+        accumulators: Vec<Value>,
+        descriptors: Vec<Value>,
+    ) -> Ptr<Operation> {
+        let f32_ty = FP32Type::get(ctx);
+        let mut operands = Vec::with_capacity(accumulators.len() + descriptors.len());
+        operands.extend(accumulators);
+        operands.extend(descriptors);
+
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![f32_ty.into(); WGMMA_M64N64_F32_ACCUMULATOR_COUNT],
+            operands,
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for WgmmaMmaGroupValuesM64N64K16F32Bf16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let operand_count = op.get_num_operands();
+        let result_count = op.get_num_results();
+
+        if result_count != WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 requires exactly 32 f32 results"
+            );
+        }
+
+        if operand_count < WGMMA_M64N64_F32_ACCUMULATOR_COUNT + 2 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 requires 32 f32 accumulators and one or more descriptor pairs"
+            );
+        }
+
+        let descriptor_count = operand_count - WGMMA_M64N64_F32_ACCUMULATOR_COUNT;
+        if !descriptor_count.is_multiple_of(2) {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 descriptors must form pairs"
+            );
+        }
+
+        for accumulator_index in 0..WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 accumulator operands must be f32"
+                );
+            }
+
+            if !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 results must be f32"
+                );
+            }
+        }
+
+        for descriptor_index in WGMMA_M64N64_F32_ACCUMULATOR_COUNT..operand_count {
+            if !is_u64(ctx, op.get_operand(descriptor_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16 descriptors must be u64"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Register WGMMA operations with the context.
 pub(super) fn register(ctx: &mut Context) {
     WgmmaMakeSmemDescOp::register(ctx);
     WgmmaMmaM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaGroupM64N64K16F32Bf16Op::register(ctx);
+    WgmmaMmaGroupValuesM64N64K16F32Bf16Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -37,7 +37,7 @@ use dialect_nvvm::ops::{
     Tcgen05Ld16x32bx2X1RawOp, Tcgen05Ld16x256bPureOp, Tcgen05MmaF16Op, ThreadfenceBlockOp,
     ThreadfenceOp, ThreadfenceSystemOp, VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp,
     VoteSyncUniOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
 };
 
 #[test]
@@ -87,6 +87,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("wgmma.rs", "WgmmaMakeSmemDescOp"),
         ("wgmma.rs", "WgmmaMmaM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupM64N64K16F32Bf16Op"),
+        ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32Bf16Op"),
     ];
     expected.sort_unstable();
     found.sort_unstable();
@@ -4298,6 +4299,7 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
     let u32_ty = IntegerType::get(&ctx, 32, Signedness::Unsigned);
     let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    let f32_ty = FP32Type::get(&ctx);
     let pointer_ty = MirPtrType::get_generic(&mut ctx, u8_ty.into(), false);
     let accumulator_pointer_ty = MirPtrType::get_generic(&mut ctx, u8_ty.into(), true);
     let global_pointer_ty = MirPtrType::get_global(&mut ctx, u8_ty.into(), false);
@@ -4312,6 +4314,7 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
             mutable_global_pointer_ty.into(),
             u32_ty.into(),
             u64_ty.into(),
+            f32_ty.into(),
         ],
     );
     let pointer = block.deref(&ctx).get_argument(0);
@@ -4320,6 +4323,7 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     let mutable_global_pointer = block.deref(&ctx).get_argument(3);
     let u32_value = block.deref(&ctx).get_argument(4);
     let u64_value = block.deref(&ctx).get_argument(5);
+    let f32_value = block.deref(&ctx).get_argument(6);
 
     let vprintf = VprintfOp::build(&mut ctx, pointer, pointer);
     assert!(VprintfOp::new(vprintf).verify(&ctx).is_ok());
@@ -4518,6 +4522,118 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
                 .is_err()
         );
     }
+
+    let value_group = WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 32],
+        vec![u64_value, u64_value, u64_value, u64_value],
+    );
+    {
+        let value_group_ref = value_group.deref(&ctx);
+        assert_eq!(value_group_ref.get_num_operands(), 36);
+        assert_eq!(value_group_ref.get_num_results(), 32);
+    }
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(value_group)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let too_few_accumulators = WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 31],
+        vec![u64_value, u64_value],
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(too_few_accumulators)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let missing_descriptors =
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(&mut ctx, vec![f32_value; 32], vec![]);
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(missing_descriptors)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let incomplete_descriptor_pair = WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 32],
+        vec![u64_value, u64_value, u64_value],
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(incomplete_descriptor_pair)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut wrong_accumulator_operands = vec![f32_value; 32];
+    wrong_accumulator_operands[0] = u32_value;
+    wrong_accumulator_operands.extend([u64_value, u64_value]);
+    let wrong_accumulator = Operation::new(
+        &mut ctx,
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 32],
+        wrong_accumulator_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(wrong_accumulator)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut wrong_descriptor_operands = vec![f32_value; 32];
+    wrong_descriptor_operands.extend([u32_value, u64_value]);
+    let wrong_descriptor = Operation::new(
+        &mut ctx,
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 32],
+        wrong_descriptor_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(wrong_descriptor)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut valid_value_operands = vec![f32_value; 32];
+    valid_value_operands.extend([u64_value, u64_value]);
+
+    let wrong_result_count = Operation::new(
+        &mut ctx,
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 31],
+        valid_value_operands.clone(),
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(wrong_result_count)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut wrong_result_types = vec![f32_ty.into(); 32];
+    wrong_result_types[0] = u32_ty.into();
+    let wrong_result_type = Operation::new(
+        &mut ctx,
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        wrong_result_types,
+        valid_value_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N64K16F32Bf16Op::new(wrong_result_type)
+            .verify(&ctx)
+            .is_err()
+    );
 }
 
 #[test]

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -39,7 +39,8 @@ use dialect_mir::ops::{
 use dialect_nvvm::ops::{
     AssertFailOp, CvtaGenericToSharedOffsetOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicLoadOp,
     NvvmAtomicRmwOp, NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp, ReadPtxSregNclusterIdOp,
-    VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
+    VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -1060,6 +1061,23 @@ impl MirToLlvmConversion for WgmmaMmaGroupM64N64K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma_group(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaGroupValuesM64N64K16F32Bf16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma_group_values(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -6,13 +6,20 @@
 //! WGMMA conversion for Hopper `sm_90a`.
 
 use crate::convert::intrinsics::common::*;
-use llvm_export::types::VoidType;
-use pliron::builtin::types::{IntegerType, Signedness};
+use llvm_export::ops as llvm;
+use llvm_export::types::{self as llvm_types, VoidType};
+use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
 use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
+use pliron::irbuild::inserter::Inserter;
 use pliron::irbuild::rewriter::Rewriter;
+use pliron::location::Located;
+use pliron::op::Op;
 use pliron::operation::Operation;
 use pliron::result::Result;
+use pliron::r#type::TypeHandle;
+
+const VALUE_ACCUMULATOR_COUNT: usize = 32;
 
 /// Convert WGMMA make_smem_desc to inline PTX.
 pub(crate) fn convert_make_smem_desc(
@@ -86,6 +93,41 @@ fn deferred_group_template(mma_count: usize) -> String {
     template
 }
 
+fn value_accumulator_operand_list() -> String {
+    (0..VALUE_ACCUMULATOR_COUNT)
+        .map(|index| format!("${index}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn value_group_template(mma_count: usize) -> String {
+    let mut template = String::from("{\n    wgmma.fence.sync.aligned;\n");
+    let accumulators = value_accumulator_operand_list();
+    let descriptor_base = VALUE_ACCUMULATOR_COUNT * 2;
+
+    for mma_index in 0..mma_count {
+        let desc_a = descriptor_base + mma_index * 2;
+        let desc_b = desc_a + 1;
+        template.push_str(&format!(
+            "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+             {{{accumulators}}}, ${desc_a}, ${desc_b}, 1, 1, 1, 0, 0;\n"
+        ));
+    }
+
+    template.push_str("    wgmma.commit_group.sync.aligned;\n");
+    template.push_str("    wgmma.wait_group.sync.aligned 0;\n");
+    template.push('}');
+    template
+}
+
+fn value_group_constraints(descriptor_count: usize) -> String {
+    let mut constraints = vec!["=f".to_owned(); VALUE_ACCUMULATOR_COUNT];
+    constraints.extend((0..VALUE_ACCUMULATOR_COUNT).map(|index| index.to_string()));
+    constraints.extend((0..descriptor_count).map(|_| "l".to_owned()));
+    constraints.push("~{memory}".to_owned());
+    constraints.join(",")
+}
+
 /// Lower a complete deferred BF16 WGMMA group.
 ///
 /// The inline-PTX scope owns 32 explicit accumulator registers. It loads them
@@ -123,6 +165,67 @@ pub(crate) fn convert_mma_group(
     Ok(())
 }
 
+/// Lower a value-form BF16 WGMMA group to one multi-result inline-PTX scope.
+///
+/// The first 32 input operands are tied to 32 `=f` outputs. Descriptor operands
+/// follow the tied inputs. The entire fence/MMA+/commit/wait sequence remains in
+/// one convergent side-effecting asm statement, so LLVM cannot insert a spill
+/// boundary while an asynchronous WGMMA group is in flight.
+pub(crate) fn convert_mma_group_values(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let loc = op.deref(ctx).loc();
+    let result_count = op.deref(ctx).get_num_results();
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+
+    if result_count != VALUE_ACCUMULATOR_COUNT {
+        return pliron::input_err_noloc!(
+            "value-form WGMMA group requires exactly 32 accumulator results"
+        );
+    }
+    if operands.len() < VALUE_ACCUMULATOR_COUNT + 2 {
+        return pliron::input_err_noloc!(
+            "value-form WGMMA group requires 32 accumulator inputs and one or more descriptor pairs"
+        );
+    }
+
+    let descriptor_count = operands.len() - VALUE_ACCUMULATOR_COUNT;
+    if !descriptor_count.is_multiple_of(2) {
+        return pliron::input_err_noloc!("value-form WGMMA group descriptors must form pairs");
+    }
+
+    let mma_count = descriptor_count / 2;
+    let template = value_group_template(mma_count);
+    let constraints = value_group_constraints(descriptor_count);
+
+    let f32_ty = FP32Type::get(ctx);
+    let struct_ty: TypeHandle =
+        llvm_types::StructType::get_unnamed(ctx, vec![f32_ty.into(); VALUE_ACCUMULATOR_COUNT])
+            .into();
+
+    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+
+    let aggregate = asm_op.deref(ctx).get_result(0);
+
+    let mut extracted_values = Vec::with_capacity(VALUE_ACCUMULATOR_COUNT);
+
+    for index in 0..VALUE_ACCUMULATOR_COUNT {
+        let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![index as u32])
+            .map_err(|error| pliron::input_error!(loc.clone(), "{}", error))?;
+
+        rewriter.insert_operation(ctx, extract.get_operation());
+
+        extracted_values.push(extract.get_operation().deref(ctx).get_result(0));
+    }
+
+    rewriter.replace_operation_with_values(ctx, op, extracted_values);
+
+    Ok(())
+}
+
 /// Reject an unfused pointer-form MMA operation.
 ///
 /// Reaching this converter means the pre-lowering adapter could not prove a
@@ -140,7 +243,7 @@ pub(crate) fn convert_mma(
 
 #[cfg(test)]
 mod tests {
-    use super::deferred_group_template;
+    use super::{deferred_group_template, value_group_constraints, value_group_template};
 
     #[test]
     fn deferred_template_keeps_loads_before_wait_and_stores_after_wait() {
@@ -154,5 +257,47 @@ mod tests {
         let first_store = template.find("st.f32 [$0").unwrap();
         assert!(first_mma < wait);
         assert!(wait < first_store);
+    }
+
+    #[test]
+    fn value_template_uses_tied_accumulators_without_memory_round_trip() {
+        let template = value_group_template(2);
+        assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+        assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(
+            template.matches("wgmma.commit_group.sync.aligned").count(),
+            1
+        );
+        assert_eq!(
+            template.matches("wgmma.wait_group.sync.aligned 0").count(),
+            1
+        );
+        assert!(!template.contains("ld.f32"));
+        assert!(!template.contains("st.f32"));
+        assert!(!template.contains(".reg .f32"));
+        assert!(template.contains("$64, $65"));
+        assert!(template.contains("$66, $67"));
+
+        let constraints = value_group_constraints(4);
+        assert_eq!(
+            constraints
+                .split(',')
+                .filter(|value| *value == "=f")
+                .count(),
+            32
+        );
+        for index in 0..32 {
+            let expected = index.to_string();
+            assert!(
+                constraints
+                    .split(',')
+                    .any(|value| value == expected.as_str())
+            );
+        }
+        assert_eq!(
+            constraints.split(',').filter(|value| *value == "l").count(),
+            4
+        );
+        assert!(constraints.ends_with("~{memory}"));
     }
 }

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -8715,6 +8715,151 @@ fn test_deferred_wgmma_group_lowers_to_one_register_lifetime_scope() -> Result<(
 }
 
 #[test]
+fn test_value_form_wgmma_group_lowers_to_tied_register_inline_ptx() -> Result<(), anyhow::Error> {
+    use llvm_export::types as llvm_types;
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+    use pliron::r#type::Typed;
+
+    const ACCUMULATOR_LEN: usize = 32;
+    const DESCRIPTOR_COUNT: usize = 4;
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+
+    let argument_types = (0..ACCUMULATOR_LEN)
+        .map(|_| f32_ty.into())
+        .chain((0..DESCRIPTOR_COUNT).map(|_| u64_ty.into()))
+        .collect::<Vec<pliron::r#type::TypeHandle>>();
+
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, argument_types);
+
+    let accumulators = (0..ACCUMULATOR_LEN)
+        .map(|index| entry.deref(&ctx).get_argument(index))
+        .collect::<Vec<_>>();
+    let descriptors = (0..DESCRIPTOR_COUNT)
+        .map(|index| entry.deref(&ctx).get_argument(ACCUMULATOR_LEN + index))
+        .collect::<Vec<_>>();
+
+    nvvm::WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(&mut ctx, accumulators, descriptors)
+        .insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let matching = lowered_kernel_body(&ctx, module_ptr)
+        .into_iter()
+        .filter_map(|operation| Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx))
+        .filter(|asm| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| {
+                    template.contains("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+
+    let asm = &matching[0];
+    let asm_op = asm.get_operation();
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("value-form WGMMA template");
+
+    assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+    assert_eq!(
+        template.matches("wgmma.commit_group.sync.aligned").count(),
+        1
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1
+    );
+    for forbidden in [".reg .f32", "ld.f32", "st.f32"] {
+        assert!(
+            !template.contains(forbidden),
+            "value-form WGMMA must not materialize accumulator memory via {forbidden:?}: {template}"
+        );
+    }
+
+    let accumulator_operands = (0..ACCUMULATOR_LEN)
+        .map(|index| format!("${index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    assert!(
+        template.contains(&format!("{{{accumulator_operands}}}")),
+        "WGMMA must consume the 32 output operands as one accumulator tuple: {template}"
+    );
+    assert!(template.contains("$64, $65"), "{template}");
+    assert!(template.contains("$66, $67"), "{template}");
+
+    let mut expected_constraints = vec!["=f".to_owned(); ACCUMULATOR_LEN];
+    expected_constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
+    expected_constraints.extend((0..DESCRIPTOR_COUNT).map(|_| "l".to_owned()));
+    expected_constraints.push("~{memory}".to_owned());
+    let expected_constraints = expected_constraints.join(",");
+
+    assert_eq!(
+        asm.get_attr_inline_asm_constraints(&ctx)
+            .map(|value| String::from((*value).clone()))
+            .as_deref(),
+        Some(expected_constraints.as_str())
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+
+    let asm_ref = asm_op.deref(&ctx);
+    assert_eq!(
+        asm_ref.get_num_operands(),
+        ACCUMULATOR_LEN + DESCRIPTOR_COUNT
+    );
+    assert_eq!(
+        asm_ref.get_num_results(),
+        1,
+        "LLVM inline asm must return the 32 WGMMA accumulator values as one struct"
+    );
+
+    let aggregate = asm_ref.get_result(0);
+    let aggregate_ty = aggregate.get_type(&ctx);
+    let aggregate_ty = aggregate_ty.deref(&ctx);
+    let struct_ty = aggregate_ty
+        .downcast_ref::<llvm_types::StructType>()
+        .expect("value-form WGMMA inline asm must return an LLVM struct");
+    assert_eq!(struct_ty.num_fields(), ACCUMULATOR_LEN);
+    for index in 0..ACCUMULATOR_LEN {
+        assert!(
+            struct_ty
+                .field_type(index)
+                .deref(&ctx)
+                .downcast_ref::<FP32Type>()
+                .is_some(),
+            "WGMMA result field {index} must remain f32"
+        );
+    }
+
+    let extract_indices = lowered_kernel_body(&ctx, module_ptr)
+        .into_iter()
+        .filter_map(|operation| Operation::get_op::<llvm::ExtractValueOp>(operation, &ctx))
+        .filter_map(|extract| {
+            let extract_op = extract.get_operation().deref(&ctx);
+            (extract_op.get_operand(0) == aggregate).then(|| extract.indices(&ctx))
+        })
+        .collect::<Vec<_>>();
+
+    let expected_indices = (0..ACCUMULATOR_LEN)
+        .map(|index| vec![index as u32])
+        .collect::<Vec<_>>();
+    assert_eq!(
+        extract_indices, expected_indices,
+        "all 32 value-form WGMMA results must be extracted in constraint order"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_pointer_form_wgmma_sequence_is_fused_before_lowering() -> Result<(), anyhow::Error> {
     use dialect_mir::types::MirPtrType;
     use pliron::builtin::attributes::IntegerAttr;


### PR DESCRIPTION
This PR is stacked on #679 and is the second of six planned PRs for #605.

## Summary

Add an internal value-form BF16 WGMMA group that carries the 32 per-thread
`f32` accumulator values explicitly through SSA operands and results.

The new `nvvm.wgmma_mma_group_values_m64n64k16_f32_bf16` operation:

- takes 32 `f32` accumulator values followed by one or more `u64`
  descriptor pairs;
- returns 32 `f32` accumulator values;
- lowers the complete fence/MMA+/commit/`wait_group<0>` sequence into one
  convergent inline-PTX region;
- ties each accumulator input to its corresponding output register;
- does not materialize the accumulator through `ld.f32` / `st.f32` inside
  the WGMMA lifetime.

The existing pointer-form deferred group remains unchanged and available as
the fallback path.

## Motivation

#679 established that a real BF16 `m64n64k16` WGMMA can carry all 32
per-thread accumulator values through tied inline-asm operands/results and
reach `ptxas` for `sm_90a` without spills.

This PR turns that feasibility result into an internal dialect operation and
production lowering that later transformations can use to keep accumulators
register-resident across WGMMA regions.

## Implementation

- Add `WgmmaMmaGroupValuesM64N64K16F32Bf16Op`.
- Verify:
  - exactly 32 `f32` accumulator operands;
  - exactly 32 `f32` results;
  - one or more descriptor pairs;
  - all descriptors are `u64`.
- Register the new handwritten NVVM operation.
- Add its `MirToLlvmConversion` implementation.
- Lower it to one convergent inline-PTX statement with:
  - 32 `=f` outputs;
  - tied input constraints `0..31`;
  - `l` constraints for descriptors;
  - a memory clobber.
- Extract the 32 LLVM aggregate results back into individual SSA values.
- Add dialect and lowering coverage for the new operation.

## Validation

```text
dialect-nvvm:
  50 passed

mir-lower:
  166 unit tests passed
  90 integration tests passed

cuda-oxide-codegen:
  137 unit tests passed
  integration tests passed
````

The WGMMA backend feasibility test from #679 was also re-run successfully:

```text
ptxas info : Compiling entry function 'wgmma_value_carrier_kernel' for 'sm_90a'
0 bytes stack frame
0 bytes spill stores
0 bytes spill loads
Used 58 registers
```

`git diff --check` is clean.

## Scope

This PR does not yet:

* adapt the existing accumulator pointer path to the value-form operation;
* change selection or fallback behavior;
* recognize or fuse a counted K-loop;
* support partial `wait_group<N>` values;
* keep multiple committed groups in flight.

Those are left to subsequent PRs.
