### PR TITLE
ci(book): bound the book workflow's two jobs

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,6 +29,11 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A pip install plus one sphinx-build; the job settles in ~2 minutes. Every
+    # other workflow in the repo bounds its jobs, and an unbounded one that
+    # hangs -- a wedged install, a sphinx that never returns -- burns to the
+    # 6-hour default instead of failing.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -68,6 +73,9 @@ jobs:
       group: pages
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    # One deploy-pages action. It waits on the Pages API, which is exactly the
+    # kind of step worth bounding rather than leaving to the 6-hour default.
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Every job in every other workflow carries `timeout-minutes`. `book.yml`'s two
were the only unbounded ones in the repo — I checked all ten workflows by parsing
them, not by grepping, because a naive grep also counts `push:` / `pull_request:`
under `on:` and inflates the number badly.

An unbounded job that hangs — a wedged `pip install`, a `sphinx-build` that never
returns, a Pages deployment waiting on an API that never answers — runs to
GitHub's **6-hour** default instead of failing, holding a runner and telling
nobody.

| job | bound | why |
|---|---|---|
| `build` | 15 min | a pip install and one `sphinx-build`; settles in ~2 today, so this is generous enough not to trip on a slow runner |
| `deploy` | 10 min | one `deploy-pages` action waiting on the Pages API |

**The `build` job is the one I added in #744, and I left the bound off it** — so
this is mine to tidy rather than a find. `deploy` predates that.

## Verification

- With these two, **no job in any workflow lacks a bound** (`uses:` reusable
  calls excepted, where the timeout belongs to the callee — that is why `ci.yml`
  is correctly absent from the list).
- `book.yml` still parses as YAML, both jobs reporting the intended values.