### PR TITLE
build(just): lint and document the codegen workspace, as CI does

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,9 +15,24 @@ fmt:
 fmt-check:
     cargo oxide fmt --check
 
-# Run clippy with warnings as errors
+# Lint every scope CI's clippy job lints, minus the per-example pass.
+#
+# CI runs clippy three times: over the root workspace, over
+# crates/rustc-codegen-cuda (its own [workspace] for the rustc_private dylibs,
+# which `--workspace` from the root cannot reach), and once per example. The
+# first two are here. `--workspace --all-targets` matches CI exactly; the
+# previous `--all-targets --lib --tests` narrowed target selection and so
+# skipped bin and example targets that CI lints, `cuda-host/examples/` among
+# them.
+#
+# The per-example pass stays CI-only: it is one clippy run per example across
+# 200-odd separate workspaces, which is a CI job rather than something to wait
+# on locally.
+# Run clippy with warnings as errors (root + codegen workspaces)
 clippy:
-    cargo clippy --all-targets --lib --tests -- -D warnings
+    cargo clippy --workspace --all-targets -- -D warnings
+    # Its own [workspace], so `--workspace` above stops at that boundary.
+    cd crates/rustc-codegen-cuda && cargo clippy --all-targets -- -D warnings
 
 # Run clippy and auto-fix warnings
 clippy-fix:
@@ -92,13 +107,17 @@ test-cuda:
 doc-check:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
     cargo test --doc --workspace --exclude cuda-bindings
+    # The docs gate builds this workspace's rustdoc separately too (#725); the
+    # root `--workspace` cannot reach it.
+    cd crates/rustc-codegen-cuda && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
 # Run all checks (fmt + clippy + tests + guards + docs). Includes `test-cuda`:
 # `clippy` and `doc-check` already build cuda-bindings, so this recipe needs a
 # CUDA toolkit either way. Machines without even a toolkit get `test`. A driver
 # is no longer required: `test-cuda` shadows the toolkit's libcuda stub itself.
 # `check-guards` covers the status-guard and cargo-deny workflows in full; see
-# its comment for prerequisites. Still CI-only: naming-guard (its grep pipeline
+# its comment for prerequisites. Still CI-only: clippy's per-example pass (one
+# run per example workspace), naming-guard (its grep pipeline
 # lives inline in the workflow, with no script to invoke), examples-compile
 # (needs the CUDA codegen backend), the book build, and CodeQL.
 # Run CI's gates minus naming-guard, examples-compile, book, CodeQL

--- a/Justfile
+++ b/Justfile
@@ -20,10 +20,10 @@ fmt-check:
 # CI runs clippy three times: over the root workspace, over
 # crates/rustc-codegen-cuda (its own [workspace] for the rustc_private dylibs,
 # which `--workspace` from the root cannot reach), and once per example. The
-# first two are here. `--workspace --all-targets` matches CI exactly; the
-# previous `--all-targets --lib --tests` narrowed target selection and so
-# skipped bin and example targets that CI lints, `cuda-host/examples/` among
-# them.
+# first two are here, the root invocation spelled the way CI spells it.
+# (Cargo's target-selection flags are additive and the virtual root workspace
+# has no default-members, so the earlier `--all-targets --lib --tests` covered
+# the same members and targets; the spelling was the only difference.)
 #
 # The per-example pass stays CI-only: it is one clippy run per example across
 # 200-odd separate workspaces, which is a CI job rather than something to wait


### PR DESCRIPTION
`just check` claims to run CI's gates minus a named few. Two of its recipes were
narrower than the jobs they mirror, both in the same way: they miss
`crates/rustc-codegen-cuda`, which carries its own `[workspace]` for the
`rustc_private` dylibs, so `--workspace` from the root stops at that boundary.

The `test` recipe already handles that crate (`cd crates/rustc-codegen-cuda &&
cargo test --lib`). These two never did.

## clippy

CI lints **three** scopes; the recipe ran one:

| scope | CI | `just clippy` (before) |
|---|---|---|
| root workspace | `cargo clippy --workspace --all-targets` | `cargo clippy --all-targets --lib --tests` |
| codegen workspace | `cd crates/rustc-codegen-cuda && cargo clippy --all-targets` | — |
| per example | one run per example | — |

Two problems in that first cell: no `--workspace`, and `--all-targets --lib
--tests` **narrows** target selection, so it skips bin and example targets CI
lints — `cuda-host/examples/finalize_nvvm_ir.rs` among them. Now
`--workspace --all-targets`, matching CI, plus the codegen workspace.

## doc-check

The docs gate builds this workspace's rustdoc separately under `-D warnings`
too. **That job is mine, from #725, and I did not add it here** — same omission
as #814's missing timeout.

## The per-example pass stays CI-only

It is one clippy run per example across 200-odd separate workspaces — a CI job,
not something to wait on locally. `check`'s comment now names it as CI-only
rather than implying clippy is covered in full, which is the part that was
actually misleading.

## Verification

Both widened recipes **pass here**, which was the real risk — widening a gate
can surface new lints:

- `just clippy` — clean across both workspaces, 0 issues, exit 0;
- `just doc-check` — builds the codegen rustdoc warning-free, exit 0.

So this closes a coverage gap without landing new work.

## Merge order

**#835 is stacked on this one.** Both edit the same `Still CI-only:` sentence —
this PR adds clippy's per-example pass to it, #835 removes naming-guard — so they
conflicted until #835 was rebased onto this branch. Merging this one first keeps
that resolution valid; if #835 lands first its squash carries this change too and
this PR becomes an empty duplicate.

#836 and #838 also touch the `Justfile`/manifests but at unrelated lines, and I
verified all five merge clean in either order after the rebase.
