### PR TITLE
ci: check the device names the book puts in prose and tables

### DIFF
--- a/scripts/check-book-api-names.sh
+++ b/scripts/check-book-api-names.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Verify every device-API call the book shows in a Rust code block resolves to a
-# function `cuda-device` actually exports.
+# Verify every device-API name the book shows resolves to a function
+# `cuda-device` actually exports.
 #
 # The failure this catches is silent and has now happened three times. #797
 # found the intrinsics guide pointing at op files that no longer existed; the
@@ -10,13 +10,25 @@
 # when the book names a function the tree does not have: it renders, it builds,
 # and a reader finds out by pasting it.
 #
-# Scope, chosen so the guard is precise rather than merely broad:
+# Two passes, because the book names APIs two ways:
 #
-#   * Only ```rust fenced blocks. A name in prose may legitimately be a PTX
-#     instruction (`shfl.sync.bfly`), a module path, or a function from another
-#     project; inside a Rust block a `warp::foo(...)` is a call and has to exist.
-#     Restricting to code blocks is what takes this from dozens of false
-#     positives to none.
+#   * A call in a ```rust fenced block -- `warp::foo(...)` -- which a reader
+#     pastes, so the name has to exist.
+#   * A backticked, module-qualified name in prose or a table, with or without a
+#     following `(`. This pass is what #815 needed and the first pass would have
+#     missed: that fix removed one code-block line, `warp::shuffle_xor_i32(...)`,
+#     *and* four table rows written `shuffle_xor_{f32,i32}(val, mask)`. Only the
+#     first is a call.
+#
+# Backticks are what keep the second pass precise. Restricting to code blocks
+# was originally about avoiding matches on a PTX mnemonic (`shfl.sync.bfly`), a
+# module path, or another project's function in running text. A backticked,
+# module-qualified name is a claim about this API wherever it appears, so it is
+# safe to check; unqualified table entries stay out of scope, since deciding
+# which module a bare `shuffle_xor` belongs to is guesswork.
+#
+# Scope otherwise unchanged, so the guard stays precise rather than merely broad:
+#
 #   * Only the device modules -- `warp`, `thread`, `grid`, `cluster`. Those are
 #     the paths the book uses in kernel examples and the ones that rot. Host
 #     APIs are checked by rustdoc, which builds under `-D warnings`.
@@ -64,11 +76,36 @@ CALL = re.compile(
 )
 EXPORTED = re.compile(r"pub (?:unsafe )?fn ([A-Za-z_][A-Za-z0-9_]*)")
 
+# The same qualified names in prose or a table. The brace group deliberately does
+# not require its own leading `_`: the identifier class is greedy and would
+# otherwise swallow the `_` in `threadIdx_{x,y,z}`, leaving `{x,y,z}` unmatched
+# and the truncated `threadIdx_` reported as missing.
+PROSE_NAME = re.compile(
+    r"`(?:cuda_device::)?(warp|thread|grid|cluster)::"
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\{[A-Za-z0-9_,]+\})?)"
+)
+# `name_{a,b,c}` is the book's shorthand for a family, live today in
+# `thread::threadIdx_{x,y,z}()` and the notation that carried #815's fictional
+# rows. Expanded, so a family with one bad member fails on that member instead of
+# passing as an unrecognised literal.
+BRACES = re.compile(r"^(.*)_\{([A-Za-z0-9_,]+)\}$")
+
+
+def expand(name):
+    """`foo_{a,b}` -> [`foo_a`, `foo_b`]; anything else -> [itself]."""
+    match = BRACES.match(name)
+    if not match:
+        return [name]
+    stem, options = match.group(1), match.group(2)
+    return [f"{stem}_{option.strip()}" for option in options.split(",") if option.strip()]
+
+
 pages = sorted(glob.glob(os.path.join(book_root, "**", "*.md"), recursive=True))
 if len(pages) < 20:
     sys.exit(f"parse self-test failed: found {len(pages)} book pages under {book_root}")
 
 calls = {}
+mentions = {}
 blocks = 0
 for page in pages:
     with open(page, encoding="utf-8") as handle:
@@ -78,8 +115,23 @@ for page in pages:
         for match in CALL.finditer(block):
             calls.setdefault((match.group(1), match.group(2)), set()).add(page)
 
+    # Everything outside a fenced block, so each name is counted once by
+    # whichever pass owns it.
+    prose = re.sub(r"```.*?```", "", text, flags=re.S)
+    for match in PROSE_NAME.finditer(prose):
+        for name in expand(match.group(2)):
+            mentions.setdefault((match.group(1), name), set()).add(page)
+
 if blocks < 20:
     sys.exit(f"parse self-test failed: read {blocks} rust code blocks from the book")
+
+# Both passes have to find something, or a rot in either regex reads as a clean
+# book rather than a broken check.
+if len(mentions) < 5:
+    sys.exit(
+        f"parse self-test failed: found {len(mentions)} qualified device names in "
+        "the book's prose and tables"
+    )
 
 exported = set()
 sources = sorted(glob.glob(os.path.join(device_root, "**", "*.rs"), recursive=True))
@@ -96,30 +148,50 @@ if len(exported) < 200:
         f"{len(sources)} files under {device_root}"
     )
 
-missing = sorted(
-    (module, name, sorted(where))
-    for (module, name), where in calls.items()
-    if name not in exported
-)
 
-if missing:
-    print(
-        "error: the book calls device functions that cuda-device does not export:",
-        file=sys.stderr,
+def unresolved(found):
+    return sorted(
+        (module, name, sorted(where))
+        for (module, name), where in found.items()
+        if name not in exported
     )
-    for module, name, where in missing:
+
+
+def report(found, heading, closing):
+    if not found:
+        return False
+    print(heading, file=sys.stderr)
+    for module, name, where in found:
         pages_text = ", ".join(os.path.relpath(p, book_root) for p in where)
         print(f"  {module}::{name}   in {pages_text}", file=sys.stderr)
     print(file=sys.stderr)
-    print(
-        "A Rust code block is something a reader pastes. Either the function was\n"
-        "renamed and the book missed it, or the example was written from memory.",
-        file=sys.stderr,
+    print(closing, file=sys.stderr)
+    return True
+
+
+failed = report(
+    unresolved(calls),
+    "error: the book calls device functions that cuda-device does not export:",
+    "A Rust code block is something a reader pastes. Either the function was\n"
+    "renamed and the book missed it, or the example was written from memory.",
+)
+failed = (
+    report(
+        unresolved(mentions),
+        "error: the book names device functions that cuda-device does not export:",
+        "These are in prose or a table rather than a code block, which is where the\n"
+        "fictional `shuffle_xor_{f32,i32}` rows survived until #815. A `_{a,b}`\n"
+        "family is expanded, so the member named above is the one that is missing.",
     )
+    or failed
+)
+
+if failed:
     sys.exit(1)
 
 print(
-    f"OK: all {len(calls)} device-API calls in the book's {blocks} Rust blocks "
-    f"resolve against cuda-device's {len(exported)} exported functions."
+    f"OK: all {len(calls)} device-API calls in the book's {blocks} Rust blocks, and "
+    f"{len(mentions)} qualified names in its prose and tables, resolve against "
+    f"cuda-device's {len(exported)} exported functions."
 )
 PY


### PR DESCRIPTION
## The gap, with the receipt

#819 reads only ```rust fenced blocks, and said so on purpose: a call is something a reader pastes, while a name in running text might be a PTX mnemonic or another project's function. That scoping left **half of the very bug it was written for** uncovered.

#815 removed two things from the API quick reference:

```diff
-// i32 variants
-let partner_i = warp::shuffle_xor_i32(val, mask);      <- #819 catches this
...
-| `shuffle_xor_{f32,i32}(val, mask)`    | Exchange with lane `id ^ mask`    |
-| `shuffle_down_{f32,i32}(val, delta)`  | Read from lane `id + delta`       |
-| `shuffle_up_{f32,i32}(val, delta)`    | Read from lane `id - delta`       |   <- it does not
-| `shuffle_{f32,i32}(val, src)`         | Read from specific lane           |
```

Only the first is a call. Reinstating one of those table rows today passes the guard.

## The change

A second pass over everything outside a fenced block, restricted to **backticked, module-qualified** names. Backticks are what make it precise: a backticked `warp::foo` is a claim about this API wherever it appears, so the false positives that motivated the code-block-only scope do not arise.

`_{a,b,c}` families are expanded, so a family with one bad member fails on *that member* rather than passing as an unrecognised literal. The notation is live today in `thread::threadIdx_{x,y,z}()`, and it is exactly what carried #815's rows.

## What it still cannot do

Unqualified table entries stay out of scope. #815's rows as literally written (`shuffle_xor_{f32,i32}`, no `warp::`) would need a section-to-module mapping, and inventing one is guesswork — so this catches them only in the qualified form the book now tends to use. I would rather state that limit than imply the hole is fully closed.

## Verified

Passes clean: 34 calls in 271 Rust blocks, 31 qualified names in prose and tables, against cuda-device's 1161 exported functions. Exits 1 under four mutations:

| mutation | reported |
|---|---|
| #815's table row reinstated, qualified | `warp::shuffle_xor_i32` |
| bad axis in the live shorthand | `thread::threadIdx_q` |
| broken call in a code block (pre-existing pass) | `warp::popc_nope` |
| prose regex rotted | `parse self-test failed: found 0 qualified device names` |

Both passes now self-test for a non-empty result, since the new regex is the likelier of the two to break quietly. One implementation note that cost a debug cycle: the brace group must not require its own leading `_`, because the identifier class is greedy and otherwise swallows the `_` in `threadIdx_{x,y,z}`, leaving the truncated `threadIdx_` reported as missing. No GPU needed.