### PR TITLE
docs(book): document constant memory, which the book never mentioned

### DIFF
--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -41,10 +41,13 @@ fn helper(x: f32) -> f32 { x * x }
 
 | Attribute                                   | Purpose                                                             |
 |:--------------------------------------------|:--------------------------------------------------------------------|
+| `#[cuda_module]`                            | Collect a module's kernels into a typed host module with a `load` and launchers |
 | `#[kernel]`                                 | Mark a function as a GPU kernel entry point (`.entry` in PTX)       |
 | `#[device]`                                 | Mark a helper function or `extern "C"` block for device compilation |
 | `#[unroll]` / `#[unroll(N)]`               | Request full unrolling, or unrolling by a factor `N >= 2`            |
 | `#[launch_bounds(max_threads, min_blocks)]` | Occupancy hints for register allocation                             |
+| `#[constant]`                               | Place a `ConstantMemory<T>` static in constant memory, with a host `set_<name>` |
+| `#[launch_contract(...)]`                   | Declare the launch shape a kernel requires, unlocking a safe (non-`unsafe`) launch |
 | `#[cluster_launch(x, y, z)]`                | Set compile-time cluster dimensions (Hopper+)                       |
 | `#[cooperative_launch]`                     | Launch cooperatively via `#[cuda_module]` (enables `grid::sync()`)  |
 | `#[convergent]`                             | Mark as convergent (barrier semantics)                              |

--- a/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
+++ b/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
@@ -411,9 +411,10 @@ mod kernels {
 }
 ```
 
-The macro generates a host setter per constant, named `set_` plus the static's
-name in snake case, so `SCALE` becomes `set_scale` and `TABLE_CONST` becomes
-`set_table_const`:
+The macro generates two host setters per constant, named `set_` plus the
+static's name lowercased, so `SCALE` becomes `set_scale` and `TABLE_CONST`
+becomes `set_table_const`. The plain form is stream-ordered; a
+`set_<name>_blocking` sibling does a synchronous one-shot copy instead:
 
 ```rust
 let module = kernels::load(&ctx)?;
@@ -439,7 +440,9 @@ the storage instead, so the index stays in constant space and the read is a
 single `ld.const`.
 
 The `constant_memory_table` example measures both against the third option, a
-plain `const T: [f32; N]` materialized as an immutable device global:
+plain `const T: [f32; N]` materialized as an immutable device global. Measured
+on an A10G (sm_86), 256-entry `f32` table, 64 dependent lookups per thread
+over 8388608 threads, all variants bit-identical:
 
 | index        | `get()` | `get_ref()` | `const [f32; N]` (global) |
 |:-------------|--------:|------------:|--------------------------:|

--- a/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
+++ b/cuda-oxide-book/gpu-programming/memory-and-data-movement.md
@@ -20,6 +20,7 @@ latency, and scope:
 | **Registers**              | Per thread  | ~255 × 32-bit                | 0 cycles         | Local variables                      |
 | **Shared memory**          | Per block   | 48--228 KB (arch-dependent)  | ~5 cycles        | `SharedArray`, `DynamicSharedArray`  |
 | **L1 cache**               | Per SM      | Combined with shared         | Hardware-managed | Automatic                            |
+| **Constant memory**        | All threads | 64 KB, read-only on device   | Broadcast-cached | `ConstantMemory` via `#[constant]`   |
 | **L2 cache**               | Chip-wide   | Up to 50 MB (Hopper)         | ~30 cycles       | Automatic                            |
 | **Global memory (DRAM)**   | All threads | 16--80 GB (HBM)              | ~400 cycles      | `DeviceBuffer`, `DeviceBox`          |
 
@@ -378,6 +379,89 @@ Multiple dynamic arrays can share the same allocation by using
 :::{seealso}
 [CUDA Programming Guide -- Shared Memory](https://docs.nvidia.com/cuda/cuda-programming-guide/#shared-memory)
 for details on bank conflicts, broadcasting, and optimal access patterns.
+:::
+
+## Constant memory -- `#[constant]`
+
+Constant memory is a small, read-only window the host writes between launches
+and every thread in the grid reads. It is served by a cache built for
+**broadcast**: when all lanes of a warp want the same address it is one
+transaction, and when they want different addresses those are served in
+sequence.
+
+Declare it as a `static` inside a `#[cuda_module]`:
+
+```rust
+#[cuda_module]
+mod kernels {
+    use cuda_device::{ConstantMemory, DisjointSlice, constant, kernel, thread};
+
+    #[constant]
+    static SCALE: ConstantMemory<f32> = ConstantMemory::UNINIT;
+
+    #[kernel]
+    pub fn multiply(mut out: DisjointSlice<f32>) {
+        let s = SCALE.get();
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if let Some(e) = out.get_mut(idx) {
+            *e = (i as f32) * s;
+        }
+    }
+}
+```
+
+The macro generates a host setter per constant, named `set_` plus the static's
+name in snake case, so `SCALE` becomes `set_scale` and `TABLE_CONST` becomes
+`set_table_const`:
+
+```rust
+let module = kernels::load(&ctx)?;
+module.set_scale(&stream, &3.0)?;
+```
+
+`ConstantMemory<T>` accepts `T: ConstantMemoryValue`, an unsafe marker
+implemented for the primitive integers and floats, `*const T` / `*mut T`,
+tuples up to eight elements, and arrays of those. The requirement it encodes is
+that an all-zero bit pattern is a valid `T`, since `ConstantMemory::UNINIT`
+starts out zeroed -- which is why references and `NonZero*` types are excluded,
+and why a custom struct needs an explicit `#[repr(C)]` layout before opting in.
+
+### `get()` versus `get_ref()`
+
+This is the one thing worth knowing before using it for anything but a scalar.
+
+`get()` returns a by-value copy. A value has no address, so indexing a
+`ConstantMemory<[f32; N]>` copy at a runtime index forces the whole array to be
+spilled to the thread's local depot first -- one store per element, in *every*
+thread -- and the lookup then reads thread-private memory. `get_ref()` borrows
+the storage instead, so the index stays in constant space and the read is a
+single `ld.const`.
+
+The `constant_memory_table` example measures both against the third option, a
+plain `const T: [f32; N]` materialized as an immutable device global:
+
+| index        | `get()` | `get_ref()` | `const [f32; N]` (global) |
+|:-------------|--------:|------------:|--------------------------:|
+| divergent    | 16048us |      7616us |                 **322us** |
+| warp-uniform | 16065us |   **258us** |                     322us |
+
+Two conclusions. `get_ref` is worth 2.1x over `get` on a divergent index and
+62x on a warp-uniform one, so prefer it for anything larger than a scalar. And
+constant memory is not simply "faster memory": on a divergent index it is 23.7x
+*behind* an ordinary array constant, because a warp's divergent reads of a small
+table coalesce and stay resident in L1 while the constant cache serves the
+distinct addresses in sequence. Reach for `#[constant]` when the index is
+warp-uniform; reach for a plain `const` array when it is not.
+
+Reads are not folded away across launches: the `UnsafeCell` interior keeps the
+storage mutable as far as the compiler is concerned, so a `set_<name>` between
+launches stays visible. Repeated reads of one entry *within* a launch may still
+be merged, which is sound, because the host only writes between launches.
+
+:::{seealso}
+[CUDA Programming Guide -- `__constant__`](https://docs.nvidia.com/cuda/cuda-programming-guide/#constant)
+for the hardware limits and caching rules this maps onto.
 :::
 
 ## Unified memory and HMM


### PR DESCRIPTION
## The gap

The book had **no coverage of constant memory at all**. Across every page:

```console
$ grep -rc '#\[constant\]' cuda-oxide-book/     # 0
$ grep -rc 'ConstantMemory'  cuda-oxide-book/   # 0
$ grep -rci 'constant memory' cuda-oxide-book/  # 0
```

Meanwhile the tree ships the `#[constant]` attribute macro, the `ConstantMemory<T>` wrapper, a generated host setter per constant, and four examples (`constant_memory`, `_simple`, `_coeffs`, `_table`). The memory-hierarchy table listed registers, shared, L1, L2 and global — and skipped the tier in between.

## The change

A section in the memory chapter plus the missing hierarchy row, covering what a reader cannot get from `--help` or a rustdoc page they do not know to open:

- declaration inside `#[cuda_module]`, and the generated setter's naming — `SCALE` → `set_scale`, `TABLE_CONST` → `set_table_const`;
- what `ConstantMemoryValue` admits, **and why**: the all-zero bit pattern must be a valid `T` because `UNINIT` starts zeroed, which is what excludes references and `NonZero*` and makes `#[repr(C)]` a precondition for custom structs;
- **`get()` vs `get_ref()`**, the trap worth writing down. `get()` hands back a value, and a value indexed at runtime spills the whole array to the thread's local depot first — one store per element, in every thread — while `get_ref()` keeps the read in constant space as a single `ld.const`;
- the measurement `constant_memory_table` already carries, including the part that makes constant memory a *choice* rather than an upgrade:

| index | `get()` | `get_ref()` | `const [f32; N]` (global) |
|:--|--:|--:|--:|
| divergent | 16048us | 7616us | **322us** |
| warp-uniform | 16065us | **258us** | 322us |

On a divergent index constant memory is **23.7x behind** a plain array constant, because a warp's divergent reads of a small table coalesce and stay in L1 while the constant cache serves distinct addresses in sequence.

## Also: the attribute table was incomplete

The API quick reference listed 9 of the 11 `#[proc_macro_attribute]` macros. `#[constant]` appeared **nowhere on the page**; `#[cuda_module]` and `#[launch_contract]` only inside another row's prose. The table now matches `cuda-macros`' attribute set exactly, plus `#[unroll]`, which is a statement attribute rather than a proc-macro one:

```
real   : 11  [cluster_launch constant convergent cooperative_launch cuda_module
              device kernel launch_bounds launch_contract pure readonly]
missing: []
```

## Verified

Every claim checked against the tree, not from memory: setter naming and both read paths against the examples, the trait bounds against `constant.rs`, and the numbers against `ConstantMemory::get_ref`'s own rustdoc table. `check-book-api-names.sh` passes and `just book` builds warning-free. No GPU needed.