### PR TITLE
Expose ptxas resource diagnostics from native finalization

### DIFF
--- a/crates/cuda-artifact-finalizer/src/diagnostics.rs
+++ b/crates/cuda-artifact-finalizer/src/diagnostics.rs
@@ -1,0 +1,188 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Parsing of non-semantic CUDA compiler resource diagnostics.
+//!
+//! nvJitLink can forward `ptxas -v` output through its InfoLog. This module
+//! converts that human-readable output into a stable internal representation
+//! without making the raw text part of artifact provenance.
+
+/// Per-kernel resource usage reported by ptxas.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KernelResourceUsage {
+    /// Kernel entry name as emitted in PTX/cubin.
+    pub kernel: String,
+    /// Register count reported by ptxas, when present.
+    pub registers: Option<u32>,
+    /// Bytes written to local memory because of register spills.
+    pub spill_store_bytes: u64,
+    /// Bytes read from local memory because of register spills.
+    pub spill_load_bytes: u64,
+}
+
+impl KernelResourceUsage {
+    /// Whether ptxas reported any register spill traffic for this kernel.
+    pub fn has_spills(&self) -> bool {
+        self.spill_store_bytes != 0 || self.spill_load_bytes != 0
+    }
+}
+
+/// Parse ptxas resource statistics from an nvJitLink InfoLog.
+///
+/// The parser intentionally keys off stable ptxas phrases rather than exact
+/// whitespace or the complete line prefix. CUDA versions vary the amount of
+/// padding around `ptxas info`, while the resource phrases themselves remain
+/// stable.
+pub(crate) fn parse_ptxas_resource_usage(log: &str) -> Vec<KernelResourceUsage> {
+    let mut usage = Vec::new();
+    let mut current_kernel: Option<String> = None;
+
+    for line in log.lines() {
+        if let Some(kernel) = kernel_name_from_line(line) {
+            ensure_kernel(&mut usage, &kernel);
+            current_kernel = Some(kernel);
+        }
+
+        let Some(kernel) = current_kernel.as_deref() else {
+            continue;
+        };
+        let entry = ensure_kernel(&mut usage, kernel);
+
+        if let Some(registers) =
+            number_before(line, " registers").and_then(|value| u32::try_from(value).ok())
+            && line.contains("Used ")
+        {
+            entry.registers = Some(entry.registers.map_or(registers, |old| old.max(registers)));
+        }
+
+        if let Some(bytes) = number_before(line, " bytes spill stores") {
+            entry.spill_store_bytes = entry.spill_store_bytes.max(bytes);
+        }
+        if let Some(bytes) = number_before(line, " bytes spill loads") {
+            entry.spill_load_bytes = entry.spill_load_bytes.max(bytes);
+        }
+    }
+
+    usage
+}
+
+fn kernel_name_from_line(line: &str) -> Option<String> {
+    if let Some(rest) = line
+        .split_once("Compiling entry function '")
+        .map(|(_, rest)| rest)
+        && let Some((kernel, _)) = rest.split_once('\'')
+        && !kernel.is_empty()
+    {
+        return Some(kernel.to_string());
+    }
+
+    if let Some((_, rest)) = line.split_once("Function properties for ") {
+        let kernel = rest.trim().trim_matches('\'');
+        if !kernel.is_empty() {
+            return Some(kernel.to_string());
+        }
+    }
+
+    None
+}
+
+fn ensure_kernel<'a>(
+    usage: &'a mut Vec<KernelResourceUsage>,
+    kernel: &str,
+) -> &'a mut KernelResourceUsage {
+    if let Some(index) = usage.iter().position(|entry| entry.kernel == kernel) {
+        return &mut usage[index];
+    }
+
+    usage.push(KernelResourceUsage {
+        kernel: kernel.to_string(),
+        registers: None,
+        spill_store_bytes: 0,
+        spill_load_bytes: 0,
+    });
+    usage.last_mut().expect("entry was just pushed")
+}
+
+fn number_before(line: &str, marker: &str) -> Option<u64> {
+    let marker_start = line.find(marker)?;
+    line[..marker_start].split_whitespace().last()?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_zero_and_nonzero_spills_for_multiple_kernels() {
+        let log = r#"
+ptxas info    : Compiling entry function 'kernel_a' for 'sm_90a'
+ptxas info    : Function properties for kernel_a
+    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
+ptxas info    : Used 128 registers, used 0 barriers, 392 bytes cmem[0]
+ptxas info    : Compiling entry function 'kernel_b' for 'sm_90a'
+ptxas info    : Function properties for kernel_b
+    32 bytes stack frame, 24 bytes spill stores, 16 bytes spill loads
+ptxas info    : Used 127 registers, used 0 barriers, 392 bytes cmem[0]
+"#;
+
+        assert_eq!(
+            parse_ptxas_resource_usage(log),
+            vec![
+                KernelResourceUsage {
+                    kernel: "kernel_a".to_string(),
+                    registers: Some(128),
+                    spill_store_bytes: 0,
+                    spill_load_bytes: 0,
+                },
+                KernelResourceUsage {
+                    kernel: "kernel_b".to_string(),
+                    registers: Some(127),
+                    spill_store_bytes: 24,
+                    spill_load_bytes: 16,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_kernel_sections_merge_conservatively() {
+        let log = r#"
+ptxas info : Compiling entry function 'kernel' for 'sm_90'
+ptxas info : 0 bytes spill stores, 0 bytes spill loads
+ptxas info : Used 64 registers
+ptxas info : Function properties for kernel
+ptxas info : 8 bytes spill stores, 4 bytes spill loads
+ptxas info : Used 72 registers
+"#;
+
+        assert_eq!(
+            parse_ptxas_resource_usage(log),
+            vec![KernelResourceUsage {
+                kernel: "kernel".to_string(),
+                registers: Some(72),
+                spill_store_bytes: 8,
+                spill_load_bytes: 4,
+            }]
+        );
+    }
+
+    #[test]
+    fn unrelated_info_log_text_is_ignored() {
+        assert!(parse_ptxas_resource_usage("nvJitLink: timing only\n").is_empty());
+    }
+
+    #[test]
+    fn has_spills_checks_both_directions() {
+        let mut usage = KernelResourceUsage {
+            kernel: "kernel".to_string(),
+            registers: None,
+            spill_store_bytes: 0,
+            spill_load_bytes: 0,
+        };
+        assert!(!usage.has_spills());
+        usage.spill_load_bytes = 4;
+        assert!(usage.has_spills());
+    }
+}

--- a/crates/cuda-artifact-finalizer/src/diagnostics.rs
+++ b/crates/cuda-artifact-finalizer/src/diagnostics.rs
@@ -16,6 +16,9 @@ pub struct KernelResourceUsage {
     pub kernel: String,
     /// Register count reported by ptxas, when present.
     pub registers: Option<u32>,
+    /// Per-thread local-memory stack frame in bytes. Nonzero when locals are
+    /// demoted to local memory; distinct from register-spill traffic.
+    pub stack_frame_bytes: u64,
     /// Bytes written to local memory because of register spills.
     pub spill_store_bytes: u64,
     /// Bytes read from local memory because of register spills.
@@ -57,6 +60,9 @@ pub(crate) fn parse_ptxas_resource_usage(log: &str) -> Vec<KernelResourceUsage> 
             entry.registers = Some(entry.registers.map_or(registers, |old| old.max(registers)));
         }
 
+        if let Some(bytes) = number_before(line, " bytes stack frame") {
+            entry.stack_frame_bytes = entry.stack_frame_bytes.max(bytes);
+        }
         if let Some(bytes) = number_before(line, " bytes spill stores") {
             entry.spill_store_bytes = entry.spill_store_bytes.max(bytes);
         }
@@ -79,7 +85,9 @@ fn kernel_name_from_line(line: &str) -> Option<String> {
     }
 
     if let Some((_, rest)) = line.split_once("Function properties for ") {
-        let kernel = rest.trim().trim_matches('\'');
+        // Some log shapes terminate the line with a colon after the (possibly
+        // quoted) name: "Function properties for '_Z3fooPi':".
+        let kernel = rest.trim().trim_end_matches(':').trim_matches('\'');
         if !kernel.is_empty() {
             return Some(kernel.to_string());
         }
@@ -99,6 +107,7 @@ fn ensure_kernel<'a>(
     usage.push(KernelResourceUsage {
         kernel: kernel.to_string(),
         registers: None,
+        stack_frame_bytes: 0,
         spill_store_bytes: 0,
         spill_load_bytes: 0,
     });
@@ -133,12 +142,14 @@ ptxas info    : Used 127 registers, used 0 barriers, 392 bytes cmem[0]
                 KernelResourceUsage {
                     kernel: "kernel_a".to_string(),
                     registers: Some(128),
+                    stack_frame_bytes: 0,
                     spill_store_bytes: 0,
                     spill_load_bytes: 0,
                 },
                 KernelResourceUsage {
                     kernel: "kernel_b".to_string(),
                     registers: Some(127),
+                    stack_frame_bytes: 32,
                     spill_store_bytes: 24,
                     spill_load_bytes: 16,
                 },
@@ -162,6 +173,26 @@ ptxas info : Used 72 registers
             vec![KernelResourceUsage {
                 kernel: "kernel".to_string(),
                 registers: Some(72),
+                stack_frame_bytes: 0,
+                spill_store_bytes: 8,
+                spill_load_bytes: 4,
+            }]
+        );
+    }
+
+    #[test]
+    fn quoted_function_properties_name_with_trailing_colon_is_unwrapped() {
+        let log = r#"
+ptxas info    : Function properties for '_Z8kernel_bPf':
+    16 bytes stack frame, 8 bytes spill stores, 4 bytes spill loads
+"#;
+
+        assert_eq!(
+            parse_ptxas_resource_usage(log),
+            vec![KernelResourceUsage {
+                kernel: "_Z8kernel_bPf".to_string(),
+                registers: None,
+                stack_frame_bytes: 16,
                 spill_store_bytes: 8,
                 spill_load_bytes: 4,
             }]
@@ -174,13 +205,16 @@ ptxas info : Used 72 registers
     }
 
     #[test]
-    fn has_spills_checks_both_directions() {
+    fn has_spills_checks_both_directions_and_ignores_stack_frame() {
         let mut usage = KernelResourceUsage {
             kernel: "kernel".to_string(),
             registers: None,
+            stack_frame_bytes: 0,
             spill_store_bytes: 0,
             spill_load_bytes: 0,
         };
+        assert!(!usage.has_spills());
+        usage.stack_frame_bytes = 32;
         assert!(!usage.has_spills());
         usage.spill_load_bytes = 4;
         assert!(usage.has_spills());

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -10,14 +10,16 @@
 //! build-time materialization and runtime fallback use the same typed target,
 //! FMA, debug, input-order, validation, and provenance rules.
 
+mod diagnostics;
 mod link;
 mod nvvm;
 mod options;
 mod provenance;
 mod validation;
 
+pub use diagnostics::KernelResourceUsage;
 pub use libnvvm_sys::{CudaArch, CudaArchParseError, LibdeviceNotFound, NvvmError, find_libdevice};
-pub use link::LtoLinker;
+pub use link::{LinkReport, LtoLinker};
 pub use nvjitlink_sys::NvJitLinkError;
 pub use nvvm::NvvmCompiler;
 pub use options::{DebugPolicy, FinalizationOptions, FinalizerOutput, NamedInput};
@@ -134,6 +136,24 @@ impl Finalizer {
         )
     }
 
+    /// Compile NVVM IR to cubin and collect ptxas resource diagnostics.
+    pub fn materialize_nvvm_ir_with_report(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        options: &FinalizationOptions,
+    ) -> Result<LinkReport, FinalizerError> {
+        let ltoir = self
+            .compiler
+            .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
+        let ltoir_name = format!("{module_name}.ltoir");
+        self.linker.link_ltoir_with_report(
+            &[NamedInput::new(&ltoir_name, &ltoir)],
+            options,
+            FinalizerOutput::Cubin,
+        )
+    }
+
     /// Link ordered LTOIR modules to cubin or PTX.
     pub fn link_ltoir(
         &self,
@@ -142,6 +162,16 @@ impl Finalizer {
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
         self.linker.link_ltoir(inputs, options, output)
+    }
+
+    /// Link ordered LTOIR modules while collecting ptxas resource diagnostics.
+    pub fn link_ltoir_with_report(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.linker.link_ltoir_with_report(inputs, options, output)
     }
 
     /// Compiler component, including exact libdevice bytes and provenance.

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -137,6 +137,11 @@ impl Finalizer {
     }
 
     /// Compile NVVM IR to cubin and collect ptxas resource diagnostics.
+    ///
+    /// The diagnostics are best-effort: on an nvJitLink too old to accept the
+    /// reporting options, the link is retried without them and the report's
+    /// info log and resource usage are empty. See
+    /// [`LtoLinker::link_ltoir_with_report`].
     pub fn materialize_nvvm_ir_with_report(
         &self,
         module_name: &str,
@@ -165,6 +170,11 @@ impl Finalizer {
     }
 
     /// Link ordered LTOIR modules while collecting ptxas resource diagnostics.
+    ///
+    /// The diagnostics are best-effort: on an nvJitLink too old to accept the
+    /// reporting options, the link is retried without them and the report's
+    /// info log and resource usage are empty. See
+    /// [`LtoLinker::link_ltoir_with_report`].
     pub fn link_ltoir_with_report(
         &self,
         inputs: &[NamedInput<'_>],

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -341,4 +341,125 @@ entry:
             );
         }
     }
+
+    /// Legacy-dialect NVVM IR for a kernel that ptxas must spill: `values`
+    /// floats stay live across `rounds` of all-to-all mixing while a
+    /// `maxnreg` annotation caps the kernel far below that live set.
+    fn spilling_kernel_nvvm_ir(values: usize, rounds: usize, maxnreg: u32) -> String {
+        use std::fmt::Write;
+
+        let mut body = String::new();
+        for i in 0..values {
+            let _ = writeln!(
+                body,
+                "  %ptr{i} = getelementptr inbounds float, float* %data, i64 {i}"
+            );
+            let _ = writeln!(body, "  %v0_{i} = load float, float* %ptr{i}, align 4");
+        }
+        for round in 0..rounds {
+            let next = round + 1;
+            for i in 0..values {
+                let mul_with = (i + 1) % values;
+                let add_with = (i + 3) % values;
+                let _ = writeln!(
+                    body,
+                    "  %m{next}_{i} = fmul float %v{round}_{i}, %v{round}_{mul_with}"
+                );
+                let _ = writeln!(
+                    body,
+                    "  %v{next}_{i} = fadd float %m{next}_{i}, %v{round}_{add_with}"
+                );
+            }
+        }
+        for i in 0..values {
+            let _ = writeln!(
+                body,
+                "  store float %v{rounds}_{i}, float* %ptr{i}, align 4"
+            );
+        }
+
+        // `@llvm.used` keeps the kernel alive through LTO, exactly as
+        // cuda-oxide's NVVM exporter emits it for real kernels; without it
+        // nvJitLink dead-strips the annotation-marked kernel and links an
+        // empty module.
+        format!(
+            r#"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+@llvm.used = appending global [1 x i8*] [i8* bitcast (void (float*)* @spill_kernel to i8*)], section "llvm.metadata"
+
+define void @spill_kernel(float* %data) {{
+entry:
+{body}  ret void
+}}
+
+!nvvm.annotations = !{{!0, !1}}
+!nvvmir.version = !{{!2}}
+!0 = !{{void (float*)* @spill_kernel, !"kernel", i32 1}}
+!1 = !{{void (float*)* @spill_kernel, !"maxnreg", i32 {maxnreg}}}
+!2 = !{{i32 2, i32 0, i32 3, i32 1}}
+"#
+        )
+    }
+
+    #[test]
+    #[ignore = "requires discoverable CUDA Toolkit libNVVM, nvJitLink, and libdevice"]
+    fn live_link_report_parses_ptxas_resource_usage_for_a_spilling_kernel() {
+        const MAXNREG: u32 = 32;
+
+        let finalizer = Finalizer::discover().unwrap();
+        let options = FinalizationOptions::new("sm_86".parse().unwrap());
+        let nvvm_ir = spilling_kernel_nvvm_ir(64, 4, MAXNREG);
+        let ltoir = finalizer
+            .compiler()
+            .compile_nvvm_ir_to_ltoir("spill.ll", nvvm_ir.as_bytes(), &options)
+            .unwrap();
+        let input = [NamedInput::new("spill.ltoir", &ltoir)];
+
+        let report = finalizer
+            .link_ltoir_with_report(&input, &options, FinalizerOutput::Cubin)
+            .unwrap();
+        assert!(is_valid_cubin(&report.image));
+
+        // A missing info log means the toolkit silently degraded the report;
+        // this test exists exactly to catch the diagnostic options or the log
+        // format drifting away from what the parser expects.
+        let raw_log = report
+            .info_log
+            .as_deref()
+            .expect("nvJitLink accepted the diagnostic options and produced an info log");
+        println!("--- raw nvJitLink info log ---\n{raw_log}");
+        println!(
+            "--- parsed resource usage ---\n{:#?}",
+            report.resource_usage
+        );
+
+        let usage = report
+            .resource_usage
+            .iter()
+            .find(|usage| usage.kernel == "spill_kernel")
+            .expect("ptxas resource lines for spill_kernel were parsed from the info log");
+        let registers = usage
+            .registers
+            .expect("ptxas reported a register count for spill_kernel");
+        assert!(
+            (1..=MAXNREG).contains(&registers),
+            "maxnreg({MAXNREG}) kernel reported an implausible register count: {registers}"
+        );
+        assert!(
+            usage.has_spills(),
+            "64 live values under maxnreg({MAXNREG}) must spill: {usage:?}"
+        );
+        for (figure, bytes) in [
+            ("stack frame", usage.stack_frame_bytes),
+            ("spill stores", usage.spill_store_bytes),
+            ("spill loads", usage.spill_load_bytes),
+        ] {
+            assert!(
+                (1..=65_536).contains(&bytes),
+                "implausible {figure} byte count for spill_kernel: {bytes}"
+            );
+        }
+    }
 }

--- a/crates/cuda-artifact-finalizer/src/link.rs
+++ b/crates/cuda-artifact-finalizer/src/link.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::diagnostics::{KernelResourceUsage, parse_ptxas_resource_usage};
 use crate::nvvm::{loaded_tool_digest, report_changed_tool};
 use crate::options::{FinalizationOptions, FinalizerOutput, NamedInput};
 use crate::provenance::{
@@ -11,7 +12,7 @@ use crate::provenance::{
 };
 use crate::validation::is_valid_cubin;
 use crate::{FinalizerError, validate_name};
-use nvjitlink_sys::{InputType, LibNvJitLink, Linker};
+use nvjitlink_sys::{InputType, LibNvJitLink, LinkOutput, Linker};
 use std::sync::{Arc, Mutex, OnceLock};
 
 struct LoadedLinkerTool {
@@ -21,6 +22,17 @@ struct LoadedLinkerTool {
 
 static LINKER_TOOL: OnceLock<Arc<LoadedLinkerTool>> = OnceLock::new();
 static LINKER_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Final linker output plus resource diagnostics collected from ptxas.
+#[derive(Debug)]
+pub struct LinkReport {
+    /// Complete cubin or PTX image.
+    pub image: Vec<u8>,
+    /// Raw nvJitLink informational output, when available.
+    pub info_log: Option<String>,
+    /// Per-kernel ptxas resource usage parsed from the informational output.
+    pub resource_usage: Vec<KernelResourceUsage>,
+}
 
 /// Driver-independent ordered LTOIR linker.
 #[derive(Clone)]
@@ -60,13 +72,39 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
+        Ok(self.link_ltoir_impl(inputs, options, output, false)?.image)
+    }
+
+    /// Link LTOIR while collecting non-semantic ptxas resource diagnostics.
+    ///
+    /// For cubin output this requests nvJitLink verbose output and `ptxas -v`.
+    /// Those reporting flags are intentionally excluded from artifact digests.
+    pub fn link_ltoir_with_report(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.link_ltoir_impl(inputs, options, output, true)
+    }
+
+    fn link_ltoir_impl(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+        collect_resource_usage: bool,
+    ) -> Result<LinkReport, FinalizerError> {
         validate_inputs(inputs)?;
         with_revalidated_tool_identity(
             "nvJitLink",
             self.tool.digest,
             || current_linker_tool_digest(&self.tool),
             || {
-                let option_storage = options.nvjitlink_options(output);
+                let mut option_storage = options.nvjitlink_options(output);
+                if collect_resource_usage {
+                    option_storage.extend(options.nvjitlink_diagnostic_options(output));
+                }
                 let option_refs = option_storage
                     .iter()
                     .map(String::as_str)
@@ -75,9 +113,10 @@ impl LtoLinker {
                 for input in inputs {
                     linker.add(InputType::Ltoir, input.bytes, input.name)?;
                 }
-                let image = match output {
-                    FinalizerOutput::Cubin => linker.finish()?,
-                    FinalizerOutput::Ptx => linker.finish_ptx()?,
+
+                let LinkOutput { image, info_log } = match output {
+                    FinalizerOutput::Cubin => linker.finish_with_info_log()?,
+                    FinalizerOutput::Ptx => linker.finish_ptx_with_info_log()?,
                 };
                 if output == FinalizerOutput::Cubin && !is_valid_cubin(&image) {
                     return Err(FinalizerError::InvalidCubin);
@@ -85,7 +124,20 @@ impl LtoLinker {
                 if output == FinalizerOutput::Ptx && image.is_empty() {
                     return Err(FinalizerError::EmptyPtx);
                 }
-                Ok(image)
+
+                let resource_usage = if collect_resource_usage {
+                    info_log
+                        .as_deref()
+                        .map(parse_ptxas_resource_usage)
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+                Ok(LinkReport {
+                    image,
+                    info_log,
+                    resource_usage,
+                })
             },
         )
     }

--- a/crates/cuda-artifact-finalizer/src/link.rs
+++ b/crates/cuda-artifact-finalizer/src/link.rs
@@ -77,8 +77,15 @@ impl LtoLinker {
 
     /// Link LTOIR while collecting non-semantic ptxas resource diagnostics.
     ///
-    /// For cubin output this requests nvJitLink verbose output and `ptxas -v`.
-    /// Those reporting flags are intentionally excluded from artifact digests.
+    /// For cubin output this requests nvJitLink verbose output and `ptxas -v`,
+    /// and bypasses nvJitLink's own JIT cache: a cache hit skips ptxas and
+    /// would return an empty report. The reporting flags are intentionally
+    /// excluded from artifact digests.
+    ///
+    /// The report is best-effort: if the loaded nvJitLink rejects the
+    /// reporting options with `NVJITLINK_ERROR_UNRECOGNIZED_OPTION`, the link
+    /// is retried once without them and the returned [`LinkReport`] carries
+    /// the linked image with no info log and no resource usage.
     pub fn link_ltoir_with_report(
         &self,
         inputs: &[NamedInput<'_>],
@@ -101,45 +108,67 @@ impl LtoLinker {
             self.tool.digest,
             || current_linker_tool_digest(&self.tool),
             || {
-                let mut option_storage = options.nvjitlink_options(output);
-                if collect_resource_usage {
-                    option_storage.extend(options.nvjitlink_diagnostic_options(output));
+                match self.run_link(inputs, options, output, collect_resource_usage) {
+                    // Older nvJitLink versions reject the diagnostic-only
+                    // reporting options with NVJITLINK_ERROR_UNRECOGNIZED_OPTION.
+                    // The caller asked for the same program plus a best-effort
+                    // report, so degrade to a plain link with an empty report
+                    // rather than failing the whole link.
+                    Err(FinalizerError::NvJitLink(error))
+                        if collect_resource_usage && error.is_unrecognized_option() =>
+                    {
+                        self.run_link(inputs, options, output, false)
+                    }
+                    result => result,
                 }
-                let option_refs = option_storage
-                    .iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>();
-                let mut linker = Linker::new(&self.tool.library, &option_refs)?;
-                for input in inputs {
-                    linker.add(InputType::Ltoir, input.bytes, input.name)?;
-                }
-
-                let LinkOutput { image, info_log } = match output {
-                    FinalizerOutput::Cubin => linker.finish_with_info_log()?,
-                    FinalizerOutput::Ptx => linker.finish_ptx_with_info_log()?,
-                };
-                if output == FinalizerOutput::Cubin && !is_valid_cubin(&image) {
-                    return Err(FinalizerError::InvalidCubin);
-                }
-                if output == FinalizerOutput::Ptx && image.is_empty() {
-                    return Err(FinalizerError::EmptyPtx);
-                }
-
-                let resource_usage = if collect_resource_usage {
-                    info_log
-                        .as_deref()
-                        .map(parse_ptxas_resource_usage)
-                        .unwrap_or_default()
-                } else {
-                    Vec::new()
-                };
-                Ok(LinkReport {
-                    image,
-                    info_log,
-                    resource_usage,
-                })
             },
         )
+    }
+
+    fn run_link(
+        &self,
+        inputs: &[NamedInput<'_>],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+        collect_resource_usage: bool,
+    ) -> Result<LinkReport, FinalizerError> {
+        let mut option_storage = options.nvjitlink_options(output);
+        if collect_resource_usage {
+            option_storage.extend(options.nvjitlink_diagnostic_options(output));
+        }
+        let option_refs = option_storage
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        let mut linker = Linker::new(&self.tool.library, &option_refs)?;
+        for input in inputs {
+            linker.add(InputType::Ltoir, input.bytes, input.name)?;
+        }
+
+        let LinkOutput { image, info_log } = match output {
+            FinalizerOutput::Cubin => linker.finish_with_info_log()?,
+            FinalizerOutput::Ptx => linker.finish_ptx_with_info_log()?,
+        };
+        if output == FinalizerOutput::Cubin && !is_valid_cubin(&image) {
+            return Err(FinalizerError::InvalidCubin);
+        }
+        if output == FinalizerOutput::Ptx && image.is_empty() {
+            return Err(FinalizerError::EmptyPtx);
+        }
+
+        let resource_usage = if collect_resource_usage {
+            info_log
+                .as_deref()
+                .map(parse_ptxas_resource_usage)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        Ok(LinkReport {
+            image,
+            info_log,
+            resource_usage,
+        })
     }
 
     /// Digest every semantic input to an ordered LTOIR link.

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -99,10 +99,19 @@ impl FinalizationOptions {
     ///
     /// These options deliberately stay out of artifact provenance and cache keys:
     /// they request compiler reporting without changing the generated program.
+    ///
+    /// `-no-cache` bypasses nvJitLink's own JIT cache for cubin output. A
+    /// cache hit skips ptxas entirely and replays no info log, so a warm link
+    /// would silently return an empty resource report; the report path exists
+    /// to observe a real compile.
     pub(crate) fn nvjitlink_diagnostic_options(&self, output: FinalizerOutput) -> Vec<String> {
         match output {
             FinalizerOutput::Cubin => {
-                vec!["-verbose".to_string(), "-Xptxas=-v".to_string()]
+                vec![
+                    "-verbose".to_string(),
+                    "-Xptxas=-v".to_string(),
+                    "-no-cache".to_string(),
+                ]
             }
             FinalizerOutput::Ptx => vec!["-verbose".to_string()],
         }
@@ -190,17 +199,18 @@ mod tests {
 
         assert_eq!(
             options.nvjitlink_diagnostic_options(FinalizerOutput::Cubin),
-            ["-verbose", "-Xptxas=-v"]
+            ["-verbose", "-Xptxas=-v", "-no-cache"]
         );
         assert_eq!(
             options.nvjitlink_diagnostic_options(FinalizerOutput::Ptx),
             ["-verbose"]
         );
+        let diagnostic = options.nvjitlink_diagnostic_options(FinalizerOutput::Cubin);
         assert!(
             options
                 .nvjitlink_options(FinalizerOutput::Cubin)
                 .iter()
-                .all(|option| option != "-verbose" && option != "-Xptxas=-v")
+                .all(|option| !diagnostic.contains(option))
         );
     }
 

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -95,6 +95,19 @@ impl FinalizationOptions {
         options
     }
 
+    /// Non-semantic nvJitLink options used only to collect resource diagnostics.
+    ///
+    /// These options deliberately stay out of artifact provenance and cache keys:
+    /// they request compiler reporting without changing the generated program.
+    pub(crate) fn nvjitlink_diagnostic_options(&self, output: FinalizerOutput) -> Vec<String> {
+        match output {
+            FinalizerOutput::Cubin => {
+                vec!["-verbose".to_string(), "-Xptxas=-v".to_string()]
+            }
+            FinalizerOutput::Ptx => vec!["-verbose".to_string()],
+        }
+    }
+
     fn fma_option(&self) -> &'static str {
         if self.allow_fma_contraction {
             "-fma=1"
@@ -168,6 +181,26 @@ mod tests {
             base.with_debug_policy(DebugPolicy::Full)
                 .nvjitlink_options(FinalizerOutput::Cubin),
             ["-arch=sm_90a", "-lto", "-fma=0", "-g"]
+        );
+    }
+
+    #[test]
+    fn resource_diagnostics_are_separate_from_semantic_link_options() {
+        let options = FinalizationOptions::new("sm_90a".parse().unwrap());
+
+        assert_eq!(
+            options.nvjitlink_diagnostic_options(FinalizerOutput::Cubin),
+            ["-verbose", "-Xptxas=-v"]
+        );
+        assert_eq!(
+            options.nvjitlink_diagnostic_options(FinalizerOutput::Ptx),
+            ["-verbose"]
+        );
+        assert!(
+            options
+                .nvjitlink_options(FinalizerOutput::Cubin)
+                .iter()
+                .all(|option| option != "-verbose" && option != "-Xptxas=-v")
         );
     }
 

--- a/crates/nvjitlink-sys/src/lib.rs
+++ b/crates/nvjitlink-sys/src/lib.rs
@@ -60,6 +60,8 @@ struct NvJitLinkResult(c_int);
 
 impl NvJitLinkResult {
     const SUCCESS: Self = Self(0);
+    /// `NVJITLINK_ERROR_UNRECOGNIZED_OPTION` from `nvJitLink.h`.
+    const UNRECOGNIZED_OPTION: Self = Self(1);
 }
 
 /// nvJitLink input kinds (`nvJitLinkInputType`). Mirrors `nvJitLink.h`.
@@ -148,6 +150,21 @@ pub enum NvJitLinkError {
         /// nvJitLink error log, if available.
         log: Option<String>,
     },
+}
+
+impl NvJitLinkError {
+    /// Whether nvJitLink rejected an option string with
+    /// `NVJITLINK_ERROR_UNRECOGNIZED_OPTION`.
+    ///
+    /// Callers that pass optional, non-semantic options (for example
+    /// diagnostic reporting flags) can use this to detect an older nvJitLink
+    /// that predates the option and retry without it.
+    pub fn is_unrecognized_option(&self) -> bool {
+        matches!(
+            self,
+            Self::Call { code, .. } if *code == NvJitLinkResult::UNRECOGNIZED_OPTION.0
+        )
+    }
 }
 
 // ============================================================================
@@ -879,6 +896,24 @@ mod tests {
     }
 
     #[test]
+    fn unrecognized_option_is_detected_only_for_its_result_code() {
+        let unrecognized = NvJitLinkError::Call {
+            operation: "nvJitLinkCreate",
+            code: NvJitLinkResult::UNRECOGNIZED_OPTION.0,
+            log: None,
+        };
+        assert!(unrecognized.is_unrecognized_option());
+
+        let other_call = NvJitLinkError::Call {
+            operation: "nvJitLinkComplete",
+            code: 6,
+            log: None,
+        };
+        assert!(!other_call.is_unrecognized_option());
+        assert!(!NvJitLinkError::PtxOutputUnavailable.is_unrecognized_option());
+    }
+
+    #[test]
     fn ptx_input_has_exactly_one_terminal_nul_in_ffi_backing() {
         let poisoned_storage = b".version 7.1\nX";
         let ptx = &poisoned_storage[..poisoned_storage.len() - 1];
@@ -957,6 +992,20 @@ mod tests {
                 PathBuf::from("/usr/local/cuda"),
                 PathBuf::from("/opt/cuda"),
             ]
+        );
+    }
+
+    #[test]
+    #[ignore = "requires an installed CUDA Toolkit with nvJitLink"]
+    fn installed_toolkit_rejects_unknown_options_with_unrecognized_option() {
+        let library = LibNvJitLink::load().expect("load nvJitLink");
+        let Err(error) = Linker::new(&library, &["-arch=sm_86", "-cuda-oxide-unknown-option"])
+        else {
+            panic!("nvJitLink accepts only documented options");
+        };
+        assert!(
+            error.is_unrecognized_option(),
+            "expected NVJITLINK_ERROR_UNRECOGNIZED_OPTION, got: {error}"
         );
     }
 

--- a/crates/nvjitlink-sys/src/lib.rs
+++ b/crates/nvjitlink-sys/src/lib.rs
@@ -327,6 +327,18 @@ impl LibNvJitLink {
 // Linker (RAII)
 // ============================================================================
 
+/// Linked image plus nvJitLink's best-effort informational log.
+///
+/// The log is populated when the selected nvJitLink options request
+/// informational output, for example `-verbose` or `-Xptxas=-v`.
+#[derive(Debug)]
+pub struct LinkOutput {
+    /// Complete cubin or PTX bytes returned by nvJitLink.
+    pub image: Vec<u8>,
+    /// Informational messages emitted by nvJitLink and its compiler stages.
+    pub info_log: Option<String>,
+}
+
 /// RAII wrapper around an `nvJitLinkHandle`.
 ///
 /// Typical usage:
@@ -423,6 +435,15 @@ impl<'a> Linker<'a> {
     /// If `CUDA_OXIDE_VERBOSE` is set in the environment, the nvJitLink
     /// info log (timings, sm_XY chosen, etc.) is forwarded to `stderr`.
     pub fn finish(self) -> Result<Vec<u8>, NvJitLinkError> {
+        Ok(self.finish_with_info_log()?.image)
+    }
+
+    /// Drive the link and return the cubin together with the nvJitLink info log.
+    ///
+    /// Unlike [`Self::finish`], this preserves informational compiler output for
+    /// callers that need structured post-link diagnostics. The raw log remains
+    /// best-effort: nvJitLink is allowed to produce no informational messages.
+    pub fn finish_with_info_log(self) -> Result<LinkOutput, NvJitLinkError> {
         let r = unsafe { (self.nvj.complete)(self.handle) };
         check(self.nvj, &self, r, "nvJitLinkComplete")?;
 
@@ -430,19 +451,19 @@ impl<'a> Linker<'a> {
         let r = unsafe { (self.nvj.get_linked_cubin_size)(self.handle, &mut size) };
         check(self.nvj, &self, r, "nvJitLinkGetLinkedCubinSize")?;
 
-        let mut buf = vec![0u8; size];
+        let mut image = vec![0u8; size];
         let r =
-            unsafe { (self.nvj.get_linked_cubin)(self.handle, buf.as_mut_ptr() as *mut c_void) };
+            unsafe { (self.nvj.get_linked_cubin)(self.handle, image.as_mut_ptr() as *mut c_void) };
         check(self.nvj, &self, r, "nvJitLinkGetLinkedCubin")?;
 
-        // Forward the info log if anyone is listening (helpful with `-verbose`).
-        if let Some(info) = self.try_info_log()
+        let info_log = self.try_info_log();
+        if let Some(info) = info_log.as_deref()
             && std::env::var_os("CUDA_OXIDE_VERBOSE").is_some()
         {
             eprintln!("--- nvJitLink info log ---\n{info}");
         }
 
-        Ok(buf)
+        Ok(LinkOutput { image, info_log })
     }
 
     /// Drive the link and return linked PTX text.
@@ -455,6 +476,11 @@ impl<'a> Linker<'a> {
     /// The PTX functions are optional so older nvJitLink versions can still
     /// produce cubins.
     pub fn finish_ptx(self) -> Result<Vec<u8>, NvJitLinkError> {
+        Ok(self.finish_ptx_with_info_log()?.image)
+    }
+
+    /// Drive the link and return linked PTX together with the nvJitLink info log.
+    pub fn finish_ptx_with_info_log(self) -> Result<LinkOutput, NvJitLinkError> {
         let get_size = self
             .nvj
             .get_linked_ptx_size
@@ -471,17 +497,18 @@ impl<'a> Linker<'a> {
         let r = unsafe { get_size(self.handle, &mut size) };
         check(self.nvj, &self, r, "nvJitLinkGetLinkedPtxSize")?;
 
-        let mut buf = vec![0u8; size];
-        let r = unsafe { get(self.handle, buf.as_mut_ptr() as *mut c_char) };
+        let mut image = vec![0u8; size];
+        let r = unsafe { get(self.handle, image.as_mut_ptr() as *mut c_char) };
         check(self.nvj, &self, r, "nvJitLinkGetLinkedPtx")?;
 
-        if let Some(info) = self.try_info_log()
+        let info_log = self.try_info_log();
+        if let Some(info) = info_log.as_deref()
             && std::env::var_os("CUDA_OXIDE_VERBOSE").is_some()
         {
             eprintln!("--- nvJitLink info log ---\n{info}");
         }
 
-        Ok(buf)
+        Ok(LinkOutput { image, info_log })
     }
 
     /// Best-effort retrieval of the error log.


### PR DESCRIPTION
Part of #708 

## Summary

Adds structured access to `ptxas` resource diagnostics produced during nvJitLink finalization.

This is the first part of #708. It provides the resource-reporting infrastructure needed for a later change to warn when kernels compiled with `#[launch_bounds]` spill registers.

## Changes

* preserve the nvJitLink informational log alongside linked cubin/PTX output;
* request verbose nvJitLink / `ptxas` reporting when resource diagnostics are explicitly collected;
* parse per-kernel:

  * register usage;
  * spill store bytes;
  * spill load bytes;
* expose the parsed resource data through `LinkReport`;
* keep diagnostic-only nvJitLink options separate from semantic link options so they do not affect provenance or artifact cache keys.

Existing `finish`, `finish_ptx`, and normal finalization APIs retain their previous behavior.

## Testing

Added unit coverage for:

* zero and non-zero spill reports;
* multiple kernels in one log;
* repeated resource sections;
* unrelated informational output;
* spill detection in either direction;
* separation of diagnostic and semantic nvJitLink options.

Validated with:

```text
cargo fmt --all
cargo check
cargo test
cargo clippy --all-targets -- -D warnings
```

All checks pass.
