### PR TITLE
ci: match tuple variants in the CLI command-reference guard

### DIFF
--- a/scripts/check-cli-doc-coverage.sh
+++ b/scripts/check-cli-doc-coverage.sh
@@ -79,7 +79,19 @@ if not enum_body:
 # Variant-level attributes sit at the same 4-space indent as the variant. Field
 # attributes inside a body are indented deeper and never match.
 ATTR = re.compile(r"^ {4}#\[command\((.*)\)\]$")
-VARIANT = re.compile(r"^ {4}([A-Z][A-Za-z0-9]*)\s*[{,]?\s*$")
+# All three variant shapes, because missing one is silent rather than loud: an
+# unmatched variant is simply never required to appear in the table.
+#
+#     Clean,            unit          -> ends after the comma (or at EOF)
+#     Run {             struct        -> body follows on deeper-indented lines
+#     Profile(String),  tuple         -> fields follow on the same line
+#
+# The 4-space indent is what separates variants from everything else in the
+# block: doc comments start with `/`, attributes with `#`, a body's closing brace
+# with `}`, and a variant's own fields are indented deeper. So the identifier
+# only has to be followed by one of `{`, `(`, `,` or end of line -- not by
+# nothing, which is what skipped the tuple form.
+VARIANT = re.compile(r"^ {4}([A-Z][A-Za-z0-9]*)\s*(?:[{(,]|$)")
 
 commands = []
 hidden = []


### PR DESCRIPTION
The follow-up you noted on #803 — *"the variant regex skips tuple variants (none
exist today); extending it closes the one silent hole."*

## The hole

The pattern was:

```python
VARIANT = re.compile(r"^ {4}([A-Z][A-Za-z0-9]*)\s*[{,]?\s*$")
```

It requires the line to **end** after an optional `{` or `,`. A tuple variant
carries its fields on the same line — `Profile(String),` — so it matched nothing
and that subcommand was never required to appear in the book's table.

Silent, which is the bad direction for a guard: a missed variant does not fail,
it just quietly stops being checked.

## The fix

The identifier may now be followed by `{`, `(`, `,` or end of line, covering all
three variant shapes:

```
Clean,            unit    -> ends after the comma (or at EOF)
Run {             struct  -> body follows on deeper-indented lines
Profile(String),  tuple   -> fields follow on the same line
```

Widening is safe because the **4-space indent** is what separates variants from
everything else in the block: doc comments start with `/`, attributes with `#`, a
body's closing brace with `}`, and a variant's own fields are indented deeper. So
nothing else in the enum body can match. The comment now records that reasoning,
since it is the load-bearing assumption.

## Verification — ten mutation cases

Three new ones for this change:

| mutation | result |
|---|---|
| single-line tuple variant, no row | caught (`profile`) |
| **multi-line** tuple variant, no row | caught (`bisect`) — a reflowed field list does not reopen the hole |
| tuple variant carrying `hide = true` | **correctly excluded** — the case a wider pattern could plausibly have broken |

And #803's original seven, all still caught with no regression: new unit/struct
variant, deleted row, invented row, a row for the hidden command, a rename, and
both parse self-tests.

Also re-ran the checks you verified independently on #803:

- widened parse still agrees with the built binary — **15** visible subcommands,
  **15** table rows, zero disagreement;
- `just check-guards` green end to end;
- both inputs bit-identical after the mutation run (`git diff` clean).

One script, one regex, one comment. No behaviour change today, since the enum has
no tuple variants — this is the hole closing before something falls in it.