### PR TITLE
fix(mir-importer): support compiler_fence in device code

### DIFF
--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -883,6 +883,34 @@ fn extract_type_info_from_generics(
     })
 }
 
+/// The route a core atomic intrinsic takes through [`dispatch_core_intrinsic`].
+///
+/// The two fences carry no element-type generic, only an ordering const, so
+/// they must be picked out by name before the type extraction shared by the
+/// load/store/RMW/CAS paths. A fence that misses this routing is reported as
+/// a missing element type, which is not the problem (issue #781 was exactly
+/// that for `compiler_fence`).
+#[derive(Debug, PartialEq, Eq)]
+enum CoreIntrinsicRoute {
+    /// `atomic_singlethreadfence` (`core::sync::atomic::compiler_fence`):
+    /// constrains only the optimizer and must emit no hardware barrier.
+    CompilerFence,
+    /// `atomic_fence` (`core::sync::atomic::fence`): a hardware barrier at
+    /// system scope.
+    HardwareFence,
+    /// Everything else: element-typed load/store/RMW/CAS dispatch.
+    Typed,
+}
+
+/// Classify a core atomic intrinsic op name (see [`parse_core_intrinsic_op`]).
+fn route_core_intrinsic(op_name: &str) -> CoreIntrinsicRoute {
+    match op_name {
+        "singlethreadfence" => CoreIntrinsicRoute::CompilerFence,
+        "fence" => CoreIntrinsicRoute::HardwareFence,
+        _ => CoreIntrinsicRoute::Typed,
+    }
+}
+
 /// Dispatch a `std::intrinsics::atomic_*` / `core::intrinsics::atomic_*` call.
 ///
 /// Extracts the generic args (type, ordering) from the `func` operand and
@@ -906,42 +934,40 @@ pub fn dispatch_core_intrinsic(
 ) -> TranslationResult<Ptr<Operation>> {
     let op_name = parse_core_intrinsic_op(path).unwrap_or("");
 
-    // `atomic_singlethreadfence` (from `core::sync::atomic::compiler_fence`)
-    // has no element-type generic either, so it must be routed here for the
-    // same reason `fence` is: otherwise it reaches the load/store/RMW type
-    // extraction and reports a missing element type, which is not the problem.
-    if op_name == "singlethreadfence" {
-        let orderings = extract_core_intrinsic_orderings(func, &loc, 1)?;
-        return emit_core_compiler_fence(
-            ctx,
-            args,
-            destination,
-            target,
-            block_ptr,
-            prev_op,
-            value_map,
-            block_map,
-            loc,
-            orderings[0].clone(),
-        );
-    }
-
-    // `atomic_fence` has no element-type generic, only its ordering const.
-    // Route it before the common type extraction used by load/store/RMW/CAS.
-    if op_name == "fence" {
-        let orderings = extract_core_intrinsic_orderings(func, &loc, 1)?;
-        return emit_core_atomic_fence(
-            ctx,
-            args,
-            destination,
-            target,
-            block_ptr,
-            prev_op,
-            value_map,
-            block_map,
-            loc,
-            orderings[0].clone(),
-        );
+    // The ordering-only fences must be routed by name before the common type
+    // extraction used by load/store/RMW/CAS (see [`CoreIntrinsicRoute`]).
+    match route_core_intrinsic(op_name) {
+        CoreIntrinsicRoute::CompilerFence => {
+            let orderings = extract_core_intrinsic_orderings(func, &loc, 1)?;
+            return emit_core_compiler_fence(
+                ctx,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+                orderings[0].clone(),
+            );
+        }
+        CoreIntrinsicRoute::HardwareFence => {
+            let orderings = extract_core_intrinsic_orderings(func, &loc, 1)?;
+            return emit_core_atomic_fence(
+                ctx,
+                args,
+                destination,
+                target,
+                block_ptr,
+                prev_op,
+                value_map,
+                block_map,
+                loc,
+                orderings[0].clone(),
+            );
+        }
+        CoreIntrinsicRoute::Typed => {}
     }
 
     // Extract generic args from the func operand.
@@ -1126,7 +1152,7 @@ fn core_atomic_width_is_supported(bit_width: u32) -> bool {
 // NVVM ops as the cuda_device emit functions.
 // =============================================================================
 
-/// Emit a core compiler fence.
+/// Build the barrier op for a core compiler fence.
 ///
 /// `core::sync::atomic::compiler_fence` constrains only the compiler: it forbids
 /// reordering memory operations across itself and emits no hardware instruction,
@@ -1135,6 +1161,40 @@ fn core_atomic_width_is_supported(bit_width: u32) -> bool {
 /// the mechanism the first-class fence routes already use, minus the instruction
 /// text. That survives the libNVVM-safe route, which rejects the LLVM `fence`
 /// instruction outright.
+///
+/// `Relaxed` is refused. Safe Rust cannot build it: `compiler_fence(Relaxed)`
+/// panics in core. Only a direct nightly intrinsic call reaches here, and a
+/// relaxed compiler fence orders nothing, so refuse it rather than emit a
+/// barrier that silently means something else.
+fn build_compiler_fence_barrier(
+    ctx: &mut Context,
+    loc: &Location,
+    ordering: &AtomicOrdering,
+) -> TranslationResult<Ptr<Operation>> {
+    if matches!(ordering, AtomicOrdering::Relaxed) {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "core compiler fence cannot use Relaxed ordering".to_owned()
+            )
+        );
+    }
+
+    // No results, and therefore no `=` output constraints, which is what the
+    // inline-PTX verifier checks the two against.
+    Ok(InlinePtxOp::build(
+        ctx,
+        vec![],
+        vec![],
+        "",
+        "~{memory}",
+        true,
+        false,
+    ))
+}
+
+/// Emit a core compiler fence (see [`build_compiler_fence_barrier`] for the
+/// encoding and the `Relaxed` refusal).
 ///
 /// MIR args: none; ordering is carried by a const generic.
 #[allow(clippy::too_many_arguments)]
@@ -1160,22 +1220,7 @@ fn emit_core_compiler_fence(
         );
     }
 
-    // Safe Rust cannot build this: `compiler_fence(Relaxed)` panics in core.
-    // Only a direct nightly intrinsic call reaches here, and a relaxed compiler
-    // fence orders nothing, so refuse it rather than emit a barrier that
-    // silently means something else.
-    if matches!(ordering, AtomicOrdering::Relaxed) {
-        return input_err!(
-            loc.clone(),
-            TranslationErr::unsupported(
-                "core compiler fence cannot use Relaxed ordering".to_owned()
-            )
-        );
-    }
-
-    // No results, and therefore no `=` output constraints, which is what the
-    // inline-PTX verifier checks the two against.
-    let barrier = InlinePtxOp::build(ctx, vec![], vec![], "", "~{memory}", true, false);
+    let barrier = build_compiler_fence_barrier(ctx, &loc, &ordering)?;
     barrier.deref_mut(ctx).set_loc(loc.clone());
 
     if let Some(prev) = prev_op {
@@ -1613,10 +1658,122 @@ fn emit_core_atomic_cmpxchg(
 #[cfg(test)]
 mod tests {
     use super::{
-        core_atomic_width_is_supported, intrinsic_ordering_from_discriminant,
-        parse_core_intrinsic_op,
+        CoreIntrinsicRoute, build_compiler_fence_barrier, core_atomic_width_is_supported,
+        intrinsic_ordering_from_discriminant, parse_core_intrinsic_op, route_core_intrinsic,
     };
-    use dialect_nvvm::ops::AtomicOrdering;
+    use dialect_nvvm::ops::{AtomicOrdering, InlinePtxOp};
+    use pliron::common_traits::Verify;
+    use pliron::context::Context;
+    use pliron::location::Location;
+
+    fn test_context() -> Context {
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        dialect_nvvm::register(&mut ctx);
+        ctx
+    }
+
+    /// The regression gate for issue #781: `singlethreadfence` (the intrinsic
+    /// behind `core::sync::atomic::compiler_fence`) must take the
+    /// compiler-fence route through `dispatch_core_intrinsic`. Without this
+    /// routing it falls through to the element-typed dispatch and any kernel
+    /// calling `compiler_fence` fails to compile with a missing-element-type
+    /// diagnostic.
+    #[test]
+    fn compiler_fence_takes_the_compiler_fence_route() {
+        assert_eq!(
+            route_core_intrinsic("singlethreadfence"),
+            CoreIntrinsicRoute::CompilerFence
+        );
+    }
+
+    /// `fence` stays on the hardware-barrier route and the element-typed ops
+    /// stay on the typed dispatch: the compiler-fence routing must not widen.
+    #[test]
+    fn fence_and_typed_ops_keep_their_routes() {
+        assert_eq!(
+            route_core_intrinsic("fence"),
+            CoreIntrinsicRoute::HardwareFence
+        );
+        for op in ["load", "store", "xadd", "cxchg", "cxchgweak", ""] {
+            assert_eq!(
+                route_core_intrinsic(op),
+                CoreIntrinsicRoute::Typed,
+                "{op:?}"
+            );
+        }
+    }
+
+    /// `compiler_fence(Relaxed)` panics in core, so only a direct nightly
+    /// intrinsic call can carry Relaxed here. The importer refuses it instead
+    /// of emitting a barrier that silently means something else.
+    #[test]
+    fn compiler_fence_refuses_relaxed_ordering() {
+        let mut ctx = test_context();
+        let err =
+            build_compiler_fence_barrier(&mut ctx, &Location::Unknown, &AtomicOrdering::Relaxed)
+                .expect_err("Relaxed must be refused");
+        assert!(
+            err.to_string().contains("Relaxed"),
+            "diagnostic must name the refused ordering: {err}"
+        );
+    }
+
+    /// Every ordering safe Rust can pass to `compiler_fence` encodes as an
+    /// empty, volatile, non-convergent inline-PTX block whose only content is
+    /// the `~{memory}` clobber: no instruction text (so no hardware `fence` or
+    /// `membar`), no results, and it satisfies the inline-PTX verifier (zero
+    /// results paired against zero `=` output constraints).
+    #[test]
+    fn compiler_fence_barrier_is_an_empty_memory_clobber() {
+        let mut ctx = test_context();
+        for ordering in [
+            AtomicOrdering::Acquire,
+            AtomicOrdering::Release,
+            AtomicOrdering::AcqRel,
+            AtomicOrdering::SeqCst,
+        ] {
+            let op = build_compiler_fence_barrier(&mut ctx, &Location::Unknown, &ordering)
+                .unwrap_or_else(|e| panic!("{ordering:?} must be accepted: {e}"));
+            let barrier = InlinePtxOp::new(op);
+            assert_eq!(
+                barrier
+                    .get_attr_ptx_template(&ctx)
+                    .map(|s| String::from((*s).clone()))
+                    .as_deref(),
+                Some(""),
+                "{ordering:?}: the barrier must emit no PTX instruction"
+            );
+            assert_eq!(
+                barrier
+                    .get_attr_ptx_constraints(&ctx)
+                    .map(|s| String::from((*s).clone()))
+                    .as_deref(),
+                Some("~{memory}"),
+                "{ordering:?}: the barrier must clobber memory"
+            );
+            assert!(
+                barrier
+                    .get_attr_ptx_sideeffect(&ctx)
+                    .is_some_and(|b| bool::from((*b).clone())),
+                "{ordering:?}: the barrier must be side-effecting"
+            );
+            assert!(
+                barrier
+                    .get_attr_ptx_convergent(&ctx)
+                    .is_some_and(|b| !bool::from((*b).clone())),
+                "{ordering:?}: the barrier must not be convergent"
+            );
+            assert_eq!(
+                op.deref(&ctx).get_num_results(),
+                0,
+                "{ordering:?}: the barrier has no results"
+            );
+            barrier
+                .verify(&ctx)
+                .unwrap_or_else(|e| panic!("{ordering:?}: verifier must accept the barrier: {e}"));
+        }
+    }
 
     /// Both ordering-only fences must be recognised by name. `singlethreadfence`
     /// carries no element type, so if it is not matched here it falls through to

--- a/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs
@@ -67,6 +67,7 @@ use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::values::ValueMap;
 use crate::translator::{rvalue, types};
 
+use dialect_nvvm::ops::InlinePtxOp;
 use dialect_nvvm::ops::atomic::{
     AtomicOrdering, AtomicRmwKind, AtomicScope, NvvmAtomicCmpxchgOp, NvvmAtomicFenceOp,
     NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp,
@@ -905,6 +906,26 @@ pub fn dispatch_core_intrinsic(
 ) -> TranslationResult<Ptr<Operation>> {
     let op_name = parse_core_intrinsic_op(path).unwrap_or("");
 
+    // `atomic_singlethreadfence` (from `core::sync::atomic::compiler_fence`)
+    // has no element-type generic either, so it must be routed here for the
+    // same reason `fence` is: otherwise it reaches the load/store/RMW type
+    // extraction and reports a missing element type, which is not the problem.
+    if op_name == "singlethreadfence" {
+        let orderings = extract_core_intrinsic_orderings(func, &loc, 1)?;
+        return emit_core_compiler_fence(
+            ctx,
+            args,
+            destination,
+            target,
+            block_ptr,
+            prev_op,
+            value_map,
+            block_map,
+            loc,
+            orderings[0].clone(),
+        );
+    }
+
     // `atomic_fence` has no element-type generic, only its ordering const.
     // Route it before the common type extraction used by load/store/RMW/CAS.
     if op_name == "fence" {
@@ -926,7 +947,8 @@ pub fn dispatch_core_intrinsic(
     // Extract generic args from the func operand.
     let is_cmpxchg = op_name == "cxchg" || op_name == "cxchgweak";
     let expected_orderings = if is_cmpxchg { 2 } else { 1 };
-    let (type_info, orderings) = extract_core_intrinsic_generics(func, &loc, expected_orderings)?;
+    let (type_info, orderings) =
+        extract_core_intrinsic_generics(func, &loc, expected_orderings, op_name)?;
     let ordering = orderings[0].clone();
 
     // Route by operation name
@@ -1054,6 +1076,7 @@ fn extract_core_intrinsic_generics(
     func: &mir::Operand,
     loc: &Location,
     expected_orderings: usize,
+    op_name: &str,
 ) -> TranslationResult<(AtomicTypeInfo, Vec<AtomicOrdering>)> {
     if let mir::Operand::Constant(const_op) = func
         && let TyKind::RigidTy(RigidTy::FnDef(_, substs)) = const_op.const_.ty().kind()
@@ -1061,9 +1084,10 @@ fn extract_core_intrinsic_generics(
         let Some(type_info) = extract_type_info_from_generics(&substs) else {
             return input_err!(
                 loc.clone(),
-                TranslationErr::unsupported(
-                    "could not extract element type from core atomic intrinsic generics"
-                )
+                TranslationErr::unsupported(format!(
+                    "unsupported core atomic operation `{op_name}`: no element type in its \
+                         generics, and it is not one of the ordering-only fences"
+                ))
             );
         };
 
@@ -1101,6 +1125,92 @@ fn core_atomic_width_is_supported(bit_width: u32) -> bool {
 // from cuda_device (no ordering arg, different arg count).  They build the same
 // NVVM ops as the cuda_device emit functions.
 // =============================================================================
+
+/// Emit a core compiler fence.
+///
+/// `core::sync::atomic::compiler_fence` constrains only the compiler: it forbids
+/// reordering memory operations across itself and emits no hardware instruction,
+/// so unlike `fence` it must not become a PTX `fence` or `membar`. The encoding
+/// is an empty side-effecting inline PTX block carrying a `~{memory}` clobber --
+/// the mechanism the first-class fence routes already use, minus the instruction
+/// text. That survives the libNVVM-safe route, which rejects the LLVM `fence`
+/// instruction outright.
+///
+/// MIR args: none; ordering is carried by a const generic.
+#[allow(clippy::too_many_arguments)]
+fn emit_core_compiler_fence(
+    ctx: &mut Context,
+    args: &[mir::Operand],
+    destination: &mir::Place,
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+    ordering: AtomicOrdering,
+) -> TranslationResult<Ptr<Operation>> {
+    if !args.is_empty() {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "core compiler fence expects no arguments, got {}",
+                args.len()
+            ))
+        );
+    }
+
+    // Safe Rust cannot build this: `compiler_fence(Relaxed)` panics in core.
+    // Only a direct nightly intrinsic call reaches here, and a relaxed compiler
+    // fence orders nothing, so refuse it rather than emit a barrier that
+    // silently means something else.
+    if matches!(ordering, AtomicOrdering::Relaxed) {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(
+                "core compiler fence cannot use Relaxed ordering".to_owned()
+            )
+        );
+    }
+
+    // No results, and therefore no `=` output constraints, which is what the
+    // inline-PTX verifier checks the two against.
+    let barrier = InlinePtxOp::build(ctx, vec![], vec![], "", "~{memory}", true, false);
+    barrier.deref_mut(ctx).set_loc(loc.clone());
+
+    if let Some(prev) = prev_op {
+        barrier.insert_after(ctx, prev);
+    } else {
+        barrier.insert_at_front(block_ptr, ctx);
+    }
+
+    // `core::sync::atomic::compiler_fence` returns unit.
+    let unit_ty = dialect_mir::types::MirTupleType::get(ctx, vec![]);
+    let unit_op = Operation::new(
+        ctx,
+        MirConstructTupleOp::get_concrete_op_info(),
+        vec![unit_ty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    unit_op.deref_mut(ctx).set_loc(loc.clone());
+    unit_op.insert_after(ctx, barrier);
+    let unit_val = unit_op.deref(ctx).get_result(0);
+
+    emit_store_result_and_goto(
+        ctx,
+        destination,
+        unit_val,
+        target,
+        block_ptr,
+        unit_op,
+        value_map,
+        block_map,
+        loc,
+        "core compiler fence call without target block",
+    )
+}
 
 /// Emit a core atomic fence.
 ///
@@ -1502,8 +1612,43 @@ fn emit_core_atomic_cmpxchg(
 
 #[cfg(test)]
 mod tests {
-    use super::{core_atomic_width_is_supported, intrinsic_ordering_from_discriminant};
+    use super::{
+        core_atomic_width_is_supported, intrinsic_ordering_from_discriminant,
+        parse_core_intrinsic_op,
+    };
     use dialect_nvvm::ops::AtomicOrdering;
+
+    /// Both ordering-only fences must be recognised by name. `singlethreadfence`
+    /// carries no element type, so if it is not matched here it falls through to
+    /// the load/store/RMW generics extraction and is reported as a missing
+    /// element type -- which is what issue #781 was.
+    #[test]
+    fn ordering_only_fences_are_recognised_by_name() {
+        for (path, expected) in [
+            ("core::intrinsics::atomic_fence", "fence"),
+            ("std::intrinsics::atomic_fence", "fence"),
+            (
+                "core::intrinsics::atomic_singlethreadfence",
+                "singlethreadfence",
+            ),
+            (
+                "std::intrinsics::atomic_singlethreadfence",
+                "singlethreadfence",
+            ),
+        ] {
+            assert_eq!(parse_core_intrinsic_op(path), Some(expected), "{path}");
+        }
+    }
+
+    /// `singlethreadfence` must not be confused with `fence`: they take
+    /// different routes, one emitting a hardware barrier and one emitting none.
+    #[test]
+    fn compiler_fence_is_not_parsed_as_a_hardware_fence() {
+        assert_ne!(
+            parse_core_intrinsic_op("core::intrinsics::atomic_singlethreadfence"),
+            parse_core_intrinsic_op("core::intrinsics::atomic_fence")
+        );
+    }
 
     #[test]
     fn core_atomics_accept_only_current_backend_widths() {

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -3068,6 +3068,86 @@ fn test_inline_ptx_supports_thirty_two_tied_f32_results() -> Result<(), anyhow::
     Ok(())
 }
 
+/// The mir-importer encodes `core::sync::atomic::compiler_fence` (issue #781)
+/// as an empty, volatile, non-convergent inline-PTX block whose only content
+/// is a `~{memory}` clobber. It must lower to a void side-effecting inline asm
+/// call with the clobber intact and no instruction text, so no hardware
+/// `fence` or `membar` can reach the emitted PTX.
+#[test]
+fn test_compiler_fence_encoding_lowers_to_empty_sideeffect_asm() -> Result<(), anyhow::Error> {
+    use llvm_export::types as llvm_types;
+    use pliron::r#type::Typed;
+
+    let mut ctx = make_test_ctx();
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, vec![]);
+
+    let barrier = nvvm::InlinePtxOp::build(&mut ctx, vec![], vec![], "", "~{memory}", true, false);
+    barrier.insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let mut found_barrier = false;
+    for op in lowered_kernel_body(&ctx, module_ptr) {
+        let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(op, &ctx) else {
+            continue;
+        };
+        assert!(
+            !found_barrier,
+            "expected exactly one inline asm op in the lowered kernel"
+        );
+        found_barrier = true;
+
+        let template = inline_asm
+            .get_attr_inline_asm_template(&ctx)
+            .map(|s| String::from((*s).clone()));
+        assert_eq!(
+            template.as_deref(),
+            Some(""),
+            "compiler fence must emit no PTX instruction"
+        );
+        assert_eq!(
+            inline_asm
+                .get_attr_inline_asm_constraints(&ctx)
+                .map(|s| String::from((*s).clone()))
+                .as_deref(),
+            Some("~{memory}"),
+            "compiler fence must keep its memory clobber"
+        );
+        assert!(
+            llvm::inline_asm_sideeffect(&ctx, inline_asm.get_operation()),
+            "compiler fence must stay side-effecting so the optimizer cannot drop it"
+        );
+        assert!(
+            inline_asm
+                .get_attr_inline_asm_convergent(&ctx)
+                .is_some_and(|b| !bool::from((*b).clone())),
+            "compiler fence must not be convergent"
+        );
+        // The zero-result lowering path models the void call as a single
+        // result of `llvm.void` type, so assert on the type rather than on
+        // the result count.
+        let result_ty = inline_asm
+            .get_operation()
+            .deref(&ctx)
+            .get_result(0)
+            .get_type(&ctx);
+        assert!(
+            result_ty
+                .deref(&ctx)
+                .downcast_ref::<llvm_types::VoidType>()
+                .is_some(),
+            "compiler fence lowers to a void inline asm call"
+        );
+    }
+
+    assert!(
+        found_barrier,
+        "expected the compiler-fence inline asm op in the lowered kernel"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_cluster_grid_compatibility_ops_keep_original_lowering() -> Result<(), anyhow::Error> {
     use pliron::builtin::types::{IntegerType, Signedness};

--- a/crates/rustc-codegen-cuda/examples/scoped_atomic_load_store/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/scoped_atomic_load_store/src/main.rs
@@ -41,7 +41,7 @@ const N: usize = 256;
 #[cuda_module]
 mod kernels {
     use super::*;
-    use core::sync::atomic::{Ordering, fence};
+    use core::sync::atomic::{Ordering, compiler_fence, fence};
     use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU32, DeviceAtomicU64};
 
     /// Each thread publishes a payload with a release store, then reads its
@@ -82,6 +82,12 @@ mod kernels {
         // Exercise the source-level core fence path from issue #723. Core
         // atomics use system scope, so Release lowers to fence.acq_rel.sys.
         fence(Ordering::Release);
+
+        // `compiler_fence` is the weaker sibling (issue #781): it constrains
+        // only the optimizer and must emit no hardware barrier at all, so it
+        // lowers to an empty side-effecting asm carrying a `~{memory}` clobber.
+        // Placed between two stores, which is the ordering it exists to keep.
+        compiler_fence(Ordering::Release);
 
         // Pair writers with readers without spinning: a hung example is a far
         // worse failure mode than a slightly weaker test, and the instruction


### PR DESCRIPTION
Closes #781.

Reproduced your diagnosis exactly: `atomic_singlethreadfence` carries only an
ordering, so it fell through to the load/store/RMW generics extraction and got
reported as a missing element type. It is routed ahead of that now, reusing the
ordering-only extractor #747 added.

## No hardware barrier, and that is checked

A compiler fence constrains only the optimizer, so it must not become a PTX
`fence` or `membar`. The encoding is your suggestion — an **empty**
side-effecting inline PTX block with a `~{memory}` clobber, the #695 mechanism
minus the instruction text.

Rather than assert that indirectly, I built the example both ways on the fixed
compiler and diffed the emitted barriers:

| without `compiler_fence` | with it |
|---|---|
| 1 `fence.acq_rel.sys` | 1 `fence.acq_rel.sys` |
| 2 `fence.sc.gpu` | 2 `fence.sc.gpu` |
| 1 `membar.sys` | 1 `membar.sys` |

Identical. The fence costs no instruction.

## It needed no new dialect op or scope

I first went looking at `AtomicScope`, but adding a thread variant ripples into
`LlvmSyncScope` and `map_scope` across three crates. `InlinePtxOp` already
carries a template and constraints and is already emitted from the importer for
`ptx_asm!`, and its verifier pairs results against `=` output constraints — so
zero results with `~{memory}` is valid, and the whole change lands in one file.

## Relaxed, and the diagnostic

`Relaxed` is refused rather than lowered: safe Rust cannot reach it
(`compiler_fence(Relaxed)` panics in core), only a direct nightly intrinsic call
can, and a relaxed compiler fence orders nothing.

The residual diagnostic now names the operation instead of blaming generics,
which is what made this failure mode confusing in the first place.

## Verified

* **Before**, stock `main`: `Unsupported construct: could not extract element
  type from core atomic intrinsic generics`
* **After**: compiles; the barrier diff above; **A10G (sm_86) executes it and
  reports SUCCESS** (`.gpu-evidence/20260810T084433Z.log`)
* Scoped smoketest over the atomics examples: **8/8**
  (`.gpu-evidence/20260810T085042Z.log`)
* Two importer tests pinning that both ordering-only fences are recognised by
  name and that `singlethreadfence` is not conflated with `fence` — the exact
  confusion that caused this
* `cargo fmt --check` (root + example), `clippy --all-targets -D warnings`,
  and `-p mir-importer -p mir-lower -p dialect-nvvm` unit tests (5 suites)

The source-level touch went into `scoped_atomic_load_store`, the example #747
already uses for the fence routes, so both siblings are now covered in one place.

One judgement call worth flagging: you suggested a lowering test shaped like
`test_first_class_atomic_fence_lowers_at_system_scope`. Because this encodes at
import time rather than through a dialect fence op, the equivalent assertion is
the PTX barrier diff above, which I think is the stronger check — it asserts on
real emitted PTX rather than on the op tree. Happy to add a mir-lower test too if
you would rather have both.