### PR TITLE
ci: guard the book's CLI command reference against subcommand drift

### DIFF
--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -76,3 +76,19 @@ jobs:
       # Reads sources only: no rustup, no cargo, no CUDA toolkit.
       - name: Verify every copy of the toolchain pin agrees
         run: bash scripts/check-toolchain-parity.sh
+
+  # The book's Command reference is the only complete list of the CLI surface in
+  # the docs, and adding a subcommand to the clap enum is a one-line change that
+  # leaves it silently short -- `test`, `fmt`, `update` and `emit-ltoir` were all
+  # missing when that table was written (#794).
+  cli-doc-coverage:
+    name: CLI command reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # Reads the clap enum and the book: no cargo, no build, no network.
+      - name: Verify the book documents every cargo oxide subcommand
+        run: bash scripts/check-cli-doc-coverage.sh

--- a/Justfile
+++ b/Justfile
@@ -125,19 +125,26 @@ smoketest *args:
 check-errors:
     scripts/check-error-example-status.sh
 
-# The status-guard pair (error* examples in STATUS.md, and the smoketest
-# example contract) plus all three cargo-deny jobs: `cargo deny check` enforces
+# Every status-guard job (error* examples in STATUS.md, the smoketest example
+# contract, the README crate inventory, toolchain-pin parity, and the book's CLI
+# command reference) plus all three cargo-deny jobs: `cargo deny check` enforces
 # deny.toml over the root workspace's resolved graph, the license inventory
 # covers what the workspace declares, and deny.toml holds over the example
 # workspaces. These were only reachable by reading the workflows, so `just
-# check` could pass while status-guard or cargo-deny failed. Prerequisites:
-# `cargo-deny` on PATH (`cargo install cargo-deny --locked`) and `python3`
-# (three of the scripts drive it). The scripts are invoked via `bash` as CI
-# does: two of the four carry no exec bit.
+# check` could pass while status-guard or cargo-deny failed. Keep this list in
+# step when a guard is added to either workflow -- the crate-inventory and
+# toolchain-parity jobs were added to CI without being added here, which is the
+# same drift this recipe exists to prevent. Prerequisites: `cargo-deny` on PATH
+# (`cargo install cargo-deny --locked`) and `python3` (most of the scripts drive
+# it). The scripts are invoked via `bash` as CI does, since not all of them
+# carry an exec bit.
 # Run the status-guard and cargo-deny CI jobs (needs cargo-deny, python3)
 check-guards:
     bash scripts/check-error-example-status.sh
     bash scripts/check-example-smoketest-contract.sh
+    bash scripts/check-crate-inventory.sh
+    bash scripts/check-toolchain-parity.sh
+    bash scripts/check-cli-doc-coverage.sh
     cargo deny check
     bash scripts/check-dependency-licenses.sh
     bash scripts/check-example-license-policy.sh

--- a/scripts/check-cli-doc-coverage.sh
+++ b/scripts/check-cli-doc-coverage.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Verify the book's Command reference lists every `cargo oxide` subcommand.
+#
+# The table in `cuda-oxide-book/getting-started/installation.md` is the only
+# complete list of the CLI surface anywhere in the docs, and nothing fails when
+# it falls behind: adding a subcommand to the clap enum is a one-line change
+# that leaves the table silently short. Four commands (`test`, `fmt`, `update`,
+# `emit-ltoir`) were already missing when that table was written, so the drift
+# is not hypothetical.
+#
+# Both directions are checked. A missing row is the common case; a row for a
+# command that no longer exists is the other one, and it is worse, because a
+# reader trusts it and gets `unrecognized subcommand`.
+#
+# Subcommands are read from the `Commands` enum in
+# `crates/cargo-oxide/src/main.rs` rather than from `cargo oxide --help`. The
+# enum is the definition, reading it needs no cargo, no toolchain and no build,
+# and it keeps this guard in the same source-only class as its siblings -- a
+# guard that needs a 15-minute backend build to answer a documentation question
+# would not be run.
+#
+# Two kinds of command are deliberately not required to appear:
+#
+#   * anything carrying `hide = true`, which is hidden from `--help` itself
+#     (`__materializer-provenance` today, internal plumbing);
+#   * clap's generated `help`, which is not in the enum at all, so reading the
+#     enum excludes it without a special case.
+#
+# Descriptions are out of scope. clap's short help is a variant's doc-comment
+# first line, while the table's cells deliberately add MyST backticks around
+# names like `cuda-gdb` and `setup`; comparing them literally would fail on
+# correct prose, and normalising invites the brittleness this guard exists to
+# avoid. What matters is that every command is listed and no listed command is
+# fictional.
+#
+# Run this after adding, renaming or removing a subcommand.
+set -euo pipefail
+
+export LC_ALL=C
+
+cd "$(dirname "$0")/.."
+
+MAIN=crates/cargo-oxide/src/main.rs
+BOOK=cuda-oxide-book/getting-started/installation.md
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: python3 is required to verify the CLI command reference" >&2
+    echo "       refusing to report success from a check that cannot run" >&2
+    exit 1
+fi
+
+test -s "${MAIN}"
+test -s "${BOOK}"
+
+python3 - "${MAIN}" "${BOOK}" <<'PY'
+import re
+import sys
+
+main_path, book_path = sys.argv[1], sys.argv[2]
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+main_src = read(main_path)
+book_src = read(book_path)
+
+# The enum body, from its header to the first column-0 `}`. Variant bodies are
+# indented deeper, so they cannot terminate this span.
+enum_body = re.search(r"^enum Commands \{\n(.*?)^\}", main_src, re.M | re.S)
+if not enum_body:
+    sys.exit(
+        f"parse self-test failed: no `enum Commands {{` block in {main_path}; "
+        "the CLI was restructured, so fix this guard before trusting it"
+    )
+
+# Variant-level attributes sit at the same 4-space indent as the variant. Field
+# attributes inside a body are indented deeper and never match.
+ATTR = re.compile(r"^ {4}#\[command\((.*)\)\]$")
+VARIANT = re.compile(r"^ {4}([A-Z][A-Za-z0-9]*)\s*[{,]?\s*$")
+
+commands = []
+hidden = []
+pending = ""
+for line in enum_body.group(1).splitlines():
+    attr = ATTR.match(line)
+    if attr:
+        pending += attr.group(1)
+        continue
+    variant = VARIANT.match(line)
+    if not variant:
+        # Doc comments, blank lines and body content: keep any pending
+        # attribute, since a doc comment may sit between it and the variant.
+        if line.strip() and not line.lstrip().startswith("///"):
+            if not line.startswith(" " * 8) and line.strip() not in ("},", "}"):
+                pending = ""
+        continue
+
+    name_override = re.search(r'name\s*=\s*"([^"]+)"', pending)
+    is_hidden = re.search(r"hide\s*=\s*true", pending) is not None
+    pending = ""
+
+    if name_override:
+        name = name_override.group(1)
+    else:
+        # CamelCase -> kebab-case: EmitLtoir -> emit-ltoir.
+        name = re.sub(r"(?<!^)(?=[A-Z])", "-", variant.group(1)).lower()
+
+    (hidden if is_hidden else commands).append(name)
+
+if len(commands) < 10:
+    sys.exit(
+        f"parse self-test failed: read {len(commands)} visible subcommands "
+        f"(plus {len(hidden)} hidden) from {main_path}"
+    )
+
+# Only the Command reference section counts. installation.md carries several
+# other tables (prerequisites, toolkit versions); a name appearing in one of
+# those is not an entry in the CLI reference.
+section = re.search(
+    r"^### Command reference$(.*?)(?=^#{2,3} )", book_src, re.M | re.S
+)
+if not section:
+    sys.exit(
+        f"parse self-test failed: no `### Command reference` section in "
+        f"{book_path}; it was renamed or removed, so fix this guard"
+    )
+
+# Leading underscores are matched on purpose: the hidden commands are named
+# `__like-this`, and a row documenting one has to be reported rather than
+# skipped as unrecognised text.
+listed = re.findall(r"^\|\s*`([a-z_][a-z0-9_-]*)`\s*\|", section.group(1), re.M)
+if len(listed) < 10:
+    sys.exit(
+        f"parse self-test failed: read {len(listed)} rows from the Command "
+        f"reference in {book_path}"
+    )
+
+missing = [c for c in commands if c not in listed]
+unknown = [row for row in listed if row not in commands]
+
+failures = []
+if missing:
+    failures.append(
+        "these subcommands have no row in the Command reference:\n"
+        + "".join(f"    {c}\n" for c in missing)
+    )
+if unknown:
+    detail = ""
+    for row in unknown:
+        why = " (hidden from --help)" if row in hidden else " (no such subcommand)"
+        detail += f"    {row}{why}\n"
+    failures.append(
+        "the Command reference lists commands the CLI does not expose:\n" + detail
+    )
+
+if failures:
+    print(f"error: {book_path} is out of step with {main_path}", file=sys.stderr)
+    for failure in failures:
+        print("  " + failure.rstrip(), file=sys.stderr)
+    print(file=sys.stderr)
+    print(
+        "The table is the only complete list of the CLI in the docs. Add or "
+        "remove the row,\ncopying the layout from a neighbour; the description "
+        "column is clap's own short help.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    f"OK: {book_path} documents all {len(commands)} `cargo oxide` subcommands "
+    f"({len(hidden)} hidden one(s) correctly excluded)."
+)
+PY


### PR DESCRIPTION
The follow-up you offered on #794 — *"Happy to take the drift guard as a
follow-up if you are up for it."*

## Why

#794 added the Command reference table because the book documented 11 of the
CLI's 15 subcommands; `test`, `fmt`, `update` and `emit-ltoir` appeared nowhere.
Nothing stops it falling behind again: adding a variant to the clap enum is a
one-line change, and no build compares the two.

`scripts/check-cli-doc-coverage.sh` compares the `Commands` enum in
`crates/cargo-oxide/src/main.rs` against the rows under `### Command reference`,
**in both directions**. A missing row is the common case; a row for a command
that no longer exists is worse, because a reader trusts it and gets
`unrecognized subcommand`.

## Design choices

**Subcommands come from the enum, not from `cargo oxide --help`.** The enum is
the definition, reading it needs no cargo and no build, and it keeps this guard
in the same source-only class as its siblings — a guard that needed a backend
build to answer a documentation question would not get run. I cross-checked the
parse against the built binary: both report the same **15** commands, zero
disagreement.

**Not required to appear:** anything carrying `hide = true`
(`__materializer-provenance` today) and clap's generated `help`, which is not in
the enum at all, so reading the enum excludes it without a special case.

**Descriptions are out of scope.** clap's short help is a variant's doc-comment
first line, while the table's cells deliberately add MyST backticks around names
like `cuda-gdb` and `setup`; comparing them literally would fail on correct
prose, and normalising invites the brittleness the guard exists to avoid.

## A defect found while wiring it up

`check-guards` was running **five of the seven** guards. The `crate-inventory`
and `toolchain-pin-parity` jobs went into `status-guard.yml` in #793 and #790
**without being added to the recipe**, so `just check` could pass while
status-guard failed — precisely the drift #729 and #788 built that recipe to
prevent. That was my omission in those two PRs. All three are in now, and the
stale counts in its comment ("the status-guard pair", "two of the four") are
corrected. Every `scripts/check-*.sh` is now referenced by both the Justfile and
a workflow.

## Verification

Clean tree:

```
OK: cuda-oxide-book/getting-started/installation.md documents all 15
`cargo oxide` subcommands (1 hidden one(s) correctly excluded).
```

Seven mutations, each failing and naming the cause:

| mutation | caught as |
|---|---|
| new visible subcommand added to the enum | `profile` |
| row deleted from the table | `emit-ltoir` |
| table lists a command that does not exist | `benchmark (no such subcommand)` |
| table documents the hidden command | `__materializer-provenance (hidden from --help)` |
| subcommand renamed (`Doctor` → `Diagnose`) | `diagnose` |
| book section heading renamed | parse self-test |
| `enum Commands` renamed | parse self-test |

The fourth case initially **passed** — my row pattern was `[a-z][a-z0-9-]*`, so a
`__`-prefixed name never matched and the hidden-command branch was unreachable
dead code. Widened to `[a-z_][a-z0-9_-]*`, with a comment on why the underscore
is deliberate.

`just check-guards` green end to end (exit 0, all eight legs), and
`status-guard.yml` parses as YAML with five jobs.

No Rust changed, so `cargo fmt` / `clippy` are untouched by this.