### PR TITLE
docs(github): point the PR template's testing checklist at `just check`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,10 @@
 
 ## Testing
 
-<!-- How did you verify this? Paste relevant `cargo oxide run` / `cargo test` output, or smoketest results. -->
-- [ ] `cargo oxide run <example>` passes
-- [ ] `cargo test --workspace` passes
+<!-- How did you verify this? Paste relevant `cargo oxide run` / `just check`
+output, or smoketest results. -->
+- [ ] `just check` passes (the local mirror of CI: fmt, clippy, tests, guards, docs)
+- [ ] `cargo oxide run <example>` passes, or `scripts/smoketest.sh -o '^<example>$'`
 - [ ] New example added (if applicable)
 
 ## Checklist
@@ -19,4 +20,4 @@
 - [ ] SPDX headers on new source files
 
 ---
-> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/Fua7DeKnm).
+> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).


### PR DESCRIPTION
## The defect

The PR template asks contributors to tick:

```
- [ ] `cargo test --workspace` passes
```

That is not the gate this repo runs, and it quietly covers less than it looks:

1. **It cannot reach `crates/rustc-codegen-cuda`.** That crate carries its own `[workspace]` for the rustc-private dylibs, so it is not a root member — `cargo metadata` lists 25 packages and the backend is not among them — and neither `--workspace` nor `-p` from the root crosses that boundary. CI covers it in a separate job, and the Justfile's `test` recipe says so in a comment.
2. **It skips eight tests.** `oxide-artifacts` has `default = []`; measured on the current tree, `cargo test -p oxide-artifacts --all-targets` runs **14** tests, and `--features object` runs **22** — the ELF emit/extract set.
3. **On a driverless machine the CUDA-linked packages fail to *load*** with `libcuda.so.1`, which reads as a broken checkout rather than a test failure. `just test-cuda` shadows the toolkit's stub under that name, as `unit-tests.yml` does.

`just check` handles all three, and CONTRIBUTING.md has pointed at it since #837 — so the template was the odd one out.

## The change

The checklist now names `just check`, and keeps `cargo oxide run <example>` with the scoped smoketest as an alternative, since that is what actually proves an example (a `cargo check` never links, and a plain `cargo build` in an example dir dies on the artifact anchor).

Also updates the stale Discord invite on the template's last line to the one `1b4f7e7d` chose for README.md. The other five stale references are a **separate PR**, deliberately scoped so the two do not share a file.

No GPU needed.