### PR TITLE
test(codegen): cover ptr::swap_nonoverlapping and slice::copy_within

### DIFF
--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -21,7 +21,7 @@
 //!   CUDA_OXIDE_NO_OPT=1 cargo oxide run mem_swap
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{kernel, thread, DisjointSlice};
+use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_module;
 
 #[cuda_module]

--- a/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
@@ -3,29 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! `core::mem::swap` / `mem::replace` on the device (regression).
+//! Device-side regression coverage for memory swapping and replacement.
 //!
-//! `mem::swap`/`mem::replace` lower to the compiler intrinsic
-//! `core::intrinsics::typed_swap_nonoverlapping`, which has no MIR body. Before
-//! the fix this bailed with
-//! `rustc intrinsic core::intrinsics::typed_swap_nonoverlapping is not yet
-//! supported on the device`. The fix lowers it as a temp-free load/load/
-//! store/store crossover.
+//! `mem::swap` lowers to `core::intrinsics::typed_swap_nonoverlapping`, which
+//! cuda-oxide handles as a load/load/store/store crossover.
 //!
-//! Each lane loads `a[i]` and `b[i]` into two locals, `mem::swap`s them, then
-//! `mem::replace`s a sentinel into one. The result is encoded so the host can
-//! verify both operations:
-//!   out[i] = x*1000 + old = b[i]*1000 + a[i]
+//! `mem::replace` follows the ordinary read/write replacement path on the pinned
+//! Rust toolchain (`read_via_copy` + `write_via_move`, lowered before backend
+//! codegen).
 //!
-//! Run: cargo oxide run mem_swap
+//! This example also covers the public `core::ptr::swap_nonoverlapping` API.
+//! That path is distinct from `mem::swap`: libcore performs a runtime byte-count
+//! calculation and swaps non-overlapping regions in aligned chunks.
+//!
+//! Usage:
+//!   cargo oxide run mem_swap
+//!   CUDA_OXIDE_NO_OPT=1 cargo oxide run mem_swap
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_device::{kernel, thread, DisjointSlice};
 use cuda_host::cuda_module;
 
 #[cuda_module]
 mod kernels {
     use super::*;
+
+    #[repr(C, align(16))]
+    #[derive(Clone, Copy)]
+    struct AlignedBlock {
+        words: [u32; 4],
+    }
 
     #[kernel]
     pub fn swap_kernel(a: &[i32], b: &[i32], mut out: DisjointSlice<i32>) {
@@ -33,13 +40,71 @@ mod kernels {
         let i = t.get();
         let mut x = a[i];
         let mut y = b[i];
-        // mem::swap -> typed_swap_nonoverlapping(&mut x, &mut y)
+
+        // `mem::swap` reaches `typed_swap_nonoverlapping`.
         core::mem::swap(&mut x, &mut y); // now x = b[i], y = a[i]
-        // mem::replace also routes through the swap intrinsic:
+
+        // `mem::replace` exercises the ordinary read/write replacement path.
         let old = core::mem::replace(&mut y, 7); // old = a[i], y = 7
+
         if let Some(slot) = out.get_mut(t) {
-            // encode both: x (= b[i]) and old (= a[i])
+            // Encode both: x (= b[i]) and old (= a[i]).
             *slot = x * 1000 + old;
+        }
+    }
+
+    /// Swap two non-overlapping regions containing two 16-byte-aligned blocks.
+    #[kernel]
+    pub fn swap_nonoverlapping_kernel(seed: u32, mut out: DisjointSlice<u32>) {
+        if thread::index_1d().get() != 0 {
+            return;
+        }
+
+        let mut left = [
+            AlignedBlock {
+                words: [seed + 1, seed + 2, seed + 3, seed + 4],
+            },
+            AlignedBlock {
+                words: [seed + 5, seed + 6, seed + 7, seed + 8],
+            },
+        ];
+        let mut right = [
+            AlignedBlock {
+                words: [seed + 101, seed + 102, seed + 103, seed + 104],
+            },
+            AlignedBlock {
+                words: [seed + 105, seed + 106, seed + 107, seed + 108],
+            },
+        ];
+
+        unsafe {
+            // SAFETY: `left` and `right` are separate live stack allocations.
+            // Their ranges are non-overlapping, each base pointer is aligned for
+            // `AlignedBlock`, and both contain exactly two initialized elements.
+            core::ptr::swap_nonoverlapping(left.as_mut_ptr(), right.as_mut_ptr(), 2);
+
+            // One active thread owns the complete output region. Keep
+            // result export explicit so this regression does not depend on
+            // array/slice iterator lowering.
+            let ptr = out.as_mut_ptr();
+
+            ptr.write(left[0].words[0]);
+            ptr.add(1).write(left[0].words[1]);
+            ptr.add(2).write(left[0].words[2]);
+            ptr.add(3).write(left[0].words[3]);
+            ptr.add(4).write(left[1].words[0]);
+            ptr.add(5).write(left[1].words[1]);
+            ptr.add(6).write(left[1].words[2]);
+            ptr.add(7).write(left[1].words[3]);
+
+            ptr.add(8).write(right[0].words[0]);
+            ptr.add(9).write(right[0].words[1]);
+            ptr.add(10).write(right[0].words[2]);
+            ptr.add(11).write(right[0].words[3]);
+            ptr.add(12).write(right[1].words[0]);
+            ptr.add(13).write(right[1].words[1]);
+            ptr.add(14).write(right[1].words[2]);
+            ptr.add(15).write(right[1].words[3]);
         }
     }
 }
@@ -47,7 +112,7 @@ mod kernels {
 const N: usize = 64;
 
 fn main() {
-    println!("=== core::mem::swap / mem::replace on device ===\n");
+    println!("=== core memory swap primitives on device ===");
 
     let ctx = CudaContext::new(0).expect("Failed to create CUDA context");
     let module = kernels::load(&ctx).expect("Failed to load embedded CUDA module");
@@ -64,23 +129,42 @@ fn main() {
         block_dim: (N as u32, 1, 1),
         shared_mem_bytes: 0,
     };
+
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe { module.swap_kernel(stream.as_ref(), config, &d_a, &d_b, &mut d_out) }
-        .expect("Kernel launch failed");
+        .expect("swap_kernel launch");
 
     let out = d_out.to_host_vec(&stream).unwrap();
-    let mut ok = true;
     for (i, got) in out.iter().enumerate() {
         let want = (100 + i as i32) * 1000 + i as i32; // b[i]*1000 + a[i]
-        if *got != want {
-            println!("FAIL: lane {i}: out={got} (want {want})");
-            ok = false;
-            break;
-        }
+        assert_eq!(*got, want, "swap_kernel lane {i}");
     }
-    if ok {
-        println!("SUCCESS: all {N} lanes swapped+replaced correctly (out = b*1000 + a)");
-    } else {
-        std::process::exit(1);
+    println!("PASS: mem::swap");
+    println!("PASS: mem::replace");
+
+    const SEED: u32 = 17;
+    const SWAP_WORDS: usize = 16;
+
+    let mut swap_out = DeviceBuffer::<u32>::zeroed(&stream, SWAP_WORDS).unwrap();
+    let single_thread = LaunchConfig::for_num_elems(1);
+
+    // SAFETY: one thread is sufficient and the output buffer has all 16 words.
+    unsafe {
+        module.swap_nonoverlapping_kernel(stream.as_ref(), single_thread, SEED, &mut swap_out)
     }
+    .expect("swap_nonoverlapping_kernel launch");
+
+    let got = swap_out.to_host_vec(&stream).unwrap();
+    let expected: Vec<u32> = (101..=108)
+        .map(|offset| SEED + offset)
+        .chain((1..=8).map(|offset| SEED + offset))
+        .collect();
+
+    assert_eq!(
+        got, expected,
+        "ptr::swap_nonoverlapping should exchange both aligned regions"
+    );
+    println!("PASS: ptr::swap_nonoverlapping (2 x 16-byte aligned blocks)");
+
+    println!("PASS: mem_swap");
 }

--- a/crates/rustc-codegen-cuda/examples/ptr_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ptr_copy/src/main.rs
@@ -19,7 +19,7 @@
 //!   CUDA_OXIDE_NO_OPT=1 cargo oxide run ptr_copy
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{cuda_module, kernel, thread, DisjointSlice};
+use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
 
 #[cuda_module]
 mod kernels {

--- a/crates/rustc-codegen-cuda/examples/ptr_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ptr_copy/src/main.rs
@@ -3,20 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Regression test for `core::ptr::copy` (the overlap-safe move).
+//! Regression coverage for overlap-safe device memory moves.
 //!
 //! Unlike `copy_nonoverlapping` (which reaches MIR as a `CopyNonOverlapping`
-//! statement and already lowers to `llvm.memcpy`), `core::ptr::copy` bottoms
-//! out in the `core::intrinsics::copy` intrinsic, which the device backend did
-//! not lower — codegen failed with "rustc intrinsic `copy` is not yet supported
-//! on the device". libcore reaches it from `ptr::swap`, `slice` rotates, and
-//! similar routines. The fix lowers it to the overlap-safe `llvm.memmove`.
+//! statement and lowers to `llvm.memcpy`), `core::ptr::copy` bottoms out in the
+//! `core::intrinsics::copy` intrinsic. cuda-oxide lowers that path to the
+//! overlap-safe `llvm.memmove`.
+//!
+//! The example also covers `[T]::copy_within`, whose libcore implementation
+//! performs its checked range arithmetic and then reaches the same `ptr::copy`
+//! path. Both forward and backward overlapping copies are verified.
 //!
 //! Usage:
 //!   cargo oxide run ptr_copy
+//!   CUDA_OXIDE_NO_OPT=1 cargo oxide run ptr_copy
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
+use cuda_device::{cuda_module, kernel, thread, DisjointSlice};
 
 #[cuda_module]
 mod kernels {
@@ -35,10 +38,64 @@ mod kernels {
             }
         }
     }
+
+    /// Exercise `slice::copy_within` with overlap in both relative directions.
+    #[kernel]
+    pub fn copy_within_overlap(seed: i32, mut out: DisjointSlice<i32>) {
+        if thread::index_1d().get() != 0 {
+            return;
+        }
+
+        let original = [
+            seed,
+            seed + 1,
+            seed + 2,
+            seed + 3,
+            seed + 4,
+            seed + 5,
+            seed + 6,
+            seed + 7,
+        ];
+
+        let mut forward = original;
+        let mut backward = original;
+
+        // Destination begins inside the source range: dst > src.
+        forward.copy_within(0..6, 2);
+
+        // Source begins inside the destination range: dst < src.
+        backward.copy_within(2..8, 0);
+
+        unsafe {
+            // One active thread owns the complete output region. Keep result
+            // export explicit so this regression does not depend on iterator
+            // lowering in addition to `copy_within`.
+            let ptr = out.as_mut_ptr();
+
+            ptr.write(forward[0]);
+            ptr.add(1).write(forward[1]);
+            ptr.add(2).write(forward[2]);
+            ptr.add(3).write(forward[3]);
+            ptr.add(4).write(forward[4]);
+            ptr.add(5).write(forward[5]);
+            ptr.add(6).write(forward[6]);
+            ptr.add(7).write(forward[7]);
+
+            ptr.add(8).write(backward[0]);
+            ptr.add(9).write(backward[1]);
+            ptr.add(10).write(backward[2]);
+            ptr.add(11).write(backward[3]);
+            ptr.add(12).write(backward[4]);
+            ptr.add(13).write(backward[5]);
+            ptr.add(14).write(backward[6]);
+            ptr.add(15).write(backward[7]);
+        }
+    }
 }
 
 fn main() {
     println!("=== ptr_copy ===");
+
     const N: usize = 96;
     let input: Vec<i32> = (0..N as i32).map(|i| i * 3 - 7).collect();
 
@@ -49,15 +106,45 @@ fn main() {
 
     let din = DeviceBuffer::from_host(&stream, &input).unwrap();
     let mut out = DeviceBuffer::<i32>::zeroed(&stream, N).unwrap();
+
     // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
     unsafe { module.shift_right_one(&stream, cfg, &din, &mut out, N) }
         .expect("shift_right_one launch");
+
     let got = out.to_host_vec(&stream).unwrap();
 
     let mut want = input.clone();
     for k in (1..N).rev() {
         want[k] = want[k - 1];
     }
+
     assert_eq!(got, want, "shift_right_one (overlapping ptr::copy)");
-    println!("PASS: ptr_copy (overlapping forward move via memmove)");
+    println!("PASS: ptr::copy (overlapping forward move via memmove)");
+
+    const COPY_WITHIN_SEED: i32 = 100;
+    const COPY_WITHIN_WORDS: usize = 16;
+
+    let mut copy_within_out = DeviceBuffer::<i32>::zeroed(&stream, COPY_WITHIN_WORDS).unwrap();
+
+    // SAFETY: one thread is sufficient and the output buffer has all 16 values.
+    unsafe {
+        module.copy_within_overlap(
+            &stream,
+            LaunchConfig::for_num_elems(1),
+            COPY_WITHIN_SEED,
+            &mut copy_within_out,
+        )
+    }
+    .expect("copy_within_overlap launch");
+
+    let got = copy_within_out.to_host_vec(&stream).unwrap();
+    let expected = vec![
+        100, 101, 100, 101, 102, 103, 104, 105, // forward overlap
+        102, 103, 104, 105, 106, 107, 106, 107, // backward overlap
+    ];
+
+    assert_eq!(got, expected, "slice::copy_within forward/backward overlap");
+    println!("PASS: slice::copy_within (forward and backward overlap)");
+
+    println!("PASS: ptr_copy");
 }


### PR DESCRIPTION
Closes #827 

## Summary

Extend the existing memory regressions with direct device-side coverage for:

- `core::ptr::swap_nonoverlapping`
- `[T]::copy_within`

No compiler changes are required.

The existing memcpy, memmove, typed-swap, load, and store infrastructure already supports the operations produced by these APIs. This PR adds API-level conformance coverage around the remaining alignment, non-overlap, and overlap boundaries.

## `ptr::swap_nonoverlapping`

`mem_swap` now directly exercises `core::ptr::swap_nonoverlapping` in addition to its existing `mem::swap` and `mem::replace` coverage.

The new kernel uses:

```rust
#[repr(C, align(16))]
#[derive(Clone, Copy)]
struct AlignedBlock {
    words: [u32; 4],
}
```

and swaps two elements between two independent arrays:

```rust
core::ptr::swap_nonoverlapping(
    left.as_mut_ptr(),
    right.as_mut_ptr(),
    2,
);
```

This deliberately exercises:

```text
two distinct allocations
16-byte element alignment
16-byte element size
count = 2
32 bytes exchanged in each direction
```

The values depend on a runtime kernel parameter, and both complete regions are written to host-observable output after the swap.

The host verifies:

```text
left_after  == right_before
right_after == left_before
```

The existing `mem_swap` documentation is also corrected to distinguish the pinned toolchain's implementation paths:

```text
mem::swap
    -> typed_swap_nonoverlapping

mem::replace
    -> read/write replacement path
```

## `slice::copy_within`

`ptr_copy` already verifies a direct overlapping `ptr::copy`, which exercises cuda-oxide's memmove lowering.

This PR additionally calls `[T]::copy_within` directly and verifies overlapping moves in both directions.

Forward overlap:

```text
source       0..6
destination  2
dst > src
```

For an input:

```text
[a, b, c, d, e, f, g, h]
```

the expected result is:

```text
[a, b, a, b, c, d, e, f]
```

Backward overlap:

```text
source       2..8
destination  0
dst < src
```

Expected result:

```text
[c, d, e, f, g, h, g, h]
```

Testing both directions makes the overlap-safe semantics observable and guards against accidentally treating `copy_within` as a memcpy-style operation.

## Why no compiler change is needed

The relevant compiler paths are already implemented:

* non-overlapping copies use the existing memcpy lowering
* overlapping `ptr::copy` uses the existing memmove lowering
* `mem::swap` has existing typed-swap support
* ordinary loads and stores already support the runtime implementation used by `ptr::swap_nonoverlapping`

`slice::copy_within` ultimately reaches `ptr::copy`, so it reuses the existing memmove path.

The new regressions pass without changes to the importer, MIR dialect, MIR-to-LLVM lowering, or exporter.

## Scope

This PR modifies only:

```text
crates/rustc-codegen-cuda/examples/mem_swap/src/main.rs
crates/rustc-codegen-cuda/examples/ptr_copy/src/main.rs
```

No files are added.

No compiler, dialect, exporter, smoketest-script, or Rustlantis sources are changed.

## Validation

Validated on an NVIDIA GeForce RTX 5060 Laptop GPU (`sm_120a`).

Optimized `mem_swap`:

```bash
cargo oxide run mem_swap
```

```text
=== core memory swap primitives on device ===
PASS: mem::swap
PASS: mem::replace
PASS: ptr::swap_nonoverlapping (2 x 16-byte aligned blocks)
PASS: mem_swap
```

Low-MIR-optimization `mem_swap`:

```bash
CUDA_OXIDE_NO_OPT=1 cargo oxide run mem_swap
```

passes with the same results.

Optimized `ptr_copy`:

```bash
cargo oxide run ptr_copy
```

and low-MIR-optimization execution:

```bash
CUDA_OXIDE_NO_OPT=1 cargo oxide run ptr_copy
```

both pass with:

```text
=== ptr_copy ===
PASS: ptr::copy (overlapping forward move via memmove)
PASS: slice::copy_within (forward and backward overlap)
PASS: ptr_copy
```

Scoped runtime smoketest:

```text
[ 1/ 2] mem_swap ... PASS
[ 2/ 2] ptr_copy ... PASS

Pass:    2 / 2
Fail:    0 / 2
```

Scoped compile-only smoketest:

```text
[ 1/ 2] mem_swap ... PASS (compiled)
[ 2/ 2] ptr_copy ... PASS (compiled)

Pass:    2 / 2
Fail:    0 / 2
```

Repository hygiene:

```bash
cargo fmt --all -- --check
git diff --check
```

Both pass cleanly.
