### PR TITLE
docs(warp): point integer reductions at redux.sync, with the measurement

### DIFF
--- a/crates/cuda-device/src/cooperative_groups.rs
+++ b/crates/cuda-device/src/cooperative_groups.rs
@@ -998,6 +998,25 @@ impl WarpShuffle for f32 {
 /// the butterfly converges all lanes onto the same answer, which is the
 /// usual ergonomic shape and matches CUB's `WarpReduce`.
 ///
+/// # Performance: integers on `sm_80`+ have a one-instruction form
+///
+/// This is generic over `T`, so a full warp always costs five shuffles plus
+/// five combines. For **integer** reductions on Ampere and newer,
+/// [`crate::warp::redux_sync_add`] and its `min`/`max`/`and`/`or`/`xor`
+/// siblings do the whole reduction in a single `redux.sync` instruction.
+/// Measured on an A10G (`sm_86`) over 1M threads reducing 64 times each:
+/// 159.4 µs per launch here against 33.6 µs for `redux.sync`, **4.74x**, with
+/// bit-identical results. That is the primitive in isolation — a kernel that
+/// reduces once after a memory-bound pass will see far less.
+///
+/// This function does not select that form for you: `redux.sync` will not
+/// assemble below `sm_80`, and device code has no way to ask what target it is
+/// being compiled for (see
+/// [#811](https://github.com/NVlabs/cuda-oxide/issues/811)). Call it directly
+/// when you know the target is Ampere+, gating on
+/// `CudaContext::compute_capability` as the `redux_sum` example does. Floats
+/// keep this butterfly — there is no `f32` `redux` before `sm_100`.
+///
 /// `N` is the tile size (1, 2, 4, 8, 16, or 32) — already validated by
 /// [`ThreadBlock::tiled_partition`] at construction time.
 ///

--- a/cuda-oxide-book/advanced/warp-level-programming.md
+++ b/cuda-oxide-book/advanced/warp-level-programming.md
@@ -64,7 +64,7 @@ inside a shuffle pattern would be both unnecessary and wasteful.
 
 The most common shuffle pattern is a **butterfly reduction**: in
 ⌈log₂(32)⌉ = 5 steps, every lane accumulates the sum (or min, max, etc.)
-of all 32 values. No shared memory, no barriers, five instructions.
+of all 32 values. No shared memory, no barriers, five shuffle steps.
 
 ```{figure} images/warp-shuffle-reduction.svg
 :align: center
@@ -112,6 +112,57 @@ the 32 per-warp results to shared memory, `sync_threads()`, then reduce
 the warp-level results with one final warp. This hybrid approach is faster
 than a pure shared memory tree because it eliminates 5 levels of barriers.
 :::
+
+### Integers on Ampere: one instruction instead of ten
+
+Every reduction above -- the hand-written butterflies, and the generic
+`cooperative_groups::warp_reduce` -- costs five shuffles plus five combines.
+For **integer** reductions on `sm_80` and newer there is a single hardware
+instruction, `redux.sync`, exposed one function per operation:
+
+| function | reduces |
+|:---------|:--------|
+| `warp::redux_sync_add(mask, v)` | wrapping sum, `u32` |
+| `warp::redux_sync_min_u32` / `_min_i32` | minimum |
+| `warp::redux_sync_max_u32` / `_max_i32` | maximum |
+| `warp::redux_sync_and` / `_or` / `_xor` | bitwise |
+
+```rust
+use cuda_device::warp;
+
+const FULL_MASK: u32 = 0xffff_ffff;
+
+// The whole reduction. One instruction, every lane holds the result.
+let total = warp::redux_sync_add(FULL_MASK, my_value);
+```
+
+Measured on an A10G (`sm_86`), 1M threads each performing 64 full-warp `u32`
+sum reductions: the butterfly form takes 159.4 µs per launch, the `redux.sync`
+form 33.6 µs -- **4.74x**, with bit-identical results. Wrapping `u32` addition
+is associative modulo 2³² and min/max/and/or/xor are exact, so reduction order
+cannot change the answer.
+
+That figure is the primitive measured in isolation: the probe kernel does
+almost nothing but reduce. A kernel that reduces once at the end of a
+memory-bound pass will see very little. Reach for this where reductions sit in
+an inner loop.
+
+Three constraints:
+
+- **Integers only.** There is no `f32`/`f64` form before `sm_100`, so float
+  reductions keep the butterfly.
+- **A full, converged warp.** All 32 lanes must be live and must reach the same
+  call with the same mask -- the same contract the shuffle reductions already
+  require. Sub-warp tiles and short tail warps keep the shuffle path (see
+  `reduce_sum_f32_partial` and friends for the tail case).
+- **It will not assemble below `sm_80`.** Gate the call the way the `redux_sum`
+  example does, on `ctx.compute_capability()`, or restrict the build to Ampere
+  and newer.
+
+`warp_reduce` does not select this form for you today; making it do so
+automatically needs a way for device code to know its target architecture,
+which is the open question in
+[#811](https://github.com/NVlabs/cuda-oxide/issues/811).
 
 ---
 


### PR DESCRIPTION
Option 3 from #811 — document the gap, change no API.

`warp_reduce` is generic over `T`, so a full warp always costs five shuffles plus
five combines. `redux.sync` does an integer reduction in **one** instruction and
cuda-oxide has exposed it since #223/#258 — but nothing told a reader that, so
the book taught the butterfly and stopped there.

## The number

A10G (`sm_86`), 1M threads × 64 full-warp `u32` sum reductions, 30 timed launches
after 5 warmup, same kernel with only the reduction call swapped:

| form | µs/launch |
|---|---|
| butterfly (`warp_reduce` / hand-written) | 159.4 |
| `warp::redux_sync_add` | **33.6** |
| | **4.74x** |

Bit-identical: wrapping `u32` addition is associative modulo 2³² and
min/max/and/or/xor are exact, so reduction order cannot change the answer.

## Where it went

Both places a reader might look:

- the book's **Warp reduction** section gains a subsection naming all eight
  functions, the measurement, and the constraints;
- **`warp_reduce`'s own rustdoc** carries a short performance note, since that is
  what someone about to call it actually reads.

## Scope, stated in both

The probe kernel does almost nothing but reduce, so **4.74x sizes the primitive,
not an application**. A kernel that reduces once after a memory-bound pass will
see very little. Both texts say so — I would rather a reader calibrate than take
a micro-benchmark as a promise.

Three constraints are spelled out rather than implied:

- **Integers only** — there is no `f32` `redux` before `sm_100`, so floats keep
  the butterfly.
- **A full converged 32-lane warp** — which is the contract the shuffle
  reductions already require (#672: "every lane must be launched and
  converged"), so this asks nothing new. Sub-warp tiles and short tails stay on
  shuffles, with a pointer to `reduce_sum_f32_partial` for the tail case.
- **It will not assemble below `sm_80`** — so the call needs gating the way the
  `redux_sum` example gates it, on `compute_capability`.

## One small correction alongside

The sentence above the new subsection said the butterfly is "five instructions".
It is five shuffles *plus* five combines, and the new subsection counts
instructions a few lines later, so I changed it to "five shuffle steps" to keep
the two consistent.

## Not closing #811

No API or codegen change here. #811 stays open for making `warp_reduce` select
this form automatically, which needs device code to know its target architecture
— the broader design question. This documents what is available today.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p cuda-device` clean, so the
  intra-doc link to `redux_sync_add` resolves;
- `sphinx-build -W --keep-going -b html` succeeds;
- all eight function names, `reduce_sum_f32_partial`, and the `redux_sum`
  capability gate checked against the source rather than remembered;
- `cargo fmt --check` clean.