### PR TITLE
fix(atomics): load the embedded CUDA module

### DIFF
--- a/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
@@ -44,7 +44,7 @@ use cuda_device::atomic::{
     AtomicOrdering, BlockAtomicU32, DeviceAtomicF32, DeviceAtomicF64, DeviceAtomicI32,
     DeviceAtomicI64, DeviceAtomicU32, DeviceAtomicU64,
 };
-use cuda_device::{kernel, thread, DisjointSlice};
+use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_module;
 
 // =============================================================================

--- a/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/atomics/src/main.rs
@@ -44,7 +44,7 @@ use cuda_device::atomic::{
     AtomicOrdering, BlockAtomicU32, DeviceAtomicF32, DeviceAtomicF64, DeviceAtomicI32,
     DeviceAtomicI64, DeviceAtomicU32, DeviceAtomicU64,
 };
-use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_device::{kernel, thread, DisjointSlice};
 use cuda_host::cuda_module;
 
 // =============================================================================
@@ -578,10 +578,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("atomics.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
 
     const N: usize = 256;
 


### PR DESCRIPTION
Refs #722

### Summary

The `atomics` example explicitly loads `atomics.ptx` from the filesystem:

```rust
ctx.load_module_from_file("atomics.ptx")
```

That works for the normal PTX path, but it is incompatible with `--materialize-cubin`, where the device artifact is embedded as a cubin rather than consumed from an external PTX file.

Use the generated `kernels::load(&ctx)` loader instead. This delegates artifact selection to the embedded-module loader and works for both PTX and materialized cubin payloads.

### Relation to #722

While investigating #722 on current `main`, I could reproduce its `cargo oxide run atomics --materialize-cubin --arch sm_120` failure, but not the reported cache-invalidation cause.

The output mode transition does rebuild the device owner:

```text
cargo oxide build atomics --arch sm_120
cargo oxide build atomics --materialize-cubin --arch sm_120
cargo oxide build atomics --arch sm_120
```

`atomics` is recompiled on each PTX → cubin → PTX transition.

The same transition also works end-to-end with `vecadd`, which already uses the embedded module loader.

The remaining `atomics` failure comes from the example explicitly opening `atomics.ptx`. Switching it to `kernels::load(&ctx)` makes the original run reproducer succeed in all three states:

```text
cargo oxide run atomics
cargo oxide run atomics --materialize-cubin --arch sm_120
cargo oxide run atomics
```

All 20 atomic runtime tests pass in each mode.

This therefore fixes the current #722 reproducer without changing the existing codegen invalidation mechanism.

### Validation

```text
cargo fmt --all
cargo test -p cargo-oxide
cargo clippy -p cargo-oxide --all-targets -- -D warnings
```

`cargo-oxide` tests:

```text
154 passed; 0 failed
```

Runtime validation:

```text
cargo oxide run atomics
# SUCCESS: All 20 atomic tests passed

cargo oxide run atomics --materialize-cubin --arch sm_120
# SUCCESS: All 20 atomic tests passed

cargo oxide run atomics
# SUCCESS: All 20 atomic tests passed
```

Control using an example that already loads embedded artifacts:

```text
cargo oxide run vecadd --arch sm_120
cargo oxide run vecadd --materialize-cubin --arch sm_120
cargo oxide run vecadd --arch sm_120
```

All three runs succeed.