### PR TITLE
test(codegen): cover drop suppression and MaybeUninit lifecycle

### DIFF
--- a/crates/rustc-codegen-cuda/examples/drop_glue/README.md
+++ b/crates/rustc-codegen-cuda/examples/drop_glue/README.md
@@ -1,30 +1,73 @@
 # drop_glue
 
-Positive test: verifies that device-side drop glue compiles and
-executes correctly.
+Positive device-side conformance test for drop execution and suppression
+semantics.
 
 ## What this tests
 
 rustc emits `TerminatorKind::Drop` for places whose type has drop glue
 (non-`Copy` types with an `impl Drop`, recursively through fields and
-parameters). cuda-oxide now translates these drops into device-side
+parameters). cuda-oxide translates effectful drops into device-side
 `drop_in_place` calls so destructors run on the GPU.
 
-This example owns a `DropMarker` whose `Drop::drop` writes `0xDEADBEEF`
-through a captured pointer. The host verifies the sentinel was written,
-confirming that the destructor executed on the device.
+The historical regression remains intact: a `DropMarker` writes
+`0xDEADBEEF` through a captured pointer when it leaves scope, and the host
+verifies that this happens for all 256 threads.
+
+The example also covers the core initialization/drop wrappers that either
+suppress or explicitly trigger destruction:
+
+- ordinary scope exit runs `Drop`;
+- `ManuallyDrop::new` suppresses automatic destruction;
+- `ManuallyDrop::drop` explicitly runs the contained destructor;
+- `mem::forget` consumes a value without running `Drop`;
+- dropping `MaybeUninit<T>` does not drop an initialized `T`;
+- `MaybeUninit::write` followed by `assume_init_drop` explicitly drops `T`;
+- `MaybeUninit::assume_init_read` produces an owned `T` that subsequently
+  follows normal drop semantics.
+
+The focused kernel uses a `DropMarker` whose destructor writes
+`0xDEADBEEF`. Each lane starts with a distinct value, allowing the host to
+distinguish a destructor that ran from one that was correctly suppressed.
+
+## Coverage matrix
+
+| Lane | Operation | Expected result |
+| --- | --- | --- |
+| 0 | ordinary scope exit | `0xDEADBEEF` |
+| 1 | `ManuallyDrop::new` | `0x22220000` |
+| 2 | `ManuallyDrop::drop` | `0xDEADBEEF` |
+| 3 | `mem::forget` | `0x44440000` |
+| 4 | `MaybeUninit::new` leaving scope | `0x55550000` |
+| 5 | `MaybeUninit::write` + `assume_init_drop` | `0xDEADBEEF` |
+| 6 | `MaybeUninit::assume_init_read` | `0xDEADBEEF` |
 
 ## Usage
+
+Optimized:
 
 ```bash
 cargo oxide run drop_glue
 ```
 
+Low MIR optimization:
+
+```bash
+CUDA_OXIDE_NO_OPT=1 cargo oxide run drop_glue
+```
+
 ## Expected output
 
-The build succeeds and the kernel writes `0xDEADBEEF` into every output
-element via drop glue:
+```text
+=== drop_glue ===
 
-```
 SUCCESS: drop glue wrote sentinel in all 256 elements
+PASS: ordinary scope exit runs drop glue
+PASS: ManuallyDrop suppresses automatic drop
+PASS: ManuallyDrop::drop runs drop glue
+PASS: mem::forget suppresses drop
+PASS: MaybeUninit suppresses contained drop
+PASS: MaybeUninit::assume_init_drop runs drop glue
+PASS: MaybeUninit::assume_init_read preserves inhabited drop path
+PASS: initialization/drop conformance
 ```

--- a/crates/rustc-codegen-cuda/examples/drop_glue/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/drop_glue/src/main.rs
@@ -3,20 +3,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Positive test: device-side drop glue.
+//! Positive test: device-side drop execution and suppression semantics.
 //!
-//! Verifies that types with `impl Drop` compile and execute correctly on
-//! the device. A `DropMarker` writes a sentinel through a captured pointer
-//! when it goes out of scope; the host checks the sentinel after launch.
+//! Verifies ordinary device-side drop glue together with core wrappers that
+//! intentionally suppress or explicitly trigger destruction:
+//!
+//! - `ManuallyDrop::new`
+//! - `ManuallyDrop::drop`
+//! - `mem::forget`
+//! - `MaybeUninit::new`
+//! - `MaybeUninit::write` + `assume_init_drop`
+//! - `MaybeUninit::assume_init_read`
 //!
 //! Usage:
 //!   cargo oxide run drop_glue
 //!
-//! Expected: build succeeds, kernel writes 0xDEADBEEF via drop glue.
+//! Expected: all drop execution and suppression checks pass.
+
+use core::mem::{ManuallyDrop, MaybeUninit};
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, kernel, thread};
 use cuda_host::cuda_module;
+
+const DROP_SENTINEL: u32 = 0xDEAD_BEEF;
 
 pub struct DropMarker {
     target: *mut u32,
@@ -25,7 +35,7 @@ pub struct DropMarker {
 impl Drop for DropMarker {
     fn drop(&mut self) {
         unsafe {
-            self.target.write(0xDEAD_BEEFu32);
+            self.target.write(DROP_SENTINEL);
         }
     }
 }
@@ -42,7 +52,67 @@ mod kernels {
             let _m = DropMarker {
                 target: slot as *mut u32,
             };
-            // _m drops at end of scope; expected to write 0xDEADBEEF.
+            // `_m` drops at end of scope and writes `DROP_SENTINEL`.
+        }
+    }
+
+    #[kernel]
+    pub fn drop_control_kernel(mut out: DisjointSlice<u32>) {
+        if thread::index_1d().get() != 0 {
+            return;
+        }
+
+        unsafe {
+            // SAFETY: the host launches exactly one active thread and supplies
+            // a seven-element output allocation owned by this thread.
+            let out_ptr = out.as_mut_ptr();
+
+            // Lane 0: ordinary scope exit runs drop glue.
+            let slot = out_ptr.add(0);
+            slot.write(0x1111_0000);
+            {
+                let _marker = DropMarker { target: slot };
+            }
+
+            // Lane 1: ManuallyDrop suppresses automatic drop glue.
+            let slot = out_ptr.add(1);
+            slot.write(0x2222_0000);
+            {
+                let _marker = ManuallyDrop::new(DropMarker { target: slot });
+            }
+
+            // Lane 2: ManuallyDrop::drop explicitly runs drop glue.
+            let slot = out_ptr.add(2);
+            slot.write(0x3333_0000);
+            let mut marker = ManuallyDrop::new(DropMarker { target: slot });
+            ManuallyDrop::drop(&mut marker);
+
+            // Lane 3: mem::forget consumes the value without running Drop.
+            let slot = out_ptr.add(3);
+            slot.write(0x4444_0000);
+            core::mem::forget(DropMarker { target: slot });
+
+            // Lane 4: dropping an initialized MaybeUninit<T> does not drop T.
+            let slot = out_ptr.add(4);
+            slot.write(0x5555_0000);
+            {
+                let _marker = MaybeUninit::new(DropMarker { target: slot });
+            }
+
+            // Lane 5: initialize through MaybeUninit and explicitly drop T.
+            let slot = out_ptr.add(5);
+            slot.write(0x6666_0000);
+            let mut marker = MaybeUninit::<DropMarker>::uninit();
+            marker.write(DropMarker { target: slot });
+            marker.assume_init_drop();
+
+            // Lane 6: assume_init_read returns an owned T that drops normally.
+            let slot = out_ptr.add(6);
+            slot.write(0x7777_0000);
+            {
+                let marker = MaybeUninit::new(DropMarker { target: slot });
+                let _owned = marker.assume_init_read();
+            }
         }
     }
 }
@@ -54,6 +124,7 @@ fn main() {
     let stream = ctx.default_stream();
     let module = kernels::load(&ctx).expect("load module");
 
+    // Historical regression: ordinary device-side Drop over many threads.
     const N: usize = 256;
     let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N).unwrap();
 
@@ -68,11 +139,11 @@ fn main() {
 
     let mut errors = 0usize;
     for (i, &val) in out.iter().enumerate() {
-        if val != 0xDEAD_BEEF {
+        if val != DROP_SENTINEL {
             if errors < 5 {
                 eprintln!(
-                    "  FAIL drop_glue[{}]: got {:#010X} expected 0xDEADBEEF",
-                    i, val
+                    "  FAIL drop_glue[{}]: got {:#010X} expected {:#010X}",
+                    i, val, DROP_SENTINEL
                 );
             }
             errors += 1;
@@ -85,4 +156,47 @@ fn main() {
         eprintln!("FAIL: {} errors", errors);
         std::process::exit(1);
     }
+
+    // Focused initialization/drop conformance matrix.
+    let mut controls_dev = DeviceBuffer::<u32>::zeroed(&stream, 7).unwrap();
+
+    // SAFETY: exactly one thread owns the seven-element output allocation.
+    unsafe {
+        module
+            .drop_control_kernel(&stream, LaunchConfig::for_num_elems(1), &mut controls_dev)
+            .expect("drop_control_kernel launch");
+    }
+
+    let got = controls_dev.to_host_vec(&stream).unwrap();
+    let expected = [
+        DROP_SENTINEL,
+        0x2222_0000,
+        DROP_SENTINEL,
+        0x4444_0000,
+        0x5555_0000,
+        DROP_SENTINEL,
+        DROP_SENTINEL,
+    ];
+
+    if got.as_slice() != expected {
+        eprintln!("FAIL: initialization/drop conformance mismatch");
+        for (i, (&actual, &wanted)) in got.iter().zip(expected.iter()).enumerate() {
+            if actual != wanted {
+                eprintln!(
+                    "  lane {}: got {:#010X} expected {:#010X}",
+                    i, actual, wanted
+                );
+            }
+        }
+        std::process::exit(1);
+    }
+
+    println!("PASS: ordinary scope exit runs drop glue");
+    println!("PASS: ManuallyDrop suppresses automatic drop");
+    println!("PASS: ManuallyDrop::drop runs drop glue");
+    println!("PASS: mem::forget suppresses drop");
+    println!("PASS: MaybeUninit suppresses contained drop");
+    println!("PASS: MaybeUninit::assume_init_drop runs drop glue");
+    println!("PASS: MaybeUninit::assume_init_read preserves inhabited drop path");
+    println!("PASS: initialization/drop conformance");
 }


### PR DESCRIPTION
Closes #851

## Summary

Extend the existing `drop_glue` device regression with direct conformance coverage for Rust initialization and drop-suppression semantics involving:

- `ManuallyDrop`
- `mem::forget`
- `MaybeUninit`
- ordinary and explicit drop glue

The required compiler infrastructure is already present, so this PR adds regression coverage only.

No compiler code is changed.

## What changed

The historical `drop_glue` regression remains intact: 256 device threads each create a `DropMarker` whose destructor writes `0xDEADBEEF`, and the host verifies that all destructors execute.

A second focused kernel adds a seven-lane execution/suppression matrix.

### Ordinary drop

A normal `DropMarker` leaves scope and must execute its destructor.

Expected:

```text
0xDEADBEEF
```

### `ManuallyDrop::new`

A `DropMarker` wrapped in `ManuallyDrop` leaves scope without an explicit drop.

Expected:

```text
0x22220000
```

The unchanged value verifies that automatic destruction was suppressed.

### `ManuallyDrop::drop`

The contained `DropMarker` is explicitly destroyed with:

```rust
ManuallyDrop::drop(&mut marker)
```

Expected:

```text
0xDEADBEEF
```

This exercises the explicit `drop_in_place` path used by `ManuallyDrop::drop`.

### `mem::forget`

A `DropMarker` is consumed by:

```rust
core::mem::forget(...)
```

Expected:

```text
0x44440000
```

The unchanged value verifies that `Drop` was suppressed.

### `MaybeUninit::new`

An initialized:

```rust
MaybeUninit<DropMarker>
```

leaves scope without extracting or explicitly dropping the contained value.

Expected:

```text
0x55550000
```

This verifies that destroying the `MaybeUninit` wrapper does not destroy its initialized payload.

### `MaybeUninit::assume_init_drop`

A `MaybeUninit<DropMarker>` is created with `uninit()`, initialized with `write()`, and explicitly destroyed with:

```rust
assume_init_drop()
```

Expected:

```text
0xDEADBEEF
```

This covers initialized union storage followed by explicit drop glue.

### `MaybeUninit::assume_init_read`

An initialized `MaybeUninit<DropMarker>` is read with:

```rust
assume_init_read()
```

The returned owned `DropMarker` then leaves scope normally.

Expected:

```text
0xDEADBEEF
```

This exercises the valid inhabitedness/read path followed by ordinary drop glue.

## Coverage matrix

```text
ordinary scope exit                    -> drop runs
ManuallyDrop::new                      -> drop suppressed
ManuallyDrop::drop                     -> drop runs
mem::forget                            -> drop suppressed
MaybeUninit::new                       -> contained drop suppressed
MaybeUninit::assume_init_drop          -> drop runs
MaybeUninit::assume_init_read          -> returned value drops normally
```

## Existing coverage retained

This PR does not duplicate the broader initialization/drop regressions already present in the repository.

Existing examples remain responsible for:

```text
uninit_const
  MaybeUninit::uninit
  MaybeUninit::write
  MaybeUninit::assume_init
  fully-uninitialized constant handling

assume_init_uninhabited_trap
  assert_inhabited
  uninhabited MaybeUninit trap semantics

union_aggregate
  general union representation and lowering
```

## Files

Modified:

```text
crates/rustc-codegen-cuda/examples/drop_glue/README.md
crates/rustc-codegen-cuda/examples/drop_glue/src/main.rs
```

No files are added.

No changes are made to:

```text
mir-importer
mir-lower
dialect-mir
rustc-codegen-cuda compiler infrastructure
smoketest infrastructure
Rustlantis
```

## Validation

Validated on an NVIDIA GeForce RTX 5060 Laptop GPU (`sm_120a`).

Optimized execution:

```bash
cargo oxide run drop_glue
```

Low-MIR-optimization execution:

```bash
CUDA_OXIDE_NO_OPT=1 cargo oxide run drop_glue
```

Both pass with:

```text
SUCCESS: drop glue wrote sentinel in all 256 elements
PASS: ordinary scope exit runs drop glue
PASS: ManuallyDrop suppresses automatic drop
PASS: ManuallyDrop::drop runs drop glue
PASS: mem::forget suppresses drop
PASS: MaybeUninit suppresses contained drop
PASS: MaybeUninit::assume_init_drop runs drop glue
PASS: MaybeUninit::assume_init_read preserves inhabited drop path
PASS: initialization/drop conformance
```

Existing initialization/drop baselines were also validated in both optimized and low-MIR-optimization modes:

```text
uninit_const                         PASS
assume_init_uninhabited_trap         PASS
union_aggregate                      PASS
```

Scoped runtime smoketest:

```text
[ 1/ 4] assume_init_uninhabited_trap ... PASS
[ 2/ 4] drop_glue                    ... PASS
[ 3/ 4] uninit_const                 ... PASS
[ 4/ 4] union_aggregate              ... PASS

Pass: 4 / 4
Fail: 0 / 4
```

Scoped compile-only smoketest:

```text
[ 1/ 4] assume_init_uninhabited_trap ... PASS (compiled)
[ 2/ 4] drop_glue                    ... PASS (compiled)
[ 3/ 4] uninit_const                 ... PASS (compiled)
[ 4/ 4] union_aggregate              ... PASS (compiled)

Pass: 4 / 4
Fail: 0 / 4
```

Example hygiene:

```bash
(
  cd crates/rustc-codegen-cuda/examples/drop_glue
  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
)
```

Repository hygiene:

```bash
cargo fmt --all -- --check
git diff --check
```

All checks pass cleanly.
