### PR TITLE
ci: stop the error-example status guard passing on an empty read

### DIFF
--- a/scripts/check-error-example-status.sh
+++ b/scripts/check-error-example-status.sh
@@ -43,6 +43,38 @@ collect < <(
 )
 in_smoketest=("${COLLECTED[@]+"${COLLECTED[@]}"}")
 
+# Parse self-test, the way this guard's eight siblings open.
+#
+# Every comparison below iterates one of the three lists, so a list that comes
+# back empty makes the loops over it do nothing and the guard exit 0 with its
+# success message -- reporting that everything is classified while having
+# classified nothing. Each extraction is one `find` pattern or one `sed`
+# expression away from that: rename the example prefix, reflow STATUS.md's
+# table, or wrap `ERROR_EXAMPLES=(` across lines, and the corresponding list
+# silently becomes empty. `set -e` does not help, because the failure is a
+# command substitution producing no output rather than a non-zero status.
+#
+# So require all three to be non-empty and fail loudly, naming the extraction to
+# fix, rather than trusting a clean result from an empty read.
+self_test_failed=0
+check_nonempty() {
+    local count="$1" what="$2" how="$3"
+    if [[ "${count}" -eq 0 ]]; then
+        echo "error: parse self-test failed: found no ${what}" >&2
+        echo "       ${how}" >&2
+        self_test_failed=1
+    fi
+}
+check_nonempty "${#on_disk[@]}" "error* example directories" \
+    "fix the find in this script, or the examples really are all gone"
+check_nonempty "${#in_status[@]}" "names in STATUS.md" \
+    "its table layout changed; fix the sed that reads the first column"
+check_nonempty "${#in_smoketest[@]}" "names in smoketest.sh ERROR_EXAMPLES" \
+    "the array moved or wrapped across lines; that sed needs one line"
+if [[ ${self_test_failed} -ne 0 ]]; then
+    exit 1
+fi
+
 contains() {
     local needle="$1"; shift
     printf '%s\n' "$@" | grep -qx "$needle"
@@ -62,6 +94,12 @@ for ex in "${in_status[@]}"; do
         echo "error: STATUS.md lists '$ex' but no such directory exists" >&2; fail=1
     fi
 done
+
+# No reverse check for the smoketest array here on purpose:
+# check-example-smoketest-contract.sh already rejects a name in any
+# `*_EXAMPLES` array that is not a real example directory, across all thirteen
+# arrays rather than just this one. Repeating it here would give the same
+# condition two owners that can drift apart.
 
 [[ $fail -eq 0 ]] && echo "OK: all error* examples are documented and classified."
 exit $fail

--- a/scripts/check-error-example-status.sh
+++ b/scripts/check-error-example-status.sh
@@ -45,14 +45,17 @@ in_smoketest=("${COLLECTED[@]+"${COLLECTED[@]}"}")
 
 # Parse self-test, the way this guard's eight siblings open.
 #
-# Every comparison below iterates one of the three lists, so a list that comes
-# back empty makes the loops over it do nothing and the guard exit 0 with its
-# success message -- reporting that everything is classified while having
-# classified nothing. Each extraction is one `find` pattern or one `sed`
-# expression away from that: rename the example prefix, reflow STATUS.md's
-# table, or wrap `ERROR_EXAMPLES=(` across lines, and the corresponding list
-# silently becomes empty. `set -e` does not help, because the failure is a
-# command substitution producing no output rather than a non-zero status.
+# An empty on-disk list makes loop 1 vacuous and lets loop 2 pass (the
+# directories it re-checks exist regardless of what the broken `find`
+# returned), so the guard exits 0 with its success message -- reporting that
+# everything is classified while having classified nothing. The same goes for
+# every list coming back empty at once, say after a tree restructure. An empty
+# STATUS.md or ERROR_EXAMPLES read alone did fail before this self-test, but
+# per-example and blaming the wrong side. Each extraction is one `find`
+# pattern or one `sed` expression away from empty: rename the example prefix,
+# reflow STATUS.md's table, or wrap `ERROR_EXAMPLES=(` across lines. `set -e`
+# does not help, because the failure is a command substitution producing no
+# output rather than a non-zero status.
 #
 # So require all three to be non-empty and fail loudly, naming the extraction to
 # fix, rather than trusting a clean result from an empty read.


### PR DESCRIPTION
## The defect

`check-error-example-status.sh` compares three lists: the `error*` directories on disk, the names in `STATUS.md`, and the names in smoketest.sh's `ERROR_EXAMPLES`. Every comparison iterates one of them, so a list that comes back **empty** makes the loops over it do nothing and the script exits 0 with

```
OK: all error* examples are documented and classified.
```

having classified nothing. Changing only the find pattern reproduces it — `error*` to anything matching no directory, with `STATUS.md` and `smoketest.sh` read perfectly well:

```console
$ bash scripts/check-error-example-status.sh
OK: all error* examples are documented and classified.
$ echo $?
0
```

Each list is one expression away from that: the find pattern, the `sed` reading STATUS.md's first column, and the `sed` reading `ERROR_EXAMPLES=(...)` — which needs the array to open and close on **one line**, and it is already 12 entries long. `set -e` does not see any of it, because the failure is a command substitution producing no output rather than a non-zero status.

This is the only one of the nine `check-*.sh` guards without a parse self-test.

## The change

Require all three lists to be non-empty first, each naming the extraction to fix.

## Correction since I opened this

The first version of this PR also added a reverse check for stale names in `ERROR_EXAMPLES`, and claimed that direction was missing. **That was wrong** — `check-example-smoketest-contract.sh` already rejects any name in any `*_EXAMPLES` array that is not a real example directory, across all thirteen arrays, and its message is better than mine:

```console
$ # plant a stale name in ERROR_EXAMPLES, then run the sibling guard
error: smoketest example contract violated
  ERROR_EXAMPLES names 1 example(s) that do not exist: zzz_deleted
```

I have dropped that half and left a comment recording why this script does not take a second owner for the same condition. What remains is only the self-test, which is genuinely absent today.

## Verified by mutation — each exits 1 with the intended message

| mutation | result |
|---|---|
| find pattern matches nothing | `parse self-test failed: found no error* example directories` |
| STATUS.md path/sed reads nothing | `parse self-test failed: found no names in STATUS.md` |
| `ERROR_EXAMPLES` sed matches nothing | `parse self-test failed: found no names in smoketest.sh ERROR_EXAMPLES` |

A clean tree still passes, and the two pre-existing directions (dropping a `STATUS.md` row, dropping an `ERROR_EXAMPLES` entry) still fire. No GPU needed.