### PR TITLE
fix(mir-lower): scope the __shared_mem_N counter to one module

### DIFF
--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -665,6 +665,7 @@ pub fn convert_global_alloc_dc(
     op: Ptr<Operation>,
     _operands_info: &OperandsInfo,
     device_globals: &mut DeviceGlobalsMap,
+    next_device_global_index: &mut usize,
 ) -> Result<()> {
     use pliron::builtin::attributes::{StringAttr, TypeAttr};
 
@@ -748,6 +749,7 @@ pub fn convert_global_alloc_dc(
             ctx,
             op,
             device_globals,
+            next_device_global_index,
             DeviceGlobalSpec {
                 key: &global_key,
                 mir_type: mir_global_type,
@@ -779,10 +781,15 @@ struct DeviceGlobalSpec<'a> {
     immutable: bool,
 }
 
+/// `next_device_global_index` is scoped to one `MirToLlvmConversionDriver`
+/// instance (one module), not a process-global counter: `N` is a function of
+/// this module's own MIR walk order, not of how many other modules have
+/// lowered a device global earlier in the process (#706).
 fn create_device_global(
     ctx: &mut Context,
     op: Ptr<Operation>,
     device_globals: &mut DeviceGlobalsMap,
+    next_device_global_index: &mut usize,
     spec: DeviceGlobalSpec<'_>,
 ) -> Result<pliron::identifier::Identifier> {
     // An explicit initializer is already the evaluated Rust allocation image.
@@ -830,9 +837,8 @@ fn create_device_global(
                 ))
             })?
         } else {
-            static DEVICE_GLOBAL_COUNTER: std::sync::atomic::AtomicUsize =
-                std::sync::atomic::AtomicUsize::new(0);
-            let counter = DEVICE_GLOBAL_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let counter = *next_device_global_index;
+            *next_device_global_index += 1;
             format!("__device_global_{counter}").try_into().unwrap()
         };
 
@@ -2236,34 +2242,41 @@ mod tests {
         assert_eq!(count_ops::<llvm::AddressOfOp>(&ctx, &body), 3);
     }
 
-    /// A `__shared_mem_N` index must depend only on the module being
-    /// lowered, not on how many shared allocations any OTHER module has
-    /// already lowered in this process (#706). Before the fix, `N` came
-    /// from a `static AtomicUsize` shared across every call in the process,
-    /// so lowering the second of these two modules would have produced
-    /// `__shared_mem_1`, not `__shared_mem_0`.
+    /// A `__shared_mem_N` or `__device_global_N` index must depend only on
+    /// the module being lowered, not on how many allocations any OTHER
+    /// module has already lowered in this process (#706). Before the fix,
+    /// each `N` came from a `static AtomicUsize` shared across every call in
+    /// the process, so lowering the second of these two modules would have
+    /// produced `__shared_mem_1` and `__device_global_1`, not the `_0` names.
     #[test]
-    fn shared_mem_index_is_per_module_not_process_global() {
+    fn shared_and_device_global_indices_are_per_module_not_process_global() {
         for _ in 0..2 {
             let mut ctx = make_ctx();
             let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
             append_shared_alloc(&mut ctx, block, "k", 64);
+            append_global_alloc(&mut ctx, block, "ordinary_static", false);
             append_mir_return(&mut ctx, block, vec![]);
 
             crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
 
             let top = module_top_block(&ctx, module_ptr);
-            let global = top
+            let names: Vec<String> = top
                 .deref(&ctx)
                 .iter(&ctx)
-                .find_map(|op| Operation::get_op::<llvm::GlobalOp>(op, &ctx))
-                .expect("expected an llvm.global for the shared allocation");
-            assert_eq!(
-                global.get_symbol_name(&ctx).to_string(),
-                "__shared_mem_0",
+                .filter_map(|op| Operation::get_op::<llvm::GlobalOp>(op, &ctx))
+                .map(|g| g.get_symbol_name(&ctx).to_string())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "__shared_mem_0"),
                 "a module with exactly one shared allocation must always name it \
                  __shared_mem_0, regardless of how many other modules already lowered \
-                 one in this process"
+                 one in this process (got {names:?})"
+            );
+            assert!(
+                names.iter().any(|n| n == "__device_global_0"),
+                "a module with exactly one ordinary device global must always name it \
+                 __device_global_0, regardless of how many other modules already \
+                 lowered one in this process (got {names:?})"
             );
         }
     }

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -525,6 +525,7 @@ pub fn convert_shared_alloc_dc(
     op: Ptr<Operation>,
     _operands_info: &OperandsInfo,
     shared_globals: &mut SharedGlobalsMap,
+    next_shared_mem_index: &mut usize,
 ) -> Result<()> {
     use pliron::builtin::attributes::{IntegerAttr, TypeAttr};
 
@@ -574,6 +575,7 @@ pub fn convert_shared_alloc_dc(
             ctx,
             op,
             shared_globals,
+            next_shared_mem_index,
             mir_elem_type,
             size,
             alignment,
@@ -600,10 +602,17 @@ pub fn convert_shared_alloc_dc(
 /// `alloc_key` is `Some`, the key is moved into `shared_globals` so that
 /// later allocations with the same key reuse this global (caller is
 /// expected to have already checked the cache for a hit).
+///
+/// `next_shared_mem_index` is scoped to one `MirToLlvmConversionDriver`
+/// instance (one module), not a process-global counter: `N` is a function of
+/// this module's own MIR walk order, not of how many other modules have
+/// lowered a shared allocation earlier in the process (#706).
+#[allow(clippy::too_many_arguments)]
 fn create_shared_global(
     ctx: &mut Context,
     op: Ptr<Operation>,
     shared_globals: &mut SharedGlobalsMap,
+    next_shared_mem_index: &mut usize,
     mir_elem_type: TypeHandle,
     size: u64,
     alignment: u64,
@@ -612,8 +621,8 @@ fn create_shared_global(
     let llvm_elem_type = convert_type(ctx, mir_elem_type).map_err(anyhow_to_pliron)?;
     let array_type = ArrayType::get(ctx, llvm_elem_type, size);
 
-    static SHARED_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-    let counter = SHARED_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let counter = *next_shared_mem_index;
+    *next_shared_mem_index += 1;
     let name: pliron::identifier::Identifier =
         format!("__shared_mem_{counter}").try_into().unwrap();
 
@@ -2225,6 +2234,38 @@ mod tests {
         // Each of the three mir.shared_alloc ops becomes one addressof.
         let body = kernel_blocks(&ctx, module_ptr);
         assert_eq!(count_ops::<llvm::AddressOfOp>(&ctx, &body), 3);
+    }
+
+    /// A `__shared_mem_N` index must depend only on the module being
+    /// lowered, not on how many shared allocations any OTHER module has
+    /// already lowered in this process (#706). Before the fix, `N` came
+    /// from a `static AtomicUsize` shared across every call in the process,
+    /// so lowering the second of these two modules would have produced
+    /// `__shared_mem_1`, not `__shared_mem_0`.
+    #[test]
+    fn shared_mem_index_is_per_module_not_process_global() {
+        for _ in 0..2 {
+            let mut ctx = make_ctx();
+            let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+            append_shared_alloc(&mut ctx, block, "k", 64);
+            append_mir_return(&mut ctx, block, vec![]);
+
+            crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+            let top = module_top_block(&ctx, module_ptr);
+            let global = top
+                .deref(&ctx)
+                .iter(&ctx)
+                .find_map(|op| Operation::get_op::<llvm::GlobalOp>(op, &ctx))
+                .expect("expected an llvm.global for the shared allocation");
+            assert_eq!(
+                global.get_symbol_name(&ctx).to_string(),
+                "__shared_mem_0",
+                "a module with exactly one shared allocation must always name it \
+                 __shared_mem_0, regardless of how many other modules already lowered \
+                 one in this process"
+            );
+        }
     }
 
     fn append_global_alloc(

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -215,6 +215,12 @@ pub struct MirToLlvmConversionDriver {
     /// MIR walk order rather than of how many OTHER modules have lowered a
     /// shared allocation earlier in the process. See #706.
     pub next_shared_mem_index: usize,
+    /// Next `__device_global_N` index. Scoped to one driver instance for the
+    /// same reason as `next_shared_mem_index`: the assigned index is a
+    /// function of this module's own MIR walk order rather than of how many
+    /// OTHER modules have lowered a device global earlier in the process.
+    /// See #706.
+    pub next_device_global_index: usize,
 }
 
 fn is_mir_or_nvvm_op(ctx: &Context, op: Ptr<Operation>) -> bool {
@@ -308,6 +314,7 @@ impl DialectConversion for MirToLlvmConversionDriver {
                 op,
                 operands_info,
                 &mut self.device_globals,
+                &mut self.next_device_global_index,
             );
         }
         if opid == dialect_mir::ops::MirExternSharedOp::get_opid_static() {
@@ -375,6 +382,7 @@ pub fn lower_mir_to_llvm_with_options(
         device_globals: FxHashMap::default(),
         dynamic_smem_alignments: FxHashMap::default(),
         next_shared_mem_index: 0,
+        next_device_global_index: 0,
     };
     // pliron's DialectConversion now reports an IRStatus (Changed/Unchanged);
     // lowering only cares about success, so discard it.

--- a/crates/mir-lower/src/lib.rs
+++ b/crates/mir-lower/src/lib.rs
@@ -209,6 +209,12 @@ pub struct MirToLlvmConversionDriver {
     pub device_globals: DeviceGlobalsMap,
     /// Per-owning-function dynamic shared memory alignment tracking.
     pub dynamic_smem_alignments: DynamicSmemAlignmentMap,
+    /// Next `__shared_mem_N` index. Scoped to one driver instance (one
+    /// `lower_mir_to_llvm` call, i.e. one module), not a process-global
+    /// counter, so the assigned index is a function of this module's own
+    /// MIR walk order rather than of how many OTHER modules have lowered a
+    /// shared allocation earlier in the process. See #706.
+    pub next_shared_mem_index: usize,
 }
 
 fn is_mir_or_nvvm_op(ctx: &Context, op: Ptr<Operation>) -> bool {
@@ -292,6 +298,7 @@ impl DialectConversion for MirToLlvmConversionDriver {
                 op,
                 operands_info,
                 &mut self.shared_globals,
+                &mut self.next_shared_mem_index,
             );
         }
         if opid == dialect_mir::ops::MirGlobalAllocOp::get_opid_static() {
@@ -367,6 +374,7 @@ pub fn lower_mir_to_llvm_with_options(
         shared_globals: FxHashMap::default(),
         device_globals: FxHashMap::default(),
         dynamic_smem_alignments: FxHashMap::default(),
+        next_shared_mem_index: 0,
     };
     // pliron's DialectConversion now reports an IRStatus (Changed/Unchanged);
     // lowering only cares about success, so discard it.


### PR DESCRIPTION
Closes #706.

## Problem

Static shared-memory globals were named from a process-global `AtomicUsize`, so the `__shared_mem_N` index depended on how many other modules the process had lowered first and in what thread order. Two builds of identical source could emit the same globals under different names.

```text
Before: lower module A, then module B, in one process:
    A's tile -> @__shared_mem_0
    B's tile -> @__shared_mem_1
  next build lowers B first (parallel scheduling):
    B's tile -> @__shared_mem_0    <- same source, new name every build

After: the counter restarts at 0 for every module:
    B's tile -> @__shared_mem_0    <- stable on every rebuild
```

## Fix

- `MirToLlvmConversionDriver` gains `next_shared_mem_index: usize`, initialised where `shared_globals`/`device_globals` already are, threaded into `create_shared_global` exactly like the existing dedup maps. No new mechanism: the driver is already instantiated fresh once per module for the same reason.
- Regression test lowers two fresh modules in one process and asserts both name their first shared block `__shared_mem_0`, which the old code could never satisfy.

## Maintainer commit on top (b78a338b)

The identical process-global counter behind `__device_global_N` sat 200 lines below in the same file. Extended the same fix: `next_device_global_index` on the driver, threaded the same way, and the regression test now also asserts both modules name their first device global `__device_global_0`. Device codegen naming is now reproducible end to end.
