### PR TITLE
build: pin rustfmt in rust-toolchain.toml like clippy

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -18,11 +18,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      # rust-toolchain.toml pins nightly-2026-04-03 but does not list
-      # rustfmt as a component. Add it explicitly so `cargo fmt` resolves
-      # against the same nightly the rest of CI uses.
-      - name: Install rustfmt for the pinned nightly
-        run: rustup component add rustfmt
+      # rustfmt comes from rust-toolchain.toml's component list, like clippy,
+      # so `cargo fmt` resolves against the same nightly as the rest of CI.
 
       - name: Check root workspace formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -180,8 +180,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install rustfmt for the pinned nightly
-        run: rustup component add rustfmt
+      # cuda-intrinsics-gen shells out to rustfmt when it writes generated
+      # sources; it comes from rust-toolchain.toml's component list.
 
       - name: Check generated intrinsic outputs
         run: cargo run -p cuda-intrinsics-gen -- check

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -5888,7 +5888,7 @@ const GIT_REPO: &str = "https://github.com/NVlabs/cuda-oxide.git";
 
 const RUST_TOOLCHAIN_TOML: &str = r#"[toolchain]
 channel = "nightly-2026-04-03"
-components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]
+components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "rustfmt", "llvm-tools"]
 "#;
 
 const SCAFFOLD_GITIGNORE_EXTRA: &[&str] = &[

--- a/crates/rustc-codegen-cuda/rust-toolchain.toml
+++ b/crates/rustc-codegen-cuda/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # rustc_private APIs change between nightly versions.
 [toolchain]
 channel = "nightly-2026-04-03"
-components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]
+components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "rustfmt", "llvm-tools"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,10 @@
 [toolchain]
 channel = "nightly-2026-04-03"
-components = ["rust-src", "rustc-dev", "rust-analyzer", "clippy", "llvm-tools"]
+components = [
+    "rust-src",
+    "rustc-dev",
+    "rust-analyzer",
+    "clippy",
+    "rustfmt",
+    "llvm-tools",
+]


### PR DESCRIPTION
Closes #726.

`clippy` was in the component list; `rustfmt` was not — though `cargo fmt
--check` is a required gate exactly like clippy. A fresh checkout produced a
toolchain that could not run the fmt gate.

CI compensated instead of closing the gap, and had **already copied the
workaround once**:

* `fmt.yml` — its comment named the cause outright: *"rust-toolchain.toml pins
  nightly-2026-04-03 but does not list rustfmt as a component."*
* `unit-tests.yml` — the `generated-intrinsics` job needs it too, because
  `cuda-intrinsics-gen` shells out to rustfmt when writing generated sources.

Both steps are removed; the toolchain file now carries the component, so a third
job needing rustfmt gets it for free.

## Verified

```
$ rustup show active-toolchain
nightly-2026-04-03-x86_64-unknown-linux-gnu (overridden by 'rust-toolchain.toml')

$ cargo fmt --version
rustfmt 1.9.0-nightly (55e86c9968 2026-04-02)     # matches the pin

$ cargo fmt --all -- --check                                     # root: pass
$ (cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)    # codegen: pass
```

Both workflow files still parse as YAML. No GPU needed.

If you would rather keep the explicit `rustup component add rustfmt` steps as
belt-and-braces, I am happy to restore them and land only the toolchain change.