### PR TITLE
build(just): add a `book` recipe so the book gate can be run locally

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -124,6 +124,30 @@ pipeline example:
 smoketest *args:
     scripts/smoketest.sh {{args}}
 
+# Build the book exactly as the CI gate does. Needs python3; nothing else.
+#
+# `-W` turns every Sphinx warning into an error, so a broken cross-reference, a
+# malformed directive, or a page dropped from a toctree fails here instead of
+# after merge. One trap worth knowing before writing a link: the book sets
+# `heading_anchors=0`, so a markdown `[text](#some-heading)` is an error even
+# though the rendered HTML contains both the href and a matching id.
+#
+# Deliberately not part of `check`: it is the only gate needing a Python
+# virtualenv, and `check` otherwise requires none. The venv is built once and
+# reused; `cuda-oxide-book/_build/` is gitignored.
+# Build the book warning-free, as the book CI gate does (needs python3)
+book:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    venv=cuda-oxide-book/_build/venv
+    if [ ! -x "${venv}/bin/sphinx-build" ]; then
+        echo "Creating the book virtualenv (once) ..."
+        python3 -m venv "${venv}"
+        "${venv}/bin/pip" install --quiet -r cuda-oxide-book/requirements.txt
+    fi
+    "${venv}/bin/sphinx-build" -W --keep-going -b html \
+        cuda-oxide-book cuda-oxide-book/_build/html
+
 # Verify every error* example is in STATUS.md and smoketest.sh ERROR_EXAMPLES
 check-errors:
     scripts/check-error-example-status.sh

--- a/Justfile
+++ b/Justfile
@@ -128,9 +128,10 @@ smoketest *args:
 #
 # `-W` turns every Sphinx warning into an error, so a broken cross-reference, a
 # malformed directive, or a page dropped from a toctree fails here instead of
-# after merge. One trap worth knowing before writing a link: the book sets
-# `heading_anchors=0`, so a markdown `[text](#some-heading)` is an error even
-# though the rendered HTML contains both the href and a matching id.
+# after merge. One trap worth knowing before writing a link: `conf.py` sets no
+# heading-anchor option and MyST's auto-generated heading anchors are off by
+# default, so a markdown `[text](#some-heading)` is an error even though the
+# rendered HTML contains both the href and a matching id.
 #
 # Deliberately not part of `check`: it is the only gate needing a Python
 # virtualenv, and `check` otherwise requires none. The venv is built once and
@@ -140,6 +141,7 @@ book:
     #!/usr/bin/env bash
     set -euo pipefail
     venv=cuda-oxide-book/_build/venv
+    # Stale (requirements.txt changed, install half-failed)? rm -rf cuda-oxide-book/_build/venv
     if [ ! -x "${venv}/bin/sphinx-build" ]; then
         echo "Creating the book virtualenv (once) ..."
         python3 -m venv "${venv}"


### PR DESCRIPTION
The book gate is strict — `sphinx-build -W --keep-going`, so every warning is an
error — and it had **no local counterpart**. Nothing in CONTRIBUTING or the
book's own README says how to build it, so a contributor editing a page could
only find out by pushing.

## Why it matters more than it sounds

That gate is easy to trip in ways the rendered page does not reveal. A markdown
`[text](#some-heading)` link **fails it**, because the book sets
`heading_anchors=0` — even though the emitted HTML contains both the `href` and a
matching `id` and works fine in a browser. I hit exactly that on #794 and only
caught it because I happened to be building the book by hand.

The recipe's comment records that trap, since it is worth knowing *before*
writing a link.

## What it does

Mirrors the CI job exactly — the same
`pip install -r cuda-oxide-book/requirements.txt`, the same
`sphinx-build -W --keep-going -b html`. The virtualenv is created once under
`cuda-oxide-book/_build/` and reused on later runs.

Not wired into `check`: it is the only gate needing a Python virtualenv, and
`check` otherwise needs none. `check`'s comment already lists the book as
CI-only, which stays accurate for that recipe.

## Verification

- cold run creates the venv and reports `build succeeded`, exit 0;
- warm run reuses it;
- `git status` afterwards shows only the Justfile change.

*(I started to also add `cuda-oxide-book/_build/` to the root `.gitignore`, then
found `cuda-oxide-book/.gitignore` already carries `_build/` — so that edit was
redundant and I dropped it. The recipe relies on the existing rule.)*