### PR TITLE
fix(cuda-device): add ptx_asm output markers through arity 32

### DIFF
--- a/crates/cuda-device/src/ptx.rs
+++ b/crates/cuda-device/src/ptx.rs
@@ -74,8 +74,8 @@ pub const fn __ptx_asm_c<const N: usize>(value: &'static [u8; N]) -> &'static [u
 }
 
 // Rust has no variadic generics, so expose marker stubs for fixed arities.
-// Output markers support up to 24 arguments: 16 explicit inputs plus up to
-// 8 hidden tied inputs generated for `inout` operands. Void markers require
+// Output markers support up to 32 arguments: 16 explicit inputs plus up to
+// 16 hidden tied inputs generated for `inout` operands. Void markers require
 // only 16 arguments because `inout` always produces an output.
 define_ptx_asm_out!(__ptx_asm_out_0;);
 define_ptx_asm_out!(__ptx_asm_out_1; a0: A0);
@@ -102,6 +102,14 @@ define_ptx_asm_out!(__ptx_asm_out_21; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5
 define_ptx_asm_out!(__ptx_asm_out_22; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21);
 define_ptx_asm_out!(__ptx_asm_out_23; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22);
 define_ptx_asm_out!(__ptx_asm_out_24; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23);
+define_ptx_asm_out!(__ptx_asm_out_25; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24);
+define_ptx_asm_out!(__ptx_asm_out_26; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25);
+define_ptx_asm_out!(__ptx_asm_out_27; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26);
+define_ptx_asm_out!(__ptx_asm_out_28; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26, a27: A27);
+define_ptx_asm_out!(__ptx_asm_out_29; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26, a27: A27, a28: A28);
+define_ptx_asm_out!(__ptx_asm_out_30; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26, a27: A27, a28: A28, a29: A29);
+define_ptx_asm_out!(__ptx_asm_out_31; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26, a27: A27, a28: A28, a29: A29, a30: A30);
+define_ptx_asm_out!(__ptx_asm_out_32; a0: A0, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8, a9: A9, a10: A10, a11: A11, a12: A12, a13: A13, a14: A14, a15: A15, a16: A16, a17: A17, a18: A18, a19: A19, a20: A20, a21: A21, a22: A22, a23: A23, a24: A24, a25: A25, a26: A26, a27: A27, a28: A28, a29: A29, a30: A30, a31: A31);
 
 define_ptx_asm_void!(__ptx_asm_void_0;);
 define_ptx_asm_void!(__ptx_asm_void_1; a0: A0);

--- a/crates/cuda-macros/tests/pass/ptx_asm_inout.rs
+++ b/crates/cuda-macros/tests/pass/ptx_asm_inout.rs
@@ -153,7 +153,10 @@ fn evaluates_complex_place() {
     let _ = values;
 }
 
-fn maximum_marker_arity() {
+// Not the reachable maximum (that is 16 inout + 16 in = arity 32, exercised
+// against the real crate in ptx_asm_marker_arity_contract.rs); this file's
+// mock marker surface stops at 24.
+fn eight_inouts_with_full_input_block() {
     let mut o0 = 0u32;
     let mut o1 = 1u32;
     let mut o2 = 2u32;

--- a/crates/cuda-macros/tests/pass/ptx_asm_marker_arity_contract.rs
+++ b/crates/cuda-macros/tests/pass/ptx_asm_marker_arity_contract.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validates that every output marker arity reachable from `ptx_asm!` exists
+//! in the real `cuda_device::ptx` marker surface.
+
+#![allow(dead_code, unused_imports, unused_variables)]
+
+use cuda_macros::ptx_asm;
+use cuda_device::ptx::{
+    __ptx_asm_out_25, __ptx_asm_out_26, __ptx_asm_out_27, __ptx_asm_out_28,
+    __ptx_asm_out_29, __ptx_asm_out_30, __ptx_asm_out_31, __ptx_asm_out_32,
+};
+
+fn maximum_marker_arity() {
+    let mut o0 = 0u32;
+    let mut o1 = 1u32;
+    let mut o2 = 2u32;
+    let mut o3 = 3u32;
+    let mut o4 = 4u32;
+    let mut o5 = 5u32;
+    let mut o6 = 6u32;
+    let mut o7 = 7u32;
+    let mut o8 = 8u32;
+    let mut o9 = 9u32;
+    let mut o10 = 10u32;
+    let mut o11 = 11u32;
+    let mut o12 = 12u32;
+    let mut o13 = 13u32;
+    let mut o14 = 14u32;
+    let mut o15 = 15u32;
+
+    unsafe {
+        ptx_asm!(
+            "nop;",
+            inout("+r") o0,
+            inout("+r") o1,
+            inout("+r") o2,
+            inout("+r") o3,
+            inout("+r") o4,
+            inout("+r") o5,
+            inout("+r") o6,
+            inout("+r") o7,
+            inout("+r") o8,
+            inout("+r") o9,
+            inout("+r") o10,
+            inout("+r") o11,
+            inout("+r") o12,
+            inout("+r") o13,
+            inout("+r") o14,
+            inout("+r") o15,
+            in("r") 0u32,
+            in("r") 1u32,
+            in("r") 2u32,
+            in("r") 3u32,
+            in("r") 4u32,
+            in("r") 5u32,
+            in("r") 6u32,
+            in("r") 7u32,
+            in("r") 8u32,
+            in("r") 9u32,
+            in("r") 10u32,
+            in("r") 11u32,
+            in("r") 12u32,
+            in("r") 13u32,
+            in("r") 14u32,
+            in("r") 15u32,
+            options(register_only),
+        );
+    }
+
+    let _ = (
+        o0, o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12, o13, o14, o15,
+    );
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/ptx_asm.rs
+++ b/crates/cuda-macros/tests/ptx_asm.rs
@@ -25,6 +25,7 @@ fn ptx_asm_accepts_compile_time_strings() {
 fn ptx_asm_accepts_inout() {
     let t = trybuild::TestCases::new();
     t.pass("tests/pass/ptx_asm_inout.rs");
+    t.pass("tests/pass/ptx_asm_marker_arity_contract.rs");
 }
 
 #[test]

--- a/crates/mir-importer/src/translator/terminator/intrinsics/asm.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/asm.rs
@@ -773,12 +773,12 @@ mod tests {
     }
 
     #[test]
-    fn parses_output_marker_with_24_inputs() {
-        let kind = InlinePtxCallKind::from_path("cuda_device::ptx::__ptx_asm_out_24")
+    fn parses_output_marker_with_32_inputs() {
+        let kind = InlinePtxCallKind::from_path("cuda_device::ptx::__ptx_asm_out_32")
             .expect("output marker should be recognized");
 
-        assert!(matches!(kind, InlinePtxCallKind::Output { inputs: 24 }));
-        assert_eq!(kind.inputs(), 24);
+        assert!(matches!(kind, InlinePtxCallKind::Output { inputs: 32 }));
+        assert_eq!(kind.inputs(), 32);
         assert!(kind.has_output());
     }
 }


### PR DESCRIPTION
Closes #775 

## Summary

Extend the hidden `ptx_asm!` output marker surface from arity 24 through arity 32.

`ptx_asm!` supports up to 16 explicit inputs and up to 16 `inout` operands. Since each `inout` operand generates a hidden tied-input argument, a valid invocation can require:

```text
16 explicit inputs + 16 hidden tied inputs = 32 marker arguments
```

`cuda-device` previously exposed output markers only through `__ptx_asm_out_24`, leaving valid macro expansions for arities 25–32 unresolved.

## Changes

* Add `__ptx_asm_out_25` through `__ptx_asm_out_32`.
* Update the `cuda-device` marker-arity documentation from 24 to 32 arguments.
* Add a `trybuild` regression test against the real `cuda_device::ptx` marker surface.
* Exercise the maximum supported case with 16 `inout` operands and 16 explicit inputs.
* Update the MIR importer marker parsing boundary test from arity 24 to 32.

Void markers remain capped at 16 because `inout` operands always produce an output.

## Validation

```text
cargo fmt --all -- --check
cargo test -p cuda-macros --test ptx_asm
cargo test -p cuda-device --lib --tests
cargo test -p mir-importer parses_output_marker_with_32_inputs
cargo clippy -p cuda-device -p cuda-macros -p mir-importer --all-targets -- -D warnings
```

All checks pass.
