### PR TITLE
docs(book): document the launch-bounds spill warning and its escape hatch

### DIFF
--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -282,6 +282,47 @@ pub fn my_kernel(...) { }
 
 :::
 
+### When the bound forces spills
+
+A launch bound is ultimately a cap on registers per thread: promising ptxas more
+resident threads leaves each of them fewer registers to work with. If the kernel
+needs more than the cap allows, ptxas does not fail -- it **spills** the excess
+to local memory, and the occupancy the bound bought is then paid for again on
+every access to a spilled value.
+
+That is easy to miss, because the build succeeds. cuda-oxide warns instead, at
+the kernel's definition span:
+
+```text
+warning: kernel `cuda_oxide_kernel_a1b2c3d4_my_kernel` compiled with
+         `#[launch_bounds(256, 2)]` and spills registers
+  = note: ptxas reports 96 bytes spill stores and 96 bytes spill loads
+  = note: ptxas allocated 40 registers per thread
+  = help: relax `min_blocks_per_sm` or reduce register pressure
+```
+
+(Byte counts and register totals are whatever ptxas reported for your kernel.)
+Only kernels carrying `#[launch_bounds]` are checked -- without a bound there is
+no promise for ptxas to satisfy at the expense of registers.
+
+The usual responses are to raise `max_threads`, drop or relax `min_blocks`, or
+cut register pressure in the kernel itself. Spilling is not automatically wrong:
+a kernel can be faster spilling a little at high occupancy than not spilling at
+low occupancy. The warning exists because that is a trade worth making
+deliberately rather than by accident.
+
+:::{warning}
+`#[allow(...)]` does **not** silence these. They are raw span diagnostics rather
+than lints, so the suppression attribute does not apply to them. The escape
+hatch is an environment variable, meant for builds that measured the spill and
+accepted it:
+
+```bash
+CUDA_OXIDE_NO_SPILL_WARN=1 cargo oxide build my_kernels
+```
+
+:::
+
 ## The collector -- how device code is discovered
 
 When you build with `cargo oxide`, the `rustc-codegen-cuda` backend runs a

--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -303,7 +303,10 @@ warning: kernel `cuda_oxide_kernel_a1b2c3d4_my_kernel` compiled with
 
 (Byte counts and register totals are whatever ptxas reported for your kernel.)
 Only kernels carrying `#[launch_bounds]` are checked -- without a bound there is
-no promise for ptxas to satisfy at the expense of registers.
+no promise for ptxas to satisfy at the expense of registers. The warning can
+only fire in builds that materialize a native cubin (`--materialize-cubin`, or
+any build that embeds a cubin): a plain PTX build never runs ptxas, so there is
+no resource report to inspect.
 
 The usual responses are to raise `max_threads`, drop or relax `min_blocks`, or
 cut register pressure in the kernel itself. Spilling is not automatically wrong:
@@ -318,7 +321,7 @@ hatch is an environment variable, meant for builds that measured the spill and
 accepted it:
 
 ```bash
-CUDA_OXIDE_NO_SPILL_WARN=1 cargo oxide build my_kernels
+CUDA_OXIDE_NO_SPILL_WARN=1 cargo oxide build my_kernels --materialize-cubin
 ```
 
 :::


### PR DESCRIPTION
## The gap

#757 taught the backend to warn when a `#[launch_bounds]` kernel spills
registers. The warning is user-facing and **nothing in the book mentions it**, so
the first time anyone meets it is in their own build output.

Two things make that worse than an ordinary documentation gap:

- **The build still succeeds.** A bound ptxas can only satisfy by spilling to
  local memory is a silent trade — occupancy bought, then paid for again on
  every access to a spilled value. The warning is the only signal that happened.
- **`#[allow(...)]` does not silence it.** These are raw span diagnostics rather
  than lints, so the attribute a Rust user reaches for first does nothing. The
  only escape hatch is `CUDA_OXIDE_NO_SPILL_WARN=1`, which appears in **no**
  documentation — it exists solely as a doc comment on
  `emit_launch_bounds_spill_warnings`.

## The change

The `#[launch_bounds]` section now carries the diagnostic's actual shape:

```text
warning: kernel `cuda_oxide_kernel_a1b2c3d4_my_kernel` compiled with
         `#[launch_bounds(256, 2)]` and spills registers
  = note: ptxas reports 96 bytes spill stores and 96 bytes spill loads
  = note: ptxas allocated 40 registers per thread
  = help: relax `min_blocks_per_sm` or reduce register pressure
```

…plus what it means, that only kernels carrying `#[launch_bounds]` are checked,
the usual responses, and the environment variable in a `warning` admonition so
the `#[allow]` dead end is hard to miss.

It also says plainly that **spilling is not automatically wrong** — a kernel can
be faster spilling a little at high occupancy than not spilling at low — because
the point of the warning is to make that a deliberate trade rather than an
accidental one, which is the intent recorded on the emitting function.

Every message string is quoted from `crates/rustc-codegen-cuda/src/lib.rs`
rather than paraphrased (I diffed them against the source). The byte and
register figures are illustrative and labelled as such, since they are whatever
ptxas reports for a given kernel.

## Verification

`sphinx-build -W --keep-going -b html`, as the book gate runs it: exit 0.

## Note for triage

Issue #708 asked for exactly this warning and is **still open** even though #757
merged it — looks like another squash merge where the `Closes` did not fire.
Flagging rather than touching it.