### PR TITLE
fix(scripts): let smoketest run on the bash macOS ships

### DIFF
--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -323,7 +323,12 @@ echo ""
 
 # ---- Example selection ---------------------------------------------------
 
-mapfile -t ALL_EXAMPLES < <(
+# Read loop rather than `mapfile`: that builtin arrived in bash 4, and macOS
+# still ships bash 3.2 as /bin/bash, where this line ended the run outright.
+ALL_EXAMPLES=()
+while IFS= read -r example_name; do
+    ALL_EXAMPLES+=("${example_name}")
+done < <(
     cd crates/rustc-codegen-cuda/examples
     for manifest in */Cargo.toml; do
         [[ -e "${manifest}" ]] || continue
@@ -752,7 +757,11 @@ verdict_compile() {
 EXTRA_RUSTFLAGS=""
 invoke_cargo_oxide() {
     if [[ -n "${EXTRA_RUSTFLAGS}" ]]; then
-        if [[ -v CARGO_ENCODED_RUSTFLAGS ]]; then
+        # `${var+x}` rather than `[[ -v var ]]`, which needs bash 4.2 and is a
+        # *parse* error on the bash 3.2 that macOS ships. Both mean "set, even
+        # if empty" -- not "non-empty", which matters because the branch below
+        # decides on that basis whether to prepend the 0x1f separator.
+        if [[ -n "${CARGO_ENCODED_RUSTFLAGS+x}" ]]; then
             local encoded_flags="${CARGO_ENCODED_RUSTFLAGS}"
             if [[ -n "${encoded_flags}" ]]; then
                 encoded_flags+=$'\x1f'
@@ -1147,7 +1156,10 @@ run_cargo() {
         nvvm_control_cg1="$(awk '/^define .*@compile_tcgen05_control_cg1\(/,/^}/' "${nvvm_ll}" 2>/dev/null)"
         nvvm_control_cg2="$(awk '/^define .*@compile_tcgen05_control_cg2\(/,/^}/' "${nvvm_ll}" 2>/dev/null)"
         local -a nvvm_control_attrs=()
-        mapfile -t nvvm_control_attrs < <(
+        local nvvm_control_attr_line
+        while IFS= read -r nvvm_control_attr_line; do
+            nvvm_control_attrs+=("${nvvm_control_attr_line}")
+        done < <(
             sed -nE '/call void asm sideeffect "tcgen05\.(commit|shift)\.cta_group::[12]/s/.* (#[0-9]+)$/\1/p' \
                 <<<"${nvvm_control_cg1}"$'\n'"${nvvm_control_cg2}"
         )
@@ -1189,7 +1201,10 @@ run_cargo() {
         nvvm_mma_inline_count="$(grep -cE 'call void asm sideeffect ".*tcgen05\.mma' <<<"${nvvm_mma_base}"$'\n'"${nvvm_mma_ws}")"
         nvvm_mma_memory_count="$(grep -E 'call void asm sideeffect ".*tcgen05\.mma' <<<"${nvvm_mma_base}"$'\n'"${nvvm_mma_ws}" | grep -cF '~{memory}')"
         local -a nvvm_mma_attrs=()
-        mapfile -t nvvm_mma_attrs < <(
+        local nvvm_mma_attr_line
+        while IFS= read -r nvvm_mma_attr_line; do
+            nvvm_mma_attrs+=("${nvvm_mma_attr_line}")
+        done < <(
             sed -nE '/call void asm sideeffect ".*tcgen05\.mma/s/.* (#[0-9]+)$/\1/p' \
                 <<<"${nvvm_mma_base}"$'\n'"${nvvm_mma_ws}"
         )


### PR DESCRIPTION
Follow-up to #823, which fixed this class in `check-error-example-status.sh` and deliberately left `smoketest.sh` alone because the fix could not be exercised at the time. It now has been, on both platforms, so here it is.

## Problem

`scripts/smoketest.sh` cannot start on macOS, and the first failure is a **parse** error — the file never runs a single line:

```console
$ bash -n scripts/smoketest.sh
scripts/smoketest.sh: line 760: conditional binary operator expected
scripts/smoketest.sh: line 760: syntax error near `CARGO_ENCODED_RUSTFLAGS'
scripts/smoketest.sh: line 760: `        if [[ -v CARGO_ENCODED_RUSTFLAGS ]]; then'
```

macOS still ships **bash 3.2.57** as `/bin/bash`, frozen there since bash moved to GPLv3, and the script uses two constructs newer than that:

| construct | needs | effect on bash 3.2 |
|---|---|---|
| `[[ -v CARGO_ENCODED_RUSTFLAGS ]]` | bash 4.2 | **syntax error** — nothing parses, so nothing runs |
| `mapfile` (3 uses) | bash 4 | run ends at example selection, before any example is picked |

Every CI runner is `ubuntu-latest`, so neither is reachable from CI.

## Fix

`mapfile` → read loops, and `-v` → `${var+x}`.

The `${var+x}` form is the exact equivalent of `-v`, and the difference matters here: both mean **"set, even if empty"**, not "non-empty". The branch underneath relies on precisely that distinction when it decides whether to prepend the `0x1f` separator, so `[[ -n "$CARGO_ENCODED_RUSTFLAGS" ]]` would have been a silent behaviour change. There is a comment at the call site saying so, to stop a future simplification from reintroducing it.

Checked against all three states:

```console
$ unset X;  [[ -n "${X+x}" ]] && echo set || echo unset   # unset
$ X="";     [[ -n "${X+x}" ]] && echo set || echo unset   # set
$ X="a";    [[ -n "${X+x}" ]] && echo set || echo unset   # set
```

## Verification

Same commit, both platforms.

**macOS 15 (aarch64), bash 3.2.57**

```console
# before
$ bash -n scripts/smoketest.sh
scripts/smoketest.sh: line 760: syntax error near `CARGO_ENCODED_RUSTFLAGS'

# after
$ bash -n scripts/smoketest.sh          # parses
$ bash scripts/smoketest.sh --only '^vecadd$'
cuda-oxide smoketest @ eefc28c0
GPU: no GPU detected
[ 1/ 1] vecadd                           ... FAIL (exit=101) [20s]
===== SMOKETEST SUMMARY =====
Pass:    0 / 1
Fail:    1 / 1
```

The run still fails on macOS, and it should: there is no CUDA toolkit there. The point is *how* it fails — through the script's own reporting, naming the real cause, instead of dying in the shell:

```
cuda-bindings: could not find cuda.h in the CUDA toolkit at `/usr/local/cuda`.
```

**Ubuntu 24.04 (x86_64), GNU bash 5.2.21, Tesla T4** — confirming the working path is untouched:

```console
$ bash -n scripts/smoketest.sh && echo PARSE-OK
PARSE-OK
$ bash scripts/smoketest.sh --only '^vecadd$' --no-color
LTOIR arch: sm_75 (modern: sm_100)
[ 1/ 1] vecadd                           ... PASS [106s]
===== SMOKETEST SUMMARY =====
Pass:    1 / 1
Fail:    0 / 1
```

## Scope

Only the two bash-4 constructs. A full sweep for others found none: no `readarray`, no `declare -A`, no `${var^^}`/`${var,,}`, no `coproc`, no `&>>` anywhere under `scripts/`.
