### PR TITLE
docs(cuda-oxide-codegen): fix verify_operation's stale mir-importer comment

### DIFF
--- a/crates/cuda-oxide-codegen/src/verify.rs
+++ b/crates/cuda-oxide-codegen/src/verify.rs
@@ -14,7 +14,8 @@ use pliron::printable::Printable;
 ///
 /// On failure, attempts to find the innermost failing operation for better
 /// error messages.
-// mir-importer pipeline plumbing; not part of the frontend contract.
+// cuda-oxide-codegen's own standalone pipeline plumbing (prep.rs,
+// pipeline.rs); not part of the frontend contract.
 #[doc(hidden)]
 pub fn verify_operation(
     ctx: &Context,

--- a/crates/cuda-oxide-codegen/src/verify.rs
+++ b/crates/cuda-oxide-codegen/src/verify.rs
@@ -14,8 +14,11 @@ use pliron::printable::Printable;
 ///
 /// On failure, attempts to find the innermost failing operation for better
 /// error messages.
-// cuda-oxide-codegen's own standalone pipeline plumbing (prep.rs,
-// pipeline.rs); not part of the frontend contract.
+// Verification gate shared by this crate's own pipeline stages (prep.rs,
+// pipeline.rs) and, through the `__private` re-export in lib.rs, by
+// mir-importer's per-function post-translation check. That cross-crate hook
+// is why this is `pub` + `#[doc(hidden)]`; it is not part of the
+// experimental standalone frontend contract.
 #[doc(hidden)]
 pub fn verify_operation(
     ctx: &Context,


### PR DESCRIPTION
Part of #712.

## What this PR now does

`verify_operation`'s doc comment described it as "mir-importer pipeline plumbing; not part of the frontend contract", which understated its in-crate role. The first version of this PR swapped that for a claim that mir-importer never calls it; that premise turned out to be wrong (easy to miss: both crates have a `pipeline.rs`), and the corrected comment now names the full consumer set:

- this crate's own standalone pipeline stages (`prep.rs`, `pipeline.rs`);
- `mir-importer`, via the `cuda_oxide_codegen::__private` re-export (`lib.rs:126`), which calls it at `mir-importer/src/pipeline.rs:319` as the per-function post-translation verification gate on the live `#[kernel]` path.

That second consumer is why the function is `pub` + `#[doc(hidden)]`, and why demoting it to `pub(crate)` or deleting the re-export would break every normal kernel build. The comment now says so, which is the maintenance-safety point of the fix.

Gates: `cargo fmt --all -- --check`, `cargo clippy -p cuda-oxide-codegen -- -D warnings`, `cargo doc --no-deps -p cuda-oxide-codegen` (RUSTDOCFLAGS=-D warnings), all green.

Note for #712: item 2 of the issue carries the same "mir-importer never calls it" claim and should be corrected the same way.
