### PR TITLE
test(codegen): cover strict and exposed pointer provenance APIs

### DIFF
--- a/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ptr_offset_from/src/main.rs
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Regression coverage for raw pointer distance and wrapping-offset intrinsics.
+//! Regression coverage for raw pointer distance, wrapping-offset, and provenance APIs.
 //!
 //! The stable raw pointer methods lower through rustc intrinsics in MIR:
 //! `offset_from_unsigned` uses `ptr_offset_from_unsigned`, while
 //! `offset_from` and the byte-oriented wrappers use `ptr_offset_from`.
-//! Safe `wrapping_offset`/`wrapping_add` use `arith_offset`. cuda-oxide must
-//! preserve signed distances, scale offsets by the pointee type, retain pointer
-//! mutability through libcore's cast, and leave zero-sized pointees stationary.
+//! Safe `wrapping_offset`/`wrapping_add` use `arith_offset`. Strict-provenance
+//! `addr`, `with_addr`, and `map_addr`, plus exposed-provenance
+//! `expose_provenance` and `with_exposed_provenance`, must preserve the expected
+//! pointer/address semantics. cuda-oxide must preserve signed distances, scale
+//! offsets by the pointee type, retain pointer mutability through libcore's cast,
+//! and leave zero-sized pointees stationary.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
@@ -47,18 +50,33 @@ mod kernels {
                 *out.get_unchecked_mut(7) = *(base as *mut u32).wrapping_add(lo) as i64;
                 *out.get_unchecked_mut(8) =
                     (wrapping_offset(base.cast::<()>(), hi as isize) == base.cast::<()>()) as i64;
+
                 let wrapped = base.wrapping_offset(extreme).addr();
                 let byte_delta = wrapped.wrapping_sub(base.addr());
                 let expected_delta = (extreme as usize).wrapping_mul(core::mem::size_of::<u32>());
                 *out.get_unchecked_mut(9) = (byte_delta == expected_delta) as i64;
                 *out.get_unchecked_mut(10) =
                     (wrapping_offset(base.cast::<()>(), extreme) == base.cast::<()>()) as i64;
+
+                let with_addr = base.with_addr(hi_ptr.addr());
+                *out.get_unchecked_mut(11) = (*with_addr == values[hi]) as i64;
+
+                let mapped = base.map_addr(|addr| {
+                    addr.wrapping_add(hi.wrapping_mul(core::mem::size_of::<u32>()))
+                });
+                *out.get_unchecked_mut(12) = (*mapped == values[hi]) as i64;
+
+                let exposed = hi_ptr.expose_provenance();
+                *out.get_unchecked_mut(13) = (exposed == hi_ptr.addr()) as i64;
+
+                let reconstructed = core::ptr::with_exposed_provenance::<u32>(exposed);
+                *out.get_unchecked_mut(14) = (*reconstructed == values[hi]) as i64;
             }
         }
     }
 }
 
-const SLOTS: usize = 11;
+const SLOTS: usize = 15;
 
 fn main() {
     let ctx = CudaContext::new(0).expect("ctx");
@@ -102,6 +120,10 @@ fn main() {
         1,
         1,
         1,
+        1,
+        1,
+        1,
+        1,
     ];
 
     let mut errors = 0;
@@ -113,9 +135,9 @@ fn main() {
     }
 
     if errors == 0 {
-        println!("SUCCESS: pointer distances and wrapping offsets are correct");
+        println!("SUCCESS: pointer distance, wrapping, and provenance operations are correct");
     } else {
-        println!("FAILURE: {errors} pointer offset mismatches");
+        println!("FAILURE: {errors} pointer/provenance mismatches");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Closes #862 

## Summary

Extend the `ptr_offset_from` regression example with coverage for Rust's strict
and exposed pointer provenance APIs.

The new checks cover:

- `with_addr`
- `map_addr`
- `expose_provenance`
- `with_exposed_provenance`

The tests verify both address manipulation and successful dereference after
pointer reconstruction.

This is regression coverage only; no compiler code is changed.

## Validation

- `cargo oxide run ptr_offset_from`
- `CUDA_OXIDE_NO_OPT=1 cargo oxide run ptr_offset_from`
- `cargo fmt --check`
- `cargo clippy --manifest-path crates/rustc-codegen-cuda/examples/ptr_offset_from/Cargo.toml --all-targets -- -D warnings`
- `scripts/smoketest.sh --only '^ptr_offset_from$' --no-color`

All checks pass.