### PR TITLE
chore: add the missing SPDX header to two first-party sources

### DIFF
--- a/crates/mir-importer/src/translator/layout.rs
+++ b/crates/mir-importer/src/translator/layout.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared readers over rustc's aggregate layout metadata.
 //!
 //! Both the type importer (`translator/types.rs`, which records tag and

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/kernels.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/kernels.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Size-specialized device kernels for the canonical gemm_sol_final example.
 // include!d into main.rs so the #[cuda_module] macro sees an inline module
 // (it rejects file modules). Host validation and benchmarking remain in main.rs.


### PR DESCRIPTION
Closes #730.

CONTRIBUTING requires every first-party source file to identify Apache-2.0 with
an SPDX header. Two do not, and in both cases **every sibling does**:

| file | siblings with a header |
|---|---|
| `crates/mir-importer/src/translator/layout.rs` | 8 of 8 |
| `crates/rustc-codegen-cuda/examples/gemm_sol_final/src/kernels.rs` | `main.rs`, the only other file there |

`kernels.rs` is `include!`d into `main.rs` rather than reached through a `mod`
declaration, which is the likely reason it was missed.

## One deliberate choice

This adds **only** `// SPDX-License-Identifier: Apache-2.0`, not the
`SPDX-FileCopyrightText: ... NVIDIA CORPORATION` line the siblings carry.
CONTRIBUTING says:

> Add a copyright notice only when you are the copyright holder or are
> authorized to name the holder.

I am neither, so I have not asserted it. Anyone who is authorised should feel
free to extend these two to the full header.

## Deliberately out of scope

* `crates/fuzzer/rustlantis/**` (32 files) is vendored — CONTRIBUTING says those
  keep their upstream notices.
* Eight trybuild fixtures also lack headers, but their `.stderr` files pin exact
  line numbers (`device_reserved_name.rs:4:4`), so a header shifts every line and
  breaks the expectation. It is fixable — headered fixtures have `.stderr`
  offsets that account for it — but it needs `.stderr` regeneration, which is
  separate churn. Happy to do it as a follow-up if you want it.

## Verified

`cargo fmt --check` passes for the root workspace and `gemm_sol_final`;
`cargo test -p mir-importer --lib` still passes (928 tests). After this, no
first-party source file outside those two excluded groups is missing a header.
No GPU needed.