### PR TITLE
fix(mir-importer): lower DST layout for slice-tailed structs

### DIFF
--- a/crates/mir-importer/src/translator/terminator/intrinsics/layout.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/layout.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Rust dynamic-layout intrinsics for slices and `str`.
+//! Rust dynamic-layout intrinsics for slices, `str`, and slice-tailed structs.
 //!
 //! `core::mem::size_of_val` and `core::mem::align_of_val` inline to the
 //! corresponding `core::intrinsics::*` calls when their argument is a DST.
@@ -14,6 +14,8 @@
 //!
 //! - `[T]`: size = `len * size_of::<T>()`, align = `align_of::<T>()`
 //! - `str`: size = byte length, align = 1
+//! - `struct S { prefix: ..., tail: [T] }`: size and alignment are computed
+//!   from rustc's field offset/layout plus the runtime tail length metadata
 //!
 //! Sized types are also accepted as a defensive fallback for low-MIR-opt
 //! builds, where the intrinsic may survive even though optimized MIR normally
@@ -24,7 +26,7 @@ use crate::error::{TranslationErr, TranslationResult};
 use crate::translator::values::ValueMap;
 use crate::translator::{rvalue, types};
 use dialect_mir::attributes::FieldIndexAttr;
-use dialect_mir::ops::{MirConstantOp, MirExtractFieldOp, MirMulOp};
+use dialect_mir::ops::{MirAddOp, MirConstantOp, MirDivOp, MirExtractFieldOp, MirMulOp};
 use dialect_mir::types::MirSliceType;
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::attributes::IntegerAttr;
@@ -196,6 +198,244 @@ fn emit_usize_mul_constant(
     (mul.deref(ctx).get_result(0), mul)
 }
 
+/// Add a compile-time `usize` constant to a runtime `usize`.
+fn emit_usize_add_constant(
+    ctx: &mut Context,
+    lhs: Value,
+    rhs: u64,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Ptr<Operation>,
+    loc: Location,
+) -> (Value, Ptr<Operation>) {
+    if rhs == 0 {
+        return (lhs, prev_op);
+    }
+
+    let (rhs_value, rhs_op) = emit_usize_constant(ctx, rhs, block_ptr, Some(prev_op), loc.clone());
+    let usize_ty = types::get_usize_type(ctx);
+    let add = Operation::new(
+        ctx,
+        MirAddOp::get_concrete_op_info(),
+        vec![usize_ty.to_handle()],
+        vec![lhs, rhs_value],
+        vec![],
+        0,
+    );
+    add.deref_mut(ctx).set_loc(loc);
+    add.insert_after(ctx, rhs_op);
+    (add.deref(ctx).get_result(0), add)
+}
+
+/// Round a runtime `usize` up to a compile-time power-of-two alignment.
+fn emit_usize_align_up(
+    ctx: &mut Context,
+    value: Value,
+    alignment: u64,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Ptr<Operation>,
+    loc: Location,
+) -> (Value, Ptr<Operation>) {
+    if alignment <= 1 {
+        return (value, prev_op);
+    }
+
+    debug_assert!(alignment.is_power_of_two());
+
+    let (biased, add_op) =
+        emit_usize_add_constant(ctx, value, alignment - 1, block_ptr, prev_op, loc.clone());
+    let (align_value, align_op) =
+        emit_usize_constant(ctx, alignment, block_ptr, Some(add_op), loc.clone());
+
+    let usize_ty = types::get_usize_type(ctx);
+    let div = Operation::new(
+        ctx,
+        MirDivOp::get_concrete_op_info(),
+        vec![usize_ty.to_handle()],
+        vec![biased, align_value],
+        vec![],
+        0,
+    );
+    div.deref_mut(ctx).set_loc(loc.clone());
+    div.insert_after(ctx, align_op);
+    let quotient = div.deref(ctx).get_result(0);
+
+    let mul = Operation::new(
+        ctx,
+        MirMulOp::get_concrete_op_info(),
+        vec![usize_ty.to_handle()],
+        vec![quotient, align_value],
+        vec![],
+        0,
+    );
+    mul.deref_mut(ctx).set_loc(loc);
+    mul.insert_after(ctx, div);
+    (mul.deref(ctx).get_result(0), mul)
+}
+
+/// Return the trailing field of a slice-tailed struct.
+fn trailing_struct_field(ty: &Ty, loc: &Location) -> TranslationResult<(Ty, usize, Option<u64>)> {
+    let TyKind::RigidTy(RigidTy::Adt(adt_def, substs)) = ty.kind() else {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "expected a struct DST while computing dynamic layout; got {:?}",
+                ty.kind()
+            ))
+        );
+    };
+
+    if !matches!(adt_def.kind(), rustc_public::ty::AdtKind::Struct) {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "dynamic slice-tail layout requires a struct; got {:?}",
+                adt_def.kind()
+            ))
+        );
+    }
+
+    let variants = adt_def.variants();
+    let variant = variants.first().ok_or_else(|| {
+        input_error!(
+            loc.clone(),
+            TranslationErr::unsupported("slice-tailed struct has no field variant".to_string())
+        )
+    })?;
+    let fields = variant.fields();
+    let last_index = fields.len().checked_sub(1).ok_or_else(|| {
+        input_error!(
+            loc.clone(),
+            TranslationErr::unsupported("slice-tailed struct has no fields".to_string())
+        )
+    })?;
+    let last_ty = fields[last_index].ty_with_args(&substs);
+
+    Ok((last_ty, last_index, adt_def.repr().pack))
+}
+
+/// Compute the ABI alignment of a slice-tailed struct DST.
+///
+/// The tail metadata is a length, so alignment is fully determined by the
+/// monomorphized prefix, the trailing element type, and any `repr(packed)` cap.
+fn slice_tail_alignment(value_ty: &Ty, loc: &Location) -> TranslationResult<u64> {
+    match value_ty.kind() {
+        TyKind::RigidTy(RigidTy::Slice(element_ty)) => {
+            Ok(rust_layout_shape(&element_ty, "slice-tail element", loc)?.abi_align)
+        }
+        TyKind::RigidTy(RigidTy::Str) => Ok(1),
+        TyKind::RigidTy(RigidTy::Adt(..)) => {
+            let (last_ty, _last_index, packed) = trailing_struct_field(value_ty, loc)?;
+            let shape = rust_layout_shape(value_ty, "slice-tailed struct", loc)?;
+            let mut tail_align = slice_tail_alignment(&last_ty, loc)?;
+
+            if let Some(packed) = packed {
+                tail_align = tail_align.min(packed);
+            }
+
+            Ok(shape.abi_align.max(tail_align))
+        }
+        _ => input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "unsupported unsized tail while computing alignment: {:?}",
+                value_ty.kind()
+            ))
+        ),
+    }
+}
+
+/// Compute runtime size and static ABI alignment for a slice-tailed DST.
+///
+/// This mirrors rustc's DST layout rule for aggregate tails:
+///
+/// `size = align_up(last_field_offset + dynamic_tail_size, full_alignment)`.
+///
+/// The same runtime metadata value is threaded recursively for nested
+/// slice-tailed structs because their metadata is the ultimate slice length.
+#[allow(clippy::too_many_arguments)]
+fn emit_slice_tail_size_and_align(
+    ctx: &mut Context,
+    value_ty: &Ty,
+    metadata_len: Value,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Ptr<Operation>,
+    loc: Location,
+) -> TranslationResult<(Value, u64, Ptr<Operation>)> {
+    match value_ty.kind() {
+        TyKind::RigidTy(RigidTy::Slice(element_ty)) => {
+            let element_layout = rust_layout_shape(&element_ty, "slice-tail element", &loc)?;
+            let element_size =
+                size_to_u64(element_layout.size.bytes(), "slice-tail element", &loc)?;
+            let (size, size_op) =
+                emit_usize_mul_constant(ctx, metadata_len, element_size, block_ptr, prev_op, loc);
+            Ok((size, element_layout.abi_align, size_op))
+        }
+        TyKind::RigidTy(RigidTy::Str) => Ok((metadata_len, 1, prev_op)),
+        TyKind::RigidTy(RigidTy::Adt(..)) => {
+            let (last_ty, last_index, packed) = trailing_struct_field(value_ty, &loc)?;
+            let shape = rust_layout_shape(value_ty, "slice-tailed struct", &loc)?;
+            let tail_offset = match &shape.fields {
+                rustc_public::abi::FieldsShape::Arbitrary { offsets } => offsets
+                    .get(last_index)
+                    .map(|offset| offset.bytes())
+                    .ok_or_else(|| {
+                        input_error!(
+                            loc.clone(),
+                            TranslationErr::unsupported(format!(
+                                "slice-tailed struct layout has {} offsets for field {}",
+                                offsets.len(),
+                                last_index
+                            ))
+                        )
+                    })?,
+                other => {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(format!(
+                            "slice-tailed struct has unsupported field layout: {other:?}"
+                        ))
+                    );
+                }
+            };
+            let tail_offset = size_to_u64(tail_offset, "slice-tailed struct tail offset", &loc)?;
+
+            let (tail_size, mut tail_align, tail_op) = emit_slice_tail_size_and_align(
+                ctx,
+                &last_ty,
+                metadata_len,
+                block_ptr,
+                prev_op,
+                loc.clone(),
+            )?;
+
+            if let Some(packed) = packed {
+                tail_align = tail_align.min(packed);
+            }
+
+            let full_align = shape.abi_align.max(tail_align);
+            let (unrounded_size, add_op) = emit_usize_add_constant(
+                ctx,
+                tail_size,
+                tail_offset,
+                block_ptr,
+                tail_op,
+                loc.clone(),
+            );
+            let (full_size, align_op) =
+                emit_usize_align_up(ctx, unrounded_size, full_align, block_ptr, add_op, loc);
+
+            Ok((full_size, full_align, align_op))
+        }
+        _ => input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "unsupported unsized tail while computing size: {:?}",
+                value_ty.kind()
+            ))
+        ),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn emit_size_of_val(
     ctx: &mut Context,
@@ -244,13 +484,29 @@ fn emit_size_of_val(
             )?;
             emit_slice_len(ctx, fat_value, block_ptr, after_operand, loc)
         }
+        TyKind::RigidTy(RigidTy::Adt(..)) if types::slice_tail_element_ty(value_ty).is_some() => {
+            let (fat_value, after_operand) = rvalue::translate_operand(
+                ctx,
+                body,
+                arg,
+                value_map,
+                block_ptr,
+                prev_op,
+                loc.clone(),
+            )?;
+            let (len, after_len) =
+                emit_slice_len(ctx, fat_value, block_ptr, after_operand, loc.clone())?;
+            let (size, _align, after_layout) =
+                emit_slice_tail_size_and_align(ctx, value_ty, len, block_ptr, after_len, loc)?;
+            Ok((size, after_layout))
+        }
         _ => {
             let shape = rust_layout_shape(value_ty, "size_of_val pointee", &loc)?;
             if !shape.is_sized() {
                 return input_err!(
                     loc,
                     TranslationErr::unsupported(format!(
-                        "size_of_val currently supports slices, str, and Sized pointees; got {:?}",
+                        "size_of_val currently supports slices, str, slice-tailed structs, and Sized pointees; got {:?}",
                         value_ty.kind()
                     ))
                 );
@@ -273,13 +529,16 @@ fn emit_align_of_val(
             rust_layout_shape(&element_ty, "slice element", &loc)?.abi_align
         }
         TyKind::RigidTy(RigidTy::Str) => 1,
+        TyKind::RigidTy(RigidTy::Adt(..)) if types::slice_tail_element_ty(value_ty).is_some() => {
+            slice_tail_alignment(value_ty, &loc)?
+        }
         _ => {
             let shape = rust_layout_shape(value_ty, "align_of_val pointee", &loc)?;
             if !shape.is_sized() {
                 return input_err!(
                     loc,
                     TranslationErr::unsupported(format!(
-                        "align_of_val currently supports slices, str, and Sized pointees; got {:?}",
+                        "align_of_val currently supports slices, str, slice-tailed structs, and Sized pointees; got {:?}",
                         value_ty.kind()
                     ))
                 );
@@ -291,7 +550,7 @@ fn emit_align_of_val(
     Ok(emit_usize_constant(ctx, alignment, block_ptr, prev_op, loc))
 }
 
-/// Lower `core::intrinsics::{size_of_val, align_of_val}` for slices and `str`.
+/// Lower `core::intrinsics::{size_of_val, align_of_val}` for supported DSTs.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_rust_layout_intrinsic(
     ctx: &mut Context,

--- a/crates/rustc-codegen-cuda/examples/dst_metadata/README.md
+++ b/crates/rustc-codegen-cuda/examples/dst_metadata/README.md
@@ -6,13 +6,32 @@ Regression coverage for device-side DST layout metadata through
 ## What this tests
 
 CUDA Oxide represents slice-shaped fat pointers as `(data_ptr, len)`. This
-example verifies the two libcore layout intrinsics for the DST shapes that use
-length metadata:
+example verifies the two libcore layout intrinsics for DST shapes whose metadata
+is a runtime length:
 
 - `&[u32]`: `size_of_val` must compute `len * size_of::<u32>()`, while
   `align_of_val` is `align_of::<u32>()`.
 - `str`: the metadata is a UTF-8 byte length, so `size_of_val` returns that byte
   length and `align_of_val` is 1.
+- `&Header<[u16]>`: the metadata is the length of the trailing slice. The
+  runtime size must include the statically laid out prefix, the inline tail, and
+  final ABI padding. The test also reads prefix fields and the trailing-slice
+  length metadata through the fat pointer.
+
+The struct case uses:
+
+```rust
+#[repr(C)]
+struct Header<T: ?Sized> {
+    head: u64,
+    tag: u8,
+    tail: T,
+}
+```
+
+and unsizes `&Header<[u16; 4]>` to `&Header<[u16]>`. The mixed-width prefix is
+intentional: it makes padding and final size rounding observable instead of
+testing only a packed-looking layout.
 
 The string input is `oxide✓`. It has six Unicode scalar values but eight UTF-8
 bytes, so the test distinguishes byte-length metadata from character count.
@@ -37,5 +56,8 @@ PASS: size_of_val on &[u32]
 PASS: align_of_val on &[u32]
 PASS: size_of_val on str
 PASS: align_of_val on str
+PASS: size_of_val on &Header<[u16]>
+PASS: align_of_val on &Header<[u16]>
+PASS: unsized-tail metadata and prefix fields
 PASS: dst_metadata
 ```

--- a/crates/rustc-codegen-cuda/examples/dst_metadata/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/dst_metadata/src/main.rs
@@ -8,12 +8,25 @@
 //! The slice case exercises runtime fat-pointer length metadata with a
 //! non-byte element type. The `str` case reinterprets a runtime UTF-8 byte
 //! slice as `str`, preserving the same `(data, byte_len)` fat-pointer layout.
+//! The slice-tailed struct case exercises Rust's aggregate DST layout rule:
+//! a sized prefix followed inline by a runtime-length `[T]` tail.
 //!
 //! Usage:
 //!   cargo oxide run dst_metadata
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, cuda_module, kernel, thread};
+
+#[repr(C)]
+struct Header<T: ?Sized> {
+    head: u64,
+    tag: u8,
+    tail: T,
+}
+
+const HEADER_HEAD: u64 = 0x1122_3344_5566_7788;
+const HEADER_TAG: u8 = 0x5a;
+const HEADER_TAIL: [u16; 4] = [11, 22, 33, 44];
 
 #[cuda_module]
 mod kernels {
@@ -52,6 +65,33 @@ mod kernels {
             let out_ptr = out.as_mut_ptr();
             out_ptr.write(size);
             out_ptr.add(1).write(align);
+        }
+    }
+
+    /// Report layout and projection behavior for `Header<[u16]>`.
+    #[kernel]
+    pub fn struct_tail_metadata(mut out: DisjointSlice<usize>) {
+        if thread::index_1d().get() != 0 {
+            return;
+        }
+
+        let concrete = Header {
+            head: HEADER_HEAD,
+            tag: HEADER_TAG,
+            tail: HEADER_TAIL,
+        };
+        let value: &Header<[u16]> = &concrete;
+
+        let size = core::mem::size_of_val(value);
+        let align = core::mem::align_of_val(value);
+
+        unsafe {
+            let out_ptr = out.as_mut_ptr();
+            out_ptr.write(size);
+            out_ptr.add(1).write(align);
+            out_ptr.add(2).write(value.tail.len());
+            out_ptr.add(3).write(value.tag as usize);
+            out_ptr.add(4).write(value.head as usize);
         }
     }
 }
@@ -106,5 +146,35 @@ fn main() {
     );
     println!("PASS: size_of_val on str");
     println!("PASS: align_of_val on str");
+
+    let concrete = Header {
+        head: HEADER_HEAD,
+        tag: HEADER_TAG,
+        tail: HEADER_TAIL,
+    };
+    let value: &Header<[u16]> = &concrete;
+    let expected_size = core::mem::size_of_val(value);
+    let expected_align = core::mem::align_of_val(value);
+    let mut struct_out = DeviceBuffer::<usize>::zeroed(&stream, 5).unwrap();
+
+    // SAFETY: one thread writes five `usize` values to a five-element output.
+    unsafe { module.struct_tail_metadata(&stream, cfg, &mut struct_out) }
+        .expect("struct_tail_metadata launch");
+
+    let struct_result = struct_out.to_host_vec(&stream).unwrap();
+    assert_eq!(
+        struct_result[0], expected_size,
+        "size_of_val(&Header<[u16]>)"
+    );
+    assert_eq!(
+        struct_result[1], expected_align,
+        "align_of_val(&Header<[u16]>)"
+    );
+    assert_eq!(struct_result[2], HEADER_TAIL.len(), "tail metadata");
+    assert_eq!(struct_result[3], HEADER_TAG as usize, "tag projection");
+    assert_eq!(struct_result[4], HEADER_HEAD as usize, "head projection");
+    println!("PASS: size_of_val on &Header<[u16]>");
+    println!("PASS: align_of_val on &Header<[u16]>");
+    println!("PASS: unsized-tail metadata and prefix fields");
     println!("PASS: dst_metadata");
 }


### PR DESCRIPTION
Closes #868 

## Summary

Extend `size_of_val` and `align_of_val` lowering to support structs with slice tails, such as:

```rust
#[repr(C)]
struct Header<T: ?Sized> {
    head: u64,
    tag: u8,
    tail: T,
}

let value: &Header<[u16]>;
```

Previously, the layout intrinsics supported slices, `str`, and sized pointees, but rejected unsized struct pointees such as slice-tailed structs.

## What changed

The MIR importer now computes dynamic layout for slice-tailed structs by combining:

* the statically known offset of the trailing unsized field,
* the runtime slice metadata,
* the dynamic size and alignment of the trailing field,
* the struct's static alignment requirements,
* `#[repr(packed)]` alignment constraints where applicable,
* final ABI size rounding.

`align_of_val` uses the same tail-layout rules while keeping the resulting alignment statically known.

## Example coverage

The `dst_metadata` example now includes:

```rust
#[repr(C)]
struct Header<T: ?Sized> {
    head: u64,
    tag: u8,
    tail: T,
}
```

and verifies a coercion from:

```rust
&Header<[u16; 4]>
```

to:

```rust
&Header<[u16]>
```

The device result is compared against the host for:

* `size_of_val`
* `align_of_val`
* trailing slice length metadata
* prefix-field access through the DST reference

The mixed-width prefix intentionally makes padding and final layout rounding observable.

## Scope

This PR only addresses dynamic layout for slice-tailed structs.

Direct constant indexing of a projected `MirSliceType`, for example:

```rust
value.tail[1]
```

is a separate projection-lowering gap tracked in #870 

## Validation

Validated on an NVIDIA GeForce RTX 5060 Laptop GPU with:

```text
cargo oxide run dst_metadata
CUDA_OXIDE_NO_OPT=1 cargo oxide run dst_metadata
scripts/smoketest.sh -o '^dst_metadata$'
scripts/smoketest.sh --compile-only -o '^dst_metadata$'
```

All four pass.

Observed runtime output includes:

```text
PASS: size_of_val on &Header<[u16]>
PASS: align_of_val on &Header<[u16]>
PASS: unsized-tail metadata and prefix fields
PASS: dst_metadata
```
