### PR TITLE
ci(book): fail the book build on Sphinx warnings

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,8 +29,15 @@ jobs:
       - name: Install dependencies
         run: pip install -r cuda-oxide-book/requirements.txt
 
+      # `-W` matches the Rust docs gate, which builds under
+      # RUSTDOCFLAGS="-D warnings". Without it a broken cross-reference, a
+      # malformed directive or a page dropped from a toctree still exits 0 and
+      # publishes. `--keep-going` reports every warning in one run instead of
+      # stopping at the first.
       - name: Build Sphinx site
-        run: sphinx-build -b html cuda-oxide-book cuda-oxide-book/_build/html
+        run: >-
+          sphinx-build -W --keep-going -b html
+          cuda-oxide-book cuda-oxide-book/_build/html
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/cuda-oxide-book/Makefile
+++ b/cuda-oxide-book/Makefile
@@ -1,4 +1,6 @@
-SPHINXOPTS    ?=
+# Warnings are errors, as in CI (.github/workflows/book.yml) and in the Rust
+# docs gate. Override for a draft build:  SPHINXOPTS= make html
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
Closes #732.

The book is the only documentation surface without warnings-as-errors. The Rust
docs gate builds under `RUSTDOCFLAGS="-D warnings"` and `docs.yml` states the
reason — *"keeps broken intra-doc links and uncompilable doc examples from
accumulating silently"* — while `sphinx-build` ran bare.

## Demonstrated

Appending one dangling link to `index.md`:

```
$ sphinx-build -b html cuda-oxide-book _build            # what CI runs today
build succeeded.
exit 0                                                    # <- publishes it

$ sphinx-build -W --keep-going -b html cuda-oxide-book _build
WARNING: 'myst' cross-reference target not found: 'does-not-exist.md' [myst.xref_missing]
exit 1
```

`--keep-going` reports every warning in one run instead of stopping at the first,
which matters when a rename breaks several references at once.

## Costs nothing today

The book is already clean — `sphinx-build -W --keep-going` exits **0 with zero
warnings** on `main` (Sphinx 9.1.0, installed from
`cuda-oxide-book/requirements.txt`).

The `Makefile` gets the same default so `make html` catches locally what CI
catches, and it stays overridable for a draft build:

```
SPHINXOPTS= make html
```

Verified `make html` still exits 0 with the new default.

## One caveat, stated plainly

`requirements.txt` uses `>=` constraints, so CI floats to the newest Sphinx. A
future release that introduces a deprecation warning would then fail the book
build rather than merely mention it. `--keep-going` at least surfaces all of them
at once. If you would rather not take that exposure, pinning the Sphinx major in
`requirements.txt` removes it — happy to add that here or drop the `-W` entirely.

No GPU needed for any of this.