### PR TITLE
debug: expose closure environments in full debug

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -2999,7 +2999,7 @@ pub enum DeviceDebug {
     Off,
     /// Preserve source line mappings without disabling optimization.
     LineTables,
-    /// Emit full debug information; libNVVM finalization runs unoptimized.
+    /// Emit full debug information; MIR optimization is disabled and libNVVM finalization runs unoptimized.
     Full,
 }
 
@@ -5826,17 +5826,48 @@ fn strip_wrapper_owned_codegen_cfgs(flags: &mut Vec<String>) {
     *flags = retained;
 }
 
+fn command_requests_full_device_debug_with_env(
+    cmd: &Command,
+    inherited_debug: Option<&str>,
+) -> bool {
+    let effective_debug = match cmd
+        .get_envs()
+        .find(|(name, _)| *name == std::ffi::OsStr::new("CUDA_OXIDE_DEBUG"))
+    {
+        Some((_, Some(value))) => Some(value.to_string_lossy().into_owned()),
+        Some((_, None)) => None,
+        None => inherited_debug.map(str::to_owned),
+    };
+
+    effective_debug.is_some_and(|value| value.trim().eq_ignore_ascii_case("full"))
+}
+
+fn append_full_debug_mir_rustflag(
+    encoded: &mut String,
+    cmd: &Command,
+    inherited_debug: Option<&str>,
+) {
+    if !command_requests_full_device_debug_with_env(cmd, inherited_debug) {
+        return;
+    }
+    if !encoded.is_empty() {
+        encoded.push(ENCODED_RUSTFLAGS_SEPARATOR);
+    }
+    encoded.push_str("-Zmir-opt-level=0");
+}
+
 fn apply_codegen_rustflags(
     cmd: &mut Command,
     ctx: &Context,
     profile: CodegenProfilePolicy,
     device_cfgs: &[String],
 ) {
-    cmd.env(
-        "CARGO_ENCODED_RUSTFLAGS",
-        build_encoded_rustflags(ctx, profile, device_cfgs),
-    )
-    .env_remove("RUSTFLAGS");
+    let mut encoded = build_encoded_rustflags(ctx, profile, device_cfgs);
+    let inherited_debug = std::env::var("CUDA_OXIDE_DEBUG").ok();
+    append_full_debug_mir_rustflag(&mut encoded, cmd, inherited_debug.as_deref());
+
+    cmd.env("CARGO_ENCODED_RUSTFLAGS", encoded)
+        .env_remove("RUSTFLAGS");
 }
 
 /// Apply the two deliberately different Cargo cache boundaries:
@@ -10676,5 +10707,37 @@ edition = "2024"
         assert_ne!(off, fp(&line_tables));
         assert_ne!(off, fp(&full));
         assert_ne!(fp(&line_tables), fp(&full));
+    }
+
+    #[test]
+    fn full_device_debug_disables_mir_optimization() {
+        let cmd = Command::new("cargo");
+        let mut encoded = "base".to_string();
+
+        append_full_debug_mir_rustflag(&mut encoded, &cmd, Some("full"));
+
+        assert_eq!(decoded_rustflags(&encoded), ["base", "-Zmir-opt-level=0"]);
+    }
+
+    #[test]
+    fn line_tables_keep_normal_mir_optimization() {
+        let mut cmd = Command::new("cargo");
+        cmd.env("CUDA_OXIDE_DEBUG", "line");
+        let mut encoded = "base".to_string();
+
+        append_full_debug_mir_rustflag(&mut encoded, &cmd, None);
+
+        assert_eq!(decoded_rustflags(&encoded), ["base"]);
+    }
+
+    #[test]
+    fn explicit_line_tables_override_inherited_full_debug_for_mir_optimization() {
+        let mut cmd = Command::new("cargo");
+        cmd.env("CUDA_OXIDE_DEBUG", "line");
+        let mut encoded = "base".to_string();
+
+        append_full_debug_mir_rustflag(&mut encoded, &cmd, Some("full"));
+
+        assert_eq!(decoded_rustflags(&encoded), ["base"]);
     }
 }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -5839,7 +5839,13 @@ fn command_requests_full_device_debug_with_env(
         None => inherited_debug.map(str::to_owned),
     };
 
-    effective_debug.is_some_and(|value| value.trim().eq_ignore_ascii_case("full"))
+    // Shared alias table: the codegen backend parses `CUDA_OXIDE_DEBUG`
+    // with the same function, so every spelling the backend treats as
+    // full debug (including `2`) also disables MIR optimization here.
+    effective_debug.is_some_and(|value| {
+        cuda_artifact_finalizer::DebugPolicy::parse_env_override(&value)
+            == Some(cuda_artifact_finalizer::DebugPolicy::Full)
+    })
 }
 
 fn append_full_debug_mir_rustflag(
@@ -10653,12 +10659,21 @@ edition = "2024"
 
     #[test]
     fn device_debug_env_value_matches_the_backend_parser() {
-        // These must be strings `device_debug_kind_with_override` accepts; a typo
-        // would silently fall through to the profile-derived default instead of
-        // failing, so pin them.
+        // The exported strings must round-trip through the shared
+        // `CUDA_OXIDE_DEBUG` parser (the same one the codegen backend uses);
+        // a typo would silently fall through to the profile-derived default
+        // instead of failing, so check the actual parse.
         assert_eq!(DeviceDebug::Off.env_value(), None);
         assert_eq!(DeviceDebug::LineTables.env_value(), Some("line"));
         assert_eq!(DeviceDebug::Full.env_value(), Some("full"));
+        assert_eq!(
+            cuda_artifact_finalizer::DebugPolicy::parse_env_override("line"),
+            Some(cuda_artifact_finalizer::DebugPolicy::LineTables)
+        );
+        assert_eq!(
+            cuda_artifact_finalizer::DebugPolicy::parse_env_override("full"),
+            Some(cuda_artifact_finalizer::DebugPolicy::Full)
+        );
     }
 
     #[test]
@@ -10715,6 +10730,20 @@ edition = "2024"
         let mut encoded = "base".to_string();
 
         append_full_debug_mir_rustflag(&mut encoded, &cmd, Some("full"));
+
+        assert_eq!(decoded_rustflags(&encoded), ["base", "-Zmir-opt-level=0"]);
+    }
+
+    #[test]
+    fn numeric_full_debug_alias_disables_mir_optimization() {
+        // The backend accepts `CUDA_OXIDE_DEBUG=2` as full debug; the shared
+        // parser guarantees the build policy agrees, so `2` must disable MIR
+        // optimization exactly like `full`.
+        let mut cmd = Command::new("cargo");
+        cmd.env("CUDA_OXIDE_DEBUG", "2");
+        let mut encoded = "base".to_string();
+
+        append_full_debug_mir_rustflag(&mut encoded, &cmd, None);
 
         assert_eq!(decoded_rustflags(&encoded), ["base", "-Zmir-opt-level=0"]);
     }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -3706,7 +3706,21 @@ pub fn codegen_show_pipeline(
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release"]).current_dir(&example_dir);
 
-    apply_config_env(&mut cmd, ctx);
+    // The shared codegen env (including the CLI debug level) must be on the
+    // command before the rustflags decision below: a full-debug request adds
+    // `-Zmir-opt-level=0`, and `apply_codegen_rustflags` reads the command's
+    // `CUDA_OXIDE_DEBUG` to see it. This is the same ordering build/run use.
+    apply_common_codegen_env(
+        &mut cmd,
+        ctx,
+        true,
+        no_fmad,
+        unchecked_indexing,
+        device_debug,
+    );
+    cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
+    cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
+    cmd.env("CUDA_OXIDE_DUMP_LLVM", "1");
     let fingerprint = pipeline_codegen_fingerprint(
         ctx,
         no_fmad,
@@ -3723,22 +3737,8 @@ pub fn codegen_show_pipeline(
         &[],
         &fingerprint,
     );
-    cmd.env("CUDA_OXIDE_VERBOSE", "1");
-    cmd.env("CUDA_OXIDE_SHOW_RUSTC_MIR", "1");
-    cmd.env("CUDA_OXIDE_DUMP_MIR", "1");
-    cmd.env("CUDA_OXIDE_DUMP_LLVM", "1");
-    if no_fmad {
-        cmd.env("CUDA_OXIDE_NO_FMA", "1");
-    }
-    if unchecked_indexing {
-        cmd.env("CUDA_OXIDE_UNCHECKED_INDEXING", "1");
-    }
-    if let Some(level) = device_debug.env_value() {
-        cmd.env("CUDA_OXIDE_DEBUG", level);
-    }
 
     apply_output_mode(&mut cmd, emit_nvvm_ir, target_arch, &materialization);
-    apply_ld_library_path(&mut cmd, ctx);
 
     println!("Building {}...", example);
     println!();

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -17,6 +17,29 @@ pub enum DebugPolicy {
     Full,
 }
 
+impl DebugPolicy {
+    /// Parse a `CUDA_OXIDE_DEBUG` value into a debug policy.
+    ///
+    /// This is the single alias table for the environment variable. The
+    /// rustc codegen backend uses it to select the DWARF emission level,
+    /// and cargo-oxide uses it to decide build policy (a full-debug build
+    /// disables MIR optimization so aggregate locals survive to DWARF).
+    /// Keeping both behind one parser means every accepted spelling, such
+    /// as `2` for `full`, drives the whole pipeline consistently.
+    ///
+    /// Returns `None` for unrecognized values so callers fall back to
+    /// their own defaults.
+    #[must_use]
+    pub fn parse_env_override(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "0" | "off" | "none" => Some(Self::None),
+            "1" | "line" | "lines" | "line-tables" | "line-tables-only" => Some(Self::LineTables),
+            "2" | "full" => Some(Self::Full),
+            _ => None,
+        }
+    }
+}
+
 /// Typed options shared by the libNVVM and nvJitLink stages.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FinalizationOptions {
@@ -172,6 +195,35 @@ impl<'a> NamedInput<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_policy_env_override_accepts_every_alias() {
+        for (value, expected) in [
+            ("0", DebugPolicy::None),
+            ("off", DebugPolicy::None),
+            ("none", DebugPolicy::None),
+            ("1", DebugPolicy::LineTables),
+            ("line", DebugPolicy::LineTables),
+            ("lines", DebugPolicy::LineTables),
+            ("line-tables", DebugPolicy::LineTables),
+            ("line-tables-only", DebugPolicy::LineTables),
+            ("2", DebugPolicy::Full),
+            ("full", DebugPolicy::Full),
+        ] {
+            assert_eq!(
+                DebugPolicy::parse_env_override(value),
+                Some(expected),
+                "alias `{value}` must parse"
+            );
+        }
+        // Whitespace and case are ignored, unknown values are rejected.
+        assert_eq!(
+            DebugPolicy::parse_env_override(" Full "),
+            Some(DebugPolicy::Full)
+        );
+        assert_eq!(DebugPolicy::parse_env_override("verbose"), None);
+        assert_eq!(DebugPolicy::parse_env_override(""), None);
+    }
 
     #[test]
     fn option_order_preserves_target_lto_output_fma_and_debug_policy() {

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -1708,4 +1708,131 @@ mod tests {
             "`is_inline_always` must become an LLVM dialect alwaysinline attribute before export",
         );
     }
+
+    /// Closure environments must be described as composite debug types with
+    /// member offsets taken from rustc's real layout, not declaration order.
+    ///
+    /// `debug_type_for_ty` needs a live compiler session (closure types and
+    /// layouts only exist inside one), so this test drives the pinned rustc
+    /// in-process on a small fixture via `rustc_public::run!`, extracts the
+    /// closure-typed local, and asserts on the returned plain data outside
+    /// the session. The fixture is compiled with `-Zmir-opt-level=0`, the
+    /// same flag cargo-oxide adds for full device debug, so the closure
+    /// local survives to MIR exactly as in a real full-debug build.
+    ///
+    /// The `u32`-before-`u64` capture order is deliberate: rustc's layout
+    /// sorts closure fields by descending alignment, placing the `u64` at
+    /// offset 0 and the `u32` at offset 8. Sequential declaration-order
+    /// offsets would put `capture_0` at 0, so this fails loudly if the
+    /// composite type ever stops using the layout's field offsets.
+    #[test]
+    fn closure_environment_debug_type_uses_layout_offsets() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_closure_debug_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("closure_debug_fixture.rs");
+        std::fs::write(
+            &fixture,
+            r#"
+pub fn closure_host(a: u32, b: u64) -> u32 {
+    let add = move |x: u32| x + a + (b as u32);
+    add(1)
+}
+"#,
+        )
+        .unwrap();
+
+        // The rustup shim resolves the same pinned toolchain this test binary
+        // was built with, so the in-process driver and the sysroot agree.
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=closure_debug_fixture".to_string(),
+            "--emit=metadata".to_string(),
+            "-Zmir-opt-level=0".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        // rustc needs more stack than the default test-thread allowance.
+        let debug_type = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    let closure_ty = rustc_public::all_local_items()
+                        .into_iter()
+                        .filter_map(|item| item.body())
+                        .flat_map(|body| body.locals().to_vec())
+                        .map(|decl| decl.ty)
+                        .find(|ty| matches!(ty.kind(), TyKind::RigidTy(RigidTy::Closure(..))))
+                        .expect("fixture must contain a closure-typed local");
+                    std::ops::ControlFlow::<(), _>::Continue(debug_type_for_ty(&closure_ty))
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        std::fs::remove_dir_all(&root).ok();
+
+        let Some(DebugLocalTypeKind::Struct {
+            size_bits, members, ..
+        }) = debug_type
+        else {
+            panic!("closure environment must produce a composite debug type, got {debug_type:?}");
+        };
+        assert_eq!(size_bits, 128, "u64 + u32 environment is 16 bytes");
+        assert_eq!(members.len(), 2, "one member per capture");
+
+        assert_eq!(members[0].name, "capture_0");
+        assert_eq!(
+            members[0].offset_bits, 64,
+            "the u32 capture sits after the u64 in rustc's layout"
+        );
+        match &members[0].ty {
+            DebugLocalTypeKind::Basic {
+                name, size_bits, ..
+            } => {
+                assert_eq!(name, "u32");
+                assert_eq!(*size_bits, 32);
+            }
+            other => panic!("capture_0 must be a basic u32, got {other:?}"),
+        }
+
+        assert_eq!(members[1].name, "capture_1");
+        assert_eq!(
+            members[1].offset_bits, 0,
+            "the u64 capture is layout-first despite being declared second"
+        );
+        match &members[1].ty {
+            DebugLocalTypeKind::Basic {
+                name, size_bits, ..
+            } => {
+                assert_eq!(name, "u64");
+                assert_eq!(*size_bits, 64);
+            }
+            other => panic!("capture_1 must be a basic u64, got {other:?}"),
+        }
+    }
 }

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -563,17 +563,13 @@ struct LocalDebugInfo {
     source_scope: u32,
 }
 
-/// Build the first full-debug variable map.
+/// Build the full-debug variable map for whole MIR locals.
 ///
-/// This stage only supports simple whole-local bindings:
-///
-/// ```text
-/// debug name => _3
-/// ```
-///
-/// Fragments/projections need `DIExpression(DW_OP_LLVM_fragment, ...)` and more
-/// value-location tracking, so they are intentionally skipped until the basic
-/// local/argument path is solid.
+/// The cargo-oxide full-debug path disables MIR optimization, so closure
+/// environments stay as aggregate locals instead of being split into SROA
+/// fragments. Composite debug records are intentionally skipped here; closure
+/// locals use the normal whole-local path and are described by
+/// `debug_type_for_ty`.
 fn collect_debug_locals(
     ctx: &mut Context,
     body: &mir::Body,
@@ -768,6 +764,14 @@ fn debug_type_for_ty_at(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
                 name: reference_name(pointee, mutability),
                 size_bits: 64,
             })
+        }
+        TyKind::RigidTy(RigidTy::Closure(closure_def, substs)) if depth < MAX_DEBUG_TYPE_DEPTH => {
+            let upvar_tys = types::closure_upvar_tys(&substs)?;
+            let fields = upvar_tys
+                .into_iter()
+                .enumerate()
+                .map(|(idx, upvar_ty)| (format!("capture_{idx}"), upvar_ty));
+            debug_struct_type(ty, format!("{:?}", closure_def.def_id()), fields, depth)
         }
         TyKind::RigidTy(RigidTy::Tuple(subtypes)) if depth < MAX_DEBUG_TYPE_DEPTH => {
             let name = format!(

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -75,7 +75,9 @@ pub fn get_usize_type(
 /// rustc suffix-encodes closure substitutions as
 /// `[parent_args..., closure_kind, closure_sig, tupled_upvars]`, so the upvars
 /// tuple is the last generic arg, not a fixed index.
-fn closure_upvar_tys(substs: &rustc_public::ty::GenericArgs) -> Option<Vec<rustc_public::ty::Ty>> {
+pub(super) fn closure_upvar_tys(
+    substs: &rustc_public::ty::GenericArgs,
+) -> Option<Vec<rustc_public::ty::Ty>> {
     let rustc_public::ty::GenericArgKind::Type(upvar_tuple_ty) = substs.0.last()? else {
         return None;
     };

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -13,6 +13,7 @@
 //! - Shared memory address casting
 //! - 64-bit arithmetic
 //! - Parallel for loop patterns
+//! - Full-debug closure environments
 //!
 //! Run: cargo oxide run compiler_features
 
@@ -55,6 +56,24 @@ mod kernels {
             let maybe: Option<u32> = if val > 0 { Some(val) } else { None };
             let result = maybe.unwrap_or_default();
             *out_elem = result;
+        }
+    }
+
+    /// Full-debug fixture for closure environment DWARF.
+    ///
+    /// The `move` closure forces two scalar captures into the environment so
+    /// cuda-gdb can verify the generated composite type and inspect both
+    /// `capture_0` and `capture_1`.
+    #[kernel]
+    pub fn test_closure_debug(seed: u32, mut out: DisjointSlice<u32>) {
+        let idx = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let captured_u32 = seed + 10;
+            let captured_u64 = 0x1_0000_0020u64;
+            let closure = move |x: u32| x + captured_u32 + captured_u64 as u32;
+            *out_elem = seed; // CUDA_OXIDE_DEBUG_CLOSURE_BREAKPOINT
+            let closure_result = closure(5u32);
+            *out_elem = closure_result;
         }
     }
 
@@ -563,6 +582,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             assert_eq!(result[0], expected, "test_option({}) failed", val);
             println!("  ✓ val={}: {} (expected {})", val, result[0], expected);
         }
+    }
+
+    // Test closure lowering and keep a deterministic full-debug fixture live.
+    println!("Testing: test_closure_debug");
+    {
+        let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
+        // capture_0 = seed + 10 = 17, capture_1 low 32 bits = 32, x = 5.
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_closure_debug((stream).as_ref(), cfg, 7u32, &mut out_dev) }?;
+        let result = out_dev.to_host_vec(&stream)?;
+        assert_eq!(result[0], 54, "test_closure_debug failed");
+        println!("  ✓ Result: {} (expected 54)", result[0]);
     }
 
     // Test for loop sum

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -830,15 +830,19 @@ fn device_debug_kind_with_override(
     rustc_debug: DebugInfo,
     override_value: Option<&str>,
 ) -> llvm_export::export::DebugKind {
-    if let Some(value) = override_value {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "0" | "off" | "none" => return llvm_export::export::DebugKind::Off,
-            "1" | "line" | "lines" | "line-tables" | "line-tables-only" => {
-                return llvm_export::export::DebugKind::LineTables;
+    // The alias table lives in cuda-artifact-finalizer so cargo-oxide's
+    // build policy (full debug disables MIR optimization) and this DWARF
+    // emission level can never disagree about what a value means.
+    if let Some(policy) =
+        override_value.and_then(cuda_artifact_finalizer::DebugPolicy::parse_env_override)
+    {
+        return match policy {
+            cuda_artifact_finalizer::DebugPolicy::None => llvm_export::export::DebugKind::Off,
+            cuda_artifact_finalizer::DebugPolicy::LineTables => {
+                llvm_export::export::DebugKind::LineTables
             }
-            "2" | "full" => return llvm_export::export::DebugKind::Full,
-            _ => {}
-        }
+            cuda_artifact_finalizer::DebugPolicy::Full => llvm_export::export::DebugKind::Full,
+        };
     }
 
     match rustc_debug {
@@ -915,6 +919,12 @@ mod tests {
         );
         assert_eq!(
             device_debug_kind_with_override(DebugInfo::None, Some("full")),
+            llvm_export::export::DebugKind::Full
+        );
+        // The nvcc-style numeric spelling goes through the same shared
+        // parser, so it must select full debug here exactly like "full".
+        assert_eq!(
+            device_debug_kind_with_override(DebugInfo::None, Some("2")),
             llvm_export::export::DebugKind::Full
         );
     }

--- a/scripts/debug-smoketest.sh
+++ b/scripts/debug-smoketest.sh
@@ -9,6 +9,11 @@
 # show real values (scalars, pointers, and struct fields), not just metadata
 # in the emitted IR.
 #
+# For compiler_features, a second debugger pass validates closure-environment
+# DWARF specifically: the source breakpoint stops after a `move` closure has
+# been initialized, and cuda-gdb must expose `capture_0` and `capture_1` as
+# inspectable members of the closure local.
+#
 # This complements scripts/smoketest.sh (which validates the compile pipeline)
 # by validating debugger *consumption* of the DWARF we emit.
 #
@@ -61,7 +66,9 @@ export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIB
 
 # Drive cuda-gdb: stop at a kernel, walk to the kernel frame, dump args/locals.
 GDB_LOG="$(mktemp)"
-trap 'rm -f "$GDB_LOG"' EXIT
+CLOSURE_GDB_LOG="$(mktemp)"
+trap 'rm -f "$GDB_LOG" "$CLOSURE_GDB_LOG"' EXIT
+
 # Run from the example dir: the host binary resolves its embedded device
 # artifact relative to the working directory.
 ( cd "$EXAMPLE_DIR" && timeout 300 "$CUDA_GDB" --batch \
@@ -87,8 +94,47 @@ grep -qiE "CUDA thread hit .*Breakpoint" "$GDB_LOG" || { echo "debug-smoketest: 
 grep -qE "= [0-9]|0x[0-9a-f]|\{.*:" "$GDB_LOG"        || { echo "debug-smoketest: FAIL (no inspectable args/locals)"; fail=1; }
 grep -qiE "INVALID_PTX|JIT compilation failed|No device code" "$GDB_LOG" && { echo "debug-smoketest: FAIL (PTX did not load under cuda-gdb)"; fail=1; }
 
+# compiler_features contains a dedicated closure-environment fixture. Break on
+# the source line immediately after the closure is created, then require
+# cuda-gdb to describe and print both captured fields.
+if [ "$EXAMPLE" = "compiler_features" ]; then
+    CLOSURE_SOURCE="$EXAMPLE_DIR/src/main.rs"
+    CLOSURE_MARKER="CUDA_OXIDE_DEBUG_CLOSURE_BREAKPOINT"
+    CLOSURE_LINE="$(grep -nF "$CLOSURE_MARKER" "$CLOSURE_SOURCE" | head -1 | cut -d: -f1)"
+
+    if [ -z "$CLOSURE_LINE" ]; then
+        echo "debug-smoketest: FAIL (closure debug breakpoint marker not found)"
+        fail=1
+    else
+        ( cd "$EXAMPLE_DIR" && timeout 300 "$CUDA_GDB" --batch \
+            -ex 'set pagination off' \
+            -ex 'set breakpoint pending on' \
+            -ex "break $CLOSURE_SOURCE:$CLOSURE_LINE" \
+            -ex 'run' \
+            -ex 'frame 0' \
+            -ex 'ptype closure' \
+            -ex 'print closure' \
+            -ex 'backtrace' \
+            -ex 'kill' \
+            "./target/release/$EXAMPLE" ) >"$CLOSURE_GDB_LOG" 2>&1
+
+        echo "----- cuda-gdb closure output (tail) -----"
+        tail -25 "$CLOSURE_GDB_LOG"
+        echo "------------------------------------------"
+
+        grep -qiE "CUDA thread hit .*Breakpoint" "$CLOSURE_GDB_LOG" || { echo "debug-smoketest: FAIL (closure source breakpoint did not hit)"; fail=1; }
+        grep -qE "capture_0[[:space:]]*:[[:space:]]*(0x[[:xdigit:]]+|[0-9]+)" "$CLOSURE_GDB_LOG" || { echo "debug-smoketest: FAIL (closure capture_0 is not inspectable)"; fail=1; }
+        grep -qE "capture_1[[:space:]]*:[[:space:]]*(0x[[:xdigit:]]+|[0-9]+)" "$CLOSURE_GDB_LOG" || { echo "debug-smoketest: FAIL (closure capture_1 is not inspectable)"; fail=1; }
+        grep -qiE "INVALID_PTX|JIT compilation failed|No device code" "$CLOSURE_GDB_LOG" && { echo "debug-smoketest: FAIL (closure-debug PTX did not load under cuda-gdb)"; fail=1; }
+    fi
+fi
+
 if [ "$fail" -eq 0 ]; then
-    echo "debug-smoketest: PASS (source debugging + info args/locals verified on $ARCH)"
+    if [ "$EXAMPLE" = "compiler_features" ]; then
+        echo "debug-smoketest: PASS (source debugging + closure environments verified on $ARCH)"
+    else
+        echo "debug-smoketest: PASS (source debugging + info args/locals verified on $ARCH)"
+    fi
     exit 0
 fi
 exit 1


### PR DESCRIPTION
## Summary

Add full-debug support for Rust closure environments.

When full device debugging is enabled, `cargo-oxide` now disables MIR optimization so closure environments remain represented as aggregate MIR locals instead of being split into scalar replacement fragments.

The MIR importer describes closure types as composite debug types using their captured upvar types and rustc's actual layout. This allows cuda-gdb to inspect captured values as `capture_0`, `capture_1`, and so on.

The `compiler_features` debug fixture and `debug-smoketest.sh` validate closure environments end to end.

## Changes

* Add `-Zmir-opt-level=0` for full device debug builds.
* Preserve normal MIR optimization for line-table-only debugging.
* Emit composite debug types for `RigidTy::Closure`.
* Reuse closure upvar extraction for debug type construction.
* Add a deterministic two-capture closure fixture to `compiler_features`.
* Extend the cuda-gdb smoke test to verify that both captures are inspectable.
* Add `cargo-oxide` tests covering full-debug MIR optimization policy and environment precedence.

## Why disable MIR optimization in full debug?

With optimized MIR, rustc can scalar-replace the closure environment and expose its captures as independent debug fragments rather than preserving the closure as a whole local.

Although those fragments can be carried through LLVM IR, the NVPTX debug pipeline does not currently provide the same reliable cuda-gdb experience for the reconstructed closure value.

Disabling MIR optimization in full-debug mode preserves the closure environment as an aggregate local. This allows the existing alloca-based variable-debug path to describe the complete closure and lets cuda-gdb inspect its captures directly.

Line-table-only debugging remains optimized.

## Validation

```text
cargo fmt --check
cargo test -p cargo-oxide
cargo test -p mir-importer
bash -n scripts/debug-smoketest.sh
scripts/debug-smoketest.sh
git diff --check
```

Results:

```text
cargo-oxide:   173 passed
mir-importer: 1059 passed
debug-smoketest: PASS
```

On `sm_120`, cuda-gdb resolves the closure type and both captured values:

```text
type = struct ... {
  capture_0: u32,
  capture_1: u64,
}

$1 = ... {capture_0: 17, capture_1: 4294967328}
```

Advances #226.
