### PR TITLE
fix(examples): load the embedded module in the hashmap bench bins

### DIFF
--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
@@ -261,7 +261,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v2.ptx")?)?;
+    // The device artifact is embedded in this binary, so the bench needs no
+    // loose `hashmap_v2.ptx` beside the manifest -- the same load `main.rs`
+    // already uses.
+    let module = kernels::load(&ctx)?;
 
     print_environment_banner(&ctx)?;
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
@@ -266,7 +266,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v3.ptx")?)?;
+    // The device artifact is embedded in this binary, so the bench needs no
+    // loose `hashmap_v3.ptx` beside the manifest -- the same load `main.rs`
+    // already uses.
+    let module = kernels::load(&ctx)?;
 
     print_environment_banner(&ctx)?;
 


### PR DESCRIPTION
The last actionable piece of #782, named in your #804 review — *"#782 stays open
for the six deliberate loaders, the generic-module cubin gap, and the hashmap
bench bins."*

## The change

`hashmap_v2/src/bin/bench.rs` and `hashmap_v3/src/bin/bench.rs` still did:

```rust
let module = kernels::from_module(ctx.load_module_from_file("hashmap_vN.ptx")?)?;
```

so each only ran when a previous `cargo oxide build` had left that file beside the
manifest. Both crates' `main.rs` were converted in #787 — only these secondary
bins were missed, and **mine was the sweep that missed them**: #804 grepped
`examples/*/src/main.rs` and never looked at `src/bin/*.rs`. Neither module is
contracted or generic, so both take the plain `kernels::load(&ctx)` their own
`main.rs` already uses.

Each bench binary carries its own `.oxart` section with the bundle named for its
package, which is what makes the anchor resolve in a secondary bin.

## Verification — A10G (sm_86), driver 595.71.05

Every run executes the built bench binary directly with **all loose `.ptx` and
`.cubin` deleted first**, so only the embedded payload can serve it:

| check | result |
|---|---|
| `hashmap_v2` bench, 0 loose artifacts | exit 0 — 7529 / 7626 / 6960 Mops/s single-thread, **11.4–17.2x** over CPU hashbrown |
| `hashmap_v3` bench, 0 loose artifacts | exit 0 — tile_16 at 3710 / 3164 / 3002 Mops/s, dedup insert to 10322 Mops/s |
| `smoketest.sh` over both + `vecadd` | **3/3 PASS** — the `main.rs` path unregressed |

## A correction to my own first draft

I initially wrote in both comments that this makes the benches work under
`--materialize-cubin`. **It does not**, and the run said so — both examples fail
that build with:

```
cuda-oxide has not yet legalized atomic compare-exchange operations for legacy
NVVM IR; use ordinary PTX output or a Blackwell NVVM target
```

That is a **third** cubin blocker, separate from the generic-module one #804 hit,
and unsurprising for a hashmap — it needs CAS. The claim is out of the comments.
What this PR fixes is the loose-`.ptx` half only.

Worth noting against #782: the error text suggests a Blackwell NVVM target may
succeed where sm_86 cannot, so this may look different on your sm_120. I have not
observed that, so I am not claiming it.

## Where #782 stands after this

Targets loading a module from a path go **eight to six**, and all six are the
deliberate ones you identified: `interop_cubin_identity` plus the three
`*_ffi_test` load a cubin they build themselves as the point of the test, and
`tma_copy` / `wgmma` already load the embedded module and keep a loose read only
as an existence-checked fallback. So the loose-`.ptx` sweep is complete; what
remains on that issue is the cubin gaps (now two distinct ones) rather than any
unconverted loader.