### PR TITLE
ci: pin the lock on the root cargo-deny run

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -35,8 +35,14 @@ jobs:
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
 
+      # `--locked` so a stale committed lock fails the run instead of being
+      # re-resolved on the way past. Without it this step rewrites the very
+      # Cargo.lock it is judging -- verified: deleting a package block from the
+      # lock still exits 0 here and leaves the file rewritten, while --locked
+      # stops with "cannot update the lock file". The other two runs below and
+      # in scripts/ already pass it.
       - name: Run cargo-deny
-        run: cargo deny check
+        run: cargo deny --locked check
 
       # crates/rustc-codegen-cuda carries its own `[workspace]` for the
       # rustc-private dylibs, so the run above stops at that boundary and never

--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ check-guards:
     bash scripts/check-crate-inventory.sh
     bash scripts/check-toolchain-parity.sh
     bash scripts/check-cli-doc-coverage.sh
-    cargo deny check
+    cargo deny --locked check
     cargo deny --manifest-path crates/rustc-codegen-cuda/Cargo.toml --locked check
     bash scripts/check-dependency-licenses.sh
     bash scripts/check-example-license-policy.sh


### PR DESCRIPTION
The one-word follow-up from the #805 review — *"Your `--locked` note on the root
run is a one-word follow-up; we'll take it."*

The root `cargo deny check` was the only cargo-deny invocation in the tree
without `--locked`. The backend-workspace run added beside it in #805 has it, and
so has every per-example run in `check-example-license-policy.sh` since #681.

## It is not only an inconsistency

Without `--locked` the root run re-resolves on the way past, so **it can rewrite
the very `Cargo.lock` it is judging.** Deleting one package block from the
committed lock and running each form:

| form | exit | effect |
|---|---|---|
| `cargo deny --locked check` | **1** | `cannot update the lock file /…/Cargo.lock because --locked was passed to prevent this` |
| `cargo deny check` | 0 | **left `Cargo.lock` rewritten** |

So a stale committed lock passes this gate today unnoticed, and the gate hides
the evidence by fixing it in place. That is the reasoning already written down for
the example workspaces — the committed lock is what the policy must judge — and
the same reasoning `check-dependency-licenses.sh` gives for its
`cargo metadata --locked` ("a check that can rewrite its own input is not a
check").

## No behaviour change today

The root lock is current: both forms report `advisories ok, bans ok, licenses ok,
sources ok` at exit 0. The flag only fires once the lock drifts.

## Scope

Two command lines — the workflow step and the `check-guards` recipe — plus a
comment recording why. I left the two *prose* mentions of `cargo deny check` in
comments alone: both describe which graph the root run reaches, which this flag
does not change, and threading `--locked` through sentences about workspace
boundaries would add noise rather than accuracy. Say the word if you'd rather
they matched verbatim.

## Verification

- `just check-guards` green end to end (nine legs).
- `.github/workflows/cargo-deny.yml` still parses as YAML; the `check` job now
  runs `cargo deny --locked check` then the backend run.
- All three executable cargo-deny invocations now pin the lock; the only
  remaining unpinned matches are backticked prose.
- `Cargo.lock` bit-identical after the mutation test (`git diff` clean).