### PR TITLE
fix(cuda-bindings): select targets/ by full build target, and reach Tegra

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -3931,7 +3931,13 @@ pub fn doctor(ctx: &Context) {
     // cuda-bindings' build script (issue #87).
     print!("CUDA headers (cuda.h)... ");
     let toolkit = cuda_toolkit_root(|var| std::env::var(var).ok());
-    let header_candidates = cuda_header_candidates(&toolkit, std::env::consts::ARCH);
+    let target_dir_override = std::env::var("CUDA_TOOLKIT_TARGET_DIR").ok();
+    let header_candidates = cuda_header_candidates(
+        &toolkit,
+        target_dir_override.as_deref(),
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+    );
     match header_candidates.iter().find(|path| path.is_file()) {
         Some(found) => println!("✓ {}", found.display()),
         None => {
@@ -4232,9 +4238,9 @@ pub fn doctor(ctx: &Context) {
 /// variable among `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, else `/usr/local/cuda`.
 ///
 /// Kept in lockstep BY HAND with `crates/cuda-bindings/build.rs`
-/// (`cuda_toolkit_dir` / `find_cuda_include_dir` / `toolkit_target_dir`):
-/// doctor cannot import that probe because build.rs logic is not a library.
-/// If the build.rs discovery changes, mirror it here.
+/// (`cuda_toolkit_dir` / `find_cuda_include_dir`): doctor cannot import that
+/// probe because build.rs logic is not a library. If the build.rs discovery
+/// changes, mirror it here.
 fn cuda_toolkit_root(mut get_env: impl FnMut(&str) -> Option<String>) -> String {
     ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
         .iter()
@@ -4244,21 +4250,39 @@ fn cuda_toolkit_root(mut get_env: impl FnMut(&str) -> Option<String>) -> String 
 
 /// Candidate `cuda.h` paths under `toolkit`, in probe order: the standard
 /// `include/` layout first, then the redistributable `targets/<dir>/include`
-/// layout. CUDA names the target dirs after the GPU platform, not the Rust
-/// triple: x86_64 hosts use `x86_64-linux`, aarch64 servers use `sbsa-linux`.
+/// layouts. CUDA names the target dirs after the GPU platform, not the Rust
+/// triple: x86_64 Linux hosts use `x86_64-linux`; aarch64 Linux is ambiguous
+/// between servers (`sbsa-linux`) and Tegra (`aarch64-linux`), so both are
+/// probed in that order. A non-blank `target_dir_override` (the
+/// `CUDA_TOOLKIT_TARGET_DIR` variable, like nvcc's `-target-dir`) replaces
+/// the table with that single directory.
 ///
-/// `arch` is the host CPU architecture; the caller passes
-/// `std::env::consts::ARCH` (doctor runs at runtime, so there is no cargo
-/// `TARGET` to consult). Injected as a parameter for unit tests.
-fn cuda_header_candidates(toolkit: &str, arch: &str) -> Vec<PathBuf> {
+/// Kept in lockstep BY HAND with the selection table in
+/// `crates/cuda-bindings/toolkit_target.rs` (`resolve_toolkit_target_dirs`):
+/// doctor cannot import it because build-script sources are not a library.
+/// If the selection there changes, mirror it here.
+///
+/// `arch` and `os` are the host CPU architecture and OS; the caller passes
+/// `std::env::consts::ARCH` / `std::env::consts::OS` (doctor runs at
+/// runtime, so there are no cargo target cfgs to consult). Injected as
+/// parameters for unit tests.
+fn cuda_header_candidates(
+    toolkit: &str,
+    target_dir_override: Option<&str>,
+    arch: &str,
+    os: &str,
+) -> Vec<PathBuf> {
     let base = Path::new(toolkit);
     let mut candidates = vec![base.join("include/cuda.h")];
-    let target_dir = match arch {
-        "x86_64" => Some("x86_64-linux"),
-        "aarch64" => Some("sbsa-linux"),
-        _ => None,
+    let target_dirs: Vec<&str> = match target_dir_override.filter(|dir| !dir.trim().is_empty()) {
+        Some(dir) => vec![dir],
+        None => match (arch, os) {
+            ("x86_64", "linux") => vec!["x86_64-linux"],
+            ("aarch64", "linux") => vec!["sbsa-linux", "aarch64-linux"],
+            _ => vec![],
+        },
     };
-    if let Some(dir) = target_dir {
+    for dir in target_dirs {
         candidates.push(base.join("targets").join(dir).join("include/cuda.h"));
     }
     candidates
@@ -8833,24 +8857,46 @@ device-owner = { path = "../device-owner" }
     fn cuda_header_candidates_cover_standard_and_redistributable_layouts() {
         // Standard install layout first, then the matching targets/ layout.
         assert_eq!(
-            cuda_header_candidates("/usr/local/cuda", "x86_64"),
+            cuda_header_candidates("/usr/local/cuda", None, "x86_64", "linux"),
             vec![
                 PathBuf::from("/usr/local/cuda/include/cuda.h"),
                 PathBuf::from("/usr/local/cuda/targets/x86_64-linux/include/cuda.h"),
             ]
         );
-        // aarch64 servers use the sbsa-linux target dir.
+        // aarch64 Linux is ambiguous between servers (sbsa-linux) and Tegra
+        // (aarch64-linux), so both are probed, servers first.
         assert_eq!(
-            cuda_header_candidates("/opt/ctk", "aarch64"),
+            cuda_header_candidates("/opt/ctk", None, "aarch64", "linux"),
             vec![
                 PathBuf::from("/opt/ctk/include/cuda.h"),
                 PathBuf::from("/opt/ctk/targets/sbsa-linux/include/cuda.h"),
+                PathBuf::from("/opt/ctk/targets/aarch64-linux/include/cuda.h"),
             ]
         );
-        // Unknown host arch: only the standard layout is probed.
+        // Unknown host arch or non-Linux OS: only the standard layout.
         assert_eq!(
-            cuda_header_candidates("/opt/ctk", "riscv64"),
+            cuda_header_candidates("/opt/ctk", None, "riscv64", "linux"),
             vec![PathBuf::from("/opt/ctk/include/cuda.h")]
+        );
+        assert_eq!(
+            cuda_header_candidates("/opt/ctk", None, "aarch64", "macos"),
+            vec![PathBuf::from("/opt/ctk/include/cuda.h")]
+        );
+        // CUDA_TOOLKIT_TARGET_DIR replaces the table with one directory;
+        // a blank value means "unset".
+        assert_eq!(
+            cuda_header_candidates("/opt/ctk", Some("aarch64-linux"), "aarch64", "linux"),
+            vec![
+                PathBuf::from("/opt/ctk/include/cuda.h"),
+                PathBuf::from("/opt/ctk/targets/aarch64-linux/include/cuda.h"),
+            ]
+        );
+        assert_eq!(
+            cuda_header_candidates("/opt/ctk", Some("  "), "x86_64", "linux"),
+            vec![
+                PathBuf::from("/opt/ctk/include/cuda.h"),
+                PathBuf::from("/opt/ctk/targets/x86_64-linux/include/cuda.h"),
+            ]
         );
     }
 

--- a/crates/cuda-bindings/build.rs
+++ b/crates/cuda-bindings/build.rs
@@ -36,6 +36,9 @@ fn main() {
 /// directory, writing `bindings.rs` into `OUT_DIR`.
 fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
+    // Emitting any rerun-if-changed disables cargo's default "rerun on any
+    // package change", so the `include!`d selection table needs naming.
+    println!("cargo:rerun-if-changed=toolkit_target.rs");
     for var in TOOLKIT_ENV_VARS {
         println!("cargo:rerun-if-env-changed={var}");
     }
@@ -68,16 +71,20 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-/// CUDA toolkit `targets/` directory name for cargo's build `TARGET`, when
-/// the toolkit ships one for that architecture. CUDA names these layouts
-/// after the GPU platform, not the Rust triple: x86_64 hosts use
-/// `x86_64-linux` and aarch64 servers use `sbsa-linux`.
-fn toolkit_target_dir() -> Option<&'static str> {
-    let target = env::var("TARGET").ok()?;
-    match target.split('-').next()? {
-        "x86_64" => Some("x86_64-linux"),
-        "aarch64" => Some("sbsa-linux"),
-        _ => None,
+// The `targets/<dir>` selection table, shared verbatim with
+// `tests/toolkit_target.rs` so it can be unit tested.
+include!("toolkit_target.rs");
+
+/// [`toolkit_target_dirs`] for the target cargo is building for, read from
+/// `CARGO_CFG_TARGET_ARCH` / `CARGO_CFG_TARGET_OS`. Empty when either is
+/// unset, which keeps discovery on the plain `{toolkit}/include` layout
+/// rather than guessing.
+fn build_target_dirs() -> &'static [&'static str] {
+    let arch = env::var("CARGO_CFG_TARGET_ARCH");
+    let os = env::var("CARGO_CFG_TARGET_OS");
+    match (&arch, &os) {
+        (Ok(arch), Ok(os)) => toolkit_target_dirs(arch, os),
+        _ => &[],
     }
 }
 
@@ -85,22 +92,20 @@ fn toolkit_target_dir() -> Option<&'static str> {
 /// for standard installs, or `{toolkit}/targets/<dir>/include` for
 /// redistributable layouts that have no top-level `include/`.
 ///
-/// Only the single `targets/` directory matching cargo's build `TARGET` is
-/// probed. Globbing all of `targets/*` would let another architecture's
-/// headers and stubs shadow the right ones on multi-target installs
-/// (`sbsa-linux` sorts before `x86_64-linux`).
+/// Only the `targets/` directories [`toolkit_target_dirs`] lists for the
+/// build target's own architecture are probed, in order. Globbing all of
+/// `targets/*` would let another architecture's headers and stubs shadow the
+/// right ones on multi-target installs (`sbsa-linux` sorts before
+/// `x86_64-linux`).
 ///
 /// A missing `cuda.h` is a hard error here: bindgen cannot run without it,
 /// and failing now produces one clean message instead of raw clang
 /// diagnostics.
 fn find_cuda_include_dir(toolkit: &str) -> Result<PathBuf, String> {
     let base = Path::new(toolkit);
-    let mut candidates = vec![base.join("include")];
-    if let Some(target_dir) = toolkit_target_dir() {
-        candidates.push(base.join("targets").join(target_dir).join("include"));
-    }
+    let candidates = toolkit_include_candidates(base, build_target_dirs());
 
-    if let Some(dir) = candidates.iter().find(|dir| dir.join("cuda.h").is_file()) {
+    if let Some(dir) = select_include_dir(&candidates) {
         return Ok(dir.clone());
     }
 
@@ -149,11 +154,11 @@ fn probe_event_elapsed_time_v2(cuda_h: &Path) {
 
 /// Candidate directories for `rustc-link-search=native` when linking against the driver library.
 ///
-/// Adds `{toolkit}/lib64` and `{toolkit}/lib64/stubs` when `lib64` exists. If the build
-/// target's `{toolkit}/targets/<dir>/include/cuda.h` exists (redistributable / cross-layout
-/// install), also adds that target's `lib` and `lib/stubs`. Only the single `targets/`
-/// directory matching cargo's build `TARGET` is considered, never all of `targets/*`.
-/// Order is preserved; duplicates are not filtered.
+/// Adds `{toolkit}/lib64` and `{toolkit}/lib64/stubs` when `lib64` exists. For each
+/// `targets/<dir>` candidate whose `include/cuda.h` exists (redistributable / cross-layout
+/// install), also adds that target's `lib` and `lib/stubs`. Only the candidates
+/// [`toolkit_target_dirs`] lists for the build target's own architecture are considered,
+/// never all of `targets/*`. Order is preserved; duplicates are not filtered.
 fn collect_lib_paths(toolkit: &str) -> Vec<PathBuf> {
     let base = PathBuf::from(toolkit);
     let mut paths = vec![];
@@ -164,7 +169,7 @@ fn collect_lib_paths(toolkit: &str) -> Vec<PathBuf> {
         paths.push(lib64.join("stubs"));
     }
 
-    if let Some(target_dir) = toolkit_target_dir() {
+    for target_dir in build_target_dirs() {
         let target_root = base.join("targets").join(target_dir);
         if target_root.join("include/cuda.h").is_file() {
             paths.push(target_root.join("lib"));

--- a/crates/cuda-bindings/build.rs
+++ b/crates/cuda-bindings/build.rs
@@ -12,6 +12,15 @@ const TOOLKIT_ENV_VARS: [&str; 2] = ["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
 /// Toolkit root fallback when none of [`TOOLKIT_ENV_VARS`] is set.
 const DEFAULT_TOOLKIT_DIR: &str = "/usr/local/cuda";
 
+/// Environment variable naming the CUDA `targets/<dir>` tree to use,
+/// overriding the arch+OS table in `toolkit_target.rs`. The value is a
+/// directory name under `{toolkit}/targets/` (e.g. `aarch64-linux`), the
+/// same shape nvcc's `-target-dir` flag takes; CMake exposes the equivalent
+/// selection as `CUDAToolkit_TARGET_DIR`. The named directory is still
+/// probed for `cuda.h`, so a wrong value fails with the clear discovery
+/// error instead of silently falling back to the table.
+const TOOLKIT_TARGET_DIR_ENV: &str = "CUDA_TOOLKIT_TARGET_DIR";
+
 /// Returns the CUDA toolkit install root: the first set variable among
 /// [`TOOLKIT_ENV_VARS`], otherwise [`DEFAULT_TOOLKIT_DIR`]. Used for include
 /// paths, library search paths, and bindgen’s Clang configuration.
@@ -42,6 +51,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     for var in TOOLKIT_ENV_VARS {
         println!("cargo:rerun-if-env-changed={var}");
     }
+    println!("cargo:rerun-if-env-changed={TOOLKIT_TARGET_DIR_ENV}");
     println!("cargo::rustc-check-cfg=cfg(cuda_has_cuEventElapsedTime_v2)");
 
     let toolkit = cuda_toolkit_dir();
@@ -75,27 +85,28 @@ fn run() -> Result<(), Box<dyn Error>> {
 // `tests/toolkit_target.rs` so it can be unit tested.
 include!("toolkit_target.rs");
 
-/// [`toolkit_target_dirs`] for the target cargo is building for, read from
-/// `CARGO_CFG_TARGET_ARCH` / `CARGO_CFG_TARGET_OS`. Empty when either is
-/// unset, which keeps discovery on the plain `{toolkit}/include` layout
+/// The `targets/<dir>` candidates for the target cargo is building for: the
+/// [`TOOLKIT_TARGET_DIR_ENV`] override when set, otherwise
+/// [`toolkit_target_dirs`] for `CARGO_CFG_TARGET_ARCH` /
+/// `CARGO_CFG_TARGET_OS`. Empty when the override is absent and either cfg
+/// is unset, which keeps discovery on the plain `{toolkit}/include` layout
 /// rather than guessing.
-fn build_target_dirs() -> &'static [&'static str] {
-    let arch = env::var("CARGO_CFG_TARGET_ARCH");
-    let os = env::var("CARGO_CFG_TARGET_OS");
-    match (&arch, &os) {
-        (Ok(arch), Ok(os)) => toolkit_target_dirs(arch, os),
-        _ => &[],
-    }
+fn build_target_dirs() -> Vec<String> {
+    let override_dir = env::var(TOOLKIT_TARGET_DIR_ENV).ok();
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    resolve_toolkit_target_dirs(override_dir.as_deref(), &arch, &os)
 }
 
 /// Returns the include directory containing `cuda.h`: `{toolkit}/include`
 /// for standard installs, or `{toolkit}/targets/<dir>/include` for
 /// redistributable layouts that have no top-level `include/`.
 ///
-/// Only the `targets/` directories [`toolkit_target_dirs`] lists for the
-/// build target's own architecture are probed, in order. Globbing all of
-/// `targets/*` would let another architecture's headers and stubs shadow the
-/// right ones on multi-target installs (`sbsa-linux` sorts before
+/// Only the `targets/` directories [`build_target_dirs`] yields (the
+/// [`TOOLKIT_TARGET_DIR_ENV`] override, or the [`toolkit_target_dirs`] table
+/// for the build target's own architecture) are probed, in order. Globbing
+/// all of `targets/*` would let another architecture's headers and stubs
+/// shadow the right ones on multi-target installs (`sbsa-linux` sorts before
 /// `x86_64-linux`).
 ///
 /// A missing `cuda.h` is a hard error here: bindgen cannot run without it,
@@ -103,7 +114,7 @@ fn build_target_dirs() -> &'static [&'static str] {
 /// diagnostics.
 fn find_cuda_include_dir(toolkit: &str) -> Result<PathBuf, String> {
     let base = Path::new(toolkit);
-    let candidates = toolkit_include_candidates(base, build_target_dirs());
+    let candidates = toolkit_include_candidates(base, &build_target_dirs());
 
     if let Some(dir) = select_include_dir(&candidates) {
         return Ok(dir.clone());
@@ -157,7 +168,7 @@ fn probe_event_elapsed_time_v2(cuda_h: &Path) {
 /// Adds `{toolkit}/lib64` and `{toolkit}/lib64/stubs` when `lib64` exists. For each
 /// `targets/<dir>` candidate whose `include/cuda.h` exists (redistributable / cross-layout
 /// install), also adds that target's `lib` and `lib/stubs`. Only the candidates
-/// [`toolkit_target_dirs`] lists for the build target's own architecture are considered,
+/// [`build_target_dirs`] yields for the build target (override or table) are considered,
 /// never all of `targets/*`. Order is preserved; duplicates are not filtered.
 fn collect_lib_paths(toolkit: &str) -> Vec<PathBuf> {
     let base = PathBuf::from(toolkit);

--- a/crates/cuda-bindings/tests/toolkit_target.rs
+++ b/crates/cuda-bindings/tests/toolkit_target.rs
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Coverage for the build script's CUDA `targets/<dir>` selection table.
+//!
+//! `build.rs` pulls in the same file with `include!`, because cargo never
+//! builds a build script as a test target.
+
+include!("../toolkit_target.rs");
+
+/// `(target_arch, target_os, expected candidates)`.
+const CASES: &[(&str, &str, &[&str])] = &[
+    // x86_64 Linux: the one server layout.
+    ("x86_64", "linux", &["x86_64-linux"]),
+    // aarch64 Linux is ambiguous between server and Tegra, so both are
+    // offered. `sbsa-linux` stays first to preserve today's resolution on an
+    // install that carries both.
+    ("aarch64", "linux", &["sbsa-linux", "aarch64-linux"]),
+    // Non-Linux hosts have no `targets/` tree at all. Before the full
+    // arch+os match these fell through an arch-only check and claimed a
+    // Linux directory: `aarch64-apple-darwin` resolved to `sbsa-linux` and
+    // `x86_64-pc-windows-msvc` to `x86_64-linux`.
+    ("aarch64", "macos", &[]),
+    ("x86_64", "macos", &[]),
+    ("x86_64", "windows", &[]),
+    ("aarch64", "windows", &[]),
+    // `aarch64-linux-android` splits into components containing "linux" but
+    // is not a CUDA platform; keying off `CARGO_CFG_TARGET_OS` rejects it.
+    ("aarch64", "android", &[]),
+    // Architectures CUDA does not ship.
+    ("riscv64", "linux", &[]),
+    ("powerpc64le", "linux", &[]),
+    ("", "", &[]),
+];
+
+#[test]
+fn toolkit_target_dirs_matches_table() {
+    for &(arch, os, expected) in CASES {
+        assert_eq!(
+            toolkit_target_dirs(arch, os),
+            expected,
+            "unexpected targets/ candidates for arch={arch:?} os={os:?}"
+        );
+    }
+}
+
+#[test]
+fn every_candidate_is_a_linux_directory_for_its_own_arch() {
+    // The property that PR #88's `targets/*` glob broke: a candidate must
+    // never belong to another architecture, or a multi-target install hands
+    // the build the wrong headers.
+    for &(arch, os, expected) in CASES {
+        for dir in expected {
+            assert!(
+                dir.ends_with("-linux"),
+                "candidate {dir:?} for arch={arch:?} os={os:?} is not a Linux tree"
+            );
+            let owner_arch = dir.trim_end_matches("-linux");
+            assert!(
+                owner_arch == arch || (arch == "aarch64" && owner_arch == "sbsa"),
+                "candidate {dir:?} belongs to {owner_arch:?}, not arch={arch:?}"
+            );
+        }
+    }
+}
+
+/// Builds a throwaway toolkit tree containing a `cuda.h` at each given
+/// relative directory, and returns its root. No temp-dir crate: this package
+/// takes no new dependencies.
+fn fake_toolkit(tag: &str, include_dirs: &[&str]) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "cuda-oxide-toolkit-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    for dir in include_dirs {
+        let full = root.join(dir);
+        std::fs::create_dir_all(&full).expect("create fake toolkit dir");
+        std::fs::write(full.join("cuda.h"), b"/* fake */\n").expect("write fake cuda.h");
+    }
+    root
+}
+
+#[test]
+fn tegra_layout_resolves_to_aarch64_linux() {
+    // The layout this change exists for: CUDA for Tegra ships only
+    // `targets/aarch64-linux/`, and no top-level `include/`.
+    let root = fake_toolkit("tegra", &["targets/aarch64-linux/include"]);
+    let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("aarch64", "linux"));
+    let selected = select_include_dir(&candidates).expect("Tegra layout must resolve");
+    assert_eq!(selected, &root.join("targets/aarch64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn sbsa_layout_still_resolves_to_sbsa_linux() {
+    let root = fake_toolkit("sbsa", &["targets/sbsa-linux/include"]);
+    let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("aarch64", "linux"));
+    let selected = select_include_dir(&candidates).expect("sbsa layout must resolve");
+    assert_eq!(selected, &root.join("targets/sbsa-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn multi_target_install_never_hands_x86_64_the_sbsa_headers() {
+    // The failure mode that got the `targets/*` glob in #88 rejected:
+    // `sbsa-linux` sorts before `x86_64-linux`.
+    let root = fake_toolkit(
+        "multi",
+        &[
+            "targets/sbsa-linux/include",
+            "targets/x86_64-linux/include",
+            "targets/aarch64-linux/include",
+        ],
+    );
+    let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("x86_64", "linux"));
+    let selected = select_include_dir(&candidates).expect("x86_64 layout must resolve");
+    assert_eq!(selected, &root.join("targets/x86_64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn top_level_include_wins_over_any_targets_tree() {
+    let root = fake_toolkit("standard", &["include", "targets/x86_64-linux/include"]);
+    let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("x86_64", "linux"));
+    let selected = select_include_dir(&candidates).expect("standard layout must resolve");
+    assert_eq!(selected, &root.join("include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn non_linux_probes_only_the_top_level_include() {
+    let root = fake_toolkit("darwin", &["targets/sbsa-linux/include"]);
+    let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("aarch64", "macos"));
+    assert_eq!(candidates, vec![root.join("include")]);
+    assert!(
+        select_include_dir(&candidates).is_none(),
+        "a macOS build must not resolve the sbsa-linux headers"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn non_linux_never_resolves_a_target_dir() {
+    for os in ["macos", "windows", "android", "ios", "freebsd", "none"] {
+        for arch in ["x86_64", "aarch64", "riscv64"] {
+            assert!(
+                toolkit_target_dirs(arch, os).is_empty(),
+                "arch={arch:?} os={os:?} must not resolve a targets/ directory"
+            );
+        }
+    }
+}

--- a/crates/cuda-bindings/tests/toolkit_target.rs
+++ b/crates/cuda-bindings/tests/toolkit_target.rs
@@ -132,6 +132,56 @@ fn top_level_include_wins_over_any_targets_tree() {
 }
 
 #[test]
+fn env_override_is_the_single_targets_candidate() {
+    // CUDA_TOOLKIT_TARGET_DIR names one tree by hand, like nvcc's
+    // `-target-dir`: the table's candidates are not consulted at all.
+    let root = fake_toolkit(
+        "override",
+        &[
+            "targets/sbsa-linux/include",
+            "targets/aarch64-linux/include",
+        ],
+    );
+    let dirs = resolve_toolkit_target_dirs(Some("aarch64-linux"), "aarch64", "linux");
+    assert_eq!(dirs, vec!["aarch64-linux".to_string()]);
+    let candidates = toolkit_include_candidates(&root, &dirs);
+    let selected = select_include_dir(&candidates).expect("override layout must resolve");
+    assert_eq!(selected, &root.join("targets/aarch64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+
+    // A blank override means "unset": the table decides, as before.
+    for blank in [None, Some(""), Some("  ")] {
+        assert_eq!(
+            resolve_toolkit_target_dirs(blank, "aarch64", "linux"),
+            vec!["sbsa-linux".to_string(), "aarch64-linux".to_string()],
+            "blank override {blank:?} must fall back to the table"
+        );
+    }
+}
+
+#[test]
+fn wrong_env_override_fails_instead_of_falling_back() {
+    // The override is existence-probed, not trusted: a typo must surface as
+    // the "could not find cuda.h" error listing exactly what was probed,
+    // never as a silent fallback to another architecture's tree.
+    let root = fake_toolkit("override-bad", &["targets/sbsa-linux/include"]);
+    let dirs = resolve_toolkit_target_dirs(Some("aarch64-qnx"), "aarch64", "linux");
+    let candidates = toolkit_include_candidates(&root, &dirs);
+    assert_eq!(
+        candidates,
+        vec![
+            root.join("include"),
+            root.join("targets/aarch64-qnx/include")
+        ]
+    );
+    assert!(
+        select_include_dir(&candidates).is_none(),
+        "a wrong override must not resolve the sbsa-linux headers"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn non_linux_probes_only_the_top_level_include() {
     let root = fake_toolkit("darwin", &["targets/sbsa-linux/include"]);
     let candidates = toolkit_include_candidates(&root, toolkit_target_dirs("aarch64", "macos"));

--- a/crates/cuda-bindings/toolkit_target.rs
+++ b/crates/cuda-bindings/toolkit_target.rs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Selection of the CUDA toolkit `targets/<dir>` tree for a build target.
+//
+// Regular `//` comments, not `//!`: this file is pulled in with `include!`
+// from both `build.rs` and `tests/toolkit_target.rs`, and an inner doc
+// comment is only legal at the top of a real module. Cargo never builds a
+// build script as a test target, so sharing the source this way is what lets
+// the table below be covered by `cargo test` rather than only by whichever
+// machine happens to run the build.
+
+/// CUDA toolkit `targets/` directory names to probe for a build target, most
+/// specific first. Empty when CUDA ships no `targets/` tree for that platform.
+///
+/// `target_arch` and `target_os` are cargo's `CARGO_CFG_TARGET_ARCH` and
+/// `CARGO_CFG_TARGET_OS` for the *build target*, not the host. Those two are
+/// used rather than splitting the `TARGET` triple because the triple's field
+/// count varies (`arch-vendor-os-env` vs `arch-os-env`) and because
+/// `aarch64-linux-android` would otherwise look like a Linux target.
+///
+/// CUDA names these trees after the GPU platform, not the Rust triple:
+///
+/// | platform | directory |
+/// |---|---|
+/// | x86_64 Linux | `x86_64-linux` |
+/// | aarch64 Linux, server (Grace, Ampere Altra) | `sbsa-linux` |
+/// | aarch64 Linux, Tegra (Jetson, Drive) | `aarch64-linux` |
+///
+/// aarch64 returns both server and Tegra names because a Rust aarch64 Linux
+/// triple does not distinguish them -- Jetson builds natively as
+/// `aarch64-unknown-linux-gnu`, exactly like a Grace server. The callers probe
+/// these in order and take the first that actually contains `cuda.h`, so a
+/// single-target install resolves unambiguously either way. `sbsa-linux` is
+/// listed first so that an install carrying both trees keeps the directory it
+/// resolves to today.
+///
+/// This is deliberately *not* a glob over `targets/*`: on a multi-target
+/// install that would let another architecture's headers and stubs shadow the
+/// right ones, because `sbsa-linux` sorts before `x86_64-linux`. Every
+/// candidate returned here is for the requested architecture only.
+fn toolkit_target_dirs(target_arch: &str, target_os: &str) -> &'static [&'static str] {
+    if target_os != "linux" {
+        return &[];
+    }
+    match target_arch {
+        "x86_64" => &["x86_64-linux"],
+        "aarch64" => &["sbsa-linux", "aarch64-linux"],
+        _ => &[],
+    }
+}
+
+/// Include directories to probe for `cuda.h`, in priority order: the standard
+/// top-level `{toolkit}/include`, then `{toolkit}/targets/<dir>/include` for
+/// each candidate from [`toolkit_target_dirs`].
+///
+/// Fully-qualified `std::path` types, because `build.rs` already imports
+/// `Path` and `PathBuf` and this file is `include!`d into it.
+fn toolkit_include_candidates(
+    toolkit: &std::path::Path,
+    target_dirs: &[&str],
+) -> Vec<std::path::PathBuf> {
+    let mut candidates = vec![toolkit.join("include")];
+    for target_dir in target_dirs {
+        candidates.push(toolkit.join("targets").join(target_dir).join("include"));
+    }
+    candidates
+}
+
+/// The first candidate that actually contains `cuda.h`.
+fn select_include_dir(candidates: &[std::path::PathBuf]) -> Option<&std::path::PathBuf> {
+    candidates.iter().find(|dir| dir.join("cuda.h").is_file())
+}

--- a/crates/cuda-bindings/toolkit_target.rs
+++ b/crates/cuda-bindings/toolkit_target.rs
@@ -52,15 +52,38 @@ fn toolkit_target_dirs(target_arch: &str, target_os: &str) -> &'static [&'static
     }
 }
 
+/// [`toolkit_target_dirs`] with the `CUDA_TOOLKIT_TARGET_DIR` override
+/// applied: when `override_dir` carries a non-blank value, that value is the
+/// single `targets/` candidate, naming one tree by hand exactly like nvcc's
+/// `-target-dir` flag. The override is deliberately not existence-checked
+/// here; callers still probe the candidate for `cuda.h`, so a wrong value
+/// fails with the clear discovery error instead of silently falling back to
+/// the table.
+fn resolve_toolkit_target_dirs(
+    override_dir: Option<&str>,
+    target_arch: &str,
+    target_os: &str,
+) -> Vec<String> {
+    match override_dir.filter(|dir| !dir.trim().is_empty()) {
+        Some(dir) => vec![dir.to_string()],
+        None => toolkit_target_dirs(target_arch, target_os)
+            .iter()
+            .map(|dir| (*dir).to_string())
+            .collect(),
+    }
+}
+
 /// Include directories to probe for `cuda.h`, in priority order: the standard
 /// top-level `{toolkit}/include`, then `{toolkit}/targets/<dir>/include` for
-/// each candidate from [`toolkit_target_dirs`].
+/// each candidate from [`resolve_toolkit_target_dirs`].
 ///
 /// Fully-qualified `std::path` types, because `build.rs` already imports
-/// `Path` and `PathBuf` and this file is `include!`d into it.
+/// `Path` and `PathBuf` and this file is `include!`d into it. Generic over
+/// the directory-name slice so both the table's `&[&str]` and the resolved
+/// `Vec<String>` feed in unchanged.
 fn toolkit_include_candidates(
     toolkit: &std::path::Path,
-    target_dirs: &[&str],
+    target_dirs: &[impl AsRef<std::path::Path>],
 ) -> Vec<std::path::PathBuf> {
     let mut candidates = vec![toolkit.join("include")];
     for target_dir in target_dirs {

--- a/crates/cuda-core/build.rs
+++ b/crates/cuda-core/build.rs
@@ -26,11 +26,16 @@ use std::path::{Path, PathBuf};
 const TOOLKIT_ENV_VARS: &[&str] = &["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
 const DEFAULT_TOOLKIT_DIR: &str = "/usr/local/cuda";
 
+/// Overrides the `targets/<dir>` selection with a single directory name,
+/// like nvcc's `-target-dir`; matches `cuda-bindings`.
+const TOOLKIT_TARGET_DIR_ENV: &str = "CUDA_TOOLKIT_TARGET_DIR";
+
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(cuda_has_multicast)");
     for var in TOOLKIT_ENV_VARS {
         println!("cargo:rerun-if-env-changed={var}");
     }
+    println!("cargo:rerun-if-env-changed={TOOLKIT_TARGET_DIR_ENV}");
 
     let Some(cuda_h) = find_cuda_header() else {
         return;
@@ -41,15 +46,33 @@ fn main() {
     }
 }
 
-/// CUDA toolkit `targets/` directory name for cargo's build `TARGET`,
-/// matching `cuda-bindings`: CUDA names these layouts after the GPU
-/// platform, not the Rust triple.
-fn toolkit_target_dir() -> Option<&'static str> {
-    let target = env::var("TARGET").ok()?;
-    match target.split('-').next()? {
-        "x86_64" => Some("x86_64-linux"),
-        "aarch64" => Some("sbsa-linux"),
-        _ => None,
+/// CUDA toolkit `targets/` directory names to probe for cargo's build
+/// target, most specific first.
+///
+/// Kept in lockstep BY HAND with the selection table in
+/// `crates/cuda-bindings/toolkit_target.rs` (`resolve_toolkit_target_dirs`):
+/// build scripts cannot import each other's sources across crates. If the
+/// selection there changes, mirror it here. CUDA names these layouts after
+/// the GPU platform, not the Rust triple, and an aarch64 Linux triple is
+/// ambiguous between servers (`sbsa-linux`) and Tegra (`aarch64-linux`), so
+/// both are probed in that order. A non-blank [`TOOLKIT_TARGET_DIR_ENV`]
+/// replaces the table with that single directory.
+fn toolkit_target_dirs() -> Vec<String> {
+    if let Some(dir) = env::var(TOOLKIT_TARGET_DIR_ENV)
+        .ok()
+        .filter(|dir| !dir.trim().is_empty())
+    {
+        return vec![dir];
+    }
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if os != "linux" {
+        return vec![];
+    }
+    match arch.as_str() {
+        "x86_64" => vec!["x86_64-linux".to_string()],
+        "aarch64" => vec!["sbsa-linux".to_string(), "aarch64-linux".to_string()],
+        _ => vec![],
     }
 }
 
@@ -62,7 +85,7 @@ fn find_cuda_header() -> Option<PathBuf> {
         .unwrap_or_else(|| DEFAULT_TOOLKIT_DIR.to_string());
     let base = Path::new(&toolkit);
     let mut candidates = vec![base.join("include")];
-    if let Some(target_dir) = toolkit_target_dir() {
+    for target_dir in toolkit_target_dirs() {
         candidates.push(base.join("targets").join(target_dir).join("include"));
     }
     candidates


### PR DESCRIPTION
Closes #698.

## Problem

`toolkit_target_dir()` matched only the first segment of the target triple, so architecture alone decided the CUDA `targets/<dir>` layout and the OS was never consulted:

- `aarch64-apple-darwin` probed `targets/sbsa-linux/` (a Linux-only tree) and `x86_64-pc-windows-msvc` probed `targets/x86_64-linux/`.
- CUDA for Tegra was unreachable: Jetson and Drive install under `targets/aarch64-linux/`, while aarch64 was hard-wired to the ARM server tree (`sbsa-linux`).

```text
# A CUDA-for-Tegra install ships only:
#   /usr/local/cuda/targets/aarch64-linux/include/cuda.h

Before: probes include/, then targets/sbsa-linux/  -> not found, error
After:  probes include/, targets/sbsa-linux/, targets/aarch64-linux/
        -> found; matching lib dirs join the link search path
```

## Fix

- Selection keys off `CARGO_CFG_TARGET_ARCH` + `CARGO_CFG_TARGET_OS` (robust against 3- vs 4-field triples; correctly excludes Android), returns nothing for non-Linux, and yields ordered candidates for aarch64 Linux: `["sbsa-linux", "aarch64-linux"]`, walked by the existing `cuda.h` existence probe. `sbsa-linux` stays first, so installs carrying both trees resolve exactly as today.
- The table lives in one shared file (`toolkit_target.rs`) used by both `build.rs` consumers and a synthetic-tree integration suite. Preserves the single-architecture anti-glob decision from #172, with a test asserting it.
- The shape matches CMake's `FindCUDAToolkit` selection almost exactly.

## Maintainer commit on top (b65208b6)

- `CUDA_TOOLKIT_TARGET_DIR` env override (the nvcc `-target-dir` / CMake `CUDAToolkit_TARGET_DIR` equivalent): if set, it is the single `targets/` candidate, still existence-probed so typos fail with the existing clear error; `cargo:rerun-if-env-changed` wired; two override tests added. This settles the dual-tree ambiguity (a Jetson cross sysroot carrying both trees can now pin `aarch64-linux`).
- The two hand-lockstep copies of the old logic are mirrored to the new selection: cargo-oxide's doctor (`cuda_header_candidates`) and cuda-core's `build.rs`. Without this, a Tegra user would build fine and then `cargo oxide doctor` would exit 1 claiming cuda.h is missing. Their lockstep comments now name `toolkit_target.rs`.
