### PR TITLE
feat(cuda-core): add a context scheduling-policy wrapper

### DIFF
--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -406,14 +406,17 @@ impl CudaContext {
     /// (`CU_CTX_SCHED_MASK`) are replaced, any other flag bit the process has
     /// set independently (e.g. `CU_CTX_MAP_HOST`) is preserved.
     ///
-    /// CUDA's own docs note `cuDevicePrimaryCtxSetFlags` can return
-    /// `CUDA_ERROR_INVALID_CONTEXT` once the primary context is active.
-    /// Measured on an RTX 5060 (driver 595.71.05, CUDA 13.3): calling this
-    /// immediately after [`CudaContext::new`] -- i.e. after the context has
-    /// already been retained and made current, which `new` always does --
-    /// succeeds. Treat a `CUDA_ERROR_INVALID_CONTEXT` result as that
-    /// documented restriction surfacing on a driver or usage pattern where
-    /// it does apply, not as this wrapper being wrong.
+    /// The policy is process-wide state on the device's primary context:
+    /// it affects every [`CudaContext`] clone of this device, and any
+    /// runtime-API user of the same device in this process, not just this
+    /// handle. The read-modify-write over `CU_CTX_SCHED_MASK` is also not
+    /// atomic: a concurrent flag writer on the same device can interleave
+    /// between the get and the set, and one side's update is then lost.
+    ///
+    /// Historical note: before CUDA 11, `cuDevicePrimaryCtxSetFlags` failed
+    /// with `CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE` once the primary context was
+    /// active. That restriction was lifted; the flags now apply to the
+    /// already-active context.
     pub fn set_sync_policy(&self, policy: SyncPolicy) -> Result<(), DriverError> {
         self.bind_to_thread()?;
         unsafe {

--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -88,6 +88,58 @@ impl PartialEq for CudaContext {
 }
 impl Eq for CudaContext {}
 
+/// Context scheduling policy (`CU_CTX_SCHED_*`), governing how the driver
+/// waits when the calling host thread blocks on GPU work (a stream or
+/// context synchronize).
+///
+/// Set via [`CudaContext::set_sync_policy`], read via
+/// [`CudaContext::sync_policy`]. The trade-off is host CPU against wake
+/// latency: [`Spin`](Self::Spin) burns a full core for the lowest latency,
+/// [`BlockingSync`](Self::BlockingSync) frees the core but wakes later. On a
+/// host with spare cores this trade rarely matters; on a CPU-constrained one
+/// (few physical cores, a sync-heavy pipeline) it can cost double-digit
+/// percentages of host CPU for no wall-clock benefit, which is the case
+/// [`BlockingSync`](Self::BlockingSync) exists to fix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SyncPolicy {
+    /// Driver-chosen default: spin if the process has more logical CPUs than
+    /// active contexts, otherwise yield.
+    Auto,
+    /// Spin the calling thread while waiting. Lowest latency, highest CPU use.
+    Spin,
+    /// Yield the calling thread's timeslice while waiting.
+    Yield,
+    /// Block the calling thread on a synchronization primitive while
+    /// waiting. Lowest CPU use, highest wake latency.
+    BlockingSync,
+}
+
+impl SyncPolicy {
+    fn to_raw(self) -> cuda_bindings::CUctx_flags_enum {
+        match self {
+            SyncPolicy::Auto => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_AUTO,
+            SyncPolicy::Spin => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_SPIN,
+            SyncPolicy::Yield => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_YIELD,
+            SyncPolicy::BlockingSync => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_BLOCKING_SYNC,
+        }
+    }
+
+    /// Decodes the scheduling bits (`CU_CTX_SCHED_MASK`) out of a raw flags
+    /// word. `None` for a driver-reserved combination this enum does not
+    /// name (the mask is 3 bits wide; only 4 of 8 values are assigned today).
+    fn from_raw(raw: cuda_bindings::CUctx_flags_enum) -> Option<Self> {
+        match raw & cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_MASK {
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_AUTO => Some(SyncPolicy::Auto),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_SPIN => Some(SyncPolicy::Spin),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_YIELD => Some(SyncPolicy::Yield),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_BLOCKING_SYNC => {
+                Some(SyncPolicy::BlockingSync)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl CudaContext {
     fn device_attribute(
         &self,
@@ -342,6 +394,62 @@ impl CudaContext {
         self.device_attribute(
             cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
         )
+    }
+
+    /// Sets the context's scheduling policy (`CU_CTX_SCHED_*`).
+    ///
+    /// Wraps `cuDevicePrimaryCtxSetFlags_v2`, scoped to this context's
+    /// device rather than `cuCtxSetFlags`'s "whatever is current on this
+    /// thread": [`CudaContext`] retains and owns a specific device's primary
+    /// context, so the device-scoped call is the one that matches what this
+    /// type actually holds. Read-modify-write: only the 3 scheduling bits
+    /// (`CU_CTX_SCHED_MASK`) are replaced, any other flag bit the process has
+    /// set independently (e.g. `CU_CTX_MAP_HOST`) is preserved.
+    ///
+    /// CUDA's own docs note `cuDevicePrimaryCtxSetFlags` can return
+    /// `CUDA_ERROR_INVALID_CONTEXT` once the primary context is active.
+    /// Measured on an RTX 5060 (driver 595.71.05, CUDA 13.3): calling this
+    /// immediately after [`CudaContext::new`] -- i.e. after the context has
+    /// already been retained and made current, which `new` always does --
+    /// succeeds. Treat a `CUDA_ERROR_INVALID_CONTEXT` result as that
+    /// documented restriction surfacing on a driver or usage pattern where
+    /// it does apply, not as this wrapper being wrong.
+    pub fn set_sync_policy(&self, policy: SyncPolicy) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        unsafe {
+            let mut current = MaybeUninit::uninit();
+            let mut active = MaybeUninit::uninit();
+            cuda_bindings::cuDevicePrimaryCtxGetState(
+                self.cu_device,
+                current.as_mut_ptr(),
+                active.as_mut_ptr(),
+            )
+            .result()?;
+            let current = current.assume_init();
+            let new_flags =
+                (current & !cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_MASK) | policy.to_raw();
+            cuda_bindings::cuDevicePrimaryCtxSetFlags_v2(self.cu_device, new_flags).result()
+        }
+    }
+
+    /// Returns the context's current scheduling policy (`CU_CTX_SCHED_*`).
+    ///
+    /// `None` if the driver reports a scheduling value this enum does not
+    /// name (see [`SyncPolicy::from_raw`](SyncPolicy) -- the mask has more
+    /// bit patterns than the driver assigns meanings to today).
+    pub fn sync_policy(&self) -> Result<Option<SyncPolicy>, DriverError> {
+        self.bind_to_thread()?;
+        unsafe {
+            let mut flags = MaybeUninit::uninit();
+            let mut active = MaybeUninit::uninit();
+            cuda_bindings::cuDevicePrimaryCtxGetState(
+                self.cu_device,
+                flags.as_mut_ptr(),
+                active.as_mut_ptr(),
+            )
+            .result()?;
+            Ok(SyncPolicy::from_raw(flags.assume_init()))
+        }
     }
 
     /// Atomically reads and clears the sticky error state.

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -63,7 +63,7 @@ pub mod stream;
 /// CUDA Virtual Memory Management (VMM) for physical alloc, VA reservation, and mapping.
 pub mod vmm;
 
-pub use context::CudaContext;
+pub use context::{CudaContext, SyncPolicy};
 /// Raw CUDA driver bindings re-exported for direct access when needed.
 pub use cuda_bindings as sys;
 /// `#[derive(DeviceCopy)]` macro, re-exported next to the `DeviceCopy` trait so

--- a/crates/cuda-core/tests/context_sync_policy.rs
+++ b/crates/cuda-core/tests/context_sync_policy.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaContext::{set_sync_policy, sync_policy}` round-trip.
+//!
+//! Its own test binary (not merged into `device_buffer.rs`'s): the context's
+//! scheduling flags are shared, process-wide state on the primary context
+//! (`cuDevicePrimaryCtxSetFlags_v2`), so setting them from a test that runs
+//! concurrently with others in the same binary would race. A single test
+//! function exercising every policy in sequence keeps the whole check inside
+//! one thread.
+
+use cuda_core::{CudaContext, SyncPolicy};
+
+#[test]
+fn sync_policy_round_trips_through_every_named_value() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+
+    for policy in [
+        SyncPolicy::BlockingSync,
+        SyncPolicy::Spin,
+        SyncPolicy::Yield,
+        SyncPolicy::Auto,
+        // Land on BlockingSync last: it is the one #705 asks for, and this
+        // proves the round trip through every other value first didn't
+        // leave some other bit set that corrupts it.
+        SyncPolicy::BlockingSync,
+    ] {
+        ctx.set_sync_policy(policy)
+            .unwrap_or_else(|e| panic!("set_sync_policy({policy:?}) failed: {e:?}"));
+        let got = ctx
+            .sync_policy()
+            .unwrap_or_else(|e| panic!("sync_policy() after set({policy:?}) failed: {e:?}"));
+        assert_eq!(
+            got,
+            Some(policy),
+            "sync_policy() must read back exactly what set_sync_policy({policy:?}) wrote"
+        );
+    }
+}


### PR DESCRIPTION
Closes #705.

`CudaContext` exposed no way to choose the primary context's `CU_CTX_SCHED_*` policy. The default (`CU_CTX_SCHED_AUTO`) may spin the calling thread while waiting on a sync, which is close to free on a host with spare cores and a real cost on a CPU-constrained one. Reaching `CU_CTX_SCHED_BLOCKING_SYNC` today means going through `cuda_core::sys` directly and re-deriving the primary-context caveat below at every call site.

## Changes

- `SyncPolicy`: `Auto` / `Spin` / `Yield` / `BlockingSync`, mapped to and from `CU_CTX_SCHED_*`.
- `CudaContext::set_sync_policy`: read-modify-write over `cuDevicePrimaryCtxGetState`/`cuDevicePrimaryCtxSetFlags_v2`, replacing only the 3 scheduling bits (`CU_CTX_SCHED_MASK`) so any other flag bit (`CU_CTX_MAP_HOST`, etc.) set independently survives.
- `CudaContext::sync_policy`: reads the current policy back.

## Rationale

Chosen: `cuDevicePrimaryCtxSetFlags_v2`/`cuDevicePrimaryCtxGetState`, scoped to the device `CudaContext` retains. Alternative: `cuCtxSetFlags`/ `cuCtxGetFlags`, scoped to whatever context is current on the calling thread. Rejected: `CudaContext` retains and owns one device's primary context specifically, so the device-scoped pair matches what the type actually holds rather than depending on thread-local current-context state a caller could change out from under it.

CUDA's own docs note `cuDevicePrimaryCtxSetFlags` can return `CUDA_ERROR_INVALID_CONTEXT` once the primary context is active, which `CudaContext::new` always makes it (retain, then `cuCtxSetCurrent` inside `bind_to_thread`). Measured on an RTX 5060 (driver 595.71.05, CUDA 13.3): `set_sync_policy` right after `CudaContext::new` succeeds. The wrapper still returns `Result`, so a driver or usage pattern where the documented restriction does apply surfaces as an `Err`, not a panic.

## Validation

`crates/cuda-core/tests/context_sync_policy.rs`, its own test binary (the scheduling flags are shared, process-wide state on the primary context, so sharing a binary with concurrently-run tests would race): round-trips `set_sync_policy` -> `sync_policy` through every named value in sequence, landing on `BlockingSync` last. Run on an RTX 5060 (sm_120a):

```text
test sync_policy_round_trips_through_every_named_value ... ok
```

Full `cargo test -p cuda-core` still green (26 + 1 + 13 + 3 + ... = every existing suite, 0 failed).

Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo check --workspace --all-targets`, `cargo doc --no-deps -p cuda-core` (RUSTDOCFLAGS=-D warnings), `cargo deny check`, all green.
