### PR TITLE
test(codegen): resolve the POSIX stand-in tools instead of assuming /bin

### DIFF
--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -701,15 +701,31 @@ mod tests {
             .push(message.to_string());
     }
 
+    /// Locates a POSIX utility the tests drive as a stand-in for a real tool.
+    ///
+    /// The location is not portable: Linux ships `true` and `false` in `/bin`,
+    /// while macOS ships them only in `/usr/bin`. Hardcoding either directory
+    /// makes a `#[cfg(unix)]` test fail on a platform that predicate covers, so
+    /// resolve the path instead of assuming one.
+    #[cfg(unix)]
+    fn posix_utility(name: &str) -> String {
+        ["/bin", "/usr/bin"]
+            .iter()
+            .map(|directory| format!("{directory}/{name}"))
+            .find(|path| Path::new(path).exists())
+            .unwrap_or_else(|| panic!("no `{name}` utility in /bin or /usr/bin"))
+    }
+
     #[test]
     #[cfg(unix)]
     fn legacy_opt_failure_warns_but_experimental_mode_fails() {
+        let opt_path = posix_utility("false");
         let toolchain = LlvmToolchain {
-            llc_path: "/bin/true".to_string(),
+            llc_path: posix_utility("true"),
             llc_major: Some(21),
             llc_from_env: false,
             opt: Some(crate::llvm_tools::OptTool {
-                path: "/bin/false".to_string(),
+                path: opt_path.clone(),
                 major: Some(21),
             }),
             llvm_link: None,
@@ -724,7 +740,11 @@ mod tests {
 
         let error = optimize_ll(input, &[], &toolchain, &opts, true).unwrap_err();
         assert!(matches!(&error, PipelineError::Optimization(_)));
-        assert!(error.to_string().contains("opt (/bin/false) failed"));
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("opt ({opt_path}) failed"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`legacy_opt_failure_warns_but_experimental_mode_fails` (`crates/cuda-oxide-codegen/src/ptx.rs`) is gated `#[cfg(unix)]` but hardcodes two Linux-only paths:

```rust
llc_path: "/bin/true".to_string(),
opt: Some(OptTool { path: "/bin/false".to_string(), major: Some(21) }),
```

macOS is `unix`, and it ships both utilities **only** in `/usr/bin` — there is no `/bin/true` or `/bin/false`:

```console
$ ls -l /bin/false /bin/true
ls: /bin/false: No such file or directory
ls: /bin/true: No such file or directory
$ ls /usr/bin/false /usr/bin/true
/usr/bin/false	/usr/bin/true
```

So the spawn fails with `ENOENT`, `optimize_ll` takes its `Err(error)` arm (`"failed to run opt (...)"`, `ptx.rs:182`) instead of the ran-and-exited-non-zero arm (`"opt (...) failed with status ..."`, `ptx.rs:165`), and the closing assertion misses:

```
thread 'ptx::tests::legacy_opt_failure_warns_but_experimental_mode_fails' panicked at
crates/cuda-oxide-codegen/src/ptx.rs:727:9:
assertion failed: error.to_string().contains("opt (/bin/false) failed")
```

The earlier assertions pass either way, because both arms emit `continuing with unoptimized IR` — only the strict-mode message distinguishes them, which is what makes this quiet.

Upstream CI runs `ubuntu-latest` only, so no runner reaches this.

## Fix

Resolve the utility through `/bin` then `/usr/bin` and assert against the path actually used, rather than swapping one hardcoded guess for another.

On Linux the helper returns `/bin/true` and `/bin/false` — byte-identical to the strings that were hardcoded — so behaviour there is unchanged by construction. On macOS it finds them in `/usr/bin` and the test finally exercises the branch it was written for.

## Verification

Both platforms, same commit, `nightly-2026-04-03`.

**macOS 15 (aarch64-apple-darwin)** — the platform that was broken:

```console
# before, on upstream/main
$ cargo test -p cuda-oxide-codegen --lib
test result: FAILED. 168 passed; 1 failed
assertion failed: error.to_string().contains("opt (/bin/false) failed")

# after
$ cargo test -p cuda-oxide-codegen --lib
test result: ok. 169 passed; 0 failed
```

**Linux (x86_64-unknown-linux-gnu, Ubuntu 24.04)** — confirming nothing regressed:

```console
$ cargo test -p cuda-oxide-codegen --lib
test result: ok. 169 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.96s
```

On Linux the helper resolves to `/bin/true` and `/bin/false` — the exact strings
that were hardcoded — so the test executes precisely the path it did before. The
assertion is now built from the resolved path rather than a literal, so the test
no longer depends on which directory the utility lives in.

## Upstream gates

Run on macOS:

- `cargo fmt --all -- --check` — clean, in all three CI scopes (root, `crates/rustc-codegen-cuda`, and each of the 205 example manifests)
- `cargo test --workspace` excluding the five CUDA-linked crates (`cuda-host`, `cuda-macros`, `cuda-bindings`, `cuda-core`, `cuda-async`), which cannot build without a CUDA toolkit — all green

Not run here, and untouched by this change: `clippy`, doc/doctests, and `tests/libdevice_linking.rs`, which needs a runnable `llvm-link` matching the selected `llc`'s LLVM major. That target fails identically on this machine with and without this patch.
