### PR TITLE
docs(contributing): point formatting at every workspace CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,19 @@ flakes enabled, `nix develop` is the quickest way to get everything in place.
 
 ### Formatting and Style
 
-- Run `cargo fmt` before submitting. All code must be formatted with
-  `rustfmt`.
-- Run `cargo clippy` and address any warnings where reasonable.
+- Run `cargo oxide fmt` before submitting. All code must be formatted with
+  `rustfmt`. Use `cargo oxide fmt` rather than a bare `cargo fmt`: the codegen
+  backend and every example are their own workspaces, so `cargo fmt` at the
+  repository root reaches none of them, while the `fmt` CI job checks all three
+  scopes and will fail on code you never had a chance to format.
+- Run clippy and address any warnings where reasonable. It has the same three
+  scopes, and there is no single command covering them:
+
+  ```bash
+  cargo clippy --workspace --all-targets -- -D warnings
+  (cd crates/rustc-codegen-cuda && cargo clippy --all-targets -- -D warnings)
+  # and per example, as .github/workflows/clippy.yml does
+  ```
 - Follow existing code patterns and conventions in the crate you are
   modifying.
 


### PR DESCRIPTION
Closes #739.

CONTRIBUTING said *"Run `cargo fmt` before submitting"*. But
`crates/rustc-codegen-cuda` and every example are their **own workspaces** (the
backend is swapped in via RUSTFLAGS, so they cannot live in the root
`[workspace]`), and a bare `cargo fmt` at the root reaches neither — while
`fmt.yml` checks all three scopes in three separate steps.

So following the instruction literally gives you a clean local run and a red CI.

## Demonstrated

Appending an unformatted function to `crates/rustc-codegen-cuda/src/materialize.rs`:

```
$ cargo fmt --check                                              # what CONTRIBUTING said
exit 0        <- misses it entirely

$ (cd crates/rustc-codegen-cuda && cargo fmt --all -- --check)   # what CI runs
exit 1        <- catches it

$ cargo oxide fmt --check
exit 1        <- catches it
```

## The fix names a command that already exists

`cargo oxide fmt` is documented in its own `--help` as *"Format all crates (root
workspace, codegen backend, examples)"* — exactly the three scopes CI checks.
CONTRIBUTING simply never mentioned it.

Clippy has the same three scopes and **no** single covering command
(`clippy.yml` runs root, then `rustc-codegen-cuda`, then each example), so this
spells its invocations out rather than implying one command suffices.

Documentation only. No GPU needed.