### PR TITLE
feat(mir-importer): support bare struct array constants

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -11502,11 +11502,14 @@ mod pointer_array_constant_type_tests {
         );
 
         // Widening the shared predicate to tuples deliberately widens this form
-        // too: the doc contract on `promotable_array_element` is that `TABLE[i]`
-        // and `(&TABLE)[i]` cannot drift apart. Nothing here enumerates fields --
-        // the initializer is rustc's evaluated byte image and the size-agreement
-        // check rejects any layout the dialect reproduces differently -- so a
-        // tuple element travels this path exactly as a scalar does.
+        // too: `promotable_array_element` still gates both the value form's
+        // promotion and this reference form, and only bare-value *admission*
+        // is wider now (a struct table falls back to element-wise
+        // materialization, which this form does not have). Nothing here
+        // enumerates fields -- the initializer is rustc's evaluated byte image
+        // and the size-agreement check rejects any layout the dialect
+        // reproduces differently -- so a tuple element travels this path
+        // the same way a scalar does.
         let tuple_ty: TypeHandle = MirTupleType::get(&mut ctx, vec![u32_ty]).into();
         let tuple_array: TypeHandle = MirArrayType::get(&mut ctx, tuple_ty, 2).into();
         assert!(

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -6246,12 +6246,12 @@ pub(crate) fn emit_promoted_immutable_global(
 /// Whether an array's elements are cheap enough to be worth promoting the whole
 /// array to an immutable global and copying it in.
 ///
-/// This is the one element gate for both promoted-constant paths: the bare
-/// array value form ([`translate_array_constant_into_alloca`]) and the
-/// pointer-to-array form ([`translate_ptr_to_array_constant`], via
-/// [`validate_ptr_to_array_constant_type`]). `TABLE[i]` and `(&TABLE)[i]` must
-/// agree on what an admissible element is, so both paths ask here and cannot
-/// drift apart.
+/// This is the element gate for the immutable-global promotion optimization
+/// used by bare array values ([`translate_array_constant_into_alloca`]) and for
+/// the pointer-to-array form ([`translate_ptr_to_array_constant`], via
+/// [`validate_ptr_to_array_constant_type`]). It is deliberately narrower than
+/// bare-array value admission: an unpromotable bare value can fall back to
+/// element-wise materialization, while a pointer-to-array constant cannot.
 ///
 /// Admits primitive scalars, enums carrying no payload, tuples whose every field
 /// is itself admissible, and nested arrays of any of those. `ty` is the array
@@ -6268,11 +6268,12 @@ pub(crate) fn emit_promoted_immutable_global(
 /// read addressed in place, the promotion is what removes the depot — the two
 /// only pay off together.
 ///
-/// Structs stay out because the element-wise path does not build arrays of them
-/// either, so there would be nothing to fall back to. A payload-carrying enum
-/// stays out because reading one back still round-trips the payload through
-/// memory: the address walker resolves enum payload fields for writes, not for
-/// reads.
+/// Structs remain outside immutable-global promotion in this change. Bare
+/// struct arrays have an element-wise fallback, but widening this predicate
+/// would also widen the pointer-to-array form, which is a separate change. A
+/// payload-carrying enum stays out because reading one back still round-trips
+/// the payload through memory: the address walker resolves enum payload fields
+/// for writes, not for reads.
 fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
     use dialect_mir::types::{MirArrayType, MirEnumType, MirTupleType};
 
@@ -6530,11 +6531,10 @@ pub(crate) fn translate_array_constant_into_alloca(
 /// Enforce the pointer-to-array constant element boundary, as a hard error.
 ///
 /// The admission question is [`promotable_array_element`], the same predicate
-/// the bare array value path asks, so the two promoted-constant paths share one
-/// boundary and cannot drift: a table the value form promotes is also reachable
-/// through `&TABLE`. What differs is what rejection means. The value form falls
-/// back to element-wise materialization, while a pointer-to-array constant has
-/// no other lowering, so an inadmissible element type is an input error.
+/// used by the bare array value path's immutable-global optimization. A bare
+/// array that fails this gate can still fall back to element-wise materialization;
+/// a pointer-to-array constant has no such fallback, so failure here is an input
+/// error. Structs therefore remain outside this reference form in this change.
 fn validate_ptr_to_array_constant_type(
     ctx: &Context,
     ty: TypeHandle,
@@ -6588,10 +6588,10 @@ fn translate_array_value_constant(
         array_ty.element_type()
     };
 
-    // Bare array values support primitive scalars, enums, tuples with supported
-    // fields, or nested arrays of those. Struct elements remain outside this
-    // entry point; arrays nested inside struct constants have their own
-    // layout-aware aggregate path.
+    // Bare array values support primitive scalars, enums, tuples, structs, and
+    // nested arrays of those. Struct elements are decoded through the existing
+    // layout-aware aggregate path while pointer-to-array promotion remains
+    // intentionally unchanged.
     validate_array_value_element_type(ctx, element_ty, &loc)?;
 
     let rust_array_ty = constant.const_.ty();
@@ -6752,6 +6752,7 @@ fn build_array_op_from_bytes(
         Int { width: u32, signedness: Signedness },
         Array,
         Tuple,
+        Struct,
     }
     let elem_kind = {
         let elem_obj = element_ty_ptr.deref(ctx);
@@ -6770,13 +6771,15 @@ fn build_array_op_from_bytes(
             ElemKind::Array
         } else if elem_obj.is::<dialect_mir::types::MirTupleType>() {
             ElemKind::Tuple
+        } else if elem_obj.is::<dialect_mir::types::MirStructType>() {
+            ElemKind::Struct
         } else {
             return input_err!(
                 loc,
                 TranslationErr::unsupported(format!(
                     "Array constant element type is not supported by byte lowering: {:?}. \
-                     Byte lowering handles primitive scalars, tuples with supported fields, \
-                     or nested arrays of those. Enum elements decode from a constant \
+                     Byte lowering handles primitive scalars, tuples, structs, or nested \
+                     arrays of those. Enum elements decode from a constant \
                      allocation instead, so an enum array that reaches byte lowering (e.g. \
                      one with a zero-sized element) cannot be materialized here.",
                     elem_obj
@@ -6923,7 +6926,7 @@ fn build_array_op_from_bytes(
                 last_op,
                 loc.clone(),
             )?,
-            ElemKind::Tuple => translate_constant_value_from_bytes(
+            ElemKind::Tuple | ElemKind::Struct => translate_constant_value_from_bytes(
                 ctx,
                 &rust_element_ty,
                 element_ty_ptr,
@@ -10730,11 +10733,10 @@ fn translate_struct_constant_from_alloc(
 /// Element kinds admitted by a bare array value constant
 /// (`translate_array_value_constant`).
 ///
-/// Primitive scalars, enums, tuples, and nested arrays are supported at this
-/// entry point. Arrays of structs are not materialized here. Nested arrays are
-/// walked recursively so an unsupported leaf cannot hide behind nesting.
-/// Arrays inside struct or tuple constants are dispatched through
-/// [`translate_constant_value_from_alloc`] and are not governed by this gate.
+/// Primitive scalars, enums, tuples, structs, and nested arrays are supported
+/// at this entry point. Nested arrays are walked recursively so an unsupported
+/// leaf cannot hide behind nesting. Struct elements reuse the same layout-aware
+/// aggregate decoders used when structs appear inside other constants.
 fn validate_array_value_element_type(
     ctx: &Context,
     element_ty: TypeHandle,
@@ -10747,6 +10749,7 @@ fn validate_array_value_element_type(
             || elem_obj.is::<FP32Type>()
             || elem_obj.is::<FP64Type>()
             || elem_obj.is::<dialect_mir::types::MirTupleType>()
+            || elem_obj.is::<dialect_mir::types::MirStructType>()
             || elem_obj.is::<dialect_mir::types::MirEnumType>()
         {
             return Ok(());
@@ -10756,8 +10759,8 @@ fn validate_array_value_element_type(
                 loc.clone(),
                 TranslationErr::unsupported(format!(
                     "Array constant element type is not supported: {:?}. Supported array \
-                     constants are primitive scalars, enums, tuples with supported fields, \
-                     or nested arrays of those.",
+                     constants are primitive scalars, enums, tuples, structs, or nested \
+                     arrays of those.",
                     elem_obj
                 ))
             );
@@ -11712,7 +11715,7 @@ mod promotable_array_element_tests {
         let struct_array: TypeHandle = MirArrayType::get(&mut ctx, struct_ty, 4).into();
         assert!(
             !promotable_array_element(&ctx, struct_array),
-            "struct elements stay outside, as they are for the element-wise path"
+            "struct elements remain outside immutable-global promotion in this change"
         );
 
         // A tuple is only as promotable as its fields: a struct field keeps the
@@ -11965,14 +11968,14 @@ mod aggregate_relocation_tests {
         )
         .into();
         assert!(
-            validate_array_value_element_type(&ctx, struct_ty, &Location::Unknown).is_err(),
-            "bare arrays of structs are documented as not materialized and must stay rejected"
+            validate_array_value_element_type(&ctx, struct_ty, &Location::Unknown).is_ok(),
+            "bare struct arrays are materialized by the layout-aware aggregate decoder"
         );
 
         let struct_array_ty: TypeHandle = MirArrayType::get(&mut ctx, struct_ty, 2).into();
         assert!(
-            validate_array_value_element_type(&ctx, struct_array_ty, &Location::Unknown).is_err(),
-            "nesting must not hide an unsupported struct leaf"
+            validate_array_value_element_type(&ctx, struct_array_ty, &Location::Unknown).is_ok(),
+            "nesting preserves supported struct leaves"
         );
 
         let ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();

--- a/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
@@ -14,6 +14,8 @@
 //! - non-empty all-ZST tuples whose fields have equal offsets,
 //! - tuple arrays whose fields rustc reorders in memory,
 //! - tuple arrays containing an over-aligned zero-sized field,
+//! - bare arrays of padded and nested struct constants,
+//! - bare arrays of over-aligned zero-sized struct constants,
 //! - direct padded tuple constants,
 //! - pointer-to-array constants (`&[T; N]`), which predate bare-array support,
 //! - tuple arrays containing pointers to device statics,
@@ -57,6 +59,54 @@ const REORDERED_TUPLE_TABLE: [(u8, u32, u64); 2] = [
     (0xa5, 0x1122_3344, 0x0102_0304_0506_0708),
     (0x5a, 0x99aa_bbcc, 0x8877_6655_4433_2211),
 ];
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct PaddedStruct {
+    tag: u8,
+    value: u32,
+}
+
+const PADDED_STRUCT_TABLE: [PaddedStruct; 2] = [
+    PaddedStruct {
+        tag: 0xa5,
+        value: 0x1122_3344,
+    },
+    PaddedStruct {
+        tag: 0x5a,
+        value: 0x99aa_bbcc,
+    },
+];
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct NestedStruct {
+    inner: PaddedStruct,
+    wide: u64,
+}
+
+const NESTED_STRUCT_TABLE: [NestedStruct; 2] = [
+    NestedStruct {
+        inner: PaddedStruct {
+            tag: 0x33,
+            value: 0x0102_0304,
+        },
+        wide: 0x1112_1314_1516_1718,
+    },
+    NestedStruct {
+        inner: PaddedStruct {
+            tag: 0xcc,
+            value: 0xa1a2_a3a4,
+        },
+        wide: 0x8182_8384_8586_8788,
+    },
+];
+
+#[derive(Clone, Copy)]
+#[repr(align(32))]
+struct ZstStruct;
+
+const ZST_STRUCT_TABLE: [ZstStruct; 2] = [ZstStruct, ZstStruct];
 
 #[derive(Clone, Copy)]
 #[repr(align(32))]
@@ -147,6 +197,32 @@ mod kernels {
     }
 
     #[inline(never)]
+    fn padded_struct_array_value(i: usize) -> u32 {
+        let value = PADDED_STRUCT_TABLE[i & 1];
+        (value.tag as u32)
+            .wrapping_mul(257)
+            .wrapping_add(value.value)
+    }
+
+    #[inline(never)]
+    fn nested_struct_array_value(i: usize) -> u32 {
+        let value = NESTED_STRUCT_TABLE[i & 1];
+        (value.inner.tag as u32)
+            .wrapping_mul(257)
+            .wrapping_add(value.inner.value)
+            .wrapping_mul(257)
+            .wrapping_add(value.wide as u32)
+            .wrapping_mul(257)
+            .wrapping_add((value.wide >> 32) as u32)
+    }
+
+    #[inline(never)]
+    fn zst_struct_array_value(i: usize) -> u32 {
+        let value = ZST_STRUCT_TABLE[i & 1];
+        ((&value as *const ZstStruct as usize) & 31) as u32
+    }
+
+    #[inline(never)]
     fn direct_tuple_value() -> (u8, u32) {
         DIRECT_TUPLE
     }
@@ -182,6 +258,9 @@ mod kernels {
             let all_zst = all_zst_tuple_array_value(i);
             let reordered = reordered_tuple_array_value(i);
             let overaligned_zst = overaligned_zst_tuple_array_value(i);
+            let padded_struct = padded_struct_array_value(i);
+            let nested_struct = nested_struct_array_value(i);
+            let zst_struct = zst_struct_array_value(i);
 
             *slot = nested
                 .wrapping_mul(257)
@@ -199,7 +278,13 @@ mod kernels {
                 .wrapping_mul(257)
                 .wrapping_add(reordered)
                 .wrapping_mul(257)
-                .wrapping_add(overaligned_zst);
+                .wrapping_add(overaligned_zst)
+                .wrapping_mul(257)
+                .wrapping_add(padded_struct)
+                .wrapping_mul(257)
+                .wrapping_add(nested_struct)
+                .wrapping_mul(257)
+                .wrapping_add(zst_struct);
         }
 
         let tid_enum = thread::index_1d();
@@ -244,6 +329,23 @@ fn expected_u32(i: usize) -> u32 {
 
     let (_, overaligned_zst) = OVERALIGNED_ZST_TUPLE_TABLE[i & 1];
 
+    let padded_value = PADDED_STRUCT_TABLE[i & 1];
+    let padded_struct = (padded_value.tag as u32)
+        .wrapping_mul(257)
+        .wrapping_add(padded_value.value);
+
+    let nested_value = NESTED_STRUCT_TABLE[i & 1];
+    let nested_struct = (nested_value.inner.tag as u32)
+        .wrapping_mul(257)
+        .wrapping_add(nested_value.inner.value)
+        .wrapping_mul(257)
+        .wrapping_add(nested_value.wide as u32)
+        .wrapping_mul(257)
+        .wrapping_add((nested_value.wide >> 32) as u32);
+
+    let zst_value = ZST_STRUCT_TABLE[i & 1];
+    let zst_struct = ((&zst_value as *const ZstStruct as usize) & 31) as u32;
+
     nested
         .wrapping_mul(257)
         .wrapping_add(pointer)
@@ -261,6 +363,12 @@ fn expected_u32(i: usize) -> u32 {
         .wrapping_add(reordered)
         .wrapping_mul(257)
         .wrapping_add(overaligned_zst as u32)
+        .wrapping_mul(257)
+        .wrapping_add(padded_struct)
+        .wrapping_mul(257)
+        .wrapping_add(nested_struct)
+        .wrapping_mul(257)
+        .wrapping_add(zst_struct)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -323,7 +431,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if failures == 0 {
         println!(
-            "array_constants: PASS ({N} threads; primitive, enum, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, pointer-to-array, and tuple-array static-pointer constants)"
+            "array_constants: PASS ({N} threads; primitive, enum, padded/reordered/over-aligned tuple, padded/nested/ZST struct, pointer-to-array, and tuple-array static-pointer constants)"
         );
         Ok(())
     } else {

--- a/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
@@ -92,6 +92,25 @@ require_shape \
     "direct padded tuple value in LLVM slot 2" \
     'insertvalue \{ i8, \[3 x i8\], i32 \} .* i32 41, 2'
 
+# Bare struct arrays must use the same rustc-recorded field offsets as direct
+# struct constants. `PaddedStruct` is `#[repr(C)] { u8, u32 }`, so the lowered
+# element contains an explicit three-byte padding slot before the u32.
+padded_struct_symbol='array_constants__kernels__padded_struct_array_value'
+require_symbol_shape "${llvm_ir}" llvm "${padded_struct_symbol}" \
+    "padded bare-struct array storage" \
+    'alloca \[2 x \{ i8, \[3 x i8\], i32 \}\]'
+
+# Recursive aggregate decoding must preserve the inner struct's padding while
+# placing the following u64 at its `#[repr(C)]` offset.
+nested_struct_symbol='array_constants__kernels__nested_struct_array_value'
+require_symbol_shape "${llvm_ir}" llvm "${nested_struct_symbol}" \
+    "nested bare-struct array storage" \
+    'alloca \[2 x \{ \{ i8, \[3 x i8\], i32 \}, i64 \}\]'
+
+# The standalone over-aligned ZST struct array has no data bytes to pin in LLVM
+# IR. Runtime coverage in `array_constants` checks that indexing it still
+# materializes a correctly aligned value.
+
 # Nested tuple with a zero-sized field: the ZST is stripped, but padding and
 # the outer u32's physical slot remain layout-exact. The array form is now
 # materialized from rustc's evaluated allocation, so the values are pinned as the


### PR DESCRIPTION
Closes #854 

## Summary

Adds support for bare arrays whose elements are structs.

The MIR importer already has layout-aware struct constant decoding for allocation-backed constants and byte-backed aggregate decoding. This change extends the bare-array element boundary and byte-array dispatch so struct elements can reuse those existing paths.

## What changed

- Allow `MirStructType` elements in bare array value constants.
- Extend byte-backed array materialization to dispatch struct elements through the existing aggregate constant decoder.
- Keep immutable-global promotion unchanged.
- Keep pointer-to-array struct constants unsupported.
- Add regression coverage for:
  - padded `#[repr(C)]` structs,
  - nested structs,
  - over-aligned zero-sized structs.
- Add LLVM code-shape checks for padded and nested struct array storage.

## Scope

This intentionally does not change `promotable_array_element`.

Bare array values can fall back to element-wise materialization, while pointer-to-array constants require the immutable-global path. Widening the promotion predicate here would therefore also widen pointer-to-array semantics, which is outside this change.

Unions are also out of scope.

## Validation

```text
cargo test -p mir-importer
1068 passed; 0 failed

cargo clippy -p mir-importer --all-targets -- -D warnings
PASS

cargo oxide run array_constants
PASS

./crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
array_constants code shape: PASS

CUDA_OXIDE_NO_OPT=1 cargo oxide run array_constants
PASS
```

The GPU regression covers primitive, enum, tuple, padded/nested/ZST struct, pointer-to-array, and tuple-array static-pointer constants.
