### PR TITLE
docs(rustc-codegen-cuda): gate this workspace's rustdoc and fix its broken links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,3 +65,18 @@ jobs:
           # bindgen-generated C doxygen comments, and its `doctest = false`
           # (which `cargo test --doc` otherwise bypasses) signals that intent.
           cargo test --doc --workspace --exclude cuda-bindings
+
+      # `rustc-codegen-cuda` is its own [workspace] (it links against
+      # rustc-private dylibs), so `--workspace` above never reaches it. fmt,
+      # clippy and unit-tests each carry a dedicated step for that crate;
+      # this gate did not, which is how four broken intra-doc links in its
+      # crate-level documentation went unreported.
+      - name: Build docs (warning-free) for rustc-codegen-cuda
+        working-directory: crates/rustc-codegen-cuda
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          sysroot="$(rustc --print sysroot)"
+          export LIBRARY_PATH="${sysroot}/lib:${LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${sysroot}/lib:${LD_LIBRARY_PATH:-}"
+          cargo doc --no-deps

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -176,7 +176,8 @@
 //! because rustc's MIR pretty-printer routinely emits `std::*` for items
 //! that are merely re-exported from `core`.
 //!
-//! See [`collector::should_collect_from_crate`] for the exact policy.
+//! See `DeviceCollector::should_collect_from_crate` in `collector` for the
+//! exact policy.
 //!
 //! ### Why `std::*` shows up in MIR dumps (and isn't a problem)
 //!
@@ -289,9 +290,15 @@
 //!
 //! ## Module Structure
 //!
-//! - [`collector`]: Device function collection via MIR call graph traversal
-//! - [`device_codegen`]: Bridge to the cuda-oxide pipeline (MIR → PTX)
-//! - [`layout`]: Unified type layouts for host/device ABI compatibility
+//! These are private implementation modules, so they are named rather than
+//! linked: rustdoc rejects a link from public crate documentation to a private
+//! item.
+//!
+//! - `collector`: Device function collection via MIR call graph traversal
+//! - `device_codegen`: Bridge to the cuda-oxide pipeline (MIR → PTX)
+//! - `generated_intrinsics`: Generated intrinsic definitions and dispatch
+//! - `materialize`: Strict, opt-in build-time finalization of embedded device
+//!   artifacts
 
 #![feature(rustc_private)]
 #![allow(unused_imports)]


### PR DESCRIPTION
Closes #724.

`crates/rustc-codegen-cuda` is its own `[workspace]` (rustc-private dylibs), so
the root `cargo doc --workspace` in `docs.yml` never reaches it. Every other gate
has a dedicated step for that crate — `fmt`, `clippy`, `unit-tests` — and docs
did not.

That gap hid four real errors. The gate's own command, run against that
workspace on `main`:

```
$ cd crates/rustc-codegen-cuda && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
error: unresolved link to `collector::should_collect_from_crate`
error: public documentation for `rustc_codegen_cuda` links to private item `collector`
error: public documentation for `rustc_codegen_cuda` links to private item `device_codegen`
error: unresolved link to `layout`
error: could not document `rustc_codegen_cuda`
```

## What was wrong

* `collector` and `device_codegen` are private (`mod`, not `pub mod`), so linking
  to them from public crate docs is rejected. Now named, not linked.
* `should_collect_from_crate` is a private method on the private
  `DeviceCollector<'tcx>` — that path could never have resolved, so it reads as
  `DeviceCollector::should_collect_from_crate` in prose.
* **`layout` has never been a module in this crate.** The "Module Structure" list
  documented a module that does not exist, while omitting `generated_intrinsics`
  and `materialize`. Corrected to the four that do exist.

Only documentation comments changed; no code.

## Verified

```
$ cd crates/rustc-codegen-cuda && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
    Finished `dev` profile
exit 0
```

`cargo fmt --check` passes for both the root workspace and
`crates/rustc-codegen-cuda`. No GPU needed for any of this.

The new step mirrors the existing `rustc-codegen-cuda` steps in `fmt.yml` and
`clippy.yml`, so the gate cannot silently skip that workspace again.