### PR TITLE
test(codegen): extend checked integer semantics coverage

### DIFF
--- a/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
@@ -22,7 +22,7 @@
 //!   CUDA_OXIDE_NO_OPT=1 cargo oxide run checked_arith
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{kernel, thread, DisjointSlice};
+use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_module;
 
 #[cuda_module]

--- a/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
@@ -3,21 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Checked arithmetic smoke test.
+//! Checked and overflowing integer arithmetic conformance test.
 //!
-//! Verifies that `overflowing_add`, `overflowing_sub`, and `overflowing_mul`
-//! return the correct (result, overflow) pair. Before the fix, the overflow
-//! flag was hardcoded to `false`; now it is computed by the proper LLVM
-//! overflow intrinsics.
+//! The historical regression verifies that `overflowing_add`,
+//! `overflowing_sub`, and `overflowing_mul` return the correct
+//! `(wrapping_result, overflow)` pair. Before the fix, the overflow flag was
+//! hardcoded to `false`; it is now computed by the proper LLVM overflow
+//! intrinsics.
 //!
-//! Each kernel encodes both the wrapping result (low byte) and the overflow
-//! flag (bit 8) into a single u32 output so the host can check both in one
-//! pass.
+//! This example also exercises the public `checked_add`, `checked_sub`, and
+//! `checked_mul` APIs. Those operations share Rust's checked binary arithmetic
+//! machinery but expose overflow as `None` rather than as a boolean flag.
+//! Unsigned `u8` and signed `i8` cases cover both overflow and non-overflow
+//! paths, including `Some(0)` so it cannot be confused with `None`.
 //!
-//! Run: cargo oxide run checked_arith
+//! Run:
+//!   cargo oxide run checked_arith
+//!   CUDA_OXIDE_NO_OPT=1 cargo oxide run checked_arith
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_device::{kernel, thread, DisjointSlice};
 use cuda_host::cuda_module;
 
 #[cuda_module]
@@ -56,6 +61,80 @@ mod kernels {
             *o = (result as u32) | ((overflow as u32) << 8);
         }
     }
+
+    /// Exercise unsigned `checked_{add,sub,mul}` and encode each `Option<u8>`.
+    ///
+    /// Encoding:
+    /// - `None` -> 0
+    /// - `Some(value)` -> bit 8 set, payload in bits 0..7
+    #[kernel]
+    pub fn checked_u8(
+        a: &[u8],
+        b: &[u8],
+        mut add_out: DisjointSlice<u32>,
+        mut sub_out: DisjointSlice<u32>,
+        mut mul_out: DisjointSlice<u32>,
+    ) {
+        let i = thread::index_1d().get();
+
+        if let Some(o) = add_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_add(b[i]) {
+                Some(value) => 0x100 | value as u32,
+                None => 0,
+            };
+        }
+
+        if let Some(o) = sub_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_sub(b[i]) {
+                Some(value) => 0x100 | value as u32,
+                None => 0,
+            };
+        }
+
+        if let Some(o) = mul_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_mul(b[i]) {
+                Some(value) => 0x100 | value as u32,
+                None => 0,
+            };
+        }
+    }
+
+    /// Exercise signed `checked_{add,sub,mul}` and encode each `Option<i8>`.
+    ///
+    /// Encoding:
+    /// - `None` -> 0
+    /// - `Some(value)` -> bit 8 set, two's-complement payload in bits 0..7
+    #[kernel]
+    pub fn checked_i8(
+        a: &[i8],
+        b: &[i8],
+        mut add_out: DisjointSlice<u32>,
+        mut sub_out: DisjointSlice<u32>,
+        mut mul_out: DisjointSlice<u32>,
+    ) {
+        let i = thread::index_1d().get();
+
+        if let Some(o) = add_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_add(b[i]) {
+                Some(value) => 0x100 | value as u8 as u32,
+                None => 0,
+            };
+        }
+
+        if let Some(o) = sub_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_sub(b[i]) {
+                Some(value) => 0x100 | value as u8 as u32,
+                None => 0,
+            };
+        }
+
+        if let Some(o) = mul_out.get_mut(thread::index_1d()) {
+            *o = match a[i].checked_mul(b[i]) {
+                Some(value) => 0x100 | value as u8 as u32,
+                None => 0,
+            };
+        }
+    }
 }
 
 fn check(label: &str, got: u32, expected_result: u8, expected_overflow: bool) -> bool {
@@ -66,6 +145,34 @@ fn check(label: &str, got: u32, expected_result: u8, expected_overflow: bool) ->
             "  FAIL {label}: result={got_result} (want {expected_result}), \
              overflow={got_overflow} (want {expected_overflow})"
         );
+        false
+    } else {
+        true
+    }
+}
+
+fn check_checked_u8(label: &str, got: u32, expected: Option<u8>) -> bool {
+    let want = match expected {
+        Some(value) => 0x100 | value as u32,
+        None => 0,
+    };
+
+    if got != want {
+        eprintln!("  FAIL {label}: encoded=0x{got:03x} (want 0x{want:03x}, {expected:?})");
+        false
+    } else {
+        true
+    }
+}
+
+fn check_checked_i8(label: &str, got: u32, expected: Option<i8>) -> bool {
+    let want = match expected {
+        Some(value) => 0x100 | value as u8 as u32,
+        None => 0,
+    };
+
+    if got != want {
+        eprintln!("  FAIL {label}: encoded=0x{got:03x} (want 0x{want:03x}, {expected:?})");
         false
     } else {
         true
@@ -123,7 +230,78 @@ fn main() {
         .expect("checked_mul launch");
     let out_mul = out_dev.to_host_vec(&stream).unwrap();
 
+    // --- checked_{add,sub,mul} for unsigned u8 ---
+    //
+    // The four pairs deliberately include overflow, non-overflow, and Some(0):
+    //   200, 100 -> add None;     sub Some(100); mul None
+    //   100, 200 -> add None;     sub None;      mul None
+    //    20,  10 -> add Some(30); sub Some(10);  mul Some(200)
+    //     0,   0 -> add Some(0);  sub Some(0);   mul Some(0)
+    let checked_u8_a: Vec<u8> = vec![200, 100, 20, 0];
+    let checked_u8_b: Vec<u8> = vec![100, 200, 10, 0];
+    let checked_u8_a_dev = DeviceBuffer::from_host(&stream, &checked_u8_a).unwrap();
+    let checked_u8_b_dev = DeviceBuffer::from_host(&stream, &checked_u8_b).unwrap();
+    let mut checked_u8_add_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
+    let mut checked_u8_sub_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
+    let mut checked_u8_mul_dev = DeviceBuffer::<u32>::zeroed(&stream, 4).unwrap();
+
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.checked_u8(
+            &stream,
+            cfg,
+            &checked_u8_a_dev,
+            &checked_u8_b_dev,
+            &mut checked_u8_add_dev,
+            &mut checked_u8_sub_dev,
+            &mut checked_u8_mul_dev,
+        )
+    }
+    .expect("checked_u8 launch");
+
+    let checked_u8_add = checked_u8_add_dev.to_host_vec(&stream).unwrap();
+    let checked_u8_sub = checked_u8_sub_dev.to_host_vec(&stream).unwrap();
+    let checked_u8_mul = checked_u8_mul_dev.to_host_vec(&stream).unwrap();
+
+    // --- checked_{add,sub,mul} for signed i8 ---
+    //
+    // These values force the signed LLVM overflow paths in both directions
+    // while retaining ordinary and Some(0) results:
+    //    120,  10 -> add None;       sub Some(110);  mul None
+    //   -120, -20 -> add None;       sub Some(-100); mul None
+    //    120, -20 -> add Some(100);  sub None;       mul None
+    //   -120,  20 -> add Some(-100); sub None;       mul None
+    //     10,  10 -> add Some(20);   sub Some(0);    mul Some(100)
+    //    -10,  10 -> add Some(0);    sub Some(-20);  mul Some(-100)
+    let checked_i8_a: Vec<i8> = vec![120, -120, 120, -120, 10, -10];
+    let checked_i8_b: Vec<i8> = vec![10, -20, -20, 20, 10, 10];
+    let checked_i8_a_dev = DeviceBuffer::from_host(&stream, &checked_i8_a).unwrap();
+    let checked_i8_b_dev = DeviceBuffer::from_host(&stream, &checked_i8_b).unwrap();
+    let mut checked_i8_add_dev = DeviceBuffer::<u32>::zeroed(&stream, 6).unwrap();
+    let mut checked_i8_sub_dev = DeviceBuffer::<u32>::zeroed(&stream, 6).unwrap();
+    let mut checked_i8_mul_dev = DeviceBuffer::<u32>::zeroed(&stream, 6).unwrap();
+
+    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+    unsafe {
+        module.checked_i8(
+            &stream,
+            LaunchConfig::for_num_elems(6),
+            &checked_i8_a_dev,
+            &checked_i8_b_dev,
+            &mut checked_i8_add_dev,
+            &mut checked_i8_sub_dev,
+            &mut checked_i8_mul_dev,
+        )
+    }
+    .expect("checked_i8 launch");
+
+    let checked_i8_add = checked_i8_add_dev.to_host_vec(&stream).unwrap();
+    let checked_i8_sub = checked_i8_sub_dev.to_host_vec(&stream).unwrap();
+    let checked_i8_mul = checked_i8_mul_dev.to_host_vec(&stream).unwrap();
+
     let mut ok = true;
+
+    // Historical overflowing arithmetic regression.
     ok &= check("add[0] 200+100", out_add[0], 44, true);
     ok &= check("add[1] 100+50", out_add[1], 150, false);
     ok &= check("add[2] 255+1", out_add[2], 0, true);
@@ -139,8 +317,57 @@ fn main() {
     ok &= check("mul[2] 255*2", out_mul[2], 254, true);
     ok &= check("mul[3] 1*1", out_mul[3], 1, false);
 
+    // Unsigned checked arithmetic.
+    let expected_u8_add = [None, None, Some(30), Some(0)];
+    let expected_u8_sub = [Some(100), None, Some(10), Some(0)];
+    let expected_u8_mul = [None, None, Some(200), Some(0)];
+
+    for i in 0..4 {
+        ok &= check_checked_u8(
+            &format!("checked_add<u8>[{i}]"),
+            checked_u8_add[i],
+            expected_u8_add[i],
+        );
+        ok &= check_checked_u8(
+            &format!("checked_sub<u8>[{i}]"),
+            checked_u8_sub[i],
+            expected_u8_sub[i],
+        );
+        ok &= check_checked_u8(
+            &format!("checked_mul<u8>[{i}]"),
+            checked_u8_mul[i],
+            expected_u8_mul[i],
+        );
+    }
+
+    // Signed checked arithmetic.
+    let expected_i8_add = [None, None, Some(100), Some(-100), Some(20), Some(0)];
+    let expected_i8_sub = [Some(110), Some(-100), None, None, Some(0), Some(-20)];
+    let expected_i8_mul = [None, None, None, None, Some(100), Some(-100)];
+
+    for i in 0..6 {
+        ok &= check_checked_i8(
+            &format!("checked_add<i8>[{i}]"),
+            checked_i8_add[i],
+            expected_i8_add[i],
+        );
+        ok &= check_checked_i8(
+            &format!("checked_sub<i8>[{i}]"),
+            checked_i8_sub[i],
+            expected_i8_sub[i],
+        );
+        ok &= check_checked_i8(
+            &format!("checked_mul<i8>[{i}]"),
+            checked_i8_mul[i],
+            expected_i8_mul[i],
+        );
+    }
+
     if ok {
         println!("SUCCESS: all overflowing_{{add,sub,mul}} results correct");
+        println!("PASS: checked_add/sub/mul (unsigned u8)");
+        println!("PASS: checked_add/sub/mul (signed i8)");
+        println!("PASS: checked_arith");
     } else {
         std::process::exit(1);
     }


### PR DESCRIPTION
Closes #829 

## Summary

Extend the existing `checked_arith` device regression with direct conformance coverage for:

- `checked_add`
- `checked_sub`
- `checked_mul`

The existing example already covers `overflowing_{add,sub,mul}` on unsigned `u8`. This PR adds the corresponding `checked_*` API semantics and exercises both unsigned and signed checked arithmetic.

No compiler changes are required.

## What changed

The existing historical `overflowing_*` regression remains intact.

Two additional device paths cover `checked_{add,sub,mul}` for:

```text
u8
i8
```

The result encoding distinguishes:

```text
None        -> no success bit
Some(value) -> success bit + 8-bit payload
```

This intentionally makes:

```text
None
```

different from:

```text
Some(0)
```

so zero-valued successful arithmetic cannot accidentally pass as an overflow result.

## Unsigned coverage

The `u8` cases exercise:

* addition overflow and success
* subtraction underflow and success
* multiplication overflow and success
* successful zero-valued results

Examples include:

```text
200 + 100 -> None
20 + 10   -> Some(30)

100 - 200 -> None
20 - 10   -> Some(10)

200 * 100 -> None
20 * 10   -> Some(200)

0 + 0     -> Some(0)
```

This complements the existing unsigned `overflowing_*` regression and verifies the public `Option`-returning API contract.

## Signed coverage

The new `i8` cases exercise the signed overflow paths, including both positive and negative boundaries.

Examples include:

```text
120 + 10      -> None
-120 + -20    -> None
120 + -20     -> Some(100)

-120 - 20     -> None
120 - (-20)   -> None
10 - 10       -> Some(0)

120 * 10      -> None
-120 * -20    -> None
10 * 10       -> Some(100)
-10 * 10      -> Some(-100)
```

This gives end-to-end coverage for the signed LLVM overflow intrinsic selection in addition to the unsigned paths already covered by the example.

## Existing integer-semantics coverage

No duplicate coverage is added for the other lane-64 families.

`primitive_stress` already exercises:

* wrapping arithmetic
* saturating arithmetic
* `rotate_left`
* `rotate_right`
* `reverse_bits`

This PR therefore changes only the existing `checked_arith` example.

## Scope

Modified:

```text
crates/rustc-codegen-cuda/examples/checked_arith/src/main.rs
```

No files are added.

No changes are made to:

* `mir-importer`
* `mir-lower`
* `dialect-mir`
* `llvm-export`
* smoketest infrastructure
* Rustlantis

## Validation

Validated on an NVIDIA GeForce RTX 5060 Laptop GPU (`sm_120a`).

Optimized checked arithmetic:

```bash
cargo oxide run checked_arith
```

Low-MIR-optimization checked arithmetic:

```bash
CUDA_OXIDE_NO_OPT=1 cargo oxide run checked_arith
```

Both pass with:

```text
SUCCESS: all overflowing_{add,sub,mul} results correct
PASS: checked_add/sub/mul (unsigned u8)
PASS: checked_add/sub/mul (signed i8)
PASS: checked_arith
```

Existing integer semantics regression:

```bash
cargo oxide run primitive_stress
CUDA_OXIDE_NO_OPT=1 cargo oxide run primitive_stress
```

Both pass:

```text
PASS char constants and casts
PASS u128/i128 arithmetic
PASS usize/isize arithmetic
PASS bit intrinsic methods
PASS saturating arithmetic intrinsics
PASS float math intrinsics

Passed: 6
Failed: 0
```

Scoped runtime smoketest:

```text
[ 1/ 2] checked_arith      ... PASS
[ 2/ 2] primitive_stress   ... PASS (LTOIR)

Pass: 2 / 2
Fail: 0 / 2
```

Scoped compile-only smoketest:

```text
[ 1/ 2] checked_arith      ... PASS (compiled)
[ 2/ 2] primitive_stress   ... PASS (verified and compiled by libNVVM)

Pass: 2 / 2
Fail: 0 / 2
```

Repository hygiene:

```bash
cargo fmt --all -- --check
git diff --check
```

Both pass cleanly.
