### PR TITLE
feat(cuda-core): report stream completion without blocking

### DIFF
--- a/crates/cuda-core/src/stream.rs
+++ b/crates/cuda-core/src/stream.rs
@@ -87,6 +87,36 @@ impl CudaStream {
         unsafe { cuda_bindings::cuStreamSynchronize(self.cu_stream) }.result()
     }
 
+    /// Returns `true` when every operation enqueued on this stream has
+    /// completed, `false` while any is still in flight. Never blocks.
+    ///
+    /// Wraps `cuStreamQuery`, mapping `CUDA_SUCCESS` to `Ok(true)` and
+    /// `CUDA_ERROR_NOT_READY` to `Ok(false)`, as
+    /// [`CudaEvent::query`](crate::event::CudaEvent::query) does for
+    /// `cuEventQuery`. Any other code is a real driver error.
+    ///
+    /// This is the completion half of the async bridge that
+    /// [`launch_host_function`](Self::launch_host_function) opens: a
+    /// `Future::poll` implementation needs to ask whether work has finished
+    /// without parking the executor's thread, which
+    /// [`synchronize`](Self::synchronize) cannot answer.
+    ///
+    /// A sticky error from earlier work on the stream surfaces here rather
+    /// than as `Ok(false)`, the same way it would from
+    /// [`synchronize`](Self::synchronize).
+    ///
+    /// On the default stream this reports the completion of every blocking
+    /// stream in the context, since the default stream orders against them
+    /// all.
+    pub fn query(&self) -> Result<bool, DriverError> {
+        self.ctx.bind_to_thread()?;
+        match unsafe { cuda_bindings::cuStreamQuery(self.cu_stream) } {
+            cuda_bindings::cudaError_enum_CUDA_SUCCESS => Ok(true),
+            cuda_bindings::cudaError_enum_CUDA_ERROR_NOT_READY => Ok(false),
+            err => Err(DriverError(err)),
+        }
+    }
+
     /// Creates a new non-blocking stream that waits on all prior work in
     /// `self` before executing its own.
     ///

--- a/crates/cuda-core/tests/stream_query.rs
+++ b/crates/cuda-core/tests/stream_query.rs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaStream::query` reports completion without blocking.
+//!
+//! Work is enqueued with `launch_host_function` rather than a kernel: the
+//! point under test is the driver's completion status for a stream, a host
+//! callback holds the stream busy for a known interval, and `cuda-core`'s own
+//! tests do not compile device code.
+
+use cuda_core::CudaContext;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+/// Long enough that the first query lands inside it on a loaded machine,
+/// short enough to keep the suite quick.
+const BUSY: Duration = Duration::from_millis(500);
+
+#[test]
+fn an_idle_stream_reports_complete() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create stream");
+
+    assert!(
+        stream.query().expect("query() failed on an idle stream"),
+        "a stream with nothing enqueued must report complete"
+    );
+}
+
+#[test]
+fn query_reports_in_flight_work_and_never_blocks() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create stream");
+    let finished = Arc::new(AtomicBool::new(false));
+
+    let callback_finished = finished.clone();
+    stream
+        .launch_host_function(move || {
+            std::thread::sleep(BUSY);
+            callback_finished.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to enqueue the host callback");
+
+    // The call itself must return while the callback is still running. A
+    // query() that fell back to synchronize() would pass an "is it done"
+    // assertion later on, so the check is on both the answer and the time
+    // taken to give it.
+    let before = Instant::now();
+    let in_flight = stream.query().expect("query() failed on a busy stream");
+    let elapsed = before.elapsed();
+
+    assert!(
+        !in_flight,
+        "a stream whose host callback is still sleeping must report incomplete"
+    );
+    assert!(
+        elapsed < BUSY / 2,
+        "query() must return without waiting for the work, took {elapsed:?}"
+    );
+    assert!(
+        !finished.load(Ordering::SeqCst),
+        "the callback must still have been running when query() answered"
+    );
+
+    stream.synchronize().expect("synchronize() failed");
+    assert!(
+        stream.query().expect("query() failed after synchronize()"),
+        "a stream must report complete once its work has finished"
+    );
+    assert!(
+        finished.load(Ordering::SeqCst),
+        "synchronize() must have waited for the callback"
+    );
+}


### PR DESCRIPTION
Closes #763.

`CudaEvent` carries both halves of the completion question. `CudaStream` carried only the blocking half, so asking whether a stream had finished cost the calling thread its progress.

## Summary

Adds `CudaStream::query`, wrapping `cuStreamQuery` with the mapping `CudaEvent::query` already uses for `cuEventQuery`.

```rust
pub fn query(&self) -> Result<bool, DriverError>
```

## Changes

- `crates/cuda-core/src/stream.rs`: `CudaStream::query`, mapping `CUDA_SUCCESS` to `Ok(true)` and `CUDA_ERROR_NOT_READY` to `Ok(false)`, with any other status returned as a `DriverError`.
- `crates/cuda-core/tests/stream_query.rs`: two tests.

## Rationale

The `stream` module documents `launch_host_function` as the bridge between stream completion and Rust `async` futures. A `Future::poll` completes that bridge only if it can ask whether work has finished and return `Poll::Pending` when it has not, and `synchronize` cannot answer without parking the executor's thread, which is the failure the bridge exists to avoid.

Mirroring `CudaEvent::query` rather than inventing a shape keeps one reading of `CUDA_ERROR_NOT_READY` in the crate. That status is a completion answer rather than a fault, and a caller that saw it as an error would treat every unfinished stream as broken.

The test enqueues work with `launch_host_function` rather than a kernel, since what is under test is the driver's completion status for a stream and `cuda-core`'s own tests compile no device code.

Asserting only that a busy stream answers `false` would pass against an implementation that blocked first and answered afterwards, so the test also holds `query` to returning inside a fraction of the interval the callback occupies, and checks the callback had not yet run when the answer came. Replacing the body with `self.synchronize()?; Ok(true)` fails it and leaves the idle-stream test passing.

## Validation

RTX 5060 Laptop GPU, compute capability 12.0, CUDA 13.3, driver 610.43.03.

```text
cargo test -p cuda-core                     26 unit, 32 integration, 2 doc, 3 ignored, 0 failed
cargo test -p cuda-core --test stream_query 2 passed
cargo clippy -p cuda-core --all-targets     clean
cargo fmt --check -p cuda-core              clean
RUSTDOCFLAGS="-D warnings" cargo doc -p cuda-core --no-deps   clean
```
