### PR TITLE
docs(book): document the two device-debug flags, not just the env override

### DIFF
--- a/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
+++ b/cuda-oxide-book/gpu-programming/error-handling-and-debugging.md
@@ -192,8 +192,8 @@ cuda-oxide has three device debug modes:
 | Mode | How to enable it | What you get | Cost |
 |:-----|:-----------------|:-------------|:-----|
 | Off | default for normal `build` / `run` | Fastest generated PTX, no source mapping | none |
-| Line tables | `cargo oxide debug`, or `CUDA_OXIDE_DEBUG=line-tables` | Source breakpoints, stepping, backtraces | low |
-| Full | `CUDA_OXIDE_DEBUG=full cargo oxide debug <example>` | Line tables plus basic argument/local inspection | higher |
+| Line tables | `--lineinfo`, `cargo oxide debug`, or `CUDA_OXIDE_DEBUG=line-tables` | Source breakpoints, stepping, backtraces | low |
+| Full | `--device-debug`, or `CUDA_OXIDE_DEBUG=full` | Line tables plus basic argument/local inspection | higher |
 
 Think of line tables as a map from machine instructions back to source lines:
 
@@ -267,6 +267,23 @@ The `CUDA_OXIDE_DEBUG` override works with `build`, `run`, `pipeline`, and
 CUDA_OXIDE_DEBUG=line-tables cargo oxide pipeline vecadd
 CUDA_OXIDE_DEBUG=full cargo oxide debug vecadd
 ```
+
+Each mode also has a flag, which is what the environment variable is a shorthand
+for. `--lineinfo` selects line tables and `--device-debug` selects full debug,
+matching `nvcc -lineinfo` and `nvcc -G`; both are accepted by `build`, `run`,
+`pipeline`, `test`, `sanitize`, `inspect`, and `emit-ltoir`:
+
+```bash
+cargo oxide build vecadd --lineinfo
+cargo oxide run vecadd --device-debug        # same as CUDA_OXIDE_DEBUG=full
+```
+
+Two rules settle what happens when they are combined. `--device-debug`
+supersedes `--lineinfo`, so passing both gives full debug. And *omitting* both
+does not mean "off": the flags export `CUDA_OXIDE_DEBUG` for the build only when
+they ask for something, so an absent flag leaves a level the surrounding
+environment already set alone instead of quietly opting out of it. A flag that is
+present does export, and so wins over an inherited value.
 
 Useful aliases:
 


### PR DESCRIPTION
## The gap

The debug-info section of `error-handling-and-debugging.md` reaches all three modes through `CUDA_OXIDE_DEBUG` and `cargo oxide debug`, and never mentions `--lineinfo` or `--device-debug`. That is backwards from how the CLI presents them — their own help text calls the environment variable the alternative:

```
--lineinfo      ... (nvcc `-lineinfo`). Also settable via CUDA_OXIDE_DEBUG=line
--device-debug  ... (nvcc `-G`). Supersedes --lineinfo. Also settable via CUDA_OXIDE_DEBUG=full
```

Seven subcommands take them — `build`, `run`, `pipeline`, `test`, `sanitize`, `inspect`, `emit-ltoir` — and a reader following this page has no way to learn they exist. The adjacent `bounds-checks.md` already documents the analogous pair both ways (`--unchecked-indexing`   # same thing`), so this page is the outlier.

## The change

Adds the flags to the mode table and beside the override, with the two rules that decide a combination:

- `--device-debug` supersedes `--lineinfo` (from `DeviceDebug::from_flags`);
- omitting both is **not** the same as asking for `off`, because `DeviceDebug::Off` deliberately returns `None` from `env_value` rather than exporting `off` — so an absent flag leaves a level the surrounding environment already set alone, while a present flag exports and wins.

I deliberately did not touch the existing sentence listing which subcommands the *env var* works with. The flags' list is directly checkable from `--help`; the env var's is not, and I have not verified it.

## Verified

Empirically on `vecadd`, which is the equivalence the new text claims:

| build | `.loc` | `.file` |
|---|---|---|
| default | 0 | 0 |
| `--lineinfo` | 21 | 2 |
| `CUDA_OXIDE_DEBUG=line-tables` | 21 | 2 |

Flag availability read from `cargo oxide <sub> --help` per subcommand; precedence and the export rule from `DeviceDebug::from_flags` / `env_value`. `just book` builds warning-free (`build succeeded`, exit 0). No GPU needed — compile only.