### PR TITLE
build(just): let clippy fix mode reach the codegen workspace

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,9 +34,18 @@ clippy:
     # Its own [workspace], so `--workspace` above stops at that boundary.
     cd crates/rustc-codegen-cuda && cargo clippy --all-targets -- -D warnings
 
-# Run clippy and auto-fix warnings
+# Fix mode for the recipe above, and it has to cover the same ground: a warning
+# the gate reports in the codegen backend had no `--fix` pass to answer it,
+# because that crate's own [workspace] puts it outside every root invocation.
+#
+# The root line only changes spelling, to match `clippy` above: target flags are
+# additive and the virtual root workspace has no default-members, so
+# `--all-targets --lib --tests` already selected the same members and targets.
+# Run clippy and auto-fix warnings (root + codegen workspaces)
 clippy-fix:
-    cargo clippy --all-targets --lib --tests --fix --allow-dirty --allow-staged
+    cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged
+    # Its own [workspace], so `--workspace` above stops at that boundary.
+    cd crates/rustc-codegen-cuda && cargo clippy --all-targets --fix --allow-dirty --allow-staged
 
 # Run unit tests for every package CI covers, so `just check` predicts CI.
 # Mirrors .github/workflows/unit-tests.yml; keep the two in step.


### PR DESCRIPTION
The follow-up you offered when #834 landed: *"`clippy-fix` widening left as a follow-up if you want fix mode to reach the codegen workspace too."*

## The gap

#834 gave `clippy` a second pass for `crates/rustc-codegen-cuda`, because that crate carries its own `[workspace]` for the rustc-private dylibs and no root invocation crosses that boundary. `clippy-fix` never got one, so a warning the gate reports there had no `--fix` pass to answer it — the one place where fix mode was both useful and absent.

## The change

Adds the same second pass, spelled the way `clippy` spells it.

The root line only changes spelling: target flags are additive and the virtual root workspace has no default-members, so `--all-targets --lib --tests` already selected the same members and targets. I've said that in the comment rather than repeating the wrong rationale you corrected on #834.

## Verified

- `just clippy-fix` runs both passes and the second reaches `rustc_codegen_cuda` (visible in its output);
- exits 0 on a clean tree and rewrites nothing — `git status` shows only the `Justfile` afterwards;
- `just --list` still renders, and the docstring now says "(root + codegen workspaces)" to match `clippy`.

No GPU needed for any of it.