### PR TITLE
build: link each crate's README from its manifest

### DIFF
--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cargo subcommand for cuda-oxide: build and run Rust GPU programs"
+readme = "README.md"
 
 [[bin]]
 name = "cargo-oxide"

--- a/crates/cuda-artifact-finalizer/Cargo.toml
+++ b/crates/cuda-artifact-finalizer/Cargo.toml
@@ -3,6 +3,7 @@ name = "cuda-artifact-finalizer"
 version = "0.2.1"
 edition.workspace = true
 description = "Driver-independent NVVM IR and LTOIR finalization for cuda-oxide"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/cuda-async/Cargo.toml
+++ b/crates/cuda-async/Cargo.toml
@@ -3,6 +3,7 @@ name = "cuda-async"
 version = "0.2.1"
 edition.workspace = true
 description = "Async execution layer for CUDA device operations"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/cuda-bindings/Cargo.toml
+++ b/crates/cuda-bindings/Cargo.toml
@@ -3,6 +3,7 @@ name = "cuda-bindings"
 version = "0.2.1"
 edition.workspace = true
 description = "Raw FFI bindings to the CUDA driver API via bindgen"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/cuda-core/Cargo.toml
+++ b/crates/cuda-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "cuda-core"
 version = "0.2.1"
 edition.workspace = true
 description = "Safe RAII wrappers around the CUDA driver API (idiomatic host-side CUDA)"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/cuda-device/Cargo.toml
+++ b/crates/cuda-device/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Device-side intrinsics and types for CUDA kernels in Rust"
+readme = "README.md"
 
 [dependencies]
 # Inherits the workspace entry, which sets `default-features = false` and so

--- a/crates/cuda-host/Cargo.toml
+++ b/crates/cuda-host/Cargo.toml
@@ -3,6 +3,7 @@ name = "cuda-host"
 version = "0.2.1"
 edition.workspace = true
 description = "Host-side utilities for CUDA kernel development"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/cuda-intrinsics-gen/Cargo.toml
+++ b/crates/cuda-intrinsics-gen/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 publish = false
 description = "Extractor and deterministic source generator for cuda-oxide intrinsics"
+readme = "README.md"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/cuda-intrinsics/Cargo.toml
+++ b/crates/cuda-intrinsics/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Generated low-level CUDA intrinsic declarations for cuda-oxide"
+readme = "README.md"
 
 [lib]
 doctest = false

--- a/crates/cuda-macros/Cargo.toml
+++ b/crates/cuda-macros/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Procedural macros for CUDA kernel development (#[kernel], #[device], etc.)"
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/crates/cuda-oxide-codegen/Cargo.toml
+++ b/crates/cuda-oxide-codegen/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Experimental rustc-independent cuda-oxide PTX backend"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/dialect-iket/Cargo.toml
+++ b/crates/dialect-iket/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Semantic IKET dialect for in-kernel event tracing"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/dialect-mir/Cargo.toml
+++ b/crates/dialect-mir/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MIR dialect for Pliron IR framework (Rust MIR representation)"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/dialect-nvvm/Cargo.toml
+++ b/crates/dialect-nvvm/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "NVVM dialect for Pliron IR framework (NVIDIA GPU intrinsics)"
+readme = "README.md"
 
 [dependencies]
 dialect-mir = { workspace = true }

--- a/crates/fuzzer/Cargo.toml
+++ b/crates/fuzzer/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Differential codegen fuzzer support for cuda-oxide (rustlantis adapter, trace API)"
+readme = "README.md"
 
 # `rustlantis/` is a vendored upstream workspace used as an external program
 # generator. It is invoked via `cargo build` from `tools/mir_generator.py`,

--- a/crates/iket-lower/Cargo.toml
+++ b/crates/iket-lower/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Lowering policy and runtime-compatible encoding for dialect-iket"
+readme = "README.md"
 
 [dependencies]
 dialect-iket = { workspace = true }

--- a/crates/libnvvm-sys/Cargo.toml
+++ b/crates/libnvvm-sys/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Runtime (dlopen) bindings to NVIDIA libNVVM (ships with the CUDA Toolkit)"
+readme = "README.md"
 
 [dependencies]
 libloading = { workspace = true }

--- a/crates/llvm-export/Cargo.toml
+++ b/crates/llvm-export/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Re-exports pliron-llvm and emits the LLVM dialect as textual LLVM IR"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/mir-importer/Cargo.toml
+++ b/crates/mir-importer/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Rust MIR to Pliron IR translation and compilation pipeline"
+readme = "README.md"
 
 [dependencies]
 rustc-hash = { workspace = true }

--- a/crates/mir-lower/Cargo.toml
+++ b/crates/mir-lower/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "dialect-mir to LLVM dialect lowering pass"
+readme = "README.md"
 
 [dependencies]
 rustc-hash = { workspace = true }

--- a/crates/mir-transforms/Cargo.toml
+++ b/crates/mir-transforms/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Optimization passes over the MIR dialect (loop unroll, ...)"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/nvjitlink-sys/Cargo.toml
+++ b/crates/nvjitlink-sys/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Runtime (dlopen) bindings to NVIDIA nvJitLink (ships with the CUDA Toolkit)"
+readme = "README.md"
 
 [dependencies]
 libloading = { workspace = true }

--- a/crates/nvvm-transforms/Cargo.toml
+++ b/crates/nvvm-transforms/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Target-aware LLVM dialect legalization for NVVM"
+readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }

--- a/crates/oxide-artifacts/Cargo.toml
+++ b/crates/oxide-artifacts/Cargo.toml
@@ -3,6 +3,7 @@ name = "oxide-artifacts"
 version = "0.2.1"
 edition.workspace = true
 description = "Architecture-neutral embedded device artifact metadata for cuda-oxide"
+readme = "README.md"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/reserved-oxide-symbols/Cargo.toml
+++ b/crates/reserved-oxide-symbols/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reserved-oxide-symbols"
 version = "0.2.1"
 description = "INTERNAL: cuda-oxide workspace symbol-name contract. Not a public API."
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Nihal Pasham <nihalp@nvidia.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/NVlabs/cuda-oxide.git"
 description = "Unified host/device compilation backend for rustc (CUDA/PTX codegen)"
+readme = "README.md"
 
 # IMPORTANT: Must be dylib for rustc to load as codegen backend
 [lib]


### PR DESCRIPTION
Every workspace crate has had a README since #818, and no manifest pointed at
one. This adds an explicit `readme = "README.md"` key to all twenty-six.

What the key changes: Cargo has auto-inferred a root `README.md` since 1.46,
so crates.io already picked these files up without it (and docs.rs front pages
render the crate docs from `lib.rs`, not the README, either way). What the
explicit key adds is robustness and self-documentation: if a named README is
renamed or deleted, `cargo package` fails loudly instead of silently
publishing a bare page, and tools reading crate metadata get a stated link
rather than an inference. Large workspaces (tokio, serde, clap) write the key
for the same reason.

## Per-crate, not inherited — deliberately

`[workspace.package]` already carries `edition`, `authors`, `license` and
`repository`, and each crate inherits them with `.workspace = true`. `readme`
cannot follow that pattern: Cargo resolves a workspace-level `readme`
**relative to the workspace root**, so inheriting it would point all
twenty-six crates at the top-level README instead of their own. There is no
relative-to-member form, so the key belongs in each manifest — placed next to
`description`, the other per-crate metadata key.

Applied to all twenty-six, including the two `publish = false` crates. The key
is inert there, and a uniform rule is easier to keep than an exception list
that invites the question later.

## Verification

- `cargo metadata --locked` parses; every member reports a readme (as before
  via inference; now stated explicitly);
- every `readme` path points at a file that exists (checked, 0 broken);
- `scripts/check-dependency-licenses.sh`, which reads `cargo metadata`, is
  still green — the one guard this could plausibly have disturbed.

No code, no behaviour change.

*(Maintainer edit: reworded the motivation and first verification bullet — the
original text described READMEs as unreachable without the key, but Cargo
auto-infers a root README.md since 1.46; the key's value is the fail-loud
`cargo package` check and explicitness, not new rendering.)*