### PR TITLE
fix(mir-lower): preserve source locations across lowering

### DIFF
--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -14957,15 +14957,15 @@ fn render_lowering(catalog: &CatalogFile, hash: &str) -> String {
         );
     }
     let void_ty = llvm_types::VoidType::get(ctx);
-    let inline_asm = inline_asm_convergent(
+    inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         void_ty.into(),
         operands,
         template,
         constraints,
     );
-    crate::convert::preserve_location(ctx, op, inline_asm);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }
@@ -14996,6 +14996,7 @@ fn convert_generated_tcgen05_load(
         let inline_asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             scalar_ty,
             operands,
             template,
@@ -15012,6 +15013,7 @@ fn convert_generated_tcgen05_load(
     let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         result_ty.into(),
         operands,
         template,
@@ -15095,6 +15097,7 @@ fn convert_generated_tcgen05_load(
             inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 &template,
@@ -15174,7 +15177,7 @@ fn convert_generated_tcgen05_load(
         )
         .unwrap();
         output.push_str(
-            "    fn convert(\n        &self,\n        ctx: &mut Context,\n        rewriter: &mut DialectConversionRewriter,\n        operands_info: &OperandsInfo,\n    ) -> Result<()> {\n        let op = self.get_operation();\n        match context::lowering_options(ctx).intrinsic_backend {\n            IntrinsicBackend::LlvmNvptx => {\n                convert_active_mask(ctx, rewriter, op, operands_info)\n            }\n            IntrinsicBackend::LibNvvm => {\n                let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n                let inline_asm = inline_asm_convergent(\n                    ctx,\n                    rewriter,\n                    i32_ty.into(),\n                    vec![],\n                    \"activemask.b32 $0;\",\n                    \"=r,~{memory}\",\n                );\n                rewriter.replace_operation(ctx, op, inline_asm);\n                Ok(())\n            }\n        }\n    }\n}\n\n",
+            "    fn convert(\n        &self,\n        ctx: &mut Context,\n        rewriter: &mut DialectConversionRewriter,\n        operands_info: &OperandsInfo,\n    ) -> Result<()> {\n        let op = self.get_operation();\n        match context::lowering_options(ctx).intrinsic_backend {\n            IntrinsicBackend::LlvmNvptx => {\n                convert_active_mask(ctx, rewriter, op, operands_info)\n            }\n            IntrinsicBackend::LibNvvm => {\n                let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n                let inline_asm = inline_asm_convergent(\n                    ctx,\n                    rewriter,\n                    op,\n                    i32_ty.into(),\n                    vec![],\n                    \"activemask.b32 $0;\",\n                    \"=r,~{memory}\",\n                );\n                rewriter.replace_operation(ctx, op, inline_asm);\n                Ok(())\n            }\n        }\n    }\n}\n\n",
         );
     }
     if ldmatrix(catalog).next().is_some() {
@@ -15236,7 +15239,7 @@ fn convert_generated_tcgen05_load(
     if let Some(record) = movmatrix(catalog).next() {
         writeln!(
             output,
-            "#[op_interface_impl]\nimpl MirToLlvmConversion for {} {{\n    fn convert(\n        &self,\n        ctx: &mut Context,\n        rewriter: &mut DialectConversionRewriter,\n        _operands_info: &OperandsInfo,\n    ) -> Result<()> {{\n        let op = self.get_operation();\n        let operands: Vec<_> = op.deref(ctx).operands().collect();\n        if operands.len() != 1 {{\n            return pliron::input_err_noloc!(\n                \"movmatrix_trans_b16 requires 1 operand, got {{}}\",\n                operands.len()\n            );\n        }}\n        let result_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, result_ty.into(), operands, {:?}, \"=r,r\",\n        );\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())\n    }}\n}}\n",
+            "#[op_interface_impl]\nimpl MirToLlvmConversion for {} {{\n    fn convert(\n        &self,\n        ctx: &mut Context,\n        rewriter: &mut DialectConversionRewriter,\n        _operands_info: &OperandsInfo,\n    ) -> Result<()> {{\n        let op = self.get_operation();\n        let operands: Vec<_> = op.deref(ctx).operands().collect();\n        if operands.len() != 1 {{\n            return pliron::input_err_noloc!(\n                \"movmatrix_trans_b16 requires 1 operand, got {{}}\",\n                operands.len()\n            );\n        }}\n        let result_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, op, result_ty.into(), operands, {:?}, \"=r,r\",\n        );\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())\n    }}\n}}\n",
             record.dialect.op_type,
             movmatrix_template(record),
         )
@@ -15477,7 +15480,7 @@ fn convert_generated_tcgen05_load(
             .unwrap();
         }
         output.push_str(
-            "            _ => return pliron::input_err!(\n                self.get_operation().deref(ctx).loc(),\n                \"nvvm.cluster_barrier mode has no generated lowering recipe\",\n            ),\n        };\n        let op = self.get_operation();\n        let void_ty = llvm_types::VoidType::get(ctx);\n        match context::lowering_options(ctx).intrinsic_backend {\n            IntrinsicBackend::LlvmNvptx => {\n                let function_ty = llvm_types::FuncType::get(ctx, void_ty.into(), vec![], false);\n                call_intrinsic(ctx, rewriter, op, recipe.0, function_ty, vec![])?;\n            }\n            IntrinsicBackend::LibNvvm => {\n                inline_asm_convergent(ctx, rewriter, void_ty.into(), vec![], recipe.1, \"~{memory}\");\n            }\n        }\n        rewriter.erase_operation(ctx, op);\n        Ok(())\n    }\n}\n\n",
+            "            _ => return pliron::input_err!(\n                self.get_operation().deref(ctx).loc(),\n                \"nvvm.cluster_barrier mode has no generated lowering recipe\",\n            ),\n        };\n        let op = self.get_operation();\n        let void_ty = llvm_types::VoidType::get(ctx);\n        match context::lowering_options(ctx).intrinsic_backend {\n            IntrinsicBackend::LlvmNvptx => {\n                let function_ty = llvm_types::FuncType::get(ctx, void_ty.into(), vec![], false);\n                call_intrinsic(ctx, rewriter, op, recipe.0, function_ty, vec![])?;\n            }\n            IntrinsicBackend::LibNvvm => {\n                inline_asm_convergent(ctx, rewriter, op, void_ty.into(), vec![], recipe.1, \"~{memory}\");\n            }\n        }\n        rewriter.erase_operation(ctx, op);\n        Ok(())\n    }\n}\n\n",
         );
 
         let arrive = cluster_barriers(catalog)
@@ -15514,7 +15517,7 @@ fn convert_generated_tcgen05_load(
         output.push_str("            }\n            IntrinsicBackend::LibNvvm => {\n");
         writeln!(
             output,
-            "                inline_asm_convergent(ctx, rewriter, void_ty.into(), vec![], {:?}, \"~{{memory}}\");",
+            "                inline_asm_convergent(ctx, rewriter, op, void_ty.into(), vec![], {:?}, \"~{{memory}}\");",
             format!(
                 "{} {}",
                 cluster_barrier_template(arrive),
@@ -15565,7 +15568,7 @@ fn convert_generated_tcgen05_load(
                              \"~{memory}\"\n\
                          };\n\
                          inline_asm_convergent(\n\
-                             ctx, rewriter, void_ty.into(), operands, ptx, constraints,\n\
+                             ctx, rewriter, op, void_ty.into(), operands, ptx, constraints,\n\
                          );\n\
                      }\n\
                  }\n\
@@ -15979,14 +15982,14 @@ fn convert_generated_tcgen05_load(
             ClusterMemoryOperation::MapSharedRank => {
                 writeln!(
                     output,
-                    "        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, i64_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        let mapped = asm.deref(ctx).get_result(0);\n        let shared_pointer_ty = llvm_types::PointerType::get(ctx, 3);\n        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, shared_pointer_ty.into());\n        rewriter.insert_operation(ctx, int_to_ptr.get_operation());\n        rewriter.replace_operation(ctx, op, int_to_ptr.get_operation());\n        Ok(())"
+                    "        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, op, i64_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        let mapped = asm.deref(ctx).get_result(0);\n        let shared_pointer_ty = llvm_types::PointerType::get(ctx, 3);\n        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, shared_pointer_ty.into());\n        rewriter.insert_operation(ctx, int_to_ptr.get_operation());\n        rewriter.replace_operation(ctx, op, int_to_ptr.get_operation());\n        Ok(())"
                 )
                 .unwrap();
             }
             ClusterMemoryOperation::ReadU32 => {
                 writeln!(
                     output,
-                    "        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, i32_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())"
+                    "        let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, op, i32_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())"
                 )
                 .unwrap();
             }
@@ -16051,7 +16054,7 @@ fn convert_generated_tcgen05_load(
             MbarrierExtendedAdapter::PointerTxCountBytesToTokenDroppingTxCount => {
                 writeln!(
                     output,
-                    "        let result_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(ctx, rewriter, result_ty.into(), operands, {template:?}, {constraints:?});\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())"
+                    "        let result_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(ctx, rewriter, op, result_ty.into(), operands, {template:?}, {constraints:?});\n        rewriter.replace_operation(ctx, op, asm);\n        Ok(())"
                 )
                 .unwrap();
             }
@@ -16059,7 +16062,7 @@ fn convert_generated_tcgen05_load(
             | MbarrierExtendedAdapter::PointerParityToPredicate => {
                 writeln!(
                     output,
-                    "        let result_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(ctx, rewriter, result_ty.into(), operands, {template:?}, {constraints:?});\n        let asm_result = asm.deref(ctx).get_result(0);\n        let result = trunc_to_i1(ctx, rewriter, asm_result);\n        let DefiningEntity::Op(result_op) = result.defining_entity() else {{ unreachable!() }};\n        rewriter.replace_operation(ctx, op, result_op);\n        Ok(())"
+                    "        let result_ty = IntegerType::get(ctx, 32, Signedness::Signless);\n        let asm = inline_asm_convergent(ctx, rewriter, op, result_ty.into(), operands, {template:?}, {constraints:?});\n        let asm_result = asm.deref(ctx).get_result(0);\n        let result = trunc_to_i1(ctx, rewriter, asm_result);\n        let DefiningEntity::Op(result_op) = result.defining_entity() else {{ unreachable!() }};\n        rewriter.replace_operation(ctx, op, result_op);\n        Ok(())"
                 )
                 .unwrap();
             }
@@ -16068,7 +16071,7 @@ fn convert_generated_tcgen05_load(
             | MbarrierExtendedAdapter::NanosecondsToVoid => {
                 writeln!(
                     output,
-                    "        let void_ty = llvm_types::VoidType::get(ctx);\n        inline_asm_convergent(ctx, rewriter, void_ty.into(), operands, {template:?}, {constraints:?});\n        rewriter.erase_operation(ctx, op);\n        Ok(())"
+                    "        let void_ty = llvm_types::VoidType::get(ctx);\n        inline_asm_convergent(ctx, rewriter, op, void_ty.into(), operands, {template:?}, {constraints:?});\n        rewriter.erase_operation(ctx, op);\n        Ok(())"
                 )
                 .unwrap();
             }
@@ -16577,10 +16580,10 @@ impl MirToLlvmConversion for Tcgen05MmaOp {
         );
         match record.debug_control.as_ref().unwrap().operation {
             DebugControlOperation::Trap => output.push_str(
-                "        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], \"trap;\", \"\");\n",
+                "        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], \"trap;\", \"\");\n",
             ),
             DebugControlOperation::Breakpoint => output.push_str(
-                "        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], \"brkpt;\", \"\");\n",
+                "        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], \"brkpt;\", \"\");\n",
             ),
             DebugControlOperation::Pmevent => output.push_str(
                 "        let Some(event_id) = self.event_id(ctx) else {\n\
@@ -16590,7 +16593,7 @@ impl MirToLlvmConversion for Tcgen05MmaOp {
                      );\n\
                  };\n\
                  let template = format!(\"pmevent {event_id};\");\n\
-                 inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], &template, \"\");\n",
+                 inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], &template, \"\");\n",
             ),
         }
         output.push_str("        rewriter.erase_operation(ctx, op);\n        Ok(())\n    }\n}\n\n");
@@ -16613,7 +16616,7 @@ impl MirToLlvmConversion for Tcgen05MmaOp {
             )
             .unwrap();
             output.push_str(
-                "            }\n            IntrinsicBackend::LibNvvm => {\n                inline_asm_convergent(ctx, rewriter, void_ty.into(), vec![], \"bar.sync 0;\", \"~{memory}\");\n            }\n        }\n        rewriter.erase_operation(ctx, op);\n        Ok(())\n    }\n}\n\n",
+                "            }\n            IntrinsicBackend::LibNvvm => {\n                inline_asm_convergent(ctx, rewriter, op, void_ty.into(), vec![], \"bar.sync 0;\", \"~{memory}\");\n            }\n        }\n        rewriter.erase_operation(ctx, op);\n        Ok(())\n    }\n}\n\n",
             );
         } else {
             debug_assert!(threadfence_ptx_level(record).is_some());
@@ -24268,10 +24271,10 @@ mod tests {
             assert!(lowering.contains(&format!("impl MirToLlvmConversion for {op}")));
         }
         assert!(lowering.contains(
-            "inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], \"trap;\", \"\")"
+            "inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], \"trap;\", \"\")"
         ));
         assert!(lowering.contains(
-            "inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], \"brkpt;\", \"\")"
+            "inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], \"brkpt;\", \"\")"
         ));
         assert!(lowering.contains("let template = format!(\"pmevent {event_id};\")"));
 

--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -14957,7 +14957,7 @@ fn render_lowering(catalog: &CatalogFile, hash: &str) -> String {
         );
     }
     let void_ty = llvm_types::VoidType::get(ctx);
-    inline_asm_convergent(
+    let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
         void_ty.into(),
@@ -14965,6 +14965,7 @@ fn render_lowering(catalog: &CatalogFile, hash: &str) -> String {
         template,
         constraints,
     );
+    crate::convert::preserve_location(ctx, op, inline_asm);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }

--- a/crates/mir-lower/src/convert/generated_intrinsics.rs
+++ b/crates/mir-lower/src/convert/generated_intrinsics.rs
@@ -289,15 +289,15 @@ fn convert_generated_tcgen05_void(
         );
     }
     let void_ty = llvm_types::VoidType::get(ctx);
-    let inline_asm = inline_asm_convergent(
+    inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         void_ty.into(),
         operands,
         template,
         constraints,
     );
-    crate::convert::preserve_location(ctx, op, inline_asm);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }
@@ -329,8 +329,15 @@ fn convert_generated_tcgen05_load(
         FP32Type::get(ctx).into()
     };
     if count == 1 {
-        let inline_asm =
-            inline_asm_convergent(ctx, rewriter, scalar_ty, operands, template, constraints);
+        let inline_asm = inline_asm_convergent(
+            ctx,
+            rewriter,
+            op,
+            scalar_ty,
+            operands,
+            template,
+            constraints,
+        );
         let result = inline_asm.deref(ctx).get_result(0);
         rewriter.replace_operation_with_values(ctx, op, vec![result]);
         return Ok(());
@@ -340,6 +347,7 @@ fn convert_generated_tcgen05_load(
     let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         result_ty.into(),
         operands,
         template,
@@ -408,6 +416,7 @@ fn convert_generated_stmatrix(
             inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 &template,
@@ -1357,6 +1366,7 @@ impl MirToLlvmConversion for ActiveMaskOp {
                 let inline_asm = inline_asm_convergent(
                     ctx,
                     rewriter,
+                    op,
                     i32_ty.into(),
                     vec![],
                     "activemask.b32 $0;",
@@ -1817,6 +1827,7 @@ impl MirToLlvmConversion for MovmatrixTransB16Op {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;",
@@ -7946,7 +7957,15 @@ impl MirToLlvmConversion for ClusterBarrierOp {
                 call_intrinsic(ctx, rewriter, op, recipe.0, function_ty, vec![])?;
             }
             IntrinsicBackend::LibNvvm => {
-                inline_asm_convergent(ctx, rewriter, void_ty.into(), vec![], recipe.1, "~{memory}");
+                inline_asm_convergent(
+                    ctx,
+                    rewriter,
+                    op,
+                    void_ty.into(),
+                    vec![],
+                    recipe.1,
+                    "~{memory}",
+                );
             }
         }
         rewriter.erase_operation(ctx, op);
@@ -7988,6 +8007,7 @@ impl MirToLlvmConversion for ClusterSyncOp {
                 inline_asm_convergent(
                     ctx,
                     rewriter,
+                    op,
                     void_ty.into(),
                     vec![],
                     "barrier.cluster.arrive.aligned; barrier.cluster.wait.aligned;",
@@ -8032,7 +8052,15 @@ fn convert_generated_wgmma_control(
             } else {
                 "~{memory}"
             };
-            inline_asm_convergent(ctx, rewriter, void_ty.into(), operands, ptx, constraints);
+            inline_asm_convergent(
+                ctx,
+                rewriter,
+                op,
+                void_ty.into(),
+                operands,
+                ptx,
+                constraints,
+            );
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -9700,6 +9728,7 @@ impl MirToLlvmConversion for DsmemReadU32Op {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             i32_ty.into(),
             vec![shared_pointer, rank],
             "{ .reg .u64 %mapped; mapa.shared::cluster.u64 %mapped, $1, $2; ld.shared::cluster.u32 $0, [%mapped]; }",
@@ -9732,6 +9761,7 @@ impl MirToLlvmConversion for MapaSharedClusterOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             i64_ty.into(),
             vec![shared_pointer, rank],
             "mapa.shared::cluster.u64 $0, $1, $2;",
@@ -9766,6 +9796,7 @@ impl MirToLlvmConversion for FenceMbarrierInitReleaseClusterOp {
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "fence.mbarrier_init.release.cluster;",
@@ -9796,6 +9827,7 @@ impl MirToLlvmConversion for FenceProxyAsyncGenericAcquireSharedClusterClusterOp
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "fence.proxy.async::generic.acquire.sync_restrict::shared::cluster.cluster;",
@@ -9826,6 +9858,7 @@ impl MirToLlvmConversion for FenceProxyAsyncGenericReleaseSharedCtaClusterOp {
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster;",
@@ -9856,6 +9889,7 @@ impl MirToLlvmConversion for FenceProxyAsyncSharedCtaOp {
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "fence.proxy.async.shared::cta;",
@@ -9886,6 +9920,7 @@ impl MirToLlvmConversion for MbarrierArriveClusterOp {
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "mbarrier.arrive.release.cluster.shared::cluster.b64 _, [$0];",
@@ -9917,6 +9952,7 @@ impl MirToLlvmConversion for MbarrierArriveExpectTxSharedOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 $0, [$1], $2;",
@@ -9948,6 +9984,7 @@ impl MirToLlvmConversion for MbarrierArriveExpectTxClusterOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "mbarrier.arrive.expect_tx.relaxed.cluster.shared::cta.b64 $0, [$1], $2;",
@@ -9979,6 +10016,7 @@ impl MirToLlvmConversion for MbarrierTryWaitSharedOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "{ .reg .pred %p0; mbarrier.try_wait.shared.b64 %p0, [$1], $2; selp.b32 $0, 1, 0, %p0; }",
@@ -10015,6 +10053,7 @@ impl MirToLlvmConversion for MbarrierTryWaitParitySharedOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "{ .reg .pred %p0; mbarrier.try_wait.parity.shared::cta.b64 %p0, [$1], $2; selp.b32 $0, 1, 0, %p0; }",
@@ -10051,6 +10090,7 @@ impl MirToLlvmConversion for MbarrierTryWaitParityClusterOp {
         let asm = inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             result_ty.into(),
             operands,
             "{ .reg .pred %p0; mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64 %p0, [$1], $2; selp.b32 $0, 1, 0, %p0; }",
@@ -10086,6 +10126,7 @@ impl MirToLlvmConversion for NanosleepOp {
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             "nanosleep.u32 $0;",
@@ -17198,7 +17239,7 @@ impl MirToLlvmConversion for BreakpointOp {
     ) -> Result<()> {
         let op = self.get_operation();
         let void_ty = llvm_types::VoidType::get(ctx);
-        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], "brkpt;", "");
+        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], "brkpt;", "");
         rewriter.erase_operation(ctx, op);
         Ok(())
     }
@@ -17221,7 +17262,7 @@ impl MirToLlvmConversion for PmEventOp {
             );
         };
         let template = format!("pmevent {event_id};");
-        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], &template, "");
+        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], &template, "");
         rewriter.erase_operation(ctx, op);
         Ok(())
     }
@@ -17237,7 +17278,7 @@ impl MirToLlvmConversion for TrapOp {
     ) -> Result<()> {
         let op = self.get_operation();
         let void_ty = llvm_types::VoidType::get(ctx);
-        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], "trap;", "");
+        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], "trap;", "");
         rewriter.erase_operation(ctx, op);
         Ok(())
     }
@@ -17272,6 +17313,7 @@ impl MirToLlvmConversion for Barrier0Op {
                 inline_asm_convergent(
                     ctx,
                     rewriter,
+                    op,
                     void_ty.into(),
                     vec![],
                     "bar.sync 0;",

--- a/crates/mir-lower/src/convert/generated_intrinsics.rs
+++ b/crates/mir-lower/src/convert/generated_intrinsics.rs
@@ -289,7 +289,7 @@ fn convert_generated_tcgen05_void(
         );
     }
     let void_ty = llvm_types::VoidType::get(ctx);
-    inline_asm_convergent(
+    let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
         void_ty.into(),
@@ -297,6 +297,7 @@ fn convert_generated_tcgen05_void(
         template,
         constraints,
     );
+    crate::convert::preserve_location(ctx, op, inline_asm);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }

--- a/crates/mir-lower/src/convert/intrinsics/asm.rs
+++ b/crates/mir-lower/src/convert/intrinsics/asm.rs
@@ -88,7 +88,8 @@ pub(crate) fn convert_inline_ptx(
                 convergent,
             );
             let asm_op = inline_asm.get_operation();
-            crate::convert::preserve_location(ctx, op, asm_op);
+            // No explicit location copy: `replace_operation` propagates the
+            // replaced op's location onto a location-less replacement.
             llvm::set_inline_asm_sideeffect(ctx, asm_op, sideeffect);
             rewriter.insert_operation(ctx, asm_op);
             rewriter.replace_operation(ctx, op, asm_op);

--- a/crates/mir-lower/src/convert/intrinsics/asm.rs
+++ b/crates/mir-lower/src/convert/intrinsics/asm.rs
@@ -66,6 +66,7 @@ pub(crate) fn convert_inline_ptx(
                 convergent,
             );
             let asm_op = inline_asm.get_operation();
+            crate::convert::preserve_location(ctx, op, asm_op);
             llvm::set_inline_asm_sideeffect(ctx, asm_op, sideeffect);
             rewriter.insert_operation(ctx, asm_op);
             rewriter.erase_operation(ctx, op);
@@ -87,6 +88,7 @@ pub(crate) fn convert_inline_ptx(
                 convergent,
             );
             let asm_op = inline_asm.get_operation();
+            crate::convert::preserve_location(ctx, op, asm_op);
             llvm::set_inline_asm_sideeffect(ctx, asm_op, sideeffect);
             rewriter.insert_operation(ctx, asm_op);
             rewriter.replace_operation(ctx, op, asm_op);
@@ -116,6 +118,7 @@ pub(crate) fn convert_inline_ptx(
                 convergent,
             );
             let asm_op = inline_asm.get_operation();
+            crate::convert::preserve_location(ctx, op, asm_op);
             llvm::set_inline_asm_sideeffect(ctx, asm_op, sideeffect);
             rewriter.insert_operation(ctx, asm_op);
 
@@ -125,6 +128,7 @@ pub(crate) fn convert_inline_ptx(
             for i in 0..n {
                 let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![i as u32])
                     .map_err(|error| pliron::input_error!(loc.clone(), "{}", error))?;
+                crate::convert::preserve_location(ctx, op, extract.get_operation());
                 rewriter.insert_operation(ctx, extract.get_operation());
                 extracted_values.push(extract.get_operation().deref(ctx).get_result(0));
             }

--- a/crates/mir-lower/src/convert/intrinsics/atomic.rs
+++ b/crates/mir-lower/src/convert/intrinsics/atomic.rs
@@ -408,6 +408,7 @@ pub(crate) fn convert_atomic_store(
     );
 
     let asm_op = inline_asm.get_operation();
+    crate::convert::preserve_location(ctx, op, asm_op);
     rewriter.insert_operation(ctx, asm_op);
     rewriter.erase_operation(ctx, op);
 

--- a/crates/mir-lower/src/convert/intrinsics/cluster.rs
+++ b/crates/mir-lower/src/convert/intrinsics/cluster.rs
@@ -41,6 +41,7 @@ pub(crate) fn convert_cluster_idx(
     let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         i32_type.into(),
         vec![],
         CLUSTER_IDX_ASM,
@@ -60,6 +61,7 @@ pub(crate) fn convert_num_clusters(
     let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         i32_type.into(),
         vec![],
         NUM_CLUSTERS_ASM,

--- a/crates/mir-lower/src/convert/intrinsics/common.rs
+++ b/crates/mir-lower/src/convert/intrinsics/common.rs
@@ -652,7 +652,7 @@ mod tests {
             name: "source-intrinsic".to_string(),
             child_loc: Box::new(Location::Unknown),
         };
-        trigger.deref_mut(&mut ctx).set_loc(expected.clone());
+        trigger.deref_mut(&ctx).set_loc(expected.clone());
 
         assert!(
             run_helper_action(&mut ctx, module_ptr, HelperAction::InlineAsmConvergent).is_none()

--- a/crates/mir-lower/src/convert/intrinsics/common.rs
+++ b/crates/mir-lower/src/convert/intrinsics/common.rs
@@ -140,6 +140,7 @@ pub fn call_intrinsic(
     let sym_name: pliron::identifier::Identifier = intrinsic_name.try_into().unwrap();
     let callee = CallOpCallable::Direct(sym_name);
     let llvm_call = llvm::CallOp::new(ctx, callee, func_ty, args);
+    crate::convert::preserve_location(ctx, current_op, llvm_call.get_operation());
     rewriter.insert_operation(ctx, llvm_call.get_operation());
 
     Ok(llvm_call.get_operation())

--- a/crates/mir-lower/src/convert/intrinsics/common.rs
+++ b/crates/mir-lower/src/convert/intrinsics/common.rs
@@ -147,9 +147,13 @@ pub fn call_intrinsic(
 }
 
 /// Create an inline assembly operation with the convergent attribute.
+///
+/// `current_op` is the MIR op being converted; its source location is copied
+/// onto the inline asm op so line info survives lowering.
 pub fn inline_asm_convergent(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
+    current_op: Ptr<Operation>,
     result_ty: pliron::r#type::TypeHandle,
     inputs: Vec<Value>,
     asm_template: &str,
@@ -163,6 +167,7 @@ pub fn inline_asm_convergent(
         constraints,
         AsmKind::Convergent,
     );
+    crate::convert::preserve_location(ctx, current_op, inline_asm.get_operation());
     rewriter.insert_operation(ctx, inline_asm.get_operation());
     inline_asm.get_operation()
 }
@@ -173,9 +178,13 @@ pub fn inline_asm_convergent(
 /// (e.g., `cp.async` copies). Unlike `inline_asm_convergent`, the emitted asm
 /// is marked `sideeffect` only, allowing LLVM to move or duplicate it across
 /// divergent control flow when legal.
+///
+/// `current_op` is the MIR op being converted; its source location is copied
+/// onto the inline asm op so line info survives lowering.
 pub fn inline_asm_sideeffect(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
+    current_op: Ptr<Operation>,
     result_ty: pliron::r#type::TypeHandle,
     inputs: Vec<Value>,
     asm_template: &str,
@@ -189,6 +198,7 @@ pub fn inline_asm_sideeffect(
         constraints,
         AsmKind::SideEffect,
     );
+    crate::convert::preserve_location(ctx, current_op, inline_asm.get_operation());
     rewriter.insert_operation(ctx, inline_asm.get_operation());
     inline_asm.get_operation()
 }
@@ -293,6 +303,7 @@ mod tests {
                     inline_asm_convergent(
                         ctx,
                         rewriter,
+                        op,
                         void_ty.into(),
                         vec![],
                         "bar.sync 0;",
@@ -307,6 +318,7 @@ mod tests {
                     inline_asm_sideeffect(
                         ctx,
                         rewriter,
+                        op,
                         void_ty.into(),
                         vec![dst, value],
                         "st.global.u32 [$0], $1;",
@@ -363,7 +375,7 @@ mod tests {
         (module_ptr, entry)
     }
 
-    fn append_trigger(ctx: &mut Context, block: Ptr<BasicBlock>) {
+    fn append_trigger(ctx: &mut Context, block: Ptr<BasicBlock>) -> Ptr<Operation> {
         let trigger = Operation::new(
             ctx,
             mir::MirStorageLiveOp::get_concrete_op_info(),
@@ -373,6 +385,7 @@ mod tests {
             0,
         );
         trigger.insert_at_back(block, ctx);
+        trigger
     }
 
     fn run_helper_action(
@@ -626,6 +639,28 @@ mod tests {
             asm.get_attr_inline_asm_convergent(&ctx)
                 .is_some_and(|b| bool::from((*b).clone()))
         );
+    }
+
+    #[test]
+    fn inline_asm_convergent_copies_the_source_op_location() {
+        use pliron::location::{Located, Location};
+
+        let mut ctx = make_ctx();
+        let (module_ptr, entry) = build_test_func(&mut ctx, vec![]);
+        let trigger = append_trigger(&mut ctx, entry);
+        let expected = Location::Named {
+            name: "source-intrinsic".to_string(),
+            child_loc: Box::new(Location::Unknown),
+        };
+        trigger.deref_mut(&mut ctx).set_loc(expected.clone());
+
+        assert!(
+            run_helper_action(&mut ctx, module_ptr, HelperAction::InlineAsmConvergent).is_none()
+        );
+
+        let asms = find_body_ops::<llvm::InlineAsmOp>(&ctx, module_ptr);
+        assert_eq!(asms.len(), 1);
+        assert_eq!(asms[0].get_operation().deref(&ctx).loc(), expected);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/intrinsics/cp_async.rs
+++ b/crates/mir-lower/src/convert/intrinsics/cp_async.rs
@@ -47,6 +47,7 @@ pub(crate) fn convert_generated_cp_async_copy(
         IntrinsicBackend::LibNvvm => lower_copy_with_inline_ptx(
             ctx,
             rewriter,
+            op,
             operands,
             cache_policy,
             copy_size,
@@ -90,7 +91,7 @@ pub(crate) fn convert_generated_cp_async_control(
             lower_control_with_llvm_intrinsic(ctx, rewriter, op, operands, typed_intrinsic_name)?;
         }
         IntrinsicBackend::LibNvvm => {
-            lower_control_with_inline_ptx(ctx, rewriter, operands, operation);
+            lower_control_with_inline_ptx(ctx, rewriter, op, operands, operation);
         }
     }
 
@@ -165,6 +166,7 @@ pub(crate) fn convert_generated_cp_async_mbarrier(
             inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 vec![barrier],
                 template,
@@ -260,6 +262,7 @@ fn lower_copy_with_llvm_intrinsic(
 fn lower_copy_with_inline_ptx(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
     operands: Vec<Value>,
     cache_policy: &str,
     copy_size: u32,
@@ -296,6 +299,7 @@ fn lower_copy_with_inline_ptx(
     inline_asm_sideeffect(
         ctx,
         rewriter,
+        op,
         void_ty.into(),
         inputs,
         &format!(
@@ -372,6 +376,7 @@ fn lower_control_with_llvm_intrinsic(
 fn lower_control_with_inline_ptx(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
     operands: Vec<Value>,
     operation: &str,
 ) {
@@ -385,6 +390,7 @@ fn lower_control_with_inline_ptx(
     inline_asm_sideeffect(
         ctx,
         rewriter,
+        op,
         void_ty.into(),
         operands,
         template,

--- a/crates/mir-lower/src/convert/intrinsics/execution_control.rs
+++ b/crates/mir-lower/src/convert/intrinsics/execution_control.rs
@@ -36,6 +36,7 @@ pub(crate) fn convert_counted_barrier(
         inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             operands,
             ptx,
@@ -68,7 +69,7 @@ pub(crate) fn convert_grid_dependency(
     }
     let void_ty = llvm_types::VoidType::get(ctx);
     if context::lowering_options(ctx).intrinsic_backend == IntrinsicBackend::LibNvvm {
-        inline_asm_sideeffect(ctx, rewriter, void_ty.into(), vec![], ptx, "");
+        inline_asm_sideeffect(ctx, rewriter, op, void_ty.into(), vec![], ptx, "");
     } else {
         let function_ty = llvm_types::FuncType::get(ctx, void_ty.into(), vec![], false);
         call_intrinsic(ctx, rewriter, op, intrinsic_name, function_ty, vec![])?;
@@ -98,7 +99,7 @@ pub(crate) fn convert_setmaxnreg(
     let void_ty = llvm_types::VoidType::get(ctx);
     if context::lowering_options(ctx).intrinsic_backend == IntrinsicBackend::LibNvvm {
         let template = format!("setmaxnreg.{direction}.sync.aligned.u32 {register_count};");
-        inline_asm_convergent(ctx, rewriter, void_ty.into(), vec![], &template, "");
+        inline_asm_convergent(ctx, rewriter, op, void_ty.into(), vec![], &template, "");
     } else {
         let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
         let function_ty =

--- a/crates/mir-lower/src/convert/intrinsics/ldmatrix.rs
+++ b/crates/mir-lower/src/convert/intrinsics/ldmatrix.rs
@@ -89,6 +89,7 @@ pub(crate) fn convert_generated_ldmatrix<I: LdmatrixInstructionHead>(
         IntrinsicBackend::LibNvvm => lower_with_inline_ptx(
             ctx,
             rewriter,
+            op,
             shared_pointer,
             result_ty,
             register_count,
@@ -166,6 +167,7 @@ fn lower_with_llvm_intrinsic(
 fn lower_with_inline_ptx(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
     shared_pointer: Value,
     result_ty: TypeHandle,
     register_count: usize,
@@ -191,6 +193,7 @@ fn lower_with_inline_ptx(
     inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         result_ty,
         vec![pointer_address],
         &template,

--- a/crates/mir-lower/src/convert/intrinsics/mbarrier.rs
+++ b/crates/mir-lower/src/convert/intrinsics/mbarrier.rs
@@ -70,6 +70,7 @@ pub(crate) fn convert_init(
             inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 vec![bar_ptr, count],
                 "mbarrier.init.shared.b64 [$0], $1;",
@@ -111,6 +112,7 @@ pub(crate) fn convert_arrive(
         IntrinsicBackend::LibNvvm => inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             i64_ty.into(),
             vec![bar_ptr],
             "mbarrier.arrive.shared.b64 $0, [$1];",
@@ -142,6 +144,7 @@ pub(crate) fn convert_test_wait(
     let asm_op = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         i32_ty.into(),
         vec![bar_ptr, token],
         asm_template,
@@ -190,6 +193,7 @@ pub(crate) fn convert_inval(
             inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 vec![bar_ptr],
                 "mbarrier.inval.shared.b64 [$0];",

--- a/crates/mir-lower/src/convert/intrinsics/tma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/tma.rs
@@ -97,7 +97,7 @@ fn convert_g2s_impl(
 
         let (template, constraints) = g2s_inline_asm(dims, multicast, cta_group);
 
-        inline_asm_convergent(
+        let lowered = inline_asm_convergent(
             ctx,
             rewriter,
             void_ty.into(),
@@ -105,6 +105,7 @@ fn convert_g2s_impl(
             &template,
             &constraints,
         );
+        crate::convert::preserve_location(ctx, op, lowered);
         rewriter.erase_operation(ctx, op);
         return Ok(());
     }
@@ -143,6 +144,7 @@ fn convert_g2s_impl(
     let sym_name: pliron::identifier::Identifier = intrinsic_name.as_str().try_into().unwrap();
     let callee = CallOpCallable::Direct(sym_name);
     let llvm_call = llvm::CallOp::new(ctx, callee, func_ty, call_args);
+    crate::convert::preserve_location(ctx, op, llvm_call.get_operation());
     rewriter.insert_operation(ctx, llvm_call.get_operation());
     rewriter.erase_operation(ctx, op);
 
@@ -206,7 +208,7 @@ pub(crate) fn convert_s2g(
         let mut inputs = vec![src_casted, operands[1]];
         inputs.extend(operands[2..].iter().copied());
         let (template, constraints) = s2g_inline_asm(dims);
-        inline_asm_convergent(
+        let lowered = inline_asm_convergent(
             ctx,
             rewriter,
             void_ty.into(),
@@ -214,6 +216,7 @@ pub(crate) fn convert_s2g(
             &template,
             &constraints,
         );
+        crate::convert::preserve_location(ctx, op, lowered);
         rewriter.erase_operation(ctx, op);
         return Ok(());
     }
@@ -241,6 +244,7 @@ pub(crate) fn convert_s2g(
     let sym_name: pliron::identifier::Identifier = intrinsic_name.as_str().try_into().unwrap();
     let callee = CallOpCallable::Direct(sym_name);
     let llvm_call = llvm::CallOp::new(ctx, callee, func_ty, call_args);
+    crate::convert::preserve_location(ctx, op, llvm_call.get_operation());
     rewriter.insert_operation(ctx, llvm_call.get_operation());
     rewriter.erase_operation(ctx, op);
 
@@ -376,7 +380,7 @@ pub(crate) fn convert_reduce_s2g(
             let mut inputs = vec![src_casted, operands[1]];
             inputs.extend(operands[2..].iter().copied());
 
-            inline_asm_convergent(
+            let lowered = inline_asm_convergent(
                 ctx,
                 rewriter,
                 void_ty.into(),
@@ -384,6 +388,7 @@ pub(crate) fn convert_reduce_s2g(
                 &template,
                 &constraints,
             );
+            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
 
@@ -413,7 +418,7 @@ pub(crate) fn convert_prefetch_tensormap(
             call_intrinsic(ctx, rewriter, op, intrinsic_name, function_ty, operands)?;
         }
         IntrinsicBackend::LibNvvm => {
-            inline_asm_sideeffect(
+            let lowered = inline_asm_sideeffect(
                 ctx,
                 rewriter,
                 void_ty.into(),
@@ -421,6 +426,7 @@ pub(crate) fn convert_prefetch_tensormap(
                 "prefetch.tensormap [$0];",
                 "l,~{memory}",
             );
+            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -527,7 +533,7 @@ pub(crate) fn convert_prefetch_tile(
                 constraints.push("l");
             }
             constraints.push("~{memory}");
-            inline_asm_convergent(
+            let lowered = inline_asm_convergent(
                 ctx,
                 rewriter,
                 void_ty.into(),
@@ -535,6 +541,7 @@ pub(crate) fn convert_prefetch_tile(
                 &template,
                 &constraints.join(","),
             );
+            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -586,7 +593,7 @@ pub(crate) fn convert_tensormap_replace(
         "r"
     });
     constraints.push("~{memory}");
-    inline_asm_sideeffect(
+    let lowered = inline_asm_sideeffect(
         ctx,
         rewriter,
         void_ty.into(),
@@ -594,6 +601,7 @@ pub(crate) fn convert_tensormap_replace(
         &template,
         &constraints.join(","),
     );
+    crate::convert::preserve_location(ctx, op, lowered);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }
@@ -643,7 +651,7 @@ pub(crate) fn convert_tensormap_fence(
             } else {
                 format!("fence.proxy.tensormap::generic.release.{scope};")
             };
-            inline_asm_sideeffect(
+            let lowered = inline_asm_sideeffect(
                 ctx,
                 rewriter,
                 void_ty.into(),
@@ -651,6 +659,7 @@ pub(crate) fn convert_tensormap_fence(
                 &template,
                 if acquire { "l,~{memory}" } else { "~{memory}" },
             );
+            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -696,7 +705,7 @@ pub(crate) fn convert_control(
                 "wait_group_read" => ("cp.async.bulk.wait_group.read $0;", "n,~{memory}"),
                 _ => unreachable!("operation was validated"),
             };
-            inline_asm_sideeffect(
+            let lowered = inline_asm_sideeffect(
                 ctx,
                 rewriter,
                 void_ty.into(),
@@ -704,6 +713,7 @@ pub(crate) fn convert_control(
                 template,
                 constraints,
             );
+            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);

--- a/crates/mir-lower/src/convert/intrinsics/tma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/tma.rs
@@ -97,15 +97,15 @@ fn convert_g2s_impl(
 
         let (template, constraints) = g2s_inline_asm(dims, multicast, cta_group);
 
-        let lowered = inline_asm_convergent(
+        inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             inputs,
             &template,
             &constraints,
         );
-        crate::convert::preserve_location(ctx, op, lowered);
         rewriter.erase_operation(ctx, op);
         return Ok(());
     }
@@ -208,15 +208,15 @@ pub(crate) fn convert_s2g(
         let mut inputs = vec![src_casted, operands[1]];
         inputs.extend(operands[2..].iter().copied());
         let (template, constraints) = s2g_inline_asm(dims);
-        let lowered = inline_asm_convergent(
+        inline_asm_convergent(
             ctx,
             rewriter,
+            op,
             void_ty.into(),
             inputs,
             &template,
             &constraints,
         );
-        crate::convert::preserve_location(ctx, op, lowered);
         rewriter.erase_operation(ctx, op);
         return Ok(());
     }
@@ -380,15 +380,15 @@ pub(crate) fn convert_reduce_s2g(
             let mut inputs = vec![src_casted, operands[1]];
             inputs.extend(operands[2..].iter().copied());
 
-            let lowered = inline_asm_convergent(
+            inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 inputs,
                 &template,
                 &constraints,
             );
-            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
 
@@ -418,15 +418,15 @@ pub(crate) fn convert_prefetch_tensormap(
             call_intrinsic(ctx, rewriter, op, intrinsic_name, function_ty, operands)?;
         }
         IntrinsicBackend::LibNvvm => {
-            let lowered = inline_asm_sideeffect(
+            inline_asm_sideeffect(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 "prefetch.tensormap [$0];",
                 "l,~{memory}",
             );
-            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -533,15 +533,15 @@ pub(crate) fn convert_prefetch_tile(
                 constraints.push("l");
             }
             constraints.push("~{memory}");
-            let lowered = inline_asm_convergent(
+            inline_asm_convergent(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 &template,
                 &constraints.join(","),
             );
-            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -593,15 +593,15 @@ pub(crate) fn convert_tensormap_replace(
         "r"
     });
     constraints.push("~{memory}");
-    let lowered = inline_asm_sideeffect(
+    inline_asm_sideeffect(
         ctx,
         rewriter,
+        op,
         void_ty.into(),
         operands,
         &template,
         &constraints.join(","),
     );
-    crate::convert::preserve_location(ctx, op, lowered);
     rewriter.erase_operation(ctx, op);
     Ok(())
 }
@@ -651,15 +651,15 @@ pub(crate) fn convert_tensormap_fence(
             } else {
                 format!("fence.proxy.tensormap::generic.release.{scope};")
             };
-            let lowered = inline_asm_sideeffect(
+            inline_asm_sideeffect(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 &template,
                 if acquire { "l,~{memory}" } else { "~{memory}" },
             );
-            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);
@@ -705,15 +705,15 @@ pub(crate) fn convert_control(
                 "wait_group_read" => ("cp.async.bulk.wait_group.read $0;", "n,~{memory}"),
                 _ => unreachable!("operation was validated"),
             };
-            let lowered = inline_asm_sideeffect(
+            inline_asm_sideeffect(
                 ctx,
                 rewriter,
+                op,
                 void_ty.into(),
                 operands,
                 template,
                 constraints,
             );
-            crate::convert::preserve_location(ctx, op, lowered);
         }
     }
     rewriter.erase_operation(ctx, op);

--- a/crates/mir-lower/src/convert/intrinsics/warp.rs
+++ b/crates/mir-lower/src/convert/intrinsics/warp.rs
@@ -175,6 +175,7 @@ pub(crate) fn convert_shuffle_i64(
     let asm_op = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         i64_ty.into(),
         vec![val, lane_or_delta, mask],
         &asm_template,
@@ -468,6 +469,7 @@ pub(crate) fn convert_elect_sync_inline(
     let asm_op = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         struct_ty.into(),
         vec![mask],
         asm_template,

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -50,6 +50,7 @@ pub(crate) fn convert_make_smem_desc(
     let asm_op = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         i64_ty.into(),
         vec![ptr_casted],
         asm_template,
@@ -244,6 +245,7 @@ pub(crate) fn convert_mma_group(
     inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         VoidType::get(ctx).into(),
         operands,
         &template,
@@ -294,7 +296,15 @@ pub(crate) fn convert_mma_group_values(
         llvm_types::StructType::get_unnamed(ctx, vec![f32_ty.into(); VALUE_ACCUMULATOR_COUNT])
             .into();
 
-    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        op,
+        struct_ty,
+        operands,
+        &template,
+        &constraints,
+    );
 
     let aggregate = asm_op.deref(ctx).get_result(0);
 
@@ -350,7 +360,15 @@ pub(crate) fn convert_mma_loop_values(
         llvm_types::StructType::get_unnamed(ctx, vec![f32_ty.into(); VALUE_ACCUMULATOR_COUNT])
             .into();
 
-    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        op,
+        struct_ty,
+        operands,
+        &template,
+        &constraints,
+    );
     let aggregate = asm_op.deref(ctx).get_result(0);
 
     let mut extracted_values = Vec::with_capacity(VALUE_ACCUMULATOR_COUNT);
@@ -423,7 +441,15 @@ pub(crate) fn convert_mma_pipeline_values(
     let struct_ty: TypeHandle =
         llvm_types::StructType::get_unnamed(ctx, vec![f32_ty.into(); result_count]).into();
 
-    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        op,
+        struct_ty,
+        operands,
+        &template,
+        &constraints,
+    );
     let aggregate = asm_op.deref(ctx).get_result(0);
 
     let mut extracted_values = Vec::with_capacity(result_count);

--- a/crates/mir-lower/src/convert/intrinsics/wmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wmma.rs
@@ -103,6 +103,7 @@ fn convert_generated_mma(
     let inline_asm = inline_asm_convergent(
         ctx,
         rewriter,
+        op,
         result_type.into(),
         operands,
         template,

--- a/crates/mir-lower/src/convert/mod.rs
+++ b/crates/mir-lower/src/convert/mod.rs
@@ -26,6 +26,22 @@
 //! 2. Write a `pub(crate) fn convert_*` function in the relevant submodule.
 //! 3. Add an `#[op_interface_impl]` block in [`interface_impls`].
 
+use pliron::{
+    context::{Context, Ptr},
+    location::Located,
+    operation::Operation,
+};
+
+/// Copy the source operation's location to an operation created while lowering it.
+pub(crate) fn preserve_location(
+    ctx: &mut Context,
+    source: Ptr<Operation>,
+    lowered: Ptr<Operation>,
+) -> Ptr<Operation> {
+    lowered.deref_mut(ctx).set_loc(source.deref(ctx).loc());
+    lowered
+}
+
 pub(crate) mod enum_payload_storage;
 mod generated_intrinsics;
 pub mod interface_impls;

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -714,6 +714,7 @@ pub fn convert(
         func_type,
         flattened_args,
     );
+    crate::convert::preserve_location(ctx, op, llvm_call.get_operation());
     rewriter.insert_operation(ctx, llvm_call.get_operation());
 
     let is_void = result_type.deref(ctx).is::<llvm_types::VoidType>();

--- a/crates/mir-lower/src/convert/ops/control_flow.rs
+++ b/crates/mir-lower/src/convert/ops/control_flow.rs
@@ -68,6 +68,7 @@ pub(crate) fn convert_return(
     };
 
     let llvm_ret = llvm::ReturnOp::new(ctx, ret_val);
+    crate::convert::preserve_location(ctx, op, llvm_ret.get_operation());
     rewriter.insert_operation(ctx, llvm_ret.get_operation());
     rewriter.erase_operation(ctx, op);
     Ok(())
@@ -81,6 +82,7 @@ pub(crate) fn convert_unreachable(
     _operands_info: &OperandsInfo,
 ) -> Result<()> {
     let unreachable_op = llvm::UnreachableOp::new(ctx);
+    crate::convert::preserve_location(ctx, op, unreachable_op.get_operation());
     rewriter.insert_operation(ctx, unreachable_op.get_operation());
     rewriter.erase_operation(ctx, op);
     Ok(())
@@ -130,6 +132,7 @@ pub(crate) fn convert_cond_branch(
     let false_args = operands[1 + num_true_args..].to_vec();
 
     let llvm_br = llvm::CondBrOp::new(ctx, cond, true_block, true_args, false_block, false_args);
+    crate::convert::preserve_location(ctx, op, llvm_br.get_operation());
     rewriter.insert_operation(ctx, llvm_br.get_operation());
     rewriter.erase_operation(ctx, op);
 
@@ -188,6 +191,7 @@ pub(crate) fn convert_assert(
         .insert_at_back(abort_block, ctx);
 
     let llvm_br = llvm::CondBrOp::new(ctx, cond, success_block, args.to_vec(), abort_block, vec![]);
+    crate::convert::preserve_location(ctx, op, llvm_br.get_operation());
     rewriter.insert_operation(ctx, llvm_br.get_operation());
     rewriter.erase_operation(ctx, op);
 
@@ -251,6 +255,7 @@ pub(crate) fn convert_goto(
     }
 
     let llvm_br = llvm::BrOp::new(ctx, dest, final_args);
+    crate::convert::preserve_location(ctx, op, llvm_br.get_operation());
     rewriter.insert_operation(ctx, llvm_br.get_operation());
     rewriter.erase_operation(ctx, op);
 
@@ -275,6 +280,7 @@ mod tests {
     };
     use pliron::builtin::types::{IntegerType, Signedness};
     use pliron::linked_list::ContainsLinkedList;
+    use pliron::location::{Located, Location};
     use pliron::op::Op;
     use pliron::operation::Operation;
     use pliron::r#type::TypeHandle;
@@ -295,6 +301,29 @@ mod tests {
             "void return must have no value operand"
         );
         assert_eq!(count_ops::<mir::MirReturnOp>(&ctx, &body), 0);
+    }
+
+    #[test]
+    fn control_flow_lowering_preserves_the_mir_location() {
+        let mut ctx = make_ctx();
+        let (module_ptr, entry) = build_kernel(&mut ctx, vec![], vec![]);
+        append_mir_return(&mut ctx, entry, vec![]);
+        let expected = Location::Named {
+            name: "source-return".to_string(),
+            child_loc: Box::new(Location::Unknown),
+        };
+        entry
+            .deref(&ctx)
+            .get_terminator(&ctx)
+            .unwrap()
+            .deref_mut(&ctx)
+            .set_loc(expected.clone());
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let ret = find_first::<llvm::ReturnOp>(&ctx, &body).expect("expected llvm.return");
+        assert_eq!(ret.get_operation().deref(&ctx).loc(), expected);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -135,6 +135,7 @@ pub(crate) fn convert_store(
     if let Some(align) = align {
         llvm_export::ops::set_op_alignment(ctx, llvm_store.get_operation(), align as u32);
     }
+    crate::convert::preserve_location(ctx, op, llvm_store.get_operation());
     rewriter.insert_operation(ctx, llvm_store.get_operation());
     rewriter.erase_operation(ctx, op);
     Ok(())
@@ -402,6 +403,7 @@ fn convert_mem_transfer(
         func_ty,
         vec![dst, src, bytes, volatile_val],
     );
+    crate::convert::preserve_location(ctx, op, call.get_operation());
     rewriter.insert_operation(ctx, call.get_operation());
     rewriter.erase_operation(ctx, op);
     Ok(())

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -10,6 +10,7 @@ use pliron::builtin::op_interfaces::{CallOpCallable, CallOpInterface, SymbolOpIn
 use pliron::builtin::ops::ModuleOp;
 use pliron::context::Context;
 use pliron::linked_list::ContainsLinkedList;
+use pliron::location::{Located, Location};
 use pliron::op::Op;
 use pliron::operation::Operation;
 
@@ -67,6 +68,14 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
         0,
     );
     let tid_op = nvvm::ReadPtxSregTidXOp::new(tid_op_ptr);
+    let expected_location = Location::Named {
+        name: "source-tid-x".to_string(),
+        child_loc: Box::new(Location::Unknown),
+    };
+    tid_op
+        .get_operation()
+        .deref_mut(&ctx)
+        .set_loc(expected_location.clone());
     tid_op.get_operation().insert_at_back(block, &ctx);
 
     // Add Return
@@ -91,6 +100,7 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
 
     // Verify result
     let mut found_intrinsic = false;
+    let mut found_intrinsic_call = false;
     let mut found_kernel = false;
 
     let module_op = module_ptr.deref(&ctx);
@@ -130,11 +140,28 @@ fn test_intrinsic_insertion() -> Result<(), anyhow::Error> {
                         .next()
                         .is_some()
                 );
+                let kernel_region = func_op.get_operation().deref(&ctx).get_region(0);
+                for kernel_block in kernel_region.deref(&ctx).iter(&ctx) {
+                    for body_op in kernel_block.deref(&ctx).iter(&ctx) {
+                        let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx) else {
+                            continue;
+                        };
+                        if matches!(
+                            call.callee(&ctx),
+                            CallOpCallable::Direct(symbol)
+                                if symbol.to_string() == "llvm_nvvm_read_ptx_sreg_tid_x"
+                        ) {
+                            found_intrinsic_call = true;
+                            assert_eq!(call.get_operation().deref(&ctx).loc(), expected_location);
+                        }
+                    }
+                }
             }
         }
     }
 
     assert!(found_intrinsic, "Intrinsic function declaration not found");
+    assert!(found_intrinsic_call, "Intrinsic call not found in kernel");
     assert!(found_kernel, "Kernel function not found");
 
     Ok(())
@@ -1581,6 +1608,10 @@ fn addrspace_coercion_inserts_addrspacecast_at_call_site() -> Result<(), anyhow:
     let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
     let shared_ptr_ty = MirPtrType::get_shared(&mut ctx, i32_ty.into(), true);
     let generic_ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty.into(), true);
+    let expected_call_location = Location::Named {
+        name: "source-device-call".to_string(),
+        child_loc: Box::new(Location::Unknown),
+    };
 
     // Callee: takes a *mut i32 in addrspace(3), returns ().
     let callee_func_ty = FunctionType::get(&ctx, vec![shared_ptr_ty.into()], vec![]);
@@ -1651,6 +1682,9 @@ fn addrspace_coercion_inserts_addrspacecast_at_call_site() -> Result<(), anyhow:
         );
         let call_op = mir::MirCallOp::new(call_op_ptr);
         call_op.set_attr_callee(&ctx, StringAttr::new("callee".to_string()));
+        call_op_ptr
+            .deref_mut(&ctx)
+            .set_loc(expected_call_location.clone());
         call_op_ptr.insert_at_back(block, &ctx);
 
         let ret_op = Operation::new(
@@ -1670,6 +1704,7 @@ fn addrspace_coercion_inserts_addrspacecast_at_call_site() -> Result<(), anyhow:
     mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let mut found_addrspace_cast = false;
+    let mut found_call = false;
     let module_op = module_ptr.deref(&ctx);
     let region = module_op.get_region(0);
     let block = region.deref(&ctx).iter(&ctx).next().unwrap();
@@ -1686,6 +1721,18 @@ fn addrspace_coercion_inserts_addrspacecast_at_call_site() -> Result<(), anyhow:
                 if Operation::get_op::<AddrSpaceCastOp>(body_op, &ctx).is_some() {
                     found_addrspace_cast = true;
                 }
+                if let Some(call) = Operation::get_op::<llvm::CallOp>(body_op, &ctx)
+                    && matches!(
+                        call.callee(&ctx),
+                        CallOpCallable::Direct(symbol) if symbol.to_string() == "callee"
+                    )
+                {
+                    found_call = true;
+                    assert_eq!(
+                        call.get_operation().deref(&ctx).loc(),
+                        expected_call_location
+                    );
+                }
             }
         }
     }
@@ -1694,6 +1741,7 @@ fn addrspace_coercion_inserts_addrspacecast_at_call_site() -> Result<(), anyhow:
         found_addrspace_cast,
         "caller body must contain llvm.addrspacecast for the addrspace(0) -> (3) coercion at the call site",
     );
+    assert!(found_call, "caller body must contain the lowered call");
     Ok(())
 }
 
@@ -2883,6 +2931,13 @@ fn test_multi_result_inline_ptx_lowers_to_struct_asm_and_extractvalues() -> Resu
         true,
         false,
     );
+    let expected_location = Location::Named {
+        name: "source-inline-ptx".to_string(),
+        child_loc: Box::new(Location::Unknown),
+    };
+    inline_ptx
+        .deref_mut(&ctx)
+        .set_loc(expected_location.clone());
     inline_ptx.insert_at_back(entry, &ctx);
     append_return(&mut ctx, entry);
 
@@ -2892,6 +2947,10 @@ fn test_multi_result_inline_ptx_lowers_to_struct_asm_and_extractvalues() -> Resu
     let mut extract_indices = Vec::new();
     for op in lowered_kernel_body(&ctx, module_ptr) {
         if let Some(inline_asm) = Operation::get_op::<llvm::InlineAsmOp>(op, &ctx) {
+            assert_eq!(
+                inline_asm.get_operation().deref(&ctx).loc(),
+                expected_location
+            );
             assert_eq!(
                 inline_asm
                     .get_attr_inline_asm_template(&ctx)
@@ -2926,6 +2985,7 @@ fn test_multi_result_inline_ptx_lowers_to_struct_asm_and_extractvalues() -> Resu
             }
             asm_result = Some(result);
         } else if let Some(extract) = Operation::get_op::<llvm::ExtractValueOp>(op, &ctx) {
+            assert_eq!(extract.get_operation().deref(&ctx).loc(), expected_location);
             let aggregate = extract.get_operation().deref(&ctx).get_operand(0);
             assert_eq!(
                 Some(aggregate),


### PR DESCRIPTION
## Problem

- Lowering from dialect-mir to the LLVM dialect dropped source locations: an op that knew it came from `examples/foo.rs:23` became an `llvm.call` or branch with an unknown location, so PTX line tables pointed nowhere and located diagnostics from later passes lost their anchor:

```text
// kernel source
let v = a[i] + b[i];        // vecadd.rs:23
out[i] = v;                 // vecadd.rs:24

Before (.ll, line-info build):
  %v = call float @...      ; no !dbg, line table has nothing to say
  store float %v, ptr %o    ; no !dbg
After (.ll, line-info build):
  %v = call float @..., !dbg !12    ; !12 = DILocation(line: 23)
  store float %v, ptr %o, !dbg !13  ; !13 = DILocation(line: 24)
```

## Fix

- copy the source op's location onto every op the lowering creates
- review follow-up 5f514ca7 centralizes it: `inline_asm_convergent` and `inline_asm_sideeffect` now take the source op and stamp the location themselves (the same pattern this PR gave `call_intrinsic`), which covers all ~45 inline-asm construction sites in one place (mbarrier, cp_async, wgmma, warp, cluster, wmma, ldmatrix, tma, and the generated templates), plus `convert_store`, the atomic store, and memcpy/memmove
- dropped one redundant copy: pliron's `replace_operation` already propagates the old op's location for single-result replacements (verified at the pinned pliron rev; a comment records this)
- the generator template was updated and `generated_intrinsics.rs` regenerated, so all 26 generated asm sites pass the source op too

## Gotchas

- `!dbg` only appears in line-info builds (`CUDA_OXIDE_DEBUG=line`); plain builds emit none, by design, so do not be surprised by a bare `.ll` in a default build
- two direct `llvm.CallOp` construction sites in tma.rs keep their explicit location copies because they bypass `call_intrinsic`

## Testing and validation

- mir-lower suites green (221 + 105 tests), including a new test that the shared helper copies the source location
- `cuda-intrinsics-gen check` clean (template and generated file in sync)
- end to end: `CUDA_OXIDE_DEBUG=line cargo oxide pipeline vecadd` shows `!dbg` on the device call, branches, and stores at the right lines
- CI green (43/43)
