### PR TITLE
feat(device): type tcgen05 FP8 descriptors

### DIFF
--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -581,13 +581,12 @@ impl Tcgen05InstructionDescriptor {
         b_type: Tcgen05F8ElementType,
         accumulator_type: Tcgen05AccumulatorType,
     ) -> Self {
-        let mut raw = 0u32;
-        raw |= (accumulator_type as u32) << 4;
-        raw |= (a_type as u32) << 7;
-        raw |= (b_type as u32) << 10;
-        raw |= ((shape.n >> 3) & 0x3f) << 17;
-        raw |= ((shape.m >> 4) & 0x1f) << 24;
-        Self { raw }
+        Self::builder()
+            .shape(shape)
+            .a_type_f8(a_type)
+            .b_type_f8(b_type)
+            .accumulator_type(accumulator_type)
+            .build()
     }
 
     /// Create descriptor from raw 32-bit value.
@@ -613,10 +612,12 @@ pub struct Tcgen05InstructionDescriptorBuilder {
     sparse: bool,
     // Bits 4-5: dtype
     dtype: Tcgen05AccumulatorType,
-    // Bits 7-9: atype (and btype, typically same)
-    atype: Tcgen05ElementType,
-    // Bits 10-12: btype
-    btype: Tcgen05ElementType,
+    // Bits 7-9: atype format code. The 3-bit code is stored raw because its
+    // meaning depends on the MMA kind: `Tcgen05ElementType` for f16-family
+    // kinds, `Tcgen05F8ElementType` for `.kind::f8f6f4`.
+    atype: u32,
+    // Bits 10-12: btype format code (same domain rules as atype)
+    btype: u32,
     // Bit 13: negate A
     negate_a: bool,
     // Bit 14: negate B
@@ -647,8 +648,8 @@ impl Tcgen05InstructionDescriptorBuilder {
         Self {
             sparse: false,
             dtype: Tcgen05AccumulatorType::F32,
-            atype: Tcgen05ElementType::F16,
-            btype: Tcgen05ElementType::F16,
+            atype: Tcgen05ElementType::F16 as u32,
+            btype: Tcgen05ElementType::F16 as u32,
             negate_a: false,
             negate_b: false,
             transpose_a: false,
@@ -692,22 +693,47 @@ impl Tcgen05InstructionDescriptorBuilder {
     /// Set the element type for both A and B matrices.
     #[inline(always)]
     pub const fn element_type(mut self, ty: Tcgen05ElementType) -> Self {
-        self.atype = ty;
-        self.btype = ty;
+        self.atype = ty as u32;
+        self.btype = ty as u32;
         self
     }
 
     /// Set element type for matrix A only.
     #[inline(always)]
     pub const fn a_type(mut self, ty: Tcgen05ElementType) -> Self {
-        self.atype = ty;
+        self.atype = ty as u32;
         self
     }
 
     /// Set element type for matrix B only.
     #[inline(always)]
     pub const fn b_type(mut self, ty: Tcgen05ElementType) -> Self {
-        self.btype = ty;
+        self.btype = ty as u32;
+        self
+    }
+
+    /// Set the FP8 element type for both A and B matrices.
+    ///
+    /// Only meaningful for `.kind::f8f6f4` MMA; the format code shares the
+    /// atype/btype fields with [`Tcgen05ElementType`].
+    #[inline(always)]
+    pub const fn element_type_f8(mut self, ty: Tcgen05F8ElementType) -> Self {
+        self.atype = ty as u32;
+        self.btype = ty as u32;
+        self
+    }
+
+    /// Set FP8 element type for matrix A only (`.kind::f8f6f4` MMA).
+    #[inline(always)]
+    pub const fn a_type_f8(mut self, ty: Tcgen05F8ElementType) -> Self {
+        self.atype = ty as u32;
+        self
+    }
+
+    /// Set FP8 element type for matrix B only (`.kind::f8f6f4` MMA).
+    #[inline(always)]
+    pub const fn b_type_f8(mut self, ty: Tcgen05F8ElementType) -> Self {
+        self.btype = ty as u32;
         self
     }
 
@@ -790,10 +816,10 @@ impl Tcgen05InstructionDescriptorBuilder {
         // Bit 6: Reserved (0)
 
         // Bits 7-9: atype (3 bits)
-        raw |= (self.atype as u32) << 7;
+        raw |= (self.atype & 0x7) << 7;
 
         // Bits 10-12: btype (3 bits)
-        raw |= (self.btype as u32) << 10;
+        raw |= (self.btype & 0x7) << 10;
 
         // Bit 13: Negate A
         if self.negate_a {
@@ -1464,6 +1490,15 @@ mod tests {
             Tcgen05AccumulatorType::F32,
         );
         assert_eq!(descriptor.raw(), 0x0820_0010);
+
+        // new_f8 delegates to the builder; the F8 setters must land on the
+        // same encoding.
+        let via_builder = Tcgen05InstructionDescriptor::builder()
+            .shape(Tcgen05MmaShape::M128_N128)
+            .element_type_f8(Tcgen05F8ElementType::E4M3)
+            .accumulator_type(Tcgen05AccumulatorType::F32)
+            .build();
+        assert_eq!(via_builder.raw(), descriptor.raw());
     }
 
     #[test]

--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -417,6 +417,21 @@ pub enum Tcgen05ElementType {
     TF32 = 2,
 }
 
+/// Eight-bit floating-point input formats for `.kind::f8f6f4` MMA.
+///
+/// These values occupy the same instruction-descriptor fields as
+/// [`Tcgen05ElementType`], but their meaning is selected by the MMA kind. A
+/// distinct type prevents an FP8 call site from spelling E4M3 as `F16` merely
+/// because both formats use encoding zero in their respective kind domains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Tcgen05F8ElementType {
+    /// E4M3 floating point.
+    E4M3 = 0,
+    /// E5M2 floating point.
+    E5M2 = 1,
+}
+
 /// Accumulator (output D) data type for tcgen05 MMA operations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -552,6 +567,27 @@ impl Tcgen05InstructionDescriptor {
             .element_type(Tcgen05ElementType::TF32)
             .accumulator_type(Tcgen05AccumulatorType::F32)
             .build()
+    }
+
+    /// Create a dense `.kind::f8f6f4` instruction descriptor.
+    ///
+    /// The caller must issue the descriptor through
+    /// `tcgen05_mma_shared::<2, ..>`; descriptor format values are interpreted
+    /// in the FP8 domain only when the instruction kind is `f8f6f4`.
+    #[inline(always)]
+    pub const fn new_f8(
+        shape: Tcgen05MmaShape,
+        a_type: Tcgen05F8ElementType,
+        b_type: Tcgen05F8ElementType,
+        accumulator_type: Tcgen05AccumulatorType,
+    ) -> Self {
+        let mut raw = 0u32;
+        raw |= (accumulator_type as u32) << 4;
+        raw |= (a_type as u32) << 7;
+        raw |= (b_type as u32) << 10;
+        raw |= ((shape.n >> 3) & 0x3f) << 17;
+        raw |= ((shape.m >> 4) & 0x1f) << 24;
+        Self { raw }
     }
 
     /// Create descriptor from raw 32-bit value.
@@ -1414,3 +1450,40 @@ pub fn f32_pair_to_packed_bf16(a: f32, b: f32) -> u32 {
 
 // Generated tcgen05 leaf intrinsics.
 include!("generated/tcgen05.rs");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn e4m3_m128_n128_f32_descriptor_matches_sm100_layout() {
+        let descriptor = Tcgen05InstructionDescriptor::new_f8(
+            Tcgen05MmaShape::M128_N128,
+            Tcgen05F8ElementType::E4M3,
+            Tcgen05F8ElementType::E4M3,
+            Tcgen05AccumulatorType::F32,
+        );
+        assert_eq!(descriptor.raw(), 0x0820_0010);
+    }
+
+    #[test]
+    fn fp8_a_and_b_formats_have_independent_fields() {
+        let e5m2_e4m3 = Tcgen05InstructionDescriptor::new_f8(
+            Tcgen05MmaShape::M64_N64,
+            Tcgen05F8ElementType::E5M2,
+            Tcgen05F8ElementType::E4M3,
+            Tcgen05AccumulatorType::F32,
+        );
+        assert_eq!((e5m2_e4m3.raw() >> 7) & 0x7, 1);
+        assert_eq!((e5m2_e4m3.raw() >> 10) & 0x7, 0);
+
+        let e4m3_e5m2 = Tcgen05InstructionDescriptor::new_f8(
+            Tcgen05MmaShape::M64_N64,
+            Tcgen05F8ElementType::E4M3,
+            Tcgen05F8ElementType::E5M2,
+            Tcgen05AccumulatorType::F32,
+        );
+        assert_eq!((e4m3_e5m2.raw() >> 7) & 0x7, 0);
+        assert_eq!((e4m3_e5m2.raw() >> 10) & 0x7, 1);
+    }
+}


### PR DESCRIPTION
## Problem

- Building a tcgen05 FP8 (`.kind::f8f6f4`) matmul descriptor meant hand-assembling raw bitfields: pick the right 3-bit format code for E4M3 or E5M2, shift it to the right field, mask it in, and hope you read the SM100 layout table correctly.
- Nothing type-checked the formats, so swapping the a-type and b-type codes, or using an FP16 code by mistake, compiled fine and produced a garbage descriptor at runtime:

```text
// Before: raw bits, nothing checks that 0b000 means E4M3 in this field
let desc = Tcgen05InstructionDescriptor::from_raw(
    base | (0b000 << A_TYPE_SHIFT)    // E4M3? E5M2? go read the table
         | (0b001 << B_TYPE_SHIFT),   // swap these and it still compiles
);

// After: typed formats, wrong combinations no longer expressible
let desc = Tcgen05InstructionDescriptor::new_f8(
    shape,
    Tcgen05F8ElementType::E4M3,       // a-type
    Tcgen05F8ElementType::E5M2,       // b-type
    accumulator_type,
);
```

## Fix

- adds a typed `Tcgen05F8ElementType` enum and a `new_f8` constructor, so FP8 descriptors are built from named formats instead of raw bits
- review follow-up d59e3afb: `new_f8` now delegates to the existing descriptor builder the same way `new_f16`/`new_bf16`/`new_tf32` do. The builder stores the 3-bit format code raw internally and gained F8-typed a/b setters, so `build()` is the single place descriptor bits get packed
- public signatures unchanged; the hardware encoding used by existing kernels is preserved bit for bit

## Gotchas

- covers E4M3 and E5M2 only; E2M3/E3M2/E2M1 already have matching ws intrinsics and are a natural follow-up
- format values are interpreted in the FP8 domain only when the instruction kind is `f8f6f4`; the descriptor still has to be issued through `tcgen05_mma_shared::<2, ..>`
- a test asserts the builder path produces the identical raw encoding to the previous direct packing, so there is no silent drift between the two construction routes

## Testing and validation

- cuda-device suite green (97 tests), including the SM100 descriptor-layout test and a test that a-type and b-type fields stay independent
- no compiler-surface changes and no new kernels, so no GPU gate needed
- CI green (43/43)
