### PR TITLE
docs(readme): refresh the example, crate, and subcommand inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,18 @@ cargo oxide sanitize vecadd --tool memcheck
 
 # Debug with cuda-gdb
 cargo oxide debug vecadd --tui
+
+# Run Cargo tests through the cuda-oxide backend
+cargo oxide test
+
+# Compile a crate's device code to a binary LTOIR artifact in one step
+cargo oxide emit-ltoir
+
+# Refresh the cached codegen backend
+cargo oxide update
 ```
+
+`cargo oxide --help` lists every subcommand.
 
 ## Setup
 
@@ -245,7 +256,7 @@ compiles a Rust kernel to PTX, launches it on the GPU, and prints
 
 ## Examples
 
-**60+ examples** in `crates/rustc-codegen-cuda/examples/`. Highlights:
+**190+ examples** in `crates/rustc-codegen-cuda/examples/`. Highlights:
 
 | Example              | Description                                                              |
 |----------------------|--------------------------------------------------------------------------|
@@ -278,6 +289,7 @@ cargo oxide run gemm_sol_final
 | Crate               | Description                                                               |
 |---------------------|---------------------------------------------------------------------------|
 | `cuda-device`       | Device intrinsics (`thread::*`, `warp::*`, barriers)                      |
+| `cuda-intrinsics`   | Generated low-level CUDA intrinsic declarations                           |
 | `cuda-host`         | Typed module loading, launch helpers, LTOIR loader                        |
 | `cuda-macros`       | Proc macros (`#[cuda_module]`, `#[kernel]`, `gpu_printf!`)                |
 | `cuda-bindings`     | Raw `bindgen` FFI bindings to `cuda.h`                                    |
@@ -296,12 +308,20 @@ cargo oxide run gemm_sol_final
 | `dialect-mir`        | pliron dialect modelling Rust MIR                     |
 | `llvm-export`        | pliron-llvm shim + textual `.ll` exporter             |
 | `dialect-nvvm`       | pliron dialect modelling NVVM intrinsics              |
+| `mir-transforms`     | Optimization passes over the MIR dialect (loop unroll, ...) |
+| `nvvm-transforms`    | Target-aware LLVM dialect legalization for NVVM      |
+| `cuda-oxide-codegen` | Experimental rustc-independent PTX backend           |
 
 ### Build Tooling
 
-| Crate          | Description                                          |
-|----------------|------------------------------------------------------|
-| `cargo-oxide`  | Cargo subcommand (`cargo oxide run`, etc.)           |
+| Crate                     | Description                                                    |
+|---------------------------|----------------------------------------------------------------|
+| `cargo-oxide`             | Cargo subcommand (`cargo oxide run`, etc.)                     |
+| `cuda-intrinsics-gen`     | Extractor and deterministic source generator for the intrinsics |
+| `cuda-artifact-finalizer` | Driver-independent NVVM IR and LTOIR finalization              |
+| `oxide-artifacts`         | Architecture-neutral embedded device artifact metadata         |
+| `reserved-oxide-symbols`  | Workspace-private `cuda_oxide_*` symbol-name contract          |
+| `fuzzer`                  | Differential codegen fuzzer support (rustlantis adapter)       |
 
 ### Documentation
 


### PR DESCRIPTION
Closes #741.

Three README inventories had drifted from the tree. Each is mechanically
checkable, and each is checked below.

## 1. "60+ examples" → 191

```
$ ls -d crates/rustc-codegen-cuda/examples/*/Cargo.toml | wc -l
191
```

Understated roughly threefold — the same corpus CONTRIBUTING asks pipeline
changes to be validated against. Written as "190+" so it does not go stale on the
next example.

## 2. Crate Overview listed 15 of 23 crates

Unlike the Examples table, this section carries no "Highlights" caveat, so it
reads as a complete inventory. Added:

| Crate | Table |
|---|---|
| `cuda-intrinsics` | User-Facing |
| `mir-transforms`, `nvvm-transforms`, `cuda-oxide-codegen` | Compiler |
| `cuda-intrinsics-gen`, `cuda-artifact-finalizer`, `oxide-artifacts`, `reserved-oxide-symbols`, `fuzzer` | Build Tooling |

Several are load-bearing rather than incidental: two are compiler passes, and
`reserved-oxide-symbols` is the naming contract the `naming-guard` job enforces.
Descriptions are lifted from each crate's own `Cargo.toml` `description` rather
than reworded.

## 3. Three subcommands documented nowhere

`cargo oxide --help` lists fifteen. These had **zero** mentions across
`README.md`, `CONTRIBUTING.md`, `cuda-oxide-book/` and the `Justfile`:

```
cargo oxide test        # Run Cargo tests through the cuda-oxide backend
cargo oxide emit-ltoir  # Compile device code to a binary LTOIR artifact in one step
cargo oxide update      # Refresh the cached codegen backend
```

They are in the Quick Start block now, with a pointer to `--help` for the rest.
(`list`, `fmt`, `new`, `setup` are documented in the book, so this is
specifically those three.)

## Verified

After the change, checked mechanically rather than by eye: every `crates/*`
directory appears in the Crate Overview, nothing in the overview is absent from
disk, and the example count matches the tree.

Documentation only. No GPU needed.