### PR TITLE
fix(examples): load the embedded module in the arch-gated match shapes

### DIFF
--- a/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_index/src/main.rs
@@ -311,9 +311,7 @@ fn main() {
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     println!("Device ordinal: {}\n", ctx.ordinal());
 
-    let ptx_path = concat!(env!("CARGO_MANIFEST_DIR"), "/array_index.ptx");
-
-    let module = match ctx.load_module_from_file(ptx_path) {
+    let module = match kernels::load(&ctx) {
         Ok(m) => m,
         Err(e) => {
             println!("Failed to load PTX: {}", e);
@@ -325,7 +323,6 @@ fn main() {
             return;
         }
     };
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
 
     let stream = ctx.default_stream();
 

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
@@ -3988,13 +3988,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only();
     }
 
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("gemm_sol.ptx");
-    println!("Loading PTX: {}", ptx_path.display());
-    let ptx_str = ptx_path.to_str().ok_or("PTX path must be valid UTF-8")?;
-    let module = match ctx.load_module_from_file(ptx_str) {
+    let module = match kernels::load(&ctx) {
         Ok(m) => m,
         Err(e) => {
-            if e.0 == cuda_core::sys::cudaError_enum_CUDA_ERROR_INVALID_PTX {
+            // `load` wraps the driver's own status, so reach through its
+            // `Driver` variant for the code the arm below keys on. Anything
+            // else (a missing or unsupported payload) is not "right PTX, wrong
+            // GPU" and falls through to the error return.
+            let driver_status = match &e {
+                cuda_host::EmbeddedModuleError::Driver(driver) => Some(driver.0),
+                _ => None,
+            };
+            if driver_status == Some(cuda_core::sys::cudaError_enum_CUDA_ERROR_INVALID_PTX) {
                 println!(
                     "\n⚠️  tcgen05 (5th gen tensor cores) requires sm_100 (datacenter Blackwell only)."
                 );
@@ -4012,7 +4017,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
     println!("PTX loaded\n");
 
     let sizes: [(usize, usize, usize); 3] = [

--- a/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
@@ -804,14 +804,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only();
     }
 
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tcgen05.ptx");
-    println!("\nLoading PTX from: {}", ptx_path.display());
-    let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;
-    let module = match ctx.load_module_from_file(ptx_file) {
+    let module = match kernels::load(&ctx) {
         Ok(m) => m,
         Err(e) => {
-            println!("\n❌ cuModuleLoad failed: {:?} (CUresult = {:?})", e, e.0);
-            if e.0 == sys::cudaError_enum_CUDA_ERROR_INVALID_PTX {
+            // `load` wraps the driver's own status, so reach through its
+            // `Driver` variant for the code the arms below key on. Anything
+            // else (a missing or unsupported payload) is not "right PTX, wrong
+            // GPU" and falls through to the error return.
+            let driver_status = match &e {
+                cuda_host::EmbeddedModuleError::Driver(driver) => Some(driver.0),
+                _ => None,
+            };
+            println!("\n❌ embedded module load failed: {e:?} (driver status = {driver_status:?})");
+            if driver_status == Some(sys::cudaError_enum_CUDA_ERROR_INVALID_PTX) {
                 println!("   CUDA_ERROR_INVALID_PTX — the driver rejected the PTX.");
                 println!("   PTX target: sm_100a, GPU: sm_{}{}", major, minor);
                 println!(
@@ -822,7 +827,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
     println!("✓ PTX loaded successfully\n");
 
     run_tcgen05_fence_test(&stream, &module)?;

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
@@ -249,13 +249,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return verify_ptx_only();
     }
 
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tcgen05_matmul.ptx");
-    println!("\nLoading PTX from: {}", ptx_path.display());
-    let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;
-    let module = match ctx.load_module_from_file(ptx_file) {
+    let module = match kernels::load(&ctx) {
         Ok(m) => m,
         Err(e) => {
-            if e.0 == cuda_sys::cudaError_enum_CUDA_ERROR_INVALID_PTX {
+            // `load` wraps the driver's own status, so reach through its
+            // `Driver` variant for the code the arms below key on. Anything
+            // else (a missing or unsupported payload) is not "right PTX, wrong
+            // GPU" and falls through to the error return.
+            let driver_status = match &e {
+                cuda_host::EmbeddedModuleError::Driver(driver) => Some(driver.0),
+                _ => None,
+            };
+            if driver_status == Some(cuda_sys::cudaError_enum_CUDA_ERROR_INVALID_PTX) {
                 println!(
                     "\n⚠️  tcgen05 (5th gen tensor cores) requires sm_100 (datacenter Blackwell only)."
                 );
@@ -273,7 +278,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
-    let module = kernels::from_module(module).expect("Failed to initialize typed CUDA module");
     println!("✓ PTX loaded successfully\n");
 
     run_tiled_kernel_test(&stream, &module)?;

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
@@ -164,24 +164,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let ptx_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tma_multicast.ptx");
-    println!("Loading PTX from: {}", ptx_path.display());
-    let ptx_file = ptx_path.to_str().ok_or("PTX path is not valid UTF-8")?;
-
-    match ctx.load_module_from_file(ptx_file) {
+    match kernels::load(&ctx) {
         Ok(module) => {
-            let module =
-                kernels::from_module(module).expect("Failed to initialize typed CUDA module");
-            println!("✓ PTX loaded successfully\n");
+            println!("✓ embedded module loaded successfully\n");
             run_tma_multicast_test(&stream, &module)?;
         }
         Err(e) => {
             // TMA multicast needs sm_100a (Blackwell datacenter). On every
-            // other GPU the cubin won't JIT and `load_module_from_file`
-            // returns DriverError(218). Treat that as a clean skip so the
-            // smoketest's failure-marker scan doesn't flag this as a
-            // regression — the PTX itself was generated, which is all this
-            // example can verify off-hopper datacenter.
+            // other GPU the cubin won't JIT and the driver returns 218, which
+            // `load` surfaces through its `Driver` variant. Treat that as a
+            // clean skip so the smoketest's failure-marker scan doesn't flag
+            // this as a regression — the PTX itself was generated, which is
+            // all this example can verify off-hopper datacenter.
             println!("\nskipping: TMA multicast requires sm_100a");
             println!("  driver reported: {}", e);
             println!("  TMA multicast requires sm_100a or later (B100/B200/GB200, and sm_120).");


### PR DESCRIPTION
Follow-up to #787, which converted the 66 examples that call `.expect(...)`
on the load. These five were held back and are a tidy unit on their own.

## The problem

Each still read a loose `<name>.ptx` from `CARGO_MANIFEST_DIR` and wrapped it
with `kernels::from_module`, so it only ran when an earlier `cargo oxide build`
had left that file beside the manifest. `kernels::load` embeds the artifact in
the binary and needs neither the path nor the second call.

## Why these five needed their own change

They `match` on the load result instead of calling `.expect(...)`, and three of
them key off the driver status inside the `Err` arm to tell "right PTX, wrong
GPU" from a genuine failure. `load` returns `EmbeddedModuleError` rather than
`DriverError`, so `e.0` no longer resolves. Those arms now reach through the
`Driver` variant:

```rust
let driver_status = match &e {
    cuda_host::EmbeddedModuleError::Driver(driver) => Some(driver.0),
    _ => None,
};
if driver_status == Some(cuda_core::sys::cudaError_enum_CUDA_ERROR_INVALID_PTX) {
```

A non-driver variant — a missing or unsupported payload — is not an arch
mismatch, so it falls through to the existing error return rather than being
reported as one.

The gates themselves are unchanged. `tcgen05`, `tcgen05_matmul` and `gemm_sol`
still print the sm_100 advisory on `CUDA_ERROR_INVALID_PTX`; `tma_multicast`
still declares a clean `skipping:` on 218, so the smoketest's failure-marker
scan stays quiet. `array_index` and `tma_multicast` only `Display` the error and
convert directly.

## Verification

`scripts/smoketest.sh --compile-only`, the command the examples-compile gate
runs, over the five plus `vecadd` as a control:

```
[ 1/ 6] array_index      ... PASS (compiled) [20s]
[ 2/ 6] gemm_sol         ... PASS (compiled) [3s]
[ 3/ 6] tcgen05          ... PASS (verified and compiled by libNVVM) [3s]
[ 4/ 6] tcgen05_matmul   ... PASS (compiled) [1s]
[ 5/ 6] tma_multicast    ... PASS (compiled) [1s]
[ 6/ 6] vecadd           ... PASS (compiled) [0s]
Pass: 6 / 6    Fail: 0 / 6
```

`cargo fmt --check` clean in each of the five example workspaces.

**Scope of that claim, stated plainly:** compile-only is the whole check
available here. The `Err` arms these edits touch are reachable only on a GPU
that rejects the PTX — not something a compile gate exercises, and not
something an sm_100 device would hit either. The arm bodies are unchanged; what
changed is how the status is extracted before them. Worth a reviewer's eye on
that extraction rather than trusting the green gate alone.

## What remains

Five examples still load from a path after this: `coop_groups_demo` and
`cross_crate_kernel` build several typed handles from one module, and the three
`*_ffi_test` examples load LTOIR rather than PTX. Both groups are separate
questions and I have left them alone.