### PR TITLE
docs(book): document the llvm-link and libdevice overrides

### DIFF
--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -621,18 +621,23 @@ directories.
 
 ### The other two inputs the pipeline looks for
 
-`llvm-link` and `libdevice.10.bc` are needed only when device code calls into
-libdevice, and both have their own override:
+`llvm-link` is needed only when device code calls into libdevice and the PTX
+path resolves those calls with an IR-level link. `libdevice.10.bc` is needed
+more often: the NVVM path adds it to every module it finalizes, whether or not
+the kernel calls into libdevice. Both have their own override:
 
 | Variable | Selects | Discovery when unset |
 | :------- | :------ | :------------------- |
 | `CUDA_OXIDE_LLVM_LINK` | the `llvm-link` binary | the same four steps as `opt` -- beside the chosen `llc`, then the sysroot, then versioned names on `PATH`, filtered to `llc`'s major |
-| `CUDA_OXIDE_LIBDEVICE` | the `libdevice.10.bc` bitcode file, used as given | `<root>/nvvm/libdevice/libdevice.10.bc` for each of `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, `CUDA_PATH`, `/usr/local/cuda`, `/opt/cuda` |
+| `CUDA_OXIDE_LIBDEVICE` | the `libdevice.10.bc` bitcode file; a path that does not exist is skipped silently | `<root>/nvvm/libdevice/libdevice.10.bc` for each of `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, `CUDA_PATH`, `/usr/local/cuda`, `/opt/cuda` |
 
-A missing `llvm-link` is not an error on its own: resolution simply yields
-nothing and the backend stops choosing the libdevice PTX path, so a kernel that
-needed it fails later rather than at discovery. A missing `libdevice.10.bc` is
-reported directly, and the error lists every path it probed.
+When either piece is missing, the two paths react differently. An ordinary
+build does not fail: the backend's path decision sees that the IR-level link
+is unavailable and falls back to the NVVM path, the same automatic switch
+described under target selection. The experimental API's `Linking::Libdevice`
+is strict and fails up front instead, with a `LibdeviceUnavailable` error
+naming the missing piece: `libdevice.10.bc`, or an `llvm-link` sharing the
+selected `llc`'s major.
 
 ## Atomic operations in legacy NVVM IR
 

--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -619,6 +619,21 @@ usually enough -- the matching `opt` is normally found next to it, and setting
 `CUDA_OXIDE_OPT` as well is only needed when the pair is split across
 directories.
 
+### The other two inputs the pipeline looks for
+
+`llvm-link` and `libdevice.10.bc` are needed only when device code calls into
+libdevice, and both have their own override:
+
+| Variable | Selects | Discovery when unset |
+| :------- | :------ | :------------------- |
+| `CUDA_OXIDE_LLVM_LINK` | the `llvm-link` binary | the same four steps as `opt` -- beside the chosen `llc`, then the sysroot, then versioned names on `PATH`, filtered to `llc`'s major |
+| `CUDA_OXIDE_LIBDEVICE` | the `libdevice.10.bc` bitcode file, used as given | `<root>/nvvm/libdevice/libdevice.10.bc` for each of `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, `CUDA_PATH`, `/usr/local/cuda`, `/opt/cuda` |
+
+A missing `llvm-link` is not an error on its own: resolution simply yields
+nothing and the backend stops choosing the libdevice PTX path, so a kernel that
+needed it fails later rather than at discovery. A missing `libdevice.10.bc` is
+reported directly, and the error lists every path it probed.
+
 ## Atomic operations in legacy NVVM IR
 
 An “LLVM-level atomic” is an atomic instruction in the NVVM input. It is not a


### PR DESCRIPTION
#796 documented how the pipeline finds `llc` and `opt`. It needs **two more
inputs** when device code calls into libdevice, and neither override was written
down anywhere:

| Variable | Selects | Discovery when unset |
| :------- | :------ | :------------------- |
| `CUDA_OXIDE_LLVM_LINK` | the `llvm-link` binary | the same four steps as `opt` — beside the chosen `llc`, then the sysroot, then versioned names on `PATH`, filtered to `llc`'s major |
| `CUDA_OXIDE_LIBDEVICE` | `libdevice.10.bc`, used as given | `<root>/nvvm/libdevice/libdevice.10.bc` for each of `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, `CUDA_PATH`, `/usr/local/cuda`, `/opt/cuda` |

`CUDA_OXIDE_LIBDEVICE` is the odder omission, because **the error a user hits
already names it**:

```
Could not locate libdevice.10.bc. Set CUDA_OXIDE_LIBDEVICE, CUDA_TOOLKIT_PATH,
or CUDA_HOME, or install the CUDA Toolkit. Tried: ...
```

So the only place it appeared was a failure message — you had to break the build
to find out the variable exists.

## The failure modes differ, and the text says so

- A missing **`llvm-link`** is not an error by itself: resolution yields nothing
  and the backend stops choosing the libdevice PTX path, so a kernel that needed
  it fails later rather than at discovery.
- A missing **`libdevice.10.bc`** is reported directly, with every probed path
  listed.

That asymmetry is the sort of thing worth writing down, since the first one
produces a confusing downstream failure rather than an obvious one.

## Verification

Both discovery orders are taken from the source (`cuda-host/src/ltoir.rs` and
`cuda-oxide-codegen/src/llvm_tools.rs`) rather than inferred. All four LLVM-input
overrides the pipeline reads are now documented. `sphinx-build -W --keep-going`
succeeds.

*(Found by diffing `CUDA_OXIDE_*` names in the source against those in the docs —
13 remain undocumented, but the rest are either internal plumbing
(`CUDA_OXIDE_INTERNAL_*`, `CUDA_OXIDE_BUNDLE_ANCHOR`, `CUDA_OXIDE_PTX_NAME`) or
build knobs whose semantics I would want to confirm with you before writing them
down. These four are one coherent family, which is why they are one PR.)*