### PR TITLE
test(codegen): cover nested place projection composition

### DIFF
--- a/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
@@ -21,6 +21,8 @@
 //! - `shared_bytes_no_slot` mutates the variant WITHOUT a slot of its own
 //!   (`Bits` shares `Real`'s bytes), so the byte-offset addressing path runs
 //!   against the original storage.
+//! - `mutate_indexed_payload` mutates a runtime-indexed element inside an enum
+//!   array payload, covering the composed `Downcast -> Field -> Index` store path.
 //! - `shared_borrow_bool_payload` takes a SHARED borrow of a `bool` payload
 //!   and passes it to a `#[device]` helper. A bool payload's bytes use
 //!   canonical i8 storage, so no raw payload address can be handed out; the
@@ -69,6 +71,13 @@ mod kernels {
         Both(bool, f32),
         #[allow(dead_code)]
         Neither,
+    }
+
+    /// Array payload used to cover a nested `Downcast -> Field -> Index` store.
+    pub enum Bucket {
+        Data([u32; 4]),
+        #[allow(dead_code)]
+        Empty,
     }
 
     /// Scale a borrowed payload. Taking `&mut f32` across a call boundary
@@ -262,6 +271,35 @@ mod kernels {
         }
     }
 
+    /// Mutate a runtime-indexed element inside an enum's array payload.
+    ///
+    /// The indexed store exercises the composed `Downcast -> Field -> Index`
+    /// place path.
+    #[kernel]
+    pub fn mutate_indexed_payload(mut out: DisjointSlice<u32>, n: u32, column: u32, base: u32) {
+        let index = thread::index_1d();
+        let i = index.get();
+        if i >= n as usize {
+            return;
+        }
+
+        let c = (column as usize) & 3;
+        let mut bucket = Bucket::Data([0x10, 0x20, 0x30, 0x40]);
+
+        if let Bucket::Data(values) = &mut bucket {
+            values[c] = base.wrapping_add(i as u32);
+        }
+
+        let result = match bucket {
+            Bucket::Data(values) => values[c],
+            Bucket::Empty => u32::MAX,
+        };
+
+        if let Some(cell) = out.get_mut(index) {
+            *cell = result;
+        }
+    }
+
     /// The workaround this replaces: rebuild the enum from a matched copy.
     #[kernel]
     pub fn rebuild_payload(input: &[f32], mut out: DisjointSlice<f32>) {
@@ -344,6 +382,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     check("rebuild_payload", &|out| unsafe {
         module.rebuild_payload(&stream, config, &input, out)
     })?;
+
+    // Focused nested enum-payload probe. The source is intentionally separate
+    // from the f32 checks because its payload and oracle are u32.
+    {
+        const COLUMN: u32 = 3;
+        const BASE: u32 = 0x1234_0000;
+        let mut out = DeviceBuffer::from_host(&stream, &vec![u32::MAX; LEN as usize])?;
+        // SAFETY: the grid covers exactly `LEN` elements, the output buffer has
+        // that many entries, and the kernel masks COLUMN to the payload bounds.
+        unsafe { module.mutate_indexed_payload(&stream, config, &mut out, LEN, COLUMN, BASE)? };
+        stream.synchronize()?;
+        let got = out.to_host_vec(&stream)?;
+        for (i, value) in got.iter().enumerate() {
+            let expected = BASE.wrapping_add(i as u32);
+            if *value != expected {
+                return Err(format!(
+                    "mutate_indexed_payload: element {i} is {value}, expected {expected}"
+                )
+                .into());
+            }
+        }
+        println!(
+            "mutate_indexed_payload: {LEN} indexed enum payload elements mutated, exact match"
+        );
+    }
 
     // The bool-payload kernel maps each input to a variant-dependent output,
     // so it gets its own expectation instead of the uniform `* 2.0` check.

--- a/crates/rustc-codegen-cuda/examples/index_field_assign/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/index_field_assign/src/main.rs
@@ -24,6 +24,10 @@
 //! form (`arr[0].a`), then reduces the array so the host can verify the writes
 //! actually landed.
 //!
+//! `index_field_index` extends the regression coverage to a 3-level
+//! `Index -> Field -> Index` place and exercises store, load, reference, and
+//! raw-address construction against the same projected element.
+//!
 //! Usage:
 //!   cargo oxide run index_field_assign
 
@@ -38,6 +42,11 @@ mod kernels {
     struct Cell {
         a: u64,
         b: u64,
+    }
+
+    #[derive(Copy, Clone)]
+    struct NestedCell {
+        values: [u64; 4],
     }
 
     /// Each thread fills a local `[Cell; 4]` by assigning to `arr[i].a` /
@@ -83,6 +92,59 @@ mod kernels {
             *slot = s;
         }
     }
+
+    /// Exercise a genuine 3-level `Index -> Field -> Index` place.
+    ///
+    /// `row` and `column` are kernel arguments, so both projections remain
+    /// runtime indices. The same element is used as:
+    ///
+    /// - an assignment destination,
+    /// - a direct load,
+    /// - the referent of `&place`,
+    /// - the operand of `addr_of!(place)`.
+    ///
+    /// The host checks the sum of all three reads. This probe is deliberately
+    /// kept in the existing regression example so no Cargo metadata changes
+    /// are required.
+    #[kernel]
+    pub fn index_field_index(
+        mut out: DisjointSlice<u64>,
+        n: u32,
+        row: u32,
+        column: u32,
+        value: u64,
+    ) {
+        let index = thread::index_1d();
+        let tid = index.get();
+        if tid >= n as usize {
+            return;
+        }
+
+        let r = (row as usize) & 3;
+        let c = (column as usize) & 3;
+        let target = value.wrapping_add(tid as u64);
+        let mut cells = [NestedCell { values: [0; 4] }; 4];
+
+        // Store through `Index -> Field -> Index`.
+        cells[r].values[c] = target;
+
+        // Load through the same 3-level place.
+        let direct = cells[r].values[c];
+
+        // Build a reference to the same 3-level place.
+        let value_ref = &cells[r].values[c];
+        let by_ref = *value_ref;
+
+        // Build a raw address from the same 3-level place, then read it back.
+        // SAFETY: `raw` points into the live local `cells` array and remains
+        // valid for the duration of this kernel invocation.
+        let raw = core::ptr::addr_of!(cells[r].values[c]);
+        let by_raw = unsafe { *raw };
+
+        if let Some(slot) = out.get_mut(index) {
+            *slot = direct.wrapping_add(by_ref).wrapping_add(by_raw);
+        }
+    }
 }
 
 fn main() {
@@ -109,5 +171,26 @@ fn main() {
         assert_eq!(got[tid as usize], want, "thread {tid}");
     }
 
-    println!("PASS: index_field_assign (Index->Field + ConstantIndex->Field writes)");
+    // 3-level `Index -> Field -> Index` probe. Non-zero row/column values keep
+    // the intended nested projection visible while still staying in bounds.
+    const ROW: u32 = 2;
+    const COLUMN: u32 = 3;
+    const BASE: u64 = 0x1234_0000_0000_0000;
+    let mut nested_out = DeviceBuffer::<u64>::zeroed(&stream, N).unwrap();
+    // SAFETY: launch shape/resources match the kernel; the output covers all
+    // writes and ROW/COLUMN are masked to the local array bounds in the kernel.
+    unsafe { module.index_field_index(&stream, cfg, &mut nested_out, N as u32, ROW, COLUMN, BASE) }
+        .expect("index_field_index launch");
+    let nested_got = nested_out.to_host_vec(&stream).unwrap();
+
+    for tid in 0..N as u64 {
+        let target = BASE.wrapping_add(tid);
+        let want = target.wrapping_mul(3);
+        assert_eq!(nested_got[tid as usize], want, "nested thread {tid}");
+    }
+
+    println!(
+        "PASS: index_field_assign \
+         (Index->Field + ConstantIndex->Field + Index->Field->Index)"
+    );
 }


### PR DESCRIPTION
Closes #864 

## Summary

Add explicit regression coverage for nested MIR place projections that are already supported individually but were not pinned in composition:

```text
Index -> Field -> Index
Downcast -> Field -> Index
```

No compiler code changes are required. The existing place/address lowering already handles both chains correctly; this PR makes that behavior part of the executable regression suite.

## What changed

### `index_field_assign`

Extend the existing `Index -> Field` regression with a local array of:

```rust
struct NestedCell {
    values: [u64; 4],
}
```

and exercise:

```rust
cells[row].values[column]
```

with runtime `row` and `column` values.

The new kernel covers the same 3-level place as:

```text
assignment destination
direct load
shared reference
raw address via addr_of!
```

This pins:

```text
Index -> Field -> Index
```

for both value and address-based consumers.

The host verifies every thread against an exact oracle.

### `enum_payload_addr`

Add:

```rust
enum Bucket {
    Data([u32; 4]),
    Empty,
}
```

and a kernel that mutates an indexed element of the `Data` payload:

```rust
if let Bucket::Data(values) = &mut bucket {
    values[column] = base.wrapping_add(i as u32);
}
```

The imported optimized MIR resolves the payload address directly from the enum and then applies the runtime array index before storing:

```text
enum storage
    -> payload field address
    -> runtime array element address
    -> store
```

This provides regression coverage for the effective:

```text
Downcast -> Field -> Index
```

store path.

The host verifies all `1 << 20` elements exactly.

## Scope

Modified:

```text
crates/rustc-codegen-cuda/examples/index_field_assign/src/main.rs
crates/rustc-codegen-cuda/examples/enum_payload_addr/src/main.rs
```

No changes to:

```text
mir-importer
mir-lower
dialect-mir
rustc-codegen-cuda compiler infrastructure
Cargo manifests
smoketest infrastructure
```

## Validation

Example hygiene:

```bash
(
  cd crates/rustc-codegen-cuda/examples/index_field_assign
  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
)

(
  cd crates/rustc-codegen-cuda/examples/enum_payload_addr
  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
)

git diff --check
```

All pass cleanly.

Optimized execution:

```bash
cargo oxide run index_field_assign
cargo oxide run enum_payload_addr
```

Low-MIR-optimization execution:

```bash
CUDA_OXIDE_NO_OPT=1 cargo oxide run index_field_assign
CUDA_OXIDE_NO_OPT=1 cargo oxide run enum_payload_addr
```

Both modes pass.

`index_field_assign` reports:

```text
PASS: index_field_assign (Index->Field + ConstantIndex->Field + Index->Field->Index)
```

`enum_payload_addr` includes:

```text
mutate_indexed_payload: 1048576 indexed enum payload elements mutated, exact match
```

and completes with:

```text
SUCCESS
```

The `Downcast -> Field -> Index` probe was also inspected with:

```bash
CUDA_OXIDE_DUMP_MIR=1 cargo oxide run enum_payload_addr
```

The imported MIR for the indexed payload store composes the enum payload field address with a runtime array element address before the final store.
