### PR TITLE
docs(book): document --device-cfg, the only way to gate device code

### DIFF
--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -198,15 +198,30 @@ let total = {
 };
 ```
 
-Three things are worth knowing before reaching for it.
+Four things are worth knowing before reaching for it.
 
 **It is not limited to device code.** The flag travels as a rustflag, so every
 crate cargo compiles for that build sees the `cfg`, host code included.
 
-**It switches `build` and `test` into passthrough mode.** Passing it means the
-invocation no longer takes an example name, so
+**It switches `build` into passthrough mode.** Passing it means `build` no
+longer takes an example name, so
 `cargo oxide build my_example --device-cfg ampere_up` is rejected; run it from
-the crate's own directory instead.
+the crate's own directory instead. (`test` is passthrough already, flag or no
+flag.) If the gate can live in the crate's manifest, an ordinary Cargo feature
+(`#[cfg(feature = "ampere_up")]`) does the same job without giving up
+example-name invocations; `--device-cfg` earns its keep when you need a `cfg`
+injected without touching any Cargo.toml.
+
+**rustc warns about an undeclared `cfg` name.** The `unexpected_cfgs` lint
+checks every `#[cfg(...)]` against the declared set, and an injected
+`--cfg ampere_up` is not in it, so each use prints an
+`unexpected cfg condition name` warning. Declare it in the kernel crate's
+manifest to silence them:
+
+```toml
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ampere_up)"] }
+```
 
 **Nothing ties it to `--arch`.** If the `cfg` name stands for an architecture,
 you are the one keeping the two in step -- passing `--device-cfg ampere_up`

--- a/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
+++ b/cuda-oxide-book/gpu-programming/kernels-and-device-functions.md
@@ -163,6 +163,56 @@ clear error: `"CUDA-OXIDE: FORBIDDEN CRATE IN DEVICE CODE"` with a list of
 allowed crates (`core`, `alloc`, `cuda_device`, and your local crate).
 :::
 
+## Conditional compilation
+
+`#[cfg(...)]` works in device code exactly as it does anywhere else in Rust.
+What is missing is anything to gate *on*: the compiler supplies no
+target-derived `cfg`, so a kernel has no way to ask which architecture it is
+being compiled for. Arch requirements live in doc comments and are enforced by
+the caller, which is why an example that needs `redux.sync` checks
+`ctx.compute_capability()` on the host and skips rather than specializing the
+kernel.
+
+`--device-cfg NAME` is how you supply one yourself. It is repeatable, and each
+occurrence becomes a `--cfg NAME` in the build's rustflags:
+
+```bash
+# From the crate directory, not with an example name -- see below.
+cargo oxide build --device-cfg ampere_up
+```
+
+```rust
+// One instruction where the target allows it, a shuffle tree everywhere else.
+#[cfg(ampere_up)]
+let total = warp::redux_sync_add(u32::MAX, value);
+
+#[cfg(not(ampere_up))]
+let total = {
+    let mut acc = value;
+    let mut offset = 16;
+    while offset > 0 {
+        acc = acc.wrapping_add(warp::shuffle_xor(acc, offset));
+        offset /= 2;
+    }
+    acc
+};
+```
+
+Three things are worth knowing before reaching for it.
+
+**It is not limited to device code.** The flag travels as a rustflag, so every
+crate cargo compiles for that build sees the `cfg`, host code included.
+
+**It switches `build` and `test` into passthrough mode.** Passing it means the
+invocation no longer takes an example name, so
+`cargo oxide build my_example --device-cfg ampere_up` is rejected; run it from
+the crate's own directory instead.
+
+**Nothing ties it to `--arch`.** If the `cfg` name stands for an architecture,
+you are the one keeping the two in step -- passing `--device-cfg ampere_up`
+without the matching `--arch` will happily build the specialized path for
+whatever target was selected, and PTX that the assembler then rejects.
+
 (loop-unrolling)=
 
 ## Loop unrolling


### PR DESCRIPTION
## The gap

`cargo oxide build --help` advertises `--device-cfg`, and the book never mentions it (0 occurrences). That is not a minor omission: it is the **only** mechanism for conditionally compiling device code, because the compiler supplies no target-derived `cfg` and so a kernel cannot ask which architecture it is being built for. Arch requirements live in doc comments and are enforced by the caller — `redux_sum` checks `ctx.compute_capability()` on the host and skips, rather than specializing the kernel.

I found this while fixing its diagnostic in #843.

## The change

A "Conditional compilation" section on the page that already covers the other device-code attributes, with the three things `--help` cannot tell you:

- **It is not device-scoped despite the name.** The flag travels as a rustflag, so every crate cargo compiles for that build sees the `cfg`, host code included.
- **It switches `build` and `test` into passthrough mode**, so it cannot be combined with an example name and has to be run from the crate's own directory. (#843 makes the resulting error say which flag did it.)
- **Nothing ties it to `--arch`.** A `cfg` standing for an architecture is the caller's to keep in step; getting it wrong builds the specialized path for whatever target was selected, and PTX the assembler then rejects.

## Scope

Deliberately not covered: `--device-features`, which reads like a sibling but is applied only in `build_interop_device_crate`, for metadata-declared device crates. That belongs with the interop story, not on this page.

The `### Command reference` section in installation.md is also left alone — it closes with "Every command takes `--help`, which lists the flags each one accepts", so per-flag detail there would fight the file's own approach. This flag earns prose because its behaviour is not visible from `--help`.

## Verified

Both snippets use APIs I checked against the tree — `warp::redux_sync_add(u32::MAX, value)` and a `warp::shuffle_xor` butterfly — and they agree numerically, since wrapping `u32` addition is associative mod 2³² so reduction order cannot change the result.

Worth recording: my first draft used a `FULL_MASK` constant that only exists **locally inside the redux_sum example**, not as a `cuda-device` export, plus a `cooperative_groups::warp_reduce` turbofish I had not checked. A reader pasting either would have hit a name error. Both are gone.

`check-book-api-names.sh` resolves all 34 device calls across the book's 272 Rust blocks; `just book` builds warning-free. No GPU needed.