### PR TITLE
docs(book): add a cargo oxide command reference

### DIFF
--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -253,7 +253,7 @@ These components are required by the codegen backend and doctor:
 
 ## cargo-oxide
 
-`cargo-oxide` is the cargo subcommand that drives the entire build pipeline (`cargo oxide run`, `build`, `debug`, `pipeline`, etc.).
+`cargo-oxide` is the cargo subcommand that drives the entire build pipeline (`cargo oxide run`, `build`, `debug`, `pipeline`, and the rest -- the Command reference at the end of this section lists all of them).
 
 **Inside the cuda-oxide repo**, it works out of the box via a workspace alias -- no extra install step.
 
@@ -289,6 +289,52 @@ cargo oxide clean
 `inspect` is the lightweight counterpart to `cargo oxide pipeline`. `clean`
 only touches project-local outputs; it leaves the shared backend cache at
 `~/.cargo/cuda-oxide/` alone.
+
+### Command reference
+
+The full set, as `cargo oxide --help` reports it:
+
+| Command | Description |
+|---------|-------------|
+| `run` | Build and run an example or project |
+| `sanitize` | Build and run an example or project under NVIDIA Compute Sanitizer |
+| `build` | Build an example or project (compile only, don't run) |
+| `test` | Run Cargo tests through the cuda-oxide backend |
+| `emit-ltoir` | Compile a crate's device code to a binary LTOIR artifact in one step |
+| `pipeline` | Show the full compilation pipeline (MIR -> PTX/NVVM IR) with verbose output |
+| `debug` | Build with debug info and launch `cuda-gdb` |
+| `list` | List the examples bundled with the cuda-oxide workspace |
+| `inspect` | Build an example or project and print the generated PTX |
+| `fmt` | Format all crates (root workspace, codegen backend, examples) |
+| `new` | Scaffold a new standalone cuda-oxide project |
+| `clean` | Remove project-local build outputs and generated cuda-oxide artifacts |
+| `doctor` | Check that your environment is set up correctly |
+| `setup` | Build and cache the codegen backend |
+| `update` | Refresh the cached codegen backend (or run `setup` inside the workspace) |
+
+Four of these are worth calling out, because they do something `cargo` itself
+cannot:
+
+```bash
+# Run the test suite with device code compiled by the cuda-oxide backend.
+# Arguments after `--` go to cargo; with none it is a plain `cargo test`.
+cargo oxide test -- --lib
+
+# Format the root workspace, the codegen backend, and every example. Each has
+# its own [workspace], so a single `cargo fmt` at the root misses most of them.
+cargo oxide fmt
+cargo oxide fmt --check
+
+# Rebuild the cached backend after changing compiler crates or the toolchain
+# pin. Inside the workspace this advises `setup`; --force runs it.
+cargo oxide update
+
+# Produce the LTOIR a tile or C++ kernel links against. LTOIR is
+# architecture-specific, so --arch is required rather than inferred.
+cargo oxide emit-ltoir my_kernels --arch sm_90
+```
+
+Every command takes `--help`, which lists the flags each one accepts.
 
 ---
 


### PR DESCRIPTION
## The gap

The book documents 11 of the CLI's 15 subcommands, scattered across pages, with
no complete list anywhere. `test`, `fmt`, `update` and `emit-ltoir` appear
nowhere at all.

None of those four is cosmetic — each does something plain `cargo` cannot:

- **`cargo oxide test`** is the only way to run the suite with device code
  compiled by the backend.
- **`cargo oxide fmt`** covers three scopes — root workspace, codegen backend,
  and every example — because each example carries its own `[workspace]`, so a
  single `cargo fmt` at the root misses most of the tree. That is also what the
  CI fmt gate checks, which makes it the command a contributor most needs to
  know and the one least discoverable.
- **`cargo oxide update`** refreshes the cached backend after a compiler-crate
  or toolchain-pin change.
- **`cargo oxide emit-ltoir`** produces the LTOIR a tile or C++ kernel links
  against. The book discusses LTOIR on eight pages and named no way to generate
  one.

## The change

A Command reference table in the `cargo-oxide` section listing all fifteen, plus
worked examples for those four. Descriptions are clap's own, so `--help` remains
the single source of truth rather than a second one drifting alongside it.

## Verification

- The table's fifteen entries match `cargo oxide --help` **exactly** — diffed
  both directions, nothing missing and nothing invented.
- `cargo oxide fmt`'s three scopes are confirmed against `format_all` in
  `crates/cargo-oxide/src/commands.rs`, not inferred from its help text.
- `sphinx-build -W --keep-going -b html`, exactly as the book gate runs it:
  `build succeeded`, exit 0.

One note on that last point, since it is a trap for the next person editing this
book: my first draft linked the new section with `[the command
reference](#command-reference)`, which **fails the book gate** —
`WARNING: 'myst' cross-reference target not found` with `-W` turning it into an
error. The rendered HTML contains both the `href` and a matching `id`, so it
works in a browser; the gate still rejects it, because this book sets
`heading_anchors=0`. The cross-reference is plain prose instead.

## Possible follow-up

The table will drift the moment a subcommand is added, exactly as the toolchain
pin did in #790. The subcommand enum in `main.rs` is cleanly parseable (variants
kebab-cased, hidden ones carry `hide = true`), so a coverage guard in the shape
of #790/#793 is straightforward. I have deliberately not included one here —
that would be a third guard in one batch, and this PR is worth reviewing on its
own. Happy to add it if you want the table kept honest automatically.