### PR TITLE
fix(mir-importer): lower Index on slice-tailed DST values

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -5515,6 +5515,45 @@ fn rust_ty_is_slice(ty: &rustc_public::ty::Ty) -> bool {
     )
 }
 
+fn normalize_slice_value_to_data_ptr(
+    ctx: &mut Context,
+    value: Value,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> (Value, Option<Ptr<Operation>>) {
+    let slice_element_ty = {
+        let value_ty = value.get_type(ctx);
+        let value_ty_ref = value_ty.deref(ctx);
+        value_ty_ref
+            .downcast_ref::<dialect_mir::types::MirSliceType>()
+            .map(|slice_ty| slice_ty.element_type())
+    };
+    let Some(element_ty) = slice_element_ty else {
+        return (value, prev_op);
+    };
+
+    let data_ptr_ty: TypeHandle =
+        dialect_mir::types::MirPtrType::get_generic(ctx, element_ty, false).into();
+    let extract_ptr = Operation::new(
+        ctx,
+        MirExtractFieldOp::get_concrete_op_info(),
+        vec![data_ptr_ty],
+        vec![value],
+        vec![],
+        0,
+    );
+    extract_ptr.deref_mut(ctx).set_loc(loc);
+    MirExtractFieldOp::new(extract_ptr)
+        .set_attr_index(ctx, dialect_mir::attributes::FieldIndexAttr(0));
+    match prev_op {
+        Some(prev) => extract_ptr.insert_after(ctx, prev),
+        None => extract_ptr.insert_at_front(block_ptr, ctx),
+    }
+
+    (extract_ptr.deref(ctx).get_result(0), Some(extract_ptr))
+}
+
 /// Translate a MIR Place using iterative projection processing.
 /// This handles arbitrary depth projections by processing each element in sequence.
 pub fn translate_place_iterative(
@@ -5589,6 +5628,11 @@ pub fn translate_place_iterative(
     // data pointer because Index/ConstantIndex do not need metadata.
     let mut preserved_slice_deref_mutability: Option<bool> = None;
 
+    // A fat reference to a slice-tailed struct carries the runtime length of
+    // that tail in field 1. Deref scalarizes the fat value to the struct data
+    // pointer, so preserve the length for the immediately following tail Field.
+    let mut preserved_slice_tail_len: Option<Value> = None;
+
     // Process each projection element iteratively
     for (proj_idx, projection) in place.projection.iter().enumerate() {
         match projection {
@@ -5601,10 +5645,18 @@ pub fn translate_place_iterative(
                     .get_type(ctx)
                     .deref(ctx)
                     .is::<dialect_mir::types::MirSliceType>();
+                let pointer_info = get_static_pointer_info(&current_rust_ty);
                 let slice_deref_mutability =
-                    get_static_pointer_info(&current_rust_ty).and_then(|(pointee, is_mutable)| {
-                        rust_ty_is_slice(&pointee).then_some(is_mutable)
+                    pointer_info.as_ref().and_then(|(pointee, is_mutable)| {
+                        rust_ty_is_slice(pointee).then_some(*is_mutable)
                     });
+                let current_is_slice_tail_ref = pointer_info
+                    .as_ref()
+                    .is_some_and(|(pointee, _)| types::slice_tail_element_ty(pointee).is_some());
+                let next_is_slice_tail_field = matches!(
+                    place.projection.get(proj_idx + 1),
+                    Some(ProjectionElem::Field(_, field_ty)) if rust_ty_is_slice(field_ty)
+                );
 
                 if next_is_slice_subslice
                     && current_is_fat_slice
@@ -5613,7 +5665,29 @@ pub fn translate_place_iterative(
                     // Preserve the fat pair. The following Subslice consumes
                     // both data and len and advances `current_rust_ty` normally.
                     preserved_slice_deref_mutability = slice_deref_mutability;
+                    preserved_slice_tail_len = None;
                 } else {
+                    // `&S<[T]>` uses the same fat-pair carrier as a slice, but
+                    // field 0 points at the struct prefix while field 1 is the
+                    // trailing slice length. Save that metadata before Deref
+                    // reduces the value to the struct data pointer.
+                    preserved_slice_tail_len = if next_is_slice_tail_field
+                        && current_is_fat_slice
+                        && current_is_slice_tail_ref
+                    {
+                        let (len, len_op) = emit_slice_len_extract(
+                            ctx,
+                            current_value,
+                            block_ptr,
+                            current_prev_op,
+                            loc.clone(),
+                        );
+                        current_prev_op = Some(len_op);
+                        Some(len)
+                    } else {
+                        None
+                    };
+
                     (current_value, current_prev_op) = apply_deref_projection(
                         ctx,
                         current_value,
@@ -5641,6 +5715,65 @@ pub fn translate_place_iterative(
                         current_prev_op,
                         loc.clone(),
                     )?;
+                } else if let Some(tail_len) = preserved_slice_tail_len.take() {
+                    let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(
+                        tail_elem_rust_ty,
+                    )) = field_ty.kind()
+                    else {
+                        return input_err!(
+                            loc,
+                            TranslationErr::unsupported(
+                                "preserved slice-tail metadata was not consumed by a slice Field"
+                                    .to_string()
+                            )
+                        );
+                    };
+                    let tail_elem_ty = types::translate_type(ctx, &tail_elem_rust_ty)?;
+
+                    // The struct model stores an unsized `[T]` tail as the
+                    // element type `T`, because the elements live inline after
+                    // the sized prefix. Address the field as `*T`, not `*[T]`.
+                    use dialect_mir::ops::{MirConstructSliceOp, MirFieldAddrOp};
+                    let tail_ptr_ty: TypeHandle =
+                        dialect_mir::types::MirPtrType::get_generic(ctx, tail_elem_ty, false)
+                            .into();
+                    let tail_addr = Operation::new(
+                        ctx,
+                        MirFieldAddrOp::get_concrete_op_info(),
+                        vec![tail_ptr_ty],
+                        vec![current_value],
+                        vec![],
+                        0,
+                    );
+                    tail_addr.deref_mut(ctx).set_loc(loc.clone());
+                    MirFieldAddrOp::new(tail_addr).set_attr_field_index(
+                        ctx,
+                        dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                    );
+                    match current_prev_op {
+                        Some(prev) => tail_addr.insert_after(ctx, prev),
+                        None => tail_addr.insert_at_front(block_ptr, ctx),
+                    }
+                    let tail_ptr = tail_addr.deref(ctx).get_result(0);
+
+                    // Reconstruct the semantic `[T]` value from the inline tail
+                    // address plus the metadata saved from the outer fat reference.
+                    // A following Index or ConstantIndex can scalarize this
+                    // MirSliceType to field 0 and reuse the existing pointer-offset
+                    // + load path.
+                    let tail_slice_ty = dialect_mir::types::MirSliceType::get(ctx, tail_elem_ty);
+                    let construct_tail = Operation::new(
+                        ctx,
+                        MirConstructSliceOp::get_concrete_op_info(),
+                        vec![tail_slice_ty.into()],
+                        vec![tail_ptr, tail_len],
+                        vec![],
+                        0,
+                    );
+                    construct_tail.deref_mut(ctx).set_loc(loc.clone());
+                    construct_tail.insert_after(ctx, tail_addr);
+                    current_value = construct_tail.deref(ctx).get_result(0);
+                    current_prev_op = Some(construct_tail);
                 } else {
                     let current_is_ptr = current_value
                         .get_type(ctx)
@@ -5702,6 +5835,17 @@ pub fn translate_place_iterative(
                     loc.clone(),
                 )?;
                 current_prev_op = next_prev_op;
+
+                // A projected unsized slice tail is represented as a fat
+                // `MirSliceType` value. Runtime Index only needs the data
+                // pointer, so normalize it before reusing the pointer path.
+                (current_value, current_prev_op) = normalize_slice_value_to_data_ptr(
+                    ctx,
+                    current_value,
+                    block_ptr,
+                    current_prev_op,
+                    loc.clone(),
+                );
 
                 // Determine indexable kind upfront so we drop the immutable borrow
                 // before creating operations (which need &mut ctx).
@@ -5830,6 +5974,17 @@ pub fn translate_place_iterative(
                     );
                 }
                 let index = *offset as usize;
+
+                // A projected unsized slice tail is represented as a fat
+                // `MirSliceType` value. ConstantIndex only needs the data
+                // pointer, so normalize it before reusing the pointer path.
+                (current_value, current_prev_op) = normalize_slice_value_to_data_ptr(
+                    ctx,
+                    current_value,
+                    block_ptr,
+                    current_prev_op,
+                    loc.clone(),
+                );
 
                 // Determine indexable kind upfront so we drop the immutable borrow
                 // before creating operations (which need &mut ctx).

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -44,13 +44,14 @@ raw-pointer shapes the unified `translate_place_address` walker must lower:
 | 19 | `test_inline_never_node_fn`          | Exact issue #120 `node()` MIR shape            |
 | 20 | `test_holder_deref_tail`             | `&hr.0[k]` with Deref inside the tail          |
 
-plus **2 slice-value regression kernels** that pin the two indexing forms on
-a projected unsized slice tail:
+plus **3 slice-value regression kernels** that pin the two indexing forms on
+a projected unsized slice tail, and the tail byte offset behind padding:
 
 | #  | Variant                              | Shape pinned                                   |
 |:---|:-------------------------------------|:-----------------------------------------------|
 | 21 | `test_slice_tail_constant_index`     | `Field(tail) -> MirSliceType -> ConstantIndex` |
 | 22 | `test_slice_tail_runtime_index`      | `Field(tail) -> MirSliceType -> Index`         |
+| 23 | `test_slice_tail_padded_offset`      | `[u16]` tail at byte offset 10 behind padding  |
 
 Each kernel writes a difference (`r1 - r0`, or original-local readback for
 the write-through variants) for inputs chosen so a correct implementation
@@ -65,6 +66,11 @@ runtime tail length long enough for `Field(tail)` to reconstruct a
 `ConstantIndex`, while `test_slice_tail_runtime_index` uses a data-derived
 runtime `Index`. Both normalize the semantic slice value to its data pointer
 before reusing the existing pointer-offset + load lowering.
+`test_slice_tail_padded_offset` repeats both indexing forms on the
+issue #870 repro layout (`head: u64`, `tag: u8`, `tail: [u16]`), whose
+tail sits at byte offset 10 behind a padding byte: `SliceTail` places its
+tail at offset 4 with no padding, so only the padded variant can catch a
+wrong-tail-offset bug in the `Field(tail)` address computation.
 
 ## Trigger conditions
 
@@ -114,7 +120,7 @@ the fix, the same MIR lowers to
 %v9 = load float, ptr %v8                                              ; correct
 ```
 
-and all 22 kernels report `PASS` (the harness prints a final `SUCCESS`
+and all 23 kernels report `PASS` (the harness prints a final `SUCCESS`
 marker and exits non-zero if any kernel reports a wrong diff).
 
 ## Build & run

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -44,11 +44,27 @@ raw-pointer shapes the unified `translate_place_address` walker must lower:
 | 19 | `test_inline_never_node_fn`          | Exact issue #120 `node()` MIR shape            |
 | 20 | `test_holder_deref_tail`             | `&hr.0[k]` with Deref inside the tail          |
 
+plus **2 slice-value regression kernels** that pin the two indexing forms on
+a projected unsized slice tail:
+
+| #  | Variant                              | Shape pinned                                   |
+|:---|:-------------------------------------|:-----------------------------------------------|
+| 21 | `test_slice_tail_constant_index`     | `Field(tail) -> MirSliceType -> ConstantIndex` |
+| 22 | `test_slice_tail_runtime_index`      | `Field(tail) -> MirSliceType -> Index`         |
+
 Each kernel writes a difference (`r1 - r0`, or original-local readback for
 the write-through variants) for inputs chosen so a correct implementation
 must produce `+5.0` for every element. The harness prints `PASS` per kernel,
 tracks failures, prints a final `SUCCESS` marker when every kernel passes,
 and exits non-zero if any kernel reports a wrong diff.
+
+The slice-value regressions construct a `SliceTail<[f32; 2]>` and unsize it to
+`&SliceTail<[f32]>`. Deref of the fat struct reference must preserve the
+runtime tail length long enough for `Field(tail)` to reconstruct a
+`MirSliceType` value. `test_slice_tail_constant_index` then exercises a literal
+`ConstantIndex`, while `test_slice_tail_runtime_index` uses a data-derived
+runtime `Index`. Both normalize the semantic slice value to its data pointer
+before reusing the existing pointer-offset + load lowering.
 
 ## Trigger conditions
 
@@ -98,8 +114,8 @@ the fix, the same MIR lowers to
 %v9 = load float, ptr %v8                                              ; correct
 ```
 
-and all 20 kernels report `PASS` (the harness prints a final `SUCCESS`
-marker and exits non-zero on any failure).
+and all 22 kernels report `PASS` (the harness prints a final `SUCCESS`
+marker and exits non-zero if any kernel reports a wrong diff).
 
 ## Build & run
 

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -15,6 +15,7 @@
  *     struct Holder<'a>(&'a [f32; 2]); &h.0[k]           // deref in the tail
  *     value.tail[1]                                      // DST slice tail + const index
  *     value.tail[k]                                      // DST slice tail + runtime index
+ *     padded.tail[k]                                     // DST slice tail behind padding
  *
  * Each kernel writes the difference compute(1) - compute(0), with inputs
  * designed so the two slots differ: a dropped index reads slot 0 twice
@@ -88,6 +89,17 @@ pub struct Holder<'a>(pub &'a [f32; 2]);
 #[repr(C)]
 pub struct SliceTail<T: ?Sized> {
     pub head: u32,
+    pub tail: T,
+}
+
+/// The exact issue #870 repro layout: `head: u64` plus `tag: u8` put the
+/// `[u16]` tail at byte offset 10, behind one padding byte. `SliceTail`
+/// places its tail at offset 4 with no padding, so only this struct can
+/// catch a wrong-tail-offset bug in the slice-tail Field lowering.
+#[repr(C)]
+pub struct PaddedTail<T: ?Sized> {
+    pub head: u64,
+    pub tag: u8,
     pub tail: T,
 }
 
@@ -669,6 +681,44 @@ mod kernels {
             *slot = r1 - r0;
         }
     }
+
+    /// Padded tail offset (issue #870 repro layout): the `[u16]` tail sits
+    /// at byte offset 10, behind `head: u64`, `tag: u8`, and one padding
+    /// byte. Reads the tail with BOTH constant and runtime indices; the
+    /// all-ones sentinels in `head` and `tag` make any wrong tail offset
+    /// read 0xFF bytes (or shifted elements) and break the +5.0 oracle.
+    #[kernel]
+    pub fn test_slice_tail_padded_offset(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let a = input[i][0] as u16;
+        let b = input[i][1] as u16;
+        let concrete = PaddedTail {
+            head: u64::MAX,
+            tag: 0xFF,
+            tail: [a, b, b, b],
+        };
+        let value: &PaddedTail<[u16]> = &concrete;
+
+        // Constant indices into the padded tail: c1 - c0 == +5.
+        let c0 = value.tail[0];
+        let c1 = value.tail[1];
+
+        // Data-derived so rustc keeps a runtime Index projection. The test
+        // input makes k == 2 at runtime; tail[2] == tail[3], so the runtime
+        // pair contributes 0 and the +5.0 harness oracle is preserved.
+        let k = ((input[0][0] as usize) & 1) + 2;
+        let r0 = value.tail[k];
+        let r1 = value.tail[k + 1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = (c1 as f32 - c0 as f32) + (r1 as f32 - r0 as f32);
+        }
+    }
 }
 
 const N: usize = 4;
@@ -845,6 +895,10 @@ fn main() {
     all_pass &= run_and_report("test_slice_tail_runtime_index", &stream, |s, cfg, i, o| {
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.test_slice_tail_runtime_index(s, cfg, i, o) }.expect("launch")
+    });
+    all_pass &= run_and_report("test_slice_tail_padded_offset", &stream, |s, cfg, i, o| {
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_slice_tail_padded_offset(s, cfg, i, o) }.expect("launch")
     });
 
     if all_pass {

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -13,6 +13,8 @@
  *     addr_of! / addr_of_mut!                            // raw-pointer paths
  *     &mut local.field[k]                                // write-through
  *     struct Holder<'a>(&'a [f32; 2]); &h.0[k]           // deref in the tail
+ *     value.tail[1]                                      // DST slice tail + const index
+ *     value.tail[k]                                      // DST slice tail + runtime index
  *
  * Each kernel writes the difference compute(1) - compute(0), with inputs
  * designed so the two slots differ: a dropped index reads slot 0 twice
@@ -81,6 +83,13 @@ fn node(p: &Pair, k: usize) -> &f32 {
 /// when `h` is itself behind a reference). Exercises the address walker's
 /// Deref arm.
 pub struct Holder<'a>(pub &'a [f32; 2]);
+
+/// Struct with an unsized slice tail used to pin slice-value projections.
+#[repr(C)]
+pub struct SliceTail<T: ?Sized> {
+    pub head: u32,
+    pub tail: T,
+}
 
 /// Out-of-line accessor pinning the `[Deref, Field(0), Deref, Index(k)]`
 /// projection chain in its own MIR body.
@@ -607,6 +616,59 @@ mod kernels {
             *slot = *r1 - *r0;
         }
     }
+
+    // ── Slice-value projection regressions ───────────────────────────────
+
+    /// ConstantIndex directly on the `MirSliceType` value produced by
+    /// projecting the unsized slice tail of a DST struct (issue #870).
+    #[kernel]
+    pub fn test_slice_tail_constant_index(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let concrete = SliceTail {
+            head: 0,
+            tail: input[i],
+        };
+        let value: &SliceTail<[f32]> = &concrete;
+
+        let r0 = value.tail[0];
+        let r1 = value.tail[1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = r1 - r0;
+        }
+    }
+
+    /// Runtime Index directly on the `MirSliceType` value produced by
+    /// projecting the unsized slice tail of a DST struct.
+    #[kernel]
+    pub fn test_slice_tail_runtime_index(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let concrete = SliceTail {
+            head: 0,
+            tail: input[i],
+        };
+        let value: &SliceTail<[f32]> = &concrete;
+
+        // Data-derived so rustc keeps a runtime Index projection. The test
+        // input makes k == 0 at runtime, preserving the +5.0 harness oracle.
+        let k = (input[0][0] as usize) & 1;
+        let r0 = value.tail[k];
+        let r1 = value.tail[k + 1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = r1 - r0;
+        }
+    }
 }
 
 const N: usize = 4;
@@ -775,6 +837,14 @@ fn main() {
     all_pass &= run_and_report("test_holder_deref_tail", &stream, |s, cfg, i, o| {
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.test_holder_deref_tail(s, cfg, i, o) }.expect("launch")
+    });
+    all_pass &= run_and_report("test_slice_tail_constant_index", &stream, |s, cfg, i, o| {
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_slice_tail_constant_index(s, cfg, i, o) }.expect("launch")
+    });
+    all_pass &= run_and_report("test_slice_tail_runtime_index", &stream, |s, cfg, i, o| {
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_slice_tail_runtime_index(s, cfg, i, o) }.expect("launch")
     });
 
     if all_pass {


### PR DESCRIPTION
Closes #872 

## Summary

Support runtime `Index` projections on `MirSliceType` values produced by projecting the unsized slice tail of a DST struct.

This is the runtime-index counterpart of the `ConstantIndex` support added for #870.

The relevant projection chain is:

```text
Deref
  -> Field(tail)
  -> MirSliceType
  -> Index(k)
```

## Root cause

The iterative place-value walker already supports runtime `Index` for:

```text
MirArrayType
MirPtrType
```

but a projected slice tail is represented semantically as a `MirSliceType`.

After the slice-tail metadata is preserved and the tail value reconstructed,
the runtime `Index` path still sees the fat slice value directly and therefore
does not enter the existing pointer-based indexing path.

## What changed

The slice-value-to-data-pointer normalization is shared by both runtime
`Index` and `ConstantIndex`.

For a `MirSliceType<T>` value, the importer now:

```text
MirSliceType<T>
  -> extract field 0
  -> ptr<T>
```

and then reuses the existing pointer lowering.

For runtime `Index`, the resulting path is:

```text
MirSliceType<T>
  -> data pointer
  -> MirPtrOffsetOp(runtime_index)
  -> MirLoadOp
```

The existing array and thin-pointer indexing behavior remains unchanged.

## Regression coverage

`ref_index_projections` now includes:

```rust
let concrete = SliceTail {
    head: 0,
    tail: input[i],
};

let value: &SliceTail<[f32]> = &concrete;

let k = (input[0][0] as usize) & 1;
let r0 = value.tail[k];
let r1 = value.tail[k + 1];
```

The runtime-derived `k` forces the MIR path:

```text
Field(tail)
  -> MirSliceType
  -> Index
```

The harness verifies that the two loads access different tail elements and
produce the expected `+5.0` difference.

`ref_index_projections` now contains 22 regression kernels.

## Validation

Validated with:

```text
cargo oxide run ref_index_projections
CUDA_OXIDE_NO_OPT=1 cargo oxide run ref_index_projections
cargo test -p mir-importer
cargo clippy -p mir-importer --all-targets -- -D warnings
scripts/smoketest.sh -o '^ref_index_projections$'
scripts/smoketest.sh --compile-only -o '^ref_index_projections$'
cargo oxide pipeline ref_index_projections
git diff --check
```

Results:

```text
test_slice_tail_constant_index    PASS
test_slice_tail_runtime_index     PASS
SUCCESS: all kernels passed
```

Both optimized and `CUDA_OXIDE_NO_OPT=1` runs pass all 22 kernels.

`mir-importer` passes all 1068 unit tests.

Both filtered smoketests pass:

```text
Pass: 1 / 1
Fail: 0 / 1
```
