### PR TITLE
fix(examples): load the embedded module in the hashmap bench binaries

### DIFF
--- a/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs
@@ -261,7 +261,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v2.ptx")?)?;
+    let module = kernels::load(&ctx)?;
 
     print_environment_banner(&ctx)?;
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs
@@ -266,7 +266,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
-    let module = kernels::from_module(ctx.load_module_from_file("hashmap_v3.ptx")?)?;
+    let module = kernels::load(&ctx)?;
 
     print_environment_banner(&ctx)?;
 


### PR DESCRIPTION
## Summary

#787 converted example mains from reading a loose `<name>.ptx` off disk (`ctx.load_module_from_file`) to `kernels::load`, but the `hashmap_v2` and `hashmap_v3` perf bench binaries (`src/bin/bench.rs`) were left on the old pattern. A `--materialize-cubin` build never writes the loose file, so the bench would fail with CUDA error 301 while the module sat embedded in the binary it just built.

This PR switches both bench mains to `kernels::load`, matching the converted example mains (and the `vecadd`/`atomics` precedent).

## Changes

- `crates/rustc-codegen-cuda/examples/hashmap_v2/src/bin/bench.rs`: `kernels::from_module(ctx.load_module_from_file("hashmap_v2.ptx")?)?` -> `kernels::load(&ctx)?`
- `crates/rustc-codegen-cuda/examples/hashmap_v3/src/bin/bench.rs`: same for `hashmap_v3.ptx`

Both binaries use the `#[cuda_module]`-generated `kernels` module from the shared library crate, so `kernels::load` is already available (the same path the converted `main.rs` uses).

## Verification

- `cargo fmt -- --check` clean in both example workspaces
- `scripts/check-example-smoketest-contract.sh` passes
- The `kernels::load(&ctx)?` form matches the pattern #787 merged for `Result`-returning mains (e.g. `cast_tests`)
- GPU/smoketest verification requires hardware (see CI)

## Standards

- [x] DCO sign-off on the commit
- [x] Rebased on latest `upstream/main` (`eefc28c0`)

Refs #782
