### PR TITLE
build(just): mirror the generated-intrinsics CI job

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -99,6 +99,27 @@ test-cuda:
         -p cuda-oxide-codegen -p cuda-macros -p cuda-host -p cuda-async
     cargo test -p cuda-core --lib
 
+# Mirror unit-tests.yml's third job, `generated-intrinsics`: the three gates a
+# change under crates/cuda-intrinsics-gen has to pass. Nothing else here ran
+# them, so a catalog edit could clear `just check` and still fail CI -- and the
+# catalog is the majority of the intrinsic surface (986 entries, 35 generated
+# files, against 7 hand-written op modules).
+#
+# Needs no CUDA toolkit: `--skip-terminal` is CI's own flag for runners without
+# the recorded CUDA 13.3 ptxas, leaving the pinned llc identity and the exact
+# emitted PTX as what gets checked, and llc comes from the pinned toolchain.
+# The whole recipe is ~13s.
+#
+# `base_ref` is what the append-only ABI ledger is compared against. CI uses the
+# pull request's base SHA and falls back to `HEAD^` for pushes; `HEAD^` is
+# therefore right for a single-commit branch, and anything longer wants its own
+# branch point -- `just check-intrinsics upstream/main`.
+# Run the generated-intrinsics CI job (catalog, PTX routes, ABI ledger)
+check-intrinsics base_ref="HEAD^":
+    cargo run -p cuda-intrinsics-gen -- check
+    cargo run -p cuda-intrinsics-gen -- probe --all --skip-terminal
+    cargo run -p cuda-intrinsics-gen -- check-abi-history --base-ref {{base_ref}}
+
 # Build docs warning-free + run doctests (mirrors the docs CI gate). The `test`
 # recipe uses `--all-targets`, which skips doctests, so this covers them.
 # cuda-bindings is excluded from doctests (its generated C doc comments are not
@@ -115,12 +136,14 @@ doc-check:
 # `clippy` and `doc-check` already build cuda-bindings, so this recipe needs a
 # CUDA toolkit either way. Machines without even a toolkit get `test`. A driver
 # is no longer required: `test-cuda` shadows the toolkit's libcuda stub itself.
-# `check-guards` covers the status-guard and cargo-deny workflows in full; see
-# its comment for prerequisites. Still CI-only: clippy's per-example pass (one
-# run per example workspace), examples-compile (needs the CUDA codegen
-# backend), the book build, and CodeQL.
+# `check-guards` covers the status-guard and cargo-deny workflows in full, and
+# `check-intrinsics` the generated-intrinsics job; see their comments for
+# prerequisites. Still CI-only: clippy's per-example pass (one run per example
+# workspace), examples-compile (needs the CUDA codegen backend), and CodeQL. The
+# book gate has a local mirror too, but `just book` stays out of `check` as the
+# one gate needing a Python virtualenv.
 # Run CI's gates minus examples-compile, book, CodeQL
-check: fmt-check clippy test test-cuda check-guards doc-check
+check: fmt-check clippy test test-cuda check-guards check-intrinsics doc-check
 
 # Clean project-local Cargo outputs and known cuda-oxide artifacts
 clean-artifacts:


### PR DESCRIPTION
## The gap

`unit-tests.yml` has three jobs. `just test` mirrors the first two; the third, `generated-intrinsics`, had no local mirror and was not disclosed as CI-only either, so the `check` docstring implied coverage it did not have. A catalog edit could pass `just check` and still fail CI.

That matters in proportion to the surface: the generated catalog is **986 entries across 35 generated files**, against 7 hand-written op modules, so it is the majority of the intrinsic surface.

The three gates:

| gate | what it catches |
|---|---|
| `check` | checked-in generated sources drifted from the catalog |
| `probe --all --skip-terminal` | a route no longer lowers to the recorded PTX |
| `check-abi-history --base-ref` | the append-only ABI ledger was rewritten |

## Why they join `check` rather than sit beside it

Measured here: **check 3s, probe 9s, abi-history 1s** — ~13s total, and no CUDA toolkit required. `--skip-terminal` is CI's own flag for runners without the recorded CUDA 13.3 ptxas, which leaves the pinned llc identity and the exact emitted PTX as what gets checked; llc comes from the pinned toolchain (it selected `22.1.2-rust-1.96.0-nightly` here, and the run passes with `CUDA_HOME` unset).

`base_ref` defaults to `HEAD^`, matching CI's own fallback for pushes — right for a single-commit branch, and anything longer wants its own branch point: `just check-intrinsics upstream/main`.

## One correction included

The `check` docstring listed the book build as CI-only, which stopped being true when #836 gave it a local mirror. `just book` is excluded from `check` deliberately — the one gate needing a Python virtualenv — not for want of a recipe. Reworded to say that.

## Verified

- `just check-intrinsics` passes on a clean tree: 986 routes probed, 986 ledger entries preserved;
- the default and an explicit `base_ref` both dry-run correctly (`just -n`);
- `just --list` shows the recipe with its default, and `check` resolves with it in the dependency list.

No GPU needed.