### PR TITLE
fix(scripts): make the error-example guard run outside GNU userland

### DIFF
--- a/scripts/check-error-example-status.sh
+++ b/scripts/check-error-example-status.sh
@@ -8,23 +8,38 @@ cd "$(dirname "$0")/.."
 
 fail=0
 
+# `mapfile` is a bash 4 builtin and `grep -P` is a GNU extension; macOS ships
+# neither (bash 3.2, BSD grep), so this guard aborted there before it checked
+# anything. Collect with a read loop and extract with `sed` instead -- both
+# portable, and the extracted values are unchanged.
+collect() {
+    COLLECTED=()
+    local line
+    while IFS= read -r line; do
+        COLLECTED+=("$line")
+    done
+}
+
 # Examples that exist on disk.
-mapfile -t on_disk < <(
+collect < <(
     find crates/rustc-codegen-cuda/examples -mindepth 1 -maxdepth 1 \
         -type d -name 'error*' -exec basename {} \; | sort
 )
+on_disk=("${COLLECTED[@]+"${COLLECTED[@]}"}")
 
 # Examples listed in STATUS.md (backtick-quoted names in the table).
-mapfile -t in_status < <(
-    grep -oP '^\|\s*`\K[^`]+' \
+collect < <(
+    sed -n 's/^|[[:space:]]*`\([^`]*\)`.*/\1/p' \
         crates/rustc-codegen-cuda/STATUS.md | sort
 )
+in_status=("${COLLECTED[@]+"${COLLECTED[@]}"}")
 
 # Examples listed in ERROR_EXAMPLES in smoketest.sh.
-mapfile -t in_smoketest < <(
-    grep -oP 'ERROR_EXAMPLES=\(\K[^)]+' scripts/smoketest.sh \
+collect < <(
+    sed -n 's/.*ERROR_EXAMPLES=(\([^)]*\)).*/\1/p' scripts/smoketest.sh \
         | tr ' ' '\n' | grep -v '^$' | sort
 )
+in_smoketest=("${COLLECTED[@]+"${COLLECTED[@]}"}")
 
 contains() {
     local needle="$1"; shift


### PR DESCRIPTION
## Problem

`scripts/check-error-example-status.sh` cannot run on macOS. It aborts at line 12, before checking anything:

```console
$ bash scripts/check-error-example-status.sh
scripts/check-error-example-status.sh: line 12: mapfile: command not found
$ echo $?
127
```

Two independent GNU/Linux assumptions, and CI cannot see either because every runner is `ubuntu-latest`:

- **`mapfile`** (3 uses) is a bash 4 builtin. macOS still ships **bash 3.2.57** as `/bin/bash` — it has been frozen there since bash moved to GPLv3 — so `#!/usr/bin/env bash` resolves to a shell without it.
- **`grep -oP … \K`** (2 uses) is a GNU extension. macOS ships BSD grep:

```console
$ /usr/bin/grep --version
grep (BSD grep, GNU compatible) 2.6.0-FreeBSD
$ echo test | /usr/bin/grep -oP 'te\Kst'
grep: invalid option -- P
```

This matters beyond tidiness: `ship`-time instructions tell contributors to run this guard locally after touching an `error*` example, so on macOS it is silently useless — exit 127 looks like a broken script rather than an unmet check.

## Fix

Collect each list with a `while IFS= read -r` loop and extract with `sed` BREs. Both are POSIX-portable and change nothing about what is extracted.

The existing `${arr[@]+"${arr[@]}"}` empty-array guards are kept — bash 3.2 needs them under `set -u`, which is the same reason they were there before.

`scripts/smoketest.sh` uses `mapfile` in three more places and has the same limitation. It is deliberately **not** touched here: it needs a CUDA toolchain and a GPU, so a fix there could not be exercised the way this one was. Happy to send it separately if you want it.

## Verification

The risk with a rewrite like this is a guard that stops checking and prints `OK` anyway, so each platform was run twice — once as-is, once with one entry deleted from `STATUS.md` to prove the guard still fails.

**macOS 15 (aarch64), bash 3.2.57, BSD grep 2.6.0-FreeBSD**

```console
# before
$ bash scripts/check-error-example-status.sh
scripts/check-error-example-status.sh: line 12: mapfile: command not found   # exit 127

# after
$ bash scripts/check-error-example-status.sh
OK: all error* examples are documented and classified.

# after, with `error_heap_alloc` removed from STATUS.md
$ bash scripts/check-error-example-status.sh
error: error_heap_alloc is not in STATUS.md                                  # exit 1
```

**Ubuntu 24.04 (x86_64), GNU bash 5.2.21, GNU sed 4.9**

```console
$ bash scripts/check-error-example-status.sh
OK: all error* examples are documented and classified.

$ sed -i '/error_heap_alloc/d' crates/rustc-codegen-cuda/STATUS.md
$ bash scripts/check-error-example-status.sh
error: error_heap_alloc is not in STATUS.md                                  # exit 1
```

The extraction was also cross-checked against ground truth rather than against the old pipeline alone: all three lists (`on_disk`, `in_status`, `in_smoketest`) hold the same 12 names, and that set equals the `error*` directories actually present under `crates/rustc-codegen-cuda/examples`.

## Upstream gates

No Rust changed, so the Rust gates are untouched by this diff. Run anyway on macOS: `cargo fmt --all -- --check` clean in all three CI scopes.
