### PR TITLE
perf(mir-lower): carry proved alignment through an array-element address

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -39,12 +39,12 @@
 use crate::convert::enum_payload_storage::{coerce_enum_payload_value, enum_payload_storage_type};
 use crate::convert::types::{
     EnumSlotMap, StructLayoutInfo, StructSlotMap, build_enum_slot_map, build_struct_slot_map,
-    build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
-    llvm_type_contains_i1, make_slice_struct, mir_type_abi_align,
+    build_union_storage_type, convert_type, get_type_size, is_zero_sized_type,
+    llvm_byte_faithful_twin, llvm_type_contains_i1, make_slice_struct, mir_type_abi_align,
 };
 use dialect_mir::ops::{
-    MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp, MirInsertFieldOp,
-    MirSetDiscriminantOp,
+    MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
+    MirInsertFieldOp, MirSetDiscriminantOp,
 };
 use dialect_mir::types::{
     EnumCarrierKind, EnumLayoutKind, MirArrayType, MirDisjointSliceType, MirEnumType, MirPtrType,
@@ -1903,11 +1903,98 @@ pub(crate) fn convert_array_element_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Value(index)];
 
+    let element_align = stamp_element_address_alignment(ctx, arr_ptr, pointee_ty, index);
+
     let gep_op = llvm::GetElementPtrOp::new(ctx, arr_ptr, gep_indices, llvm_array_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
+    if let Some(align) = element_align {
+        llvm_export::ops::set_address_alignment(ctx, gep_op.get_operation(), align);
+    }
     rewriter.replace_operation(ctx, op, gep_op.get_operation());
 
     Ok(())
+}
+
+/// Alignment an array-element address provably has, in bytes.
+///
+/// The field path records this already ([`stamp_field_address_alignment`]), but
+/// an element address recorded nothing, so `lanes[0] + lanes[1]` on an
+/// `#[repr(C, align(8))]` `[f32; 2]` still exported two `align 4` loads and
+/// LoadStoreVectorizer refused to fuse them. Reading the same element into a
+/// local first happens to work, because SROA then loads the whole aggregate and
+/// the alignment comes from its type — so the cost depended on whether the
+/// source copied the element or read through it.
+///
+/// Two facts combine. The array's own alignment is `abi_align`, and whatever the
+/// *base pointer* already proved is stronger when the array is itself a field of
+/// an over-aligned aggregate: `&table[i].lanes` carries the outer struct's
+/// alignment, which the array type alone does not know. Element `i` then sits at
+/// byte `i * stride`, so it is aligned to `gcd(base, i * stride)` — and to `base`
+/// itself at index zero. A runtime index can land on any element, so it gets
+/// `gcd(base, stride)`, which every element satisfies.
+///
+/// Answers `None` — leaving the previous behaviour — when neither the base nor
+/// the array type records an alignment, or the stride is unknown. As on the
+/// field path, a wrong answer here is a miscompile, so every uncertain case
+/// declines rather than guesses.
+fn stamp_element_address_alignment(
+    ctx: &Context,
+    arr_ptr: Value,
+    array_ty: TypeHandle,
+    index: Value,
+) -> Option<u32> {
+    const fn gcd(a: u64, b: u64) -> u64 {
+        if b == 0 { a } else { gcd(b, a % b) }
+    }
+
+    // What the base address already proved, else what the array type states.
+    let base_align = arr_ptr
+        .defining_op()
+        .and_then(|def| llvm_export::ops::address_alignment(ctx, def))
+        .map(u64::from)
+        .or_else(|| mir_type_abi_align(ctx, array_ty))?;
+    if base_align == 0 {
+        return None;
+    }
+
+    let element_ty = {
+        let array_ref = array_ty.deref(ctx);
+        array_ref.downcast_ref::<MirArrayType>()?.element_type()
+    };
+    let stride = get_type_size(ctx, element_ty);
+    if stride == 0 {
+        return None;
+    }
+
+    let provable = match constant_index_value(ctx, index) {
+        Some(0) => base_align,
+        Some(i) => gcd(base_align, i.checked_mul(stride)?),
+        // Any element is reachable, so claim only what every stride preserves.
+        None => gcd(base_align, stride),
+    };
+
+    // Same guard as the field path: dialect-mir does not verifier-enforce a
+    // power-of-two `abi_align` for every aggregate, and a non-power-of-two
+    // `align N` is invalid LLVM IR that llc rejects.
+    if !provable.is_power_of_two() {
+        return None;
+    }
+    u32::try_from(provable).ok()
+}
+
+/// The constant an index operand holds, if it is one.
+fn constant_index_value(ctx: &Context, index: Value) -> Option<u64> {
+    let defining_op = index.defining_op()?;
+    if let Some(constant) = Operation::get_op::<MirConstantOp>(defining_op, ctx) {
+        return constant
+            .get_attr_value(ctx)
+            .map(|attribute| attribute.value().to_u64());
+    }
+    let constant = Operation::get_op::<llvm::ConstantOp>(defining_op, ctx)?;
+    let attribute = constant.get_value(ctx);
+    attribute
+        .downcast_ref::<pliron::builtin::attributes::IntegerAttr>()
+        .map(|integer| integer.value().to_u64())
 }
 
 #[cfg(test)]

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -39,8 +39,8 @@
 use crate::convert::enum_payload_storage::{coerce_enum_payload_value, enum_payload_storage_type};
 use crate::convert::types::{
     EnumSlotMap, StructLayoutInfo, StructSlotMap, build_enum_slot_map, build_struct_slot_map,
-    build_union_storage_type, convert_type, get_type_size, is_zero_sized_type,
-    llvm_byte_faithful_twin, llvm_type_contains_i1, make_slice_struct, mir_type_abi_align,
+    build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
+    llvm_type_contains_i1, make_slice_struct, mir_element_stride, mir_type_abi_align,
 };
 use dialect_mir::ops::{
     MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
@@ -1903,7 +1903,7 @@ pub(crate) fn convert_array_element_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Value(index)];
 
-    let element_align = stamp_element_address_alignment(ctx, arr_ptr, pointee_ty, index);
+    let element_align = element_address_provable_alignment(ctx, arr_ptr, pointee_ty, index);
 
     let gep_op = llvm::GetElementPtrOp::new(ctx, arr_ptr, gep_indices, llvm_array_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
@@ -1936,8 +1936,12 @@ pub(crate) fn convert_array_element_addr(
 /// Answers `None` — leaving the previous behaviour — when neither the base nor
 /// the array type records an alignment, or the stride is unknown. As on the
 /// field path, a wrong answer here is a miscompile, so every uncertain case
-/// declines rather than guesses.
-fn stamp_element_address_alignment(
+/// declines rather than guesses. That is why the stride comes from
+/// [`mir_element_stride`], which is exact or `None`: an LLVM-level size
+/// approximation would guess 8 for a MIR aggregate element it does not
+/// model, and e.g. `[[f32; 3]; 4]` under an align-8 base would then claim
+/// align 8 on element addresses that are only 4-aligned.
+fn element_address_provable_alignment(
     ctx: &Context,
     arr_ptr: Value,
     array_ty: TypeHandle,
@@ -1961,7 +1965,7 @@ fn stamp_element_address_alignment(
         let array_ref = array_ty.deref(ctx);
         array_ref.downcast_ref::<MirArrayType>()?.element_type()
     };
-    let stride = get_type_size(ctx, element_ty);
+    let stride = mir_element_stride(ctx, element_ty)?;
     if stride == 0 {
         return None;
     }
@@ -1983,18 +1987,21 @@ fn stamp_element_address_alignment(
 }
 
 /// The constant an index operand holds, if it is one.
+///
+/// `APInt::to_u64` truncates wider values, so a >64-bit constant could be
+/// misread as a small offset multiplier. Fail closed on such widths, as
+/// `integer_constant_u64` in the extract-element fast path does.
 fn constant_index_value(ctx: &Context, index: Value) -> Option<u64> {
     let defining_op = index.defining_op()?;
     if let Some(constant) = Operation::get_op::<MirConstantOp>(defining_op, ctx) {
-        return constant
-            .get_attr_value(ctx)
-            .map(|attribute| attribute.value().to_u64());
+        let value = constant.get_attr_value(ctx)?.value();
+        return (value.bw() <= 64).then(|| value.to_u64());
     }
     let constant = Operation::get_op::<llvm::ConstantOp>(defining_op, ctx)?;
     let attribute = constant.get_value(ctx);
-    attribute
-        .downcast_ref::<pliron::builtin::attributes::IntegerAttr>()
-        .map(|integer| integer.value().to_u64())
+    let integer = attribute.downcast_ref::<pliron::builtin::attributes::IntegerAttr>()?;
+    let value = integer.value();
+    (value.bw() <= 64).then(|| value.to_u64())
 }
 
 #[cfg(test)]

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -1721,6 +1721,249 @@ mod tests {
         assert_eq!(lowered_element_load_alignment(32, 2, 4, Some(0)), Some(4));
     }
 
+    /// Like [`lowered_element_load_alignment`], but for an array whose element
+    /// is an aggregate built by `element_ty_of` (which also reports the
+    /// element's stored size in bytes). The claim on the element address must
+    /// then come from the element's *exact* stride — rustc's stored size,
+    /// padding included — not from any LLVM-level approximation.
+    ///
+    /// With `load_first_scalar` the element must itself be an array and the
+    /// access becomes `s.lanes[index][0]`, mirroring the nested-read chain
+    /// where the outer stamp is inherited by the inner index-0 address and
+    /// ends up on a scalar load that LoadStoreVectorizer trusts. Without it,
+    /// the element itself is loaded.
+    ///
+    /// Reports `(element address stamp, final load alignment)`.
+    fn lowered_aggregate_element_alignments(
+        element_ty_of: impl FnOnce(&mut Context) -> (TypeHandle, u64),
+        element_count: u64,
+        struct_abi_align: u64,
+        index: Option<u64>,
+        load_first_scalar: bool,
+    ) -> (Option<u32>, Option<u32>) {
+        use dialect_mir::attributes::FieldIndexAttr;
+        use pliron::builtin::attributes::IntegerAttr;
+        use std::num::NonZeroUsize;
+
+        let mut ctx = make_ctx();
+        let (element_ty, elem_bytes) = element_ty_of(&mut ctx);
+        let inner_scalar_ty = load_first_scalar.then(|| {
+            let element_ref = element_ty.deref(&ctx);
+            element_ref
+                .downcast_ref::<MirArrayType>()
+                .expect("load_first_scalar needs an array element")
+                .element_type()
+        });
+        let array_ty: TypeHandle = MirArrayType::get(&mut ctx, element_ty, element_count).into();
+        let struct_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "AggregateElementAlign".into(),
+            vec!["lanes".into()],
+            vec![array_ty],
+            vec![],
+            vec![0],
+            elem_bytes * element_count,
+            struct_abi_align,
+        )
+        .into();
+        let struct_ptr_ty = MirPtrType::get_generic(&mut ctx, struct_ty, false);
+        let array_ptr_ty = MirPtrType::get_generic(&mut ctx, array_ty, false);
+        let element_ptr_ty = MirPtrType::get_generic(&mut ctx, element_ty, false);
+        let i64_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+
+        let (module_ptr, block) =
+            build_kernel(&mut ctx, vec![struct_ptr_ty.into(), i64_ty], vec![]);
+        let struct_ptr_val = block.deref(&ctx).get_argument(0);
+
+        // &s.lanes -- carries the struct's alignment onto the array address.
+        let field_addr_op = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![array_ptr_ty.into()],
+            vec![struct_ptr_val],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr_op).set_attr_field_index(&ctx, FieldIndexAttr(0));
+        field_addr_op.insert_at_back(block, &ctx);
+        let array_ptr_val = field_addr_op.deref(&ctx).get_result(0);
+
+        let constant_index = |ctx: &mut Context, i: u64| {
+            let constant = Operation::new(
+                ctx,
+                mir::MirConstantOp::get_concrete_op_info(),
+                vec![i64_ty],
+                vec![],
+                vec![],
+                0,
+            );
+            mir::MirConstantOp::new(constant).set_attr_value(
+                ctx,
+                IntegerAttr::new(
+                    IntegerType::get(ctx, 64, Signedness::Signed),
+                    APInt::from_u64(i, NonZeroUsize::new(64).unwrap()),
+                ),
+            );
+            constant.insert_at_back(block, ctx);
+            constant.deref(ctx).get_result(0)
+        };
+
+        let index_val = match index {
+            Some(i) => constant_index(&mut ctx, i),
+            None => block.deref(&ctx).get_argument(1),
+        };
+
+        let elem_addr_op = Operation::new(
+            &mut ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty.into()],
+            vec![array_ptr_val, index_val],
+            vec![],
+            0,
+        );
+        elem_addr_op.insert_at_back(block, &ctx);
+        let elem_ptr_val = elem_addr_op.deref(&ctx).get_result(0);
+
+        let (loaded_ty, loaded_ptr_val) = match inner_scalar_ty {
+            Some(scalar_ty) => {
+                let zero_val = constant_index(&mut ctx, 0);
+                let scalar_ptr_ty = MirPtrType::get_generic(&mut ctx, scalar_ty, false);
+                let inner_addr_op = Operation::new(
+                    &mut ctx,
+                    mir::MirArrayElementAddrOp::get_concrete_op_info(),
+                    vec![scalar_ptr_ty.into()],
+                    vec![elem_ptr_val, zero_val],
+                    vec![],
+                    0,
+                );
+                inner_addr_op.insert_at_back(block, &ctx);
+                (scalar_ty, inner_addr_op.deref(&ctx).get_result(0))
+            }
+            None => (element_ty, elem_ptr_val),
+        };
+
+        let load_op = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![loaded_ty],
+            vec![loaded_ptr_val],
+            vec![],
+            0,
+        );
+        load_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        // GEP order follows source order: field address, then the element
+        // address under test (then the inner index-0 address when nested).
+        let geps = find_all::<llvm::GetElementPtrOp>(&ctx, &body);
+        assert_eq!(geps.len(), if load_first_scalar { 3 } else { 2 });
+        let element_gep_align = llvm_export::ops::address_alignment(&ctx, geps[1].get_operation());
+        let load = find_first::<llvm::LoadOp>(&ctx, &body).expect("expected one llvm.load");
+        let load_align = llvm_export::ops::op_alignment(&ctx, load.get_operation());
+        (element_gep_align, load_align)
+    }
+
+    /// `[f32; 3]` element under an align-8 base: stride is 12, so a runtime
+    /// index proves `gcd(8, 12) = 4` — and the inner index-0 scalar read
+    /// inherits exactly that. Guards against sizing the element through an
+    /// LLVM-level approximation, whose guessed stride of 8 would stamp
+    /// align 8 onto addresses that are only 4-aligned (a miscompile once
+    /// LoadStoreVectorizer trusts it).
+    #[test]
+    fn convert_load_claims_exact_aggregate_stride_for_nested_array_elements() {
+        use pliron::builtin::types::FP32Type;
+        // &(#[repr(C, align(8))] struct { lanes: [[f32; 3]; 4] }).lanes[i][0]
+        let nested_f32x3 = |ctx: &mut Context| {
+            let f32_ty: TypeHandle = FP32Type::get(ctx).into();
+            (MirArrayType::get(ctx, f32_ty, 3).into(), 12)
+        };
+        assert_eq!(
+            lowered_aggregate_element_alignments(nested_f32x3, 4, 8, None, true),
+            (Some(4), Some(4))
+        );
+    }
+
+    /// A constant index into the same nested array uses the exact byte
+    /// offset: element 1 sits at byte 12 (`gcd(8, 12) = 4`), element 2 at
+    /// byte 24 (`gcd(8, 24) = 8`, the full base alignment again).
+    #[test]
+    fn convert_load_narrows_nested_element_alignment_by_exact_byte_offset() {
+        use pliron::builtin::types::FP32Type;
+        let nested_f32x3 = |ctx: &mut Context| {
+            let f32_ty: TypeHandle = FP32Type::get(ctx).into();
+            (MirArrayType::get(ctx, f32_ty, 3).into(), 12)
+        };
+        assert_eq!(
+            lowered_aggregate_element_alignments(nested_f32x3, 4, 8, Some(1), true),
+            (Some(4), Some(4))
+        );
+        assert_eq!(
+            lowered_aggregate_element_alignments(nested_f32x3, 4, 8, Some(2), true),
+            (Some(8), Some(8))
+        );
+    }
+
+    /// A tuple element's stride comes from rustc's recorded `total_size`
+    /// (trailing padding included): `(f32, f32, f32)` stores 12 bytes, so an
+    /// align-8 base proves only 4 on a runtime element address.
+    #[test]
+    fn convert_array_element_addr_takes_tuple_stride_from_recorded_layout() {
+        use pliron::builtin::types::FP32Type;
+        let f32x3_tuple = |ctx: &mut Context| {
+            let f32_ty: TypeHandle = FP32Type::get(ctx).into();
+            let tuple_ty: TypeHandle =
+                MirTupleType::get_with_layout(ctx, vec![f32_ty; 3], vec![], vec![0, 4, 8], 12, 4)
+                    .into();
+            (tuple_ty, 12)
+        };
+        let (element_gep_align, _load_align) =
+            lowered_aggregate_element_alignments(f32x3_tuple, 4, 8, None, false);
+        assert_eq!(element_gep_align, Some(4));
+    }
+
+    /// `f16` arrives from the importer as `MirFP16Type`, not the converted
+    /// LLVM `half`, and its stride is exactly 2: an align-8 base proves 2 on
+    /// a runtime element address and `gcd(8, 4) = 4` at element 2. Guards
+    /// the arm the importer actually exercises — the old sizing guessed 8
+    /// for this type too, the same over-claim as the aggregate cases.
+    #[test]
+    fn convert_load_claims_exact_f16_element_stride() {
+        let f16_scalar = |ctx: &mut Context| {
+            let f16_ty: TypeHandle = dialect_mir::types::MirFP16Type::get(ctx).into();
+            (f16_ty, 2)
+        };
+        assert_eq!(
+            lowered_aggregate_element_alignments(f16_scalar, 4, 8, None, false),
+            (Some(2), Some(2))
+        );
+        assert_eq!(
+            lowered_aggregate_element_alignments(f16_scalar, 4, 8, Some(2), false),
+            (Some(4), Some(4))
+        );
+    }
+
+    /// An element whose stored size is unknown (a struct built without rustc
+    /// layout) must not have its stride guessed: the element address claims
+    /// nothing and the load keeps the previous, weaker-but-sound behaviour.
+    #[test]
+    fn convert_array_element_addr_declines_unknown_element_stride() {
+        use pliron::builtin::types::FP32Type;
+        let opaque_struct = |ctx: &mut Context| {
+            let f32_ty: TypeHandle = FP32Type::get(ctx).into();
+            let struct_ty: TypeHandle =
+                MirStructType::get(ctx, "OpaqueElement".into(), vec!["x".into()], vec![f32_ty])
+                    .into();
+            (struct_ty, 4)
+        };
+        assert_eq!(
+            lowered_aggregate_element_alignments(opaque_struct, 4, 8, None, false),
+            (None, None)
+        );
+    }
+
     #[test]
     fn convert_dbg_value_lowers_to_llvm_dbg_value() {
         let mut ctx = make_ctx();

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -1587,6 +1587,140 @@ mod tests {
         );
     }
 
+    /// Lower `load (&arr[index])` where `arr` is the array field of an
+    /// over-aligned struct, and report the alignment the load ends up with.
+    ///
+    /// `index` of `Some(i)` builds a constant index, `None` a runtime one.
+    fn lowered_element_load_alignment(
+        element_bits: u32,
+        element_count: u64,
+        struct_abi_align: u64,
+        index: Option<u64>,
+    ) -> Option<u32> {
+        use dialect_mir::attributes::FieldIndexAttr;
+        use pliron::builtin::attributes::IntegerAttr;
+        use std::num::NonZeroUsize;
+
+        let mut ctx = make_ctx();
+        let element_ty: TypeHandle =
+            IntegerType::get(&ctx, element_bits, Signedness::Signless).into();
+        let array_ty: TypeHandle =
+            dialect_mir::types::MirArrayType::get(&mut ctx, element_ty, element_count).into();
+        let elem_bytes = u64::from(element_bits) / 8;
+        let struct_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "ElementLoadAlign".into(),
+            vec!["lanes".into()],
+            vec![array_ty],
+            vec![],
+            vec![0],
+            elem_bytes * element_count,
+            struct_abi_align,
+        )
+        .into();
+        let struct_ptr_ty = MirPtrType::get_generic(&mut ctx, struct_ty, false);
+        let array_ptr_ty = MirPtrType::get_generic(&mut ctx, array_ty, false);
+        let element_ptr_ty = MirPtrType::get_generic(&mut ctx, element_ty, false);
+        let i64_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+
+        let (module_ptr, block) =
+            build_kernel(&mut ctx, vec![struct_ptr_ty.into(), i64_ty], vec![]);
+        let struct_ptr_val = block.deref(&ctx).get_argument(0);
+
+        // &s.lanes -- carries the struct's alignment onto the array address.
+        let field_addr_op = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![array_ptr_ty.into()],
+            vec![struct_ptr_val],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr_op).set_attr_field_index(&ctx, FieldIndexAttr(0));
+        field_addr_op.insert_at_back(block, &ctx);
+        let array_ptr_val = field_addr_op.deref(&ctx).get_result(0);
+
+        let index_val = match index {
+            Some(i) => {
+                let constant = Operation::new(
+                    &mut ctx,
+                    mir::MirConstantOp::get_concrete_op_info(),
+                    vec![i64_ty],
+                    vec![],
+                    vec![],
+                    0,
+                );
+                mir::MirConstantOp::new(constant).set_attr_value(
+                    &ctx,
+                    IntegerAttr::new(
+                        IntegerType::get(&ctx, 64, Signedness::Signed),
+                        APInt::from_u64(i, NonZeroUsize::new(64).unwrap()),
+                    ),
+                );
+                constant.insert_at_back(block, &ctx);
+                constant.deref(&ctx).get_result(0)
+            }
+            None => block.deref(&ctx).get_argument(1),
+        };
+
+        let elem_addr_op = Operation::new(
+            &mut ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![element_ptr_ty.into()],
+            vec![array_ptr_val, index_val],
+            vec![],
+            0,
+        );
+        elem_addr_op.insert_at_back(block, &ctx);
+        let elem_ptr_val = elem_addr_op.deref(&ctx).get_result(0);
+
+        let load_op = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![element_ty],
+            vec![elem_ptr_val],
+            vec![],
+            0,
+        );
+        load_op.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let load = find_first::<llvm::LoadOp>(&ctx, &body).expect("expected one llvm.load");
+        llvm_export::ops::op_alignment(&ctx, load.get_operation())
+    }
+
+    /// Element 0 inherits the whole alignment the base address proved, which is
+    /// what lets the adjacent pair fuse into one wide load.
+    #[test]
+    fn convert_load_inherits_base_alignment_at_element_zero() {
+        // &(#[repr(C, align(8))] struct { lanes: [i32; 2] }).lanes[0]
+        assert_eq!(lowered_element_load_alignment(32, 2, 8, Some(0)), Some(8));
+    }
+
+    /// A nonzero constant index proves `gcd(base, i * stride)`: element 1 of an
+    /// align-8 `[i32; 2]` sits at byte 4, so it proves 4, not 8.
+    #[test]
+    fn convert_load_narrows_element_alignment_to_gcd_with_offset() {
+        assert_eq!(lowered_element_load_alignment(32, 2, 8, Some(1)), Some(4));
+    }
+
+    /// A runtime index can land on any element, so only what every stride
+    /// preserves may be claimed -- `gcd(base, stride)`, never the base itself.
+    #[test]
+    fn convert_load_claims_only_stride_alignment_for_a_runtime_index() {
+        assert_eq!(lowered_element_load_alignment(32, 2, 8, None), Some(4));
+    }
+
+    /// A base with no extra alignment proves nothing beyond the element's own
+    /// natural alignment, so the emitted access is unchanged.
+    #[test]
+    fn convert_load_keeps_natural_element_alignment_without_overalignment() {
+        assert_eq!(lowered_element_load_alignment(32, 2, 4, Some(0)), Some(4));
+    }
+
     #[test]
     fn convert_dbg_value_lowers_to_llvm_dbg_value() {
         let mut ctx = make_ctx();

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -99,8 +99,8 @@
 //! This matches the C ABI for GPU kernels.
 
 use dialect_mir::types::{
-    EnumCarrierKind, EnumLayoutKind, MirArrayType, MirDisjointSliceType, MirEnumType, MirSliceType,
-    MirStructType, MirTupleType, MirUnionType,
+    EnumCarrierKind, EnumLayoutKind, MirArrayType, MirDisjointSliceType, MirEnumType, MirFP16Type,
+    MirPtrType, MirSliceType, MirStructType, MirTupleType, MirUnionType,
 };
 use llvm_export::types as llvm_types;
 use llvm_export::types::PointerTypeExt;
@@ -1120,16 +1120,22 @@ pub(crate) fn llvm_type_is_byte_faithful(ctx: &Context, ty: TypeHandle) -> bool 
 
 /// Size of a MIR-level type from rustc layout truth, when stored.
 ///
-/// `MirStructType`, `MirUnionType`, and `MirEnumType` carry `total_size` (interior and
-/// trailing padding included) straight from rustc's layout query; arrays
-/// of such aggregates multiply it out. Returns `None` when no stored size
-/// is available (e.g. niched/single-variant enums store 0) and the caller
-/// must fall back to the LLVM-level approximation.
+/// `MirStructType`, `MirTupleType`, `MirUnionType`, and `MirEnumType` carry
+/// `total_size` (interior and trailing padding included) straight from
+/// rustc's layout query; arrays of such aggregates multiply it out. Returns
+/// `None` when no stored size is available (e.g. niched/single-variant enums
+/// store 0) and the caller must fall back to the LLVM-level approximation.
 fn mir_stored_size(ctx: &Context, mir_ty: TypeHandle) -> Option<u64> {
     let ty_ref = mir_ty.deref(ctx);
     if let Some(s) = ty_ref.downcast_ref::<MirStructType>() {
         if s.total_size() > 0 {
             return Some(s.total_size());
+        }
+        return None;
+    }
+    if let Some(t) = ty_ref.downcast_ref::<MirTupleType>() {
+        if t.total_size > 0 {
+            return Some(t.total_size);
         }
         return None;
     }
@@ -1142,10 +1148,61 @@ fn mir_stored_size(ctx: &Context, mir_ty: TypeHandle) -> Option<u64> {
     if let Some(u) = ty_ref.downcast_ref::<MirUnionType>() {
         return Some(u.total_size());
     }
-    if let Some(a) = ty_ref.downcast_ref::<dialect_mir::types::MirArrayType>() {
+    if let Some(a) = ty_ref.downcast_ref::<MirArrayType>() {
         let elem_ty = a.element_ty;
         let size = a.size;
-        return mir_stored_size(ctx, elem_ty).map(|elem_size| elem_size * size);
+        // Checked: alignment claims consume this, and a wrapped product
+        // would masquerade as a small, trusted stride.
+        return mir_stored_size(ctx, elem_ty).and_then(|elem_size| elem_size.checked_mul(size));
+    }
+    None
+}
+
+/// Exact byte stride of a MIR array's element, when provable.
+///
+/// Element `i` of an array lives at byte `i * stride`, so any alignment
+/// claim about an element address is only as strong as the stride it
+/// multiplies, and a wrong stride is a miscompile. Scalars have exact
+/// sizes; MIR aggregates answer with rustc's stored size (interior and
+/// trailing padding included) via [`mir_stored_size`]; arrays of scalars
+/// multiply out. Everything else answers `None` so the caller declines
+/// instead of guessing. In particular [`get_type_size`] is not a
+/// substitute here: it falls back to 8 for the MIR aggregate types it
+/// does not model.
+pub(crate) fn mir_element_stride(ctx: &Context, mir_ty: TypeHandle) -> Option<u64> {
+    if let Some(size) = mir_stored_size(ctx, mir_ty) {
+        return Some(size);
+    }
+    let ty_ref = mir_ty.deref(ctx);
+    if let Some(int_ty) = ty_ref.downcast_ref::<IntegerType>() {
+        return Some(u64::from(int_ty.width()).div_ceil(8));
+    }
+    // The importer's f16 is MirFP16Type; the HalfType arm covers IR that
+    // already carries the converted LLVM scalar.
+    if ty_ref.is::<MirFP16Type>() || ty_ref.is::<llvm_types::HalfType>() {
+        return Some(2);
+    }
+    if ty_ref.is::<FP32Type>() {
+        return Some(4);
+    }
+    if ty_ref.is::<FP64Type>() {
+        return Some(8);
+    }
+    if let Some(ptr_ty) = ty_ref.downcast_ref::<MirPtrType>() {
+        // Generic-space pointers are 64-bit under every data layout the
+        // exporter can choose; a shared-space pointer is 32-bit under the
+        // modern NVVM layout alone, so its stored stride is target-dependent.
+        // Claim the former, decline the latter.
+        return (ptr_ty.address_space == 0).then_some(8);
+    }
+    if let Some(array_ty) = ty_ref.downcast_ref::<MirArrayType>() {
+        // Arrays of sized aggregates already answered through
+        // `mir_stored_size` above; this recursion serves arrays of
+        // scalars and pointers, and deeper such arrays.
+        let element_ty = array_ty.element_type();
+        let count = array_ty.size();
+        drop(ty_ref);
+        return mir_element_stride(ctx, element_ty)?.checked_mul(count);
     }
     None
 }

--- a/crates/rustc-codegen-cuda/examples/aligned_field_loads/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/aligned_field_loads/src/main.rs
@@ -44,6 +44,16 @@ pub struct AlignedPair {
     pub y: f32,
 }
 
+/// The same payload and alignment, but the two lanes live in an array rather
+/// than in named fields. Reading them goes through the array-element address
+/// path instead of the field path.
+#[repr(C, align(8))]
+#[derive(Clone, Copy)]
+pub struct AlignedLanes(pub [f32; 2]);
+
+// SAFETY: `AlignedLanes` is a `repr(C)` array of two f32 with no padding.
+unsafe impl cuda_core::DeviceCopy for AlignedLanes {}
+
 // SAFETY: both are plain `repr(C)` f32 pairs -- no padding holes, pointers, or
 // interior mutability -- so a byte copy to the device is valid.
 unsafe impl cuda_core::DeviceCopy for PackedPair {}
@@ -77,6 +87,39 @@ mod kernels {
         if let Some(o) = out.get_mut(idx) {
             let p = pts[i];
             *o = p.x + p.y;
+        }
+    }
+
+    /// The array-lane form, read through the slice rather than copied into a
+    /// local first. Copying the element to a local already fused, because SROA
+    /// then loads the whole aggregate; reading through the place uses the
+    /// address path, which is what this needed.
+    #[kernel]
+    pub fn lanes_through_ref(pts: &[AlignedLanes], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if let Some(o) = out.get_mut(idx) {
+            *o = pts[i].0[0] + pts[i].0[1];
+        }
+    }
+
+    /// Cache-resident array-lane form, read through a reference: the kernel
+    /// this change speeds up.
+    #[kernel]
+    pub fn hot_lanes(pts: &[AlignedLanes], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if let Some(o) = out.get_mut(idx) {
+            let mut acc = 0.0f32;
+            let mut k = i as u32;
+            let mut r = 0;
+            while r < ROUNDS {
+                let lanes = &pts[(k as usize) & (TABLE - 1)].0;
+                acc += lanes[0] + lanes[1];
+                k = k.wrapping_mul(1664525).wrapping_add(1013904223);
+                r += 1;
+            }
+            *o = acc;
         }
     }
 
@@ -156,7 +199,12 @@ fn main() {
         })
         .collect();
 
+    let lanes: Vec<AlignedLanes> = (0..N)
+        .map(|i| AlignedLanes([i as f32, (i * 2) as f32]))
+        .collect();
+
     let packed_dev = DeviceBuffer::from_host(&stream, &packed).unwrap();
+    let lanes_dev = DeviceBuffer::from_host(&stream, &lanes).unwrap();
     let aligned_dev = DeviceBuffer::from_host(&stream, &aligned).unwrap();
     let mut out = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
@@ -216,6 +264,24 @@ fn main() {
             stream_expect
         );
         bench!(
+            "lanes_through_ref",
+            {
+                module
+                    .lanes_through_ref(&stream, cfg, &lanes_dev, &mut out)
+                    .unwrap()
+            },
+            stream_expect
+        );
+        bench!(
+            "hot_lanes",
+            {
+                module
+                    .hot_lanes(&stream, cfg, &lanes_dev, &mut out)
+                    .unwrap()
+            },
+            hot_expect
+        );
+        bench!(
             "hot_packed",
             {
                 module
@@ -236,7 +302,7 @@ fn main() {
     }
 
     if all_ok {
-        println!("\nSUCCESS: all 4 kernels bit-correct");
+        println!("\nSUCCESS: all 6 kernels bit-correct");
     } else {
         eprintln!("\nMISMATCH");
         std::process::exit(1);

--- a/crates/rustc-codegen-cuda/examples/aligned_field_loads/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/aligned_field_loads/verify-code-shape.sh
@@ -59,8 +59,12 @@ reject_entry_shape() {
 vector_load='ld\.global\.v2\.b32'
 scalar_load='ld\.global\.b32'
 
-# The align(8) kernels must fuse the field pair into a single wide load.
-for kernel in aligned_pair hot_aligned; do
+# The align(8) kernels must fuse the pair into a single wide load. The `lanes`
+# kernels reach the same two f32 through an array index rather than named
+# fields, and read them through a reference rather than copying the element to
+# a local -- the shape that keeps the load on the address path, where the
+# alignment has to be carried explicitly.
+for kernel in aligned_pair hot_aligned lanes_through_ref hot_lanes; do
     require_entry_shape "${kernel}" \
         "vectorized field-pair load" "${vector_load}"
     reject_entry_shape "${kernel}" \
@@ -68,7 +72,9 @@ for kernel in aligned_pair hot_aligned; do
 done
 
 # The natural-align-4 controls prove nothing wider than the f32 itself, so
-# fusing them would be claiming alignment the source never guaranteed.
+# fusing them would be claiming alignment the source never guaranteed. They
+# guard both the field path and the element path: nothing in this change may
+# widen an access whose base is only 4-byte aligned.
 for kernel in packed_pair hot_packed; do
     require_entry_shape "${kernel}" \
         "scalar field load" "${scalar_load}"


### PR DESCRIPTION
Refs #745 — the array-element half you scoped in the #746 merge review.

#746 taught a *field* address to record what it proves, so `c.x + c.y` on an
`#[repr(C, align(8))]` element fuses into one `ld.global.v2.b32`. An **element**
address recorded nothing, so the same two f32 reached through an array index
still exported two `align 4` loads.

## One correction to the scope note

The note said `c.0[0] + c.0[1]` still emits two narrow loads. On current `main`
that exact spelling **already fuses** — I checked before building anything. The
local copy is what saves it: `let c = pts[i]` lets SROA load the whole 8-byte
aggregate, and the alignment comes from its type.

The shape that genuinely still failed is reading **through the place**:

```rust
let c = pts[i]; c.0[0] + c.0[1]      // already one wide load
pts[i].0[0] + pts[i].0[1]            // two narrow loads
let l = &pts[i].0; l[0] + l[1]       // two narrow loads   <- the table idiom
```

So the cost depended on whether the source copied the element or read through
it, which is not a distinction a programmer should have to know. The example
covers the reading-through form, since the copying form was never broken.

## The arithmetic

Two facts combine. Whatever the base pointer **already proved** beats the array
type alone when the array is a field of an over-aligned aggregate —
`&table[i].lanes` carries the outer struct's alignment, which `[f32; 2]` does
not know. Element `i` then sits at byte `i * stride`:

| index | provable |
|---|---|
| constant 0 | `base` |
| constant `i` | `gcd(base, i * stride)` |
| runtime | `gcd(base, stride)` — what *every* element satisfies |

All from rustc's layout. Uncertain cases decline, and the same power-of-two
guard you added to the field stamp applies here.

## PTX

| kernel | before | after |
|---|---|---|
| `lanes_through_ref` | 2 `ld.global.b32` | **1 `ld.global.v2.b32`** |
| `hot_lanes` | 4 `ld.global.b32` | **2 `ld.global.v2.b32`** |
| `packed_pair` (align-4 control) | 2 `ld.global.b32` | unchanged |
| `hot_packed` (align-4 control) | 4 `ld.global.b32` | unchanged |

## Measured — A10G (sm_86, 595.71.05)

4194304 threads, 30 timed launches after 5 warmup, all bit-correct. Same example
built by both compilers:

| kernel | stock `main` | this | speedup |
|---|---:|---:|---:|
| `packed_pair` | 105.0 | 104.6 | 1.00x |
| `aligned_pair` (#746's) | 104.9 | 104.8 | 1.00x |
| `lanes_through_ref` | 104.9 | 105.0 | 1.00x |
| `hot_packed` (**control**) | 1253.5 | 1253.5 | **1.00x** |
| `hot_aligned` (#746's) | 628.6 | 633.0 | 1.00x |
| **`hot_lanes`** | **1253.6** | **629.5** | **1.99x** |

Evidence: stock `.gpu-evidence/20260810T050351Z.log`, this branch
`20260810T045728Z.log`.

Streaming does not move and should not — bandwidth-bound at ~480 GB/s, where two
consecutive loads already coalesce into the same transactions. `hot_packed` is
identical to the byte across both builds, so the comparison is controlled *and*
it guards against claiming alignment an align-4 base never had.

## Gates

* Full smoketest on the A10G: **196 / 196, 0 fail**, 1224s
  (`.gpu-evidence/20260810T050600Z.log`).
* Four `mir-lower` unit tests mirroring yours on the field path: element zero
  inherits the base, a nonzero constant index narrows to the gcd, a runtime
  index claims only the stride, and a base with no over-alignment changes
  nothing.
* `verify-code-shape.sh` extended to both new kernels, so the fusion stays
  CI-checked without a GPU.
* Locally: fmt (3 scopes), clippy `-D warnings`, 11 unit-test suites.

## Neighbour

#750 also touches `mir-lower/src/convert/ops/aggregate.rs` (enum payload
storage) — different region, no overlap with the alignment machinery; whichever
lands first, the other rebases trivially.

Closes #745.
