### PR TITLE
feat(device): add native packed f32x2 arithmetic

### DIFF
--- a/crates/cuda-device/src/f32x2.rs
+++ b/crates/cuda-device/src/f32x2.rs
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Native SM100 two-lane `f32` arithmetic.
+//!
+//! Unlike [`crate::vector::F32x2`], which is an over-aligned memory element,
+//! these operations consume and produce [`crate::Float2`] register groups and
+//! lower to one `fma.rn.f32x2` or `add.rn.f32x2` PTX instruction.
+
+use crate::{Float2, ptx_asm};
+
+/// Pack two scalar f32 values into the PTX f32x2 register representation.
+#[inline(always)]
+pub fn pack_f32x2(lo: f32, hi: f32) -> u64 {
+    let result: u64;
+    unsafe {
+        ptx_asm!(
+            "mov.b64 %0, {%1, %2};",
+            out("=l") result,
+            in("f") lo,
+            in("f") hi,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Return the low scalar lane from a packed PTX f32x2 register.
+#[inline(always)]
+pub fn unpack_f32x2_lo(value: u64) -> f32 {
+    let result: f32;
+    unsafe {
+        ptx_asm!(
+            "mov.b64 {%0, _}, %1;",
+            out("=f") result,
+            in("l") value,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Return the high scalar lane from a packed PTX f32x2 register.
+#[inline(always)]
+pub fn unpack_f32x2_hi(value: u64) -> f32 {
+    let result: f32;
+    unsafe {
+        ptx_asm!(
+            "mov.b64 {_, %0}, %1;",
+            out("=f") result,
+            in("l") value,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Add the two scalar lanes of a packed PTX f32x2 register.
+#[inline(always)]
+pub fn horizontal_add_f32x2_packed(value: u64) -> f32 {
+    let result: f32;
+    unsafe {
+        ptx_asm!(
+            "{ .reg .f32 lo, hi; mov.b64 {lo, hi}, %1; add.f32 %0, lo, hi; }",
+            out("=f") result,
+            in("l") value,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Packed-register form of [`fma_f32x2`].
+#[inline(always)]
+pub fn fma_f32x2_packed(a: u64, b: u64, c: u64) -> u64 {
+    let result: u64;
+    unsafe {
+        ptx_asm!(
+            "fma.rn.f32x2 %0, %1, %2, %3;",
+            out("=l") result,
+            in("l") a,
+            in("l") b,
+            in("l") c,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Packed-register form of [`add_f32x2`].
+#[inline(always)]
+pub fn add_f32x2_packed(a: u64, b: u64) -> u64 {
+    let result: u64;
+    unsafe {
+        ptx_asm!(
+            "add.rn.f32x2 %0, %1, %2;",
+            out("=l") result,
+            in("l") a,
+            in("l") b,
+            options(register_only),
+        );
+    }
+    result
+}
+
+/// Two-lane round-to-nearest-even fused multiply-add (`a * b + c`).
+#[inline(always)]
+pub fn fma_f32x2(a: Float2, b: Float2, c: Float2) -> Float2 {
+    // PTX models f32x2 as one 64-bit register pair. Keep that representation
+    // at the asm boundary so ptxas can reuse the input/output pairs directly.
+    let result = fma_f32x2_packed(
+        pack_f32x2(a.x(), a.y()),
+        pack_f32x2(b.x(), b.y()),
+        pack_f32x2(c.x(), c.y()),
+    );
+    Float2::new([unpack_f32x2_lo(result), unpack_f32x2_hi(result)])
+}
+
+/// Two-lane round-to-nearest-even addition.
+#[inline(always)]
+pub fn add_f32x2(a: Float2, b: Float2) -> Float2 {
+    let result = add_f32x2_packed(pack_f32x2(a.x(), a.y()), pack_f32x2(b.x(), b.y()));
+    Float2::new([unpack_f32x2_lo(result), unpack_f32x2_hi(result)])
+}

--- a/crates/cuda-device/src/lib.rs
+++ b/crates/cuda-device/src/lib.rs
@@ -6,6 +6,10 @@
 #![feature(f16)]
 #![no_std]
 
+// Proc-macro expansions use the public crate path so the same expansion works
+// both here and in downstream device crates.
+extern crate self as cuda_device;
+
 pub use cuda_macros::{
     cluster_launch, constant, convergent, cooperative_launch, cuda_module, device, gpu_printf,
     kernel, launch_bounds, launch_contract, ptx_asm, pure, readonly,
@@ -30,6 +34,7 @@ pub mod disjoint;
 pub mod dotprod;
 pub mod f16;
 pub mod f16x2;
+pub mod f32x2;
 pub mod fence;
 pub mod float;
 pub mod grid;

--- a/crates/cuda-oxide-codegen/src/target.rs
+++ b/crates/cuda-oxide-codegen/src/target.rs
@@ -131,6 +131,13 @@ fn contains_sm90_features(contents: &str) -> bool {
         || contains_multimem_features(contents)
 }
 
+/// Native two-lane f32 arithmetic requires PTX 8.2 and sm_100+.
+fn contains_f32x2_features(contents: &str) -> bool {
+    ["add.rn.f32x2", "fma.rn.f32x2"]
+        .iter()
+        .any(|mnemonic| contains_instruction_mnemonic(contents, mnemonic))
+}
+
 /// Native packed bf16 atomic add was added in PTX 7.8 for sm_90.
 fn contains_packed_bf16_atomic_features(contents: &str) -> bool {
     contains_instruction_mnemonic(contents, "atom.global.add.noftz.bf16x2")
@@ -1061,7 +1068,9 @@ pub fn detect_features_in_llvm_text(contents: &str) -> DetectedFeatures {
             DetectedFeatures::Ldmatrix,
         ),
         (
-            contains_tma_sm100_features(contents) || contains_clc_features(contents),
+            contains_tma_sm100_features(contents)
+                || contains_clc_features(contents)
+                || contains_f32x2_features(contents),
             DetectedFeatures::Sm100,
         ),
         (
@@ -1139,6 +1148,7 @@ fn detect_module_requirements_in_llvm_text(contents: &str) -> ModuleRequirements
         || contains_fence_acquire_release_features(contents)
         || contains_multimem_features(contents)
         || contains_redux_f32_features(contents)
+        || contains_f32x2_features(contents)
     {
         ptx_isa = ptx_isa.max(PtxIsaRequirement::Ptx86);
     }
@@ -2817,6 +2827,25 @@ mod tests {
                 detect_features_in_llvm_text(near_miss),
                 DetectedFeatures::Basic
             );
+        }
+    }
+
+    #[test]
+    fn f32x2_detection_requires_sm100_and_rounds_ptx82_to_ptx86() {
+        for mnemonic in ["add.rn.f32x2 $0, $1, $2;", "fma.rn.f32x2 $0, $1, $2, $3;"] {
+            assert!(contains_f32x2_features(mnemonic));
+            let requirements = detect_module_requirements_in_llvm_text(mnemonic);
+            assert_eq!(requirements.features, DetectedFeatures::Sm100);
+            // LLVM exposes PTX versions discretely; 8.6 is the nearest
+            // supported feature at or above this instruction's PTX 8.2 floor.
+            assert_eq!(requirements.ptx_isa, PtxIsaRequirement::Ptx86);
+            assert!(!arch_satisfies("sm_90", requirements.features));
+            assert!(arch_satisfies("sm_100", requirements.features));
+            assert!(arch_satisfies("sm_120", requirements.features));
+        }
+
+        for near_miss in ["add.rn.f32x2x $0, $1, $2;", "fma.rn.f32x2x $0, $1, $2, $3;"] {
+            assert!(!contains_f32x2_features(near_miss));
         }
     }
 


### PR DESCRIPTION
## Summary

- add a native packed f32x2 device type and arithmetic operations
- lower supported operations to the corresponding packed PTX instructions
- encode the PTX ISA and SM capability floors in target detection

## Testing

- cuda-device unit tests
- cuda-oxide-codegen library tests
- ptxas compatibility probes across the supported PTX ISA and SM boundaries