### PR TITLE
feat(fuzzer): fold an aggregate into the trace by its leaves

### DIFF
--- a/crates/fuzzer/README.md
+++ b/crates/fuzzer/README.md
@@ -72,24 +72,38 @@ rather than that file. Its header records this.
 - `UNSUPPORTED [adapter]`: rustlantis generated a MIR program, but our Python
   adapter refused to turn it into a cuda-oxide smoke case.
 
-For example, seed `0` dumps a `[i8; 1]`, which the trace API does not hash, so
-`--start 0 --count 2 --keep-going` currently reports:
+For example, seed `1436` returns a `*const i8`, which the trace API does not
+hash, so `--start 1436 --count 2 --keep-going` currently reports:
 
 ```text
 results:
-  seed 0: UNSUPPORTED [adapter] unsupported dumped type for Stage 2 adapter: [i8; 1] (crates/fuzzer/artifacts/seed-0-unsupported.log)
-  seed 1: PASS [run] CPU/GPU traces matched
+  seed 1436: UNSUPPORTED [adapter] unsupported return type for return-value tracing: *const i8 (crates/fuzzer/artifacts/seed-1436-unsupported.log)
+  seed 1437: PASS [run] CPU/GPU traces matched
 summary: PASS=1, UNSUPPORTED=1
 ```
 
+A pointer is a permanent refusal rather than a gap to widen later. The CPU
+oracle and the device hold different addresses for the same object by
+construction, so folding one into the trace would report a MISMATCH on every
+seed that dumped it.
+
 The typical `UNSUPPORTED [adapter]` cause is a generated `dump_var(...)` call
 or function signature that uses a type the adapter cannot rewrite. The trace
-API hashes:
+API hashes these scalars:
 
 ```text
 bool, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, char,
 f32, f64
 ```
+
+It also hashes an array or a tuple of anything in that list, to any nesting
+depth, by folding the leaves. A tuple is hashed up to arity 5, matching the
+`TraceDump` implementations. An aggregate's padding is never read, so a dumped
+`(u8, u32)` hashes as the two fields and nothing else.
+
+What remains refused at a dump site is a shape with no leaf reading, such as a
+reference or a slice. An aggregate in an *argument* position is refused
+elsewhere, by `literal_for_type`, which has no literal to construct for one.
 
 In many `UNSUPPORTED [adapter]` cases, the MIR can probably be patched by
 widening the adapter and trace API. The adapter stops because it does not yet
@@ -163,12 +177,13 @@ invocation, so the logs and `summary.jsonl` always describe only the latest run.
 
 The terminal also prints a full per-seed summary; entries that wrote a log
 append its path, relative to the repo root. Without `--keep-going` a run
-stops at the first non-PASS seed, so `--start 0 --count 2` alone would end at
-seed 0's `UNSUPPORTED`. `--start 0 --count 2 --keep-going` currently prints:
+stops at the first non-PASS seed, so `--start 1436 --count 2` alone would end
+at seed 1436's `UNSUPPORTED`. `--start 1436 --count 2 --keep-going` currently
+prints:
 
 ```text
 results:
-  seed 0: UNSUPPORTED [adapter] unsupported dumped type for Stage 2 adapter: [i8; 1] (crates/fuzzer/artifacts/seed-0-unsupported.log)
-  seed 1: PASS [run] CPU/GPU traces matched
+  seed 1436: UNSUPPORTED [adapter] unsupported return type for return-value tracing: *const i8 (crates/fuzzer/artifacts/seed-1436-unsupported.log)
+  seed 1437: PASS [run] CPU/GPU traces matched
 summary: PASS=1, UNSUPPORTED=1
 ```

--- a/crates/fuzzer/src/lib.rs
+++ b/crates/fuzzer/src/lib.rs
@@ -17,7 +17,9 @@
 //! `tools/mir_generator.py`, etc.) lives next to this library. The library
 //! itself is `no_std` and contains nothing CUDA- or std-specific.
 
-#![no_std]
+// The library is `no_std`. The test harness is not, so a test build links std
+// on the host while every real build, including the device build, does not.
+#![cfg_attr(not(test), no_std)]
 
 pub mod trace;
 

--- a/crates/fuzzer/src/trace.rs
+++ b/crates/fuzzer/src/trace.rs
@@ -152,7 +152,19 @@ fn trace_write_f64(val: f64) {
     trace_write_u64(bits);
 }
 
-/// Scalar values that can be folded into the trace.
+/// Values that can be folded into the trace.
+///
+/// A scalar folds as its bytes. An aggregate folds as its leaves, in
+/// declaration order, through those same scalar writers, so the byte sequence
+/// an aggregate produces is the one a scalar-by-scalar dump of the same leaves
+/// would produce. Composing that way keeps one trace model rather than two.
+///
+/// The fold reads leaves and never the aggregate's bytes. Padding is
+/// uninitialized, so folding raw bytes would be undefined behavior in the CPU
+/// oracle, and any layout the two backends pad differently would report a
+/// MISMATCH on every seed that touched it. Padding is also where the silent
+/// miscompile behind #393 lived, so a byte fold would bury the signal this
+/// fuzzer exists to find.
 pub trait TraceValue {
     fn trace_write(self);
 }
@@ -189,11 +201,62 @@ impl_trace_value! {
     f64 => trace_write_f64,
 }
 
-/// Aggregates of scalar values that can be folded into the trace in one call.
+/// An array folds each element in index order.
+///
+/// The walk is an indexed `while` rather than a `for` over the array's
+/// `IntoIterator`, because this code is compiled for the device as well as the
+/// host and #399 records that small local arrays consumed through iterator
+/// adapters stay in local memory. An index loop states the same thing without
+/// depending on how that resolves.
+impl<T: TraceValue + Copy, const N: usize> TraceValue for [T; N] {
+    #[inline]
+    fn trace_write(self) {
+        let mut index = 0;
+        while index < N {
+            self[index].trace_write();
+            index += 1;
+        }
+    }
+}
+
+macro_rules! impl_trace_value_tuple {
+    ($(($($field:tt: $ty:ident),+))+) => {
+        $(
+            impl<$($ty: TraceValue),+> TraceValue for ($($ty,)+) {
+                #[inline]
+                fn trace_write(self) {
+                    $(self.$field.trace_write();)+
+                }
+            }
+        )+
+    };
+}
+
+impl_trace_value_tuple! {
+    (0: A)
+    (0: A, 1: B)
+    (0: A, 1: B, 2: C)
+    (0: A, 1: B, 2: C, 3: D)
+    (0: A, 1: B, 2: C, 3: D, 4: E)
+}
+
+/// The unit type carries no leaves, so it folds to nothing.
+///
+/// The adapter prunes unit-typed values before it builds a dump tuple, so this
+/// exists for a unit nested inside an aggregate, which the adapter cannot see.
+impl TraceValue for () {
+    #[inline]
+    fn trace_write(self) {}
+}
+
+/// The argument bundle a single dump site folds into the trace.
 ///
 /// `dump_var` accepts any `TraceDump`. We provide implementations for `()` and
 /// tuples up to arity 5, which matches the largest argument bundle rustlantis
 /// emits today after we prune unit values from its `dump_var` calls.
+///
+/// This is the outer shape of a dump site. What each element may be is
+/// [`TraceValue`]'s question, and an element is free to be an aggregate.
 pub trait TraceDump {
     fn trace_dump(self);
 }
@@ -258,4 +321,65 @@ impl<A: TraceValue, B: TraceValue, C: TraceValue, D: TraceValue, E: TraceValue> 
 #[inline]
 pub fn dump_var<T: TraceDump>(value: T) {
     value.trace_dump();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fold<T: TraceValue>(value: T) -> u64 {
+        trace_reset();
+        value.trace_write();
+        trace_finish()
+    }
+
+    /// Every assertion lives in one test.
+    ///
+    /// The trace is a single `static mut`, and cargo runs test functions on
+    /// parallel threads, so two tests folding at once would race on it and
+    /// report whichever interleaving they happened to get.
+    #[test]
+    fn an_aggregate_folds_as_its_leaves() {
+        // An array folds as its elements, in index order.
+        assert_eq!(fold([1u8, 2, 3, 4]), {
+            trace_reset();
+            1u8.trace_write();
+            2u8.trace_write();
+            3u8.trace_write();
+            4u8.trace_write();
+            trace_finish()
+        });
+
+        // A tuple folds as its fields, in declaration order. `(u8, u32)` is
+        // the discriminating case: rustc lays it out with padding, and this
+        // holds only for an implementation that reads the two fields. Folding
+        // the aggregate's bytes instead would mix three padding bytes in and
+        // produce a different value here.
+        assert_eq!(fold((7u8, 0x1122_3344u32)), {
+            trace_reset();
+            7u8.trace_write();
+            0x1122_3344u32.trace_write();
+            trace_finish()
+        });
+
+        // Nesting composes: an array of tuples reaches every leaf.
+        assert_eq!(fold([(1u8, 2u16), (3u8, 4u16)]), {
+            trace_reset();
+            1u8.trace_write();
+            2u16.trace_write();
+            3u8.trace_write();
+            4u16.trace_write();
+            trace_finish()
+        });
+
+        // Order is part of the fold. An implementation walking an array
+        // backwards passes every assertion above and fails this one.
+        assert_ne!(fold([1u8, 2u8]), fold([2u8, 1u8]));
+
+        // A shape with no leaves folds to nothing, leaving the offset basis.
+        trace_reset();
+        let empty = trace_finish();
+        assert_eq!(fold([0u8; 0]), empty);
+        assert_eq!(fold(()), empty);
+    }
 }

--- a/crates/fuzzer/tools/mir_generator.py
+++ b/crates/fuzzer/tools/mir_generator.py
@@ -11,9 +11,12 @@ composites, extracts the first generated custom-MIR function, and rewrites
 rustlantis' `dump_var(...)` terminators into calls to the cuda-oxide harness'
 generic `dump_var`.
 
-Composites reach the device; only the trace boundary is scalar. A dump site or
-return position holding a tuple or an array is still refused, since the trace
-API hashes scalars alone.
+Composites reach the device, and the trace boundary now takes them: a dump site
+or return position holding a tuple or an array folds as its leaves. What is
+still refused there is a shape with no leaf reading, such as a reference, a
+slice, or a tuple wider than the arity the trace API implements. An aggregate
+in an argument position is refused separately, by `literal_for_type`, which has
+no literal to construct for one.
 
 By default it emits a complete `generated_case.rs` module for the
 `rustlantis-smoke` example: imports, adapted MIR function, deterministic call
@@ -253,8 +256,8 @@ def literal_for_type(ty: str, idx: int) -> str:
     return values[idx % len(values)]
 
 
-def supported_trace_type(ty: str) -> bool:
-    return ty in {
+SCALAR_TRACE_TYPES = frozenset(
+    {
         "bool",
         "i8",
         "i16",
@@ -272,6 +275,36 @@ def supported_trace_type(ty: str) -> bool:
         "f32",
         "f64",
     }
+)
+
+# `TraceValue` is implemented for tuples up to arity 5, matching `TraceDump`.
+MAX_TRACE_TUPLE_ARITY = 5
+
+
+def supported_trace_type(ty: str) -> bool:
+    """Report whether the harness can fold a value of this type into the trace.
+
+    A scalar folds directly. An aggregate folds as its leaves, so it is
+    supported exactly when every leaf is, which makes this a recursive
+    question rather than a set membership one.
+    """
+    ty = ty.strip()
+    if ty in SCALAR_TRACE_TYPES:
+        return True
+
+    if ty.startswith("[") and ty.endswith("]"):
+        parsed = split_type_at_semicolon(ty[1:-1])
+        if parsed is None:
+            return False
+        return supported_trace_type(parsed[0])
+
+    if ty.startswith("(") and ty.endswith(")"):
+        fields = split_args(ty[1:-1])
+        if len(fields) > MAX_TRACE_TUPLE_ARITY:
+            return False
+        return all(supported_trace_type(field) for field in fields)
+
+    return False
 
 
 def adapt_function(fn_src: str, fn_name: str) -> str:


### PR DESCRIPTION
Closes #791.

The trace API hashed 16 scalar types and nothing else, so a generated program whose dump site or return position held a tuple or an array was refused at the adapter with `unsupported dumped type`. That was 18 of the 60 seeds in the window the README quotes, and 320 of the 1000 seeds in the sweep that found #765 and #767.

## Summary

Folds an aggregate into the trace as its leaves, in declaration order, so `TraceValue` covers arrays and tuples of anything it already covered, to any nesting depth.

## Changes

- `crates/fuzzer/src/trace.rs`: `TraceValue` for `[T; N]` over a const generic, for tuples up to arity 5, and for `()`. Each walks its leaves through the existing scalar writers.
- `crates/fuzzer/src/lib.rs`: `#![cfg_attr(not(test), no_std)]`, so a test build links std on the host while every real build, the device build included, stays `no_std`.
- `crates/fuzzer/tools/mir_generator.py`: `supported_trace_type` becomes a recursive question over `[T; N]` and tuples rather than a set membership test. It governs both existing call sites, the dumped locals and the return type.
- `crates/fuzzer/README.md`: refreshes the status transcripts and the supported-type list, which this change makes stale.

## Rationale

The byte sequence an aggregate produces is exactly the one a scalar-by-scalar dump of the same leaves produces, so this widens what the trace accepts without introducing a second trace model. Nothing that hashed before hashes differently.

The fold reads leaves and never the aggregate's bytes. Padding is uninitialised, so folding raw bytes would be undefined behaviour in the CPU oracle, and any layout the two backends pad differently would report a MISMATCH on every seed that touched it. Padding is also where the silent miscompile behind #393 lived, so a byte fold would bury the signal this fuzzer exists to find. `(u8, u32)` is the discriminating case in the test: it holds only for an implementation that reads the two fields.

The array walk is an indexed `while` rather than a `for` over the array's `IntoIterator`. This crate is compiled for the device as well as the host, and #399 records that small local arrays consumed through iterator adapters stay in local memory. An index loop states the same thing without depending on how that resolves.

The tuple arity stops at 5 because `TraceDump` stops at 5, and the adapter refuses a wider one rather than emitting a program that fails to compile. Every assertion lives in one test function, because the trace is a single `static mut` and cargo runs test functions on parallel threads, so two folds at once would race on it.

## Validation

RTX 5060 Laptop GPU, compute capability 12.0, CUDA 13.3, driver 610.43.03.

Seeds 300-359, the window the README quotes, changing only the trace API and the adapter:

```text
before:  PASS=42  UNSUPPORTED=18
after:   PASS=60  UNSUPPORTED=0
```

Every refused seed became an executing differential run, and none of them mismatched. Seeds 0-99 are also 100 PASS with nothing refused.

Seeds 1000-1999, the window that produced #765 and #767:

```text
PASS=999  UNSUPPORTED=1  COMPILE_FAIL=0  MISMATCH=0
```

The recorded figure for that window on 2026-08-09 was `PASS=673 UNSUPPORTED=320 COMPILE_FAIL=7`. The seven compile failures are gone because #769 landed, and that run predates this branch, so it is a recorded baseline rather than a paired arm.

No mismatch, so this widening surfaced no new silent miscompile in that window. What it did was put 319 more programs through the device where the harness previously refused to look at them.

The one remaining refusal is seed 1436, which returns a `*const i8`:

```text
UNSUPPORTED [adapter] unsupported return type for return-value tracing: *const i8
```

That one is permanent rather than a gap to widen next. The CPU oracle and the device hold different addresses for the same object by construction, so folding a pointer into the trace would report a MISMATCH on every seed that dumped one.

The unit test discriminates. Reversing the array walk, so that it folds `[1, 2, 3, 4]` as `4, 3, 2, 1`, fails the first assertion and leaves the rest of the file passing.

```text
cargo test -p fuzzer                    1 passed, 0 failed
cargo clippy -p fuzzer --all-targets    clean
cargo fmt --check -p fuzzer             clean
```
