### PR TITLE
fix(codegen): diagnose a mismatched CUDA_OXIDE_LLVM_LINK, as opt already is

### DIFF
--- a/crates/cuda-oxide-codegen/src/llvm_tools.rs
+++ b/crates/cuda-oxide-codegen/src/llvm_tools.rs
@@ -33,6 +33,15 @@
 //!    every rejected candidate. The experimental API treats requested
 //!    optimization as strict; the legacy rustc path retains its unoptimized
 //!    fallback.
+//!
+//! `llvm-link` follows the same discovery and the same rule for an explicit
+//! override: `CUDA_OXIDE_LLVM_LINK` is respected, with a diagnostic when its
+//! major differs from the chosen `llc`'s. It writes the libdevice-linked module
+//! that `llc` then reads, so it is exposed to the same cross-major hazard as
+//! `opt`. Where it differs: absent any override, no same-major `llvm-link`
+//! resolves to `None` *silently*, because that is not an error -- the backend's
+//! path decision sees IR-level libdevice linking is unavailable and switches to
+//! the NVVM path.
 
 use crate::options::BackendOptions;
 use std::path::Path;
@@ -84,7 +93,7 @@ impl LlvmToolchain {
     pub fn resolve(opts: &BackendOptions) -> Option<Self> {
         let (llc_path, llc_major, llc_from_env) = resolve_llc(opts)?;
 
-        let (opt, diagnostics) = if opts.no_opt {
+        let (opt, mut diagnostics) = if opts.no_opt {
             // Explicit user intent: skip the middle-end, no warning needed.
             (None, Vec::new())
         } else {
@@ -118,6 +127,14 @@ impl LlvmToolchain {
         // for libdevice kernels).
         let llvm_link =
             resolve_sibling_tool("llvm-link", "CUDA_OXIDE_LLVM_LINK", &llc_path, llc_major);
+        if let Some(warning) = llvm_link_mismatch_warning(
+            std::env::var("CUDA_OXIDE_LLVM_LINK").ok().as_deref(),
+            llvm_link.as_ref().and_then(|tool| tool.major),
+            &llc_path,
+            llc_major,
+        ) {
+            diagnostics.push(warning);
+        }
 
         Some(LlvmToolchain {
             llc_path,
@@ -352,6 +369,41 @@ pub(crate) fn resolve_sibling_tool(
     } else {
         candidates.into_iter().next()
     }
+}
+
+/// Warning for an explicit `CUDA_OXIDE_LLVM_LINK` whose LLVM major differs from
+/// the chosen `llc`'s, or `None` when there is nothing to say.
+///
+/// [`resolve_sibling_tool`] returns an explicit override without checking its
+/// major, exactly as [`choose_opt`] returns an explicit `CUDA_OXIDE_OPT` -- but
+/// `choose_opt` warns about the mismatch and this path was silent. The hazard is
+/// the same one this module was written for: `llvm-link` writes the
+/// libdevice-linked module that `llc` then reads, so splitting a major across
+/// those two is precisely the "IR the older tool rejects" case.
+///
+/// `None` whenever the comparison cannot be made -- the variable is unset, the
+/// override was not runnable, or either major is unparseable -- which mirrors
+/// `choose_opt`'s `(Some, Some)` guard rather than guessing.
+pub(crate) fn llvm_link_mismatch_warning(
+    explicit_path: Option<&str>,
+    link_major: Option<u32>,
+    llc_path: &str,
+    llc_major: Option<u32>,
+) -> Option<String> {
+    let path = explicit_path?;
+    let (link_major, llc_major) = (link_major?, llc_major?);
+    if link_major == llc_major {
+        return None;
+    }
+    Some(format!(
+        "warning: LLVM version mismatch between llvm-link and llc:\n\
+         warning:   CUDA_OXIDE_LLVM_LINK = {path} (LLVM {link_major})\n\
+         warning:   llc                  = {llc_path} (LLVM {llc_major})\n\
+         warning: llvm-link writes the libdevice-linked module that llc reads, so mixing\n\
+         warning: majors can produce IR the older tool rejects.\n\
+         warning: proceeding anyway because CUDA_OXIDE_LLVM_LINK is an explicit override;\n\
+         warning: unset it (or point it at an LLVM {llc_major} llvm-link) to fix the mismatch."
+    ))
 }
 
 /// Decision-time capability probe for IR-level libdevice linking.
@@ -590,5 +642,60 @@ mod tests {
         assert_eq!(choice, OptChoice::Skip);
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("/custom/bin/llc (unknown LLVM version)"));
+    }
+    /// The explicit-override warning `choose_opt` has for `CUDA_OXIDE_OPT`, now
+    /// for `CUDA_OXIDE_LLVM_LINK`. Pinned one condition at a time, because the
+    /// silent cases are the point: this must stay quiet whenever the comparison
+    /// cannot actually be made.
+    #[test]
+    fn explicit_llvm_link_major_mismatch_is_reported() {
+        // Nothing set: the discovery path already filters to llc's major.
+        assert_eq!(
+            llvm_link_mismatch_warning(None, Some(21), "/usr/bin/llc-22", Some(22)),
+            None,
+            "an unset override is not an override"
+        );
+
+        // Set and matching.
+        assert_eq!(
+            llvm_link_mismatch_warning(
+                Some("/usr/bin/llvm-link-22"),
+                Some(22),
+                "/usr/bin/llc-22",
+                Some(22)
+            ),
+            None
+        );
+
+        // Set and mismatched: the case that was silent.
+        let warning = llvm_link_mismatch_warning(
+            Some("/usr/bin/llvm-link-21"),
+            Some(21),
+            "/usr/bin/llc-22",
+            Some(22),
+        )
+        .expect("a major mismatch on an explicit override must be reported");
+        assert!(warning.contains("CUDA_OXIDE_LLVM_LINK = /usr/bin/llvm-link-21 (LLVM 21)"));
+        assert!(warning.contains("/usr/bin/llc-22 (LLVM 22)"));
+        // The message has to say why it proceeded, as the opt one does.
+        assert!(warning.contains("explicit override"));
+        assert!(warning.contains("LLVM 22 llvm-link"));
+
+        // Either major unparseable: no comparison is possible, so no claim.
+        assert_eq!(
+            llvm_link_mismatch_warning(
+                Some("/custom/llvm-link"),
+                None,
+                "/usr/bin/llc-22",
+                Some(22)
+            ),
+            None,
+            "an unparseable llvm-link version cannot be shown to mismatch"
+        );
+        assert_eq!(
+            llvm_link_mismatch_warning(Some("/custom/llvm-link"), Some(21), "/custom/llc", None),
+            None,
+            "an unparseable llc version cannot be shown to mismatch"
+        );
     }
 }

--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -628,7 +628,7 @@ the kernel calls into libdevice. Both have their own override:
 
 | Variable | Selects | Discovery when unset |
 | :------- | :------ | :------------------- |
-| `CUDA_OXIDE_LLVM_LINK` | the `llvm-link` binary | the same four steps as `opt` -- beside the chosen `llc`, then the sysroot, then versioned names on `PATH`, filtered to `llc`'s major |
+| `CUDA_OXIDE_LLVM_LINK` | the `llvm-link` binary | the same four steps as `opt` -- beside the chosen `llc`, then the sysroot, then versioned names on `PATH`, filtered to `llc`'s major. When the variable *is* set it is respected as `CUDA_OXIDE_OPT` is, with a diagnostic naming both binaries if its major differs from `llc`'s |
 | `CUDA_OXIDE_LIBDEVICE` | the `libdevice.10.bc` bitcode file; a path that does not exist is skipped silently | `<root>/nvvm/libdevice/libdevice.10.bc` for each of `CUDA_TOOLKIT_PATH`, `CUDA_HOME`, `CUDA_PATH`, `/usr/local/cuda`, `/opt/cuda` |
 
 When either piece is missing, the two paths react differently. An ordinary


### PR DESCRIPTION
## The asymmetry

`llvm_tools.rs` exists because textual IR is not stable across LLVM majors, and it warns loudly when an explicit `CUDA_OXIDE_OPT` disagrees with the chosen `llc`:

```
warning: LLVM version mismatch between opt and llc:
warning:   CUDA_OXIDE_OPT = ... (LLVM 22)
warning:   llc            = ... (LLVM 21)
warning: mixing majors can produce IR the older tool rejects ...
```

`CUDA_OXIDE_LLVM_LINK` had no such warning. `resolve_sibling_tool` returns an explicit override straight from `probe_runnable`, before any major comparison:

```rust
if let Ok(path) = std::env::var(env_var) {
    return probe_runnable(&path);          // no major check, no diagnostic
}
```

Its own docstring says *"Explicit env var (always used if set)"* one line below *"matched to the same LLVM major"* — the env path is where those two statements disagree, and it is silent.

The hazard is not a lesser one than opt's: `llvm-link` writes the libdevice-linked module that `llc` then reads, so a major split across that pair is exactly the "IR the older tool rejects" case. The book already describes this variable as taking "the same four steps as `opt`".

## The change

Adds the missing diagnostic, worded like opt's and naming both binaries. **Nothing is rejected** — an explicit override stays an override, matching how opt treats one.

Silent by design wherever the comparison cannot be made — variable unset, override not runnable, or either major unparseable — mirroring `choose_opt`'s `(Some, Some)` guard rather than guessing. And absent any override, no same-major `llvm-link` still resolves to `None` silently, because that is *not* an error: the backend's path decision switches to NVVM.

## Verified

The decision is a pure function, so it tests without touching the environment or probing binaries. Six cases pinned one condition at a time, and mutation-tested both ways:

| mutation | result |
|---|---|
| predicate made always silent | `panicked: a major mismatch on an explicit override must be reported` |
| predicate made to warn on a matching pair | `FAILED` |

`cargo test -p cuda-oxide-codegen --lib` 170 pass, `cargo fmt --check`, `clippy -D warnings`, and rustdoc under `-D warnings` all clean; `just book` builds warning-free.

Also updates the module docstring and the book's override table, which described the unset case correctly and said nothing about the set one. No GPU needed.