### PR TITLE
docs(api-ref): the shuffle i32 variants documented here do not exist

### DIFF
--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -358,8 +358,8 @@ let from_above = warp::shuffle_down_f32(val, delta);
 let from_below = warp::shuffle_up_f32(val, delta);
 let from_lane  = warp::shuffle_f32(val, src_lane);
 
-// i32 variants
-let partner_i = warp::shuffle_xor_i32(val, mask);
+// u32 is the unsuffixed form
+let partner_u = warp::shuffle_xor(val_u32, mask);
 
 // Vote
 let all_true = warp::all(predicate);
@@ -370,12 +370,17 @@ let count    = warp::popc(mask);
 
 ### Shuffle Operations
 
-| Function                              | Description                       |
-|:--------------------------------------|:----------------------------------|
-| `shuffle_xor_{f32,i32}(val, mask)`    | Exchange with lane `id ^ mask`    |
-| `shuffle_down_{f32,i32}(val, delta)`  | Read from lane `id + delta`       |
-| `shuffle_up_{f32,i32}(val, delta)`    | Read from lane `id - delta`       |
-| `shuffle_{f32,i32}(val, src)`         | Read from specific lane           |
+The unsuffixed name takes `u32`; `_f32`, `_f64` and `_u64` are the other
+widths. Each also has a `_sync` form taking an explicit member mask. There is
+no `_i32` variant — reinterpret an `i32` and use the `u32` form, since a
+shuffle moves bits and does not interpret them.
+
+| Function                                    | Description                       |
+|:--------------------------------------------|:----------------------------------|
+| `shuffle_xor(val, mask)` + `_f32/_f64/_u64` | Exchange with lane `id ^ mask`    |
+| `shuffle_down(val, delta)` + `_f32/_f64/_u64` | Read from lane `id + delta`     |
+| `shuffle_up(val, delta)` + `_f32/_f64/_u64` | Read from lane `id - delta`       |
+| `shuffle(val, src)` + `_f32/_f64/_u64`      | Read from specific lane           |
 
 ### Vote Operations
 

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -365,7 +365,7 @@ let partner_u = warp::shuffle_xor(val_u32, mask);
 let all_true = warp::all(predicate);
 let any_true = warp::any(predicate);
 let mask     = warp::ballot(predicate);
-let count    = warp::popc(mask);
+let count    = warp::popc(predicate); // == ballot(predicate).count_ones()
 ```
 
 ### Shuffle Operations
@@ -389,7 +389,7 @@ shuffle moves bits and does not interpret them.
 | `all(pred)`    | `bool`   | True if predicate holds for all lanes        |
 | `any(pred)`    | `bool`   | True if predicate holds for any lane         |
 | `ballot(pred)` | `u32`    | Bitmask of lanes where predicate is true     |
-| `popc(mask)`   | `u32`    | Population count of set bits                 |
+| `popc(pred)`   | `u32`    | Count of lanes where predicate is true       |
 
 ---
 

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -168,7 +168,7 @@ remain unsupported.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| Warp Shuffle Operations | **Full** | `shuffle`, `shuffle_xor`, `shuffle_down`, `shuffle_up` for `i32` and `f32`. |
+| Warp Shuffle Operations | **Full** | `shuffle`, `shuffle_xor`, `shuffle_down`, `shuffle_up`. Unsuffixed forms take `u32`; `_f32`, `_u64`, `_f64` variants and a `_sync` form of each. |
 | Warp Vote Operations | **Full** | `all(pred)`, `any(pred)`, `ballot(pred)` → bitmask. |
 | Lane/Warp ID | **Full** | `lane_id()` (0–31), `warp_id()`. Direct register reads. |
 
@@ -179,7 +179,7 @@ remain unsupported.
 | Typed Group Handles | **Full** | `Grid`, `Cluster`, `ThreadBlock`, `WarpTile<N>` (N ∈ {1,2,4,8,16,32}), `CoalescedThreads`. |
 | Group Universal API | **Full** | `size()`, `thread_rank()`, `sync()` on every group handle. |
 | Warp Tile Partitioning | **Full** | `ThreadBlock::tiled_partition::<N>()` carves a sub-warp `WarpTile<N>`. `coalesced_threads()` materialises the active-lane group. |
-| Warp Collectives | **Full** | `ballot`, `all`, `any`, `shfl`, `shfl_xor`, `shfl_down`, `shfl_up` (`i32` and `f32`); `match_any` / `match_all` (`i32` and `i64`); `active_mask`. |
+| Warp Collectives | **Full** | `ballot`, `all`, `any`, `shfl`, `shfl_xor`, `shfl_down`, `shfl_up` (`u32` and `f32`); `match_any` / `match_all` (`i32` and `i64`); `active_mask`. |
 | Warp Reductions / Scans | **Full** | `warp_reduce`, `warp_scan` (inclusive). `Sum`/`Min`/`Max` for `u32`/`i32`/`f32`; `BitAnd`/`BitOr`/`BitXor` for `u32`. |
 | Block Reductions / Scans | **Full** | `block_reduce`, `block_scan` (inclusive). Const-generic over `NUM_WARPS`; same op/type matrix as warp variants; uses `__shared__` scratch. |
 | Cooperative Kernel Launch | **Full** | `#[cooperative_launch]` on a `#[cuda_module]` kernel (or `unsafe { cuda_launch! { cooperative: true, ... } }`) enables `Grid::sync()` for grid-wide barriers. |


### PR DESCRIPTION
The quick reference's warp section advertises an `i32` form for **all four**
shuffles. None exist.

```rust
// i32 variants
let partner_i = warp::shuffle_xor_i32(val, mask);   // does not compile
```

```
| `shuffle_xor_{f32,i32}(val, mask)`    | ...   <- four rows, all claiming i32
| `shuffle_down_{f32,i32}(val, delta)`  | ...
| `shuffle_up_{f32,i32}(val, delta)`    | ...
| `shuffle_{f32,i32}(val, src)`         | ...
```

`cuda_device::warp` has no `_i32` function at any width. The real set is the
**unsuffixed name for `u32`**, plus `_f32`, `_f64` and `_u64`, each with a
`_sync` form taking an explicit member mask.

This is the page most likely to be copied from, and the code line does not
compile.

## Worth more than deleting the wrong line

The page showed only the `_f32` forms, so it **never mentioned the `u32` ones at
all** — a reader shuffling integers had nothing correct to copy, which is
plausibly how the fictional `i32` entry got written in the first place. So the
example now uses the unsuffixed form, and the table lists the widths that exist
with a note that an `i32` should be reinterpreted and passed through the `u32`
form, since a shuffle moves bits without interpreting them.

## Verification

- Every function the page now names checked against
  `crates/cuda-device/src/warp.rs` — `shuffle`, `shuffle_xor`, `shuffle_down`,
  `shuffle_up`, the `_f32`/`_f64`/`_u64` suffixes and a `_sync` sample, all
  present.
- No `_i32` shuffle claim remains in any user-facing page.
- `sphinx-build -W --keep-going -b html` succeeds.

*(Found by diffing every `warp::`/`thread::`-style name the book cites against
what `cuda-device` exports. Three more citations in the compiler-internals pages
also fail to resolve; those are a separate PR, since they name mir-importer
helpers rather than user API.)*