### PR TITLE
test(finalizer): make the legacy live test require a kernel to exist

### DIFF
--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -297,9 +297,18 @@ fn validate_name(name: &str) -> Result<(), FinalizerError> {
 mod live_tests {
     use super::*;
 
+    /// `@llvm.used` keeps the kernel alive through LTO, exactly as cuda-oxide's
+    /// NVVM exporter emits it for real kernels. Without it nvJitLink's link-time
+    /// optimizer dead-strips the annotation-marked kernel as unreachable and
+    /// links an empty module: the pipeline still succeeds, so every assertion
+    /// below passed while nothing was being compiled. Measured on CUDA 13.3
+    /// before this line existed, the linked PTX was 202 bytes with zero
+    /// functions and the cubin had no entry points.
     const LEGACY_NVVM_IR: &[u8] = br#"
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
+
+@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @kernel to i8*)], section "llvm.metadata"
 
 define void @kernel() {
 entry:
@@ -337,12 +346,30 @@ entry:
                 .link_ltoir(&input, &options, FinalizerOutput::Cubin)
                 .unwrap();
             assert!(is_valid_cubin(&cubin));
+            // A cubin whose kernel was stripped is still a well-formed ELF, so
+            // `is_valid_cubin` alone cannot tell the two apart. Require the
+            // kernel's name to survive into the image.
+            assert!(
+                cubin.windows(b"kernel".len()).any(|part| part == b"kernel"),
+                "cubin has no `kernel` symbol ({} bytes): the kernel was \
+                 dead-stripped and this test is validating an empty module",
+                cubin.len()
+            );
             let ptx = finalizer
                 .link_ltoir(&input, &options, FinalizerOutput::Ptx)
                 .unwrap();
             assert!(
                 ptx.windows(b".version".len())
                     .any(|part| part == b".version")
+            );
+            // `.version` is in the header of even an empty module, so it proves
+            // only that something was emitted. The entry point is what proves
+            // the kernel made it through libNVVM and nvJitLink.
+            let ptx_text = String::from_utf8_lossy(&ptx);
+            assert!(
+                ptx_text.contains(".entry kernel"),
+                "linked PTX has no `.entry kernel` ({} bytes):\n{ptx_text}",
+                ptx.len()
             );
         }
     }


### PR DESCRIPTION
Closes #783.

Reproduced your finding independently on CUDA 13.3 before changing anything. All
three fma/debug combinations linked an empty module, and the numbers match yours
to the byte:

```
ptx_bytes=202  entries=0  visible_funcs=0  cubin_bytes=1464
ptx_bytes=202  entries=0  visible_funcs=0  cubin_bytes=1944
ptx_bytes=202  entries=0  visible_funcs=0  cubin_bytes=2160
```

`@llvm.used` fixes the stripping — the same line the newer live spill test
already carries at `lib.rs:395`, with a comment naming this exact hazard.

## The assertions are the half that keeps it fixed

The old three could not tell an empty module from a real one, which is why this
sat green for so long:

| assertion | why it passed on nothing |
|---|---|
| `!ltoir.is_empty()` | LTOIR wrapper exists regardless |
| `is_valid_cubin(&cubin)` | a stripped cubin is still a well-formed ELF |
| PTX contains `.version` | that is in the header of an empty module |

So the cubin must now contain the `kernel` symbol, and the PTX must contain
`.entry kernel`.

## Both were checked to bite

Removing **only** the keep-alive line and keeping the new assertions:

```
cubin has no `kernel` symbol (1464 bytes): the kernel was dead-stripped
and this test is validating an empty module
FAILED
```

With the line restored it passes. That is the property worth having: the
assertion fails for the original reason and says what the reason is, so the
regression cannot come back quietly.

## Verified

* all four `--ignored` live tests pass, including the spill test from #756
* the 21 default tests pass unchanged
* `cargo fmt --check`, `clippy --all-targets -D warnings`

**No GPU needed** — libNVVM and nvJitLink are host libraries, so this reproduces
anywhere a toolkit is discoverable. I ran it against CUDA 13.3 on a machine with
no NVIDIA driver at all.

Note the cubin check greps bytes for `kernel` rather than parsing the ELF symbol
table. That is deliberately the weaker of the two assertions — the PTX
`.entry kernel` check is the precise one, and the cubin check is there so a
stripped *cubin* is caught even if PTX emission were ever to change shape. Happy
to make it a real symbol-table walk if you would rather.