### PR TITLE
ci(book): build the book on pull requests, deploy only from main

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,6 +3,12 @@ name: Deploy cuda-oxide Book
 on:
   push:
     branches: [main]
+  # Validate the book on PRs too. The build job alone runs there; `deploy` is
+  # gated below, so a pull request never publishes. Without this the book was
+  # only ever built after merge, so a PR that broke it could not be caught by
+  # review or by CI.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -10,9 +16,14 @@ permissions:
   pages: write
   id-token: write
 
+# Serialising every run under one `pages` group is a deploy constraint, and
+# applying it workflow-wide would queue unrelated PR builds behind each other.
+# Scope this to the ref, and keep the single-deploy guarantee on the deploy job
+# itself. Superseded PR runs are cancelled; pushes to main are not, so a
+# publish in flight is never interrupted.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -45,6 +56,13 @@ jobs:
 
   deploy:
     needs: build
+    # Publishing is for main only. A pull request builds the book to prove it is
+    # sound and stops there; it never touches the Pages environment, and the
+    # `pages: write` / `id-token: write` permissions go unused on that path.
+    if: github.event_name != 'pull_request'
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,10 +11,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Only checkout rights by default. The Pages deployment permissions live on
+# the deploy job alone, so the build job, which is what pull requests run,
+# never holds a write token.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Serialising every run under one `pages` group is a deploy constraint, and
 # applying it workflow-wide would queue unrelated PR builds behind each other.
@@ -56,10 +57,13 @@ jobs:
 
   deploy:
     needs: build
-    # Publishing is for main only. A pull request builds the book to prove it is
-    # sound and stops there; it never touches the Pages environment, and the
-    # `pages: write` / `id-token: write` permissions go unused on that path.
+    # Publishing is for main only. A pull request builds the book to prove it
+    # is sound and stops there; it never touches the Pages environment or
+    # holds the deployment permissions below.
     if: github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
     concurrency:
       group: pages
       cancel-in-progress: false

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,8 +29,15 @@ jobs:
       - name: Install dependencies
         run: pip install -r cuda-oxide-book/requirements.txt
 
+      # `-W` matches the Rust docs gate, which builds under
+      # RUSTDOCFLAGS="-D warnings". Without it a broken cross-reference, a
+      # malformed directive or a page dropped from a toctree still exits 0 and
+      # publishes. `--keep-going` reports every warning in one run instead of
+      # stopping at the first.
       - name: Build Sphinx site
-        run: sphinx-build -b html cuda-oxide-book cuda-oxide-book/_build/html
+        run: >-
+          sphinx-build -W --keep-going -b html
+          cuda-oxide-book cuda-oxide-book/_build/html
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/cuda-oxide-book/Makefile
+++ b/cuda-oxide-book/Makefile
@@ -1,4 +1,6 @@
-SPHINXOPTS    ?=
+# Warnings are errors, as in CI (.github/workflows/book.yml) and in the Rust
+# docs gate. Override for a draft build:  SPHINXOPTS= make html
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/cuda-oxide-book/requirements.txt
+++ b/cuda-oxide-book/requirements.txt
@@ -1,4 +1,7 @@
-sphinx>=7.0
+# Upper-bounded on the major: the build runs warnings-as-errors (-W), and a
+# new Sphinx major routinely introduces warnings, which would redden every PR
+# and the main-branch deploy overnight. Bump the bound deliberately instead.
+sphinx>=7.0,<10
 pydata-sphinx-theme>=0.15
 myst-parser>=3.0
 sphinx-copybutton>=0.5


### PR DESCRIPTION
Closes #743.

**Stacked on #733 — please review only the second commit** (`fix the book build
on Sphinx warnings` is that PR). The two are halves of the same thing: #733 makes
a warning fail the build, and this makes that build actually run before merge.

## The gap

`book.yml` had no `pull_request` trigger, so the book was built **only after
merge**. Every other content gate runs on PRs:

| workflow | `pull_request`? |
|---|---|
| `ci.yml`, `docs.yml`, `examples-compile.yml`, `codeql.yml`, `naming-guard.yml`, `status-guard.yml` | yes |
| **`book.yml`** | **no** |

A PR that broke a cross-reference reached `main` unchallenged, and the first
signal was a failure on the branch everyone builds from. Combined with the
missing `-W`, the post-merge run would not have failed either.

## Why this isn't just adding the trigger

`book.yml` is a **deployment** workflow — `pages: write`, `id-token: write`, and a
`deploy` job — which is presumably why it was push-only. A naive trigger would
attempt a Pages deploy from every pull request.

So `deploy` is gated on `github.event_name != 'pull_request'`. A PR builds the
book and stops; it never touches the Pages environment, and those write
permissions go unused on that path.

The workflow-level `concurrency: group: pages` needed the same care. It exists to
serialise *deploys*; left workflow-wide it would queue unrelated PR builds behind
each other. It moves onto the `deploy` job where the constraint belongs, and the
workflow-level group becomes ref-scoped with `cancel-in-progress` only for pull
requests — so superseded PR runs are cancelled, while a publish in flight on
`main` is never interrupted.

## Verified

Parsed the workflow and checked the resulting shape rather than eyeballing it:

```
triggers: ['pull_request', 'push', 'workflow_dispatch']
workflow concurrency: group=${{ github.workflow }}-${{ github.ref }}
                      cancel-in-progress=${{ github.event_name == 'pull_request' }}
job build:  if=None                                    <- runs on PRs
job deploy: if="github.event_name != 'pull_request'"   <- never on PRs
            concurrency={'group': 'pages', 'cancel-in-progress': False}
```

No GPU needed.