### PR TITLE
fix(examples): load the embedded module instead of a loose .ptx

### DIFF
--- a/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_for_loop/src/main.rs
@@ -94,11 +94,7 @@ fn main() {
     println!("=== array_for_loop regression (issue #138) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/array_for_loop.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/barrier/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/barrier/src/main.rs
@@ -136,11 +136,7 @@ fn main() {
 
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("barrier.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     const N: usize = 256;
 
     let cfg = LaunchConfig {

--- a/crates/rustc-codegen-cuda/examples/cast_tests/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cast_tests/src/main.rs
@@ -418,9 +418,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("cast_tests.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     const N: usize = 1;
     let cfg = LaunchConfig::for_num_elems(N as u32);
 

--- a/crates/rustc-codegen-cuda/examples/clc/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/clc/src/main.rs
@@ -201,7 +201,7 @@ fn main() {
     }
 
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
-    println!("PTX loaded and assembled successfully.\n");
+    println!("Embedded CUDA module loaded successfully.\n");
 
     // ====================================================================
     // Test 0: CLC try_cancel pipeline

--- a/crates/rustc-codegen-cuda/examples/clc/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/clc/src/main.rs
@@ -200,10 +200,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("clc.ptx")
-        .expect("Load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     println!("PTX loaded and assembled successfully.\n");
 
     // ====================================================================

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -233,11 +233,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("cluster.ptx")
-        .expect("Load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let cluster_size = 4u32;
 
     // ====================================================================

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -471,9 +471,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("compiler_features.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     const N: usize = 1;
     let cfg = LaunchConfig::for_num_elems(N as u32);
 

--- a/crates/rustc-codegen-cuda/examples/complex_mul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/complex_mul/src/main.rs
@@ -81,12 +81,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     println!("Device ordinal: {}\n", ctx.ordinal());
 
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/complex_mul.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX (run `cargo oxide run complex_mul`)");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
     run_complex_square_add(&module, &stream);
 

--- a/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_aggregate/src/main.rs
@@ -131,11 +131,7 @@ fn main() {
     println!("=== Nested-aggregate constant materialization ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/const_aggregate.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX (device codegen failed?)");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     let mut d_out = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();

--- a/crates/rustc-codegen-cuda/examples/const_table_lookup/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_table_lookup/src/main.rs
@@ -302,11 +302,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("const_table_lookup.ptx")
-        .expect("Failed to load const_table_lookup.ptx");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // The `.const` variants need their tables uploaded; the others carry theirs
     // in the module image.
     module

--- a/crates/rustc-codegen-cuda/examples/const_tuple_table_lookup/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_tuple_table_lookup/src/main.rs
@@ -130,9 +130,7 @@ fn cpu_pairs() -> [(u8, u32); TABLE_LEN] {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = ctx.load_module_from_file("const_tuple_table_lookup.ptx")?;
-    let module = kernels::from_module(module)?;
-
+    let module = kernels::load(&ctx)?;
     // Deterministic, lane-divergent index spread (a multiplicative hash),
     // not a uniform pattern every warp lane would share.
     let indices_host: Vec<u32> = (0..N).map(|i| i.wrapping_mul(2_654_435_761)).collect();

--- a/crates/rustc-codegen-cuda/examples/constant_memory_table/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/constant_memory_table/src/main.rs
@@ -256,11 +256,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("constant_memory_table.ptx")
-        .expect("Failed to load constant_memory_table.ptx");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     module
         .set_table_const(&stream, &TABLE)
         .expect("upload the constant-memory table");

--- a/crates/rustc-codegen-cuda/examples/copy_aggregate_borrow/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/copy_aggregate_borrow/src/main.rs
@@ -48,9 +48,7 @@ mod kernels {
 
 fn main() {
     let context = CudaContext::new(0).expect("create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/copy_aggregate_borrow.ptx");
-    let module = context.load_module_from_file(ptx_path).expect("load PTX");
-    let module = kernels::from_module(module).expect("initialize typed module");
+    let module = kernels::load(&context).expect("Failed to load embedded CUDA module");
     let stream = context.default_stream();
 
     let shape = GridShape {

--- a/crates/rustc-codegen-cuda/examples/cvt_f16x2/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cvt_f16x2/src/main.rs
@@ -74,9 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let stream = ctx.default_stream();
-    let module = ctx.load_module_from_file("cvt_f16x2.ptx")?;
-    let module = kernels::from_module(module)?;
-
+    let module = kernels::load(&ctx)?;
     let lo_host: Vec<f32> = (0..N).map(|i| (i as f32) * 0.337 - 40.0).collect();
     let hi_host: Vec<f32> = (0..N).map(|i| (i as f32) * -1.113 + 17.5).collect();
 

--- a/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cvt_packed/src/main.rs
@@ -118,11 +118,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("cvt_packed.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // This value rounds up under round-to-nearest but truncates down under
     // round-toward-zero in both f16 and bf16.
     let lo = 1.0065_f32;

--- a/crates/rustc-codegen-cuda/examples/debug/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/debug/src/main.rs
@@ -177,9 +177,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("debug.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     // ====================================================================
     // Manually invoked failing mode: `debug --fail-assert`
     //

--- a/crates/rustc-codegen-cuda/examples/device_closures/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_closures/src/main.rs
@@ -283,11 +283,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("device_closures.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // =========================================================================
     // Test 1: Inline closure (no external captures)
     // =========================================================================

--- a/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
@@ -168,11 +168,7 @@ fn main() {
     let stream = ctx.default_stream();
     let out_dev = DeviceBuffer::<u64>::zeroed(&stream, 1).expect("Failed to allocate output");
 
-    let module = ctx
-        .load_module_from_file("device_global.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     for launch_idx in 1..=2 {
         unsafe {
             module.device_global(

--- a/crates/rustc-codegen-cuda/examples/device_panic_trap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_panic_trap/src/main.rs
@@ -129,12 +129,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     println!("Device ordinal: {}\n", ctx.ordinal());
 
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/device_panic_trap.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     // The trapping test runs last: a trap poisons the context for every

--- a/crates/rustc-codegen-cuda/examples/disjoint_from_raw_parts/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/disjoint_from_raw_parts/src/main.rs
@@ -87,9 +87,7 @@ mod kernels {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = ctx.load_module_from_file("disjoint_from_raw_parts.ptx")?;
-    let module = kernels::from_module(module)?;
-
+    let module = kernels::load(&ctx)?;
     // Two-word slice: every element carries its own index, so a constant
     // write or a misaddressed element shows up as a mismatch.
     let host: Vec<f32> = (0..LEN).map(|i| i as f32).collect();

--- a/crates/rustc-codegen-cuda/examples/dotprod/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/dotprod/src/main.rs
@@ -89,11 +89,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("dotprod.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // ---- dp4a operands ---------------------------------------------------
     // Pack bytes [1, 2, 3, 200] into u32 (little-endian: byte0 = LSB).
     //   a4 = 0xC8_03_02_01

--- a/crates/rustc-codegen-cuda/examples/dynamic_smem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/dynamic_smem/src/main.rs
@@ -229,11 +229,7 @@ fn main() {
     const N: usize = 256;
     const BLOCK_SIZE: u32 = 256;
 
-    let module = ctx
-        .load_module_from_file("dynamic_smem.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // ===== Test 1: Basic Dynamic Shared Memory (default 16-byte alignment) =====
     println!("=== Test 1: Basic DynamicSharedArray (default alignment) ===");
     {

--- a/crates/rustc-codegen-cuda/examples/elect_leader/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/elect_leader/src/main.rs
@@ -91,11 +91,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("elect_leader.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // A single warp is all we need to demonstrate election semantics.
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_abi_multi_payload/src/main.rs
@@ -105,11 +105,7 @@ fn main() {
     );
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/enum_abi_multi_payload.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 64;

--- a/crates/rustc-codegen-cuda/examples/enum_array_match/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_array_match/src/main.rs
@@ -128,11 +128,7 @@ fn main() {
     println!("=== enum_array_match regression (issue #131) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/enum_array_match.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
@@ -293,9 +293,7 @@ mod kernels {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = ctx.load_module_from_file("enum_payload_addr.ptx")?;
-    let module = kernels::from_module(module)?;
-
+    let module = kernels::load(&ctx)?;
     let host: Vec<f32> = (0..LEN).map(|i| (i % 1000) as f32 * 0.5).collect();
     let input = DeviceBuffer::from_host(&stream, &host)?;
     let config = LaunchConfig {

--- a/crates/rustc-codegen-cuda/examples/enum_table_lookup/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_table_lookup/src/main.rs
@@ -287,11 +287,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("enum_table_lookup.ptx")
-        .expect("Failed to load enum_table_lookup.ptx");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let host_in: Vec<u32> = (0..ELEMS).map(seed).collect();
     let input = DeviceBuffer::from_host(&stream, &host_in).expect("input alloc");
     let mut output = DeviceBuffer::<u32>::zeroed(&stream, ELEMS).expect("output alloc");

--- a/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/f16_stress/src/main.rs
@@ -59,8 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = ctx.load_module_from_file("f16_stress.ptx")?;
-    let module = kernels::from_module(module)?;
+    let module = kernels::load(&ctx)?;
     let cfg = LaunchConfig::for_num_elems(1);
 
     let mut passed = 0u32;

--- a/crates/rustc-codegen-cuda/examples/fn_ptr_naming/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/fn_ptr_naming/src/main.rs
@@ -55,11 +55,7 @@ fn main() {
     println!("=== fn_ptr_naming regression (issue #130) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/fn_ptr_naming.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/future_apis/src/main.rs
@@ -264,9 +264,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("future_apis.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     // ====================================================================
     // Test 1: CuSimd<f32, 4>
     // ====================================================================

--- a/crates/rustc-codegen-cuda/examples/gemm/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm/src/main.rs
@@ -113,11 +113,7 @@ fn main() {
     let b_dev = DeviceBuffer::from_host(&stream, &b).unwrap();
     let mut c_dev = DeviceBuffer::from_host(&stream, &c).unwrap();
 
-    let module = ctx
-        .load_module_from_file("gemm.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // Configure launch: 16x16 threads per block
     let block_size = 16u32;
     let grid_x = (N as u32).div_ceil(block_size);

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
@@ -604,9 +604,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("gemm_sol_final.ptx");
     println!("Loading PTX: {}", ptx_path.display());
-    let ptx_str = ptx_path.to_str().ok_or("PTX path must be valid UTF-8")?;
-    let module = ctx.load_module_from_file(ptx_str)?;
-    let module = kernels::from_module(module).expect("failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx)?;
     println!("PTX loaded\n");
 
     if do_validate {

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
@@ -602,10 +602,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only();
     }
 
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("gemm_sol_final.ptx");
-    println!("Loading PTX: {}", ptx_path.display());
+    println!("Loading embedded CUDA module");
     let module = kernels::load(&ctx)?;
-    println!("PTX loaded\n");
+    println!("Module loaded\n");
 
     if do_validate {
         println!("── Full-output correctness tests ────────────────────\n");
@@ -1031,13 +1030,17 @@ fn run_benchmark_clc_multicast_4_stage_pipeline(
     Ok(tflops)
 }
 
+/// Fallback for GPUs that cannot execute tcgen05: verify the loose PTX build
+/// artifact beside this crate against the tcgen05 contract. The main path
+/// loads the module embedded in the binary instead; only this fallback reads
+/// the loose file.
 fn verify_ptx_only() -> Result<(), Box<dyn std::error::Error>> {
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("gemm_sol_final.ptx");
     let ptx = std::fs::read_to_string(&ptx_path)?;
     verify_tcgen05_ptx_contract(&ptx)
         .map_err(|error| format!("PTX verification failed: {error}"))?;
 
-    println!("\nPTX Verification:");
+    println!("\nPTX verification (loose build artifact):");
     println!("   PTX file generated at: {}", ptx_path.display());
     println!("\n   To inspect generated PTX:");
     println!("   cat {}", ptx_path.display());

--- a/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap/src/main.rs
@@ -421,11 +421,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("hashmap.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/main.rs
@@ -22,10 +22,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("hashmap_v2.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
 
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/main.rs
@@ -22,10 +22,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("hashmap_v3.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
 
     const CAPACITY: usize = 1 << 14;
     const M: usize = CAPACITY / 2;

--- a/crates/rustc-codegen-cuda/examples/hello_constant/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/hello_constant/src/main.rs
@@ -43,11 +43,7 @@ fn main() {
 
     let out_dev = DeviceBuffer::<i32>::zeroed(&stream, 1).expect("Failed to allocate");
 
-    let module = ctx
-        .load_module_from_file("hello_constant.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     println!("Launching kernel...");
     unsafe {
         module.hello_constant(

--- a/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/helper_fn/src/main.rs
@@ -115,11 +115,7 @@ fn main() {
     let b_dev = DeviceBuffer::from_host(&stream, &b_host).unwrap();
     let mut c_dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-    let module = ctx
-        .load_module_from_file("helper_fn.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // Launch kernel
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe {

--- a/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/index2d_const/src/main.rs
@@ -44,11 +44,7 @@ fn main() {
     let input_dev = DeviceBuffer::from_host(&stream, &input_host).unwrap();
     let mut output_dev = DeviceBuffer::<f32>::zeroed(&stream, WIDTH * HEIGHT).unwrap();
 
-    let module = ctx
-        .load_module_from_file("index2d_const.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe {
         module.copy_2d_const_width(

--- a/crates/rustc-codegen-cuda/examples/lanemask_scan/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/lanemask_scan/src/main.rs
@@ -127,11 +127,7 @@ fn main() {
     const N: usize = 256;
     const WARPS: usize = N / 32;
 
-    let module = ctx
-        .load_module_from_file("lanemask_scan.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),
         grid_dim: (WARPS as u32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
@@ -128,12 +128,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let stream = ctx.default_stream();
 
-    let ptx_path =
-        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("mcast_barrier_test.ptx");
-    println!("Loading PTX: {}", ptx_path.display());
-    let module =
-        ctx.load_module_from_file(ptx_path.to_str().ok_or("PTX path must be valid UTF-8")?)?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx)?;
     println!("PTX loaded\n");
 
     for &num_iters in &[4u32, 8, 16, 32, 64, 256, 1024] {

--- a/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mcast_barrier_test/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream = ctx.default_stream();
 
     let module = kernels::load(&ctx)?;
-    println!("PTX loaded\n");
+    println!("Embedded CUDA module loaded\n");
 
     for &num_iters in &[4u32, 8, 16, 32, 64, 256, 1024] {
         print!("  {} iters ... ", num_iters);

--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -50,11 +50,7 @@ fn main() {
     println!("=== core::mem::swap / mem::replace on device ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/mem_swap.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX (device codegen failed?)");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     let a_init: Vec<i32> = (0..N as i32).collect(); // a[i] = i

--- a/crates/rustc-codegen-cuda/examples/numeric_stress/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/numeric_stress/src/main.rs
@@ -199,9 +199,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("numeric_stress.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     const N: usize = 1;
     let cfg = LaunchConfig::for_num_elems(N as u32);
 

--- a/crates/rustc-codegen-cuda/examples/option_ref_transmute/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/option_ref_transmute/src/main.rs
@@ -90,11 +90,7 @@ fn main() {
     println!("=== option_ref_transmute regression (issue #21 sibling) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/option_ref_transmute.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/option_ref_unwrap_or/src/main.rs
@@ -103,11 +103,7 @@ fn main() {
     println!("=== option_ref_unwrap_or regression (issue #132) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/option_ref_unwrap_or.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/ord_cmp/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ord_cmp/src/main.rs
@@ -240,10 +240,7 @@ fn main() {
     println!("=== Ord cmp regression test ===");
 
     let ctx = CudaContext::new(0).expect("failed to create CUDA context");
-    let module = ctx
-        .load_module_from_file(concat!(env!("CARGO_MANIFEST_DIR"), "/ord_cmp.ptx"))
-        .expect("failed to load PTX");
-    let module = kernels::from_module(module).expect("failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     let config = LaunchConfig {

--- a/crates/rustc-codegen-cuda/examples/partial_warp_reduce/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/partial_warp_reduce/src/main.rs
@@ -151,10 +151,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("partial_warp_reduce.ptx")?;
-    // SAFETY: the PTX beside this binary is the one built from `kernels`.
-    let module = unsafe { kernels::from_module(module) }?;
-
+    // SAFETY: the embedded module is the one built from this crate's
+    // `kernels`, so every generated launch method matches its kernel.
+    let module = unsafe { kernels::load(&ctx) }?;
     // Values vary within each warp, so a reduction that lost or duplicated a
     // lane lands on a different answer.
     let threads_pow2 = BLOCK_POW2 * BLOCKS;

--- a/crates/rustc-codegen-cuda/examples/printf/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/printf/src/main.rs
@@ -179,9 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("printf.ptx")?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx)?;
     let cfg = LaunchConfig {
         grid_dim: (1, 1, 1),
         block_dim: (32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/redux_minmax/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/redux_minmax/src/main.rs
@@ -108,11 +108,7 @@ fn main() {
         return;
     }
 
-    let module = ctx
-        .load_module_from_file("redux_minmax.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // A single warp is all we need to demonstrate the reduction semantics.
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/redux_sum/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/redux_sum/src/main.rs
@@ -95,11 +95,7 @@ fn main() {
     const WARPS: usize = N / 32;
     const EXPECTED: u32 = 496; // 0 + 1 + ... + 31
 
-    let module = ctx
-        .load_module_from_file("redux_sum.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),
         grid_dim: (WARPS as u32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/ref_operand_mul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_operand_mul/src/main.rs
@@ -82,12 +82,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     println!("Device ordinal: {}\n", ctx.ordinal());
 
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/ref_operand_mul.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX (run `cargo oxide run ref_operand_mul`)");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
     let ok = run_ref_pieces_mul(&module, &stream);
 

--- a/crates/rustc-codegen-cuda/examples/sharedmem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/sharedmem/src/main.rs
@@ -91,11 +91,7 @@ fn main() {
     // Test size - must match TILE size (256 elements)
     const N: usize = 256;
 
-    let module = ctx
-        .load_module_from_file("sharedmem.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // Launch config for shared memory kernels
     let cfg = LaunchConfig {
         grid_dim: (1, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/shuffle_64/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/shuffle_64/src/main.rs
@@ -136,11 +136,7 @@ fn main() {
     let (major, minor) = ctx.compute_capability().expect("compute capability");
     println!("GPU Compute Capability: sm_{}{}", major, minor);
 
-    let module = ctx
-        .load_module_from_file("shuffle_64.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // A single warp is enough to demonstrate the shuffle semantics.
     let cfg = LaunchConfig {
         block_dim: (WARP as u32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/slice_index_bounds_check/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/slice_index_bounds_check/src/main.rs
@@ -122,12 +122,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     println!("Device ordinal: {}\n", ctx.ordinal());
 
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/slice_index_bounds_check.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     // The out-of-bounds test runs last

--- a/crates/rustc-codegen-cuda/examples/step_by/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/step_by/src/main.rs
@@ -78,11 +78,7 @@ fn main() {
     println!("=== step_by regression (issue #21) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/step_by.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/swizzle_smem/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/swizzle_smem/src/main.rs
@@ -71,11 +71,7 @@ fn main() {
 
     const N: usize = DIM * DIM;
 
-    let module = ctx
-        .load_module_from_file("swizzle_smem.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let cfg = LaunchConfig {
         grid_dim: (1, 1, 1),
         block_dim: (DIM as u32, DIM as u32, 1),

--- a/crates/rustc-codegen-cuda/examples/thread_runs/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/thread_runs/src/main.rs
@@ -132,10 +132,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("thread_runs.ptx")?;
-    // SAFETY: the PTX beside this binary is the one built from `kernels`.
-    let module = unsafe { kernels::from_module(module) }?;
-
+    // SAFETY: the embedded module is the one built from this crate's
+    // `kernels`, so every generated launch method matches its kernel.
+    let module = unsafe { kernels::load(&ctx) }?;
     let host: Vec<f32> = (0..LEN).map(|i| i as f32).collect();
     let runs = LEN.div_ceil(RUN) as u32;
 

--- a/crates/rustc-codegen-cuda/examples/tiled_gemm/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tiled_gemm/src/main.rs
@@ -164,11 +164,7 @@ fn main() {
     let b_dev = DeviceBuffer::from_host(&stream, &b).unwrap();
     let mut c_dev = DeviceBuffer::from_host(&stream, &c).unwrap();
 
-    let module = ctx
-        .load_module_from_file("tiled_gemm.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // Configure launch: 16x16 threads per block (matches TILE_SIZE)
     let block_size = 16u32;
     let grid_x = (N as u32).div_ceil(block_size);

--- a/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
@@ -215,11 +215,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only(&ctx);
     }
 
-    // Load PTX module
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tma_copy.ptx");
-    println!("Loading PTX from: {}", ptx_path.display());
+    // Load the CUDA module embedded in this binary
+    println!("Loading embedded CUDA module");
     let module = kernels::load(&ctx)?;
-    println!("✓ PTX loaded successfully\n");
+    println!("✓ Module loaded successfully\n");
 
     // Run tests
     run_tma_copy_test(&stream, &module)?;
@@ -229,11 +228,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Fallback for GPUs that cannot execute the TMA kernels: inspect the loose
+/// PTX build artifact beside this crate. The main path loads the module
+/// embedded in the binary instead; only this fallback reads the loose file.
 fn verify_ptx_only(ctx: &Arc<CudaContext>) -> Result<(), Box<dyn std::error::Error>> {
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tma_copy.ptx");
+    println!("Checking loose PTX artifact: {}", ptx_path.display());
 
     if !ptx_path.exists() {
-        return Err("PTX file not found".into());
+        return Err(
+            "loose PTX artifact not found (build with `cargo oxide build tma_copy`)".into(),
+        );
     }
 
     let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;

--- a/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
@@ -218,9 +218,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load PTX module
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tma_copy.ptx");
     println!("Loading PTX from: {}", ptx_path.display());
-    let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;
-    let module = ctx.load_module_from_file(ptx_file)?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx)?;
     println!("✓ PTX loaded successfully\n");
 
     // Run tests

--- a/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/transmute_scalar_struct/src/main.rs
@@ -57,11 +57,7 @@ fn main() {
     println!("=== scalar <-> aggregate transmute (usize <-> NonNull) ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/transmute_scalar_struct.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX (device codegen failed?)");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     // Non-zero fabricated addresses (never dereferenced).

--- a/crates/rustc-codegen-cuda/examples/tuple_field_lookup/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tuple_field_lookup/src/main.rs
@@ -180,11 +180,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let stream = ctx.default_stream();
 
-    let module = ctx
-        .load_module_from_file("tuple_field_lookup.ptx")
-        .expect("Failed to load tuple_field_lookup.ptx");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let host_in: Vec<u32> = (0..ELEMS).map(seed).collect();
     let input = DeviceBuffer::from_host(&stream, &host_in).expect("input alloc");
     let mut output = DeviceBuffer::<u32>::zeroed(&stream, ELEMS).expect("output alloc");

--- a/crates/rustc-codegen-cuda/examples/tuple_return/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tuple_return/src/main.rs
@@ -52,11 +52,7 @@ fn main() {
     let stream = ctx.default_stream();
     let mut dev = DeviceBuffer::<f32>::zeroed(&stream, N).unwrap();
 
-    let module = ctx
-        .load_module_from_file("tuple_return.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe {
         module.run(

--- a/crates/rustc-codegen-cuda/examples/uninit_const/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/uninit_const/src/main.rs
@@ -42,9 +42,7 @@ mod kernels {
 
 fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/uninit_const.ptx");
-    let module = ctx.load_module_from_file(ptx_path).expect("load PTX");
-    let module = kernels::from_module(module).expect("typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
     const N: usize = 32;
     let cfg = LaunchConfig {

--- a/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unroll_smoke/src/main.rs
@@ -362,11 +362,7 @@ fn main() {
     println!("=== unroll_smoke ===\n");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/unroll_smoke.ptx");
-    let module = ctx
-        .load_module_from_file(ptx_path)
-        .expect("Failed to load PTX");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let stream = ctx.default_stream();
 
     const BLOCK: u32 = 32;

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -200,11 +200,7 @@ fn main() {
     let stream = ctx.default_stream();
     let cfg = LaunchConfig::for_num_elems(N as u32);
 
-    let module = ctx
-        .load_module_from_file("vectorization.ptx")
-        .expect("Failed to load vectorization.ptx");
-    let module = kernels::from_module(module).expect("Failed to initialize typed module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let rows = run_all(&module, &stream, cfg, N);
 
     // Flat-buffer path: allocate and fill as plain `f32`, take the `F32x4`
@@ -212,11 +208,7 @@ fn main() {
     let flat: Vec<f32> = (0..N * 4).map(|i| i as f32 * 0.25 + 1.0).collect();
     let flat_in = DeviceBuffer::from_host(&stream, &flat).expect("flat input");
     let mut flat_out = DeviceBuffer::<f32>::zeroed(&stream, N * 4).expect("flat output");
-    let view_module = ctx
-        .load_module_from_file("vectorization.ptx")
-        .expect("Failed to load vectorization.ptx for view kernels");
-    let view_module =
-        view_kernels::from_module(view_module).expect("Failed to initialize view module");
+    let view_module = view_kernels::load(&ctx).expect("Failed to load embedded view module");
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe { view_module.f32x4_view_copy(&stream, cfg, &flat_in, &mut flat_out) }
         .expect("f32x4_view_copy launch");

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -214,82 +214,125 @@ fn main() {
         .expect("f32x4_view_copy launch");
     let flat_round_trip = flat_out.to_host_vec(&stream).expect("flat readback") == flat;
 
-    // Inspect the PTX we just launched to report/assert the codegen shape.
-    let ptx = std::fs::read_to_string("vectorization.ptx")
-        .expect("vectorization.ptx not found (run with `cargo oxide run vectorization`)");
+    // Inspect the code we just launched: read the PTX back from the artifact
+    // bundle embedded in this binary. Those are the same bytes `kernels::load`
+    // handed to the driver, so the shape assertion can never diverge from what
+    // actually ran (a loose `vectorization.ptx` on disk can). A
+    // `--materialize-cubin` build embeds a cubin with no PTX text; only the
+    // textual shape check is skipped then, and says so.
+    let ptx = embedded_ptx_text();
 
-    println!(
-        "{:<11} {:<14} {:>4} {:>5}  {:<22} vectorized",
-        "rust", "cuda", "size", "align", "ptx load"
-    );
     let mut errors = 0;
     for r in &rows {
-        let body = kernel_body(&ptx, r.kernel);
-        let load = first_mem_op(body);
-        let vectorized = load.contains(".v2.") || load.contains(".v4.") || load.contains(".v8.");
         if !r.copy_ok {
             errors += 1;
             println!("  !! {} round-trip copy mismatch", r.name);
         }
-        // The robust, alignment-gated invariant this example exists to show: a
-        // type aligned to the 128-bit vector width (or wider) always fuses into
-        // a vector `ld/st.global.v*`. (Some smaller types also vectorize, and
-        // the 8-byte ones coalesce into a single `b64` -- reported, not asserted.)
-        let expect_vec = r.align >= 16;
-        if expect_vec && !vectorized {
-            errors += 1;
-            println!("  !! {} expected to vectorize but did not", r.name);
-        }
-        println!(
-            "{:<11} {:<14} {:>4} {:>5}  {:<22} {}",
-            r.name,
-            r.cuda,
-            r.size,
-            r.align,
-            load,
-            if vectorized { "yes" } else { "no" }
-        );
     }
-
-    // The in-kernel `as_vectors::<F32x4>` view over a flat `&[f32]` parameter
-    // must reach the same 128-bit transactions as the over-aligned parameter
-    // types above: this is the checked-view path the `vector` module ships.
-    let view_body = kernel_body(&ptx, "f32x4_view_copy");
     if !flat_round_trip {
         errors += 1;
         println!("  !! f32x4_view_copy round-trip copy mismatch");
     }
-    for dir in ["ld", "st"] {
-        match find_128bit_global(view_body, dir) {
-            Some(line) => println!("f32x4_view_copy: {line}"),
-            None => {
+
+    if let Some(ptx) = &ptx {
+        println!(
+            "{:<11} {:<14} {:>4} {:>5}  {:<22} vectorized",
+            "rust", "cuda", "size", "align", "ptx load"
+        );
+        for r in &rows {
+            let body = kernel_body(ptx, r.kernel);
+            let load = first_mem_op(body);
+            let vectorized =
+                load.contains(".v2.") || load.contains(".v4.") || load.contains(".v8.");
+            // The robust, alignment-gated invariant this example exists to show: a
+            // type aligned to the 128-bit vector width (or wider) always fuses into
+            // a vector `ld/st.global.v*`. (Some smaller types also vectorize, and
+            // the 8-byte ones coalesce into a single `b64` -- reported, not asserted.)
+            let expect_vec = r.align >= 16;
+            if expect_vec && !vectorized {
                 errors += 1;
-                // Deliberately not "has no 128-bit vector op". When this fires,
-                // the likely state is not a scalarized transaction but a
-                // widened one that lost its state space: measured on sm_86
-                // while #657 was open, the view path did reach 128 bits, as a
-                // generic `LD.E.128` / `ST.E.128` rather than the `LDG.E.128` /
-                // `STG.E.128` the direct path gets, and paid four extra
-                // `LDL.64`/`STL.64` local accesses on the way. What was missing
-                // was the *global* window, not the width. Say that, so whoever
-                // sees this next looks at the address space first.
-                println!(
-                    "  !! f32x4_view_copy: no 128-bit {dir}.global vector op \
-                     (the 128-bit access is there, but in the generic window)"
-                );
+                println!("  !! {} expected to vectorize but did not", r.name);
+            }
+            println!(
+                "{:<11} {:<14} {:>4} {:>5}  {:<22} {}",
+                r.name,
+                r.cuda,
+                r.size,
+                r.align,
+                load,
+                if vectorized { "yes" } else { "no" }
+            );
+        }
+
+        // The in-kernel `as_vectors::<F32x4>` view over a flat `&[f32]` parameter
+        // must reach the same 128-bit transactions as the over-aligned parameter
+        // types above: this is the checked-view path the `vector` module ships.
+        let view_body = kernel_body(ptx, "f32x4_view_copy");
+        for dir in ["ld", "st"] {
+            match find_128bit_global(view_body, dir) {
+                Some(line) => println!("f32x4_view_copy: {line}"),
+                None => {
+                    errors += 1;
+                    // Deliberately not "has no 128-bit vector op". When this fires,
+                    // the likely state is not a scalarized transaction but a
+                    // widened one that lost its state space: measured on sm_86
+                    // while #657 was open, the view path did reach 128 bits, as a
+                    // generic `LD.E.128` / `ST.E.128` rather than the `LDG.E.128` /
+                    // `STG.E.128` the direct path gets, and paid four extra
+                    // `LDL.64`/`STL.64` local accesses on the way. What was missing
+                    // was the *global* window, not the width. Say that, so whoever
+                    // sees this next looks at the address space first.
+                    println!(
+                        "  !! f32x4_view_copy: no 128-bit {dir}.global vector op \
+                         (the 128-bit access is there, but in the generic window)"
+                    );
+                }
             }
         }
+    } else {
+        println!(
+            "PTX shape check skipped: the embedded bundle has no PTX text to \
+             inspect (a --materialize-cubin build embeds a cubin)"
+        );
     }
 
     if errors == 0 {
+        let scope = if ptx.is_some() {
+            "layout, copy, and codegen all correct"
+        } else {
+            "layout and copy correct (codegen shape not inspected)"
+        };
         println!(
-            "\n\u{2713} SUCCESS: {} CUDA vector types -- layout, copy, and codegen all correct",
-            rows.len()
+            "\n\u{2713} SUCCESS: {} CUDA vector types -- {}",
+            rows.len(),
+            scope
         );
     } else {
         println!("\n\u{2717} FAILED: {} problem(s)", errors);
         std::process::exit(1);
     }
+}
+
+/// PTX text of this binary's embedded device bundle, if the bundle carries
+/// PTX. These are the bytes `kernels::load` hands to the driver, so asserting
+/// on them asserts on the code that ran. Returns `None` when the bundle holds
+/// a cubin instead (a `--materialize-cubin` build), which has no PTX text.
+fn embedded_ptx_text() -> Option<String> {
+    use cuda_host::embedded::{ArtifactPayloadKind, artifact_bundles_from_current_exe};
+
+    let bundles = artifact_bundles_from_current_exe()
+        .expect("failed to read embedded artifact bundles from the current executable");
+    let bundle = bundles
+        .into_iter()
+        .find(|bundle| bundle.name == env!("CARGO_PKG_NAME"))
+        .expect("embedded device bundle not found in the current executable");
+    let ptx = bundle.payload(ArtifactPayloadKind::Ptx)?;
+    Some(
+        std::str::from_utf8(ptx)
+            .expect("embedded PTX payload is not valid UTF-8")
+            .trim_end_matches('\0')
+            .to_string(),
+    )
 }
 
 /// PTX text of a `.visible .entry <name>` kernel, header to closing `}`.

--- a/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/warp_reduce/src/main.rs
@@ -212,11 +212,7 @@ fn main() {
 
     let data_dev = DeviceBuffer::from_host(&stream, &data_host).unwrap();
 
-    let module = ctx
-        .load_module_from_file("warp_reduce.ptx")
-        .expect("Failed to load PTX module");
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-
+    let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
     let cfg = LaunchConfig {
         block_dim: (32, 1, 1),
         grid_dim: (WARPS as u32, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/warp_sums/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/warp_sums/src/main.rs
@@ -92,10 +92,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
 
-    let module = ctx.load_module_from_file("warp_sums.ptx")?;
-    // SAFETY: the PTX beside this binary is the one built from `kernels`.
-    let module = unsafe { kernels::from_module(module) }?;
-
+    // SAFETY: the embedded module is the one built from this crate's
+    // `kernels`, so every generated launch method matches its kernel.
+    let module = unsafe { kernels::load(&ctx) }?;
     let host: Vec<f32> = (0..THREADS).map(|i| (i % 17) as f32).collect();
     let input = DeviceBuffer::from_host(&stream, &host)?;
     let mut sums = DeviceBuffer::from_host(&stream, &vec![-1.0f32; WARPS as usize])?;

--- a/crates/rustc-codegen-cuda/examples/wgmma/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/wgmma/src/main.rs
@@ -89,11 +89,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only(&ctx);
     }
 
-    // Load PTX module
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("wgmma.ptx");
-    println!("\nLoading PTX from: {}", ptx_path.display());
+    // Load the CUDA module embedded in this binary
+    println!("\nLoading embedded CUDA module");
     let module = kernels::load(&ctx)?;
-    println!("✓ PTX loaded successfully\n");
+    println!("✓ Module loaded successfully\n");
 
     // Test: Sync primitives
     run_wgmma_sync_test(&stream, &module)?;
@@ -102,11 +101,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Fallback for GPUs that cannot execute the WGMMA kernels: inspect the loose
+/// PTX build artifact beside this crate. The main path loads the module
+/// embedded in the binary instead; only this fallback reads the loose file.
 fn verify_ptx_only(ctx: &Arc<CudaContext>) -> Result<(), Box<dyn std::error::Error>> {
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("wgmma.ptx");
+    println!("Checking loose PTX artifact: {}", ptx_path.display());
 
     if !ptx_path.exists() {
-        return Err("PTX file not found".into());
+        return Err("loose PTX artifact not found (build with `cargo oxide build wgmma`)".into());
     }
 
     let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;

--- a/crates/rustc-codegen-cuda/examples/wgmma/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/wgmma/src/main.rs
@@ -92,9 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load PTX module
     let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("wgmma.ptx");
     println!("\nLoading PTX from: {}", ptx_path.display());
-    let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;
-    let module = ctx.load_module_from_file(ptx_file)?;
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
+    let module = kernels::load(&ctx)?;
     println!("✓ PTX loaded successfully\n");
 
     // Test: Sync primitives


### PR DESCRIPTION
Refs #782 — **66 of the 77 converted**, with the other 11 accounted for
explicitly rather than silently skipped.

The 77 examples that call `load_module_from_file` split three ways:

| | count |
|---|---|
| converted here | **66** |
| deferred — need a per-file decision | 10 |
| out of scope — not this pattern | 1 |

## The fix works

Your three-state reproducer, run on `barrier` before and after:

| | stock `main` | this branch |
|---|---|---|
| `cargo oxide run barrier` | 0 | 0 |
| `... --materialize-cubin --arch sm_86` | **101** — `DriverError(301` / `file not found` | **0** |
| `cargo oxide run barrier` | 0 | 0 |

## Three things were not byte-identical

Worth flagging, since the issue reads as a single substitution across all 77:

* **Three examples took `unsafe { kernels::from_module(..) }`**, and `load`
  inherits that unsafety — my first pass dropped the block and they failed to
  compile with E0133. They keep it. Their SAFETY comments also claimed *"the PTX
  beside this binary is the one built from `kernels`"*, which is no longer the
  invariant, so they now state it against the embedded module.
* **`vectorization` loads twice**, once per typed module; both sites moved.
* Dead `ptx_path` / `ptx_file` / `ptx_str` bindings — and the `println!`
  announcing the path — go with the load they fed.

## The 10 deferred, and why

These are not the mechanical change:

| examples | why |
|---|---|
| `array_index`, `gemm_sol`, `tcgen05`, `tcgen05_matmul`, `tma_multicast` | wrap the load in a `match` whose `Err` arm inspects `CUDA_ERROR_INVALID_PTX` to explain the GPU is too old. `load` returns `EmbeddedModuleError`, not `DriverError`, so keeping those diagnostics means matching `EmbeddedModuleError::Driver(e)` — a real per-file edit |
| `device_ffi_test`, `mathdx_ffi_test`, `small_type_ffi_test` | LTOIR examples that link their own cubin |
| `coop_groups_demo` | loads one module and derives several typed handles via `from_module(module.clone())`; converting it would issue a separate load per handle |
| `cross_crate_kernel` | has no `#[cuda_module]` of its own — the module belongs to a library crate — so `kernels::load` is not generated in the binary |

Happy to take all ten as a follow-up; the five `match` ones are a tidy unit and
the LTOIR three are their own question.

## The 1 out of scope

`interop_cubin_identity` is the only one of the 77 that never calls
`from_module`. It loads a cubin **it produced itself**, passed in by path, and
resolves the entry point by name with `load_function`. Loading that artifact is
precisely what the example tests, so `kernels::load` would delete its subject —
and it is unaffected by the bug anyway, since nothing there expects a `.ptx` to
appear.

## Verified

* **all 66 compile individually** — 66/66, no failures (each is its own
  workspace, so this is 66 separate builds)
* **full smoketest sweep 201/201 on an A10G**
  (`.gpu-evidence/20260810T101719Z.log`)
* three-state repro above (`20260810T100743Z.log`; stock run in the same session)
* every changed example passes its own `cargo fmt --check` — CI checks these per
  example workspace, and my first pass failed 48 of them on line wrapping

Diff is 66 files, +73/−300 — it deletes about four lines per example and adds one.