### PR TITLE
docs(book): wrap barrier::nanosleep example in unsafe

### DIFF
--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -602,7 +602,7 @@ use cuda_device::debug;
 let t = debug::clock64();       // Cycle counter
 debug::trap();                  // Abort kernel
 debug::breakpoint();            // cuda-gdb breakpoint
-cuda_device::barrier::nanosleep(1000); // Sleep ~1μs
+unsafe { cuda_device::barrier::nanosleep(1000) }; // Sleep ~1μs
 debug::prof_trigger::<7>();     // Nsight profiler trigger
 ```
 


### PR DESCRIPTION
## Summary

The API quick reference example calls `cuda_device::barrier::nanosleep(1000);` without an `unsafe` block. The function is generated as `pub unsafe fn nanosleep(ns: u32)` (included in `crates/cuda-device/src/barrier.rs` through `generated/mbarrier_extended.rs`), so the example as written does not compile.

## Change

Wrap the call in an `unsafe` block:

```rust
unsafe { cuda_device::barrier::nanosleep(1000) }; // Sleep ~1μs
```

## Verification

Compiled both forms against the current `cuda-device` crate:

- before: `error[E0133]: call to unsafe function `nanosleep` is unsafe and requires unsafe block`
- after: compiles clean

## Notes

One line, touches only the book. No issue was filed; the drift surfaced while reading the quick reference against the generated API.
