### PR TITLE
feat(cuda-core): expose the primary context's device limits

### DIFF
--- a/crates/cuda-core/src/context.rs
+++ b/crates/cuda-core/src/context.rs
@@ -88,6 +88,108 @@ impl PartialEq for CudaContext {
 }
 impl Eq for CudaContext {}
 
+/// A per-context device limit (`CU_LIMIT_*`), read with
+/// [`CudaContext::limit`] and written with [`CudaContext::set_limit`].
+///
+/// Every limit is state on the device's **primary** context, so it is shared
+/// by every [`CudaContext`] for that device, by any runtime-API user of the
+/// same device in this process, and across library boundaries. A limit set
+/// here is not scoped to the handle that set it.
+///
+/// The driver is free to clamp or round a request. Read the limit back after
+/// setting it to observe what was actually applied.
+///
+/// # Ordering constraints
+///
+/// [`PrintfFifoSize`](Self::PrintfFifoSize) and
+/// [`MallocHeapSize`](Self::MallocHeapSize) must be set **before the first
+/// kernel launch in the process that uses `printf` or device `malloc`**;
+/// afterwards the driver rejects the write with `CUDA_ERROR_INVALID_VALUE`.
+/// Because the limit lives on the shared primary context, "first launch"
+/// counts launches made through any handle, not just this one.
+///
+/// # Omitted variants
+///
+/// `CU_LIMIT_SHMEM_SIZE`, `CU_LIMIT_CIG_ENABLED` and
+/// `CU_LIMIT_CIG_SHMEM_FALLBACK_ENABLED` are absent. The first two are
+/// query-only, all three concern CIG (graphics-interop) contexts, and none
+/// predates CUDA 12.5, so naming them would need a header probe and a `cfg`
+/// in the manner of `cuda_has_cuEventElapsedTime_v2`. The seven variants
+/// below have been present since CUDA 11 and are the ones
+/// `cuCtxSetLimit`'s own documentation specifies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextLimit {
+    /// Stack size in bytes for each GPU thread (`CU_LIMIT_STACK_SIZE`).
+    ///
+    /// The driver raises this on its own whenever a launched kernel needs a
+    /// larger frame and **does not lower it again**, so a read reflects the
+    /// high-water mark of everything launched in this context so far. The
+    /// reservation scales as roughly `bytes * mp_count * threads_per_mp` and
+    /// is invisible to the allocation APIs: it simply reduces the device
+    /// memory a later allocation can obtain. Lowering it after a deep-frame
+    /// kernel has raised it is how that memory is handed back.
+    StackSize,
+    /// Size in bytes of the FIFO backing the device `printf`
+    /// (`CU_LIMIT_PRINTF_FIFO_SIZE`).
+    ///
+    /// The FIFO is circular: once a launch fills it, the **oldest** output is
+    /// overwritten and lost silently, with no error and no marker in the
+    /// stream the host prints. Raising this is the only fix for a kernel
+    /// whose output is truncated. Subject to the ordering constraint above.
+    PrintfFifoSize,
+    /// Size in bytes of the heap backing device `malloc` and `free`
+    /// (`CU_LIMIT_MALLOC_HEAP_SIZE`). Subject to the ordering constraint
+    /// above.
+    MallocHeapSize,
+    /// Maximum grid nesting depth at which a device-runtime thread may call
+    /// `cudaDeviceSynchronize` (`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`).
+    ///
+    /// Applies only to devices of compute capability below 9.0; elsewhere the
+    /// driver returns `CUDA_ERROR_UNSUPPORTED_LIMIT`. Each level of depth
+    /// reserves device memory, so a request the driver cannot back fails with
+    /// `CUDA_ERROR_OUT_OF_MEMORY` and leaves the limit settable at a lower
+    /// value.
+    DevRuntimeSyncDepth,
+    /// Maximum number of outstanding device-runtime launches from this
+    /// context (`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`), default 2048.
+    ///
+    /// Reserves device memory in proportion, and fails the same way as
+    /// [`DevRuntimeSyncDepth`](Self::DevRuntimeSyncDepth) when the
+    /// reservation cannot be met.
+    DevRuntimePendingLaunchCount,
+    /// L2 fetch granularity in bytes, 0 to 128
+    /// (`CU_LIMIT_MAX_L2_FETCH_GRANULARITY`). A hint: the platform may ignore
+    /// or clamp it, and a read need not return what was written.
+    MaxL2FetchGranularity,
+    /// Bytes of L2 set aside for persisting lines
+    /// (`CU_LIMIT_PERSISTING_L2_CACHE_SIZE`). A hint, with the same caveat as
+    /// [`MaxL2FetchGranularity`](Self::MaxL2FetchGranularity).
+    PersistingL2CacheSize,
+}
+
+impl ContextLimit {
+    /// Maps to the raw `CUlimit` the driver expects.
+    fn to_raw(self) -> cuda_bindings::CUlimit {
+        match self {
+            ContextLimit::StackSize => cuda_bindings::CUlimit_enum_CU_LIMIT_STACK_SIZE,
+            ContextLimit::PrintfFifoSize => cuda_bindings::CUlimit_enum_CU_LIMIT_PRINTF_FIFO_SIZE,
+            ContextLimit::MallocHeapSize => cuda_bindings::CUlimit_enum_CU_LIMIT_MALLOC_HEAP_SIZE,
+            ContextLimit::DevRuntimeSyncDepth => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH
+            }
+            ContextLimit::DevRuntimePendingLaunchCount => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT
+            }
+            ContextLimit::MaxL2FetchGranularity => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_MAX_L2_FETCH_GRANULARITY
+            }
+            ContextLimit::PersistingL2CacheSize => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_PERSISTING_L2_CACHE_SIZE
+            }
+        }
+    }
+}
+
 /// Context scheduling policy (`CU_CTX_SCHED_*`), governing how the driver
 /// waits when the calling host thread blocks on GPU work (a stream or
 /// context synchronize).
@@ -408,49 +510,61 @@ impl CudaContext {
         )
     }
 
-    /// Queries the per-thread device stack size, in bytes.
+    /// Reads a device limit off this context.
     ///
-    /// Wraps `cuCtxGetLimit(CU_LIMIT_STACK_SIZE, ..)`. The driver raises this
-    /// limit on its own whenever a launched kernel needs a larger frame, and
-    /// **does not lower it again afterwards**, so the value read here reflects
-    /// the high-water mark of everything launched in this context so far.
-    pub fn stack_size(&self) -> Result<usize, DriverError> {
+    /// Wraps `cuCtxGetLimit`. See [`ContextLimit`] for what each limit means,
+    /// which of them the driver treats as a hint, and why the value read back
+    /// need not equal the value written.
+    pub fn limit(&self, limit: ContextLimit) -> Result<usize, DriverError> {
         self.bind_to_thread()?;
         let mut value = MaybeUninit::uninit();
         unsafe {
-            cuda_bindings::cuCtxGetLimit(
-                value.as_mut_ptr(),
-                cuda_bindings::CUlimit_enum_CU_LIMIT_STACK_SIZE,
-            )
-            .result()?;
+            cuda_bindings::cuCtxGetLimit(value.as_mut_ptr(), limit.to_raw()).result()?;
             Ok(value.assume_init())
         }
     }
 
+    /// Writes a device limit on this context.
+    ///
+    /// Wraps `cuCtxSetLimit`. The limit is state on the device's primary
+    /// context and therefore shared process-wide; see [`ContextLimit`] for the
+    /// per-limit restrictions, including the launch-ordering constraint on
+    /// [`PrintfFifoSize`](ContextLimit::PrintfFifoSize) and
+    /// [`MallocHeapSize`](ContextLimit::MallocHeapSize).
+    ///
+    /// The driver may clamp or round the request, so call
+    /// [`limit`](Self::limit) afterwards to observe what was applied. A write
+    /// takes effect immediately and may block until previously submitted work
+    /// completes.
+    pub fn set_limit(&self, limit: ContextLimit, value: usize) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        unsafe { cuda_bindings::cuCtxSetLimit(limit.to_raw(), value) }.result()
+    }
+
+    /// Queries the per-thread device stack size, in bytes.
+    ///
+    /// Equivalent to [`limit`](Self::limit) with
+    /// [`ContextLimit::StackSize`], whose documentation describes how the
+    /// driver maintains this value.
+    pub fn stack_size(&self) -> Result<usize, DriverError> {
+        self.limit(ContextLimit::StackSize)
+    }
+
     /// Sets the per-thread device stack size, in bytes.
     ///
-    /// Wraps `cuCtxSetLimit(CU_LIMIT_STACK_SIZE, ..)`. The limit is state on
-    /// the device's primary context, shared by every [`CudaContext`] for this
-    /// device and by any runtime-API user of the same device. The driver
-    /// reserves `bytes` for *every* thread that can be resident on the device,
-    /// so the reservation scales as roughly `bytes * mp_count * threads_per_mp`,
-    /// using [`multiprocessor_count`](Self::multiprocessor_count) and
+    /// Equivalent to [`set_limit`](Self::set_limit) with
+    /// [`ContextLimit::StackSize`]. The driver reserves `bytes` for *every*
+    /// thread that can be resident on the device, so the reservation scales as
+    /// roughly `bytes * mp_count * threads_per_mp`, using
+    /// [`multiprocessor_count`](Self::multiprocessor_count) and
     /// [`max_threads_per_multiprocessor`](Self::max_threads_per_multiprocessor).
-    /// That reservation is invisible to allocation APIs: it simply reduces the
-    /// device memory a subsequent allocation can obtain. Lowering the limit
-    /// after a deep-frame kernel has raised it is the way to hand that memory
-    /// back.
     ///
     /// CUDA may clamp or round the request; call
     /// [`stack_size`](Self::stack_size) afterwards to observe what the driver
     /// actually applied. The call takes effect immediately and may block until
     /// previously submitted work completes.
     pub fn set_stack_size(&self, bytes: usize) -> Result<(), DriverError> {
-        self.bind_to_thread()?;
-        unsafe {
-            cuda_bindings::cuCtxSetLimit(cuda_bindings::CUlimit_enum_CU_LIMIT_STACK_SIZE, bytes)
-        }
-        .result()
+        self.set_limit(ContextLimit::StackSize, bytes)
     }
 
     /// Sets the context's scheduling policy (`CU_CTX_SCHED_*`).

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -63,7 +63,7 @@ pub mod stream;
 /// CUDA Virtual Memory Management (VMM) for physical alloc, VA reservation, and mapping.
 pub mod vmm;
 
-pub use context::{CudaContext, SyncPolicy};
+pub use context::{ContextLimit, CudaContext, SyncPolicy};
 /// Raw CUDA driver bindings re-exported for direct access when needed.
 pub use cuda_bindings as sys;
 /// `#[derive(DeviceCopy)]` macro, re-exported next to the `DeviceCopy` trait so

--- a/crates/cuda-core/tests/context_limits.rs
+++ b/crates/cuda-core/tests/context_limits.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaContext::{limit, set_limit}` over every [`ContextLimit`] variant.
+//!
+//! Its own test binary, for the reason `context_sync_policy.rs` has one: a
+//! limit is state on the device's primary context, shared by every handle in
+//! the process, so a test that wrote one while another test in the same binary
+//! read it would race. One test function walking the variants in sequence
+//! keeps the whole check on one thread.
+//!
+//! `MallocHeapSize` and `PrintfFifoSize` are writable here only because this
+//! binary launches no kernel: the driver refuses both once a kernel using
+//! `malloc` or `printf` has run in the process.
+
+use cuda_core::{ContextLimit, CudaContext};
+
+/// Every variant, in declaration order.
+const ALL: [ContextLimit; 7] = [
+    ContextLimit::StackSize,
+    ContextLimit::PrintfFifoSize,
+    ContextLimit::MallocHeapSize,
+    ContextLimit::DevRuntimeSyncDepth,
+    ContextLimit::DevRuntimePendingLaunchCount,
+    ContextLimit::MaxL2FetchGranularity,
+    ContextLimit::PersistingL2CacheSize,
+];
+
+/// `CUDA_ERROR_UNSUPPORTED_LIMIT`, the documented answer for a limit this
+/// device does not implement (`DevRuntimeSyncDepth` above compute 9.0).
+const UNSUPPORTED: cuda_core::sys::CUresult =
+    cuda_core::sys::cudaError_enum_CUDA_ERROR_UNSUPPORTED_LIMIT;
+
+#[test]
+fn every_limit_reads_and_the_writable_ones_round_trip() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+
+    // Reading must either succeed or give the one documented refusal. Any
+    // other status means to_raw() handed the driver a value it did not
+    // recognise.
+    for limit in ALL {
+        match ctx.limit(limit) {
+            Ok(_) => {}
+            Err(e) if e.0 == UNSUPPORTED => {}
+            Err(e) => panic!("limit({limit:?}) failed with an unexpected status: {e:?}"),
+        }
+    }
+
+    // The stack size is the one limit with an exact, driver-honoured
+    // round trip, so it is what proves set_limit reaches the right CUlimit
+    // rather than silently writing a neighbouring one.
+    let original = ctx
+        .stack_size()
+        .expect("stack_size() must be readable on any device");
+    let raised = original + 4096;
+    ctx.set_limit(ContextLimit::StackSize, raised)
+        .expect("set_limit(StackSize) failed");
+    assert_eq!(
+        ctx.limit(ContextLimit::StackSize).unwrap(),
+        raised,
+        "set_limit(StackSize, {raised}) must be observable through limit(StackSize)"
+    );
+
+    // The inherent accessors are now thin wrappers; this pins them to the
+    // same value rather than to a second, drifting implementation.
+    assert_eq!(
+        ctx.stack_size().unwrap(),
+        ctx.limit(ContextLimit::StackSize).unwrap(),
+        "stack_size() must agree with limit(StackSize)"
+    );
+    ctx.set_stack_size(original)
+        .expect("set_stack_size failed to restore the original");
+    assert_eq!(
+        ctx.stack_size().unwrap(),
+        original,
+        "set_stack_size() must agree with set_limit(StackSize, ..)"
+    );
+
+    // Writing one limit must not disturb its neighbours: a to_raw() that
+    // mapped two variants onto one CUlimit would pass every check above.
+    let heap_before = ctx.limit(ContextLimit::MallocHeapSize).unwrap();
+    let fifo_before = ctx.limit(ContextLimit::PrintfFifoSize).unwrap();
+    let heap_target = heap_before + (1 << 20);
+    ctx.set_limit(ContextLimit::MallocHeapSize, heap_target)
+        .expect("set_limit(MallocHeapSize) failed before any kernel launch");
+    assert_eq!(
+        ctx.limit(ContextLimit::MallocHeapSize).unwrap(),
+        heap_target,
+        "the malloc heap must hold the size just written"
+    );
+    assert_eq!(
+        ctx.limit(ContextLimit::PrintfFifoSize).unwrap(),
+        fifo_before,
+        "writing MallocHeapSize must leave PrintfFifoSize untouched"
+    );
+    ctx.set_limit(ContextLimit::MallocHeapSize, heap_before)
+        .expect("failed to restore the malloc heap size");
+}


### PR DESCRIPTION
Closes #759.

`CudaContext` wrapped one of the seven `CUlimit` values, the thread stack size. The rest were reachable only through `cuda_core::sys`, so raising the device `printf` FIFO meant calling `cuCtxSetLimit` by hand with a raw `CUlimit`.

## Summary

Adds `ContextLimit` and the `CudaContext::limit` and `CudaContext::set_limit` pair. `stack_size` and `set_stack_size` keep their signatures and now delegate to that pair.

## Changes

- `crates/cuda-core/src/context.rs`: `ContextLimit` with the seven limits `cuCtxSetLimit` documents, a private `to_raw`, and the `limit` and `set_limit` methods. Each variant documents its own restrictions, including which two the driver treats as hints and which one answers `CUDA_ERROR_UNSUPPORTED_LIMIT` above compute capability 9.0.
- `crates/cuda-core/src/lib.rs`: re-exports `ContextLimit` next to `CudaContext` and `SyncPolicy`.
- `crates/cuda-core/tests/context_limits.rs`: new test binary, for the reason `context_sync_policy.rs` has its own.

## Rationale

The printf FIFO is the limit that costs users output. It is circular, so once a launch fills it the driver overwrites the oldest entries and reports nothing: the launch succeeds and the printed output carries no marker where the loss happened. A truncated kernel log reads as a kernel that stopped early.

The wrapper carries two properties of that limit the caller would otherwise have to know. The driver refuses `CU_LIMIT_PRINTF_FIFO_SIZE` and `CU_LIMIT_MALLOC_HEAP_SIZE` with `CUDA_ERROR_INVALID_VALUE` once a kernel using `printf` or device `malloc` has run, and `CudaContext` retains the device's primary context, so that ordering counts every launch in the process rather than the launches made through the handle doing the write.

`CU_LIMIT_SHMEM_SIZE`, `CU_LIMIT_CIG_ENABLED` and `CU_LIMIT_CIG_SHMEM_FALLBACK_ENABLED` stay out. The first two are query-only, all three concern CIG contexts, and none predates CUDA 12.5, so naming them needs a header probe and a `cfg` in the manner of `cuda_has_cuEventElapsedTime_v2` in `crates/cuda-bindings/build.rs`. Adding them without that probe would break the build against every toolkit this repository still supports.

The test asserts an exact round trip on the stack size, pins the inherent accessors to the same value the enum path reports, and then writes `MallocHeapSize` and reads `PrintfFifoSize` back unchanged. The last assertion is the one that discriminates: a `to_raw` mapping two variants onto one `CUlimit` passes every other check in the file. Mapping `MallocHeapSize` onto `CU_LIMIT_PRINTF_FIFO_SIZE` on purpose fails it with `left: 2326528, right: 1277952`.

## Validation

RTX 5060 Laptop GPU, compute capability 12.0, CUDA 13.3, driver 610.43.03.

```text
cargo build -p cuda-core
cargo test -p cuda-core                       26 unit, 31 integration, 3 ignored, 0 failed
cargo test -p cuda-core --test context_limits 1 passed
cargo clippy -p cuda-core --all-targets       clean
cargo fmt --check -p cuda-core                clean
RUSTDOCFLAGS="-D warnings" cargo doc -p cuda-core --no-deps   clean
```

Limits read on that device, showing the documented refusal rather than a fault:

```text
StackSize                    = 1024
PrintfFifoSize               = 1277952
MallocHeapSize               = 8388608
DevRuntimeSyncDepth          -> DriverError(215, "limit is not supported on this architecture")
DevRuntimePendingLaunchCount = 2048
MaxL2FetchGranularity        = 64
PersistingL2CacheSize        = 6291456
```
