### PR TITLE
fix(mir-importer): lower ConstantIndex on slice-tailed DST values

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5576,6 +5576,11 @@ pub fn translate_place_iterative(
     // data pointer because Index/ConstantIndex do not need metadata.
     let mut preserved_slice_deref_mutability: Option<bool> = None;
 
+    // A fat reference to a slice-tailed struct carries the runtime length of
+    // that tail in field 1. Deref scalarizes the fat value to the struct data
+    // pointer, so preserve the length for the immediately following tail Field.
+    let mut preserved_slice_tail_len: Option<Value> = None;
+
     // Process each projection element iteratively
     for (proj_idx, projection) in place.projection.iter().enumerate() {
         match projection {
@@ -5588,10 +5593,18 @@ pub fn translate_place_iterative(
                     .get_type(ctx)
                     .deref(ctx)
                     .is::<dialect_mir::types::MirSliceType>();
+                let pointer_info = get_static_pointer_info(&current_rust_ty);
                 let slice_deref_mutability =
-                    get_static_pointer_info(&current_rust_ty).and_then(|(pointee, is_mutable)| {
-                        rust_ty_is_slice(&pointee).then_some(is_mutable)
+                    pointer_info.as_ref().and_then(|(pointee, is_mutable)| {
+                        rust_ty_is_slice(pointee).then_some(*is_mutable)
                     });
+                let current_is_slice_tail_ref = pointer_info
+                    .as_ref()
+                    .is_some_and(|(pointee, _)| types::slice_tail_element_ty(pointee).is_some());
+                let next_is_slice_tail_field = matches!(
+                    place.projection.get(proj_idx + 1),
+                    Some(ProjectionElem::Field(_, field_ty)) if rust_ty_is_slice(field_ty)
+                );
 
                 if next_is_slice_subslice
                     && current_is_fat_slice
@@ -5600,7 +5613,29 @@ pub fn translate_place_iterative(
                     // Preserve the fat pair. The following Subslice consumes
                     // both data and len and advances `current_rust_ty` normally.
                     preserved_slice_deref_mutability = slice_deref_mutability;
+                    preserved_slice_tail_len = None;
                 } else {
+                    // `&S<[T]>` uses the same fat-pair carrier as a slice, but
+                    // field 0 points at the struct prefix while field 1 is the
+                    // trailing slice length. Save that metadata before Deref
+                    // reduces the value to the struct data pointer.
+                    preserved_slice_tail_len = if next_is_slice_tail_field
+                        && current_is_fat_slice
+                        && current_is_slice_tail_ref
+                    {
+                        let (len, len_op) = emit_slice_len_extract(
+                            ctx,
+                            current_value,
+                            block_ptr,
+                            current_prev_op,
+                            loc.clone(),
+                        );
+                        current_prev_op = Some(len_op);
+                        Some(len)
+                    } else {
+                        None
+                    };
+
                     (current_value, current_prev_op) = apply_deref_projection(
                         ctx,
                         current_value,
@@ -5628,6 +5663,64 @@ pub fn translate_place_iterative(
                         current_prev_op,
                         loc.clone(),
                     )?;
+                } else if let Some(tail_len) = preserved_slice_tail_len.take() {
+                    let rustc_public::ty::TyKind::RigidTy(
+                        rustc_public::ty::RigidTy::Slice(tail_elem_rust_ty),
+                    ) = field_ty.kind()
+                    else {
+                        return input_err!(
+                            loc,
+                            TranslationErr::unsupported(
+                                "preserved slice-tail metadata was not consumed by a slice Field"
+                                    .to_string()
+                            )
+                        );
+                    };
+                    let tail_elem_ty = types::translate_type(ctx, &tail_elem_rust_ty)?;
+
+                    // The struct model stores an unsized `[T]` tail as the
+                    // element type `T`, because the elements live inline after
+                    // the sized prefix. Address the field as `*T`, not `*[T]`.
+                    use dialect_mir::ops::{MirConstructSliceOp, MirFieldAddrOp};
+                    let tail_ptr_ty: TypeHandle =
+                        dialect_mir::types::MirPtrType::get_generic(ctx, tail_elem_ty, false).into();
+                    let tail_addr = Operation::new(
+                        ctx,
+                        MirFieldAddrOp::get_concrete_op_info(),
+                        vec![tail_ptr_ty],
+                        vec![current_value],
+                        vec![],
+                        0,
+                    );
+                    tail_addr.deref_mut(ctx).set_loc(loc.clone());
+                    MirFieldAddrOp::new(tail_addr).set_attr_field_index(
+                        ctx,
+                        dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                    );
+                    match current_prev_op {
+                        Some(prev) => tail_addr.insert_after(ctx, prev),
+                        None => tail_addr.insert_at_front(block_ptr, ctx),
+                    }
+                    let tail_ptr = tail_addr.deref(ctx).get_result(0);
+
+                    // Reconstruct the semantic `[T]` value from the inline tail
+                    // address plus the metadata saved from the outer fat reference.
+                    // A following ConstantIndex can now scalarize this MirSliceType
+                    // to field 0 and reuse the existing pointer-offset + load path.
+                    let tail_slice_ty =
+                        dialect_mir::types::MirSliceType::get(ctx, tail_elem_ty);
+                    let construct_tail = Operation::new(
+                        ctx,
+                        MirConstructSliceOp::get_concrete_op_info(),
+                        vec![tail_slice_ty.into()],
+                        vec![tail_ptr, tail_len],
+                        vec![],
+                        0,
+                    );
+                    construct_tail.deref_mut(ctx).set_loc(loc.clone());
+                    construct_tail.insert_after(ctx, tail_addr);
+                    current_value = construct_tail.deref(ctx).get_result(0);
+                    current_prev_op = Some(construct_tail);
                 } else {
                     let current_is_ptr = current_value
                         .get_type(ctx)
@@ -5817,6 +5910,38 @@ pub fn translate_place_iterative(
                     );
                 }
                 let index = *offset as usize;
+
+                // A projected unsized slice tail is already materialized as a fat
+                // `MirSliceType` value. Normalize it to the thin data pointer before
+                // reusing the existing pointer ConstantIndex lowering below.
+                let slice_element_ty = {
+                    let cur_ty = current_value.get_type(ctx);
+                    let cur_ty_ref = cur_ty.deref(ctx);
+                    cur_ty_ref
+                        .downcast_ref::<dialect_mir::types::MirSliceType>()
+                        .map(|slice_ty| slice_ty.element_type())
+                };
+                if let Some(element_ty) = slice_element_ty {
+                    let data_ptr_ty: TypeHandle =
+                        dialect_mir::types::MirPtrType::get_generic(ctx, element_ty, false).into();
+                    let extract_ptr = Operation::new(
+                        ctx,
+                        MirExtractFieldOp::get_concrete_op_info(),
+                        vec![data_ptr_ty],
+                        vec![current_value],
+                        vec![],
+                        0,
+                    );
+                    extract_ptr.deref_mut(ctx).set_loc(loc.clone());
+                    MirExtractFieldOp::new(extract_ptr)
+                        .set_attr_index(ctx, dialect_mir::attributes::FieldIndexAttr(0));
+                    match current_prev_op {
+                        Some(prev) => extract_ptr.insert_after(ctx, prev),
+                        None => extract_ptr.insert_at_front(block_ptr, ctx),
+                    }
+                    current_value = extract_ptr.deref(ctx).get_result(0);
+                    current_prev_op = Some(extract_ptr);
+                }
 
                 // Determine indexable kind upfront so we drop the immutable borrow
                 // before creating operations (which need &mut ctx).

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -44,11 +44,24 @@ raw-pointer shapes the unified `translate_place_address` walker must lower:
 | 19 | `test_inline_never_node_fn`          | Exact issue #120 `node()` MIR shape            |
 | 20 | `test_holder_deref_tail`             | `&hr.0[k]` with Deref inside the tail          |
 
+plus **1 slice-value regression kernel** that pins issue #870:
+
+| #  | Variant                              | Shape pinned                                   |
+|:---|:-------------------------------------|:-----------------------------------------------|
+| 21 | `test_slice_tail_constant_index`     | `Field(tail) -> MirSliceType -> ConstantIndex` |
+
 Each kernel writes a difference (`r1 - r0`, or original-local readback for
 the write-through variants) for inputs chosen so a correct implementation
 must produce `+5.0` for every element. The harness prints `PASS` per kernel,
 tracks failures, prints a final `SUCCESS` marker when every kernel passes,
 and exits non-zero if any kernel reports a wrong diff.
+
+For issue #870, the regression constructs a `SliceTail<[f32; 2]>`, unsizes it
+to `&SliceTail<[f32]>`, then reads `value.tail[0]` and `value.tail[1]`. Deref of
+the fat struct reference must preserve the tail-length metadata long enough for
+the `Field(tail)` projection to reconstruct a `MirSliceType` value. The following
+`ConstantIndex` then extracts the slice data pointer and reuses the existing
+pointer-offset + load lowering.
 
 ## Trigger conditions
 
@@ -98,8 +111,8 @@ the fix, the same MIR lowers to
 %v9 = load float, ptr %v8                                              ; correct
 ```
 
-and all 20 kernels report `PASS` (the harness prints a final `SUCCESS`
-marker and exits non-zero on any failure).
+and all 21 kernels report `PASS` (the harness prints a final `SUCCESS`
+marker and exits non-zero if any kernel reports a wrong diff).
 
 ## Build & run
 

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -13,6 +13,7 @@
  *     addr_of! / addr_of_mut!                            // raw-pointer paths
  *     &mut local.field[k]                                // write-through
  *     struct Holder<'a>(&'a [f32; 2]); &h.0[k]           // deref in the tail
+ *     value.tail[1]                                      // DST slice tail + const index
  *
  * Each kernel writes the difference compute(1) - compute(0), with inputs
  * designed so the two slots differ: a dropped index reads slot 0 twice
@@ -81,6 +82,13 @@ fn node(p: &Pair, k: usize) -> &f32 {
 /// when `h` is itself behind a reference). Exercises the address walker's
 /// Deref arm.
 pub struct Holder<'a>(pub &'a [f32; 2]);
+
+/// Struct with an unsized slice tail used to pin issue #870.
+#[repr(C)]
+pub struct SliceTail<T: ?Sized> {
+    pub head: u32,
+    pub tail: T,
+}
 
 /// Out-of-line accessor pinning the `[Deref, Field(0), Deref, Index(k)]`
 /// projection chain in its own MIR body.
@@ -607,6 +615,32 @@ mod kernels {
             *slot = *r1 - *r0;
         }
     }
+
+    // ── Slice-value projection regression (issue #870) ─────────────────
+
+    /// ConstantIndex directly on the `MirSliceType` value produced by
+    /// projecting the unsized slice tail of a DST struct.
+    #[kernel]
+    pub fn test_slice_tail_constant_index(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let concrete = SliceTail {
+            head: 0,
+            tail: input[i],
+        };
+        let value: &SliceTail<[f32]> = &concrete;
+
+        let r0 = value.tail[0];
+        let r1 = value.tail[1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = r1 - r0;
+        }
+    }
 }
 
 const N: usize = 4;
@@ -775,6 +809,10 @@ fn main() {
     all_pass &= run_and_report("test_holder_deref_tail", &stream, |s, cfg, i, o| {
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.test_holder_deref_tail(s, cfg, i, o) }.expect("launch")
+    });
+    all_pass &= run_and_report("test_slice_tail_constant_index", &stream, |s, cfg, i, o| {
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_slice_tail_constant_index(s, cfg, i, o) }.expect("launch")
     });
 
     if all_pass {


### PR DESCRIPTION
Closes #870

## Summary

Support `ConstantIndex` projections on slice values produced by projecting the
unsized slice tail of a DST struct.

For example:

```rust
#[repr(C)]
struct SliceTail<T: ?Sized> {
    head: u32,
    tail: T,
}

let concrete = SliceTail {
    head: 0,
    tail: [11.0_f32, 16.0],
};

let value: &SliceTail<[f32]> = &concrete;

let x = value.tail[1];
```

Previously, this projection chain could not be lowered correctly:

```text
Deref
  -> Field(tail)
  -> MirSliceType
  -> ConstantIndex
```

## Root cause

A fat reference to a slice-tailed struct carries the trailing slice length as
metadata.

For this projection path, `Deref` scalarizes the fat reference to the struct
data pointer, so the trailing slice length must be preserved for the following
`Field` projection.

Projecting the unsized tail directly as `ptr<MirSliceType<T>>` is also invalid,
because the struct storage model represents the inline slice tail using the
element type `T`, not a fat slice value.

As a result, the projected slice tail reached `ConstantIndex` as a
`MirSliceType`, while that lowering only handled arrays and thin pointers.

## What changed

The iterative place-value walker now:

* preserves the trailing slice length when dereferencing a fat reference to a
  slice-tailed struct,
* projects the unsized tail as a pointer to its inline element type,
* reconstructs the semantic `MirSliceType` from the tail data pointer and the
  preserved length,
* normalizes that `MirSliceType` to its data pointer before lowering a forward
  `ConstantIndex`,
* reuses the existing pointer offset + load path for the final element access.

The existing slice and sized-array projection paths remain unchanged.

## Regression coverage

`ref_index_projections` now includes:

```rust
let concrete = SliceTail {
    head: 0,
    tail: input[i],
};

let value: &SliceTail<[f32]> = &concrete;

let r0 = value.tail[0];
let r1 = value.tail[1];
```

The kernel verifies that the two constant-index loads access different elements
of the trailing slice and produce the expected `+5.0` difference.

The example now contains 21 regression kernels.

## Validation

Validated with:

```text
cargo oxide run ref_index_projections
CUDA_OXIDE_NO_OPT=1 cargo oxide run ref_index_projections
cargo test -p mir-importer
cargo clippy -p mir-importer --all-targets -- -D warnings
scripts/smoketest.sh -o '^ref_index_projections$'
scripts/smoketest.sh --compile-only -o '^ref_index_projections$'
cargo oxide pipeline ref_index_projections
```

Both optimized and low-MIR-optimization runs pass all 21 kernels, including:

```text
test_slice_tail_constant_index  PASS
```

`mir-importer` also passes all 1068 unit tests.
