### PR TITLE
feat(finalizer): add standalone PTX assembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ version = "0.2.1"
 dependencies = [
  "libnvvm-sys",
  "nvjitlink-sys",
+ "nvptxcompiler-sys",
  "sha2",
  "thiserror",
 ]
@@ -934,6 +935,14 @@ dependencies = [
 
 [[package]]
 name = "nvjitlink-sys"
+version = "0.2.1"
+dependencies = [
+ "libloading",
+ "thiserror",
+]
+
+[[package]]
+name = "nvptxcompiler-sys"
 version = "0.2.1"
 dependencies = [
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/cuda-async",
     "crates/libnvvm-sys",
     "crates/nvjitlink-sys",
+    "crates/nvptxcompiler-sys",
     # Internal naming contract (workspace-private; publish = false)
     "crates/reserved-oxide-symbols",
     # Differential codegen fuzzer support
@@ -81,6 +82,7 @@ cuda-core = { path = "crates/cuda-core" }
 cuda-async = { path = "crates/cuda-async" }
 libnvvm-sys = { path = "crates/libnvvm-sys" }
 nvjitlink-sys = { path = "crates/nvjitlink-sys" }
+nvptxcompiler-sys = { path = "crates/nvptxcompiler-sys" }
 reserved-oxide-symbols = { path = "crates/reserved-oxide-symbols" }
 fuzzer = { path = "crates/fuzzer" }
 oxide-artifacts = { path = "crates/oxide-artifacts" }

--- a/crates/cuda-artifact-finalizer/Cargo.toml
+++ b/crates/cuda-artifact-finalizer/Cargo.toml
@@ -11,5 +11,6 @@ repository.workspace = true
 [dependencies]
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
+nvptxcompiler-sys = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/cuda-artifact-finalizer/README.md
+++ b/crates/cuda-artifact-finalizer/README.md
@@ -1,12 +1,19 @@
 # cuda-artifact-finalizer
 
-Driver-independent finalization of NVVM IR and LTOIR into loadable device code.
+Driver-independent finalization of NVVM IR, LTOIR, and PTX into loadable device
+code.
 
-This crate is the single owner of cuda-oxide's libNVVM and nvJitLink
-compilation policy. It deliberately does **not** link the CUDA Driver, so the
-same typed target, FMA, debug, input-order, validation, and provenance rules
-apply whether an artifact is materialized at build time (`cargo oxide build
---materialize-cubin`) or finalized at run time as a fallback.
+This crate is the single owner of cuda-oxide's libNVVM, nvJitLink, and
+nvPTXCompiler compilation policy. It deliberately does **not** link the CUDA
+Driver, so the same typed target, FMA, debug, input-order, validation, and
+provenance rules apply whether an artifact is materialized at build time
+(`cargo oxide build --materialize-cubin`) or finalized at run time as a
+fallback.
+
+`PtxAssembler` is discovered separately from the ordinary `Finalizer`. This
+keeps nvPTXCompiler optional for consumers that only use the NVVM IR pipeline,
+while providing a direct PTX-to-cubin boundary when PTX has already been
+linked.
 
 Keeping that policy in one driverless crate is what lets the two paths agree.
 A rule that lived in the runtime loader alone could not be applied during a

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -5,7 +5,8 @@
 
 //! Driver-independent CUDA artifact finalization.
 //!
-//! This crate is the single owner of cuda-oxide's libNVVM and nvJitLink
+//! This crate is the single owner of cuda-oxide's libNVVM, nvJitLink, and
+//! nvPTXCompiler
 //! compilation policy. It deliberately does not link the CUDA Driver. Both
 //! build-time materialization and runtime fallback use the same typed target,
 //! FMA, debug, input-order, validation, and provenance rules.
@@ -15,15 +16,18 @@ mod link;
 mod nvvm;
 mod options;
 mod provenance;
+mod ptx;
 mod validation;
 
 pub use diagnostics::KernelResourceUsage;
 pub use libnvvm_sys::{CudaArch, CudaArchParseError, LibdeviceNotFound, NvvmError, find_libdevice};
 pub use link::{LinkReport, LtoLinker};
 pub use nvjitlink_sys::NvJitLinkError;
+pub use nvptxcompiler_sys::NvPtxCompilerError;
 pub use nvvm::NvvmCompiler;
 pub use options::{DebugPolicy, FinalizationOptions, FinalizerOutput, NamedInput};
 pub use provenance::{ToolProvenance, recipe_digest};
+pub use ptx::PtxAssembler;
 pub use validation::is_valid_cubin;
 
 use provenance::common_provenance_digest;
@@ -40,6 +44,10 @@ pub enum FinalizerError {
     /// nvJitLink failed to load or link.
     #[error("nvJitLink: {0}")]
     NvJitLink(#[from] nvjitlink_sys::NvJitLinkError),
+
+    /// The standalone PTX compiler could not be loaded or invoked.
+    #[error("nvPTXCompiler: {0}")]
+    NvPtxCompiler(#[from] NvPtxCompilerError),
 
     /// `libdevice.10.bc` could not be found.
     #[error(

--- a/crates/cuda-artifact-finalizer/src/options.rs
+++ b/crates/cuda-artifact-finalizer/src/options.rs
@@ -40,7 +40,7 @@ impl DebugPolicy {
     }
 }
 
-/// Typed options shared by the libNVVM and nvJitLink stages.
+/// Typed options shared by the libNVVM, nvJitLink, and nvPTXCompiler stages.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FinalizationOptions {
     target: CudaArch,
@@ -124,6 +124,29 @@ impl FinalizationOptions {
     pub(crate) fn nvjitlink_ptx_options(&self) -> Vec<String> {
         let mut options = vec![format!("-arch={}", self.target.sm())];
         self.append_nvjitlink_codegen_options(&mut options);
+        options
+    }
+
+    pub(crate) fn nvptxcompiler_options(&self, verbose: bool) -> Vec<String> {
+        let mut options = vec![
+            format!("--gpu-name={}", self.target.sm()),
+            format!(
+                "--fmad={}",
+                if self.allow_fma_contraction {
+                    "true"
+                } else {
+                    "false"
+                }
+            ),
+        ];
+        match self.debug {
+            DebugPolicy::None => {}
+            DebugPolicy::LineTables => options.push("--generate-line-info".to_owned()),
+            DebugPolicy::Full => options.push("--device-debug".to_owned()),
+        }
+        if verbose {
+            options.push("--verbose".to_owned());
+        }
         options
     }
 
@@ -330,5 +353,27 @@ mod tests {
                 [expected]
             );
         }
+    }
+
+    #[test]
+    fn standalone_ptx_options_preserve_codegen_policy() {
+        let base = FinalizationOptions::new("sm_103a".parse().unwrap())
+            .with_fma_contraction(false)
+            .with_debug_policy(DebugPolicy::LineTables);
+        assert_eq!(
+            base.nvptxcompiler_options(false),
+            ["--gpu-name=sm_103a", "--fmad=false", "--generate-line-info"]
+        );
+        assert_eq!(
+            base.clone()
+                .with_debug_policy(DebugPolicy::Full)
+                .nvptxcompiler_options(true),
+            [
+                "--gpu-name=sm_103a",
+                "--fmad=false",
+                "--device-debug",
+                "--verbose"
+            ]
+        );
     }
 }

--- a/crates/cuda-artifact-finalizer/src/ptx.rs
+++ b/crates/cuda-artifact-finalizer/src/ptx.rs
@@ -1,0 +1,309 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Direct assembly of an already-linked PTX module.
+//!
+//! This route is deliberately separate from [`crate::Finalizer::discover`],
+//! so applications that only finalize NVVM IR do not acquire an
+//! nvPTXCompiler run-time dependency.
+
+use crate::diagnostics::parse_ptxas_resource_usage;
+use crate::nvvm::{loaded_tool_digest, report_changed_tool};
+use crate::provenance::{
+    StableDigest, digest_file_handle, recipe_digest, with_revalidated_tool_identity,
+};
+use crate::{FinalizationOptions, FinalizerError, LinkReport, NamedInput, is_valid_cubin};
+use nvptxcompiler_sys::{LibNvPtxCompiler, Program};
+use std::sync::{Arc, Mutex, OnceLock};
+
+struct LoadedPtxCompilerTool {
+    library: Arc<LibNvPtxCompiler>,
+    digest: Option<[u8; 32]>,
+}
+
+static PTX_COMPILER_TOOL: OnceLock<Arc<LoadedPtxCompilerTool>> = OnceLock::new();
+static PTX_COMPILER_TOOL_LOAD: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Driver-independent assembler for one already-linked PTX module.
+#[derive(Clone)]
+pub struct PtxAssembler {
+    tool: Arc<LoadedPtxCompilerTool>,
+}
+
+impl PtxAssembler {
+    /// Discover and pin nvPTXCompiler without loading libNVVM or the Driver.
+    pub fn discover() -> Result<Self, FinalizerError> {
+        Ok(Self {
+            tool: load_ptx_compiler_tool()?,
+        })
+    }
+
+    /// Digest of the exact loaded nvPTXCompiler file, when it can be proven.
+    pub fn nvptxcompiler_digest(&self) -> Option<[u8; 32]> {
+        let digest = self.tool.digest?;
+        if current_ptx_compiler_digest(&self.tool).is_some() {
+            Some(digest)
+        } else {
+            report_changed_tool("nvPTXCompiler");
+            None
+        }
+    }
+
+    /// Digest every semantic input to the standalone PTX assembly stage.
+    pub fn artifact_digest(
+        &self,
+        input: NamedInput<'_>,
+        options: &FinalizationOptions,
+    ) -> Result<Option<[u8; 32]>, FinalizerError> {
+        let logical = logical_ptx(input)?;
+        let Some(nvptxcompiler) = self.nvptxcompiler_digest() else {
+            return Ok(None);
+        };
+        Ok(Some(ptx_assembly_artifact_digest_parts(
+            NamedInput::new(input.name, logical),
+            options,
+            &nvptxcompiler,
+        )))
+    }
+
+    /// Assemble one PTX module into a validated target-specific cubin.
+    pub fn assemble_ptx(
+        &self,
+        input: NamedInput<'_>,
+        options: &FinalizationOptions,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        Ok(self.assemble_ptx_impl(input, options, false)?.image)
+    }
+
+    /// Assemble one PTX module and collect ptxas resource diagnostics.
+    pub fn assemble_ptx_with_report(
+        &self,
+        input: NamedInput<'_>,
+        options: &FinalizationOptions,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.assemble_ptx_impl(input, options, true)
+    }
+
+    fn assemble_ptx_impl(
+        &self,
+        input: NamedInput<'_>,
+        options: &FinalizationOptions,
+        collect_resource_usage: bool,
+    ) -> Result<LinkReport, FinalizerError> {
+        let logical = logical_ptx(input)?;
+        with_revalidated_tool_identity(
+            "nvPTXCompiler",
+            self.tool.digest,
+            || current_ptx_compiler_digest(&self.tool),
+            || assemble(&self.tool.library, logical, options, collect_resource_usage),
+        )
+    }
+}
+
+fn logical_ptx(input: NamedInput<'_>) -> Result<&[u8], FinalizerError> {
+    crate::validate_name(input.name)?;
+    let logical =
+        nvjitlink_sys::logical_ptx(input.bytes, input.name).map_err(|error| match error {
+            nvjitlink_sys::NvJitLinkError::InteriorNulPtx { name, .. } => {
+                FinalizerError::InteriorNulPtx { name }
+            }
+            other => FinalizerError::NvJitLink(other),
+        })?;
+    if logical.is_empty() {
+        return Err(FinalizerError::EmptyInput {
+            name: input.name.to_owned(),
+        });
+    }
+    Ok(logical)
+}
+
+fn assemble(
+    library: &LibNvPtxCompiler,
+    logical: &[u8],
+    options: &FinalizationOptions,
+    collect_resource_usage: bool,
+) -> Result<LinkReport, FinalizerError> {
+    let mut program = Program::new(library, logical)?;
+    let option_storage = options.nvptxcompiler_options(collect_resource_usage);
+    let option_refs = option_storage
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    program.compile(&option_refs)?;
+    let image = program.compiled_program()?;
+    if !is_valid_cubin(&image) {
+        return Err(FinalizerError::InvalidCubin);
+    }
+
+    let info_log = if collect_resource_usage {
+        program.info_log()
+    } else {
+        None
+    };
+    let resource_usage = info_log
+        .as_deref()
+        .map(parse_ptxas_resource_usage)
+        .unwrap_or_default();
+    Ok(LinkReport {
+        image,
+        info_log,
+        resource_usage,
+    })
+}
+
+fn current_ptx_compiler_digest(tool: &LoadedPtxCompilerTool) -> Option<[u8; 32]> {
+    let file = tool.library.loaded_file_if_unchanged()?;
+    digest_file_handle(file).ok()
+}
+
+pub(crate) fn ptx_assembly_artifact_digest_parts(
+    input: NamedInput<'_>,
+    options: &FinalizationOptions,
+    nvptxcompiler_digest: &[u8; 32],
+) -> [u8; 32] {
+    let logical = input.bytes.strip_suffix(&[0]).unwrap_or(input.bytes);
+    let mut digest = StableDigest::new()
+        .field("recipe", recipe_digest())
+        .field("route", b"ptx-to-cubin-standalone")
+        .field("input-name", input.name.as_bytes())
+        .field("input", logical);
+    for option in options.nvptxcompiler_options(false) {
+        digest = digest.field("nvptxcompiler-option", option.as_bytes());
+    }
+    digest
+        .field("libnvptxcompiler-sha256", nvptxcompiler_digest)
+        .finish()
+}
+
+fn load_ptx_compiler_tool() -> Result<Arc<LoadedPtxCompilerTool>, FinalizerError> {
+    if let Some(loaded) = PTX_COMPILER_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+    let _guard = PTX_COMPILER_TOOL_LOAD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(loaded) = PTX_COMPILER_TOOL.get() {
+        return Ok(Arc::clone(loaded));
+    }
+
+    let library = LibNvPtxCompiler::load_for_cache()?;
+    let digest = loaded_tool_digest("nvPTXCompiler", library.loaded_file_if_unchanged());
+    let loaded = Arc::new(LoadedPtxCompilerTool {
+        library: Arc::new(library),
+        digest,
+    });
+    let _ = PTX_COMPILER_TOOL.set(Arc::clone(&loaded));
+    Ok(loaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libnvvm_sys::CudaArch;
+
+    fn options() -> FinalizationOptions {
+        FinalizationOptions::new("sm_103a".parse::<CudaArch>().unwrap())
+    }
+
+    #[test]
+    fn assembly_digest_covers_input_name_bytes_options_and_tool() {
+        let options = options();
+        let base = ptx_assembly_artifact_digest_parts(
+            NamedInput::new("kernel.ptx", b"ptx"),
+            &options,
+            &[1; 32],
+        );
+        assert_ne!(
+            base,
+            ptx_assembly_artifact_digest_parts(
+                NamedInput::new("other.ptx", b"ptx"),
+                &options,
+                &[1; 32],
+            )
+        );
+        assert_ne!(
+            base,
+            ptx_assembly_artifact_digest_parts(
+                NamedInput::new("kernel.ptx", b"changed"),
+                &options,
+                &[1; 32],
+            )
+        );
+        assert_ne!(
+            base,
+            ptx_assembly_artifact_digest_parts(
+                NamedInput::new("kernel.ptx", b"ptx"),
+                &options.clone().with_fma_contraction(false),
+                &[1; 32],
+            )
+        );
+        assert_ne!(
+            base,
+            ptx_assembly_artifact_digest_parts(
+                NamedInput::new("kernel.ptx", b"ptx"),
+                &options,
+                &[2; 32],
+            )
+        );
+        assert_eq!(
+            base,
+            ptx_assembly_artifact_digest_parts(
+                NamedInput::new("kernel.ptx", b"ptx\0"),
+                &options,
+                &[1; 32],
+            )
+        );
+    }
+
+    #[test]
+    fn standalone_ptx_validation_normalizes_one_terminator_and_rejects_invalid_inputs() {
+        assert_eq!(
+            logical_ptx(NamedInput::new("kernel.ptx", b"ptx\0")).unwrap(),
+            b"ptx"
+        );
+        assert!(matches!(
+            logical_ptx(NamedInput::new("bad.ptx", b"abc\0def")),
+            Err(FinalizerError::InteriorNulPtx { ref name }) if name == "bad.ptx"
+        ));
+        assert!(matches!(
+            logical_ptx(NamedInput::new("empty.ptx", b"\0")),
+            Err(FinalizerError::EmptyInput { ref name }) if name == "empty.ptx"
+        ));
+    }
+
+    #[test]
+    #[ignore = "requires discoverable CUDA Toolkit nvPTXCompiler"]
+    fn live_assembly_emits_a_kernel_cubin() {
+        const PTX: &[u8] = br#"
+.version 8.0
+.target sm_80
+.address_size 64
+
+.visible .entry kernel() {
+    ret;
+}
+"#;
+        let assembler = PtxAssembler::discover().unwrap();
+        assert!(assembler.nvptxcompiler_digest().is_some());
+        assert!(
+            assembler
+                .artifact_digest(NamedInput::new("kernel.ptx", PTX), &options())
+                .unwrap()
+                .is_some()
+        );
+        let report = assembler
+            .assemble_ptx_with_report(NamedInput::new("kernel.ptx", PTX), &options())
+            .unwrap();
+        assert!(is_valid_cubin(&report.image));
+        assert!(
+            report
+                .image
+                .windows(b"kernel".len())
+                .any(|bytes| bytes == b"kernel")
+        );
+        assert!(report.info_log.is_some());
+    }
+}

--- a/crates/nvptxcompiler-sys/Cargo.toml
+++ b/crates/nvptxcompiler-sys/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nvptxcompiler-sys"
+version = "0.2.1"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runtime (dlopen) bindings to NVIDIA's PTX Compiler API"
+readme = "README.md"
+
+[dependencies]
+libloading = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/nvptxcompiler-sys/README.md
+++ b/crates/nvptxcompiler-sys/README.md
@@ -1,0 +1,7 @@
+# nvptxcompiler-sys
+
+Runtime-loaded, driver-independent bindings to NVIDIA's PTX Compiler API.
+
+The crate owns dynamic library discovery, symbol resolution, compiler-handle
+lifetime, option marshaling, and raw log/program retrieval. It does not link
+the CUDA Driver and requires the CUDA Toolkit only at run time.

--- a/crates/nvptxcompiler-sys/src/lib.rs
+++ b/crates/nvptxcompiler-sys/src/lib.rs
@@ -1,0 +1,365 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Runtime (`dlopen`) bindings to NVIDIA's PTX Compiler API.
+//!
+//! The API assembles one PTX module into target-specific device code without
+//! loading the CUDA Driver. [`LibNvPtxCompiler::load`] discovers the Toolkit
+//! library at run time; [`Program`] owns one compiler handle.
+
+use libloading::Library;
+use std::ffi::{CString, c_char, c_int, c_void};
+use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::ptr;
+use std::time::SystemTime;
+use thiserror::Error;
+
+type ResultCode = i32;
+type Handle = *mut c_void;
+type Create = unsafe extern "C" fn(*mut Handle, usize, *const c_char) -> ResultCode;
+type Destroy = unsafe extern "C" fn(*mut Handle) -> ResultCode;
+type Compile = unsafe extern "C" fn(Handle, c_int, *const *const c_char) -> ResultCode;
+type GetSize = unsafe extern "C" fn(Handle, *mut usize) -> ResultCode;
+type GetProgram = unsafe extern "C" fn(Handle, *mut c_void) -> ResultCode;
+type GetLog = unsafe extern "C" fn(Handle, *mut c_char) -> ResultCode;
+
+/// Failures surfaced by the PTX Compiler API binding.
+#[derive(Debug, Error)]
+pub enum NvPtxCompilerError {
+    /// No candidate shared library could be loaded completely.
+    #[error("libnvptxcompiler could not be located; tried {tried}")]
+    LibraryNotFound {
+        /// Candidate paths and their loader errors.
+        tried: String,
+    },
+
+    /// An option could not be represented by the C API.
+    #[error("compiler option contains an interior NUL byte: {option:?}")]
+    InvalidOption {
+        /// Rejected option.
+        option: String,
+    },
+
+    /// An API operation returned a non-success status.
+    #[error("nvPTXCompiler error in {operation}: status {status}{}", .log.as_ref().map(|log| format!("\n--- nvPTXCompiler log ---\n{log}")).unwrap_or_default())]
+    Call {
+        /// API operation that failed.
+        operation: &'static str,
+        /// Raw result code, preserved for forward compatibility.
+        status: ResultCode,
+        /// Best-effort compiler error log.
+        log: Option<String>,
+    },
+}
+
+/// Loaded nvPTXCompiler library and immutable function table.
+pub struct LibNvPtxCompiler {
+    create: Create,
+    destroy: Destroy,
+    compile: Compile,
+    get_program_size: GetSize,
+    get_program: GetProgram,
+    get_error_log_size: GetSize,
+    get_error_log: GetLog,
+    get_info_log_size: GetSize,
+    get_info_log: GetLog,
+    loaded_file: Option<File>,
+    loaded_identity: Option<LibraryFileIdentity>,
+    _library: Library,
+}
+
+// SAFETY: The library and immutable function table are safe to share. Each
+// `Program` owns a distinct API handle and remains neither Send nor Sync.
+unsafe impl Send for LibNvPtxCompiler {}
+unsafe impl Sync for LibNvPtxCompiler {}
+
+impl LibNvPtxCompiler {
+    /// Discover and load nvPTXCompiler without retaining a fingerprintable file.
+    pub fn load() -> Result<Self, NvPtxCompilerError> {
+        Self::load_inner(false)
+    }
+
+    /// Load nvPTXCompiler and retain the exact opened descriptor on Linux.
+    #[doc(hidden)]
+    pub fn load_for_cache() -> Result<Self, NvPtxCompilerError> {
+        Self::load_inner(true)
+    }
+
+    fn load_inner(retain_exact_file: bool) -> Result<Self, NvPtxCompilerError> {
+        let mut tried = Vec::new();
+        for candidate in library_candidates() {
+            match unsafe { load_from_path(&candidate, retain_exact_file) } {
+                Ok(library) => return Ok(library),
+                Err(error) => tried.push(format!("{}: {error}", candidate.display())),
+            }
+        }
+        Err(NvPtxCompilerError::LibraryNotFound {
+            tried: tried.join(" | "),
+        })
+    }
+
+    /// Exact retained descriptor, provided it has not changed since loading.
+    #[doc(hidden)]
+    pub fn loaded_file_if_unchanged(&self) -> Option<&File> {
+        let identity = self.loaded_identity.as_ref()?;
+        let file = self.loaded_file.as_ref()?;
+        identity.matches_file(file).then_some(file)
+    }
+}
+
+/// One nvPTXCompiler program handle.
+pub struct Program<'a> {
+    library: &'a LibNvPtxCompiler,
+    handle: Handle,
+}
+
+impl<'a> Program<'a> {
+    /// Create a program from logical, non-NUL-terminated PTX bytes.
+    pub fn new(library: &'a LibNvPtxCompiler, ptx: &[u8]) -> Result<Self, NvPtxCompilerError> {
+        let mut handle = ptr::null_mut();
+        let status = unsafe { (library.create)(&mut handle, ptx.len(), ptx.as_ptr().cast()) };
+        if status != 0 {
+            return Err(NvPtxCompilerError::Call {
+                operation: "nvPTXCompilerCreate",
+                status,
+                log: None,
+            });
+        }
+        Ok(Self { library, handle })
+    }
+
+    /// Compile with options in exact supplied order.
+    pub fn compile(&mut self, options: &[&str]) -> Result<(), NvPtxCompilerError> {
+        let storage = options
+            .iter()
+            .map(|option| {
+                CString::new(*option).map_err(|_| NvPtxCompilerError::InvalidOption {
+                    option: (*option).to_owned(),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let pointers = storage
+            .iter()
+            .map(|option| option.as_ptr())
+            .collect::<Vec<_>>();
+        let status = unsafe {
+            (self.library.compile)(self.handle, pointers.len() as c_int, pointers.as_ptr())
+        };
+        self.check(status, "nvPTXCompilerCompile")
+    }
+
+    /// Retrieve the complete compiled program bytes.
+    pub fn compiled_program(&self) -> Result<Vec<u8>, NvPtxCompilerError> {
+        let mut size = 0usize;
+        let status = unsafe { (self.library.get_program_size)(self.handle, &mut size) };
+        self.check(status, "nvPTXCompilerGetCompiledProgramSize")?;
+        let mut image = vec![0u8; size];
+        let status = unsafe { (self.library.get_program)(self.handle, image.as_mut_ptr().cast()) };
+        self.check(status, "nvPTXCompilerGetCompiledProgram")?;
+        Ok(image)
+    }
+
+    /// Best-effort informational compiler log.
+    pub fn info_log(&self) -> Option<String> {
+        self.log(self.library.get_info_log_size, self.library.get_info_log)
+    }
+
+    /// Best-effort error compiler log.
+    pub fn error_log(&self) -> Option<String> {
+        self.log(self.library.get_error_log_size, self.library.get_error_log)
+    }
+
+    fn check(&self, status: ResultCode, operation: &'static str) -> Result<(), NvPtxCompilerError> {
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(NvPtxCompilerError::Call {
+                operation,
+                status,
+                log: self.error_log(),
+            })
+        }
+    }
+
+    fn log(&self, get_size: GetSize, get_log: GetLog) -> Option<String> {
+        let mut size = 0usize;
+        if unsafe { get_size(self.handle, &mut size) } != 0 || size <= 1 {
+            return None;
+        }
+        let mut bytes = vec![0u8; size];
+        if unsafe { get_log(self.handle, bytes.as_mut_ptr().cast()) } != 0 {
+            return None;
+        }
+        if bytes.last() == Some(&0) {
+            bytes.pop();
+        }
+        Some(String::from_utf8_lossy(&bytes).into_owned())
+    }
+}
+
+impl Drop for Program<'_> {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            let _ = unsafe { (self.library.destroy)(&mut self.handle) };
+        }
+    }
+}
+
+unsafe fn load_from_path(
+    path: &Path,
+    retain_exact_file: bool,
+) -> Result<LibNvPtxCompiler, libloading::Error> {
+    #[cfg(not(target_os = "linux"))]
+    let _ = retain_exact_file;
+    #[cfg(target_os = "linux")]
+    let retained = if retain_exact_file {
+        path.canonicalize()
+            .ok()
+            .and_then(|path| File::open(path).ok())
+            .filter(|file| file.metadata().is_ok_and(|metadata| metadata.is_file()))
+    } else {
+        None
+    };
+    #[cfg(not(target_os = "linux"))]
+    let retained: Option<File> = None;
+
+    #[cfg(target_os = "linux")]
+    let load_path = retained
+        .as_ref()
+        .map(|file| PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd())))
+        .unwrap_or_else(|| path.to_owned());
+    #[cfg(not(target_os = "linux"))]
+    let load_path = path.to_owned();
+
+    let library = unsafe { Library::new(load_path) }?;
+    let loaded_identity = retained
+        .as_ref()
+        .and_then(LibraryFileIdentity::capture_file)
+        .filter(|identity| {
+            retained
+                .as_ref()
+                .is_some_and(|file| identity.matches_file(file))
+        });
+    macro_rules! symbol {
+        ($name:literal, $ty:ty) => {{
+            let value = unsafe { library.get::<$ty>(concat!($name, "\0").as_bytes()) }?;
+            *value
+        }};
+    }
+    Ok(LibNvPtxCompiler {
+        create: symbol!("nvPTXCompilerCreate", Create),
+        destroy: symbol!("nvPTXCompilerDestroy", Destroy),
+        compile: symbol!("nvPTXCompilerCompile", Compile),
+        get_program_size: symbol!("nvPTXCompilerGetCompiledProgramSize", GetSize),
+        get_program: symbol!("nvPTXCompilerGetCompiledProgram", GetProgram),
+        get_error_log_size: symbol!("nvPTXCompilerGetErrorLogSize", GetSize),
+        get_error_log: symbol!("nvPTXCompilerGetErrorLog", GetLog),
+        get_info_log_size: symbol!("nvPTXCompilerGetInfoLogSize", GetSize),
+        get_info_log: symbol!("nvPTXCompilerGetInfoLog", GetLog),
+        loaded_file: retained,
+        loaded_identity,
+        _library: library,
+    })
+}
+
+fn library_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = std::env::var_os("LIBNVPTXCOMPILER_PATH") {
+        candidates.push(PathBuf::from(path));
+    }
+    for variable in ["CUDA_TOOLKIT_PATH", "CUDA_HOME", "CUDA_PATH"] {
+        if let Some(root) = std::env::var_os(variable) {
+            candidates.push(PathBuf::from(root).join("lib64/libnvptxcompiler.so"));
+        }
+    }
+    for root in ["/usr/local/cuda", "/opt/cuda"] {
+        candidates.push(PathBuf::from(root).join("lib64/libnvptxcompiler.so"));
+    }
+    candidates.extend(
+        ["libnvptxcompiler.so.13", "libnvptxcompiler.so"]
+            .into_iter()
+            .map(PathBuf::from),
+    );
+    candidates
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct LibraryFileIdentity {
+    len: u64,
+    modified: SystemTime,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    change_time: (i64, i64),
+}
+
+impl LibraryFileIdentity {
+    fn capture_file(file: &File) -> Option<Self> {
+        let metadata = file.metadata().ok()?;
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+        Some(Self {
+            len: metadata.len(),
+            modified: metadata.modified().ok()?,
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            change_time: (metadata.ctime(), metadata.ctime_nsec()),
+        })
+    }
+
+    fn matches_file(&self, file: &File) -> bool {
+        Self::capture_file(file).as_ref() == Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_representation_accepts_future_error_codes() {
+        let error = NvPtxCompilerError::Call {
+            operation: "future operation",
+            status: i32::MAX,
+            log: None,
+        };
+        assert!(error.to_string().contains(&i32::MAX.to_string()));
+    }
+
+    #[test]
+    fn retained_identity_detects_replaced_file() {
+        let nonce = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "nvptxcompiler-sys-identity-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("tool.so");
+        let replacement = directory.join("replacement.so");
+        std::fs::write(&path, b"original").unwrap();
+        std::fs::write(&replacement, b"replacement-with-another-length").unwrap();
+        let opened = File::open(&path).unwrap();
+        let identity = LibraryFileIdentity::capture_file(&opened).unwrap();
+        assert!(identity.matches_file(&opened));
+        std::fs::rename(&replacement, &path).unwrap();
+        assert!(identity.matches_file(&opened));
+        assert_ne!(
+            LibraryFileIdentity::capture_file(&File::open(&path).unwrap()).unwrap(),
+            identity
+        );
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- add an independent nvptxcompiler-sys crate with dynamic symbol loading and RAII program ownership
- expose a typed, lazy PtxAssembler policy layer from the artifact finalizer
- report deterministic option digests and compiled resource usage without changing normal finalizer discovery

## Testing

- nvptxcompiler-sys unit tests
- cuda-artifact-finalizer unit tests and clippy
- live PTX assembly on a supported target