### PR TITLE
fix(finalizer): compile accepted NVVM IR directly

### DIFF
--- a/crates/cuda-artifact-finalizer/src/nvvm.rs
+++ b/crates/cuda-artifact-finalizer/src/nvvm.rs
@@ -94,9 +94,9 @@ impl NvvmCompiler {
                 program.add_module(&self.libdevice, "libdevice.10.bc")?;
                 program.add_module(nvvm_ir, module_name)?;
 
-                let verify = options.nvvm_verify_options();
-                let verify_refs = verify.iter().map(String::as_str).collect::<Vec<_>>();
-                program.verify(&verify_refs)?;
+                // Compilation is the authoritative acceptance boundary.
+                // nvvmVerifyProgram rejects atomic loads and stores that the
+                // same libNVVM installation can compile successfully.
                 let compile = options.nvvm_compile_options();
                 let compile_refs = compile.iter().map(String::as_str).collect::<Vec<_>>();
                 Ok(program.compile(&compile_refs)?)
@@ -232,9 +232,6 @@ pub(crate) fn nvvm_ir_artifact_digest_parts(
         .field("module", nvvm_ir)
         .field("module-order", b"libdevice.10.bc,user-nvvm-ir")
         .field("libdevice-sha256", libdevice_digest);
-    for option in options.nvvm_verify_options() {
-        digest = digest.field("nvvm-verify-option", option.as_bytes());
-    }
     for option in options.nvvm_compile_options() {
         digest = digest.field("nvvm-compile-option", option.as_bytes());
     }
@@ -244,6 +241,38 @@ pub(crate) fn nvvm_ir_artifact_digest_parts(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const MODERN_ATOMIC_LOAD_NVVM_IR: &[u8] = br#"
+target datalayout = "e-p:64:64:64-p3:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64-a:8:8"
+target triple = "nvptx64-nvidia-cuda"
+
+define void @kernel(ptr %value) {
+entry:
+  %loaded = load atomic i32, ptr %value syncscope("device") acquire, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!nvvmir.version = !{!1}
+!0 = !{ptr @kernel, !"kernel", i32 1}
+!1 = !{i32 2, i32 0, i32 3, i32 2}
+"#;
+
+    const MALFORMED_MODERN_NVVM_IR: &[u8] = br#"
+target datalayout = "e-p:64:64:64-p3:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64-a:8:8"
+target triple = "nvptx64-nvidia-cuda"
+
+define void @kernel() {
+entry:
+  %invalid = add i32 1, ptr null
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!nvvmir.version = !{!1}
+!0 = !{ptr @kernel, !"kernel", i32 1}
+!1 = !{i32 2, i32 0, i32 3, i32 2}
+"#;
 
     #[test]
     fn nvvm_digest_covers_module_name_bytes_options_and_libdevice() {
@@ -295,6 +324,32 @@ mod tests {
                 &[1; 32],
                 &[2; 32]
             )
+        );
+    }
+
+    #[test]
+    #[ignore = "requires discoverable CUDA Toolkit libNVVM and libdevice"]
+    fn live_compile_accepts_atomic_load_and_rejects_malformed_ir() {
+        let compiler = NvvmCompiler::discover().unwrap();
+        let options = FinalizationOptions::new("sm_120a".parse().unwrap());
+
+        let ltoir = compiler
+            .compile_nvvm_ir_to_ltoir("atomic-load.ll", MODERN_ATOMIC_LOAD_NVVM_IR, &options)
+            .unwrap();
+        assert!(!ltoir.is_empty());
+
+        let error = compiler
+            .compile_nvvm_ir_to_ltoir("malformed.ll", MALFORMED_MODERN_NVVM_IR, &options)
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                FinalizerError::Nvvm(libnvvm_sys::NvvmError::Call {
+                    operation: "nvvmCompileProgram",
+                    ..
+                })
+            ),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -64,10 +64,6 @@ impl FinalizationOptions {
         self.debug
     }
 
-    pub(crate) fn nvvm_verify_options(&self) -> Vec<String> {
-        vec![format!("-arch={}", self.target.compute())]
-    }
-
     pub(crate) fn nvvm_compile_options(&self) -> Vec<String> {
         let mut options = vec![
             format!("-arch={}", self.target.compute()),

--- a/crates/cuda-artifact-finalizer/src/provenance.rs
+++ b/crates/cuda-artifact-finalizer/src/provenance.rs
@@ -16,7 +16,7 @@ const DIGEST_DOMAIN: &[u8] = b"cuda-oxide/artifact-finalizer/digest/v1";
 // Bump this recipe version whenever tool invocation, option translation,
 // input ordering, output validation, or other output-affecting semantics
 // change. Cache keys and the cargo-oxide/backend handshake rely on it.
-const RECIPE: &[u8] = b"cuda-oxide/artifact-finalizer/recipe/v1";
+const RECIPE: &[u8] = b"cuda-oxide/artifact-finalizer/recipe/v2";
 
 /// Exact compiler inputs discovered alongside the loaded CUDA tools.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

Treat `nvvmCompileProgram` as the authoritative acceptance boundary for NVVM IR. `nvvmVerifyProgram` rejects some modern atomic IR that the same libNVVM installation compiles successfully, causing valid device code to fail before compilation.

## Changes

- Remove the separate `nvvmVerifyProgram` preflight from the NVVM IR compilation path.
- Preserve the existing frontend compatibility checks, deterministic module ordering, compile options, diagnostics, and output validation.
- Remove the unused verification-option contribution from the artifact digest.
- Bump the finalizer recipe version so cached artifacts and fingerprints reflect the changed acceptance semantics.
- Add a live regression test demonstrating that:
  - an atomic load accepted by libNVVM compiles successfully; and
  - malformed NVVM IR is still rejected by `nvvmCompileProgram`.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p cuda-artifact-finalizer --all-targets -- -D warnings`
- [x] `cargo test -p cuda-artifact-finalizer` — 13 passed, 2 live tests ignored
- [x] `cargo test -p cuda-artifact-finalizer nvvm::tests::live_compile_accepts_atomic_load_and_rejects_malformed_ir -- --exact --ignored` — passed with a discoverable CUDA Toolkit
- `cargo oxide run`: not applicable; this change is isolated to the artifact finalizer.
- `cargo test --workspace`: not run; the affected crate and live libNVVM path were tested directly.
- New example: not applicable.

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files — no new source files