### PR TITLE
docs: propagate the Discord invite update past README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,4 +31,4 @@ What actually happens (error message, wrong output, panic, etc.).
 Attach `.ll` / `.ptx` files if the pipeline produces them before failing.
 
 ---
-> Not sure if this is a bug? Ask in [#help on Discord](https://discord.gg/Fua7DeKnm) first.
+> Not sure if this is a bug? Ask in [#help on Discord](https://discord.gg/ZUEr4AhH5C) first.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,4 +22,4 @@ Any workaround you are currently using and why it falls short.
 Links to PTX ISA spec, CUDA docs, or prior art are very welcome.
 
 ---
-> Want to discuss the design before opening a full issue? Drop by [#contributors on Discord](https://discord.gg/Fua7DeKnm).
+> Want to discuss the design before opening a full issue? Drop by [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ cuda-oxide is licensed under the [Apache License, Version 2.0](LICENSE).
 ## Community
 
 Join the project Discord for questions, design discussions, and announcements:
-**[discord.gg/Fua7DeKnm](https://discord.gg/Fua7DeKnm)**
+**[discord.gg/ZUEr4AhH5C](https://discord.gg/ZUEr4AhH5C)**
 
 If you are unsure whether something is worth a full issue or PR, the Discord
 `#contributors` channel is a good place to ask first.

--- a/cuda-oxide-book/appendix/ecosystem.md
+++ b/cuda-oxide-book/appendix/ecosystem.md
@@ -88,7 +88,7 @@ projects mature, and we expect to keep doing so.
 
 If you're building a Rust + GPU project — or evaluating which of the above
 fits your needs — we're happy to compare notes. Join the community on
-[Discord](https://discord.gg/Fua7DeKnm) for questions, design discussions,
+[Discord](https://discord.gg/ZUEr4AhH5C) for questions, design discussions,
 and announcements, or reach the team via
 [GitHub Discussions](https://github.com/NVlabs/cuda-oxide/discussions)
 or by opening an issue on the repository.


### PR DESCRIPTION
## The defect

`1b4f7e7d` ("docs: update Discord invite") replaced `discord.gg/Fua7DeKnm` with `discord.gg/ZUEr4AhH5C` — and touched **only README.md**:

```console
$ git show 1b4f7e7d --stat
 README.md | 2 +-
```

Six other references kept the superseded link, including the three places a new contributor is most likely to follow one:

| file | context |
|---|---|
| `CONTRIBUTING.md` | the only contact route the file gives |
| `.github/ISSUE_TEMPLATE/bug_report.md` | "Ask in #help on Discord first" |
| `.github/ISSUE_TEMPLATE/feature_request.md` | "discuss the design before opening a full issue" |
| `cuda-oxide-book/appendix/ecosystem.md` | the book's community pointer |

The badge in README.md keeps the same server id (`1515530041767759993`) across that commit, so this is one server with a refreshed invite rather than a move — and the newer link is the one you chose.

## Scope

This updates four of the six. The fifth, `.github/pull_request_template.md`, is handled by a separate PR that also fixes its testing checklist, so **the two changes do not share a file**. After both, no reference to the old invite remains anywhere in the tree.

I have not tested either invite (that would mean joining), so this rests on which one the commit history says is current rather than on a claim that the old one is dead.

`just book` builds warning-free. No GPU needed.