### PR TITLE
docs(book): document how `opt` is resolved, and that it must match `llc`

### DIFF
--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -560,32 +560,6 @@ pipeline fails with a clear error. You can opt into a specific (possibly
 older) binary by setting `CUDA_OXIDE_LLC=/path/to/llc`, but simple kernels
 are the only thing guaranteed to compile on LLVM 20 and below.
 
-### Picking `opt` to match
-
-`llc` is not the only LLVM binary the pipeline runs: the middle-end
-optimization stage needs `opt`, and the two must come from the **same LLVM
-major**. Mixing them is the failure this ordering exists to prevent -- `opt`
-from one release can emit IR that `llc` from another does not accept.
-
-So `llc` is resolved first, by the table above, and its major is read from
-`llc --version`. `opt` is then chosen to match:
-
-| Priority | Source                                             | Notes                                                                 |
-| :------- | :------------------------------------------------- | :-------------------------------------------------------------------- |
-| 1st      | `$CUDA_OXIDE_OPT` (if set)                         | Always respected. A major mismatch against the chosen `llc` is not silently corrected -- it records a diagnostic naming both binaries. |
-| 2nd      | The `opt` beside the chosen `llc`                  | LLVM installs keep their tools side by side, so this is the one that matches by construction. |
-| 3rd      | Rust toolchain's `llvm-tools` `opt`                | `<sysroot>/lib/rustlib/<host>/bin/opt`.                               |
-| 4th      | `opt-22` / `opt-21` / `opt` on `PATH`              | Filtered to the same major as `llc`.                                  |
-
-If no same-major `opt` exists, resolution records a diagnostic naming every
-rejected candidate. The experimental API treats a requested optimization as
-strict and fails; the legacy rustc path falls back to running unoptimized.
-
-Because step 2 keys off whichever `llc` won, pinning `CUDA_OXIDE_LLC` alone is
-usually enough -- the matching `opt` is normally found next to it, and setting
-`CUDA_OXIDE_OPT` as well is only needed when the pair is split across
-directories.
-
 If the selected target does not match the physical GPU, the CUDA driver
 JIT-compiles the PTX at load time. First launch costs roughly 30ms while the
 driver translates; subsequent launches use a cached binary. In practice, you
@@ -618,6 +592,32 @@ and a `cta_group` parameter in LLVM 21. Older `llc` versions reject it with
 `Intrinsic has incorrect argument type!`. Rather than maintain separate
 intrinsic emitters per LLVM version, we set 21 as the minimum.
 ```
+
+### Picking `opt` to match
+
+`llc` is not the only LLVM binary the pipeline runs: the middle-end
+optimization stage needs `opt`, and the two must come from the **same LLVM
+major**. Mixing them is the failure this ordering exists to prevent -- `opt`
+from one release can emit IR that `llc` from another does not accept.
+
+So `llc` is resolved first, by the table above, and its major is read from
+`llc --version`. `opt` is then chosen to match:
+
+| Priority | Source                                             | Notes                                                                 |
+| :------- | :------------------------------------------------- | :-------------------------------------------------------------------- |
+| 1st      | `$CUDA_OXIDE_OPT` (if set)                         | Always respected. A major mismatch against the chosen `llc` is not silently corrected -- it records a diagnostic naming both binaries. |
+| 2nd      | The `opt` beside the chosen `llc`                  | LLVM installs keep their tools side by side. Still version-checked: a mismatched sibling is rejected, and it is only accepted unverified when `llc`'s own version cannot be read. |
+| 3rd      | Rust toolchain's `llvm-tools` `opt`                | `<sysroot>/lib/rustlib/<host>/bin/opt`. Filtered to the same major as `llc`. |
+| 4th      | `opt-22` / `opt-21` / `opt` on `PATH`              | Filtered to the same major as `llc`.                                  |
+
+If no same-major `opt` exists, resolution records a diagnostic naming every
+rejected candidate. The experimental API treats a requested optimization as
+strict and fails; the legacy rustc path falls back to running unoptimized.
+
+Because step 2 keys off whichever `llc` won, pinning `CUDA_OXIDE_LLC` alone is
+usually enough -- the matching `opt` is normally found next to it, and setting
+`CUDA_OXIDE_OPT` as well is only needed when the pair is split across
+directories.
 
 ## Atomic operations in legacy NVVM IR
 

--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -560,6 +560,32 @@ pipeline fails with a clear error. You can opt into a specific (possibly
 older) binary by setting `CUDA_OXIDE_LLC=/path/to/llc`, but simple kernels
 are the only thing guaranteed to compile on LLVM 20 and below.
 
+### Picking `opt` to match
+
+`llc` is not the only LLVM binary the pipeline runs: the middle-end
+optimization stage needs `opt`, and the two must come from the **same LLVM
+major**. Mixing them is the failure this ordering exists to prevent -- `opt`
+from one release can emit IR that `llc` from another does not accept.
+
+So `llc` is resolved first, by the table above, and its major is read from
+`llc --version`. `opt` is then chosen to match:
+
+| Priority | Source                                             | Notes                                                                 |
+| :------- | :------------------------------------------------- | :-------------------------------------------------------------------- |
+| 1st      | `$CUDA_OXIDE_OPT` (if set)                         | Always respected. A major mismatch against the chosen `llc` is not silently corrected -- it records a diagnostic naming both binaries. |
+| 2nd      | The `opt` beside the chosen `llc`                  | LLVM installs keep their tools side by side, so this is the one that matches by construction. |
+| 3rd      | Rust toolchain's `llvm-tools` `opt`                | `<sysroot>/lib/rustlib/<host>/bin/opt`.                               |
+| 4th      | `opt-22` / `opt-21` / `opt` on `PATH`              | Filtered to the same major as `llc`.                                  |
+
+If no same-major `opt` exists, resolution records a diagnostic naming every
+rejected candidate. The experimental API treats a requested optimization as
+strict and fails; the legacy rustc path falls back to running unoptimized.
+
+Because step 2 keys off whichever `llc` won, pinning `CUDA_OXIDE_LLC` alone is
+usually enough -- the matching `opt` is normally found next to it, and setting
+`CUDA_OXIDE_OPT` as well is only needed when the pair is split across
+directories.
+
 If the selected target does not match the physical GPU, the CUDA driver
 JIT-compiles the PTX at load time. First launch costs roughly 30ms while the
 driver translates; subsequent launches use a cached binary. In practice, you


### PR DESCRIPTION
## The gap

The lowering pipeline runs **two** LLVM binaries, and the book documents the
discovery order of only one. `llc` gets a five-row precedence table under
"Target Selection". `opt` is never mentioned — not the probe order, not
`CUDA_OXIDE_OPT`, and not the part that actually bites: **the two must come from
the same LLVM major.**

That rule is not incidental. From `LlvmToolchain::resolve`, `llc` is picked
first, its major read from `llc --version`, and `opt` is then selected to match:

1. An explicit `CUDA_OXIDE_OPT` is always respected, but a major mismatch
   against the chosen `llc` records a diagnostic naming both binaries.
2. Otherwise the `opt` sitting beside the chosen `llc` — LLVM installs keep
   their tools side by side, so this one matches by construction.
3. Otherwise sysroot `llvm-tools` `opt`, then `opt-22` / `opt-21` / `opt` on
   `PATH`, all filtered to `llc`'s major.
4. If no same-major `opt` exists, resolution names every rejected candidate. The
   experimental API treats requested optimization as strict and fails; the
   legacy rustc path keeps its unoptimized fallback.

A user whose `opt` is rejected currently has nothing to consult. The two
override variables are literally adjacent lines in `options.rs`; only one of
them is documented.

## The change

Adds the matching table immediately after the existing `llc` one, in the same
shape, plus the practical note that pinning `CUDA_OXIDE_LLC` alone is usually
enough — the sibling probe finds the matching `opt` by itself, and
`CUDA_OXIDE_OPT` is only needed when the pair is split across directories.

Sourced entirely from `crates/cuda-oxide-codegen/src/llvm_tools.rs` (the
module-level comment and `resolve`) and `options.rs`. No behaviour change.

## Verification

`sphinx-build -W --keep-going -b html`, exactly as the book gate runs it:
`build succeeded`, exit 0.