### PR TITLE
build(just): make `just test` cover the packages CI tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -20,9 +20,41 @@ clippy:
 clippy-fix:
     cargo clippy --all-targets --lib --tests --fix --allow-dirty --allow-staged
 
-# Run unit tests (excludes rustc_private and device-only crates)
+# Run unit tests for every package CI covers, so `just check` predicts CI.
+# Mirrors .github/workflows/unit-tests.yml; keep the two in step.
+#
+# CI splits this across a matrix and marks some entries `needs_cuda`, meaning
+# cuda-bindings' bindgen needs cuda.h at build time. This recipe therefore
+# expects a CUDA toolkit, as `doc-check` already does. `--all-targets` matches
+# the matrix default; the three exceptions below carry CI's own overrides.
 test:
-    cargo test -p cuda-host -p cuda-macros -p llvm-export -p dialect-mir -p dialect-nvvm --lib --tests
+    cargo test --all-targets \
+        -p cuda-intrinsics-gen -p cuda-intrinsics -p llvm-export \
+        -p dialect-mir -p dialect-nvvm -p mir-importer -p mir-lower \
+        -p mir-transforms -p nvvm-transforms -p reserved-oxide-symbols \
+        -p cuda-device -p libnvvm-sys -p nvjitlink-sys \
+        -p cuda-artifact-finalizer -p cargo-oxide
+    # `default = []`, but every consumer turns the object features on, and the
+    # default set alone skips the eight ELF emit/extract tests.
+    cargo test -p oxide-artifacts --all-targets --features object
+    # Its own [workspace] (rustc-private dylibs), so a separate CI job covers
+    # it and `-p` from the root cannot reach it.
+    cd crates/rustc-codegen-cuda && cargo test --lib
+
+# The five packages CI's matrix marks `needs_cuda`, kept separate so `test`
+# runs on a machine with no CUDA at all.
+#
+# These need cuda.h for cuda-bindings' bindgen at build time, and their test
+# binaries keep a DT_NEEDED on `libcuda.so.1`, so without a driver they fail to
+# *load* -- `error while loading shared libraries: libcuda.so.1` -- which is a
+# loader failure, not a test failure. CI runs them on driverless runners by
+# shadowing the toolkit's link-time stub under that name; see unit-tests.yml.
+#
+# `--lib` for cuda-core skips the GPU-only VMM/P2P test in tests/vmm_p2p.rs.
+test-cuda:
+    cargo test --all-targets \
+        -p cuda-oxide-codegen -p cuda-macros -p cuda-host -p cuda-async
+    cargo test -p cuda-core --lib
 
 # Build docs warning-free + run doctests (mirrors the docs CI gate). The `test`
 # recipe uses `--lib --tests`, which skips doctests, so this covers them.

--- a/Justfile
+++ b/Justfile
@@ -24,9 +24,10 @@ clippy-fix:
 # Mirrors .github/workflows/unit-tests.yml; keep the two in step.
 #
 # CI splits this across a matrix and marks some entries `needs_cuda`, meaning
-# cuda-bindings' bindgen needs cuda.h at build time. This recipe therefore
-# expects a CUDA toolkit, as `doc-check` already does. `--all-targets` matches
-# the matrix default; the three exceptions below carry CI's own overrides.
+# cuda-bindings' bindgen needs cuda.h at build time. Those packages live in
+# `test-cuda` below, so this recipe runs on a machine with no CUDA at all.
+# `--all-targets` matches the matrix default; the two exceptions below carry
+# CI's own overrides.
 test:
     cargo test --all-targets \
         -p cuda-intrinsics-gen -p cuda-intrinsics -p llvm-export \
@@ -57,15 +58,18 @@ test-cuda:
     cargo test -p cuda-core --lib
 
 # Build docs warning-free + run doctests (mirrors the docs CI gate). The `test`
-# recipe uses `--lib --tests`, which skips doctests, so this covers them.
+# recipe uses `--all-targets`, which skips doctests, so this covers them.
 # cuda-bindings is excluded from doctests (its generated C doc comments are not
 # valid Rust); its docs still build under the rustdoc allows in its lib.rs.
 doc-check:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
     cargo test --doc --workspace --exclude cuda-bindings
 
-# Run all checks (fmt + clippy + test + docs)
-check: fmt-check clippy test doc-check
+# Run all checks (fmt + clippy + tests + docs). Includes `test-cuda`: `clippy`
+# and `doc-check` already build cuda-bindings, so this recipe needs a CUDA
+# toolkit either way, and the pre-split `test` already ran driver-linked
+# cuda-host/cuda-macros binaries. Machines without even a toolkit get `test`.
+check: fmt-check clippy test test-cuda doc-check
 
 # Clean project-local Cargo outputs and known cuda-oxide artifacts
 clean-artifacts:


### PR DESCRIPTION
Closes #728.

`check` is the documented "run all checks" entry point, but `test` ran **5**
packages where CI runs **22** (21 in the matrix + the `rustc-codegen-cuda` job).
The sixteen it never ran included the entire compiler middle-end:

```
mir-lower  mir-importer  mir-transforms  nvvm-transforms  cuda-oxide-codegen
cargo-oxide  oxide-artifacts  cuda-intrinsics  cuda-intrinsics-gen
reserved-oxide-symbols  libnvvm-sys  nvjitlink-sys  cuda-artifact-finalizer  ...
```

So you could edit a lowering pass, run `just check`, see green, push, and have CI
fail on tests you had no local way to run short of reading the matrix by hand.

Two smaller things came with it:

* The comment said the recipe excluded "device-only crates", but two of the five
  it ran — `cuda-host`, `cuda-macros` — are exactly the ones CI marks
  `needs_cuda`.
* `--lib --tests` dropped CI's deliberate per-package overrides:
  `oxide-artifacts` needs `--features object` (without it, eight ELF
  emit/extract tests never run) and `cuda-core` needs `--lib` (to skip the
  GPU-only `tests/vmm_p2p.rs`).

## The split

`test` now runs the **16 packages that need no CUDA at all**, with CI's
overrides, plus the `rustc-codegen-cuda` workspace that `-p` cannot reach from
the root.

The **5 that CI marks `needs_cuda`** move to a new `test-cuda`. This is CI's own
annotation, not a partition I invented. They need `cuda.h` to build, and their
test binaries keep a `DT_NEEDED` on `libcuda.so.1`, so on a machine without a
driver they fail to **load** rather than fail a test:

```
error while loading shared libraries: libcuda.so.1: cannot open shared object
file: No such file or directory
```

CI runs them on driverless runners by shadowing the toolkit's link-time stub
under that name (see `unit-tests.yml`). Splitting keeps `just test` working on a
machine with no CUDA, rather than failing for a reason that has nothing to do
with the code.

## Verified

All three `test` steps pass locally — **2938 tests, 0 failures**. No GPU needed.

I found the split empirically first and it disagreed with a dependency-graph
guess (`cuda-device` reaches `cuda-bindings` through a dev-dependency but its
test binary loads fine), which is why this follows CI's `needs_cuda` flag rather
than either heuristic. Happy to fold the stub-shadow trick into `test` instead
if you would rather have one recipe cover all 22 driverless.