### PR TITLE
test(cargo-oxide): lock the materialize-mode round trip in the tracked fingerprint

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -8923,6 +8923,14 @@ device-owner = { path = "../device-owner" }
         assert_eq!(changed_provenance.get("device_owner"), Some(&false));
         assert_eq!(changed_provenance.get("device-consumer"), Some(&false));
 
+        // #722: a materialized build followed by a plain one must not reuse
+        // the stale cubin-path artifacts.
+        let materialize_off = cargo_artifact_freshness(&ctx, &different_output, None);
+        assert_eq!(materialize_off.get("shared_dep"), Some(&true));
+        assert_eq!(materialize_off.get("tracked_macro"), Some(&true));
+        assert_eq!(materialize_off.get("device_owner"), Some(&false));
+        assert_eq!(materialize_off.get("device-consumer"), Some(&false));
+
         std::fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## Issue

#722: device artifacts go stale when `--materialize-cubin` is toggled. The reproducer runs an example normally, then again with `--materialize-cubin`, then normally again. The third run reuses the previous mode's artifacts, so the loader gets a mismatched set (`.ptx` present, `.target` missing) and fails with CUDA error 301.

The root cause is fingerprinting: the mode must be part of what Cargo tracks for the device owner, otherwise switching modes reuses the stale build.

## What this PR does

This is a **test-only** change. The tracked-macro already reads the codegen fingerprint and materialization env vars, so toggling the mode changes the device owner's tracked environment. The existing `codegen_mode_changes_rebuild_only_the_tracked_device_owner` test covers switching materialization **on** (`provenance_switch`, `changed_provenance` legs), but nothing covered switching it **back off**, which is the reproducer's third state.

This PR adds that leg: after a materialized build, dropping the materialization handshake must rebuild the device owner again rather than reuse the stale cubin-path artifacts, while plain dependencies stay fresh.

## Why

Without this leg, the round trip is only half-tested: a future regression where the third run reuses stale artifacts would pass CI. The issue #722 itself remains open pending end-to-end verification.

## Changes

- `crates/cargo-oxide/src/commands.rs`: add a `materialize_off` leg to `codegen_mode_changes_rebuild_only_the_tracked_device_owner` asserting `device_owner` / `device-consumer` are rebuilt while `shared_dep` / `tracked_macro` stay fresh.

## Test plan

```bash
cargo test -p cargo-oxide --all-targets codegen_mode_changes_rebuild_only_the_tracked_device_owner
```

Result:

```
running 1 test
test commands::tests::codegen_mode_changes_rebuild_only_the_tracked_device_owner ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 173 filtered out
```

## Standards

- [x] DCO sign-off on the commit
- [x] `cargo fmt -p cargo-oxide -- --check` clean
- [x] `cargo clippy -p cargo-oxide --all-targets -- -D warnings` clean
- [x] Test above passes locally (macOS, x86_64)
- [x] Rebased onto latest `upstream/main` (`eefc28c0`)

Related: #722
