### PR TITLE
docs(contributing): point contributors at `just check`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,26 @@ The repository includes a `flake.nix` that provides a fully reproducible develop
 environment (CUDA 13, LLVM 22, Clang, pinned Rust nightly). If you have Nix with
 flakes enabled, `nix develop` is the quickest way to get everything in place.
 
+### Running the checks
+
+Most of CI is one command. The repository ships a `Justfile` that mirrors the
+workflows:
+
+```bash
+just check
+```
+
+It needs a CUDA toolkit and `cargo-deny` on `PATH`; it does not need a GPU --
+the CUDA-linked test packages shadow the toolkit's `libcuda` stub when no driver
+is present. Individual recipes exist for each piece, and `just --list` shows
+them with a one-line description each.
+
+A few CI jobs deliberately stay outside `just check` -- ones that need the
+codegen backend, a Python virtualenv, or GitHub's own infrastructure. The
+`check` recipe's comment in the `Justfile` names them, and is the place kept in
+step when a workflow changes; the commands below are the ones worth knowing by
+hand even so.
+
 ### Formatting and Style
 
 - Run `cargo oxide fmt` before submitting. All code must be formatted with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,10 +131,10 @@ workflows:
 just check
 ```
 
-It needs a CUDA toolkit and `cargo-deny` on `PATH`; it does not need a GPU --
-the CUDA-linked test packages shadow the toolkit's `libcuda` stub when no driver
-is present. Individual recipes exist for each piece, and `just --list` shows
-them with a one-line description each.
+It needs a CUDA toolkit, `cargo-deny`, and `python3` on `PATH`; it does not
+need a GPU -- the CUDA-linked test packages shadow the toolkit's `libcuda` stub
+when no driver is present. Individual recipes exist for each piece, and
+`just --list` shows them with a one-line description each.
 
 A few CI jobs deliberately stay outside `just check` -- ones that need the
 codegen backend, a Python virtualenv, or GitHub's own infrastructure. The


### PR DESCRIPTION
CONTRIBUTING **never mentions `just`** — zero occurrences. So the one-command
gate that #729 and #788 exist to provide is invisible to exactly the person it
was built for.

Worse, the Formatting and Style section lists the individual commands and says of
clippy that *"there is no single command covering them"*. That is true of that
one scope, but a reader comes away thinking hand-assembly is the only route, and
quietly skips the guards, the unit tests CI actually runs, and the docs gate.

## The change

A short **Running the checks** section ahead of it: `just check`, what it needs
(a CUDA toolkit and `cargo-deny`; **no GPU** — the CUDA-linked test packages
shadow the toolkit's `libcuda` stub themselves), and `just --list` for the
individual recipes.

The hand commands below it stay. They are worth knowing when you want one scope
rather than the whole gate.

## One deliberate omission

It does **not** restate which CI jobs stay outside `just check`. That list is
moving right now — #834, #835 and #836 each shift a piece in or out of it — and a
copy here would rot exactly the way the toolchain pin's copies did (#790). The
`check` recipe's own comment is the single place that names them, so this text
points there instead of duplicating it.

## Verification

Every claim checked against the Justfile rather than remembered: `check` exists,
29 recipes carry the `--list` descriptions, the `cargo-deny` prerequisite and the
libcuda-stub shadowing are both real, `check`'s comment does name the CI-only
jobs, and `just --list` runs.