### PR TITLE
feat(ptx): expose predicate and operand spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ name = "cuda-intrinsics-gen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ptx-syntax",
  "serde",
  "serde_json",
  "sha2",
@@ -1058,6 +1059,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "libnvvm-sys",
  "nvjitlink-sys",
  "oxide-artifacts",
+ "ptx-syntax",
  "reserved-oxide-symbols",
  "serde_json",
  "sha2",
@@ -407,6 +408,7 @@ dependencies = [
  "cuda-device",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -455,6 +457,7 @@ dependencies = [
  "mir-transforms",
  "nvvm-transforms",
  "pliron",
+ "ptx-syntax",
  "rustc-demangle",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialect-ptx"
+version = "0.1.0"
+dependencies = [
+ "pliron",
+ "pliron-derive",
+ "ptx-syntax",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     # Core crates
     "crates/cuda-intrinsics",
     "crates/cuda-intrinsics-gen",
+    "crates/ptx-syntax",
     "crates/cuda-device",
     "crates/cuda-artifact-finalizer",
     "crates/cuda-host",
@@ -84,6 +85,7 @@ nvjitlink-sys = { path = "crates/nvjitlink-sys" }
 reserved-oxide-symbols = { path = "crates/reserved-oxide-symbols" }
 fuzzer = { path = "crates/fuzzer" }
 oxide-artifacts = { path = "crates/oxide-artifacts" }
+ptx-syntax = { path = "crates/ptx-syntax" }
 
 # Common dependencies
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/cuda-intrinsics",
     "crates/cuda-intrinsics-gen",
     "crates/ptx-syntax",
+    "crates/dialect-ptx",
     "crates/cuda-device",
     "crates/cuda-artifact-finalizer",
     "crates/cuda-host",
@@ -62,6 +63,7 @@ pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "0d3f25df6d0
 llvm-export = { path = "crates/llvm-export" }
 dialect-mir = { path = "crates/dialect-mir" }
 dialect-iket = { path = "crates/dialect-iket" }
+dialect-ptx = { path = "crates/dialect-ptx" }
 dialect-nvvm = { path = "crates/dialect-nvvm" }
 mir-lower = { path = "crates/mir-lower" }
 iket-lower = { path = "crates/iket-lower" }

--- a/crates/cargo-oxide/Cargo.toml
+++ b/crates/cargo-oxide/Cargo.toml
@@ -23,6 +23,7 @@ cuda-artifact-finalizer = { workspace = true }
 libnvvm-sys = { workspace = true }
 nvjitlink-sys = { workspace = true }
 oxide-artifacts = { workspace = true }
+ptx-syntax = { workspace = true }
 reserved-oxide-symbols = { workspace = true }
 serde_json = "1"
 sha2 = { workspace = true }

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -1626,14 +1626,19 @@ fn ptx_recorded_target(ptx_path: &Path) -> Result<String, String> {
             ptx_path.display()
         )
     })?;
-    text.lines()
-        .find_map(|line| {
-            let mut tokens = line.split_whitespace();
-            (tokens.next() == Some(".target"))
-                .then(|| tokens.next())
-                .flatten()
-        })
-        .map(|target| target.trim_end_matches(',').to_string())
+    let document = ptx_syntax::Document::parse(&text).map_err(|error| {
+        format!(
+            "could not parse emitted PTX {} to read its target: {error}",
+            ptx_path.display()
+        )
+    })?;
+    document
+        .directives()
+        .iter()
+        .find(|directive| directive.name() == ".target")
+        .and_then(|directive| ptx_syntax::split_top_level(directive.arguments()))
+        .and_then(|arguments| arguments.first().copied())
+        .map(str::to_string)
         .filter(|target| !target.is_empty())
         .ok_or_else(|| {
             format!(

--- a/crates/cuda-host/Cargo.toml
+++ b/crates/cuda-host/Cargo.toml
@@ -16,6 +16,7 @@ half = { workspace = true }
 cuda-macros = { workspace = true, features = ["host"] }
 cuda-core = { workspace = true }
 cuda-artifact-finalizer = { workspace = true }
+ptx-syntax = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 cuda-async = { workspace = true, optional = true }

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -34,6 +34,10 @@ pub enum EmbeddedModuleError {
     #[error("embedded CUDA module '{name}' has no supported payload")]
     UnsupportedPayload { name: String },
 
+    /// PTX source could not be parsed or edited safely while merging bundles.
+    #[error("embedded CUDA module '{name}' contains invalid PTX: {reason}")]
+    InvalidPtx { name: String, reason: String },
+
     /// NVVM IR or LTOIR payload compilation failed.
     #[error("failed to build embedded CUDA module: {0}")]
     Ltoir(#[from] ltoir::LtoirError),
@@ -97,15 +101,14 @@ pub fn load_all_ptx_bundles_merged(
             } else {
                 // Strip per-file header directives; only one set is valid in a
                 // concatenated PTX module.
-                for line in ptx_str.lines() {
-                    let trimmed = line.trim_start();
-                    if trimmed.starts_with(".version")
-                        || trimmed.starts_with(".target")
-                        || trimmed.starts_with(".address_size")
-                    {
-                        continue;
+                let body = strip_ptx_module_headers(ptx_str).map_err(|reason| {
+                    EmbeddedModuleError::InvalidPtx {
+                        name: bundle.name.clone(),
+                        reason,
                     }
-                    merged.push_str(line);
+                })?;
+                merged.push_str(&body);
+                if !body.ends_with('\n') {
                     merged.push('\n');
                 }
             }
@@ -117,6 +120,21 @@ pub fn load_all_ptx_bundles_merged(
     }
 
     Ok(ctx.load_module_from_image(merged.as_bytes())?)
+}
+
+fn strip_ptx_module_headers(ptx: &str) -> Result<String, String> {
+    let document = ptx_syntax::Document::parse(ptx).map_err(|error| error.to_string())?;
+    let mut edits = ptx_syntax::EditScript::new();
+    for directive in document
+        .directives()
+        .iter()
+        .filter(|directive| matches!(directive.name(), ".version" | ".target" | ".address_size"))
+    {
+        edits
+            .delete(directive.line_span())
+            .map_err(|error| error.to_string())?;
+    }
+    edits.apply(ptx).map_err(|error| error.to_string())
 }
 
 /// Load the first embedded artifact bundle with a supported payload.
@@ -236,6 +254,21 @@ mod tests {
                 .unwrap()
                 .map(|target| target.sm()),
             Some("sm_90".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_only_structural_ptx_module_headers() {
+        let ptx = "\
+// .target sm_1
+.version 8.9
+.target sm_120a, debug
+.address_size 64
+.visible .entry kernel() { ret; }
+";
+        assert_eq!(
+            strip_ptx_module_headers(ptx).unwrap(),
+            "// .target sm_1\n.visible .entry kernel() { ret; }\n"
         );
     }
 

--- a/crates/cuda-intrinsics-gen/Cargo.toml
+++ b/crates/cuda-intrinsics-gen/Cargo.toml
@@ -15,3 +15,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
+ptx-syntax = { workspace = true }

--- a/crates/cuda-intrinsics-gen/src/ptx.rs
+++ b/crates/cuda-intrinsics-gen/src/ptx.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use ptx_syntax::{Document, split_top_level};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -232,133 +233,26 @@ pub(crate) fn instructions_with_matching_head(
     if pattern.mnemonic.is_empty() {
         return Vec::new();
     }
-
-    let source = mask_non_code(source);
-    let bytes = source.as_bytes();
-    let mut search_from = 0;
-    let mut matches = Vec::new();
-
-    while search_from < source.len() {
-        let Some(relative_start) = source[search_from..].find(pattern.mnemonic.as_str()) else {
-            break;
-        };
-        let start = search_from + relative_start;
-        search_from = start + pattern.mnemonic.len();
-
-        if !is_instruction_start(bytes, start) {
-            continue;
-        }
-
-        let mut head_end = start;
-        while head_end < bytes.len() && is_instruction_head_byte(bytes[head_end]) {
-            head_end += 1;
-        }
-        if !instruction_head_matches(&source[start..head_end], pattern) {
-            continue;
-        }
-        if bytes
-            .get(head_end)
-            .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b';')
-        {
-            continue;
-        }
-
-        let Some(statement_end) = find_top_level_semicolon(&source, head_end) else {
-            continue;
-        };
-        let Some(operands) = split_top_level(&source[head_end..statement_end]) else {
-            continue;
-        };
-        matches.push(InstructionMatch {
-            offset: start,
-            end: statement_end + 1,
-            prefix: statement_prefix(&source, start).to_owned(),
-            operands: operands
-                .into_iter()
-                .map(|operand| operand.trim().to_owned())
-                .collect(),
-        });
-    }
-
-    matches
-}
-
-fn statement_prefix(source: &str, instruction_start: usize) -> &str {
-    let statement_start = source[..instruction_start]
-        .rfind([';', '{', '}'])
-        .map_or(0, |offset| offset + 1);
-    source[statement_start..instruction_start].trim()
-}
-
-fn is_instruction_start(source: &[u8], start: usize) -> bool {
-    start == 0
-        || source[start - 1].is_ascii_whitespace()
-        || matches!(source[start - 1], b';' | b'{' | b'}' | b':')
-}
-
-fn is_instruction_head_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':')
+    let Ok(document) = Document::parse(source) else {
+        return Vec::new();
+    };
+    document
+        .instructions()
+        .iter()
+        .filter(|instruction| instruction_head_matches(instruction.head(), pattern))
+        .map(|instruction| InstructionMatch {
+            offset: instruction.head_offset(),
+            end: instruction.end_offset(),
+            prefix: instruction.prefix().to_owned(),
+            operands: instruction.operands().map(str::to_owned).collect(),
+        })
+        .collect()
 }
 
 fn instruction_head_matches(head: &str, pattern: &InstructionPattern) -> bool {
     let mut parts = head.split('.');
     parts.next() == Some(pattern.mnemonic.as_str())
         && parts.eq(pattern.modifiers.iter().map(String::as_str))
-}
-
-fn find_top_level_semicolon(source: &str, start: usize) -> Option<usize> {
-    let mut delimiters = Vec::new();
-    for (relative, byte) in source.as_bytes()[start..].iter().copied().enumerate() {
-        match byte {
-            b'{' => delimiters.push(b'}'),
-            b'[' => delimiters.push(b']'),
-            b'(' => delimiters.push(b')'),
-            b'}' | b']' | b')' if delimiters.pop() != Some(byte) => return None,
-            b'}' | b']' | b')' => {}
-            b';' if delimiters.is_empty() => return Some(start + relative),
-            _ => {}
-        }
-    }
-    None
-}
-
-fn split_top_level(source: &str) -> Option<Vec<&str>> {
-    let source = source.trim();
-    if source.is_empty() {
-        return Some(Vec::new());
-    }
-
-    let mut operands = Vec::new();
-    let mut delimiters = Vec::new();
-    let mut operand_start = 0;
-    for (index, byte) in source.bytes().enumerate() {
-        match byte {
-            b'{' => delimiters.push(b'}'),
-            b'[' => delimiters.push(b']'),
-            b'(' => delimiters.push(b')'),
-            b'}' | b']' | b')' if delimiters.pop() != Some(byte) => return None,
-            b'}' | b']' | b')' => {}
-            b',' if delimiters.is_empty() => {
-                let operand = source[operand_start..index].trim();
-                if operand.is_empty() {
-                    return None;
-                }
-                operands.push(operand);
-                operand_start = index + 1;
-            }
-            _ => {}
-        }
-    }
-    if !delimiters.is_empty() {
-        return None;
-    }
-
-    let operand = source[operand_start..].trim();
-    if operand.is_empty() {
-        return None;
-    }
-    operands.push(operand);
-    Some(operands)
 }
 
 fn operand_matches(operand: &str, pattern: &OperandPattern) -> bool {
@@ -482,82 +376,6 @@ fn enclosed_body(source: &str, open: u8, close: u8) -> Option<&str> {
         }
     }
     None
-}
-
-fn mask_non_code(source: &str) -> String {
-    #[derive(Clone, Copy)]
-    enum State {
-        Code,
-        LineComment,
-        BlockComment,
-        Quoted,
-    }
-
-    let source = source.as_bytes();
-    let mut masked = source.to_vec();
-    let mut state = State::Code;
-    let mut index = 0;
-    while index < source.len() {
-        match state {
-            State::Code if source[index..].starts_with(b"//") => {
-                masked[index] = b' ';
-                masked[index + 1] = b' ';
-                index += 2;
-                state = State::LineComment;
-            }
-            State::Code if source[index..].starts_with(b"/*") => {
-                masked[index] = b' ';
-                masked[index + 1] = b' ';
-                index += 2;
-                state = State::BlockComment;
-            }
-            State::Code if source[index] == b'"' => {
-                masked[index] = b' ';
-                index += 1;
-                state = State::Quoted;
-            }
-            State::Code => index += 1,
-            State::LineComment if source[index] == b'\n' => {
-                index += 1;
-                state = State::Code;
-            }
-            State::LineComment => {
-                masked[index] = b' ';
-                index += 1;
-            }
-            State::BlockComment if source[index..].starts_with(b"*/") => {
-                masked[index] = b' ';
-                masked[index + 1] = b' ';
-                index += 2;
-                state = State::Code;
-            }
-            State::BlockComment => {
-                if source[index] != b'\n' {
-                    masked[index] = b' ';
-                }
-                index += 1;
-            }
-            State::Quoted if source[index] == b'\\' && index + 1 < source.len() => {
-                masked[index] = b' ';
-                masked[index + 1] = b' ';
-                index += 2;
-            }
-            State::Quoted if source[index] == b'"' => {
-                masked[index] = b' ';
-                index += 1;
-                state = State::Code;
-            }
-            State::Quoted => {
-                if source[index] != b'\n' {
-                    masked[index] = b' ';
-                }
-                index += 1;
-            }
-        }
-    }
-
-    // Every replacement is one ASCII byte, so valid UTF-8 input stays valid.
-    String::from_utf8(masked).expect("masking PTX preserves UTF-8")
 }
 
 #[cfg(test)]

--- a/crates/cuda-oxide-codegen/Cargo.toml
+++ b/crates/cuda-oxide-codegen/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 pliron = { workspace = true }
+ptx-syntax = { workspace = true }
 thiserror = { workspace = true }
 dialect-mir = { workspace = true }
 dialect-iket = { workspace = true }

--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -16,6 +16,7 @@ use pliron::context::{Context, Ptr};
 use pliron::linked_list::ContainsLinkedList;
 use pliron::op::Op;
 use pliron::operation::Operation;
+use ptx_syntax::{CallableKind, Document, ParseError};
 use std::path::Path;
 
 /// An external device function declaration (for FFI with external LTOIR).
@@ -356,11 +357,6 @@ pub(crate) fn is_libdevice_symbol(name: &str) -> bool {
     name.starts_with("__nv_")
 }
 
-/// Whether `c` can appear in a PTX identifier (`followsym`).
-fn is_ptx_identifier_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_' || c == '$'
-}
-
 /// Names of `.extern .func` declarations in `ptx` that name a CUDA libdevice
 /// (`__nv_*`) symbol.
 ///
@@ -378,35 +374,19 @@ fn is_ptx_identifier_char(c: char) -> bool {
 /// device, with no diagnostic. This scan is what catches it at compile time
 /// for the self-contained output policy, where no later link step exists to
 /// resolve it.
-pub(crate) fn unresolved_libdevice_ptx_declarations(ptx: &str) -> Vec<String> {
-    let mut declared: Vec<String> = Vec::new();
-    for line in ptx.lines() {
-        let Some(rest) = line.trim_start().strip_prefix(".extern") else {
-            continue;
-        };
-        let Some(idx) = rest.find(".func") else {
-            continue;
-        };
-        let mut rest = rest[idx + ".func".len()..].trim_start();
-        // Skip the `(.param .b32 func_retval0)` clause of a value-returning
-        // declaration, matching `exported_nv_functions` in `ptx.rs`.
-        if let Some(after_open) = rest.strip_prefix('(') {
-            let Some(close) = after_open.find(')') else {
-                continue;
-            };
-            rest = after_open[close + 1..].trim_start();
-        }
-        let name: String = rest
-            .chars()
-            .take_while(|c| is_ptx_identifier_char(*c))
-            .collect();
-        if is_libdevice_symbol(&name) {
-            declared.push(name);
-        }
-    }
+pub(crate) fn unresolved_libdevice_ptx_declarations(ptx: &str) -> Result<Vec<String>, ParseError> {
+    let document = Document::parse(ptx)?;
+    let mut declared: Vec<String> = document
+        .callables()
+        .iter()
+        .filter(|callable| callable.kind() == CallableKind::Function && callable.is_extern())
+        .map(|callable| callable.name())
+        .filter(|name| is_libdevice_symbol(name))
+        .map(str::to_string)
+        .collect();
     declared.sort();
     declared.dedup();
-    declared
+    Ok(declared)
 }
 
 /// Return unresolved non-intrinsic LLVM function declarations.
@@ -842,7 +822,7 @@ mod tests {
 .func  (.param .b32 func_retval0) __nv_internal_only(
 ";
         assert_eq!(
-            unresolved_libdevice_ptx_declarations(ptx),
+            unresolved_libdevice_ptx_declarations(ptx).unwrap(),
             ["__nv_totally_not_real", "__nv_void_helper"]
         );
     }
@@ -854,6 +834,10 @@ mod tests {
 .visible .func __nv_helper(
 \tcall.uni __nv_helper, (param0);
 ";
-        assert!(unresolved_libdevice_ptx_declarations(ptx).is_empty());
+        assert!(
+            unresolved_libdevice_ptx_declarations(ptx)
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -526,7 +526,12 @@ pub fn compile_translated_module(
                 request.files.ptx.display()
             ))
         })?;
-        let unresolved = unresolved_libdevice_ptx_declarations(&ptx_text);
+        let unresolved = unresolved_libdevice_ptx_declarations(&ptx_text).map_err(|error| {
+            PipelineError::PtxGeneration(format!(
+                "failed to parse generated PTX to check for unresolved libdevice symbols ({}): {error}",
+                request.files.ptx.display()
+            ))
+        })?;
         if !unresolved.is_empty() {
             return Err(PipelineError::UnsupportedLinking {
                 symbols: unresolved,

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -15,6 +15,7 @@ use crate::target::{
 };
 use libnvvm_sys::CudaArch;
 use llvm_export::export::DebugKind;
+use ptx_syntax::{Document, EditScript, split_top_level};
 use std::path::{Path, PathBuf};
 
 /// Links `libdevice.10.bc` into the emitted IR using `llvm-link`.
@@ -629,7 +630,12 @@ fn strip_target_debug_from_ptx(ptx_path: &Path) -> Result<(), PipelineError> {
             ptx_path.display()
         ))
     })?;
-    let stripped = strip_target_debug_from_ptx_text(&ptx);
+    let stripped = strip_target_debug_from_ptx_text(&ptx).map_err(|error| {
+        PipelineError::PtxGeneration(format!(
+            "failed to edit PTX for line-table debug cleanup ({}): {error}",
+            ptx_path.display()
+        ))
+    })?;
     if stripped != ptx {
         std::fs::write(ptx_path, stripped).map_err(|e| {
             PipelineError::PtxGeneration(format!(
@@ -641,49 +647,32 @@ fn strip_target_debug_from_ptx(ptx_path: &Path) -> Result<(), PipelineError> {
     Ok(())
 }
 
-fn strip_target_debug_from_ptx_text(ptx: &str) -> String {
-    let mut out = String::with_capacity(ptx.len());
-    for line in ptx.split_inclusive('\n') {
-        let (line_body, newline) = line
-            .strip_suffix('\n')
-            .map_or((line, ""), |without_newline| (without_newline, "\n"));
-        out.push_str(&strip_target_debug_from_ptx_line(line_body));
-        out.push_str(newline);
-    }
-    out
-}
-
-fn strip_target_debug_from_ptx_line(line: &str) -> String {
-    let indent_len = line.len() - line.trim_start().len();
-    let indent = &line[..indent_len];
-    let body = &line[indent_len..];
-    let Some(rest) = body.strip_prefix(".target") else {
-        return line.to_string();
-    };
-
-    let mut parts = rest.split(',');
-    let Some(arch) = parts.next() else {
-        return line.to_string();
-    };
-
-    let options: Vec<&str> = parts
-        .map(str::trim)
-        .filter(|option| *option != "debug")
-        .collect();
-    if !rest
-        .split(',')
-        .skip(1)
-        .any(|option| option.trim() == "debug")
+fn strip_target_debug_from_ptx_text(ptx: &str) -> Result<String, String> {
+    let document = Document::parse(ptx).map_err(|error| error.to_string())?;
+    let mut edits = EditScript::new();
+    for directive in document
+        .directives()
+        .iter()
+        .filter(|directive| directive.name() == ".target")
     {
-        return line.to_string();
+        let Some(arguments) = split_top_level(directive.arguments()) else {
+            continue;
+        };
+        if arguments.first().is_none_or(|arch| *arch == "debug")
+            || !arguments[1..].contains(&"debug")
+        {
+            continue;
+        }
+        let replacement = arguments
+            .into_iter()
+            .filter(|argument| *argument != "debug")
+            .collect::<Vec<_>>()
+            .join(", ");
+        edits
+            .replace(directive.arguments_span(), replacement)
+            .map_err(|error| error.to_string())?;
     }
-
-    let mut stripped = format!("{indent}.target{arch}");
-    for option in options {
-        stripped.push_str(", ");
-        stripped.push_str(option);
-    }
-    stripped
+    edits.apply(ptx).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
@@ -1166,7 +1155,7 @@ mod tests {
 \t.b8 1;
 ";
 
-        let stripped = strip_target_debug_from_ptx_text(ptx);
+        let stripped = strip_target_debug_from_ptx_text(ptx).unwrap();
 
         assert!(
             stripped.contains(".target sm_120a\n"),
@@ -1182,7 +1171,7 @@ mod tests {
     fn line_table_ptx_cleanup_preserves_other_target_options() {
         let ptx = ".target sm_90a, texmode_independent, debug\n";
 
-        let stripped = strip_target_debug_from_ptx_text(ptx);
+        let stripped = strip_target_debug_from_ptx_text(ptx).unwrap();
 
         assert_eq!(stripped, ".target sm_90a, texmode_independent\n");
     }

--- a/crates/dialect-ptx/Cargo.toml
+++ b/crates/dialect-ptx/Cargo.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dialect-ptx"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Structured Pliron PTX dialect with lossless-source projection and emission"
+readme = "README.md"
+
+[dependencies]
+pliron = { workspace = true }
+pliron-derive = { workspace = true }
+ptx-syntax = { workspace = true }

--- a/crates/dialect-ptx/README.md
+++ b/crates/dialect-ptx/README.md
@@ -1,0 +1,22 @@
+# dialect-ptx
+
+`dialect-ptx` is CUDA Oxide's structured terminal PTX dialect. Its operation
+tree can be constructed directly with `PtxBuilder`, emitted deterministically
+with the dedicated PTX emitter, or projected from the lossless CST in
+`ptx-syntax`.
+
+The two representations have distinct authority:
+
+- `ptx-syntax::Document` owns exact external source, trivia, unknown syntax,
+  and byte-preserving edits.
+- `dialect-ptx` owns canonical structure for analysis, construction,
+  transformation, and deterministic emission.
+
+When operations originate in source, `Projection` keeps statement/scope and
+byte-span lineage in a side table. Source lineage is not a required operation
+attribute, so generated operations never need synthetic source locations.
+
+The dialect currently models module and lexical scopes, callable declarations
+and definitions, directives, generic instructions, and a raw escape hatch.
+Typed ISA operations can be added incrementally without making the lossless
+parser reject newer PTX spellings.

--- a/crates/dialect-ptx/README.md
+++ b/crates/dialect-ptx/README.md
@@ -17,6 +17,6 @@ byte-span lineage in a side table. Source lineage is not a required operation
 attribute, so generated operations never need synthetic source locations.
 
 The dialect currently models module and lexical scopes, callable declarations
-and definitions, directives, generic instructions, and a raw escape hatch.
+and definitions, directives, labels, generic instructions, and a raw escape hatch.
 Typed ISA operations can be added incrementally without making the lossless
 parser reject newer PTX spellings.

--- a/crates/dialect-ptx/README.md
+++ b/crates/dialect-ptx/README.md
@@ -20,3 +20,9 @@ The dialect currently models module and lexical scopes, callable declarations
 and definitions, directives, labels, generic instructions, and a raw escape hatch.
 Typed ISA operations can be added incrementally without making the lossless
 parser reject newer PTX spellings.
+
+`Projection::control_flow` recovers a conservative intraprocedural CFG for
+direct and indexed branches, predicated fallthrough, and terminal instructions.
+It retains CST statement/scope lineage and fails closed for unsupported PTX
+versions or unresolved targets instead of attaching guessed successors to the
+operation tree.

--- a/crates/dialect-ptx/examples/canonicalize.rs
+++ b/crates/dialect-ptx/examples/canonicalize.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use dialect_ptx::{Projection, emit_module};
+use pliron::context::Context;
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let input = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: canonicalize <input.ptx> [output.ptx]")?;
+    let output = std::env::args_os().nth(2).map(PathBuf::from);
+    let source = std::fs::read_to_string(&input)?;
+    let mut ctx = Context::new();
+    dialect_ptx::register(&mut ctx);
+    let projection = Projection::parse(&mut ctx, &source)?;
+    let emitted = emit_module(&ctx, &projection.module())?;
+    let reparsed = ptx_syntax::Document::parse(&emitted)?;
+    if !reparsed.coverage().is_complete() {
+        return Err(format!(
+            "canonical PTX is structurally incomplete: {:?}",
+            reparsed.coverage()
+        )
+        .into());
+    }
+    if let Some(output) = output {
+        std::fs::write(output, emitted)?;
+    } else {
+        print!("{emitted}");
+    }
+    Ok(())
+}

--- a/crates/dialect-ptx/src/attributes.rs
+++ b/crates/dialect-ptx/src/attributes.rs
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Attributes carried by structured PTX operations.
+
+use pliron::attribute::Attribute;
+use pliron::context::Context;
+use pliron::derive::pliron_attr;
+
+/// The two callable forms defined by PTX.
+#[pliron_attr(name = "ptx.callable_kind", format, verifier = "succ")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CallableKindAttr {
+    Entry,
+    Function,
+}
+
+pub fn register(ctx: &mut Context) {
+    CallableKindAttr::register(ctx);
+}

--- a/crates/dialect-ptx/src/builder.rs
+++ b/crates/dialect-ptx/src/builder.rs
@@ -8,7 +8,7 @@
 use crate::attributes::CallableKindAttr;
 use crate::emitter::{EmitError, emit_module};
 use crate::ops::{
-    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
@@ -121,6 +121,13 @@ pub struct PtxBodyBuilder<'builder> {
 }
 
 impl PtxBodyBuilder<'_> {
+    pub fn label(&mut self, name: &str) -> &mut Self {
+        PtxLabelOp::build(self.ctx, name)
+            .get_operation()
+            .insert_at_back(self.block, self.ctx);
+        self
+    }
+
     pub fn directive(&mut self, name: &str, arguments: &str) -> &mut Self {
         PtxDirectiveOp::build(self.ctx, name, arguments)
             .get_operation()
@@ -178,6 +185,7 @@ mod tests {
         builder.version("8.9").target("sm_120a").address_size(64);
         builder.visible_entry("kernel", "()", |body| {
             body.directive(".reg", ".b32 %r<2>;");
+            body.label("L0");
             body.instruction("", "mov.u32", ["%r0", "7"]);
             body.instruction("", "ret", std::iter::empty::<&str>());
         });
@@ -191,6 +199,7 @@ mod tests {
 .visible .entry kernel()
 {
     .reg .b32 %r<2>;
+    L0:
     mov.u32 %r0, 7;
     ret;
 }

--- a/crates/dialect-ptx/src/builder.rs
+++ b/crates/dialect-ptx/src/builder.rs
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Ergonomic construction of structured PTX operations.
+
+use crate::attributes::CallableKindAttr;
+use crate::emitter::{EmitError, emit_module};
+use crate::ops::{
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+};
+use pliron::basic_block::BasicBlock;
+use pliron::context::{Context, Ptr};
+use pliron::op::Op;
+
+/// Builder for a complete structured PTX module.
+pub struct PtxBuilder<'ctx> {
+    ctx: &'ctx mut Context,
+    module: PtxModuleOp,
+}
+
+impl<'ctx> PtxBuilder<'ctx> {
+    pub fn new(ctx: &'ctx mut Context) -> Self {
+        Self {
+            module: PtxModuleOp::build(ctx),
+            ctx,
+        }
+    }
+
+    pub fn version(&mut self, version: &str) -> &mut Self {
+        self.directive(".version", version)
+    }
+
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        self.directive(".target", target)
+    }
+
+    pub fn address_size(&mut self, bits: u8) -> &mut Self {
+        self.directive(".address_size", &bits.to_string())
+    }
+
+    pub fn directive(&mut self, name: &str, arguments: &str) -> &mut Self {
+        PtxDirectiveOp::build(self.ctx, name, arguments)
+            .get_operation()
+            .insert_at_back(self.module.body(self.ctx), self.ctx);
+        self
+    }
+
+    pub fn raw(&mut self, text: &str) -> &mut Self {
+        PtxRawOp::build(self.ctx, text)
+            .get_operation()
+            .insert_at_back(self.module.body(self.ctx), self.ctx);
+        self
+    }
+
+    pub fn callable_declaration(
+        &mut self,
+        name: &str,
+        kind: CallableKindAttr,
+        is_external: bool,
+        header: &str,
+    ) -> PtxCallableOp {
+        let callable = PtxCallableOp::build_declaration(self.ctx, name, kind, is_external, header);
+        callable
+            .get_operation()
+            .insert_at_back(self.module.body(self.ctx), self.ctx);
+        callable
+    }
+
+    pub fn callable_definition(
+        &mut self,
+        name: &str,
+        kind: CallableKindAttr,
+        is_external: bool,
+        header: &str,
+        build_body: impl FnOnce(&mut PtxBodyBuilder<'_>),
+    ) -> PtxCallableOp {
+        let callable = PtxCallableOp::build_definition(self.ctx, name, kind, is_external, header);
+        let body = callable
+            .entry_block(self.ctx)
+            .expect("a definition has an entry block");
+        callable
+            .get_operation()
+            .insert_at_back(self.module.body(self.ctx), self.ctx);
+        build_body(&mut PtxBodyBuilder {
+            ctx: self.ctx,
+            block: body,
+        });
+        callable
+    }
+
+    /// Convenience for the common public kernel form.
+    pub fn visible_entry(
+        &mut self,
+        name: &str,
+        parameters: &str,
+        build_body: impl FnOnce(&mut PtxBodyBuilder<'_>),
+    ) -> PtxCallableOp {
+        let header = format!(".visible .entry {name}{parameters}");
+        self.callable_definition(name, CallableKindAttr::Entry, false, &header, build_body)
+    }
+
+    pub fn module(&self) -> PtxModuleOp {
+        self.module
+    }
+
+    pub fn finish(self) -> PtxModuleOp {
+        self.module
+    }
+
+    pub fn emit(self) -> Result<String, EmitError> {
+        emit_module(self.ctx, &self.module)
+    }
+}
+
+/// Builder for one callable or lexical-scope body.
+pub struct PtxBodyBuilder<'builder> {
+    ctx: &'builder mut Context,
+    block: Ptr<BasicBlock>,
+}
+
+impl PtxBodyBuilder<'_> {
+    pub fn directive(&mut self, name: &str, arguments: &str) -> &mut Self {
+        PtxDirectiveOp::build(self.ctx, name, arguments)
+            .get_operation()
+            .insert_at_back(self.block, self.ctx);
+        self
+    }
+
+    pub fn instruction<I, S>(&mut self, prefix: &str, head: &str, operands: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let operands: Vec<String> = operands
+            .into_iter()
+            .map(|operand| operand.as_ref().to_string())
+            .collect();
+        PtxInstructionOp::build(self.ctx, prefix, head, operands.iter().map(String::as_str))
+            .get_operation()
+            .insert_at_back(self.block, self.ctx);
+        self
+    }
+
+    pub fn raw(&mut self, text: &str) -> &mut Self {
+        PtxRawOp::build(self.ctx, text)
+            .get_operation()
+            .insert_at_back(self.block, self.ctx);
+        self
+    }
+
+    pub fn scope(
+        &mut self,
+        header: &str,
+        build_body: impl FnOnce(&mut PtxBodyBuilder<'_>),
+    ) -> &mut Self {
+        let scope = PtxScopeOp::build(self.ctx, header);
+        let body = scope.body(self.ctx);
+        scope.get_operation().insert_at_back(self.block, self.ctx);
+        build_body(&mut PtxBodyBuilder {
+            ctx: self.ctx,
+            block: body,
+        });
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_constructs_the_dialect_and_emits_ptx() {
+        let mut ctx = Context::new();
+        crate::register(&mut ctx);
+        let mut builder = PtxBuilder::new(&mut ctx);
+        builder.version("8.9").target("sm_120a").address_size(64);
+        builder.visible_entry("kernel", "()", |body| {
+            body.directive(".reg", ".b32 %r<2>;");
+            body.instruction("", "mov.u32", ["%r0", "7"]);
+            body.instruction("", "ret", std::iter::empty::<&str>());
+        });
+        let emitted = builder.emit().unwrap();
+        assert_eq!(
+            emitted,
+            "\
+.version 8.9
+.target sm_120a
+.address_size 64
+.visible .entry kernel()
+{
+    .reg .b32 %r<2>;
+    mov.u32 %r0, 7;
+    ret;
+}
+"
+        );
+        assert!(
+            ptx_syntax::Document::parse(&emitted)
+                .unwrap()
+                .coverage()
+                .is_complete()
+        );
+    }
+}

--- a/crates/dialect-ptx/src/cfg.rs
+++ b/crates/dialect-ptx/src/cfg.rs
@@ -21,6 +21,7 @@ use ptx_syntax::{
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
+use std::ops::Range;
 
 const SUPPORTED_PTX_MAJOR: u16 = 9;
 const SUPPORTED_PTX_MINOR: u16 = 3;
@@ -74,11 +75,33 @@ impl Edge {
     }
 }
 
+/// A maximal contiguous run of block instructions in one lexical PTX scope.
+///
+/// CFG blocks and lexical scopes are orthogonal: one recovered block can
+/// contain several segments, including a return to an outer scope after a
+/// nested scope closes. The range indexes [`BasicBlock::instructions`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopeSegment {
+    scope: ScopeId,
+    instruction_range: Range<usize>,
+}
+
+impl ScopeSegment {
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    pub fn instruction_range(&self) -> Range<usize> {
+        self.instruction_range.clone()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BasicBlock {
     id: BlockId,
     labels: Vec<LabelId>,
     instructions: Vec<StatementId>,
+    scope_segments: Vec<ScopeSegment>,
     successors: Vec<Edge>,
     predecessors: Vec<Edge>,
     exit: Option<ExitKind>,
@@ -100,6 +123,10 @@ impl BasicBlock {
     /// Authoritative syntax statements for the instructions in this block.
     pub fn instructions(&self) -> &[StatementId] {
         &self.instructions
+    }
+
+    pub fn scope_segments(&self) -> &[ScopeSegment] {
+        &self.scope_segments
     }
 
     pub fn successors(&self) -> &[Edge] {
@@ -506,13 +533,16 @@ fn analyze_callable(
                 .get(ordinal + 1)
                 .copied()
                 .unwrap_or(instruction_indices.len());
+            let instructions = instruction_indices[start..end]
+                .iter()
+                .map(|index| document.instructions()[*index].statement())
+                .collect::<Vec<_>>();
+            let scope_segments = recover_scope_segments(document, &instructions);
             BasicBlock {
                 id: BlockId(ordinal),
                 labels: Vec::new(),
-                instructions: instruction_indices[start..end]
-                    .iter()
-                    .map(|index| document.instructions()[*index].statement())
-                    .collect(),
+                instructions,
+                scope_segments,
                 successors: Vec::new(),
                 predecessors: Vec::new(),
                 exit: None,
@@ -681,6 +711,36 @@ fn analyze_callable(
         name: callable_name.to_string(),
         blocks,
     })
+}
+
+fn recover_scope_segments(
+    document: &Document<'_>,
+    instructions: &[StatementId],
+) -> Vec<ScopeSegment> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    while start < instructions.len() {
+        let scope = document
+            .statement(instructions[start])
+            .expect("CFG instruction belongs to the document")
+            .scope();
+        let mut end = start + 1;
+        while end < instructions.len()
+            && document
+                .statement(instructions[end])
+                .expect("CFG instruction belongs to the document")
+                .scope()
+                == scope
+        {
+            end += 1;
+        }
+        segments.push(ScopeSegment {
+            scope,
+            instruction_range: start..end,
+        });
+        start = end;
+    }
+    segments
 }
 
 fn add_fallthrough(
@@ -913,5 +973,36 @@ Dead:
             ),
             Err(CfgError::DuplicateBranchTable { .. })
         ));
+    }
+
+    #[test]
+    fn preserves_lexical_scope_segments_inside_one_cfg_block() {
+        let source = "\
+.version 9.3
+.entry kernel() {
+    mov.u32 %r0, 0;
+    {
+        add.u32 %r0, %r0, 1;
+    }
+    sub.u32 %r0, %r0, 1;
+    ret;
+}
+";
+        let document = Document::parse(source).unwrap();
+        let cfg = ControlFlow::analyze(&document).unwrap();
+        let block = &cfg.callables()[0].blocks()[0];
+        assert_eq!(block.instructions().len(), 4);
+        assert_eq!(block.scope_segments().len(), 3);
+        assert_eq!(block.scope_segments()[0].instruction_range(), 0..1);
+        assert_eq!(block.scope_segments()[1].instruction_range(), 1..2);
+        assert_eq!(block.scope_segments()[2].instruction_range(), 2..4);
+        assert_eq!(
+            block.scope_segments()[0].scope(),
+            block.scope_segments()[2].scope()
+        );
+        assert_ne!(
+            block.scope_segments()[0].scope(),
+            block.scope_segments()[1].scope()
+        );
     }
 }

--- a/crates/dialect-ptx/src/cfg.rs
+++ b/crates/dialect-ptx/src/cfg.rs
@@ -3,15 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Conservative intraprocedural control-flow recovery for PTX.
+//! Conservative intraprocedural control-flow recovery over surface PTX.
 //!
 //! The analysis models the control-flow forms defined through PTX ISA 9.3:
 //! direct `bra`, indexed `brx.idx` via `.branchtargets`, predicated
 //! fallthrough, `ret`, `exit`, and terminating `trap`. Calls fall through
 //! within the caller. A newer PTX version or an unclosed target relation is a
 //! hard error so clients never receive a guessed graph.
+//!
+//! This graph is a read-only recovery result over [`ptx_syntax::Document`]. It
+//! deliberately does not claim that the projected Pliron operation tree has
+//! native basic-block structure. Turning this proof into native CFG is a
+//! separate, fallible normalization step.
 
-use ptx_syntax::{Document, Instruction, ScopeId, StatementId, StatementKind, split_top_level};
+use ptx_syntax::{
+    Document, Instruction, LabelId, ScopeId, StatementId, StatementKind, split_top_level,
+};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
@@ -23,6 +30,18 @@ pub enum EdgeKind {
     Fallthrough,
     Branch,
     IndexedBranch,
+}
+
+/// A control-flow edge that leaves the callable rather than targeting another
+/// recovered basic block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ExitKind {
+    /// Return from a `.func`, or terminate the calling thread from an `.entry`.
+    Return,
+    /// Terminate the current thread through `exit`.
+    Thread,
+    /// Abort execution through the PTX debug `trap` instruction.
+    Trap,
 }
 
 /// Stable index of a block within one [`CallableControlFlow`].
@@ -58,14 +77,24 @@ impl Edge {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BasicBlock {
     id: BlockId,
+    labels: Vec<LabelId>,
     instructions: Vec<StatementId>,
     successors: Vec<Edge>,
     predecessors: Vec<Edge>,
+    exit: Option<ExitKind>,
 }
 
 impl BasicBlock {
     pub fn id(&self) -> BlockId {
         self.id
+    }
+
+    /// Source labels which designate this block, in source order.
+    ///
+    /// Several PTX labels may alias the same instruction and therefore the
+    /// same recovered block.
+    pub fn labels(&self) -> &[LabelId] {
+        &self.labels
     }
 
     /// Authoritative syntax statements for the instructions in this block.
@@ -79,6 +108,13 @@ impl BasicBlock {
 
     pub fn predecessors(&self) -> &[Edge] {
         &self.predecessors
+    }
+
+    /// The callable-exit edge produced by this block's final instruction.
+    ///
+    /// A predicated exit also has a normal fallthrough successor.
+    pub fn exit(&self) -> Option<ExitKind> {
+        self.exit
     }
 }
 
@@ -204,6 +240,19 @@ pub enum CfgError {
         callable: String,
         table: String,
     },
+    DuplicateBranchTable {
+        callable: String,
+        table: String,
+    },
+    BranchTableOutsideCallableScope {
+        callable: String,
+        table: String,
+    },
+    BranchTableAfterUse {
+        callable: String,
+        instruction: StatementId,
+        table: String,
+    },
     OpenFallthrough {
         callable: String,
         instruction: StatementId,
@@ -268,6 +317,23 @@ impl fmt::Display for CfgError {
             Self::MalformedBranchTable { callable, table } => write!(
                 formatter,
                 "PTX .branchtargets table {table:?} in {callable:?} is malformed"
+            ),
+            Self::DuplicateBranchTable { callable, table } => write!(
+                formatter,
+                "PTX callable {callable:?} defines .branchtargets table {table:?} more than once"
+            ),
+            Self::BranchTableOutsideCallableScope { callable, table } => write!(
+                formatter,
+                "PTX .branchtargets table {table:?} in {callable:?} is not declared at callable scope"
+            ),
+            Self::BranchTableAfterUse {
+                callable,
+                instruction,
+                table,
+            } => write!(
+                formatter,
+                "PTX brx.idx statement {} in {callable:?} uses .branchtargets table {table:?} before its declaration",
+                instruction.index()
             ),
             Self::OpenFallthrough {
                 callable,
@@ -337,7 +403,13 @@ fn analyze_callable(
         .iter()
         .map(|index| (document.instructions()[*index].statement(), *index))
         .collect();
-    let mut labels = BTreeMap::<String, usize>::new();
+    #[derive(Clone, Copy)]
+    struct LabelBinding {
+        instruction: usize,
+        label: LabelId,
+    }
+
+    let mut labels = BTreeMap::<String, LabelBinding>::new();
     for label in document.labels().iter().filter(|label| {
         let span = label.span();
         span.start >= body_start && span.end <= body_end
@@ -354,10 +426,11 @@ fn analyze_callable(
         }) else {
             continue;
         };
-        if labels
-            .insert(label.name().to_string(), instruction)
-            .is_some()
-        {
+        let binding = LabelBinding {
+            instruction,
+            label: label.id(),
+        };
+        if labels.insert(label.name().to_string(), binding).is_some() {
             return Err(CfgError::DuplicateLabel {
                 callable: callable_name.to_string(),
                 label: label.name().to_string(),
@@ -365,7 +438,12 @@ fn analyze_callable(
         }
     }
 
-    let mut branch_tables = BTreeMap::<String, Vec<String>>::new();
+    struct BranchTable {
+        declaration_start: usize,
+        targets: Vec<String>,
+    }
+
+    let mut branch_tables = BTreeMap::<String, BranchTable>::new();
     for directive in document.directives().iter().filter(|directive| {
         let span = directive.span();
         span.start >= body_start && span.end <= body_end && directive.name() == ".branchtargets"
@@ -373,6 +451,12 @@ fn analyze_callable(
         let Some(table) = directive.labels().last() else {
             continue;
         };
+        if directive.scope() != callable_scope {
+            return Err(CfgError::BranchTableOutsideCallableScope {
+                callable: callable_name.to_string(),
+                table: table.to_string(),
+            });
+        }
         let arguments = directive.arguments().trim_end().trim_end_matches(';');
         let Some(targets) = split_top_level(arguments) else {
             return Err(CfgError::MalformedBranchTable {
@@ -386,15 +470,24 @@ fn analyze_callable(
                 table: table.to_string(),
             });
         }
-        branch_tables.insert(
-            table.to_string(),
-            targets.into_iter().map(str::to_string).collect(),
-        );
+        let branch_table = BranchTable {
+            declaration_start: directive.span().start,
+            targets: targets.into_iter().map(str::to_string).collect(),
+        };
+        if branch_tables
+            .insert(table.to_string(), branch_table)
+            .is_some()
+        {
+            return Err(CfgError::DuplicateBranchTable {
+                callable: callable_name.to_string(),
+                table: table.to_string(),
+            });
+        }
     }
 
     let mut leaders = BTreeSet::from([0usize]);
-    for instruction in labels.values() {
-        leaders.insert(positions[instruction]);
+    for binding in labels.values() {
+        leaders.insert(positions[&binding.instruction]);
     }
     for (position, instruction) in instruction_indices.iter().copied().enumerate() {
         if terminator_kind(&document.instructions()[instruction]).is_some()
@@ -415,12 +508,14 @@ fn analyze_callable(
                 .unwrap_or(instruction_indices.len());
             BasicBlock {
                 id: BlockId(ordinal),
+                labels: Vec::new(),
                 instructions: instruction_indices[start..end]
                     .iter()
                     .map(|index| document.instructions()[*index].statement())
                     .collect(),
                 successors: Vec::new(),
                 predecessors: Vec::new(),
+                exit: None,
             }
         })
         .collect();
@@ -429,8 +524,26 @@ fn analyze_callable(
         .collect();
     let label_blocks: BTreeMap<&str, usize> = labels
         .iter()
-        .map(|(label, instruction)| (label.as_str(), block_for_position[positions[instruction]]))
+        .map(|(label, binding)| {
+            (
+                label.as_str(),
+                block_for_position[positions[&binding.instruction]],
+            )
+        })
         .collect();
+    for binding in labels.values() {
+        let block = block_for_position[positions[&binding.instruction]];
+        blocks[block].labels.push(binding.label);
+    }
+    for block in &mut blocks {
+        block.labels.sort_by_key(|label| {
+            document
+                .label(*label)
+                .expect("CFG label belongs to the document")
+                .span()
+                .start
+        });
+    }
 
     for block_index in 0..blocks.len() {
         let instruction_statement = *blocks[block_index]
@@ -479,7 +592,7 @@ fn analyze_callable(
                         instruction: instruction_statement,
                     }
                 })?;
-                let targets =
+                let branch_table =
                     branch_tables
                         .get(table)
                         .ok_or_else(|| CfgError::UnknownBranchTable {
@@ -487,7 +600,14 @@ fn analyze_callable(
                             instruction: instruction_statement,
                             table: table.to_string(),
                         })?;
-                for target in targets {
+                if branch_table.declaration_start >= instruction.span().start {
+                    return Err(CfgError::BranchTableAfterUse {
+                        callable: callable_name.to_string(),
+                        instruction: instruction_statement,
+                        table: table.to_string(),
+                    });
+                }
+                for target in &branch_table.targets {
                     let target_block =
                         label_blocks.get(target.as_str()).copied().ok_or_else(|| {
                             CfgError::UnknownBranchTarget {
@@ -511,7 +631,15 @@ fn analyze_callable(
                     )?;
                 }
             }
-            Some(TerminatorKind::Return) => {
+            Some(kind @ (TerminatorKind::Return | TerminatorKind::Exit | TerminatorKind::Trap)) => {
+                blocks[block_index].exit = Some(match kind {
+                    TerminatorKind::Return => ExitKind::Return,
+                    TerminatorKind::Exit => ExitKind::Thread,
+                    TerminatorKind::Trap => ExitKind::Trap,
+                    TerminatorKind::Branch | TerminatorKind::IndexedBranch => {
+                        unreachable!("matched an exiting terminator")
+                    }
+                });
                 if instruction.predicate().is_some() {
                     add_fallthrough(
                         &mut successors,
@@ -580,6 +708,8 @@ enum TerminatorKind {
     Branch,
     IndexedBranch,
     Return,
+    Exit,
+    Trap,
 }
 
 fn terminator_kind(instruction: &Instruction<'_>) -> Option<TerminatorKind> {
@@ -587,7 +717,9 @@ fn terminator_kind(instruction: &Instruction<'_>) -> Option<TerminatorKind> {
     match (parts.next(), parts.next()) {
         (Some("bra"), _) => Some(TerminatorKind::Branch),
         (Some("brx"), Some("idx")) => Some(TerminatorKind::IndexedBranch),
-        (Some("ret" | "exit" | "trap"), _) => Some(TerminatorKind::Return),
+        (Some("ret"), _) => Some(TerminatorKind::Return),
+        (Some("exit"), _) => Some(TerminatorKind::Exit),
+        (Some("trap"), _) => Some(TerminatorKind::Trap),
         _ => None,
     }
 }
@@ -646,6 +778,7 @@ L1:
             }]
         );
         assert!(blocks[2].successors().is_empty());
+        assert_eq!(blocks[2].exit(), Some(ExitKind::Return));
     }
 
     #[test]
@@ -707,6 +840,78 @@ Done:
         assert!(matches!(
             analyze(".version 9.0\n.entry kernel() { ret;"),
             Err(CfgError::UnclosedCallable { .. })
+        ));
+    }
+
+    #[test]
+    fn preserves_alias_labels_nested_scopes_unreachable_blocks_and_exit_kinds() {
+        let source = "\
+.version 9.3
+.target sm_120a
+.visible .entry kernel() {
+    {
+L0: Alias: @%p0 ret;
+    }
+    trap;
+Dead:
+    @%p1 exit;
+    ret;
+}
+";
+        let document = Document::parse(source).unwrap();
+        let cfg = ControlFlow::analyze(&document).unwrap();
+        let blocks = cfg.callables()[0].blocks();
+        assert_eq!(blocks.len(), 4);
+
+        let label_names = |block: &BasicBlock| {
+            block
+                .labels()
+                .iter()
+                .map(|label| document.label(*label).unwrap().name())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(label_names(&blocks[0]), ["L0", "Alias"]);
+        assert_eq!(blocks[0].exit(), Some(ExitKind::Return));
+        assert_eq!(
+            blocks[0].successors(),
+            [Edge {
+                block: BlockId(1),
+                kind: EdgeKind::Fallthrough,
+            }]
+        );
+        assert_eq!(blocks[1].exit(), Some(ExitKind::Trap));
+        assert!(blocks[1].successors().is_empty());
+        assert_eq!(label_names(&blocks[2]), ["Dead"]);
+        assert_eq!(blocks[2].exit(), Some(ExitKind::Thread));
+        assert_eq!(
+            blocks[2].successors(),
+            [Edge {
+                block: BlockId(3),
+                kind: EdgeKind::Fallthrough,
+            }]
+        );
+        assert_eq!(blocks[3].exit(), Some(ExitKind::Return));
+    }
+
+    #[test]
+    fn requires_branch_target_tables_at_callable_scope_before_use() {
+        assert!(matches!(
+            analyze(
+                ".version 9.3\n.entry kernel() {\n@%p0 brx.idx %r0, targets;\ntargets: .branchtargets L0;\nL0: ret;\n}\n"
+            ),
+            Err(CfgError::BranchTableAfterUse { .. })
+        ));
+        assert!(matches!(
+            analyze(
+                ".version 9.3\n.entry kernel() {\n{ targets: .branchtargets L0; }\n@%p0 brx.idx %r0, targets;\nL0: ret;\n}\n"
+            ),
+            Err(CfgError::BranchTableOutsideCallableScope { .. })
+        ));
+        assert!(matches!(
+            analyze(
+                ".version 9.3\n.entry kernel() {\ntargets: .branchtargets L0;\ntargets: .branchtargets L0;\n@%p0 brx.idx %r0, targets;\nL0: ret;\n}\n"
+            ),
+            Err(CfgError::DuplicateBranchTable { .. })
         ));
     }
 }

--- a/crates/dialect-ptx/src/cfg.rs
+++ b/crates/dialect-ptx/src/cfg.rs
@@ -1,0 +1,712 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Conservative intraprocedural control-flow recovery for PTX.
+//!
+//! The analysis models the control-flow forms defined through PTX ISA 9.3:
+//! direct `bra`, indexed `brx.idx` via `.branchtargets`, predicated
+//! fallthrough, `ret`, `exit`, and terminating `trap`. Calls fall through
+//! within the caller. A newer PTX version or an unclosed target relation is a
+//! hard error so clients never receive a guessed graph.
+
+use ptx_syntax::{Document, Instruction, ScopeId, StatementId, StatementKind, split_top_level};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+
+const SUPPORTED_PTX_MAJOR: u16 = 9;
+const SUPPORTED_PTX_MINOR: u16 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EdgeKind {
+    Fallthrough,
+    Branch,
+    IndexedBranch,
+}
+
+/// Stable index of a block within one [`CallableControlFlow`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockId(usize);
+
+impl BlockId {
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// An adjacent block and the edge kind connecting it.
+///
+/// In [`BasicBlock::successors`] `block` is the target. In
+/// [`BasicBlock::predecessors`] it is the source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Edge {
+    block: BlockId,
+    kind: EdgeKind,
+}
+
+impl Edge {
+    pub fn block(self) -> BlockId {
+        self.block
+    }
+
+    pub fn kind(self) -> EdgeKind {
+        self.kind
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BasicBlock {
+    id: BlockId,
+    instructions: Vec<StatementId>,
+    successors: Vec<Edge>,
+    predecessors: Vec<Edge>,
+}
+
+impl BasicBlock {
+    pub fn id(&self) -> BlockId {
+        self.id
+    }
+
+    /// Authoritative syntax statements for the instructions in this block.
+    pub fn instructions(&self) -> &[StatementId] {
+        &self.instructions
+    }
+
+    pub fn successors(&self) -> &[Edge] {
+        &self.successors
+    }
+
+    pub fn predecessors(&self) -> &[Edge] {
+        &self.predecessors
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallableControlFlow {
+    callable: StatementId,
+    scope: ScopeId,
+    name: String,
+    blocks: Vec<BasicBlock>,
+}
+
+impl CallableControlFlow {
+    pub fn callable(&self) -> StatementId {
+        self.callable
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn blocks(&self) -> &[BasicBlock] {
+        &self.blocks
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlFlow {
+    callables: Vec<CallableControlFlow>,
+    by_callable: HashMap<StatementId, usize>,
+}
+
+impl ControlFlow {
+    pub fn analyze(document: &Document<'_>) -> Result<Self, CfgError> {
+        validate_ptx_version(document)?;
+        let mut callables = Vec::new();
+        for callable in document.callables() {
+            let body_span = match (callable.body_span(), callable.definition_scope()) {
+                (Some(body), Some(_)) => body,
+                (None, Some(_)) => {
+                    return Err(CfgError::UnclosedCallable {
+                        callable: callable.name().to_string(),
+                    });
+                }
+                (None, None) => continue,
+                (Some(_), None) => unreachable!("a callable body has a lexical scope"),
+            };
+            callables.push(analyze_callable(
+                document,
+                callable.statement(),
+                callable
+                    .definition_scope()
+                    .expect("a callable with a body has a definition scope"),
+                callable.name(),
+                body_span.start,
+                body_span.end,
+            )?);
+        }
+        let by_callable = callables
+            .iter()
+            .enumerate()
+            .map(|(index, callable)| (callable.callable, index))
+            .collect();
+        Ok(Self {
+            callables,
+            by_callable,
+        })
+    }
+
+    pub fn callables(&self) -> &[CallableControlFlow] {
+        &self.callables
+    }
+
+    pub fn for_callable(&self, callable: StatementId) -> Option<&CallableControlFlow> {
+        self.by_callable
+            .get(&callable)
+            .map(|index| &self.callables[*index])
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CfgError {
+    MissingPtxVersion,
+    InvalidPtxVersion {
+        value: String,
+    },
+    UnsupportedPtxVersion {
+        value: String,
+        supported: String,
+    },
+    EmptyCallable {
+        callable: String,
+    },
+    UnclosedCallable {
+        callable: String,
+    },
+    DuplicateLabel {
+        callable: String,
+        label: String,
+    },
+    BranchWithoutTarget {
+        callable: String,
+        instruction: StatementId,
+    },
+    UnknownBranchTarget {
+        callable: String,
+        instruction: StatementId,
+        target: String,
+    },
+    IndexedBranchWithoutTable {
+        callable: String,
+        instruction: StatementId,
+    },
+    UnknownBranchTable {
+        callable: String,
+        instruction: StatementId,
+        table: String,
+    },
+    MalformedBranchTable {
+        callable: String,
+        table: String,
+    },
+    OpenFallthrough {
+        callable: String,
+        instruction: StatementId,
+    },
+}
+
+impl fmt::Display for CfgError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingPtxVersion => write!(formatter, "PTX CFG requires a .version directive"),
+            Self::InvalidPtxVersion { value } => {
+                write!(formatter, "invalid PTX .version value {value:?}")
+            }
+            Self::UnsupportedPtxVersion { value, supported } => write!(
+                formatter,
+                "PTX {value} is newer than the CFG semantics ceiling {supported}"
+            ),
+            Self::EmptyCallable { callable } => {
+                write!(formatter, "PTX callable {callable:?} has no instructions")
+            }
+            Self::UnclosedCallable { callable } => {
+                write!(formatter, "PTX callable {callable:?} has an unclosed body")
+            }
+            Self::DuplicateLabel { callable, label } => write!(
+                formatter,
+                "PTX callable {callable:?} defines label {label:?} more than once"
+            ),
+            Self::BranchWithoutTarget {
+                callable,
+                instruction,
+            } => write!(
+                formatter,
+                "PTX branch statement {} in {callable:?} has no target",
+                instruction.index()
+            ),
+            Self::UnknownBranchTarget {
+                callable,
+                instruction,
+                target,
+            } => write!(
+                formatter,
+                "PTX branch statement {} in {callable:?} targets unknown label {target:?}",
+                instruction.index()
+            ),
+            Self::IndexedBranchWithoutTable {
+                callable,
+                instruction,
+            } => write!(
+                formatter,
+                "PTX brx.idx statement {} in {callable:?} has no target table",
+                instruction.index()
+            ),
+            Self::UnknownBranchTable {
+                callable,
+                instruction,
+                table,
+            } => write!(
+                formatter,
+                "PTX brx.idx statement {} in {callable:?} uses unknown table {table:?}",
+                instruction.index()
+            ),
+            Self::MalformedBranchTable { callable, table } => write!(
+                formatter,
+                "PTX .branchtargets table {table:?} in {callable:?} is malformed"
+            ),
+            Self::OpenFallthrough {
+                callable,
+                instruction,
+            } => write!(
+                formatter,
+                "PTX callable {callable:?} falls through past final instruction statement {}",
+                instruction.index()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CfgError {}
+
+fn validate_ptx_version(document: &Document<'_>) -> Result<(), CfgError> {
+    let value = document
+        .directives()
+        .iter()
+        .find(|directive| directive.name() == ".version")
+        .map(|directive| directive.arguments().trim())
+        .ok_or(CfgError::MissingPtxVersion)?;
+    let (major, minor) = value
+        .split_once('.')
+        .and_then(|(major, minor)| Some((major.parse().ok()?, minor.parse().ok()?)))
+        .ok_or_else(|| CfgError::InvalidPtxVersion {
+            value: value.to_string(),
+        })?;
+    if (major, minor) > (SUPPORTED_PTX_MAJOR, SUPPORTED_PTX_MINOR) {
+        return Err(CfgError::UnsupportedPtxVersion {
+            value: value.to_string(),
+            supported: format!("{SUPPORTED_PTX_MAJOR}.{SUPPORTED_PTX_MINOR}"),
+        });
+    }
+    Ok(())
+}
+
+fn analyze_callable(
+    document: &Document<'_>,
+    callable: StatementId,
+    callable_scope: ScopeId,
+    callable_name: &str,
+    body_start: usize,
+    body_end: usize,
+) -> Result<CallableControlFlow, CfgError> {
+    let instruction_indices: Vec<usize> = document
+        .instructions()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, instruction)| {
+            let span = instruction.span();
+            (span.start >= body_start && span.end <= body_end).then_some(index)
+        })
+        .collect();
+    if instruction_indices.is_empty() {
+        return Err(CfgError::EmptyCallable {
+            callable: callable_name.to_string(),
+        });
+    }
+
+    let positions: HashMap<usize, usize> = instruction_indices
+        .iter()
+        .enumerate()
+        .map(|(position, instruction)| (*instruction, position))
+        .collect();
+    let instruction_by_statement: HashMap<StatementId, usize> = instruction_indices
+        .iter()
+        .map(|index| (document.instructions()[*index].statement(), *index))
+        .collect();
+    let mut labels = BTreeMap::<String, usize>::new();
+    for label in document.labels().iter().filter(|label| {
+        let span = label.span();
+        span.start >= body_start && span.end <= body_end
+    }) {
+        if document
+            .statement(label.statement())
+            .is_some_and(|statement| statement.kind() == StatementKind::Directive)
+        {
+            continue;
+        }
+        let label_span = label.span();
+        let Some(instruction) = instruction_indices.iter().copied().find(|instruction| {
+            document.instructions()[*instruction].span().end > label_span.start
+        }) else {
+            continue;
+        };
+        if labels
+            .insert(label.name().to_string(), instruction)
+            .is_some()
+        {
+            return Err(CfgError::DuplicateLabel {
+                callable: callable_name.to_string(),
+                label: label.name().to_string(),
+            });
+        }
+    }
+
+    let mut branch_tables = BTreeMap::<String, Vec<String>>::new();
+    for directive in document.directives().iter().filter(|directive| {
+        let span = directive.span();
+        span.start >= body_start && span.end <= body_end && directive.name() == ".branchtargets"
+    }) {
+        let Some(table) = directive.labels().last() else {
+            continue;
+        };
+        let arguments = directive.arguments().trim_end().trim_end_matches(';');
+        let Some(targets) = split_top_level(arguments) else {
+            return Err(CfgError::MalformedBranchTable {
+                callable: callable_name.to_string(),
+                table: table.to_string(),
+            });
+        };
+        if targets.is_empty() {
+            return Err(CfgError::MalformedBranchTable {
+                callable: callable_name.to_string(),
+                table: table.to_string(),
+            });
+        }
+        branch_tables.insert(
+            table.to_string(),
+            targets.into_iter().map(str::to_string).collect(),
+        );
+    }
+
+    let mut leaders = BTreeSet::from([0usize]);
+    for instruction in labels.values() {
+        leaders.insert(positions[instruction]);
+    }
+    for (position, instruction) in instruction_indices.iter().copied().enumerate() {
+        if terminator_kind(&document.instructions()[instruction]).is_some()
+            && position + 1 < instruction_indices.len()
+        {
+            leaders.insert(position + 1);
+        }
+    }
+    let leaders: Vec<usize> = leaders.into_iter().collect();
+    let mut blocks: Vec<BasicBlock> = leaders
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(ordinal, start)| {
+            let end = leaders
+                .get(ordinal + 1)
+                .copied()
+                .unwrap_or(instruction_indices.len());
+            BasicBlock {
+                id: BlockId(ordinal),
+                instructions: instruction_indices[start..end]
+                    .iter()
+                    .map(|index| document.instructions()[*index].statement())
+                    .collect(),
+                successors: Vec::new(),
+                predecessors: Vec::new(),
+            }
+        })
+        .collect();
+    let block_for_position: Vec<usize> = (0..instruction_indices.len())
+        .map(|position| leaders.partition_point(|leader| *leader <= position) - 1)
+        .collect();
+    let label_blocks: BTreeMap<&str, usize> = labels
+        .iter()
+        .map(|(label, instruction)| (label.as_str(), block_for_position[positions[instruction]]))
+        .collect();
+
+    for block_index in 0..blocks.len() {
+        let instruction_statement = *blocks[block_index]
+            .instructions
+            .last()
+            .expect("CFG blocks are non-empty");
+        let instruction_index = instruction_by_statement[&instruction_statement];
+        let instruction = &document.instructions()[instruction_index];
+        let mut successors = BTreeSet::new();
+        match terminator_kind(instruction) {
+            Some(TerminatorKind::Branch) => {
+                let target =
+                    instruction
+                        .operands()
+                        .next()
+                        .ok_or_else(|| CfgError::BranchWithoutTarget {
+                            callable: callable_name.to_string(),
+                            instruction: instruction_statement,
+                        })?;
+                let target_block = label_blocks.get(target).copied().ok_or_else(|| {
+                    CfgError::UnknownBranchTarget {
+                        callable: callable_name.to_string(),
+                        instruction: instruction_statement,
+                        target: target.to_string(),
+                    }
+                })?;
+                successors.insert(Edge {
+                    block: BlockId(target_block),
+                    kind: EdgeKind::Branch,
+                });
+                if instruction.predicate().is_some() {
+                    add_fallthrough(
+                        &mut successors,
+                        block_index,
+                        blocks.len(),
+                        callable_name,
+                        instruction_statement,
+                    )?;
+                }
+            }
+            Some(TerminatorKind::IndexedBranch) => {
+                let operands: Vec<&str> = instruction.operands().collect();
+                let table = operands.get(1).copied().ok_or_else(|| {
+                    CfgError::IndexedBranchWithoutTable {
+                        callable: callable_name.to_string(),
+                        instruction: instruction_statement,
+                    }
+                })?;
+                let targets =
+                    branch_tables
+                        .get(table)
+                        .ok_or_else(|| CfgError::UnknownBranchTable {
+                            callable: callable_name.to_string(),
+                            instruction: instruction_statement,
+                            table: table.to_string(),
+                        })?;
+                for target in targets {
+                    let target_block =
+                        label_blocks.get(target.as_str()).copied().ok_or_else(|| {
+                            CfgError::UnknownBranchTarget {
+                                callable: callable_name.to_string(),
+                                instruction: instruction_statement,
+                                target: target.clone(),
+                            }
+                        })?;
+                    successors.insert(Edge {
+                        block: BlockId(target_block),
+                        kind: EdgeKind::IndexedBranch,
+                    });
+                }
+                if instruction.predicate().is_some() {
+                    add_fallthrough(
+                        &mut successors,
+                        block_index,
+                        blocks.len(),
+                        callable_name,
+                        instruction_statement,
+                    )?;
+                }
+            }
+            Some(TerminatorKind::Return) => {
+                if instruction.predicate().is_some() {
+                    add_fallthrough(
+                        &mut successors,
+                        block_index,
+                        blocks.len(),
+                        callable_name,
+                        instruction_statement,
+                    )?;
+                }
+            }
+            None => add_fallthrough(
+                &mut successors,
+                block_index,
+                blocks.len(),
+                callable_name,
+                instruction_statement,
+            )?,
+        }
+        blocks[block_index].successors = successors.into_iter().collect();
+    }
+
+    for source in 0..blocks.len() {
+        let successors = blocks[source].successors.clone();
+        for edge in successors {
+            blocks[edge.block.index()].predecessors.push(Edge {
+                block: BlockId(source),
+                kind: edge.kind,
+            });
+        }
+    }
+    for block in &mut blocks {
+        block.predecessors.sort();
+        block.predecessors.dedup();
+    }
+
+    Ok(CallableControlFlow {
+        callable,
+        scope: callable_scope,
+        name: callable_name.to_string(),
+        blocks,
+    })
+}
+
+fn add_fallthrough(
+    successors: &mut BTreeSet<Edge>,
+    block: usize,
+    block_count: usize,
+    callable: &str,
+    instruction: StatementId,
+) -> Result<(), CfgError> {
+    if block + 1 >= block_count {
+        return Err(CfgError::OpenFallthrough {
+            callable: callable.to_string(),
+            instruction,
+        });
+    }
+    successors.insert(Edge {
+        block: BlockId(block + 1),
+        kind: EdgeKind::Fallthrough,
+    });
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminatorKind {
+    Branch,
+    IndexedBranch,
+    Return,
+}
+
+fn terminator_kind(instruction: &Instruction<'_>) -> Option<TerminatorKind> {
+    let mut parts = instruction.head().split('.');
+    match (parts.next(), parts.next()) {
+        (Some("bra"), _) => Some(TerminatorKind::Branch),
+        (Some("brx"), Some("idx")) => Some(TerminatorKind::IndexedBranch),
+        (Some("ret" | "exit" | "trap"), _) => Some(TerminatorKind::Return),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn analyze(source: &str) -> Result<ControlFlow, CfgError> {
+        let document = Document::parse(source).unwrap();
+        ControlFlow::analyze(&document)
+    }
+
+    #[test]
+    fn recovers_direct_branches_predicates_and_loops() {
+        let cfg = analyze(
+            "\
+.version 8.9
+.target sm_120a
+.visible .entry kernel() {
+L0:
+    @%p0 bra L1;
+    add.u32 %r0, %r0, 1;
+    bra L0;
+L1:
+    ret;
+}
+",
+        )
+        .unwrap();
+        let callable = &cfg.callables()[0];
+        assert_eq!(cfg.for_callable(callable.callable()), Some(callable));
+        assert_ne!(callable.scope(), ScopeId::ROOT);
+        let blocks = callable.blocks();
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[0].id().index(), 0);
+        assert!(!blocks[0].instructions().is_empty());
+        assert_eq!(
+            blocks[0].successors(),
+            [
+                Edge {
+                    block: BlockId(1),
+                    kind: EdgeKind::Fallthrough,
+                },
+                Edge {
+                    block: BlockId(2),
+                    kind: EdgeKind::Branch,
+                },
+            ]
+        );
+        assert_eq!(
+            blocks[1].successors(),
+            [Edge {
+                block: BlockId(0),
+                kind: EdgeKind::Branch,
+            }]
+        );
+        assert!(blocks[2].successors().is_empty());
+    }
+
+    #[test]
+    fn resolves_indexed_branch_target_tables() {
+        let cfg = analyze(
+            "\
+.version 9.0
+.target sm_120a
+.visible .entry kernel() {
+targets: .branchtargets L0, L1;
+    @%p0 brx.idx %r0, targets;
+    bra Done;
+L0:
+    mov.u32 %r1, 0;
+    bra Done;
+L1:
+    mov.u32 %r1, 1;
+Done:
+    ret;
+}
+",
+        )
+        .unwrap();
+        let blocks = cfg.callables()[0].blocks();
+        assert_eq!(blocks.len(), 5);
+        assert_eq!(
+            blocks[0].successors(),
+            [
+                Edge {
+                    block: BlockId(1),
+                    kind: EdgeKind::Fallthrough,
+                },
+                Edge {
+                    block: BlockId(2),
+                    kind: EdgeKind::IndexedBranch,
+                },
+                Edge {
+                    block: BlockId(3),
+                    kind: EdgeKind::IndexedBranch,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_newer_isa_and_unclosed_targets() {
+        assert!(matches!(
+            analyze(".version 9.4\n.entry kernel() { ret; }"),
+            Err(CfgError::UnsupportedPtxVersion { .. })
+        ));
+        assert!(matches!(
+            analyze(".version 9.0\n.entry kernel() { bra Missing; }"),
+            Err(CfgError::UnknownBranchTarget { .. })
+        ));
+        assert!(matches!(
+            analyze(".version 9.0\n.entry kernel() { add.u32 %r0, %r0, 1; }"),
+            Err(CfgError::OpenFallthrough { .. })
+        ));
+        assert!(matches!(
+            analyze(".version 9.0\n.entry kernel() { ret;"),
+            Err(CfgError::UnclosedCallable { .. })
+        ));
+    }
+}

--- a/crates/dialect-ptx/src/emitter.rs
+++ b/crates/dialect-ptx/src/emitter.rs
@@ -6,7 +6,7 @@
 //! Deterministic PTX assembly-syntax emission from structured operations.
 
 use crate::ops::{
-    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
 };
 use pliron::{
     basic_block::BasicBlock,
@@ -112,6 +112,12 @@ fn emit_operation(
         }
         return Ok(());
     }
+    if let Some(label) = Operation::get_op::<PtxLabelOp>(operation, ctx) {
+        write_indent(output, indent)?;
+        output.write_str(&label.name(ctx))?;
+        output.write_str(":\n")?;
+        return Ok(());
+    }
     if let Some(scope) = Operation::get_op::<PtxScopeOp>(operation, ctx) {
         let header = scope.header(ctx);
         if !header.is_empty() {
@@ -181,6 +187,7 @@ mod tests {
 .address_size 64
 .visible .entry kernel() {
     .reg .b32 %r<2>;
+L0: @%p0 add.u32 %r0, %r0, 1;
     {
       mov.u32 %r0, 7;
     }
@@ -200,6 +207,8 @@ mod tests {
 .visible .entry kernel()
 {
     .reg .b32 %r<2>;
+    L0:
+    @%p0 add.u32 %r0, %r0, 1;
     {
         mov.u32 %r0, 7;
     }

--- a/crates/dialect-ptx/src/emitter.rs
+++ b/crates/dialect-ptx/src/emitter.rs
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Deterministic PTX assembly-syntax emission from structured operations.
+
+use crate::ops::{
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+};
+use pliron::{
+    basic_block::BasicBlock,
+    common_traits::Verify,
+    context::{Context, Ptr},
+    linked_list::ContainsLinkedList,
+    op::Op,
+    operation::Operation,
+};
+use std::fmt::{self, Write};
+
+#[derive(Debug)]
+pub enum EmitError {
+    Verification(String),
+    UnsupportedOperation(String),
+    Format(fmt::Error),
+}
+
+impl fmt::Display for EmitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Verification(error) => write!(formatter, "invalid structured PTX: {error}"),
+            Self::UnsupportedOperation(operation) => {
+                write!(formatter, "cannot emit non-PTX operation {operation}")
+            }
+            Self::Format(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+impl From<fmt::Error> for EmitError {
+    fn from(error: fmt::Error) -> Self {
+        Self::Format(error)
+    }
+}
+
+/// Emit one structured PTX module to a newly allocated string.
+pub fn emit_module(ctx: &Context, module: &PtxModuleOp) -> Result<String, EmitError> {
+    let mut output = String::new();
+    write_module(ctx, module, &mut output)?;
+    Ok(output)
+}
+
+/// Emit one structured PTX module into a caller-owned formatting sink.
+pub fn write_module(
+    ctx: &Context,
+    module: &PtxModuleOp,
+    output: &mut impl Write,
+) -> Result<(), EmitError> {
+    module
+        .get_operation()
+        .deref(ctx)
+        .verify(ctx)
+        .map_err(|error| EmitError::Verification(error.to_string()))?;
+    emit_block(ctx, module.body(ctx), 0, output)
+}
+
+fn emit_block(
+    ctx: &Context,
+    block: Ptr<BasicBlock>,
+    indent: usize,
+    output: &mut impl Write,
+) -> Result<(), EmitError> {
+    for operation in block.deref(ctx).iter(ctx) {
+        emit_operation(ctx, operation, indent, output)?;
+    }
+    Ok(())
+}
+
+fn emit_operation(
+    ctx: &Context,
+    operation: Ptr<Operation>,
+    indent: usize,
+    output: &mut impl Write,
+) -> Result<(), EmitError> {
+    if let Some(directive) = Operation::get_op::<PtxDirectiveOp>(operation, ctx) {
+        write_indent(output, indent)?;
+        output.write_str(&directive.name(ctx))?;
+        let arguments = directive.arguments(ctx);
+        if !arguments.is_empty() {
+            output.write_char(' ')?;
+            output.write_str(&arguments)?;
+        }
+        output.write_char('\n')?;
+        return Ok(());
+    }
+    if let Some(callable) = Operation::get_op::<PtxCallableOp>(operation, ctx) {
+        write_indent(output, indent)?;
+        output.write_str(callable.header(ctx).trim())?;
+        if let Some(region) = callable.region(ctx) {
+            output.write_char('\n')?;
+            write_indent(output, indent)?;
+            output.write_str("{\n")?;
+            for block in region.deref(ctx).iter(ctx) {
+                emit_block(ctx, block, indent + 1, output)?;
+            }
+            write_indent(output, indent)?;
+            output.write_str("}\n")?;
+        } else {
+            output.write_str(";\n")?;
+        }
+        return Ok(());
+    }
+    if let Some(scope) = Operation::get_op::<PtxScopeOp>(operation, ctx) {
+        let header = scope.header(ctx);
+        if !header.is_empty() {
+            write_indent(output, indent)?;
+            output.write_str(header.trim())?;
+            output.write_char('\n')?;
+        }
+        write_indent(output, indent)?;
+        output.write_str("{\n")?;
+        emit_block(ctx, scope.body(ctx), indent + 1, output)?;
+        write_indent(output, indent)?;
+        output.write_str("}\n")?;
+        return Ok(());
+    }
+    if let Some(instruction) = Operation::get_op::<PtxInstructionOp>(operation, ctx) {
+        write_indent(output, indent)?;
+        let prefix = instruction.prefix(ctx);
+        if !prefix.is_empty() {
+            output.write_str(prefix.trim())?;
+            output.write_char(' ')?;
+        }
+        output.write_str(&instruction.head(ctx))?;
+        let operands = instruction.operands(ctx);
+        if !operands.is_empty() {
+            output.write_char(' ')?;
+            for (index, operand) in operands.iter().enumerate() {
+                if index != 0 {
+                    output.write_str(", ")?;
+                }
+                output.write_str(operand)?;
+            }
+        }
+        output.write_str(";\n")?;
+        return Ok(());
+    }
+    if let Some(raw) = Operation::get_op::<PtxRawOp>(operation, ctx) {
+        let text = raw.text(ctx);
+        for line in text.trim().lines() {
+            write_indent(output, indent)?;
+            output.write_str(line.trim())?;
+            output.write_char('\n')?;
+        }
+        return Ok(());
+    }
+    Err(EmitError::UnsupportedOperation(
+        Operation::get_opid(operation, ctx).to_string(),
+    ))
+}
+
+fn write_indent(output: &mut impl Write, indent: usize) -> fmt::Result {
+    for _ in 0..indent {
+        output.write_str("    ")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Projection;
+
+    #[test]
+    fn projection_emits_canonical_nested_ptx() {
+        let source = "\
+.version 8.9
+.target sm_120a
+.address_size 64
+.visible .entry kernel() {
+    .reg .b32 %r<2>;
+    {
+      mov.u32 %r0, 7;
+    }
+    ret;
+}
+";
+        let mut ctx = Context::new();
+        crate::register(&mut ctx);
+        let projection = Projection::parse(&mut ctx, source).unwrap();
+        let emitted = emit_module(&ctx, &projection.module()).unwrap();
+        assert_eq!(
+            emitted,
+            "\
+.version 8.9
+.target sm_120a
+.address_size 64
+.visible .entry kernel()
+{
+    .reg .b32 %r<2>;
+    {
+        mov.u32 %r0, 7;
+    }
+    ret;
+}
+"
+        );
+        let reparsed = ptx_syntax::Document::parse(&emitted).unwrap();
+        assert!(reparsed.coverage().is_complete());
+    }
+}

--- a/crates/dialect-ptx/src/lib.rs
+++ b/crates/dialect-ptx/src/lib.rs
@@ -20,8 +20,8 @@ mod projection;
 pub use builder::{PtxBodyBuilder, PtxBuilder};
 pub use emitter::{EmitError, emit_module, write_module};
 pub use projection::{
-    ProjectedBlock, ProjectedCallableControlFlow, ProjectedCfgBlock, ProjectedControlFlow,
-    ProjectedNode, Projection, SourceNode,
+    ProjectedBlock, ProjectedCallableControlFlow, ProjectedCfgBlock, ProjectedCfgScopeSegment,
+    ProjectedControlFlow, ProjectedNode, Projection, SourceNode,
 };
 
 use pliron::context::Context;

--- a/crates/dialect-ptx/src/lib.rs
+++ b/crates/dialect-ptx/src/lib.rs
@@ -19,7 +19,10 @@ mod projection;
 
 pub use builder::{PtxBodyBuilder, PtxBuilder};
 pub use emitter::{EmitError, emit_module, write_module};
-pub use projection::{ProjectedBlock, ProjectedNode, Projection, SourceNode};
+pub use projection::{
+    ProjectedBlock, ProjectedCallableControlFlow, ProjectedCfgBlock, ProjectedControlFlow,
+    ProjectedNode, Projection, SourceNode,
+};
 
 use pliron::context::Context;
 use pliron::dialect::{Dialect, DialectName};

--- a/crates/dialect-ptx/src/lib.rs
+++ b/crates/dialect-ptx/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod attributes;
 pub mod builder;
+pub mod cfg;
 pub mod emitter;
 pub mod ops;
 mod projection;

--- a/crates/dialect-ptx/src/lib.rs
+++ b/crates/dialect-ptx/src/lib.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Structured PTX operations, construction, emission, and lossless-source
+//! projection.
+//!
+//! [`ptx_syntax::Document`] remains authoritative for lossless text and edits.
+//! This crate owns a canonical, independently constructible PTX operation tree;
+//! [`Projection`] records optional lineage when that tree came from source.
+
+pub mod attributes;
+pub mod builder;
+pub mod emitter;
+pub mod ops;
+mod projection;
+
+pub use builder::{PtxBodyBuilder, PtxBuilder};
+pub use emitter::{EmitError, emit_module, write_module};
+pub use projection::{ProjectedBlock, ProjectedNode, Projection, SourceNode};
+
+use pliron::context::Context;
+use pliron::dialect::{Dialect, DialectName};
+
+pub const PTX_DIALECT_NAME: &str = "ptx";
+
+pub fn register(ctx: &mut Context) {
+    Dialect::register(
+        ctx,
+        &DialectName::try_new(PTX_DIALECT_NAME).expect("valid dialect name"),
+    );
+    attributes::register(ctx);
+    ops::register(ctx);
+}

--- a/crates/dialect-ptx/src/ops.rs
+++ b/crates/dialect-ptx/src/ops.rs
@@ -123,6 +123,45 @@ impl Verify for PtxDirectiveOp {
     }
 }
 
+/// One PTX statement label. Labels remain explicit operations until control
+/// flow recovery resolves them to Pliron basic blocks.
+#[pliron_op(
+    name = "ptx.label",
+    format,
+    interfaces = [NRegionsInterface<0>, NOpdsInterface<0>, NResultsInterface<0>],
+    attributes = (label_name: StringAttr)
+)]
+pub struct PtxLabelOp;
+
+impl PtxLabelOp {
+    pub fn build(ctx: &mut Context, name: &str) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let wrapped = Self { op };
+        wrapped.set_attr_label_name(ctx, StringAttr::new(name.to_string()));
+        wrapped
+    }
+
+    pub fn name(&self, ctx: &Context) -> String {
+        self.get_attr_label_name(ctx)
+            .expect("verified ptx.label has a name")
+            .as_str()
+            .to_string()
+    }
+}
+
+impl Verify for PtxLabelOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        let Some(name) = self.get_attr_label_name(ctx) else {
+            return verify_err!(operation.loc(), "ptx.label requires a name");
+        };
+        if name.as_str().is_empty() {
+            return verify_err!(operation.loc(), "PTX label name must not be empty");
+        }
+        Ok(())
+    }
+}
+
 /// A declaration or definition of a PTX `.entry` or `.func`.
 ///
 /// Declarations have no regions. Definitions own exactly one region containing
@@ -453,6 +492,7 @@ impl Verify for PtxRawOp {
 pub fn register(ctx: &mut Context) {
     PtxModuleOp::register(ctx);
     PtxDirectiveOp::register(ctx);
+    PtxLabelOp::register(ctx);
     PtxCallableOp::register(ctx);
     PtxScopeOp::register(ctx);
     PtxInstructionOp::register(ctx);

--- a/crates/dialect-ptx/src/ops.rs
+++ b/crates/dialect-ptx/src/ops.rs
@@ -1,0 +1,460 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Structured PTX operations.
+//!
+//! These operations can be created either by projecting a lossless syntax
+//! document or directly by a producer. Source locations intentionally live in
+//! [`crate::Projection`]'s lineage table rather than in the operations, so a
+//! freshly-built module does not need to invent source spans.
+
+use crate::attributes::CallableKindAttr;
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        attributes::{BoolAttr, StringAttr, VecAttr},
+        op_interfaces::{
+            NOpdsInterface, NRegionsInterface, NResultsInterface, NoTerminatorInterface,
+            OneRegionInterface, SingleBlockRegionInterface,
+        },
+    },
+    common_traits::Verify,
+    context::{Context, Ptr},
+    linked_list::ContainsLinkedList,
+    location::Located,
+    op::Op,
+    operation::Operation,
+    region::Region,
+    result::Error,
+    verify_err,
+};
+use pliron_derive::pliron_op;
+
+/// Root of one structured PTX module.
+#[pliron_op(
+    name = "ptx.module",
+    format,
+    interfaces = [
+        NRegionsInterface<1>,
+        OneRegionInterface,
+        SingleBlockRegionInterface,
+        NoTerminatorInterface,
+        NOpdsInterface<0>,
+        NResultsInterface<0>
+    ]
+)]
+pub struct PtxModuleOp;
+
+impl PtxModuleOp {
+    pub fn build(ctx: &mut Context) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 1);
+        let region = op.deref(ctx).get_region(0);
+        BasicBlock::new(ctx, None, vec![]).insert_at_back(region, ctx);
+        Self { op }
+    }
+
+    pub fn body(&self, ctx: &Context) -> Ptr<BasicBlock> {
+        self.get_operation()
+            .deref(ctx)
+            .get_region(0)
+            .deref(ctx)
+            .get_head()
+            .expect("ptx.module always has a body block")
+    }
+}
+
+impl Verify for PtxModuleOp {
+    fn verify(&self, _ctx: &Context) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// One PTX directive at module, callable, or lexical-scope level.
+#[pliron_op(
+    name = "ptx.directive",
+    format,
+    interfaces = [NRegionsInterface<0>, NOpdsInterface<0>, NResultsInterface<0>],
+    attributes = (
+        directive_name: StringAttr,
+        directive_arguments: StringAttr
+    )
+)]
+pub struct PtxDirectiveOp;
+
+impl PtxDirectiveOp {
+    pub fn build(ctx: &mut Context, name: &str, arguments: &str) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let wrapped = Self { op };
+        wrapped.set_attr_directive_name(ctx, StringAttr::new(name.to_string()));
+        wrapped.set_attr_directive_arguments(ctx, StringAttr::new(arguments.to_string()));
+        wrapped
+    }
+
+    pub fn name(&self, ctx: &Context) -> String {
+        self.get_attr_directive_name(ctx)
+            .expect("verified ptx.directive has a name")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn arguments(&self, ctx: &Context) -> String {
+        self.get_attr_directive_arguments(ctx)
+            .expect("verified ptx.directive has arguments")
+            .as_str()
+            .to_string()
+    }
+}
+
+impl Verify for PtxDirectiveOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        let Some(name) = self.get_attr_directive_name(ctx) else {
+            return verify_err!(operation.loc(), "ptx.directive requires a name");
+        };
+        if !name.as_str().starts_with('.') {
+            return verify_err!(operation.loc(), "PTX directive name must start with '.'");
+        }
+        if self.get_attr_directive_arguments(ctx).is_none() {
+            return verify_err!(operation.loc(), "ptx.directive requires arguments");
+        }
+        Ok(())
+    }
+}
+
+/// A declaration or definition of a PTX `.entry` or `.func`.
+///
+/// Declarations have no regions. Definitions own exactly one region containing
+/// one or more PTX basic blocks. `header` is the complete spelling before the
+/// declaration semicolon or definition opening brace; consumers can gradually
+/// replace its generic pieces with typed attributes without losing syntax.
+#[pliron_op(
+    name = "ptx.callable",
+    format,
+    interfaces = [
+        SingleBlockRegionInterface,
+        NoTerminatorInterface,
+        NOpdsInterface<0>,
+        NResultsInterface<0>
+    ],
+    attributes = (
+        callable_name: StringAttr,
+        callable_kind: CallableKindAttr,
+        callable_external: BoolAttr,
+        callable_header: StringAttr
+    )
+)]
+pub struct PtxCallableOp;
+
+impl PtxCallableOp {
+    pub fn build_declaration(
+        ctx: &mut Context,
+        name: &str,
+        kind: CallableKindAttr,
+        is_extern: bool,
+        header: &str,
+    ) -> Self {
+        Self::build(ctx, name, kind, is_extern, header, false)
+    }
+
+    pub fn build_definition(
+        ctx: &mut Context,
+        name: &str,
+        kind: CallableKindAttr,
+        is_extern: bool,
+        header: &str,
+    ) -> Self {
+        Self::build(ctx, name, kind, is_extern, header, true)
+    }
+
+    fn build(
+        ctx: &mut Context,
+        name: &str,
+        kind: CallableKindAttr,
+        is_extern: bool,
+        header: &str,
+        has_body: bool,
+    ) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            usize::from(has_body),
+        );
+        let wrapped = Self { op };
+        wrapped.set_attr_callable_name(ctx, StringAttr::new(name.to_string()));
+        wrapped.set_attr_callable_kind(ctx, kind);
+        wrapped.set_attr_callable_external(ctx, BoolAttr::new(is_extern));
+        wrapped.set_attr_callable_header(ctx, StringAttr::new(header.to_string()));
+        if has_body {
+            let region = op.deref(ctx).get_region(0);
+            BasicBlock::new(ctx, None, vec![]).insert_at_back(region, ctx);
+        }
+        wrapped
+    }
+
+    pub fn name(&self, ctx: &Context) -> String {
+        self.get_attr_callable_name(ctx)
+            .expect("verified ptx.callable has a name")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn kind(&self, ctx: &Context) -> CallableKindAttr {
+        *self
+            .get_attr_callable_kind(ctx)
+            .expect("verified ptx.callable has a kind")
+    }
+
+    pub fn is_external(&self, ctx: &Context) -> bool {
+        bool::from(
+            self.get_attr_callable_external(ctx)
+                .expect("verified ptx.callable has an external flag")
+                .clone(),
+        )
+    }
+
+    pub fn header(&self, ctx: &Context) -> String {
+        self.get_attr_callable_header(ctx)
+            .expect("verified ptx.callable has a header")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn region(&self, ctx: &Context) -> Option<Ptr<Region>> {
+        (self.get_operation().deref(ctx).num_regions() == 1)
+            .then(|| self.get_operation().deref(ctx).get_region(0))
+    }
+
+    pub fn entry_block(&self, ctx: &Context) -> Option<Ptr<BasicBlock>> {
+        self.region(ctx)
+            .and_then(|region| region.deref(ctx).get_entry_block())
+    }
+
+    pub fn is_definition(&self, ctx: &Context) -> bool {
+        self.region(ctx).is_some()
+    }
+}
+
+impl Verify for PtxCallableOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        if self.get_attr_callable_name(ctx).is_none()
+            || self.get_attr_callable_kind(ctx).is_none()
+            || self.get_attr_callable_external(ctx).is_none()
+            || self.get_attr_callable_header(ctx).is_none()
+        {
+            return verify_err!(
+                operation.loc(),
+                "ptx.callable requires name, kind, external flag, and header"
+            );
+        }
+        if operation.num_regions() > 1 {
+            return verify_err!(
+                operation.loc(),
+                "ptx.callable supports at most one body region"
+            );
+        }
+        if let Some(region) = self.region(ctx)
+            && region.deref(ctx).get_entry_block().is_none()
+        {
+            return verify_err!(
+                operation.loc(),
+                "PTX callable definition requires a body block"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// An anonymous or header-owned lexical PTX scope.
+#[pliron_op(
+    name = "ptx.scope",
+    format,
+    interfaces = [
+        NRegionsInterface<1>,
+        OneRegionInterface,
+        SingleBlockRegionInterface,
+        NoTerminatorInterface,
+        NOpdsInterface<0>,
+        NResultsInterface<0>
+    ],
+    attributes = (scope_header: StringAttr)
+)]
+pub struct PtxScopeOp;
+
+impl PtxScopeOp {
+    pub fn build(ctx: &mut Context, header: &str) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 1);
+        let wrapped = Self { op };
+        wrapped.set_attr_scope_header(ctx, StringAttr::new(header.to_string()));
+        let region = op.deref(ctx).get_region(0);
+        BasicBlock::new(ctx, None, vec![]).insert_at_back(region, ctx);
+        wrapped
+    }
+
+    pub fn header(&self, ctx: &Context) -> String {
+        self.get_attr_scope_header(ctx)
+            .expect("verified ptx.scope has a header")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn body(&self, ctx: &Context) -> Ptr<BasicBlock> {
+        self.get_operation()
+            .deref(ctx)
+            .get_region(0)
+            .deref(ctx)
+            .get_entry_block()
+            .expect("ptx.scope always has a body block")
+    }
+}
+
+impl Verify for PtxScopeOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        if self.get_attr_scope_header(ctx).is_none() {
+            return verify_err!(operation.loc(), "ptx.scope requires a header attribute");
+        }
+        Ok(())
+    }
+}
+
+/// One structurally discovered or directly constructed PTX instruction.
+#[pliron_op(
+    name = "ptx.instruction",
+    format,
+    interfaces = [NRegionsInterface<0>, NOpdsInterface<0>, NResultsInterface<0>],
+    attributes = (
+        instruction_prefix: StringAttr,
+        instruction_head: StringAttr,
+        instruction_operands: VecAttr
+    )
+)]
+pub struct PtxInstructionOp;
+
+impl PtxInstructionOp {
+    pub fn build<'operand>(
+        ctx: &mut Context,
+        prefix: &str,
+        head: &str,
+        operands: impl IntoIterator<Item = &'operand str>,
+    ) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let wrapped = Self { op };
+        wrapped.set_attr_instruction_prefix(ctx, StringAttr::new(prefix.to_string()));
+        wrapped.set_attr_instruction_head(ctx, StringAttr::new(head.to_string()));
+        wrapped.set_attr_instruction_operands(
+            ctx,
+            VecAttr::new(
+                operands
+                    .into_iter()
+                    .map(|operand| StringAttr::new(operand.to_string()).into())
+                    .collect(),
+            ),
+        );
+        wrapped
+    }
+
+    pub fn prefix(&self, ctx: &Context) -> String {
+        self.get_attr_instruction_prefix(ctx)
+            .expect("verified ptx.instruction has a prefix")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn head(&self, ctx: &Context) -> String {
+        self.get_attr_instruction_head(ctx)
+            .expect("verified ptx.instruction has a head")
+            .as_str()
+            .to_string()
+    }
+
+    pub fn operands(&self, ctx: &Context) -> Vec<String> {
+        self.get_attr_instruction_operands(ctx)
+            .expect("verified ptx.instruction has operands")
+            .0
+            .iter()
+            .map(|operand| {
+                operand
+                    .downcast_ref::<StringAttr>()
+                    .expect("verified PTX operands are strings")
+                    .as_str()
+                    .to_string()
+            })
+            .collect()
+    }
+}
+
+impl Verify for PtxInstructionOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        if self.get_attr_instruction_prefix(ctx).is_none() {
+            return verify_err!(operation.loc(), "ptx.instruction requires a prefix");
+        }
+        let Some(head) = self.get_attr_instruction_head(ctx) else {
+            return verify_err!(operation.loc(), "ptx.instruction requires a head");
+        };
+        if head.as_str().is_empty() {
+            return verify_err!(operation.loc(), "PTX instruction head must not be empty");
+        }
+        let Some(operands) = self.get_attr_instruction_operands(ctx) else {
+            return verify_err!(operation.loc(), "ptx.instruction requires operands");
+        };
+        if operands
+            .0
+            .iter()
+            .any(|operand| operand.downcast_ref::<StringAttr>().is_none())
+        {
+            return verify_err!(operation.loc(), "PTX instruction operands must be strings");
+        }
+        Ok(())
+    }
+}
+
+/// A structurally retained statement for syntax not yet modeled by this dialect.
+#[pliron_op(
+    name = "ptx.raw",
+    format,
+    interfaces = [NRegionsInterface<0>, NOpdsInterface<0>, NResultsInterface<0>],
+    attributes = (raw_text: StringAttr)
+)]
+pub struct PtxRawOp;
+
+impl PtxRawOp {
+    pub fn build(ctx: &mut Context, text: &str) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let wrapped = Self { op };
+        wrapped.set_attr_raw_text(ctx, StringAttr::new(text.to_string()));
+        wrapped
+    }
+
+    pub fn text(&self, ctx: &Context) -> String {
+        self.get_attr_raw_text(ctx)
+            .expect("verified ptx.raw has text")
+            .as_str()
+            .to_string()
+    }
+}
+
+impl Verify for PtxRawOp {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let operation = self.get_operation().deref(ctx);
+        if self.get_attr_raw_text(ctx).is_none() {
+            return verify_err!(operation.loc(), "ptx.raw requires text");
+        }
+        Ok(())
+    }
+}
+
+pub fn register(ctx: &mut Context) {
+    PtxModuleOp::register(ctx);
+    PtxDirectiveOp::register(ctx);
+    PtxCallableOp::register(ctx);
+    PtxScopeOp::register(ctx);
+    PtxInstructionOp::register(ctx);
+    PtxRawOp::register(ctx);
+}

--- a/crates/dialect-ptx/src/projection.rs
+++ b/crates/dialect-ptx/src/projection.rs
@@ -5,15 +5,15 @@
 
 use crate::attributes::CallableKindAttr;
 use crate::ops::{
-    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
 use pliron::op::Op;
 use pliron::operation::Operation;
 use ptx_syntax::{
-    Callable, CallableKind, Directive, Document, Instruction, ParseError, ScopeId, StatementId,
-    StatementKind,
+    Callable, CallableKind, Directive, Document, Instruction, Label, LabelId, ParseError, ScopeId,
+    StatementId, StatementKind,
 };
 use std::collections::HashMap;
 use std::ops::Range;
@@ -21,6 +21,7 @@ use std::ops::Range;
 /// The authoritative syntax node from which a projected entity was built.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SourceNode {
+    Label { label: LabelId },
     Statement { statement: StatementId },
     Scope { scope: ScopeId },
 }
@@ -28,6 +29,7 @@ pub enum SourceNode {
 impl SourceNode {
     pub fn statement(self) -> Option<StatementId> {
         match self {
+            Self::Label { .. } => None,
             Self::Statement { statement } => Some(statement),
             Self::Scope { .. } => None,
         }
@@ -35,8 +37,16 @@ impl SourceNode {
 
     pub fn scope(self) -> Option<ScopeId> {
         match self {
+            Self::Label { .. } => None,
             Self::Statement { .. } => None,
             Self::Scope { scope } => Some(scope),
+        }
+    }
+
+    pub fn label(self) -> Option<LabelId> {
+        match self {
+            Self::Label { label } => Some(label),
+            Self::Statement { .. } | Self::Scope { .. } => None,
         }
     }
 }
@@ -176,6 +186,7 @@ struct Projector<'ctx, 'document, 'source> {
     directives: HashMap<StatementId, &'document Directive<'source>>,
     callables: HashMap<StatementId, &'document Callable<'source>>,
     instructions: HashMap<StatementId, &'document Instruction<'source>>,
+    labels: HashMap<StatementId, Vec<&'document Label<'source>>>,
     nodes: Vec<ProjectedNode>,
     blocks: Vec<ProjectedBlock>,
 }
@@ -210,6 +221,10 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
             .iter()
             .map(|instruction| (instruction.statement(), instruction))
             .collect();
+        let mut labels: HashMap<StatementId, Vec<&Label<'source>>> = HashMap::new();
+        for label in document.labels() {
+            labels.entry(label.statement()).or_default().push(label);
+        }
         Self {
             ctx,
             document,
@@ -218,6 +233,7 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
             directives,
             callables,
             instructions,
+            labels,
             nodes: Vec::new(),
             blocks: Vec::new(),
         }
@@ -318,6 +334,7 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
         scope: ScopeId,
         destination: Ptr<BasicBlock>,
     ) {
+        self.project_labels(statement, destination);
         if let Some(callable) = self.callables.get(&statement).copied() {
             let kind = match callable.kind() {
                 CallableKind::Entry => CallableKindAttr::Entry,
@@ -381,6 +398,7 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
     }
 
     fn project_statement(&mut self, statement: StatementId, destination: Ptr<BasicBlock>) {
+        let projected_labels = self.project_labels(statement, destination);
         let statement_node = self
             .document
             .statement(statement)
@@ -392,9 +410,18 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
                     .get_operation()
             }),
             StatementKind::Instruction => self.instructions.get(&statement).map(|instruction| {
+                let prefix = instruction
+                    .predicate()
+                    .map_or_else(String::new, |predicate| {
+                        format!(
+                            "@{}{}",
+                            if predicate.is_negated() { "!" } else { "" },
+                            predicate.register()
+                        )
+                    });
                 PtxInstructionOp::build(
                     self.ctx,
-                    instruction.prefix(),
+                    &prefix,
                     instruction.head(),
                     instruction.operands(),
                 )
@@ -414,6 +441,7 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
                 )
                 .get_operation()
             }),
+            StatementKind::Label if projected_labels => return,
             StatementKind::Label | StatementKind::Preprocessor | StatementKind::Unknown => None,
         }
         .unwrap_or_else(|| {
@@ -426,6 +454,20 @@ impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
             destination,
         );
     }
+
+    fn project_labels(&mut self, statement: StatementId, destination: Ptr<BasicBlock>) -> bool {
+        let labels = self.labels.get(&statement).cloned().unwrap_or_default();
+        for label in &labels {
+            let operation = PtxLabelOp::build(self.ctx, label.name()).get_operation();
+            self.record_operation(
+                operation,
+                SourceNode::Label { label: label.id() },
+                label.span(),
+                destination,
+            );
+        }
+        !labels.is_empty()
+    }
 }
 
 fn trim_header(text: &str) -> &str {
@@ -435,7 +477,7 @@ fn trim_header(text: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::{PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxRawOp, PtxScopeOp};
+    use crate::ops::{PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxScopeOp};
     use pliron::common_traits::Verify;
     use pliron::context::Context;
     use pliron::linked_list::ContainsLinkedList;
@@ -480,7 +522,7 @@ L0:
             .iter(&ctx)
             .collect();
         assert!(Operation::is_op::<PtxDirectiveOp>(callable_ops[0], &ctx));
-        assert!(Operation::is_op::<PtxRawOp>(callable_ops[1], &ctx));
+        assert!(Operation::is_op::<PtxLabelOp>(callable_ops[1], &ctx));
         assert!(Operation::is_op::<PtxInstructionOp>(callable_ops[2], &ctx));
         assert!(Operation::is_op::<PtxScopeOp>(callable_ops[3], &ctx));
         assert!(Operation::is_op::<PtxInstructionOp>(callable_ops[4], &ctx));
@@ -491,6 +533,12 @@ L0:
                 projection.source_node(node.operation()),
                 Some(node.source_node())
             );
+            if let SourceNode::Label { label } = node.source_node() {
+                assert_eq!(
+                    projection.document().label(label).unwrap().span(),
+                    node.source_span()
+                );
+            }
         }
         for block in projection.blocks() {
             assert_eq!(

--- a/crates/dialect-ptx/src/projection.rs
+++ b/crates/dialect-ptx/src/projection.rs
@@ -1,0 +1,526 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::attributes::CallableKindAttr;
+use crate::ops::{
+    PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
+};
+use pliron::basic_block::BasicBlock;
+use pliron::context::{Context, Ptr};
+use pliron::op::Op;
+use pliron::operation::Operation;
+use ptx_syntax::{
+    Callable, CallableKind, Directive, Document, Instruction, ParseError, ScopeId, StatementId,
+    StatementKind,
+};
+use std::collections::HashMap;
+use std::ops::Range;
+
+/// The authoritative syntax node from which a projected entity was built.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SourceNode {
+    Statement { statement: StatementId },
+    Scope { scope: ScopeId },
+}
+
+impl SourceNode {
+    pub fn statement(self) -> Option<StatementId> {
+        match self {
+            Self::Statement { statement } => Some(statement),
+            Self::Scope { .. } => None,
+        }
+    }
+
+    pub fn scope(self) -> Option<ScopeId> {
+        match self {
+            Self::Statement { .. } => None,
+            Self::Scope { scope } => Some(scope),
+        }
+    }
+}
+
+/// One Pliron operation and its immutable source lineage.
+#[derive(Clone, Debug)]
+pub struct ProjectedNode {
+    operation: Ptr<Operation>,
+    source_node: SourceNode,
+    source_span: Range<usize>,
+}
+
+impl ProjectedNode {
+    pub fn operation(&self) -> Ptr<Operation> {
+        self.operation
+    }
+
+    pub fn source_node(&self) -> SourceNode {
+        self.source_node
+    }
+
+    pub fn source_span(&self) -> Range<usize> {
+        self.source_span.clone()
+    }
+}
+
+/// One Pliron basic block and the lexical scope it represents.
+#[derive(Clone, Debug)]
+pub struct ProjectedBlock {
+    block: Ptr<BasicBlock>,
+    source_scope: ScopeId,
+    source_span: Range<usize>,
+}
+
+impl ProjectedBlock {
+    pub fn block(&self) -> Ptr<BasicBlock> {
+        self.block
+    }
+
+    pub fn source_scope(&self) -> ScopeId {
+        self.source_scope
+    }
+
+    pub fn source_span(&self) -> Range<usize> {
+        self.source_span.clone()
+    }
+}
+
+/// A lossless syntax document paired with a structured, independently
+/// emittable Pliron PTX module.
+pub struct Projection<'source> {
+    document: Document<'source>,
+    module: PtxModuleOp,
+    nodes: Vec<ProjectedNode>,
+    nodes_by_operation: HashMap<Ptr<Operation>, usize>,
+    blocks: Vec<ProjectedBlock>,
+    blocks_by_pointer: HashMap<Ptr<BasicBlock>, usize>,
+}
+
+impl<'source> Projection<'source> {
+    /// Parse PTX and project its structural statements and lexical scopes.
+    ///
+    /// The caller must register this dialect in `ctx` before parsing, matching
+    /// the lifecycle of CUDA Oxide's other Pliron dialects.
+    pub fn parse(ctx: &mut Context, source: &'source str) -> Result<Self, ParseError> {
+        let document = Document::parse(source)?;
+        Ok(Self::from_document(ctx, document))
+    }
+
+    /// Project an already-parsed document. Source text remains authoritative
+    /// for lossless edits; the produced operation tree is authoritative for
+    /// structured analysis, construction, and canonical emission.
+    pub fn from_document(ctx: &mut Context, document: Document<'source>) -> Self {
+        let module = PtxModuleOp::build(ctx);
+        let root_block = module.body(ctx);
+        let (nodes, blocks) = {
+            let mut projector = Projector::new(ctx, &document);
+            projector.record_block(root_block, ScopeId::ROOT);
+            projector.project_scope(ScopeId::ROOT, root_block);
+            (projector.nodes, projector.blocks)
+        };
+        let nodes_by_operation = nodes
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.operation, index))
+            .collect();
+        let blocks_by_pointer = blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| (block.block, index))
+            .collect();
+
+        Self {
+            document,
+            module,
+            nodes,
+            nodes_by_operation,
+            blocks,
+            blocks_by_pointer,
+        }
+    }
+
+    pub fn document(&self) -> &Document<'source> {
+        &self.document
+    }
+
+    pub fn module(&self) -> PtxModuleOp {
+        self.module
+    }
+
+    pub fn nodes(&self) -> &[ProjectedNode] {
+        &self.nodes
+    }
+
+    pub fn blocks(&self) -> &[ProjectedBlock] {
+        &self.blocks
+    }
+
+    pub fn source_node(&self, operation: Ptr<Operation>) -> Option<SourceNode> {
+        self.nodes_by_operation
+            .get(&operation)
+            .map(|index| self.nodes[*index].source_node)
+    }
+
+    pub fn source_scope(&self, block: Ptr<BasicBlock>) -> Option<ScopeId> {
+        self.blocks_by_pointer
+            .get(&block)
+            .map(|index| self.blocks[*index].source_scope)
+    }
+}
+
+struct Projector<'ctx, 'document, 'source> {
+    ctx: &'ctx mut Context,
+    document: &'document Document<'source>,
+    statements_by_scope: HashMap<ScopeId, Vec<StatementId>>,
+    scopes_by_parent: HashMap<ScopeId, Vec<ScopeId>>,
+    directives: HashMap<StatementId, &'document Directive<'source>>,
+    callables: HashMap<StatementId, &'document Callable<'source>>,
+    instructions: HashMap<StatementId, &'document Instruction<'source>>,
+    nodes: Vec<ProjectedNode>,
+    blocks: Vec<ProjectedBlock>,
+}
+
+impl<'ctx, 'document, 'source> Projector<'ctx, 'document, 'source> {
+    fn new(ctx: &'ctx mut Context, document: &'document Document<'source>) -> Self {
+        let mut statements_by_scope: HashMap<ScopeId, Vec<StatementId>> = HashMap::new();
+        for statement in document.statements() {
+            statements_by_scope
+                .entry(statement.scope())
+                .or_default()
+                .push(statement.id());
+        }
+        let mut scopes_by_parent: HashMap<ScopeId, Vec<ScopeId>> = HashMap::new();
+        for scope in document.scopes().iter().skip(1) {
+            if let Some(parent) = scope.parent() {
+                scopes_by_parent.entry(parent).or_default().push(scope.id());
+            }
+        }
+        let directives = document
+            .directives()
+            .iter()
+            .map(|directive| (directive.statement(), directive))
+            .collect();
+        let callables = document
+            .callables()
+            .iter()
+            .map(|callable| (callable.statement(), callable))
+            .collect();
+        let instructions = document
+            .instructions()
+            .iter()
+            .map(|instruction| (instruction.statement(), instruction))
+            .collect();
+        Self {
+            ctx,
+            document,
+            statements_by_scope,
+            scopes_by_parent,
+            directives,
+            callables,
+            instructions,
+            nodes: Vec::new(),
+            blocks: Vec::new(),
+        }
+    }
+
+    fn record_block(&mut self, block: Ptr<BasicBlock>, scope: ScopeId) {
+        let source_span = self
+            .document
+            .scope(scope)
+            .expect("projected scope belongs to the document")
+            .body_span();
+        self.blocks.push(ProjectedBlock {
+            block,
+            source_scope: scope,
+            source_span,
+        });
+    }
+
+    fn record_operation(
+        &mut self,
+        operation: Ptr<Operation>,
+        source_node: SourceNode,
+        source_span: Range<usize>,
+        destination: Ptr<BasicBlock>,
+    ) {
+        operation.insert_at_back(destination, self.ctx);
+        self.nodes.push(ProjectedNode {
+            operation,
+            source_node,
+            source_span,
+        });
+    }
+
+    fn project_scope(&mut self, scope: ScopeId, destination: Ptr<BasicBlock>) {
+        #[derive(Clone, Copy)]
+        enum Event {
+            Statement(StatementId),
+            AnonymousScope(ScopeId),
+        }
+
+        let child_scopes = self
+            .scopes_by_parent
+            .get(&scope)
+            .cloned()
+            .unwrap_or_default();
+        let scopes_by_header: HashMap<StatementId, ScopeId> = child_scopes
+            .iter()
+            .filter_map(|scope| {
+                self.document
+                    .scope(*scope)
+                    .and_then(|scope_node| scope_node.header().map(|header| (header, *scope)))
+            })
+            .collect();
+        let mut events: Vec<(usize, Event)> = self
+            .statements_by_scope
+            .get(&scope)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(|statement| {
+                let start = self
+                    .document
+                    .statement(statement)
+                    .expect("indexed statement belongs to the document")
+                    .span()
+                    .start;
+                (start, Event::Statement(statement))
+            })
+            .collect();
+        events.extend(child_scopes.into_iter().filter_map(|child| {
+            let child = self.document.scope(child)?;
+            if child.header().is_some() {
+                return None;
+            }
+            Some((child.open_span()?.start, Event::AnonymousScope(child.id())))
+        }));
+        events.sort_by_key(|(start, _)| *start);
+
+        for (_, event) in events {
+            match event {
+                Event::Statement(statement) => {
+                    if let Some(child_scope) = scopes_by_header.get(&statement).copied() {
+                        self.project_header_scope(statement, child_scope, destination);
+                    } else {
+                        self.project_statement(statement, destination);
+                    }
+                }
+                Event::AnonymousScope(child_scope) => {
+                    self.project_lexical_scope(child_scope, "", destination);
+                }
+            }
+        }
+    }
+
+    fn project_header_scope(
+        &mut self,
+        statement: StatementId,
+        scope: ScopeId,
+        destination: Ptr<BasicBlock>,
+    ) {
+        if let Some(callable) = self.callables.get(&statement).copied() {
+            let kind = match callable.kind() {
+                CallableKind::Entry => CallableKindAttr::Entry,
+                CallableKind::Function => CallableKindAttr::Function,
+            };
+            let statement_node = self
+                .document
+                .statement(statement)
+                .expect("callable statement belongs to the document");
+            let header = trim_header(statement_node.text(self.document.source()));
+            let operation = PtxCallableOp::build_definition(
+                self.ctx,
+                callable.name(),
+                kind,
+                callable.is_extern(),
+                header,
+            );
+            let body = operation
+                .entry_block(self.ctx)
+                .expect("a definition has an entry block");
+            self.record_operation(
+                operation.get_operation(),
+                SourceNode::Statement { statement },
+                statement_node.span(),
+                destination,
+            );
+            self.record_block(body, scope);
+            self.project_scope(scope, body);
+            return;
+        }
+
+        let header = self
+            .document
+            .statement(statement)
+            .expect("scope header belongs to the document")
+            .text(self.document.source());
+        self.project_lexical_scope(scope, trim_header(header), destination);
+    }
+
+    fn project_lexical_scope(
+        &mut self,
+        scope: ScopeId,
+        header: &str,
+        destination: Ptr<BasicBlock>,
+    ) {
+        let source_span = self
+            .document
+            .scope(scope)
+            .expect("projected scope belongs to the document")
+            .span();
+        let operation = PtxScopeOp::build(self.ctx, header);
+        let body = operation.body(self.ctx);
+        self.record_operation(
+            operation.get_operation(),
+            SourceNode::Scope { scope },
+            source_span,
+            destination,
+        );
+        self.record_block(body, scope);
+        self.project_scope(scope, body);
+    }
+
+    fn project_statement(&mut self, statement: StatementId, destination: Ptr<BasicBlock>) {
+        let statement_node = self
+            .document
+            .statement(statement)
+            .expect("indexed statement belongs to the document");
+        let source_span = statement_node.span();
+        let operation = match statement_node.kind() {
+            StatementKind::Directive => self.directives.get(&statement).map(|directive| {
+                PtxDirectiveOp::build(self.ctx, directive.name(), directive.arguments())
+                    .get_operation()
+            }),
+            StatementKind::Instruction => self.instructions.get(&statement).map(|instruction| {
+                PtxInstructionOp::build(
+                    self.ctx,
+                    instruction.prefix(),
+                    instruction.head(),
+                    instruction.operands(),
+                )
+                .get_operation()
+            }),
+            StatementKind::CallableHeader => self.callables.get(&statement).map(|callable| {
+                let kind = match callable.kind() {
+                    CallableKind::Entry => CallableKindAttr::Entry,
+                    CallableKind::Function => CallableKindAttr::Function,
+                };
+                PtxCallableOp::build_declaration(
+                    self.ctx,
+                    callable.name(),
+                    kind,
+                    callable.is_extern(),
+                    trim_header(statement_node.text(self.document.source())),
+                )
+                .get_operation()
+            }),
+            StatementKind::Label | StatementKind::Preprocessor | StatementKind::Unknown => None,
+        }
+        .unwrap_or_else(|| {
+            PtxRawOp::build(self.ctx, statement_node.text(self.document.source())).get_operation()
+        });
+        self.record_operation(
+            operation,
+            SourceNode::Statement { statement },
+            source_span,
+            destination,
+        );
+    }
+}
+
+fn trim_header(text: &str) -> &str {
+    text.trim().trim_end_matches([';', '{']).trim_end()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::{PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxRawOp, PtxScopeOp};
+    use pliron::common_traits::Verify;
+    use pliron::context::Context;
+    use pliron::linked_list::ContainsLinkedList;
+    use pliron::op::Op;
+
+    #[test]
+    fn projects_module_and_callable_structure_without_source_attributes() {
+        let source = "\
+.version 8.9
+.target sm_120a
+.visible .entry kernel() {
+    .reg .pred %p<2>;
+L0:
+    @%p0 future.op.u32 {%r1, %r2}, [%rd3];
+    {
+        mov.u32 %r1, 7;
+    }
+    ret;
+}
+";
+        let mut ctx = Context::new();
+        crate::register(&mut ctx);
+        let projection = Projection::parse(&mut ctx, source).unwrap();
+        assert_eq!(projection.document().source(), source);
+
+        let module_ops: Vec<_> = projection
+            .module()
+            .body(&ctx)
+            .deref(&ctx)
+            .iter(&ctx)
+            .collect();
+        assert_eq!(module_ops.len(), 3);
+        assert!(Operation::is_op::<PtxDirectiveOp>(module_ops[0], &ctx));
+        assert!(Operation::is_op::<PtxDirectiveOp>(module_ops[1], &ctx));
+        let callable = Operation::get_op::<PtxCallableOp>(module_ops[2], &ctx).unwrap();
+        assert!(callable.is_definition(&ctx));
+
+        let callable_ops: Vec<_> = callable
+            .entry_block(&ctx)
+            .unwrap()
+            .deref(&ctx)
+            .iter(&ctx)
+            .collect();
+        assert!(Operation::is_op::<PtxDirectiveOp>(callable_ops[0], &ctx));
+        assert!(Operation::is_op::<PtxRawOp>(callable_ops[1], &ctx));
+        assert!(Operation::is_op::<PtxInstructionOp>(callable_ops[2], &ctx));
+        assert!(Operation::is_op::<PtxScopeOp>(callable_ops[3], &ctx));
+        assert!(Operation::is_op::<PtxInstructionOp>(callable_ops[4], &ctx));
+
+        assert_eq!(projection.blocks().len(), 3);
+        for node in projection.nodes() {
+            assert_eq!(
+                projection.source_node(node.operation()),
+                Some(node.source_node())
+            );
+        }
+        for block in projection.blocks() {
+            assert_eq!(
+                projection.source_scope(block.block()),
+                Some(block.source_scope())
+            );
+        }
+        projection
+            .module()
+            .get_operation()
+            .deref(&ctx)
+            .verify(&ctx)
+            .unwrap();
+    }
+
+    #[test]
+    fn projects_declarations_without_inventing_body_regions() {
+        let source = ".extern .func helper(.param .b32 x);\n";
+        let mut ctx = Context::new();
+        crate::register(&mut ctx);
+        let projection = Projection::parse(&mut ctx, source).unwrap();
+        let operation = projection
+            .module()
+            .body(&ctx)
+            .deref(&ctx)
+            .iter(&ctx)
+            .next()
+            .unwrap();
+        let callable = Operation::get_op::<PtxCallableOp>(operation, &ctx).unwrap();
+        assert!(!callable.is_definition(&ctx));
+        assert!(callable.is_external(&ctx));
+    }
+}

--- a/crates/dialect-ptx/src/projection.rs
+++ b/crates/dialect-ptx/src/projection.rs
@@ -6,7 +6,7 @@
 use crate::attributes::CallableKindAttr;
 use crate::cfg::{
     BasicBlock as RecoveredBasicBlock, BlockId, CallableControlFlow, CfgError, ControlFlow, Edge,
-    ExitKind,
+    ExitKind, ScopeSegment,
 };
 use crate::ops::{
     PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
@@ -411,6 +411,19 @@ impl ProjectedCfgBlock<'_, '_> {
             })
     }
 
+    pub fn scope_segments(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ProjectedCfgScopeSegment<'_, '_>> + '_ {
+        self.recovered
+            .scope_segments()
+            .iter()
+            .map(|segment| ProjectedCfgScopeSegment {
+                projection: self.projection,
+                block: self.recovered,
+                recovered: segment,
+            })
+    }
+
     pub fn successors(&self) -> &[Edge] {
         self.recovered.successors()
     }
@@ -421,6 +434,44 @@ impl ProjectedCfgBlock<'_, '_> {
 
     pub fn exit(&self) -> Option<ExitKind> {
         self.recovered.exit()
+    }
+}
+
+/// One lexical scope segment within a recovered CFG block.
+#[derive(Clone, Copy)]
+pub struct ProjectedCfgScopeSegment<'projection, 'source> {
+    projection: &'projection Projection<'source>,
+    block: &'projection RecoveredBasicBlock,
+    recovered: &'projection ScopeSegment,
+}
+
+impl ProjectedCfgScopeSegment<'_, '_> {
+    pub fn recovered(&self) -> &ScopeSegment {
+        self.recovered
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.recovered.scope()
+    }
+
+    /// The existing lexical Pliron block for this source scope.
+    pub fn lexical_block(&self) -> Ptr<BasicBlock> {
+        self.projection
+            .block_for_source_scope(self.scope())
+            .expect("a recovered scope belongs to its projection")
+    }
+
+    pub fn instructions(&self) -> impl Iterator<Item = (StatementId, Ptr<Operation>)> + '_ {
+        self.block.instructions()[self.recovered.instruction_range()]
+            .iter()
+            .copied()
+            .map(|statement| {
+                let operation = self
+                    .projection
+                    .operation_for_statement(statement)
+                    .expect("a recovered instruction belongs to its projection");
+                (statement, operation)
+            })
     }
 }
 
@@ -882,6 +933,18 @@ Done:
                 );
                 assert!(Operation::is_op::<PtxInstructionOp>(operation, &ctx));
                 assert_eq!(cfg.block_for_operation(operation).unwrap().id(), block.id());
+            }
+            for segment in block.scope_segments() {
+                assert_eq!(
+                    projection.source_scope(segment.lexical_block()),
+                    Some(segment.scope())
+                );
+                for (statement, _) in segment.instructions() {
+                    assert_eq!(
+                        projection.document().statement(statement).unwrap().scope(),
+                        segment.scope()
+                    );
+                }
             }
         }
 

--- a/crates/dialect-ptx/src/projection.rs
+++ b/crates/dialect-ptx/src/projection.rs
@@ -4,7 +4,10 @@
  */
 
 use crate::attributes::CallableKindAttr;
-use crate::cfg::{CfgError, ControlFlow};
+use crate::cfg::{
+    BasicBlock as RecoveredBasicBlock, BlockId, CallableControlFlow, CfgError, ControlFlow, Edge,
+    ExitKind,
+};
 use crate::ops::{
     PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
 };
@@ -103,8 +106,10 @@ pub struct Projection<'source> {
     module: PtxModuleOp,
     nodes: Vec<ProjectedNode>,
     nodes_by_operation: HashMap<Ptr<Operation>, usize>,
+    nodes_by_source: HashMap<SourceNode, usize>,
     blocks: Vec<ProjectedBlock>,
     blocks_by_pointer: HashMap<Ptr<BasicBlock>, usize>,
+    blocks_by_source: HashMap<ScopeId, usize>,
 }
 
 impl<'source> Projection<'source> {
@@ -134,10 +139,20 @@ impl<'source> Projection<'source> {
             .enumerate()
             .map(|(index, node)| (node.operation, index))
             .collect();
+        let nodes_by_source = nodes
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.source_node, index))
+            .collect();
         let blocks_by_pointer = blocks
             .iter()
             .enumerate()
             .map(|(index, block)| (block.block, index))
+            .collect();
+        let blocks_by_source = blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| (block.source_scope, index))
             .collect();
 
         Self {
@@ -145,8 +160,10 @@ impl<'source> Projection<'source> {
             module,
             nodes,
             nodes_by_operation,
+            nodes_by_source,
             blocks,
             blocks_by_pointer,
+            blocks_by_source,
         }
     }
 
@@ -172,10 +189,36 @@ impl<'source> Projection<'source> {
             .map(|index| self.nodes[*index].source_node)
     }
 
+    /// Resolve source lineage back to the projected operation.
+    pub fn operation_for_source(&self, source: SourceNode) -> Option<Ptr<Operation>> {
+        self.nodes_by_source
+            .get(&source)
+            .map(|index| self.nodes[*index].operation)
+    }
+
+    pub fn operation_for_statement(&self, statement: StatementId) -> Option<Ptr<Operation>> {
+        self.operation_for_source(SourceNode::Statement { statement })
+    }
+
+    pub fn operation_for_label(&self, label: LabelId) -> Option<Ptr<Operation>> {
+        self.operation_for_source(SourceNode::Label { label })
+    }
+
+    pub fn operation_for_scope(&self, scope: ScopeId) -> Option<Ptr<Operation>> {
+        self.operation_for_source(SourceNode::Scope { scope })
+    }
+
     pub fn source_scope(&self, block: Ptr<BasicBlock>) -> Option<ScopeId> {
         self.blocks_by_pointer
             .get(&block)
             .map(|index| self.blocks[*index].source_scope)
+    }
+
+    /// Resolve one lexical source scope to its projected Pliron block.
+    pub fn block_for_source_scope(&self, scope: ScopeId) -> Option<Ptr<BasicBlock>> {
+        self.blocks_by_source
+            .get(&scope)
+            .map(|index| self.blocks[*index].block)
     }
 
     /// Recover conservative intraprocedural CFGs from the authoritative
@@ -183,6 +226,201 @@ impl<'source> Projection<'source> {
     /// lineage and fails closed when PTX control-flow semantics are uncertain.
     pub fn control_flow(&self) -> Result<ControlFlow, CfgError> {
         ControlFlow::analyze(&self.document)
+    }
+
+    /// Join recovered surface CFG with projected Pliron operations without
+    /// claiming that those operations already inhabit native CFG blocks.
+    pub fn projected_control_flow(&self) -> Result<ProjectedControlFlow<'_, 'source>, CfgError> {
+        let recovered = self.control_flow()?;
+        let mut blocks_by_source = HashMap::new();
+        for (callable_index, callable) in recovered.callables().iter().enumerate() {
+            for block in callable.blocks() {
+                for label in block.labels() {
+                    blocks_by_source.insert(
+                        SourceNode::Label { label: *label },
+                        (callable_index, block.id()),
+                    );
+                }
+                for statement in block.instructions() {
+                    blocks_by_source.insert(
+                        SourceNode::Statement {
+                            statement: *statement,
+                        },
+                        (callable_index, block.id()),
+                    );
+                }
+            }
+        }
+        Ok(ProjectedControlFlow {
+            projection: self,
+            recovered,
+            blocks_by_source,
+        })
+    }
+}
+
+/// A read-only join between recovered surface CFG and projected operations.
+///
+/// The recovered graph remains authoritative for block boundaries and edges.
+/// This view only resolves its source lineage to the corresponding Pliron ops;
+/// it does not materialize Pliron basic blocks or successors.
+pub struct ProjectedControlFlow<'projection, 'source> {
+    projection: &'projection Projection<'source>,
+    recovered: ControlFlow,
+    blocks_by_source: HashMap<SourceNode, (usize, BlockId)>,
+}
+
+impl<'projection, 'source> ProjectedControlFlow<'projection, 'source> {
+    pub fn recovered(&self) -> &ControlFlow {
+        &self.recovered
+    }
+
+    pub fn callables(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ProjectedCallableControlFlow<'_, 'source>> + '_ {
+        self.recovered
+            .callables()
+            .iter()
+            .map(|callable| ProjectedCallableControlFlow {
+                projection: self.projection,
+                recovered: callable,
+            })
+    }
+
+    pub fn for_callable_operation(
+        &self,
+        operation: Ptr<Operation>,
+    ) -> Option<ProjectedCallableControlFlow<'_, 'source>> {
+        let statement = self.projection.source_node(operation)?.statement()?;
+        self.for_callable_statement(statement)
+    }
+
+    pub fn for_callable_statement(
+        &self,
+        statement: StatementId,
+    ) -> Option<ProjectedCallableControlFlow<'_, 'source>> {
+        self.recovered
+            .for_callable(statement)
+            .map(|callable| ProjectedCallableControlFlow {
+                projection: self.projection,
+                recovered: callable,
+            })
+    }
+
+    /// Find the recovered CFG block containing one projected instruction or
+    /// label operation.
+    pub fn block_for_operation(
+        &self,
+        operation: Ptr<Operation>,
+    ) -> Option<ProjectedCfgBlock<'_, 'source>> {
+        self.block_for_source(self.projection.source_node(operation)?)
+    }
+
+    pub fn block_for_statement(
+        &self,
+        statement: StatementId,
+    ) -> Option<ProjectedCfgBlock<'_, 'source>> {
+        self.block_for_source(SourceNode::Statement { statement })
+    }
+
+    pub fn block_for_label(&self, label: LabelId) -> Option<ProjectedCfgBlock<'_, 'source>> {
+        self.block_for_source(SourceNode::Label { label })
+    }
+
+    fn block_for_source(&self, source: SourceNode) -> Option<ProjectedCfgBlock<'_, 'source>> {
+        let (callable, block) = self.blocks_by_source.get(&source).copied()?;
+        let recovered = self
+            .recovered
+            .callables()
+            .get(callable)?
+            .blocks()
+            .get(block.index())?;
+        Some(ProjectedCfgBlock {
+            projection: self.projection,
+            recovered,
+        })
+    }
+}
+
+/// One recovered callable paired with its projected `ptx.callable` operation.
+#[derive(Clone, Copy)]
+pub struct ProjectedCallableControlFlow<'projection, 'source> {
+    projection: &'projection Projection<'source>,
+    recovered: &'projection CallableControlFlow,
+}
+
+impl ProjectedCallableControlFlow<'_, '_> {
+    pub fn recovered(&self) -> &CallableControlFlow {
+        self.recovered
+    }
+
+    pub fn operation(&self) -> Ptr<Operation> {
+        self.projection
+            .operation_for_statement(self.recovered.callable())
+            .expect("a recovered callable belongs to its projection")
+    }
+
+    pub fn blocks(&self) -> impl ExactSizeIterator<Item = ProjectedCfgBlock<'_, '_>> + '_ {
+        self.recovered
+            .blocks()
+            .iter()
+            .map(|block| ProjectedCfgBlock {
+                projection: self.projection,
+                recovered: block,
+            })
+    }
+}
+
+/// One recovered CFG block with operation-level label and instruction views.
+#[derive(Clone, Copy)]
+pub struct ProjectedCfgBlock<'projection, 'source> {
+    projection: &'projection Projection<'source>,
+    recovered: &'projection RecoveredBasicBlock,
+}
+
+impl ProjectedCfgBlock<'_, '_> {
+    pub fn recovered(&self) -> &RecoveredBasicBlock {
+        self.recovered
+    }
+
+    pub fn id(&self) -> BlockId {
+        self.recovered.id()
+    }
+
+    pub fn labels(&self) -> impl Iterator<Item = (LabelId, Ptr<Operation>)> + '_ {
+        self.recovered.labels().iter().copied().map(|label| {
+            let operation = self
+                .projection
+                .operation_for_label(label)
+                .expect("a recovered label belongs to its projection");
+            (label, operation)
+        })
+    }
+
+    pub fn instructions(&self) -> impl Iterator<Item = (StatementId, Ptr<Operation>)> + '_ {
+        self.recovered
+            .instructions()
+            .iter()
+            .copied()
+            .map(|statement| {
+                let operation = self
+                    .projection
+                    .operation_for_statement(statement)
+                    .expect("a recovered instruction belongs to its projection");
+                (statement, operation)
+            })
+    }
+
+    pub fn successors(&self) -> &[Edge] {
+        self.recovered.successors()
+    }
+
+    pub fn predecessors(&self) -> &[Edge] {
+        self.recovered.predecessors()
+    }
+
+    pub fn exit(&self) -> Option<ExitKind> {
+        self.recovered.exit()
     }
 }
 
@@ -541,6 +779,10 @@ L0:
                 projection.source_node(node.operation()),
                 Some(node.source_node())
             );
+            assert_eq!(
+                projection.operation_for_source(node.source_node()),
+                Some(node.operation())
+            );
             if let SourceNode::Label { label } = node.source_node() {
                 assert_eq!(
                     projection.document().label(label).unwrap().span(),
@@ -552,6 +794,10 @@ L0:
             assert_eq!(
                 projection.source_scope(block.block()),
                 Some(block.source_scope())
+            );
+            assert_eq!(
+                projection.block_for_source_scope(block.source_scope()),
+                Some(block.block())
             );
         }
         projection
@@ -578,5 +824,72 @@ L0:
         let callable = Operation::get_op::<PtxCallableOp>(operation, &ctx).unwrap();
         assert!(!callable.is_definition(&ctx));
         assert!(callable.is_external(&ctx));
+    }
+
+    #[test]
+    fn joins_recovered_cfg_to_projected_operations_without_materializing_blocks() {
+        let source = "\
+.version 9.3
+.target sm_120a
+.visible .entry kernel() {
+L0: Alias: @%p0 bra Done;
+    {
+        add.u32 %r0, %r0, 1;
+    }
+Done:
+    ret;
+}
+";
+        let mut ctx = Context::new();
+        crate::register(&mut ctx);
+        let projection = Projection::parse(&mut ctx, source).unwrap();
+        let cfg = projection.projected_control_flow().unwrap();
+        let callable = cfg.callables().next().unwrap();
+        let callable_operation = callable.operation();
+        assert!(Operation::is_op::<PtxCallableOp>(callable_operation, &ctx));
+        assert_eq!(
+            cfg.for_callable_operation(callable_operation)
+                .unwrap()
+                .recovered()
+                .callable(),
+            callable.recovered().callable()
+        );
+
+        let blocks = callable.blocks().collect::<Vec<_>>();
+        assert_eq!(blocks.len(), 3);
+        let labels = blocks[0].labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(
+            labels
+                .iter()
+                .map(|(_, operation)| {
+                    Operation::get_op::<PtxLabelOp>(*operation, &ctx)
+                        .unwrap()
+                        .name(&ctx)
+                })
+                .collect::<Vec<_>>(),
+            ["L0", "Alias"]
+        );
+        assert_eq!(
+            cfg.block_for_operation(labels[0].1).unwrap().id(),
+            blocks[0].id()
+        );
+        for block in &blocks {
+            for (statement, operation) in block.instructions() {
+                assert_eq!(
+                    projection.source_node(operation),
+                    Some(SourceNode::Statement { statement })
+                );
+                assert!(Operation::is_op::<PtxInstructionOp>(operation, &ctx));
+                assert_eq!(cfg.block_for_operation(operation).unwrap().id(), block.id());
+            }
+        }
+
+        // Projection stays in its original lexical form: callable body plus
+        // nested scope, not three newly-materialized Pliron CFG blocks.
+        let projected_callable =
+            Operation::get_op::<PtxCallableOp>(callable_operation, &ctx).unwrap();
+        let region = projected_callable.region(&ctx).unwrap();
+        assert_eq!(region.deref(&ctx).iter(&ctx).count(), 1);
     }
 }

--- a/crates/dialect-ptx/src/projection.rs
+++ b/crates/dialect-ptx/src/projection.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::attributes::CallableKindAttr;
+use crate::cfg::{CfgError, ControlFlow};
 use crate::ops::{
     PtxCallableOp, PtxDirectiveOp, PtxInstructionOp, PtxLabelOp, PtxModuleOp, PtxRawOp, PtxScopeOp,
 };
@@ -175,6 +176,13 @@ impl<'source> Projection<'source> {
         self.blocks_by_pointer
             .get(&block)
             .map(|index| self.blocks[*index].source_scope)
+    }
+
+    /// Recover conservative intraprocedural CFGs from the authoritative
+    /// lossless syntax. The returned graph retains `StatementId`/`ScopeId`
+    /// lineage and fails closed when PTX control-flow semantics are uncertain.
+    pub fn control_flow(&self) -> Result<ControlFlow, CfgError> {
+        ControlFlow::analyze(&self.document)
     }
 }
 

--- a/crates/ptx-syntax/Cargo.toml
+++ b/crates/ptx-syntax/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ptx-syntax"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "Lossless structural views over PTX source text"
+
+[dependencies]

--- a/crates/ptx-syntax/examples/audit.rs
+++ b/crates/ptx-syntax/examples/audit.rs
@@ -1,0 +1,80 @@
+use ptx_syntax::Document;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut paths = Vec::new();
+    for argument in std::env::args_os().skip(1) {
+        collect(Path::new(&argument), &mut paths)?;
+    }
+    paths.sort();
+
+    let mut failures = 0usize;
+    let mut bytes = 0usize;
+    let mut tokens = 0usize;
+    let mut statements = 0usize;
+    let mut scopes = 0usize;
+    let mut instructions = 0usize;
+    for path in &paths {
+        let source = fs::read_to_string(path)?;
+        bytes += source.len();
+        match Document::parse(&source) {
+            Ok(document) => {
+                tokens += document.tokens().len();
+                statements += document.statements().len();
+                scopes += document.scopes().len();
+                instructions += document.instructions().len();
+                if !document.coverage().is_complete() {
+                    failures += 1;
+                    eprintln!("{}: coverage={:?}", path.display(), document.coverage());
+                    for diagnostic in document.diagnostics().iter().take(20) {
+                        let span = diagnostic.span();
+                        let line = source[..span.start]
+                            .bytes()
+                            .filter(|byte| *byte == b'\n')
+                            .count()
+                            + 1;
+                        let text = source[span]
+                            .lines()
+                            .next()
+                            .unwrap_or_default()
+                            .chars()
+                            .take(120)
+                            .collect::<String>();
+                        eprintln!("  line {line}: {:?}: {text:?}", diagnostic.kind());
+                    }
+                }
+            }
+            Err(error) => {
+                failures += 1;
+                eprintln!("{}: {error}", path.display());
+            }
+        }
+    }
+    println!(
+        "files={} bytes={} tokens={} statements={} scopes={} instructions={} incomplete={failures}",
+        paths.len(),
+        bytes,
+        tokens,
+        statements,
+        scopes,
+        instructions
+    );
+    if failures == 0 {
+        Ok(())
+    } else {
+        Err("PTX structural coverage is incomplete".into())
+    }
+}
+
+fn collect(path: &Path, paths: &mut Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
+    if path.is_dir() {
+        for entry in fs::read_dir(path)? {
+            collect(&entry?.path(), paths)?;
+        }
+    } else if path.extension().is_some_and(|extension| extension == "ptx") {
+        paths.push(path.to_owned());
+    }
+    Ok(())
+}

--- a/crates/ptx-syntax/src/edit.rs
+++ b/crates/ptx-syntax/src/edit.rs
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::fmt;
+use std::ops::Range;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EditScript {
+    edits: Vec<Edit>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Edit {
+    range: Range<usize>,
+    replacement: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EditError {
+    InvalidRange {
+        range: Range<usize>,
+    },
+    Overlap {
+        first: Range<usize>,
+        second: Range<usize>,
+    },
+    OutOfBounds {
+        range: Range<usize>,
+        source_len: usize,
+    },
+    NonCharacterBoundary {
+        offset: usize,
+    },
+}
+
+impl fmt::Display for EditError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRange { range } => write!(
+                formatter,
+                "PTX edit range {}..{} is reversed",
+                range.start, range.end
+            ),
+            Self::Overlap { first, second } => write!(
+                formatter,
+                "PTX edits {}..{} and {}..{} conflict",
+                first.start, first.end, second.start, second.end
+            ),
+            Self::OutOfBounds { range, source_len } => write!(
+                formatter,
+                "PTX edit range {}..{} exceeds source length {source_len}",
+                range.start, range.end
+            ),
+            Self::NonCharacterBoundary { offset } => {
+                write!(
+                    formatter,
+                    "PTX edit offset {offset} is not a UTF-8 boundary"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for EditError {}
+
+impl EditScript {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.edits.is_empty()
+    }
+
+    pub fn insert(&mut self, offset: usize, text: impl Into<String>) -> Result<(), EditError> {
+        self.replace(offset..offset, text)
+    }
+
+    pub fn delete(&mut self, range: Range<usize>) -> Result<(), EditError> {
+        self.replace(range, "")
+    }
+
+    pub fn replace(
+        &mut self,
+        range: Range<usize>,
+        replacement: impl Into<String>,
+    ) -> Result<(), EditError> {
+        if range.start > range.end {
+            return Err(EditError::InvalidRange { range });
+        }
+        if let Some(existing) = self
+            .edits
+            .iter()
+            .find(|edit| ranges_conflict(&edit.range, &range))
+        {
+            return Err(EditError::Overlap {
+                first: existing.range.clone(),
+                second: range,
+            });
+        }
+        self.edits.push(Edit {
+            range,
+            replacement: replacement.into(),
+        });
+        Ok(())
+    }
+
+    pub fn apply(&self, source: &str) -> Result<String, EditError> {
+        let mut edits: Vec<&Edit> = self.edits.iter().collect();
+        edits.sort_by_key(|edit| (edit.range.start, edit.range.end));
+
+        for edit in &edits {
+            if edit.range.end > source.len() {
+                return Err(EditError::OutOfBounds {
+                    range: edit.range.clone(),
+                    source_len: source.len(),
+                });
+            }
+            for offset in [edit.range.start, edit.range.end] {
+                if !source.is_char_boundary(offset) {
+                    return Err(EditError::NonCharacterBoundary { offset });
+                }
+            }
+        }
+
+        let replacement_bytes = edits
+            .iter()
+            .map(|edit| edit.replacement.len())
+            .sum::<usize>();
+        let removed_bytes = edits
+            .iter()
+            .map(|edit| edit.range.end - edit.range.start)
+            .sum::<usize>();
+        let mut output = String::with_capacity(source.len() + replacement_bytes - removed_bytes);
+        let mut cursor = 0usize;
+        for edit in edits {
+            output.push_str(&source[cursor..edit.range.start]);
+            output.push_str(&edit.replacement);
+            cursor = edit.range.end;
+        }
+        output.push_str(&source[cursor..]);
+        Ok(output)
+    }
+}
+
+fn ranges_conflict(first: &Range<usize>, second: &Range<usize>) -> bool {
+    match (first.is_empty(), second.is_empty()) {
+        (false, false) => first.start < second.end && second.start < first.end,
+        (true, true) => first.start == second.start,
+        (true, false) => first.start >= second.start && first.start <= second.end,
+        (false, true) => second.start >= first.start && second.start <= first.end,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applies_non_overlapping_edits_in_source_order() {
+        let mut edits = EditScript::new();
+        edits.replace(6..12, "PTX").unwrap();
+        edits.insert(0, "lossless ").unwrap();
+        edits.delete(12..13).unwrap();
+        assert_eq!(edits.apply("hello source!").unwrap(), "lossless hello PTX");
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_invalid_edits() {
+        let mut edits = EditScript::new();
+        edits.delete(2..5).unwrap();
+        assert!(matches!(
+            edits.insert(5, "x"),
+            Err(EditError::Overlap { .. })
+        ));
+        assert!(matches!(
+            edits.replace(Range { start: 8, end: 7 }, "x"),
+            Err(EditError::InvalidRange { .. })
+        ));
+        let mut duplicate_insert = EditScript::new();
+        duplicate_insert.insert(1, "x").unwrap();
+        assert!(matches!(
+            duplicate_insert.insert(1, "y"),
+            Err(EditError::Overlap { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_source_boundaries_when_applying() {
+        let mut out_of_bounds = EditScript::new();
+        out_of_bounds.delete(2..20).unwrap();
+        assert!(matches!(
+            out_of_bounds.apply("short"),
+            Err(EditError::OutOfBounds { .. })
+        ));
+
+        let mut inside_utf8 = EditScript::new();
+        inside_utf8.insert(1, "x").unwrap();
+        assert!(matches!(
+            inside_utf8.apply("λ"),
+            Err(EditError::NonCharacterBoundary { offset: 1 })
+        ));
+    }
+}

--- a/crates/ptx-syntax/src/lexer.rs
+++ b/crates/ptx-syntax/src/lexer.rs
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::ParseError;
+use std::ops::Range;
+
+/// The lossless lexical class of one PTX source token.
+///
+/// This deliberately stops short of assigning ISA semantics. In particular,
+/// [`Word`](Self::Word) retains identifiers, instruction heads, numeric
+/// literals, and implementation-defined spellings without rejecting syntax
+/// introduced by a newer PTX version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenKind {
+    Whitespace,
+    LineComment,
+    BlockComment,
+    QuotedString,
+    Preprocessor,
+    Word,
+    Punctuation,
+    Unknown,
+}
+
+impl TokenKind {
+    /// Whether this token carries no PTX syntax of its own.
+    pub fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            Self::Whitespace | Self::LineComment | Self::BlockComment
+        )
+    }
+}
+
+/// One lossless token represented by its exact byte range in the source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Token {
+    kind: TokenKind,
+    start: u32,
+    end: u32,
+}
+
+impl Token {
+    fn new(kind: TokenKind, span: Range<usize>) -> Self {
+        Self {
+            kind,
+            start: span
+                .start
+                .try_into()
+                .expect("the lexer rejects PTX sources larger than u32::MAX"),
+            end: span
+                .end
+                .try_into()
+                .expect("the lexer rejects PTX sources larger than u32::MAX"),
+        }
+    }
+
+    pub fn kind(&self) -> TokenKind {
+        self.kind
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.start as usize..self.end as usize
+    }
+
+    pub fn text<'source>(&self, source: &'source str) -> &'source str {
+        &source[self.span()]
+    }
+}
+
+pub(crate) fn lex(source: &str) -> Result<Vec<Token>, ParseError> {
+    if source.len() > u32::MAX as usize {
+        return Err(ParseError::SourceTooLarge {
+            bytes: source.len(),
+        });
+    }
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0usize;
+
+    while cursor < bytes.len() {
+        let start = cursor;
+        let (kind, end) = if bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+            while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+                cursor += 1;
+            }
+            (TokenKind::Whitespace, cursor)
+        } else if bytes[cursor..].starts_with(b"//") {
+            cursor += 2;
+            while bytes.get(cursor).is_some_and(|byte| *byte != b'\n') {
+                cursor += 1;
+            }
+            (TokenKind::LineComment, cursor)
+        } else if bytes[cursor..].starts_with(b"/*") {
+            cursor += 2;
+            while cursor < bytes.len() && !bytes[cursor..].starts_with(b"*/") {
+                cursor += source[cursor..]
+                    .chars()
+                    .next()
+                    .expect("cursor is before the end of the source")
+                    .len_utf8();
+            }
+            if cursor == bytes.len() {
+                return Err(ParseError::UnterminatedBlockComment { offset: start });
+            }
+            cursor += 2;
+            (TokenKind::BlockComment, cursor)
+        } else if bytes[cursor] == b'"' {
+            cursor += 1;
+            let mut closed = false;
+            while cursor < bytes.len() {
+                match bytes[cursor] {
+                    b'\\' if cursor + 1 < bytes.len() => {
+                        cursor += 1;
+                        cursor += source[cursor..]
+                            .chars()
+                            .next()
+                            .expect("an escape has a following character")
+                            .len_utf8();
+                    }
+                    b'"' => {
+                        cursor += 1;
+                        closed = true;
+                        break;
+                    }
+                    b'\n' | b'\r' => break,
+                    _ => {
+                        cursor += source[cursor..]
+                            .chars()
+                            .next()
+                            .expect("cursor is before the end of the source")
+                            .len_utf8();
+                    }
+                }
+            }
+            if !closed {
+                return Err(ParseError::UnterminatedQuotedString { offset: start });
+            }
+            (TokenKind::QuotedString, cursor)
+        } else if bytes[cursor] == b'#' && is_preprocessor_start(source, cursor) {
+            cursor = preprocessor_end(source, cursor + 1);
+            (TokenKind::Preprocessor, cursor)
+        } else if is_word_byte(bytes[cursor]) {
+            cursor += 1;
+            while bytes.get(cursor).is_some_and(|byte| is_word_byte(*byte)) {
+                cursor += 1;
+            }
+            (TokenKind::Word, cursor)
+        } else if bytes[cursor..].starts_with(b"::") {
+            cursor += 2;
+            (TokenKind::Punctuation, cursor)
+        } else if bytes[cursor].is_ascii() && !bytes[cursor].is_ascii_control() {
+            cursor += 1;
+            (TokenKind::Punctuation, cursor)
+        } else {
+            cursor += source[cursor..]
+                .chars()
+                .next()
+                .expect("cursor is before the end of the source")
+                .len_utf8();
+            (TokenKind::Unknown, cursor)
+        };
+        tokens.push(Token::new(kind, start..end));
+    }
+
+    debug_assert_eq!(tokens.first().map_or(0, |token| token.start), 0);
+    debug_assert_eq!(
+        tokens.last().map_or(0, |token| token.end),
+        source.len() as u32
+    );
+    debug_assert!(
+        tokens
+            .windows(2)
+            .all(|tokens| tokens[0].end == tokens[1].start)
+    );
+    Ok(tokens)
+}
+
+fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'%' | b'.')
+}
+
+fn is_preprocessor_start(source: &str, offset: usize) -> bool {
+    let line_start = source[..offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
+    source[line_start..offset]
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\x0c'))
+}
+
+fn preprocessor_end(source: &str, mut cursor: usize) -> usize {
+    let bytes = source.as_bytes();
+    loop {
+        let Some(relative_newline) = bytes[cursor..].iter().position(|byte| *byte == b'\n') else {
+            return bytes.len();
+        };
+        let newline = cursor + relative_newline;
+        let before_newline = newline
+            .checked_sub(1)
+            .filter(|offset| bytes[*offset] == b'\r');
+        let last = before_newline.unwrap_or(newline).checked_sub(1);
+        if last.is_some_and(|offset| bytes[offset] == b'\\') {
+            cursor = newline + 1;
+        } else {
+            return newline;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partitions_every_source_byte_without_normalizing() {
+        let source = "  .file 1 \"a;{b}\" // λ\n/* x */ mov.u32 %r1, 0;\n";
+        let tokens = lex(source).unwrap();
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.text(source))
+                .collect::<String>(),
+            source
+        );
+        assert!(
+            tokens
+                .windows(2)
+                .all(|tokens| tokens[0].end == tokens[1].start)
+        );
+        assert!(
+            tokens
+                .iter()
+                .all(|token| source.is_char_boundary(token.start as usize)
+                    && source.is_char_boundary(token.end as usize))
+        );
+        assert_eq!(std::mem::size_of::<Token>(), 12);
+    }
+
+    #[test]
+    fn keeps_preprocessor_logical_lines_opaque() {
+        let source = " #define FOO(x) \\\n  x; { }\nmov.u32 %r1, 0;";
+        let tokens = lex(source).unwrap();
+        let preprocessors = tokens
+            .iter()
+            .filter(|token| token.kind == TokenKind::Preprocessor)
+            .collect::<Vec<_>>();
+        assert_eq!(preprocessors.len(), 1);
+        assert_eq!(preprocessors[0].text(source), "#define FOO(x) \\\n  x; { }");
+    }
+
+    #[test]
+    fn reports_the_start_of_unterminated_regions() {
+        assert_eq!(
+            lex("x /* no end").unwrap_err(),
+            ParseError::UnterminatedBlockComment { offset: 2 }
+        );
+        assert_eq!(
+            lex(".file \"no end").unwrap_err(),
+            ParseError::UnterminatedQuotedString { offset: 6 }
+        );
+    }
+
+    #[test]
+    fn distinguishes_double_colons_from_label_terminators() {
+        let source = "L0: tcgen05.wait::ld.sync.aligned;";
+        let tokens = lex(source).unwrap();
+        assert_eq!(
+            tokens
+                .iter()
+                .filter(|token| !token.kind().is_trivia())
+                .map(|token| token.text(source))
+                .collect::<Vec<_>>(),
+            ["L0", ":", "tcgen05.wait", "::", "ld.sync.aligned", ";"]
+        );
+    }
+}

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -167,6 +167,8 @@ pub struct Instruction<'source> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Predicate<'source> {
     register: &'source str,
+    register_start: u32,
+    register_end: u32,
     negated: bool,
 }
 
@@ -632,6 +634,10 @@ impl<'source> Instruction<'source> {
         self.head_span.start
     }
 
+    pub fn head_span(&self) -> Range<usize> {
+        self.head_span.clone()
+    }
+
     /// Byte offset immediately after the terminal semicolon.
     pub fn end_offset(&self) -> usize {
         self.span.end
@@ -671,6 +677,10 @@ impl<'source> Instruction<'source> {
             .map(|span| &self.source[span.clone()])
     }
 
+    pub fn operand_spans(&self) -> impl ExactSizeIterator<Item = Range<usize>> + '_ {
+        self.operand_spans.iter().cloned()
+    }
+
     pub fn text(&self) -> &'source str {
         &self.source[self.span.clone()]
     }
@@ -683,6 +693,10 @@ impl<'source> Predicate<'source> {
 
     pub fn is_negated(self) -> bool {
         self.negated
+    }
+
+    pub fn register_span(self) -> Range<usize> {
+        self.register_start as usize..self.register_end as usize
     }
 }
 
@@ -1098,6 +1112,16 @@ fn instruction_from_statement<'source>(
         }
         predicate = Some(Predicate {
             register: register.text(source),
+            register_start: register
+                .span()
+                .start
+                .try_into()
+                .expect("the lexer rejects sources larger than u32::MAX"),
+            register_end: register
+                .span()
+                .end
+                .try_into()
+                .expect("the lexer rejects sources larger than u32::MAX"),
             negated: significant
                 .get(cursor.wrapping_sub(1))
                 .is_some_and(|index| tokens[*index].text(source) == "!"),
@@ -1229,10 +1253,22 @@ mod tests {
         assert_eq!(future.labels().collect::<Vec<_>>(), ["L0"]);
         assert_eq!(future.predicate().unwrap().register(), "%p1");
         assert!(future.predicate().unwrap().is_negated());
+        assert_eq!(
+            &source[future.predicate().unwrap().register_span()],
+            future.predicate().unwrap().register()
+        );
         assert_eq!(future.head(), "future.op.u32");
+        assert_eq!(&source[future.head_span()], future.head());
         assert_eq!(
             future.operands().collect::<Vec<_>>(),
             ["{%r1, %r2}", "[%rd3, {%r4, %r5}]"]
+        );
+        assert_eq!(
+            future
+                .operand_spans()
+                .map(|span| &source[span])
+                .collect::<Vec<_>>(),
+            future.operands().collect::<Vec<_>>()
         );
         assert_eq!(
             future.text(),

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -33,9 +33,31 @@ pub struct Document<'source> {
     scopes: Vec<Scope>,
     diagnostics: Vec<Diagnostic>,
     coverage: Coverage,
+    labels: Vec<Label<'source>>,
     directives: Vec<Directive<'source>>,
     callables: Vec<Callable<'source>>,
     instructions: Vec<Instruction<'source>>,
+}
+
+/// Stable index of a projected label in [`Document::labels`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LabelId(usize);
+
+impl LabelId {
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// One PTX statement label, including a label prefixed to another statement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Label<'source> {
+    source: &'source str,
+    id: LabelId,
+    statement: StatementId,
+    scope: ScopeId,
+    span: Range<usize>,
+    name_span: Range<usize>,
 }
 
 /// A typed view of one PTX directive statement.
@@ -52,6 +74,7 @@ pub struct Directive<'source> {
     line_span: Range<usize>,
     name_span: Range<usize>,
     arguments_span: Range<usize>,
+    label_name_spans: Vec<Range<usize>>,
 }
 
 /// The two callable forms defined by PTX.
@@ -69,7 +92,9 @@ pub struct Callable<'source> {
     scope: ScopeId,
     definition_scope: Option<ScopeId>,
     kind: CallableKind,
+    span: Range<usize>,
     header_span: Range<usize>,
+    body_span: Option<Range<usize>>,
     name_span: Range<usize>,
     is_extern: bool,
 }
@@ -88,6 +113,21 @@ pub struct Instruction<'source> {
     prefix_span: Range<usize>,
     head_span: Range<usize>,
     operand_spans: Vec<Range<usize>>,
+    label_name_spans: Vec<Range<usize>>,
+    predicate: Option<Predicate<'source>>,
+}
+
+/// A guard predicate recovered from an instruction statement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Predicate<'source> {
+    register: &'source str,
+    negated: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LabelSpans {
+    span: Range<usize>,
+    name_span: Range<usize>,
 }
 
 /// A lexical error which prevents reliable source-span recovery.
@@ -117,7 +157,7 @@ impl fmt::Display for ParseError {
 impl std::error::Error for ParseError {}
 
 impl<'source> Document<'source> {
-    /// Parse the structural instruction view of `source`.
+    /// Parse a lossless structural view of `source`.
     ///
     /// Tokens losslessly partition the original source. Unknown instruction
     /// heads are accepted, while unterminated comments and strings fail the
@@ -126,6 +166,7 @@ impl<'source> Document<'source> {
         let tokens = lexer::lex(source)?;
         let masked = mask_non_code(source, &tokens);
         let mut parsed = syntax::parse(source, &tokens);
+        let labels = discover_labels(source, &tokens, &parsed.statements);
         let (directives, directive_diagnostics) =
             discover_directives(source, &tokens, &parsed.statements);
         let (callables, callable_diagnostics) =
@@ -152,6 +193,7 @@ impl<'source> Document<'source> {
             scopes: parsed.scopes,
             diagnostics: parsed.diagnostics,
             coverage: parsed.coverage,
+            labels,
             directives,
             callables,
             instructions,
@@ -198,6 +240,14 @@ impl<'source> Document<'source> {
         self.coverage
     }
 
+    pub fn labels(&self) -> &[Label<'source>] {
+        &self.labels
+    }
+
+    pub fn label(&self, id: LabelId) -> Option<&Label<'source>> {
+        self.labels.get(id.index())
+    }
+
     pub fn directives(&self) -> &[Directive<'source>] {
         &self.directives
     }
@@ -211,6 +261,29 @@ impl<'source> Document<'source> {
     }
 }
 
+impl<'source> Label<'source> {
+    pub fn id(&self) -> LabelId {
+        self.id
+    }
+
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    /// Byte range covering the label name and terminal colon.
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    pub fn name(&self) -> &'source str {
+        &self.source[self.name_span.clone()]
+    }
+}
+
 impl<'source> Directive<'source> {
     pub fn statement(&self) -> StatementId {
         self.statement
@@ -220,8 +293,8 @@ impl<'source> Directive<'source> {
         self.scope
     }
 
-    /// Byte range covering the directive without leading indentation, trailing
-    /// comment, or newline.
+    /// Byte range covering optional labels and the directive without leading
+    /// indentation, trailing comment, or newline.
     pub fn span(&self) -> Range<usize> {
         self.span.clone()
     }
@@ -234,6 +307,12 @@ impl<'source> Directive<'source> {
 
     pub fn name(&self) -> &'source str {
         &self.source[self.name_span.clone()]
+    }
+
+    pub fn labels(&self) -> impl ExactSizeIterator<Item = &'source str> + '_ {
+        self.label_name_spans
+            .iter()
+            .map(|span| &self.source[span.clone()])
     }
 
     pub fn arguments(&self) -> &'source str {
@@ -267,9 +346,19 @@ impl<'source> Callable<'source> {
         self.kind
     }
 
+    /// Byte range covering the complete declaration or definition.
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
     /// Byte range from the first linkage directive through the callable name.
     pub fn header_span(&self) -> Range<usize> {
         self.header_span.clone()
+    }
+
+    /// Source range inside a definition's outer braces.
+    pub fn body_span(&self) -> Option<Range<usize>> {
+        self.body_span.clone()
     }
 
     pub fn name(&self) -> &'source str {
@@ -311,6 +400,16 @@ impl<'source> Instruction<'source> {
         &self.source[self.prefix_span.clone()]
     }
 
+    pub fn labels(&self) -> impl ExactSizeIterator<Item = &'source str> + '_ {
+        self.label_name_spans
+            .iter()
+            .map(|span| &self.source[span.clone()])
+    }
+
+    pub fn predicate(&self) -> Option<Predicate<'source>> {
+        self.predicate
+    }
+
     /// Exact opcode and ordered modifier spelling.
     pub fn head(&self) -> &'source str {
         &self.source[self.head_span.clone()]
@@ -328,11 +427,44 @@ impl<'source> Instruction<'source> {
     }
 }
 
+impl<'source> Predicate<'source> {
+    pub fn register(self) -> &'source str {
+        self.register
+    }
+
+    pub fn is_negated(self) -> bool {
+        self.negated
+    }
+}
+
 /// Split a comma-separated PTX operand list without splitting nested register
 /// lists, addresses, or parameter tuples.
 pub fn split_top_level(source: &str) -> Option<Vec<&str>> {
     split_top_level_spans(source, 0)
         .map(|spans| spans.into_iter().map(|span| &source[span]).collect())
+}
+
+fn discover_labels<'source>(
+    source: &'source str,
+    tokens: &[Token],
+    statements: &[Statement],
+) -> Vec<Label<'source>> {
+    let mut labels = Vec::new();
+    for statement in statements {
+        let significant = significant_token_indices(tokens, statement);
+        let (_, spans) = leading_label_spans(source, tokens, &significant);
+        for spans in spans {
+            labels.push(Label {
+                source,
+                id: LabelId(labels.len()),
+                statement: statement.id(),
+                scope: statement.scope(),
+                span: spans.span,
+                name_span: spans.name_span,
+            });
+        }
+    }
+    labels
 }
 
 fn discover_directives<'source>(
@@ -347,11 +479,12 @@ fn discover_directives<'source>(
         .filter(|statement| statement.kind() == StatementKind::Directive)
     {
         let significant = significant_token_indices(tokens, statement);
-        let Some(name) = significant.iter().find_map(|index| {
-            let token = &tokens[*index];
-            (token.kind() == TokenKind::Word && token.text(source).starts_with('.'))
-                .then_some(token)
-        }) else {
+        let (cursor, label_spans) = leading_label_spans(source, tokens, &significant);
+        let Some(name) = significant
+            .get(cursor)
+            .map(|index| &tokens[*index])
+            .filter(|token| token.kind() == TokenKind::Word && token.text(source).starts_with('.'))
+        else {
             diagnostics.push(Diagnostic::new(
                 DiagnosticKind::MalformedDirective,
                 statement.span(),
@@ -366,6 +499,10 @@ fn discover_directives<'source>(
             line_span: physical_line_span(source, span.start),
             arguments_span: trim_span(source, name.span().end..span.end),
             name_span: name.span(),
+            label_name_spans: label_spans
+                .into_iter()
+                .map(|spans| spans.name_span)
+                .collect(),
             span,
         });
     }
@@ -433,13 +570,22 @@ fn discover_callables<'source>(
             .iter()
             .find(|scope| scope.header() == Some(statement.id()))
             .map(Scope::id);
+        let definition = definition_scope.and_then(|scope| scopes.get(scope.index()));
+        let closed_definition = definition.filter(|scope| scope.close_span().is_some());
+        let span = closed_definition.map_or_else(
+            || statement.span(),
+            |scope| statement.span().start..scope.span().end,
+        );
+        let body_span = closed_definition.map(Scope::body_span);
         callables.push(Callable {
             source,
             statement: statement.id(),
             scope: statement.scope(),
             definition_scope,
             kind,
+            span,
             header_span: statement.span().start..name.span().end,
+            body_span,
             name_span: name.span(),
             is_extern: significant[..keyword_cursor]
                 .iter()
@@ -454,6 +600,26 @@ fn significant_token_indices(tokens: &[Token], statement: &Statement) -> Vec<usi
         .token_range()
         .filter(|index| !tokens[*index].kind().is_trivia())
         .collect()
+}
+
+fn leading_label_spans(
+    source: &str,
+    tokens: &[Token],
+    significant: &[usize],
+) -> (usize, Vec<LabelSpans>) {
+    let mut cursor = 0usize;
+    let mut spans = Vec::new();
+    while cursor + 1 < significant.len()
+        && tokens[significant[cursor]].kind() == TokenKind::Word
+        && tokens[significant[cursor + 1]].text(source) == ":"
+        && (cursor + 2 == significant.len() || tokens[significant[cursor + 2]].text(source) != ":")
+    {
+        let name_span = tokens[significant[cursor]].span();
+        let span = name_span.start..tokens[significant[cursor + 1]].span().end;
+        spans.push(LabelSpans { span, name_span });
+        cursor += 2;
+    }
+    (cursor, spans)
 }
 
 fn skip_balanced_tokens(
@@ -529,14 +695,8 @@ fn instruction_from_statement<'source>(
     statement: &Statement,
 ) -> Option<Instruction<'source>> {
     let significant = significant_token_indices(tokens, statement);
-    let mut cursor = 0usize;
-    while cursor + 1 < significant.len()
-        && tokens[significant[cursor]].kind() == TokenKind::Word
-        && tokens[significant[cursor + 1]].text(source) == ":"
-        && (cursor + 2 == significant.len() || tokens[significant[cursor + 2]].text(source) != ":")
-    {
-        cursor += 2;
-    }
+    let (mut cursor, label_spans) = leading_label_spans(source, tokens, &significant);
+    let mut predicate = None;
     if significant
         .get(cursor)
         .is_some_and(|index| tokens[*index].text(source) == "@")
@@ -548,6 +708,16 @@ fn instruction_from_statement<'source>(
         {
             cursor += 1;
         }
+        let register = tokens.get(*significant.get(cursor)?)?;
+        if register.kind() != TokenKind::Word {
+            return None;
+        }
+        predicate = Some(Predicate {
+            register: register.text(source),
+            negated: significant
+                .get(cursor.wrapping_sub(1))
+                .is_some_and(|index| tokens[*index].text(source) == "!"),
+        });
         cursor += 1;
     }
     let head_start = tokens.get(*significant.get(cursor)?)?;
@@ -579,6 +749,11 @@ fn instruction_from_statement<'source>(
         prefix_span,
         head_span,
         operand_spans,
+        label_name_spans: label_spans
+            .into_iter()
+            .map(|spans| spans.name_span)
+            .collect(),
+        predicate,
     })
 }
 
@@ -667,6 +842,9 @@ mod tests {
         assert_eq!(document.instructions().len(), 2);
         let future = &document.instructions()[0];
         assert_eq!(future.prefix(), "L0: @!%p1");
+        assert_eq!(future.labels().collect::<Vec<_>>(), ["L0"]);
+        assert_eq!(future.predicate().unwrap().register(), "%p1");
+        assert!(future.predicate().unwrap().is_negated());
         assert_eq!(future.head(), "future.op.u32");
         assert_eq!(
             future.operands().collect::<Vec<_>>(),
@@ -720,6 +898,37 @@ mod tests {
     }
 
     #[test]
+    fn projects_prefixed_and_standalone_labels_with_lineage() {
+        let source = "L0:\nL1: L2: @%p0 bra L0;\nts: .branchtargets L0, L1;\n";
+        let document = Document::parse(source).unwrap();
+        assert_eq!(
+            document
+                .labels()
+                .iter()
+                .map(Label::name)
+                .collect::<Vec<_>>(),
+            ["L0", "L1", "L2", "ts"]
+        );
+        assert_eq!(
+            document.instructions()[0].labels().collect::<Vec<_>>(),
+            ["L1", "L2"]
+        );
+        assert_eq!(
+            document.directives()[0].labels().collect::<Vec<_>>(),
+            ["ts"]
+        );
+        assert_eq!(document.directives()[0].name(), ".branchtargets");
+        assert_eq!(document.directives()[0].arguments(), "L0, L1;");
+        for label in document.labels() {
+            assert_eq!(document.label(label.id()), Some(label));
+            assert_eq!(
+                document.statement(label.statement()).unwrap().scope(),
+                label.scope()
+            );
+        }
+    }
+
+    #[test]
     fn projects_multiline_callable_headers_and_definition_scopes() {
         let source = "\
 .visible
@@ -734,10 +943,22 @@ mod tests {
         assert_eq!(document.callables()[0].kind(), CallableKind::Entry);
         assert!(!document.callables()[0].is_extern());
         assert!(document.callables()[0].definition_scope().is_some());
+        assert!(document.callables()[0].body_span().is_some());
+        assert_eq!(
+            &source[document.callables()[0].span()],
+            ".visible\n.entry kernel() { ret; }"
+        );
         assert_eq!(document.callables()[1].name(), "__nv_helper");
         assert_eq!(document.callables()[1].kind(), CallableKind::Function);
         assert!(document.callables()[1].is_extern());
         assert!(document.callables()[1].definition_scope().is_none());
+        assert_eq!(
+            document.callables()[1].span(),
+            document
+                .statement(document.callables()[1].statement())
+                .unwrap()
+                .span()
+        );
         assert_eq!(document.callables()[2].name(), "local_helper");
         assert!(!document.callables()[2].is_extern());
         assert!(document.callables()[2].definition_scope().is_some());
@@ -746,6 +967,25 @@ mod tests {
                 .statement(callable.statement())
                 .is_some_and(|statement| statement.kind() == StatementKind::CallableHeader)
         }));
+    }
+
+    #[test]
+    fn does_not_claim_an_unclosed_callable_body() {
+        let document = Document::parse(".entry incomplete() {\nret;\n").unwrap();
+        let callable = &document.callables()[0];
+        assert!(callable.definition_scope().is_some());
+        assert!(callable.body_span().is_none());
+        assert_eq!(
+            callable.span(),
+            callable.header_span().start
+                ..document.statement(callable.statement()).unwrap().span().end
+        );
+        assert!(
+            document
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.kind() == DiagnosticKind::UnterminatedDelimiter)
+        );
     }
 
     #[test]

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -256,6 +256,19 @@ impl<'source> Document<'source> {
         &self.callables
     }
 
+    /// Return every callable whose symbol exactly matches `name`.
+    ///
+    /// PTX may contain both a declaration and a definition for a symbol, so
+    /// this deliberately exposes an iterator instead of choosing one match.
+    pub fn callables_named<'document>(
+        &'document self,
+        name: &'document str,
+    ) -> impl Iterator<Item = &'document Callable<'source>> + 'document {
+        self.callables
+            .iter()
+            .filter(move |callable| callable.name() == name)
+    }
+
     pub fn instructions(&self) -> &[Instruction<'source>] {
         &self.instructions
     }
@@ -367,6 +380,30 @@ impl<'source> Callable<'source> {
 
     pub fn is_extern(&self) -> bool {
         self.is_extern
+    }
+
+    /// Original source covering the complete declaration or definition when
+    /// its extent was recovered, otherwise the structural header.
+    pub fn text(&self) -> &'source str {
+        &self.source[self.span.clone()]
+    }
+
+    /// Original source inside a definition's outer braces.
+    pub fn body_text(&self) -> Option<&'source str> {
+        self.body_span
+            .as_ref()
+            .map(|span| &self.source[span.clone()])
+    }
+
+    /// Original source preceding a definition's opening brace.
+    ///
+    /// This includes parameter lists and callable directives such as
+    /// `.maxntid`. Declarations and incomplete definitions return `None`.
+    pub fn definition_header_text(&self) -> Option<&'source str> {
+        self.body_span.as_ref().map(|body| {
+            debug_assert_eq!(self.source.as_bytes()[body.start - 1], b'{');
+            &self.source[self.span.start..body.start - 1]
+        })
     }
 }
 
@@ -992,6 +1029,37 @@ mod tests {
     fn retains_quoted_directive_arguments() {
         let document = Document::parse(".file 1 \"kernel.cu\"\n").unwrap();
         assert_eq!(document.directives()[0].arguments(), "1 \"kernel.cu\"");
+    }
+
+    #[test]
+    fn queries_callable_source_without_reconstructing_syntax() {
+        let source = "\
+.extern .func helper();
+.visible .entry kernel(
+    .param .u64 output
+)
+.maxntid 128, 1, 1
+{
+    ret;
+}
+.extern .func helper();
+";
+        let document = Document::parse(source).unwrap();
+        let helpers = document.callables_named("helper").collect::<Vec<_>>();
+        assert_eq!(helpers.len(), 2);
+
+        let kernel = document.callables_named("kernel").next().unwrap();
+        assert_eq!(
+            kernel.definition_header_text().unwrap(),
+            ".visible .entry kernel(\n    .param .u64 output\n)\n.maxntid 128, 1, 1\n"
+        );
+        assert_eq!(kernel.body_text().unwrap(), "\n    ret;\n");
+        assert_eq!(
+            kernel.text(),
+            ".visible .entry kernel(\n    .param .u64 output\n)\n.maxntid 128, 1, 1\n{\n    ret;\n}"
+        );
+        assert!(helpers[0].definition_header_text().is_none());
+        assert!(helpers[0].body_text().is_none());
     }
 
     #[test]

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -1,0 +1,532 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Lossless structural views over PTX source text.
+//!
+//! This crate deliberately does not type-check the PTX ISA. Instructions are
+//! discovered structurally, so an opcode introduced by a newer PTX version is
+//! retained with the same source spans as a known opcode. Consumers which need
+//! ISA semantics can layer that policy over [`Instruction::head`].
+
+mod lexer;
+mod syntax;
+
+pub use lexer::{Token, TokenKind};
+pub use syntax::{
+    Coverage, Diagnostic, DiagnosticKind, Scope, ScopeId, Statement, StatementId, StatementKind,
+};
+
+use std::fmt;
+use std::ops::Range;
+
+/// A parsed PTX document which borrows its source and owns only structural
+/// indices into it.
+#[derive(Clone, Debug)]
+pub struct Document<'source> {
+    source: &'source str,
+    tokens: Vec<Token>,
+    statements: Vec<Statement>,
+    scopes: Vec<Scope>,
+    diagnostics: Vec<Diagnostic>,
+    coverage: Coverage,
+    instructions: Vec<Instruction<'source>>,
+}
+
+/// One semicolon-terminated PTX instruction.
+///
+/// The source text is not normalized. Predicates and same-line labels are
+/// exposed through [`Self::prefix`], while [`Self::head`] retains the exact
+/// opcode and modifier spelling.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Instruction<'source> {
+    source: &'source str,
+    statement: StatementId,
+    scope: ScopeId,
+    span: Range<usize>,
+    prefix_span: Range<usize>,
+    head_span: Range<usize>,
+    operand_spans: Vec<Range<usize>>,
+}
+
+/// A lexical error which prevents reliable source-span recovery.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    SourceTooLarge { bytes: usize },
+    UnterminatedBlockComment { offset: usize },
+    UnterminatedQuotedString { offset: usize },
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SourceTooLarge { bytes } => {
+                write!(formatter, "PTX source is {bytes} bytes; maximum is 4 GiB")
+            }
+            Self::UnterminatedBlockComment { offset } => {
+                write!(formatter, "unterminated PTX block comment at byte {offset}")
+            }
+            Self::UnterminatedQuotedString { offset } => {
+                write!(formatter, "unterminated PTX quoted string at byte {offset}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl<'source> Document<'source> {
+    /// Parse the structural instruction view of `source`.
+    ///
+    /// Tokens losslessly partition the original source. Unknown instruction
+    /// heads are accepted, while unterminated comments and strings fail the
+    /// document because every following source span would be ambiguous.
+    pub fn parse(source: &'source str) -> Result<Self, ParseError> {
+        let tokens = lexer::lex(source)?;
+        let masked = mask_non_code(source, &tokens);
+        let mut parsed = syntax::parse(source, &tokens);
+        let (instructions, instruction_diagnostics) = discover_instructions(
+            source,
+            &masked,
+            &tokens,
+            &parsed.statements,
+            &parsed.diagnostics,
+        );
+        parsed
+            .coverage
+            .add_diagnostics(instruction_diagnostics.len());
+        parsed.diagnostics.extend(instruction_diagnostics);
+        Ok(Self {
+            source,
+            tokens,
+            statements: parsed.statements,
+            scopes: parsed.scopes,
+            diagnostics: parsed.diagnostics,
+            coverage: parsed.coverage,
+            instructions,
+        })
+    }
+
+    pub fn source(&self) -> &'source str {
+        self.source
+    }
+
+    /// Lossless lexical tokens in source order.
+    ///
+    /// Their spans are contiguous and cover exactly [`Self::source`].
+    pub fn tokens(&self) -> &[Token] {
+        &self.tokens
+    }
+
+    /// Structural statements in source order. Every non-trivia token is owned
+    /// by one statement or a lexical scope delimiter. Unrecognized input is
+    /// retained as [`StatementKind::Unknown`].
+    pub fn statements(&self) -> &[Statement] {
+        &self.statements
+    }
+
+    /// Lexical scopes in source order, beginning with [`ScopeId::ROOT`].
+    pub fn scopes(&self) -> &[Scope] {
+        &self.scopes
+    }
+
+    pub fn statement(&self, id: StatementId) -> Option<&Statement> {
+        self.statements.get(id.index())
+    }
+
+    pub fn scope(&self, id: ScopeId) -> Option<&Scope> {
+        self.scopes.get(id.index())
+    }
+
+    /// Recoverable structural problems found while retaining later nodes.
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    pub fn coverage(&self) -> Coverage {
+        self.coverage
+    }
+
+    pub fn instructions(&self) -> &[Instruction<'source>] {
+        &self.instructions
+    }
+}
+
+impl<'source> Instruction<'source> {
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    /// Byte range covering the optional predicate/labels through the terminal
+    /// semicolon. Leading indentation and trailing comments are excluded.
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    /// Byte offset at which the opcode begins.
+    pub fn head_offset(&self) -> usize {
+        self.head_span.start
+    }
+
+    /// Byte offset immediately after the terminal semicolon.
+    pub fn end_offset(&self) -> usize {
+        self.span.end
+    }
+
+    /// Optional predicate and same-line labels preceding the opcode.
+    pub fn prefix(&self) -> &'source str {
+        &self.source[self.prefix_span.clone()]
+    }
+
+    /// Exact opcode and ordered modifier spelling.
+    pub fn head(&self) -> &'source str {
+        &self.source[self.head_span.clone()]
+    }
+
+    /// Top-level operands in source order.
+    pub fn operands(&self) -> impl ExactSizeIterator<Item = &'source str> + '_ {
+        self.operand_spans
+            .iter()
+            .map(|span| &self.source[span.clone()])
+    }
+
+    pub fn text(&self) -> &'source str {
+        &self.source[self.span.clone()]
+    }
+}
+
+/// Split a comma-separated PTX operand list without splitting nested register
+/// lists, addresses, or parameter tuples.
+pub fn split_top_level(source: &str) -> Option<Vec<&str>> {
+    split_top_level_spans(source, 0)
+        .map(|spans| spans.into_iter().map(|span| &source[span]).collect())
+}
+
+fn discover_instructions<'source>(
+    source: &'source str,
+    masked: &str,
+    tokens: &[Token],
+    statements: &[Statement],
+    diagnostics: &[Diagnostic],
+) -> (Vec<Instruction<'source>>, Vec<Diagnostic>) {
+    let mut instructions = Vec::new();
+    let mut projection_diagnostics = Vec::new();
+    for statement in statements
+        .iter()
+        .filter(|statement| statement.kind() == StatementKind::Instruction)
+    {
+        if let Some(instruction) = instruction_from_statement(source, masked, tokens, statement) {
+            instructions.push(instruction);
+        } else if !diagnostics
+            .iter()
+            .any(|diagnostic| ranges_overlap(diagnostic.span(), statement.span()))
+        {
+            projection_diagnostics.push(Diagnostic::new(
+                DiagnosticKind::MalformedInstruction,
+                statement.span(),
+            ));
+        }
+    }
+    (instructions, projection_diagnostics)
+}
+
+fn ranges_overlap(left: Range<usize>, right: Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
+}
+
+fn instruction_from_statement<'source>(
+    source: &'source str,
+    masked: &str,
+    tokens: &[Token],
+    statement: &Statement,
+) -> Option<Instruction<'source>> {
+    let significant = statement
+        .token_range()
+        .filter(|index| !tokens[*index].kind().is_trivia())
+        .collect::<Vec<_>>();
+    let mut cursor = 0usize;
+    while cursor + 1 < significant.len()
+        && tokens[significant[cursor]].kind() == TokenKind::Word
+        && tokens[significant[cursor + 1]].text(source) == ":"
+        && (cursor + 2 == significant.len() || tokens[significant[cursor + 2]].text(source) != ":")
+    {
+        cursor += 2;
+    }
+    if significant
+        .get(cursor)
+        .is_some_and(|index| tokens[*index].text(source) == "@")
+    {
+        cursor += 1;
+        if significant
+            .get(cursor)
+            .is_some_and(|index| tokens[*index].text(source) == "!")
+        {
+            cursor += 1;
+        }
+        cursor += 1;
+    }
+    let head_start = tokens.get(*significant.get(cursor)?)?;
+    let mut head_end = head_start.span().end;
+    while cursor + 2 < significant.len()
+        && tokens[significant[cursor + 1]].text(source) == "::"
+        && tokens[significant[cursor + 2]].kind() == TokenKind::Word
+    {
+        cursor += 2;
+        head_end = tokens[significant[cursor]].span().end;
+    }
+    let semicolon = tokens.get(*significant.last()?)?;
+    if head_start.kind() != TokenKind::Word || semicolon.text(source) != ";" {
+        return None;
+    }
+    let head_span = head_start.span().start..head_end;
+    let prefix_span = trim_span(masked, statement.span().start..head_span.start);
+    let operands = trim_span(masked, head_span.end..semicolon.span().start);
+    let operand_spans = if operands.is_empty() {
+        Vec::new()
+    } else {
+        split_top_level_spans(&masked[operands.clone()], operands.start)?
+    };
+    Some(Instruction {
+        source,
+        statement: statement.id(),
+        scope: statement.scope(),
+        span: statement.span(),
+        prefix_span,
+        head_span,
+        operand_spans,
+    })
+}
+
+fn split_top_level_spans(source: &str, base: usize) -> Option<Vec<Range<usize>>> {
+    let leading = source.len() - source.trim_start().len();
+    let source = source.trim();
+    let base = base + leading;
+    if source.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let mut operands = Vec::new();
+    let mut delimiters = Vec::new();
+    let mut operand_start = 0usize;
+    for (index, byte) in source.bytes().enumerate() {
+        match byte {
+            b'{' => delimiters.push(b'}'),
+            b'[' => delimiters.push(b']'),
+            b'(' => delimiters.push(b')'),
+            b'}' | b']' | b')' if delimiters.pop() != Some(byte) => return None,
+            b'}' | b']' | b')' => {}
+            b',' if delimiters.is_empty() => {
+                let span = trim_span(source, operand_start..index);
+                if span.is_empty() {
+                    return None;
+                }
+                operands.push(base + span.start..base + span.end);
+                operand_start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if !delimiters.is_empty() {
+        return None;
+    }
+    let span = trim_span(source, operand_start..source.len());
+    if span.is_empty() {
+        return None;
+    }
+    operands.push(base + span.start..base + span.end);
+    Some(operands)
+}
+
+fn trim_span(source: &str, span: Range<usize>) -> Range<usize> {
+    let text = &source[span.clone()];
+    if text.trim().is_empty() {
+        return span.end..span.end;
+    }
+    let leading = text.len() - text.trim_start().len();
+    let trailing = text.trim_end().len();
+    span.start + leading..span.start + trailing
+}
+
+fn mask_non_code(source: &str, tokens: &[Token]) -> String {
+    let mut masked = source.as_bytes().to_vec();
+    for token in tokens.iter().filter(|token| {
+        matches!(
+            token.kind(),
+            TokenKind::LineComment
+                | TokenKind::BlockComment
+                | TokenKind::QuotedString
+                | TokenKind::Preprocessor
+        )
+    }) {
+        for byte in &mut masked[token.span()] {
+            if *byte != b'\n' && *byte != b'\r' {
+                *byte = b' ';
+            }
+        }
+    }
+    String::from_utf8(masked).expect("masking tokens preserves UTF-8 boundaries")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_unknown_predicated_and_multiline_instructions() {
+        let source = ".visible .entry kernel() {\n\
+                      L0: @!%p1 future.op.u32\n\
+                          {%r1, %r2}, [%rd3, {%r4, %r5}]; // tail\n\
+                      ret;\n\
+                      }\n";
+        let document = Document::parse(source).unwrap();
+        assert_eq!(document.instructions().len(), 2);
+        let future = &document.instructions()[0];
+        assert_eq!(future.prefix(), "L0: @!%p1");
+        assert_eq!(future.head(), "future.op.u32");
+        assert_eq!(
+            future.operands().collect::<Vec<_>>(),
+            ["{%r1, %r2}", "[%rd3, {%r4, %r5}]"]
+        );
+        assert_eq!(
+            future.text(),
+            "L0: @!%p1 future.op.u32\n{%r1, %r2}, [%rd3, {%r4, %r5}];"
+        );
+        assert_eq!(document.instructions()[1].head(), "ret");
+    }
+
+    #[test]
+    fn ignores_comments_strings_directives_and_operand_symbols() {
+        let source = "// fake.u32 %r1;\n\
+                      .file 1 \"quoted.u32 %r2;\"\n\
+                      .target sm_90\n\
+                      .visible .entry kernel() {\n\
+                      call.uni (%r1), helper, (%r2);\n\
+                      /* fake2.u32 %r3; */ ret;\n\
+                      }";
+        let document = Document::parse(source).unwrap();
+        assert_eq!(
+            document
+                .instructions()
+                .iter()
+                .map(Instruction::head)
+                .collect::<Vec<_>>(),
+            ["call.uni", "ret"]
+        );
+    }
+
+    #[test]
+    fn preserves_utf8_byte_offsets_while_masking_non_code() {
+        let source = "// λλ\nmov.u32 %r1, %tid.x;";
+        let document = Document::parse(source).unwrap();
+        let instruction = &document.instructions()[0];
+        assert_eq!(&source[instruction.span()], instruction.text());
+        assert_eq!(instruction.head_offset(), source.find("mov.u32").unwrap());
+    }
+
+    #[test]
+    fn supports_multiple_instructions_on_one_line() {
+        let document = Document::parse("mov.u32 %r1, 1; add.u32 %r2, %r1, 2;").unwrap();
+        assert_eq!(
+            document
+                .instructions()
+                .iter()
+                .map(Instruction::head)
+                .collect::<Vec<_>>(),
+            ["mov.u32", "add.u32"]
+        );
+    }
+
+    #[test]
+    fn keeps_valid_instructions_after_a_recoverable_statement_error() {
+        let document = Document::parse("mov.u32 %r1, [oops;\nret;").unwrap();
+        assert_eq!(
+            document
+                .instructions()
+                .iter()
+                .map(Instruction::head)
+                .collect::<Vec<_>>(),
+            ["ret"]
+        );
+        assert_eq!(
+            document.diagnostics()[0].kind(),
+            DiagnosticKind::UnterminatedDelimiter
+        );
+    }
+
+    #[test]
+    fn retains_double_colon_instruction_modifiers_in_the_head() {
+        let document = Document::parse(
+            "L0: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%r1];",
+        )
+        .unwrap();
+        let instruction = &document.instructions()[0];
+        assert_eq!(
+            instruction.head(),
+            "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+        );
+        assert_eq!(instruction.prefix(), "L0:");
+        assert_eq!(instruction.operands().collect::<Vec<_>>(), ["[%r1]"]);
+    }
+
+    #[test]
+    fn rejects_unterminated_non_code_regions() {
+        assert_eq!(
+            Document::parse("/* no end").unwrap_err(),
+            ParseError::UnterminatedBlockComment { offset: 0 }
+        );
+        assert_eq!(
+            Document::parse(".file 1 \"no end").unwrap_err(),
+            ParseError::UnterminatedQuotedString { offset: 8 }
+        );
+    }
+
+    #[test]
+    fn splits_nested_top_level_operands() {
+        assert_eq!(
+            split_top_level("{%r1, %r2}, [%rd1, {%r3, %r4}], (%r5, %r6)").unwrap(),
+            ["{%r1, %r2}", "[%rd1, {%r3, %r4}]", "(%r5, %r6)"]
+        );
+        assert!(split_top_level("%r1, [%r2").is_none());
+    }
+
+    #[test]
+    fn arbitrary_ascii_never_panics_or_loses_successfully_lexed_input() {
+        const ALPHABET: &[u8] = b" abcXYZ019_.$%@!,:;{}[]()/*\\\"#\n\t+-|=";
+        let mut state = 0x9e37_79b9_u32;
+        for length in 0..512 {
+            let mut source = String::with_capacity(length);
+            for _ in 0..length {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                source.push(ALPHABET[(state as usize) % ALPHABET.len()] as char);
+            }
+            let Ok(document) = Document::parse(&source) else {
+                continue;
+            };
+            assert_eq!(
+                document
+                    .tokens()
+                    .iter()
+                    .map(|token| token.text(&source))
+                    .collect::<String>(),
+                source
+            );
+            assert!(document.coverage().is_lossless());
+            assert!(
+                document
+                    .statements()
+                    .iter()
+                    .all(|statement| document.scope(statement.scope()).is_some())
+            );
+            assert!(document.instructions().iter().all(|instruction| {
+                document
+                    .statement(instruction.statement())
+                    .is_some_and(|statement| statement.kind() == StatementKind::Instruction)
+            }));
+        }
+    }
+}

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -10,9 +10,11 @@
 //! retained with the same source spans as a known opcode. Consumers which need
 //! ISA semantics can layer that policy over [`Instruction::head`].
 
+mod edit;
 mod lexer;
 mod syntax;
 
+pub use edit::{EditError, EditScript};
 pub use lexer::{Token, TokenKind};
 pub use syntax::{
     Coverage, Diagnostic, DiagnosticKind, Scope, ScopeId, Statement, StatementId, StatementKind,
@@ -31,7 +33,45 @@ pub struct Document<'source> {
     scopes: Vec<Scope>,
     diagnostics: Vec<Diagnostic>,
     coverage: Coverage,
+    directives: Vec<Directive<'source>>,
+    callables: Vec<Callable<'source>>,
     instructions: Vec<Instruction<'source>>,
+}
+
+/// A typed view of one PTX directive statement.
+///
+/// The view retains the original spelling and is projected from a
+/// [`StatementKind::Directive`] node; it does not independently rescan source
+/// lines.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Directive<'source> {
+    source: &'source str,
+    statement: StatementId,
+    scope: ScopeId,
+    span: Range<usize>,
+    line_span: Range<usize>,
+    name_span: Range<usize>,
+    arguments_span: Range<usize>,
+}
+
+/// The two callable forms defined by PTX.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallableKind {
+    Entry,
+    Function,
+}
+
+/// A typed view of one PTX callable declaration or definition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Callable<'source> {
+    source: &'source str,
+    statement: StatementId,
+    scope: ScopeId,
+    definition_scope: Option<ScopeId>,
+    kind: CallableKind,
+    header_span: Range<usize>,
+    name_span: Range<usize>,
+    is_extern: bool,
 }
 
 /// One semicolon-terminated PTX instruction.
@@ -86,6 +126,10 @@ impl<'source> Document<'source> {
         let tokens = lexer::lex(source)?;
         let masked = mask_non_code(source, &tokens);
         let mut parsed = syntax::parse(source, &tokens);
+        let (directives, directive_diagnostics) =
+            discover_directives(source, &tokens, &parsed.statements);
+        let (callables, callable_diagnostics) =
+            discover_callables(source, &tokens, &parsed.statements, &parsed.scopes);
         let (instructions, instruction_diagnostics) = discover_instructions(
             source,
             &masked,
@@ -93,9 +137,13 @@ impl<'source> Document<'source> {
             &parsed.statements,
             &parsed.diagnostics,
         );
-        parsed
-            .coverage
-            .add_diagnostics(instruction_diagnostics.len());
+        parsed.coverage.add_diagnostics(
+            directive_diagnostics.len()
+                + callable_diagnostics.len()
+                + instruction_diagnostics.len(),
+        );
+        parsed.diagnostics.extend(directive_diagnostics);
+        parsed.diagnostics.extend(callable_diagnostics);
         parsed.diagnostics.extend(instruction_diagnostics);
         Ok(Self {
             source,
@@ -104,6 +152,8 @@ impl<'source> Document<'source> {
             scopes: parsed.scopes,
             diagnostics: parsed.diagnostics,
             coverage: parsed.coverage,
+            directives,
+            callables,
             instructions,
         })
     }
@@ -148,8 +198,86 @@ impl<'source> Document<'source> {
         self.coverage
     }
 
+    pub fn directives(&self) -> &[Directive<'source>] {
+        &self.directives
+    }
+
+    pub fn callables(&self) -> &[Callable<'source>] {
+        &self.callables
+    }
+
     pub fn instructions(&self) -> &[Instruction<'source>] {
         &self.instructions
+    }
+}
+
+impl<'source> Directive<'source> {
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    /// Byte range covering the directive without leading indentation, trailing
+    /// comment, or newline.
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    /// Byte range covering the physical source line where the directive
+    /// begins, including its newline when present.
+    pub fn line_span(&self) -> Range<usize> {
+        self.line_span.clone()
+    }
+
+    pub fn name(&self) -> &'source str {
+        &self.source[self.name_span.clone()]
+    }
+
+    pub fn arguments(&self) -> &'source str {
+        &self.source[self.arguments_span.clone()]
+    }
+
+    pub fn arguments_span(&self) -> Range<usize> {
+        self.arguments_span.clone()
+    }
+
+    pub fn text(&self) -> &'source str {
+        &self.source[self.span.clone()]
+    }
+}
+
+impl<'source> Callable<'source> {
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    /// Scope containing the callable body, or `None` for a declaration.
+    pub fn definition_scope(&self) -> Option<ScopeId> {
+        self.definition_scope
+    }
+
+    pub fn kind(&self) -> CallableKind {
+        self.kind
+    }
+
+    /// Byte range from the first linkage directive through the callable name.
+    pub fn header_span(&self) -> Range<usize> {
+        self.header_span.clone()
+    }
+
+    pub fn name(&self) -> &'source str {
+        &self.source[self.name_span.clone()]
+    }
+
+    pub fn is_extern(&self) -> bool {
+        self.is_extern
     }
 }
 
@@ -207,6 +335,161 @@ pub fn split_top_level(source: &str) -> Option<Vec<&str>> {
         .map(|spans| spans.into_iter().map(|span| &source[span]).collect())
 }
 
+fn discover_directives<'source>(
+    source: &'source str,
+    tokens: &[Token],
+    statements: &[Statement],
+) -> (Vec<Directive<'source>>, Vec<Diagnostic>) {
+    let mut directives = Vec::new();
+    let mut diagnostics = Vec::new();
+    for statement in statements
+        .iter()
+        .filter(|statement| statement.kind() == StatementKind::Directive)
+    {
+        let significant = significant_token_indices(tokens, statement);
+        let Some(name) = significant.iter().find_map(|index| {
+            let token = &tokens[*index];
+            (token.kind() == TokenKind::Word && token.text(source).starts_with('.'))
+                .then_some(token)
+        }) else {
+            diagnostics.push(Diagnostic::new(
+                DiagnosticKind::MalformedDirective,
+                statement.span(),
+            ));
+            continue;
+        };
+        let span = statement.span();
+        directives.push(Directive {
+            source,
+            statement: statement.id(),
+            scope: statement.scope(),
+            line_span: physical_line_span(source, span.start),
+            arguments_span: trim_span(source, name.span().end..span.end),
+            name_span: name.span(),
+            span,
+        });
+    }
+    (directives, diagnostics)
+}
+
+fn discover_callables<'source>(
+    source: &'source str,
+    tokens: &[Token],
+    statements: &[Statement],
+    scopes: &[Scope],
+) -> (Vec<Callable<'source>>, Vec<Diagnostic>) {
+    let mut callables = Vec::new();
+    let mut diagnostics = Vec::new();
+    for statement in statements
+        .iter()
+        .filter(|statement| statement.kind() == StatementKind::CallableHeader)
+    {
+        let significant = significant_token_indices(tokens, statement);
+        let Some((keyword_cursor, kind)) =
+            significant.iter().enumerate().find_map(|(cursor, index)| {
+                match tokens[*index].text(source) {
+                    ".entry" => Some((cursor, CallableKind::Entry)),
+                    ".func" => Some((cursor, CallableKind::Function)),
+                    _ => None,
+                }
+            })
+        else {
+            diagnostics.push(Diagnostic::new(
+                DiagnosticKind::MalformedCallable,
+                statement.span(),
+            ));
+            continue;
+        };
+
+        let mut name_cursor = keyword_cursor + 1;
+        if kind == CallableKind::Function
+            && significant
+                .get(name_cursor)
+                .is_some_and(|index| tokens[*index].text(source) == "(")
+        {
+            let Some(after_parameters) =
+                skip_balanced_tokens(source, tokens, &significant, name_cursor, "(", ")")
+            else {
+                diagnostics.push(Diagnostic::new(
+                    DiagnosticKind::MalformedCallable,
+                    statement.span(),
+                ));
+                continue;
+            };
+            name_cursor = after_parameters;
+        }
+        let Some(name) = significant
+            .get(name_cursor)
+            .map(|index| &tokens[*index])
+            .filter(|token| token.kind() == TokenKind::Word)
+        else {
+            diagnostics.push(Diagnostic::new(
+                DiagnosticKind::MalformedCallable,
+                statement.span(),
+            ));
+            continue;
+        };
+        let definition_scope = scopes
+            .iter()
+            .find(|scope| scope.header() == Some(statement.id()))
+            .map(Scope::id);
+        callables.push(Callable {
+            source,
+            statement: statement.id(),
+            scope: statement.scope(),
+            definition_scope,
+            kind,
+            header_span: statement.span().start..name.span().end,
+            name_span: name.span(),
+            is_extern: significant[..keyword_cursor]
+                .iter()
+                .any(|index| tokens[*index].text(source) == ".extern"),
+        });
+    }
+    (callables, diagnostics)
+}
+
+fn significant_token_indices(tokens: &[Token], statement: &Statement) -> Vec<usize> {
+    statement
+        .token_range()
+        .filter(|index| !tokens[*index].kind().is_trivia())
+        .collect()
+}
+
+fn skip_balanced_tokens(
+    source: &str,
+    tokens: &[Token],
+    significant: &[usize],
+    start: usize,
+    open: &str,
+    close: &str,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    for (cursor, index) in significant.iter().enumerate().skip(start) {
+        match tokens[*index].text(source) {
+            token if token == open => depth += 1,
+            token if token == close => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(cursor + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn physical_line_span(source: &str, offset: usize) -> Range<usize> {
+    let start = source[..offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
+    let end = source[offset..]
+        .find('\n')
+        .map_or(source.len(), |newline| offset + newline + 1);
+    start..end
+}
+
 fn discover_instructions<'source>(
     source: &'source str,
     masked: &str,
@@ -245,10 +528,7 @@ fn instruction_from_statement<'source>(
     tokens: &[Token],
     statement: &Statement,
 ) -> Option<Instruction<'source>> {
-    let significant = statement
-        .token_range()
-        .filter(|index| !tokens[*index].kind().is_trivia())
-        .collect::<Vec<_>>();
+    let significant = significant_token_indices(tokens, statement);
     let mut cursor = 0usize;
     while cursor + 1 < significant.len()
         && tokens[significant[cursor]].kind() == TokenKind::Word
@@ -417,6 +697,61 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["call.uni", "ret"]
         );
+    }
+
+    #[test]
+    fn projects_directives_from_statement_nodes() {
+        let source = "  .version 8.9\n.target sm_120a, debug // generated\n";
+        let document = Document::parse(source).unwrap();
+        assert_eq!(document.directives().len(), 2);
+        let target = &document.directives()[1];
+        assert_eq!(target.name(), ".target");
+        assert_eq!(target.arguments(), "sm_120a, debug");
+        assert_eq!(target.text(), ".target sm_120a, debug");
+        assert_eq!(
+            &source[target.line_span()],
+            ".target sm_120a, debug // generated\n"
+        );
+        assert_eq!(
+            document.statement(target.statement()).unwrap().kind(),
+            StatementKind::Directive
+        );
+        assert_eq!(target.scope(), ScopeId::ROOT);
+    }
+
+    #[test]
+    fn projects_multiline_callable_headers_and_definition_scopes() {
+        let source = "\
+.visible
+.entry kernel() { ret; }
+.extern .func (.param .b32 result)
+    __nv_helper(.param .b32 input);
+.weak .func local_helper() { ret; }
+";
+        let document = Document::parse(source).unwrap();
+        assert_eq!(document.callables().len(), 3);
+        assert_eq!(document.callables()[0].name(), "kernel");
+        assert_eq!(document.callables()[0].kind(), CallableKind::Entry);
+        assert!(!document.callables()[0].is_extern());
+        assert!(document.callables()[0].definition_scope().is_some());
+        assert_eq!(document.callables()[1].name(), "__nv_helper");
+        assert_eq!(document.callables()[1].kind(), CallableKind::Function);
+        assert!(document.callables()[1].is_extern());
+        assert!(document.callables()[1].definition_scope().is_none());
+        assert_eq!(document.callables()[2].name(), "local_helper");
+        assert!(!document.callables()[2].is_extern());
+        assert!(document.callables()[2].definition_scope().is_some());
+        assert!(document.callables().iter().all(|callable| {
+            document
+                .statement(callable.statement())
+                .is_some_and(|statement| statement.kind() == StatementKind::CallableHeader)
+        }));
+    }
+
+    #[test]
+    fn retains_quoted_directive_arguments() {
+        let document = Document::parse(".file 1 \"kernel.cu\"\n").unwrap();
+        assert_eq!(document.directives()[0].arguments(), "1 \"kernel.cu\"");
     }
 
     #[test]

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -99,6 +99,16 @@ pub struct Callable<'source> {
     is_extern: bool,
 }
 
+/// A closed callable definition bound to its parsed document.
+///
+/// Binding the two prevents body-scoped queries from accepting a callable
+/// projected from another document.
+#[derive(Clone, Copy, Debug)]
+pub struct CallableDefinition<'document, 'source> {
+    document: &'document Document<'source>,
+    callable: &'document Callable<'source>,
+}
+
 /// One semicolon-terminated PTX instruction.
 ///
 /// The source text is not normalized. Predicates and same-line labels are
@@ -260,17 +270,53 @@ impl<'source> Document<'source> {
     ///
     /// PTX may contain both a declaration and a definition for a symbol, so
     /// this deliberately exposes an iterator instead of choosing one match.
-    pub fn callables_named<'document>(
+    pub fn callables_named<'document: 'query, 'query>(
         &'document self,
-        name: &'document str,
-    ) -> impl Iterator<Item = &'document Callable<'source>> + 'document {
+        name: &'query str,
+    ) -> impl Iterator<Item = &'document Callable<'source>> + 'query {
         self.callables
             .iter()
             .filter(move |callable| callable.name() == name)
     }
 
+    /// Return every closed callable definition in source order.
+    pub fn definitions(&self) -> impl Iterator<Item = CallableDefinition<'_, 'source>> {
+        self.callables
+            .iter()
+            .filter(|callable| callable.body_span.is_some())
+            .map(|callable| CallableDefinition {
+                document: self,
+                callable,
+            })
+    }
+
+    pub fn definitions_named<'document: 'query, 'query>(
+        &'document self,
+        name: &'query str,
+    ) -> impl Iterator<Item = CallableDefinition<'document, 'source>> + 'query {
+        self.definitions()
+            .filter(move |definition| definition.callable.name() == name)
+    }
+
     pub fn instructions(&self) -> &[Instruction<'source>] {
         &self.instructions
+    }
+
+    /// Return instructions fully contained by `span` in source order.
+    ///
+    /// Instructions are source-ordered, so the query finds its first possible
+    /// result with a binary search and visits only the overlapping window.
+    pub fn instructions_in(
+        &self,
+        span: Range<usize>,
+    ) -> impl Iterator<Item = &Instruction<'source>> {
+        let start = self
+            .instructions
+            .partition_point(|instruction| instruction.span.start < span.start);
+        self.instructions[start..]
+            .iter()
+            .take_while(move |instruction| instruction.span.start < span.end)
+            .filter(move |instruction| instruction.span.end <= span.end)
     }
 }
 
@@ -407,6 +453,42 @@ impl<'source> Callable<'source> {
     }
 }
 
+impl<'document, 'source> CallableDefinition<'document, 'source> {
+    pub fn callable(self) -> &'document Callable<'source> {
+        self.callable
+    }
+
+    pub fn scope(self) -> ScopeId {
+        self.callable
+            .definition_scope()
+            .expect("CallableDefinition always has a scope")
+    }
+
+    pub fn text(self) -> &'source str {
+        self.callable.text()
+    }
+
+    pub fn header_text(self) -> &'source str {
+        self.callable
+            .definition_header_text()
+            .expect("CallableDefinition always has a closed body")
+    }
+
+    pub fn body_text(self) -> &'source str {
+        self.callable
+            .body_text()
+            .expect("CallableDefinition always has a closed body")
+    }
+
+    pub fn instructions(self) -> impl Iterator<Item = &'document Instruction<'source>> + 'document {
+        self.document.instructions_in(
+            self.callable
+                .body_span()
+                .expect("CallableDefinition always has a closed body"),
+        )
+    }
+}
+
 impl<'source> Instruction<'source> {
     pub fn statement(&self) -> StatementId {
         self.statement
@@ -450,6 +532,13 @@ impl<'source> Instruction<'source> {
     /// Exact opcode and ordered modifier spelling.
     pub fn head(&self) -> &'source str {
         &self.source[self.head_span.clone()]
+    }
+
+    /// Instruction opcode without ordered modifier suffixes.
+    pub fn base_opcode(&self) -> &'source str {
+        self.head()
+            .split_once('.')
+            .map_or(self.head(), |(base, _)| base)
     }
 
     /// Top-level operands in source order.
@@ -1060,6 +1149,46 @@ mod tests {
         );
         assert!(helpers[0].definition_header_text().is_none());
         assert!(helpers[0].body_text().is_none());
+
+        let definition = document.definitions_named("kernel").next().unwrap();
+        assert_eq!(definition.callable(), kernel);
+        assert_eq!(definition.scope(), kernel.definition_scope().unwrap());
+        assert_eq!(definition.text(), kernel.text());
+        assert_eq!(
+            definition.header_text(),
+            kernel.definition_header_text().unwrap()
+        );
+        assert_eq!(definition.body_text(), kernel.body_text().unwrap());
+        assert_eq!(
+            definition
+                .instructions()
+                .map(Instruction::base_opcode)
+                .collect::<Vec<_>>(),
+            ["ret"]
+        );
+        assert_eq!(document.definitions_named("helper").count(), 0);
+        assert_eq!(document.definitions().count(), 1);
+    }
+
+    #[test]
+    fn restricts_instruction_queries_to_source_ranges() {
+        let source = ".visible .entry first() { mov.u32 %r1, 1; ret; }\n\
+.visible .entry second() { @!%p1 bra.uni done; done: exit; }\n";
+        let document = Document::parse(source).unwrap();
+        let second = document.callables_named("second").next().unwrap();
+        let instructions = document
+            .instructions_in(second.body_span().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            instructions
+                .iter()
+                .map(|instruction| instruction.head())
+                .collect::<Vec<_>>(),
+            ["bra.uni", "exit"]
+        );
+        assert_eq!(instructions[0].base_opcode(), "bra");
+        assert_eq!(instructions[1].base_opcode(), "exit");
+        assert!(document.instructions_in(10..10).next().is_none());
     }
 
     #[test]

--- a/crates/ptx-syntax/src/lib.rs
+++ b/crates/ptx-syntax/src/lib.rs
@@ -77,6 +77,42 @@ pub struct Directive<'source> {
     label_name_spans: Vec<Range<usize>>,
 }
 
+/// A typed, lossless view of one `.reg` directive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegisterDeclaration<'source> {
+    source: &'source str,
+    statement: StatementId,
+    scope: ScopeId,
+    span: Range<usize>,
+    qualifier_spans: Vec<Range<usize>>,
+    bindings: Vec<RegisterBinding<'source>>,
+}
+
+/// One scalar register or register-bank binding in a `.reg` declaration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegisterBinding<'source> {
+    source: &'source str,
+    span: Range<usize>,
+    name_span: Range<usize>,
+    bank_size: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RegisterDeclarationErrorKind {
+    MissingQualifier,
+    MissingBinding,
+    UnexpectedToken,
+    InvalidBankSize,
+}
+
+/// A `.reg` directive that cannot be interpreted without guessing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegisterDeclarationError {
+    statement: StatementId,
+    offset: usize,
+    kind: RegisterDeclarationErrorKind,
+}
+
 /// The two callable forms defined by PTX.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CallableKind {
@@ -262,6 +298,23 @@ impl<'source> Document<'source> {
         &self.directives
     }
 
+    /// Parse every `.reg` directive in source order.
+    ///
+    /// Structural parsing remains forward-compatible; consumers which need
+    /// register semantics receive an explicit error for an unfamiliar binding
+    /// grammar rather than a partial declaration.
+    pub fn register_declarations(
+        &self,
+    ) -> impl Iterator<Item = Result<RegisterDeclaration<'source>, RegisterDeclarationError>> + '_
+    {
+        self.directives
+            .iter()
+            .filter(|directive| directive.name() == ".reg")
+            .map(|directive| {
+                register_declaration_from_directive(self.source, &self.tokens, directive)
+            })
+    }
+
     pub fn callables(&self) -> &[Callable<'source>] {
         &self.callables
     }
@@ -386,6 +439,76 @@ impl<'source> Directive<'source> {
         &self.source[self.span.clone()]
     }
 }
+
+impl RegisterDeclaration<'_> {
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    pub fn qualifiers(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.qualifier_spans
+            .iter()
+            .map(|span| &self.source[span.clone()])
+    }
+
+    pub fn bindings(&self) -> &[RegisterBinding<'_>] {
+        &self.bindings
+    }
+}
+
+impl RegisterBinding<'_> {
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    /// Scalar name, or the base name of a register bank.
+    pub fn name(&self) -> &str {
+        &self.source[self.name_span.clone()]
+    }
+
+    pub fn name_span(&self) -> Range<usize> {
+        self.name_span.clone()
+    }
+
+    /// Number of concrete registers in a bank such as `%r<4>`.
+    pub fn bank_size(&self) -> Option<u32> {
+        self.bank_size
+    }
+}
+
+impl RegisterDeclarationError {
+    pub fn statement(&self) -> StatementId {
+        self.statement
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn kind(&self) -> RegisterDeclarationErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for RegisterDeclarationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "malformed PTX .reg declaration at byte {} ({:?})",
+            self.offset, self.kind
+        )
+    }
+}
+
+impl std::error::Error for RegisterDeclarationError {}
 
 impl<'source> Callable<'source> {
     pub fn statement(&self) -> StatementId {
@@ -633,6 +756,141 @@ fn discover_directives<'source>(
         });
     }
     (directives, diagnostics)
+}
+
+fn register_declaration_from_directive<'source>(
+    source: &'source str,
+    tokens: &[Token],
+    directive: &Directive<'source>,
+) -> Result<RegisterDeclaration<'source>, RegisterDeclarationError> {
+    let error = |offset, kind| RegisterDeclarationError {
+        statement: directive.statement,
+        offset,
+        kind,
+    };
+    let first_token =
+        tokens.partition_point(|token| token.span().end <= directive.arguments_span.start);
+    let significant = tokens[first_token..]
+        .iter()
+        .take_while(|token| token.span().start < directive.arguments_span.end)
+        .filter(|token| {
+            let span = token.span();
+            span.start >= directive.arguments_span.start
+                && span.end <= directive.arguments_span.end
+                && !token.kind().is_trivia()
+        })
+        .collect::<Vec<_>>();
+    let Some(semicolon) = significant.last().filter(|token| token.text(source) == ";") else {
+        return Err(error(
+            directive.arguments_span.end,
+            RegisterDeclarationErrorKind::UnexpectedToken,
+        ));
+    };
+    let body = &significant[..significant.len() - 1];
+    let mut cursor = 0;
+    let mut qualifier_spans = Vec::new();
+    while let Some(token) = body
+        .get(cursor)
+        .filter(|token| token.kind() == TokenKind::Word && token.text(source).starts_with('.'))
+    {
+        qualifier_spans.push(token.span());
+        cursor += 1;
+    }
+    if qualifier_spans.is_empty() {
+        return Err(error(
+            body.first()
+                .map_or(semicolon.span().start, |token| token.span().start),
+            RegisterDeclarationErrorKind::MissingQualifier,
+        ));
+    }
+    if cursor == body.len() {
+        return Err(error(
+            semicolon.span().start,
+            RegisterDeclarationErrorKind::MissingBinding,
+        ));
+    }
+
+    let mut bindings = Vec::new();
+    loop {
+        let Some(name) = body.get(cursor).filter(|token| {
+            token.kind() == TokenKind::Word && !token.text(source).starts_with('.')
+        }) else {
+            let offset = body
+                .get(cursor)
+                .map_or(semicolon.span().start, |token| token.span().start);
+            return Err(error(offset, RegisterDeclarationErrorKind::MissingBinding));
+        };
+        cursor += 1;
+        let mut binding_end = name.span().end;
+        let bank_size = if body
+            .get(cursor)
+            .is_some_and(|token| token.text(source) == "<")
+        {
+            let Some(size) = body.get(cursor + 1) else {
+                return Err(error(
+                    binding_end,
+                    RegisterDeclarationErrorKind::InvalidBankSize,
+                ));
+            };
+            let Some(close) = body
+                .get(cursor + 2)
+                .filter(|token| token.text(source) == ">")
+            else {
+                return Err(error(
+                    size.span().start,
+                    RegisterDeclarationErrorKind::InvalidBankSize,
+                ));
+            };
+            let size = size
+                .text(source)
+                .parse::<u32>()
+                .ok()
+                .filter(|size| *size > 0)
+                .ok_or_else(|| {
+                    error(
+                        size.span().start,
+                        RegisterDeclarationErrorKind::InvalidBankSize,
+                    )
+                })?;
+            cursor += 3;
+            binding_end = close.span().end;
+            Some(size)
+        } else {
+            None
+        };
+        bindings.push(RegisterBinding {
+            source,
+            span: name.span().start..binding_end,
+            name_span: name.span(),
+            bank_size,
+        });
+
+        match body.get(cursor).map(|token| token.text(source)) {
+            None => break,
+            Some(",") if cursor + 1 < body.len() => cursor += 1,
+            Some(",") => {
+                return Err(error(
+                    body[cursor].span().end,
+                    RegisterDeclarationErrorKind::MissingBinding,
+                ));
+            }
+            Some(_) => {
+                return Err(error(
+                    body[cursor].span().start,
+                    RegisterDeclarationErrorKind::UnexpectedToken,
+                ));
+            }
+        }
+    }
+
+    Ok(RegisterDeclaration {
+        source,
+        statement: directive.statement,
+        scope: directive.scope,
+        span: directive.span(),
+        qualifier_spans,
+        bindings,
+    })
 }
 
 fn discover_callables<'source>(
@@ -1264,6 +1522,77 @@ mod tests {
             ["{%r1, %r2}", "[%rd1, {%r3, %r4}]", "(%r5, %r6)"]
         );
         assert!(split_top_level("%r1, [%r2").is_none());
+    }
+
+    #[test]
+    fn projects_scalar_multi_binding_and_bank_register_declarations() {
+        let source = "\
+.reg .pred %p0;
+{
+    .reg .u64 dst64, mbar64;
+    .reg .v2 .b32 %pair<4>;
+}
+";
+        let document = Document::parse(source).unwrap();
+        let declarations = document
+            .register_declarations()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(declarations.len(), 3);
+        assert_eq!(declarations[0].qualifiers().collect::<Vec<_>>(), [".pred"]);
+        assert_eq!(declarations[0].bindings()[0].name(), "%p0");
+        assert_eq!(declarations[0].bindings()[0].bank_size(), None);
+        assert_eq!(
+            declarations[1]
+                .bindings()
+                .iter()
+                .map(RegisterBinding::name)
+                .collect::<Vec<_>>(),
+            ["dst64", "mbar64"]
+        );
+        assert_eq!(
+            declarations[2].qualifiers().collect::<Vec<_>>(),
+            [".v2", ".b32"]
+        );
+        assert_eq!(declarations[2].bindings()[0].name(), "%pair");
+        assert_eq!(declarations[2].bindings()[0].bank_size(), Some(4));
+        assert_eq!(&source[declarations[2].bindings()[0].span()], "%pair<4>");
+        assert_eq!(&source[declarations[2].bindings()[0].name_span()], "%pair");
+        assert_ne!(declarations[0].scope(), declarations[1].scope());
+    }
+
+    #[test]
+    fn rejects_partial_register_declaration_semantics() {
+        let source = ".reg %r0;\n.reg .b32;\n.reg .b32 %r<0>;\n.reg .b32 %r0 = 1;\n";
+        let document = Document::parse(source).unwrap();
+        let errors = document
+            .register_declarations()
+            .map(Result::unwrap_err)
+            .collect::<Vec<_>>();
+        assert_eq!(errors.len(), 4);
+        assert_eq!(
+            errors[0].kind(),
+            RegisterDeclarationErrorKind::MissingQualifier
+        );
+        assert_eq!(
+            errors[1].kind(),
+            RegisterDeclarationErrorKind::MissingBinding
+        );
+        assert_eq!(
+            errors[2].kind(),
+            RegisterDeclarationErrorKind::InvalidBankSize
+        );
+        assert_eq!(
+            errors[3].kind(),
+            RegisterDeclarationErrorKind::UnexpectedToken
+        );
+        for error in errors {
+            assert_eq!(
+                document.statement(error.statement()).unwrap().kind(),
+                StatementKind::Directive
+            );
+            assert!(error.offset() < source.len());
+        }
     }
 
     #[test]

--- a/crates/ptx-syntax/src/syntax.rs
+++ b/crates/ptx-syntax/src/syntax.rs
@@ -1,0 +1,852 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::{Token, TokenKind};
+use std::ops::Range;
+
+/// Stable index of a PTX statement in [`crate::Document::statements`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StatementId(usize);
+
+impl StatementId {
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// Stable index of a lexical PTX scope in [`crate::Document::scopes`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ScopeId(usize);
+
+impl ScopeId {
+    pub const ROOT: Self = Self(0);
+
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// The structural class of one PTX statement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatementKind {
+    Directive,
+    Instruction,
+    CallableHeader,
+    Label,
+    Preprocessor,
+    Unknown,
+}
+
+/// One PTX statement backed by exact source and token ranges.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Statement {
+    id: StatementId,
+    kind: StatementKind,
+    scope: ScopeId,
+    span: Range<usize>,
+    token_range: Range<usize>,
+}
+
+impl Statement {
+    pub fn id(&self) -> StatementId {
+        self.id
+    }
+
+    pub fn kind(&self) -> StatementKind {
+        self.kind
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    pub fn text<'source>(&self, source: &'source str) -> &'source str {
+        &source[self.span.clone()]
+    }
+
+    pub(crate) fn token_range(&self) -> Range<usize> {
+        self.token_range.clone()
+    }
+}
+
+/// One lexical scope delimited by structural braces.
+///
+/// The module root is always [`ScopeId::ROOT`] and has no opening or closing
+/// brace. An unclosed scope has no `close_span` and is accompanied by a
+/// diagnostic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Scope {
+    id: ScopeId,
+    parent: Option<ScopeId>,
+    header: Option<StatementId>,
+    span: Range<usize>,
+    open_span: Option<Range<usize>>,
+    close_span: Option<Range<usize>>,
+}
+
+impl Scope {
+    pub fn id(&self) -> ScopeId {
+        self.id
+    }
+
+    pub fn parent(&self) -> Option<ScopeId> {
+        self.parent
+    }
+
+    /// The callable or section header which immediately opened this scope.
+    pub fn header(&self) -> Option<StatementId> {
+        self.header
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    pub fn open_span(&self) -> Option<Range<usize>> {
+        self.open_span.clone()
+    }
+
+    pub fn close_span(&self) -> Option<Range<usize>> {
+        self.close_span.clone()
+    }
+
+    pub fn body_span(&self) -> Range<usize> {
+        self.open_span.as_ref().map_or(self.span.clone(), |open| {
+            open.end
+                ..self
+                    .close_span
+                    .as_ref()
+                    .map_or(self.span.end, |close| close.start)
+        })
+    }
+}
+
+/// A recoverable structural problem which did not make later byte offsets
+/// ambiguous.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Diagnostic {
+    kind: DiagnosticKind,
+    span: Range<usize>,
+}
+
+impl Diagnostic {
+    pub(crate) fn new(kind: DiagnosticKind, span: Range<usize>) -> Self {
+        Self { kind, span }
+    }
+
+    pub fn kind(&self) -> DiagnosticKind {
+        self.kind
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiagnosticKind {
+    UnknownToken,
+    UnrecognizedSyntax,
+    UnmatchedClosingDelimiter,
+    UnterminatedDelimiter,
+    UnterminatedStatement,
+    MalformedInstruction,
+}
+
+/// Byte-accounting proof for a parsed document.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Coverage {
+    source_bytes: usize,
+    token_bytes: usize,
+    non_trivia_bytes: usize,
+    recognized_bytes: usize,
+    unknown_bytes: usize,
+    diagnostic_count: usize,
+}
+
+impl Coverage {
+    pub(crate) fn add_diagnostics(&mut self, count: usize) {
+        self.diagnostic_count += count;
+    }
+
+    pub fn source_bytes(self) -> usize {
+        self.source_bytes
+    }
+
+    pub fn token_bytes(self) -> usize {
+        self.token_bytes
+    }
+
+    pub fn non_trivia_bytes(self) -> usize {
+        self.non_trivia_bytes
+    }
+
+    pub fn recognized_bytes(self) -> usize {
+        self.recognized_bytes
+    }
+
+    pub fn unknown_bytes(self) -> usize {
+        self.unknown_bytes
+    }
+
+    pub fn diagnostic_count(self) -> usize {
+        self.diagnostic_count
+    }
+
+    pub fn is_lossless(self) -> bool {
+        self.token_bytes == self.source_bytes
+    }
+
+    pub fn is_complete(self) -> bool {
+        self.is_lossless()
+            && self.recognized_bytes == self.non_trivia_bytes
+            && self.unknown_bytes == 0
+            && self.diagnostic_count == 0
+    }
+}
+
+pub(crate) struct ParsedSyntax {
+    pub statements: Vec<Statement>,
+    pub scopes: Vec<Scope>,
+    pub diagnostics: Vec<Diagnostic>,
+    pub coverage: Coverage,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Ownership {
+    Unowned,
+    Recognized,
+    Unknown,
+}
+
+pub(crate) fn parse(source: &str, tokens: &[Token]) -> ParsedSyntax {
+    let mut statements = Vec::new();
+    let mut scopes = vec![Scope {
+        id: ScopeId::ROOT,
+        parent: None,
+        header: None,
+        span: 0..source.len(),
+        open_span: None,
+        close_span: None,
+    }];
+    let mut scope_stack = vec![ScopeId::ROOT];
+    let mut diagnostics = Vec::new();
+    let mut ownership = vec![Ownership::Unowned; tokens.len()];
+    let mut next_scope_header = None;
+    let mut cursor = 0usize;
+
+    while let Some(start) = next_significant(tokens, cursor) {
+        let token = &tokens[start];
+        match token.kind() {
+            TokenKind::Preprocessor => {
+                next_scope_header = None;
+                push_statement(
+                    source,
+                    tokens,
+                    &mut statements,
+                    &mut ownership,
+                    StatementKind::Preprocessor,
+                    *scope_stack.last().expect("the root scope remains open"),
+                    start..start + 1,
+                );
+                cursor = start + 1;
+                continue;
+            }
+            TokenKind::Unknown => {
+                next_scope_header = None;
+                push_statement(
+                    source,
+                    tokens,
+                    &mut statements,
+                    &mut ownership,
+                    StatementKind::Unknown,
+                    *scope_stack.last().expect("the root scope remains open"),
+                    start..start + 1,
+                );
+                diagnostics.push(Diagnostic {
+                    kind: DiagnosticKind::UnknownToken,
+                    span: token.span(),
+                });
+                cursor = start + 1;
+                continue;
+            }
+            TokenKind::Punctuation if token.text(source) == "{" => {
+                ownership[start] = Ownership::Recognized;
+                let id = ScopeId(scopes.len());
+                let open_span = token.span();
+                scopes.push(Scope {
+                    id,
+                    parent: scope_stack.last().copied(),
+                    header: next_scope_header.take(),
+                    span: open_span.start..source.len(),
+                    open_span: Some(open_span),
+                    close_span: None,
+                });
+                scope_stack.push(id);
+                cursor = start + 1;
+                continue;
+            }
+            TokenKind::Punctuation if token.text(source) == "}" => {
+                next_scope_header = None;
+                if scope_stack.len() == 1 {
+                    push_statement(
+                        source,
+                        tokens,
+                        &mut statements,
+                        &mut ownership,
+                        StatementKind::Unknown,
+                        ScopeId::ROOT,
+                        start..start + 1,
+                    );
+                    diagnostics.push(Diagnostic {
+                        kind: DiagnosticKind::UnmatchedClosingDelimiter,
+                        span: token.span(),
+                    });
+                } else {
+                    ownership[start] = Ownership::Recognized;
+                    let scope = scope_stack.pop().expect("a non-root scope is open");
+                    let close_span = token.span();
+                    scopes[scope.index()].span.end = close_span.end;
+                    scopes[scope.index()].close_span = Some(close_span);
+                }
+                cursor = start + 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        let outcome = scan_item(source, tokens, start);
+        let token_range = if outcome.end == start {
+            start..start + 1
+        } else {
+            start..outcome.end
+        };
+        let kind = if outcome.end == start {
+            StatementKind::Unknown
+        } else {
+            classify(source, tokens, token_range.clone(), outcome.terminator)
+        };
+        let id = push_statement(
+            source,
+            tokens,
+            &mut statements,
+            &mut ownership,
+            kind,
+            *scope_stack.last().expect("the root scope remains open"),
+            token_range,
+        );
+        let span = statements[id.index()].span();
+        if kind == StatementKind::Unknown {
+            diagnostics.push(Diagnostic {
+                kind: outcome
+                    .diagnostic
+                    .unwrap_or(DiagnosticKind::UnrecognizedSyntax),
+                span,
+            });
+        } else if let Some(kind) = outcome.diagnostic {
+            diagnostics.push(Diagnostic { kind, span });
+        }
+        next_scope_header = (outcome.terminator == Terminator::Brace).then_some(id);
+        cursor = outcome.end.max(start + 1);
+    }
+
+    for scope in scope_stack.into_iter().skip(1) {
+        let open = scopes[scope.index()]
+            .open_span
+            .as_ref()
+            .expect("only non-root scopes remain unclosed");
+        diagnostics.push(Diagnostic {
+            kind: DiagnosticKind::UnterminatedDelimiter,
+            span: open.start..source.len(),
+        });
+    }
+
+    let token_bytes = tokens.iter().map(|token| token.span().len()).sum();
+    let non_trivia_bytes = tokens
+        .iter()
+        .filter(|token| !token.kind().is_trivia())
+        .map(|token| token.span().len())
+        .sum();
+    let recognized_bytes = tokens
+        .iter()
+        .zip(&ownership)
+        .filter(|(token, owner)| !token.kind().is_trivia() && **owner == Ownership::Recognized)
+        .map(|(token, _)| token.span().len())
+        .sum();
+    let unknown_bytes = non_trivia_bytes - recognized_bytes;
+    let diagnostic_count = diagnostics.len();
+
+    debug_assert!(
+        tokens
+            .iter()
+            .zip(&ownership)
+            .all(|(token, owner)| { token.kind().is_trivia() || *owner != Ownership::Unowned })
+    );
+
+    ParsedSyntax {
+        statements,
+        scopes,
+        diagnostics,
+        coverage: Coverage {
+            source_bytes: source.len(),
+            token_bytes,
+            non_trivia_bytes,
+            recognized_bytes,
+            unknown_bytes,
+            diagnostic_count,
+        },
+    }
+}
+
+fn push_statement(
+    source: &str,
+    tokens: &[Token],
+    statements: &mut Vec<Statement>,
+    ownership: &mut [Ownership],
+    kind: StatementKind,
+    scope: ScopeId,
+    token_range: Range<usize>,
+) -> StatementId {
+    let id = StatementId(statements.len());
+    let owner = if kind == StatementKind::Unknown {
+        Ownership::Unknown
+    } else {
+        Ownership::Recognized
+    };
+    for index in token_range.clone() {
+        if !tokens[index].kind().is_trivia() {
+            debug_assert_eq!(ownership[index], Ownership::Unowned);
+            ownership[index] = owner;
+        }
+    }
+    let span = tokens[token_range.start].span().start..tokens[token_range.end - 1].span().end;
+    debug_assert!(source.is_char_boundary(span.start) && source.is_char_boundary(span.end));
+    statements.push(Statement {
+        id,
+        kind,
+        scope,
+        span,
+        token_range,
+    });
+    id
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Terminator {
+    Semicolon,
+    Line,
+    Brace,
+    ScopeClose,
+    EndOfFile,
+    Recovery,
+}
+
+struct ScanOutcome {
+    end: usize,
+    terminator: Terminator,
+    diagnostic: Option<DiagnosticKind>,
+}
+
+fn scan_item(source: &str, tokens: &[Token], start: usize) -> ScanOutcome {
+    let mut cursor = start;
+    let mut delimiters = Vec::new();
+    let mut last_significant = start;
+
+    while cursor < tokens.len() {
+        let token = &tokens[cursor];
+        if token.kind().is_trivia() {
+            if delimiters.is_empty()
+                && token.text(source).contains('\n')
+                && should_end_at_line(source, tokens, start..cursor)
+            {
+                return ScanOutcome {
+                    end: last_significant + 1,
+                    terminator: Terminator::Line,
+                    diagnostic: None,
+                };
+            }
+            cursor += 1;
+            continue;
+        }
+        last_significant = cursor;
+
+        if token.kind() == TokenKind::Preprocessor && cursor != start {
+            return ScanOutcome {
+                end: cursor,
+                terminator: Terminator::Recovery,
+                diagnostic: Some(DiagnosticKind::UnterminatedStatement),
+            };
+        }
+        if token.kind() == TokenKind::Unknown {
+            return ScanOutcome {
+                end: cursor + 1,
+                terminator: Terminator::Recovery,
+                diagnostic: Some(DiagnosticKind::UnknownToken),
+            };
+        }
+
+        if token.kind() == TokenKind::Punctuation {
+            match token.text(source) {
+                ";" => {
+                    return ScanOutcome {
+                        end: cursor + 1,
+                        terminator: Terminator::Semicolon,
+                        diagnostic: (!delimiters.is_empty())
+                            .then_some(DiagnosticKind::UnterminatedDelimiter),
+                    };
+                }
+                "{" if delimiters.is_empty() && is_braced_header(source, tokens, start..cursor) => {
+                    return ScanOutcome {
+                        end: cursor,
+                        terminator: Terminator::Brace,
+                        diagnostic: None,
+                    };
+                }
+                "{" => delimiters.push("}"),
+                "[" => delimiters.push("]"),
+                "(" => delimiters.push(")"),
+                "}" | "]" | ")" => {
+                    if delimiters.last().copied() == Some(token.text(source)) {
+                        delimiters.pop();
+                    } else if delimiters.is_empty() && token.text(source) == "}" {
+                        return ScanOutcome {
+                            end: cursor,
+                            terminator: Terminator::ScopeClose,
+                            diagnostic: None,
+                        };
+                    } else {
+                        return ScanOutcome {
+                            end: cursor + 1,
+                            terminator: Terminator::Recovery,
+                            diagnostic: Some(DiagnosticKind::UnmatchedClosingDelimiter),
+                        };
+                    }
+                }
+                _ => {}
+            }
+        }
+        cursor += 1;
+    }
+
+    ScanOutcome {
+        end: last_significant + 1,
+        terminator: Terminator::EndOfFile,
+        diagnostic: (!delimiters.is_empty()).then_some(DiagnosticKind::UnterminatedDelimiter),
+    }
+}
+
+fn classify(
+    source: &str,
+    tokens: &[Token],
+    range: Range<usize>,
+    terminator: Terminator,
+) -> StatementKind {
+    let significant = significant_indices(tokens, range.clone());
+    let Some(mut cursor) = skip_labels(source, tokens, &significant, 0) else {
+        return StatementKind::Unknown;
+    };
+    if cursor == significant.len() {
+        return if matches!(terminator, Terminator::Line | Terminator::ScopeClose) {
+            StatementKind::Label
+        } else {
+            StatementKind::Unknown
+        };
+    }
+
+    if token_is(source, tokens, significant[cursor], "@") {
+        cursor += 1;
+        if cursor < significant.len() && token_is(source, tokens, significant[cursor], "!") {
+            cursor += 1;
+        }
+        if cursor >= significant.len() || tokens[significant[cursor]].kind() != TokenKind::Word {
+            return StatementKind::Unknown;
+        }
+        cursor += 1;
+    }
+    let Some(head) = significant.get(cursor).map(|index| &tokens[*index]) else {
+        return StatementKind::Unknown;
+    };
+    if head.kind() != TokenKind::Word {
+        return StatementKind::Unknown;
+    }
+    let head = head.text(source);
+    if head.starts_with('.') {
+        if contains_callable_keyword(source, tokens, range) {
+            StatementKind::CallableHeader
+        } else {
+            StatementKind::Directive
+        }
+    } else if terminator == Terminator::Semicolon && is_instruction_head(head) {
+        StatementKind::Instruction
+    } else {
+        StatementKind::Unknown
+    }
+}
+
+fn should_end_at_line(source: &str, tokens: &[Token], range: Range<usize>) -> bool {
+    let significant = significant_indices(tokens, range.clone());
+    if significant.is_empty() {
+        return false;
+    }
+    if skip_labels(source, tokens, &significant, 0) == Some(significant.len()) {
+        return true;
+    }
+    if contains_scope_header_keyword(source, tokens, range) {
+        return false;
+    }
+    let words = significant
+        .iter()
+        .filter(|index| tokens[**index].kind() == TokenKind::Word)
+        .map(|index| tokens[*index].text(source))
+        .collect::<Vec<_>>();
+    let Some(first) = words.first() else {
+        return false;
+    };
+    if !first.starts_with('.') {
+        return false;
+    }
+    if words.iter().all(|word| is_linkage_prefix(word)) {
+        return false;
+    }
+    !words.iter().any(|word| requires_semicolon(word))
+}
+
+fn is_braced_header(source: &str, tokens: &[Token], range: Range<usize>) -> bool {
+    contains_scope_header_keyword(source, tokens, range)
+}
+
+fn contains_scope_header_keyword(source: &str, tokens: &[Token], range: Range<usize>) -> bool {
+    significant_indices(tokens, range).into_iter().any(|index| {
+        tokens[index].kind() == TokenKind::Word
+            && matches!(tokens[index].text(source), ".entry" | ".func" | ".section")
+    })
+}
+
+fn contains_callable_keyword(source: &str, tokens: &[Token], range: Range<usize>) -> bool {
+    significant_indices(tokens, range).into_iter().any(|index| {
+        tokens[index].kind() == TokenKind::Word
+            && matches!(tokens[index].text(source), ".entry" | ".func")
+    })
+}
+
+fn is_linkage_prefix(word: &str) -> bool {
+    matches!(word, ".visible" | ".extern" | ".weak" | ".common")
+}
+
+fn requires_semicolon(word: &str) -> bool {
+    matches!(
+        word,
+        ".reg"
+            | ".sreg"
+            | ".const"
+            | ".global"
+            | ".local"
+            | ".param"
+            | ".shared"
+            | ".tex"
+            | ".surf"
+            | ".branchtargets"
+            | ".calltargets"
+            | ".callprototype"
+            | ".pragma"
+    )
+}
+
+fn skip_labels(
+    source: &str,
+    tokens: &[Token],
+    significant: &[usize],
+    mut cursor: usize,
+) -> Option<usize> {
+    while cursor + 1 < significant.len()
+        && tokens[significant[cursor]].kind() == TokenKind::Word
+        && token_is(source, tokens, significant[cursor + 1], ":")
+        && (cursor + 2 == significant.len()
+            || !token_is(source, tokens, significant[cursor + 2], ":"))
+    {
+        cursor += 2;
+    }
+    if cursor < significant.len() && token_is(source, tokens, significant[cursor], ":") {
+        None
+    } else {
+        Some(cursor)
+    }
+}
+
+fn significant_indices(tokens: &[Token], range: Range<usize>) -> Vec<usize> {
+    range
+        .filter(|index| !tokens[*index].kind().is_trivia())
+        .collect()
+}
+
+fn next_significant(tokens: &[Token], cursor: usize) -> Option<usize> {
+    (cursor..tokens.len()).find(|index| !tokens[*index].kind().is_trivia())
+}
+
+fn token_is(source: &str, tokens: &[Token], index: usize, expected: &str) -> bool {
+    tokens[index].text(source) == expected
+}
+
+fn is_instruction_head(head: &str) -> bool {
+    head.as_bytes()
+        .first()
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer;
+
+    fn parse_source(source: &str) -> ParsedSyntax {
+        let tokens = lexer::lex(source).unwrap();
+        parse(source, &tokens)
+    }
+
+    #[test]
+    fn classifies_multiline_headers_statements_and_scopes() {
+        let parsed = parse_source(
+            ".version 8.7\n.target sm_90\n.visible\n.entry kernel(\n.param .u64 p\n)\n{\nL0:\n@%p0 bra L0;\nret;\n}\n",
+        );
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(|statement| statement.kind)
+                .collect::<Vec<_>>(),
+            [
+                StatementKind::Directive,
+                StatementKind::Directive,
+                StatementKind::CallableHeader,
+                StatementKind::Label,
+                StatementKind::Instruction,
+                StatementKind::Instruction,
+            ]
+        );
+        assert_eq!(parsed.scopes.len(), 2);
+        let body = &parsed.scopes[1];
+        assert_eq!(body.parent(), Some(ScopeId::ROOT));
+        assert_eq!(body.header(), Some(StatementId(2)));
+        assert_eq!(
+            parsed.statements[3..]
+                .iter()
+                .map(Statement::scope)
+                .collect::<Vec<_>>(),
+            [ScopeId(1), ScopeId(1), ScopeId(1)]
+        );
+        assert!(parsed.diagnostics.is_empty());
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn keeps_initializer_and_operand_braces_inside_statements() {
+        let parsed =
+            parse_source(".global .u32 table[2] = {\n1, 2\n};\nmov.u32 {%r1, %r2}, {%r3, %r4};");
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(|statement| statement.kind)
+                .collect::<Vec<_>>(),
+            [StatementKind::Directive, StatementKind::Instruction]
+        );
+        assert_eq!(parsed.scopes.len(), 1);
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn associates_a_multiline_section_header_with_its_scope() {
+        let parsed = parse_source(".section .debug_info\n{\n.b8 1\n}\n");
+        assert_eq!(parsed.statements[0].kind(), StatementKind::Directive);
+        assert_eq!(parsed.scopes[1].header(), Some(parsed.statements[0].id()));
+        assert_eq!(parsed.statements[1].scope(), parsed.scopes[1].id());
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn makes_recovery_and_unknown_coverage_observable() {
+        let parsed = parse_source("mov.u32 %r1, [oops;\nret;");
+        assert_eq!(parsed.statements[0].kind, StatementKind::Instruction);
+        assert_eq!(parsed.statements[1].kind, StatementKind::Instruction);
+        assert_eq!(
+            parsed.diagnostics[0].kind,
+            DiagnosticKind::UnterminatedDelimiter
+        );
+        assert!(parsed.coverage.is_lossless());
+        assert!(!parsed.coverage.is_complete());
+        assert_eq!(parsed.coverage.unknown_bytes(), 0);
+        assert_eq!(parsed.coverage.diagnostic_count(), 1);
+    }
+
+    #[test]
+    fn recovers_labels_after_same_line_semicolons() {
+        let parsed = parse_source("mov.u32 %r0, 1; L1: add.u32 %r1, %r0, 1;");
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(|statement| statement.kind)
+                .collect::<Vec<_>>(),
+            [StatementKind::Instruction, StatementKind::Instruction]
+        );
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn accepts_a_label_immediately_before_a_scope_close() {
+        let parsed = parse_source("{ bra DONE; DONE: }");
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(|statement| statement.kind)
+                .collect::<Vec<_>>(),
+            [StatementKind::Instruction, StatementKind::Label]
+        );
+        assert_eq!(parsed.scopes.len(), 2);
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn does_not_confuse_double_colon_modifiers_with_labels() {
+        let parsed = parse_source(
+            "L0: tcgen05.wait::ld.sync.aligned;\nmapa.shared::cluster.u64 %rd1, %rd2, %r3;",
+        );
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(|statement| statement.kind)
+                .collect::<Vec<_>>(),
+            [StatementKind::Instruction, StatementKind::Instruction]
+        );
+        assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn diagnoses_unbalanced_structural_scopes() {
+        let unmatched = parse_source("}\nret;");
+        assert_eq!(unmatched.statements[0].kind, StatementKind::Unknown);
+        assert_eq!(
+            unmatched.diagnostics[0].kind,
+            DiagnosticKind::UnmatchedClosingDelimiter
+        );
+        assert!(unmatched.coverage.unknown_bytes() > 0);
+        assert!(!unmatched.coverage.is_complete());
+
+        let unterminated = parse_source(".entry kernel() {\nret;");
+        assert_eq!(
+            unterminated.diagnostics[0].kind,
+            DiagnosticKind::UnterminatedDelimiter
+        );
+        assert_eq!(unterminated.scopes.len(), 2);
+        assert!(unterminated.scopes[1].close_span().is_none());
+        assert!(!unterminated.coverage.is_complete());
+    }
+}

--- a/crates/ptx-syntax/src/syntax.rs
+++ b/crates/ptx-syntax/src/syntax.rs
@@ -156,6 +156,8 @@ pub enum DiagnosticKind {
     UnmatchedClosingDelimiter,
     UnterminatedDelimiter,
     UnterminatedStatement,
+    MalformedDirective,
+    MalformedCallable,
     MalformedInstruction,
 }
 
@@ -461,15 +463,24 @@ fn scan_item(source: &str, tokens: &[Token], start: usize) -> ScanOutcome {
     while cursor < tokens.len() {
         let token = &tokens[cursor];
         if token.kind().is_trivia() {
-            if delimiters.is_empty()
-                && token.text(source).contains('\n')
-                && should_end_at_line(source, tokens, start..cursor)
-            {
-                return ScanOutcome {
-                    end: last_significant + 1,
-                    terminator: Terminator::Line,
-                    diagnostic: None,
-                };
+            if token.text(source).contains('\n') {
+                if delimiters.is_empty() && should_end_at_line(source, tokens, start..cursor) {
+                    return ScanOutcome {
+                        end: last_significant + 1,
+                        terminator: Terminator::Line,
+                        diagnostic: None,
+                    };
+                }
+                if !delimiters.is_empty()
+                    && next_significant(tokens, cursor + 1)
+                        .is_some_and(|next| starts_callable_header(source, tokens, next))
+                {
+                    return ScanOutcome {
+                        end: last_significant + 1,
+                        terminator: Terminator::Recovery,
+                        diagnostic: Some(DiagnosticKind::UnterminatedDelimiter),
+                    };
+                }
             }
             cursor += 1;
             continue;
@@ -635,6 +646,28 @@ fn contains_callable_keyword(source: &str, tokens: &[Token], range: Range<usize>
     })
 }
 
+fn starts_callable_header(source: &str, tokens: &[Token], start: usize) -> bool {
+    let mut cursor = start;
+    while let Some(token) = tokens.get(cursor) {
+        if token.kind().is_trivia() {
+            if token.text(source).contains('\n') {
+                return false;
+            }
+            cursor += 1;
+            continue;
+        }
+        if token.kind() != TokenKind::Word {
+            return false;
+        }
+        match token.text(source) {
+            ".entry" | ".func" => return true,
+            word if is_linkage_prefix(word) => cursor += 1,
+            _ => return false,
+        }
+    }
+    false
+}
+
 fn is_linkage_prefix(word: &str) -> bool {
     matches!(word, ".visible" | ".extern" | ".weak" | ".common")
 }
@@ -796,6 +829,36 @@ mod tests {
             [StatementKind::Instruction, StatementKind::Instruction]
         );
         assert!(parsed.coverage.is_complete());
+    }
+
+    #[test]
+    fn recovers_a_truncated_callable_at_the_next_header() {
+        let parsed = parse_source(
+            ".visible .entry kernel(\n.extern .func helper(\n.extern .func final();\n",
+        );
+        assert_eq!(
+            parsed
+                .statements
+                .iter()
+                .map(Statement::kind)
+                .collect::<Vec<_>>(),
+            [
+                StatementKind::CallableHeader,
+                StatementKind::CallableHeader,
+                StatementKind::CallableHeader,
+            ]
+        );
+        assert_eq!(
+            parsed
+                .diagnostics
+                .iter()
+                .map(Diagnostic::kind)
+                .collect::<Vec<_>>(),
+            [
+                DiagnosticKind::UnterminatedDelimiter,
+                DiagnosticKind::UnterminatedDelimiter,
+            ]
+        );
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/examples/const_generic/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/const_generic/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -164,6 +165,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -364,6 +366,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/const_generic/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/const_generic/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/const_generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_generic/src/main.rs
@@ -68,30 +68,27 @@ fn specialization_names() -> [&'static str; 5] {
     ]
 }
 
-fn entry_body<'a>(ptx: &'a str, name: &str) -> &'a str {
-    let start_marker = format!(".visible .entry {name}(");
-    let start = ptx
-        .find(&start_marker)
-        .unwrap_or_else(|| panic!("missing PTX entry `{name}`"));
-    let rest = &ptx[start..];
-    let end = rest
-        .find("\n}")
-        .unwrap_or_else(|| panic!("unterminated PTX entry `{name}`"));
-    &rest[..end]
+fn entry_body<'source>(document: &ptx_syntax::Document<'source>, name: &str) -> &'source str {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .unwrap_or_else(|| panic!("missing or incomplete PTX entry `{name}`"))
 }
 
 fn verify_generated_ptx() {
     let ptx = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/const_generic.ptx"))
         .expect("read const_generic.ptx; run `cargo oxide build const_generic` first");
+    let document = ptx_syntax::Document::parse(&ptx).expect("parse generated PTX");
     let [value_4, value_8, unused_4, unused_8, name_only_4] = specialization_names();
 
     assert_ne!(value_4, value_8);
     assert_ne!(unused_4, unused_8);
-    let body_4 = entry_body(&ptx, value_4);
-    let body_8 = entry_body(&ptx, value_8);
-    let _unused_body_4 = entry_body(&ptx, unused_4);
-    let _unused_body_8 = entry_body(&ptx, unused_8);
-    let _name_only_body_4 = entry_body(&ptx, name_only_4);
+    let body_4 = entry_body(&document, value_4);
+    let body_8 = entry_body(&document, value_8);
+    let _unused_body_4 = entry_body(&document, unused_4);
+    let _unused_body_8 = entry_body(&document, unused_8);
+    let _name_only_body_4 = entry_body(&document, name_only_4);
     assert!(body_4.contains(".maxntid 64, 1, 1"));
     assert!(body_8.contains(".maxntid 64, 1, 1"));
     assert!(

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "cuda-device",
  "cuda-host",
  "kernel-lib",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -165,6 +166,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -374,6 +376,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/Cargo.toml
@@ -16,3 +16,4 @@ kernel-lib = { path = "kernel-lib" }
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/cross_crate_kernel/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cross_crate_kernel/src/main.rs
@@ -76,12 +76,14 @@ fn verify_generated_ptx() {
     let ptx = std::str::from_utf8(ptx)
         .expect("embedded PTX payload is not valid UTF-8")
         .trim_end_matches('\0');
+    let document = ptx_syntax::Document::parse(ptx).expect("parse embedded PTX");
 
     for name in specialization_names() {
-        let entry = format!(".visible .entry {name}(");
         assert!(
-            ptx.contains(&entry),
-            "missing cross-crate PTX entry `{name}`"
+            document.callables_named(name).any(|callable| {
+                callable.kind() == ptx_syntax::CallableKind::Entry && callable.body_text().is_some()
+            }),
+            "missing or incomplete cross-crate PTX entry `{name}`"
         );
     }
 }

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -176,6 +177,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -364,6 +366,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cuda_module_contract/src/main.rs
@@ -331,6 +331,7 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let ptx_path =
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("cuda_module_contract.ptx");
     let ptx = std::fs::read_to_string(&ptx_path)?;
+    let document = ptx_syntax::Document::parse(&ptx)?;
     let aligned_symbol = ".extern .shared .align 128 .b8 __dynamic_smem_aligned_dynamic_shared[];";
     if !ptx.contains(aligned_symbol) {
         return Err(format!(
@@ -375,12 +376,13 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
         ("helper_contract_256", ".reqntid 32, 1, 1"),
         ("explicit_aligned_u32", ".reqntid 32, 1, 1"),
     ] {
-        verify_entry_geometry(&ptx, &format!(".visible .entry {entry}("), entry, geometry)?;
+        verify_entry_geometry(&document, entry, false, entry, geometry)?;
     }
 
     verify_entry_geometry(
-        &ptx,
-        ".visible .entry generic_aligned_TID_",
+        &document,
+        "generic_aligned_TID_",
+        true,
         "generic_aligned specialization",
         ".reqntid 64, 1, 1",
     )?;
@@ -398,19 +400,26 @@ fn verify_launch_contract_ptx() -> Result<(), Box<dyn std::error::Error>> {
 /// maximum. Every kernel here declares `#[launch_bounds]`, so this is the case
 /// that would regress if the exporter stopped suppressing one of them.
 fn verify_entry_geometry(
-    ptx: &str,
-    anchor: &str,
+    document: &ptx_syntax::Document<'_>,
+    symbol: &str,
+    match_prefix: bool,
     entry: &str,
     expected: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let start = ptx
-        .find(anchor)
-        .ok_or_else(|| format!("missing PTX entry {entry}"))?;
-    let rest = &ptx[start..];
-    let end = rest[1..]
-        .find(".visible .entry ")
-        .map_or(rest.len(), |offset| offset + 1);
-    let body = &rest[..end];
+    let definition = document
+        .callables()
+        .iter()
+        .find(|callable| {
+            callable.body_text().is_some()
+                && callable.kind() == ptx_syntax::CallableKind::Entry
+                && if match_prefix {
+                    callable.name().starts_with(symbol)
+                } else {
+                    callable.name() == symbol
+                }
+        })
+        .ok_or_else(|| format!("missing or incomplete PTX entry {entry}"))?;
+    let body = definition.text();
 
     if !body.contains(expected) {
         return Err(format!("PTX entry {entry} lost its launch geometry `{expected}`").into());

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -205,6 +206,7 @@ dependencies = [
  "cuda-device",
  "cuda-host",
  "half",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -365,6 +367,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/Cargo.toml
@@ -16,3 +16,4 @@ cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }
 half = "2.4"
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
@@ -522,36 +522,29 @@ fn can_execute_tcgen05_ptx(major: i32, minor: i32) -> bool {
 
 fn verify_tcgen05_ptx_contract(ptx: &str) -> Result<(), String> {
     const TARGETS: [&str; 8] = [
-        ".target sm_100a",
-        ".target sm_101a",
-        ".target sm_103a",
-        ".target sm_110a",
-        ".target sm_100f",
-        ".target sm_101f",
-        ".target sm_103f",
-        ".target sm_110f",
+        "sm_100a", "sm_101a", "sm_103a", "sm_110a", "sm_100f", "sm_101f", "sm_103f", "sm_110f",
     ];
     const ENTRIES: [&str; 2] = [
-        ".visible .entry gemm_sol_clc_multicast_4_stage_pipeline(",
-        ".visible .entry gemm_sol_clc_multicast_4_stage_pipeline_large(",
+        "gemm_sol_clc_multicast_4_stage_pipeline",
+        "gemm_sol_clc_multicast_4_stage_pipeline_large",
     ];
 
-    let has_target = ptx.lines().map(str::trim).any(|line| {
-        TARGETS.iter().any(|target| {
-            line == *target
-                || line
-                    .strip_prefix(target)
-                    .is_some_and(|suffix| suffix.starts_with(','))
-        })
+    let document = ptx_syntax::Document::parse(ptx).map_err(|error| error.to_string())?;
+    let has_target = document.directives().iter().any(|directive| {
+        directive.name() == ".target"
+            && directive
+                .arguments()
+                .split(',')
+                .next()
+                .is_some_and(|target| TARGETS.contains(&target.trim()))
     });
     if !has_target {
         return Err("missing a supported datacenter tcgen05 target".to_string());
     }
     for entry in ENTRIES {
-        if !ptx
-            .lines()
-            .map(str::trim_start)
-            .any(|line| line.starts_with(entry))
+        if !document
+            .callables_named(entry)
+            .any(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
         {
             return Err(format!("missing expected kernel entry `{entry}`"));
         }

--- a/crates/rustc-codegen-cuda/examples/gemm_views/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -204,6 +205,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -364,6 +366,10 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/gemm_views/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-core = { path = "../../../cuda-core" }
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
@@ -747,6 +747,7 @@ fn max_abs_diff(x: &[f32], y: &[f32]) -> f32 {
 fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("gemm_views.ptx");
     let ptx = std::fs::read_to_string(&path)?;
+    let document = ptx_syntax::Document::parse(&ptx)?;
 
     for marker in [
         "__launch_contract_config",
@@ -761,10 +762,10 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let safe_naive = entry_body(&ptx, "sgemm_naive_views")?;
-    let raw_naive = entry_body(&ptx, "sgemm_naive_raw")?;
-    let safe_tiled = entry_body(&ptx, "sgemm_tiled_views")?;
-    let raw_tiled = entry_body(&ptx, "sgemm_tiled_raw")?;
+    let safe_naive = entry_body(&document, "sgemm_naive_views")?;
+    let raw_naive = entry_body(&document, "sgemm_naive_raw")?;
+    let safe_tiled = entry_body(&document, "sgemm_tiled_views")?;
+    let raw_tiled = entry_body(&document, "sgemm_tiled_raw")?;
 
     for (name, body) in [
         ("sgemm_naive_views", safe_naive),
@@ -832,19 +833,15 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn entry_body<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
-    let start = ptx
-        .find(&format!(".visible .entry {name}("))
-        .ok_or_else(|| format!("missing PTX entry `{name}`"))?;
-    let rest = &ptx[start..];
-    let open = rest
-        .find('{')
-        .ok_or_else(|| format!("PTX entry `{name}` has no body"))?;
-    let close = rest[open + 1..]
-        .find("\n}")
-        .map(|offset| open + 1 + offset + 2)
-        .ok_or_else(|| format!("PTX entry `{name}` has no closing brace"))?;
-    Ok(&rest[..close])
+fn entry_body<'source>(
+    document: &ptx_syntax::Document<'source>,
+    name: &str,
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
 fn trap_count(body: &str) -> usize {

--- a/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/src/main.rs
@@ -762,17 +762,18 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let safe_naive = entry_body(&document, "sgemm_naive_views")?;
-    let raw_naive = entry_body(&document, "sgemm_naive_raw")?;
-    let safe_tiled = entry_body(&document, "sgemm_tiled_views")?;
-    let raw_tiled = entry_body(&document, "sgemm_tiled_raw")?;
+    let safe_naive = entry(&document, "sgemm_naive_views")?;
+    let raw_naive = entry(&document, "sgemm_naive_raw")?;
+    let safe_tiled = entry(&document, "sgemm_tiled_views")?;
+    let raw_tiled = entry(&document, "sgemm_tiled_raw")?;
 
-    for (name, body) in [
+    for (name, definition) in [
         ("sgemm_naive_views", safe_naive),
         ("sgemm_naive_raw", raw_naive),
         ("sgemm_tiled_views", safe_tiled),
         ("sgemm_tiled_raw", raw_tiled),
     ] {
+        let body = definition.text();
         // These kernels declare `block = (16, 16, 1)`, so the exact shape
         // reaches the device compiler as `.reqntid` and the driver rejects any
         // other block on any axis. A thread maximum cannot express this shape:
@@ -787,10 +788,10 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
                 format!("{name} declares both .maxntid and .reqntid, which ptxas rejects").into(),
             );
         }
-        verify_no_calls(name, body)?;
+        verify_no_calls(name, definition)?;
         // Every bounds fact is proven through sentinel scalar checks; nothing
         // in these kernels may lower to a panic trap.
-        let traps = trap_count(body);
+        let traps = trap_count(definition);
         if traps != 0 {
             return Err(format!("{name} contains {traps} trap instructions").into());
         }
@@ -814,10 +815,11 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
     // The tiled pair must actually stage through shared memory and keep the
     // same global-memory traffic as the raw twin.
-    for (name, body) in [
+    for (name, definition) in [
         ("sgemm_tiled_views", safe_tiled),
         ("sgemm_tiled_raw", raw_tiled),
     ] {
+        let body = definition.text();
         for operation in ["ld.shared", "st.shared"] {
             if !body.contains(operation) {
                 return Err(format!("{name} has no {operation} traffic").into());
@@ -833,44 +835,40 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn entry_body<'source>(
-    document: &ptx_syntax::Document<'source>,
+fn entry<'document, 'source>(
+    document: &'document ptx_syntax::Document<'source>,
     name: &str,
-) -> Result<&'source str, Box<dyn std::error::Error>> {
+) -> Result<ptx_syntax::CallableDefinition<'document, 'source>, Box<dyn std::error::Error>> {
     document
-        .callables_named(name)
-        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
-        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .definitions_named(name)
+        .find(|definition| definition.callable().kind() == ptx_syntax::CallableKind::Entry)
         .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
-fn trap_count(body: &str) -> usize {
-    body.lines()
-        .filter(|line| {
-            line.split_whitespace()
-                .any(|word| word == "trap;" || word == "trap")
+fn trap_count(definition: ptx_syntax::CallableDefinition<'_, '_>) -> usize {
+    definition
+        .instructions()
+        .filter(|instruction| instruction.base_opcode() == "trap")
+        .count()
+}
+
+fn conditional_branches(definition: ptx_syntax::CallableDefinition<'_, '_>) -> usize {
+    definition
+        .instructions()
+        .filter(|instruction| {
+            instruction.base_opcode() == "bra" && instruction.predicate().is_some()
         })
         .count()
 }
 
-fn conditional_branches(body: &str) -> usize {
-    body.lines()
-        .filter(|line| line.trim_start().starts_with('@') && is_branch_instruction(line))
-        .count()
-}
-
-fn is_branch_instruction(line: &str) -> bool {
-    line.split_whitespace()
-        .any(|word| word == "bra" || word.starts_with("bra."))
-}
-
-fn is_call_instruction(line: &str) -> bool {
-    line.split_whitespace()
-        .any(|word| word == "call" || word.starts_with("call."))
-}
-
-fn verify_no_calls(name: &str, body: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if body.lines().any(is_call_instruction) {
+fn verify_no_calls(
+    name: &str,
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if definition
+        .instructions()
+        .any(|instruction| instruction.base_opcode() == "call")
+    {
         return Err(format!("{name} contains an out-of-line device call").into());
     }
     Ok(())
@@ -878,8 +876,8 @@ fn verify_no_calls(name: &str, body: &str) -> Result<(), Box<dyn std::error::Err
 
 fn compare_memory_operations(
     pair: &str,
-    safe: &str,
-    raw: &str,
+    safe: ptx_syntax::CallableDefinition<'_, '_>,
+    raw: ptx_syntax::CallableDefinition<'_, '_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for operation in ["ld", "st"] {
         let safe_ops = data_memory_operations(safe, operation);
@@ -897,21 +895,26 @@ fn compare_memory_operations(
     Ok(())
 }
 
-fn data_memory_operations(body: &str, operation: &str) -> Vec<String> {
-    let mut operations: Vec<String> = body
-        .lines()
-        .filter_map(|line| data_memory_operation(line, operation))
+fn data_memory_operations(
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+    operation: &str,
+) -> Vec<String> {
+    let mut operations: Vec<String> = definition
+        .instructions()
+        .filter_map(|instruction| data_memory_operation(instruction, operation))
         .collect();
     operations.sort();
     operations
 }
 
-fn data_memory_operation(line: &str, operation: &str) -> Option<String> {
-    let prefix = format!("{operation}.");
-    let mnemonic = line
-        .split_whitespace()
-        .find(|word| word.starts_with(&prefix))?
-        .trim_end_matches([';', ',']);
+fn data_memory_operation(
+    instruction: &ptx_syntax::Instruction<'_>,
+    operation: &str,
+) -> Option<String> {
+    if instruction.base_opcode() != operation {
+        return None;
+    }
+    let mnemonic = instruction.head();
     if mnemonic.contains(".param.") || mnemonic.contains(".shared.") || mnemonic.contains(".local.")
     {
         return None;
@@ -925,17 +928,30 @@ mod tests {
 
     #[test]
     fn ptx_parser_counts_traps_branches_and_data_operations() {
-        let body = "@%p1 bra $L__BB0_2;\n\
+        let ptx = ".visible .entry test() {\n\
+                    @%p1 bra $L__BB0_2;\n\
                     ld.global.f32 %f1, [%rd1];\n\
                     ld.shared.f32 %f2, [%r1];\n\
                     st.global.f32 [%rd2], %f3;\n\
                     trap;\n\
                     @!%p2 bra.uni $L__BB0_3;\n\
-                    call.uni helper;";
-        assert_eq!(trap_count(body), 1);
-        assert_eq!(conditional_branches(body), 2);
-        assert!(body.lines().any(is_call_instruction));
-        assert_eq!(data_memory_operations(body, "ld"), vec!["ld.global.f32"]);
-        assert_eq!(data_memory_operations(body, "st"), vec!["st.global.f32"]);
+                    call.uni helper;\n}";
+        let document = ptx_syntax::Document::parse(ptx).unwrap();
+        let definition = entry(&document, "test").unwrap();
+        assert_eq!(trap_count(definition), 1);
+        assert_eq!(conditional_branches(definition), 2);
+        assert!(
+            definition
+                .instructions()
+                .any(|instruction| instruction.base_opcode() == "call")
+        );
+        assert_eq!(
+            data_memory_operations(definition, "ld"),
+            vec!["ld.global.f32"]
+        );
+        assert_eq!(
+            data_memory_operations(definition, "st"),
+            vec!["st.global.f32"]
+        );
     }
 }

--- a/crates/rustc-codegen-cuda/examples/policy_config/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/policy_config/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -344,6 +345,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]
@@ -364,6 +366,10 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/policy_config/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/policy_config/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-core = { path = "../../../cuda-core" }
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/policy_config/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/policy_config/src/main.rs
@@ -98,16 +98,12 @@ fn specialization_names() -> [&'static str; 2] {
     ]
 }
 
-fn entry_body<'a>(ptx: &'a str, name: &str) -> &'a str {
-    let start_marker = format!(".visible .entry {name}(");
-    let start = ptx
-        .find(&start_marker)
-        .unwrap_or_else(|| panic!("missing PTX entry `{name}`"));
-    let rest = &ptx[start..];
-    let end = rest
-        .find("\n}")
-        .unwrap_or_else(|| panic!("unterminated PTX entry `{name}`"));
-    &rest[..end]
+fn entry_body<'source>(document: &ptx_syntax::Document<'source>, name: &str) -> &'source str {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .unwrap_or_else(|| panic!("missing or incomplete PTX entry `{name}`"))
 }
 
 fn is_generic_entry_name(name: &str) -> bool {
@@ -185,6 +181,7 @@ fn verify_generated_ptx() {
         .expect("read policy_config.ll; run `cargo oxide build policy_config` first");
     let ptx = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/policy_config.ptx"))
         .expect("read policy_config.ptx; run `cargo oxide build policy_config` first");
+    let document = ptx_syntax::Document::parse(&ptx).expect("parse generated PTX");
     for marker in ["__launch_bounds_config", "__unroll_config"] {
         assert!(
             !ptx.contains(marker),
@@ -217,8 +214,8 @@ fn verify_generated_ptx() {
     verify_raw_unroll_factor::<SmallTilePolicy>(&llvm_ir);
     verify_raw_unroll_factor::<WideTilePolicy>(&llvm_ir);
 
-    let small = entry_body(&ptx, small_name);
-    let wide = entry_body(&ptx, wide_name);
+    let small = entry_body(&document, small_name);
+    let wide = entry_body(&document, wide_name);
     assert!(small.contains(".maxntid 64, 1, 1"), "{small}");
     assert!(small.contains(".minnctapersm 2"), "{small}");
     assert!(wide.contains(".maxntid 256, 1, 1"), "{wide}");

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -363,7 +364,12 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
+
+[[package]]
+name = "ptx-syntax"
+version = "0.1.0"
 
 [[package]]
 name = "quote"

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-core = { path = "../../../cuda-core" }
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
@@ -310,6 +310,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("proof_carrying_views.ptx");
     let ptx = std::fs::read_to_string(&path)?;
+    let document = ptx_syntax::Document::parse(&ptx)?;
 
     for marker in [
         "__launch_contract_config",
@@ -324,13 +325,13 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let safe_element = entry_body(&ptx, "safe_element")?;
-    let raw_element = entry_body(&ptx, "raw_element")?;
-    let safe_tile = entry_body(&ptx, "safe_tile")?;
-    let raw_tile = entry_body(&ptx, "raw_tile")?;
-    let legacy_rank_guard = entry_body(&ptx, "legacy_rank_guard")?;
-    let safe_epilogue = entry_body(&ptx, "safe_epilogue")?;
-    let raw_epilogue = entry_body(&ptx, "raw_epilogue")?;
+    let safe_element = entry_body(&document, "safe_element")?;
+    let raw_element = entry_body(&document, "raw_element")?;
+    let safe_tile = entry_body(&document, "safe_tile")?;
+    let raw_tile = entry_body(&document, "raw_tile")?;
+    let legacy_rank_guard = entry_body(&document, "legacy_rank_guard")?;
+    let safe_epilogue = entry_body(&document, "safe_epilogue")?;
+    let raw_epilogue = entry_body(&document, "raw_epilogue")?;
 
     for (name, body) in [
         ("safe_element", safe_element),
@@ -449,19 +450,15 @@ fn data_memory_operation(line: &str, operation: &str) -> Option<String> {
     Some(mnemonic.to_owned())
 }
 
-fn entry_body<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
-    let start = ptx
-        .find(&format!(".visible .entry {name}("))
-        .ok_or_else(|| format!("missing PTX entry `{name}`"))?;
-    let rest = &ptx[start..];
-    let open = rest
-        .find('{')
-        .ok_or_else(|| format!("PTX entry `{name}` has no body"))?;
-    let close = rest[open + 1..]
-        .find("\n}")
-        .map(|offset| open + 1 + offset + 2)
-        .ok_or_else(|| format!("PTX entry `{name}` has no closing brace"))?;
-    Ok(&rest[..close])
+fn entry_body<'source>(
+    document: &ptx_syntax::Document<'source>,
+    name: &str,
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
 /// A kernel declaring an exact `block` in its launch contract carries that

--- a/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/proof_carrying_views/src/main.rs
@@ -325,24 +325,25 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let safe_element = entry_body(&document, "safe_element")?;
-    let raw_element = entry_body(&document, "raw_element")?;
-    let safe_tile = entry_body(&document, "safe_tile")?;
-    let raw_tile = entry_body(&document, "raw_tile")?;
-    let legacy_rank_guard = entry_body(&document, "legacy_rank_guard")?;
-    let safe_epilogue = entry_body(&document, "safe_epilogue")?;
-    let raw_epilogue = entry_body(&document, "raw_epilogue")?;
+    let safe_element = entry(&document, "safe_element")?;
+    let raw_element = entry(&document, "raw_element")?;
+    let safe_tile = entry(&document, "safe_tile")?;
+    let raw_tile = entry(&document, "raw_tile")?;
+    let legacy_rank_guard = entry(&document, "legacy_rank_guard")?;
+    let safe_epilogue = entry(&document, "safe_epilogue")?;
+    let raw_epilogue = entry(&document, "raw_epilogue")?;
 
-    for (name, body) in [
+    for (name, definition) in [
         ("safe_element", safe_element),
         ("raw_element", raw_element),
         ("safe_tile", safe_tile),
         ("raw_tile", raw_tile),
     ] {
+        let body = definition.text();
         verify_exact_block(name, body, ".reqntid 64, 1, 1")?;
         verify_u32_coordinates(name, body)?;
-        verify_no_calls(name, body)?;
-        let branches = conditional_branches(body);
+        verify_no_calls(name, definition)?;
+        let branches = conditional_branches(definition);
         let expected_branches = 1;
         if branches != expected_branches {
             return Err(format!(
@@ -350,7 +351,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
             )
             .into());
         }
-        verify_no_interior_branches(name, body)?;
+        verify_no_interior_branches(name, definition)?;
     }
 
     compare_memory_widths("element", safe_element, raw_element)?;
@@ -359,22 +360,23 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     compare_memory_operations("tile", safe_tile, raw_tile)?;
     verify_legacy_rank_guard(legacy_rank_guard)?;
 
-    for (name, body) in [
+    for (name, definition) in [
         ("safe_epilogue", safe_epilogue),
         ("raw_epilogue", raw_epilogue),
     ] {
+        let body = definition.text();
         // A 2-D contract records its real shape. A thread maximum bounds the
         // product alone, so its per-axis fields would claim one thread on Y
         // for a block that has eight.
         verify_exact_block(name, body, ".reqntid 8, 8, 1")?;
         verify_u32_coordinates(name, body)?;
-        verify_no_calls(name, body)?;
+        verify_no_calls(name, definition)?;
         for register in ["%ctaid.y", "%ntid.y", "%tid.y"] {
             if !body.contains(register) {
                 return Err(format!("{name} does not read {register}").into());
             }
         }
-        verify_no_interior_branches(name, body)?;
+        verify_no_interior_branches(name, definition)?;
     }
     let safe_epilogue_branches = conditional_branches(safe_epilogue);
     let raw_epilogue_branches = conditional_branches(raw_epilogue);
@@ -391,20 +393,24 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn verify_legacy_rank_guard(body: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn verify_legacy_rank_guard(
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let body = definition.text();
     for register in ["%ntid.y", "%nctaid.y", "%ntid.z", "%nctaid.z"] {
         if !body.contains(register) {
             return Err(format!("legacy 1D witness does not validate {register}").into());
         }
     }
-    let first_store = body
-        .lines()
-        .position(|line| data_memory_width(line, "st").is_some())
+    let instructions = definition.instructions().collect::<Vec<_>>();
+    let first_store = instructions
+        .iter()
+        .position(|instruction| data_memory_width(instruction, "st").is_some())
         .ok_or("legacy rank-guard entry has no data store")?;
-    if !body.lines().take(first_store).any(|line| {
-        let line = line.trim_start();
-        line.starts_with("@%p") && line.split_whitespace().any(|word| word == "bra")
-    }) {
+    if !instructions[..first_store]
+        .iter()
+        .any(|instruction| instruction.base_opcode() == "bra" && instruction.predicate().is_some())
+    {
         return Err("legacy 1D store is not dominated by a rank guard".into());
     }
     Ok(())
@@ -412,8 +418,8 @@ fn verify_legacy_rank_guard(body: &str) -> Result<(), Box<dyn std::error::Error>
 
 fn compare_memory_operations(
     pair: &str,
-    safe: &str,
-    raw: &str,
+    safe: ptx_syntax::CallableDefinition<'_, '_>,
+    raw: ptx_syntax::CallableDefinition<'_, '_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for operation in ["ld", "st"] {
         let safe_ops = data_memory_operations(safe, operation);
@@ -428,21 +434,26 @@ fn compare_memory_operations(
     Ok(())
 }
 
-fn data_memory_operations(body: &str, operation: &str) -> Vec<String> {
-    let mut operations: Vec<String> = body
-        .lines()
-        .filter_map(|line| data_memory_operation(line, operation))
+fn data_memory_operations(
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+    operation: &str,
+) -> Vec<String> {
+    let mut operations: Vec<String> = definition
+        .instructions()
+        .filter_map(|instruction| data_memory_operation(instruction, operation))
         .collect();
     operations.sort();
     operations
 }
 
-fn data_memory_operation(line: &str, operation: &str) -> Option<String> {
-    let prefix = format!("{operation}.");
-    let mnemonic = line
-        .split_whitespace()
-        .find(|word| word.starts_with(&prefix))?
-        .trim_end_matches([';', ',']);
+fn data_memory_operation(
+    instruction: &ptx_syntax::Instruction<'_>,
+    operation: &str,
+) -> Option<String> {
+    if instruction.base_opcode() != operation {
+        return None;
+    }
+    let mnemonic = instruction.head();
     if mnemonic.contains(".param.") || mnemonic.contains(".shared.") || mnemonic.contains(".local.")
     {
         return None;
@@ -450,14 +461,13 @@ fn data_memory_operation(line: &str, operation: &str) -> Option<String> {
     Some(mnemonic.to_owned())
 }
 
-fn entry_body<'source>(
-    document: &ptx_syntax::Document<'source>,
+fn entry<'document, 'source>(
+    document: &'document ptx_syntax::Document<'source>,
     name: &str,
-) -> Result<&'source str, Box<dyn std::error::Error>> {
+) -> Result<ptx_syntax::CallableDefinition<'document, 'source>, Box<dyn std::error::Error>> {
     document
-        .callables_named(name)
-        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
-        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .definitions_named(name)
+        .find(|definition| definition.callable().kind() == ptx_syntax::CallableKind::Entry)
         .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
@@ -501,38 +511,40 @@ fn verify_u32_coordinates(name: &str, body: &str) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
-fn conditional_branches(body: &str) -> usize {
-    body.lines()
-        .filter(|line| line.trim_start().starts_with('@') && is_branch_instruction(line))
+fn conditional_branches(definition: ptx_syntax::CallableDefinition<'_, '_>) -> usize {
+    definition
+        .instructions()
+        .filter(|instruction| {
+            instruction.base_opcode() == "bra" && instruction.predicate().is_some()
+        })
         .count()
 }
 
-fn verify_no_calls(name: &str, body: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if body.lines().any(is_call_instruction) {
+fn verify_no_calls(
+    name: &str,
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if definition
+        .instructions()
+        .any(|instruction| instruction.base_opcode() == "call")
+    {
         return Err(format!("{name} contains an out-of-line device call").into());
     }
     Ok(())
 }
 
-fn is_call_instruction(line: &str) -> bool {
-    line.split_whitespace()
-        .any(|word| word == "call" || word.starts_with("call."))
-}
-
-fn is_branch_instruction(line: &str) -> bool {
-    line.split_whitespace()
-        .any(|word| word == "bra" || word.starts_with("bra."))
-}
-
-fn verify_no_interior_branches(name: &str, body: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let lines: Vec<&str> = body.lines().collect();
-    let first_load = lines
+fn verify_no_interior_branches(
+    name: &str,
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let instructions = definition.instructions().collect::<Vec<_>>();
+    let first_load = instructions
         .iter()
-        .position(|line| data_memory_width(line, "ld").is_some())
+        .position(|instruction| data_memory_width(instruction, "ld").is_some())
         .ok_or_else(|| format!("{name} has no data load"))?;
-    if lines[first_load..]
+    if instructions[first_load..]
         .iter()
-        .any(|line| is_branch_instruction(line))
+        .any(|instruction| instruction.base_opcode() == "bra")
     {
         return Err(format!("{name} repeats a bounds branch inside its proven data range").into());
     }
@@ -541,8 +553,8 @@ fn verify_no_interior_branches(name: &str, body: &str) -> Result<(), Box<dyn std
 
 fn compare_memory_widths(
     pair: &str,
-    safe: &str,
-    raw: &str,
+    safe: ptx_syntax::CallableDefinition<'_, '_>,
+    raw: ptx_syntax::CallableDefinition<'_, '_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for operation in ["ld", "st"] {
         let safe_widths = data_memory_widths(safe, operation);
@@ -560,21 +572,23 @@ fn compare_memory_widths(
     Ok(())
 }
 
-fn data_memory_widths(body: &str, operation: &str) -> Vec<String> {
-    let mut widths: Vec<String> = body
-        .lines()
-        .filter_map(|line| data_memory_width(line, operation))
+fn data_memory_widths(
+    definition: ptx_syntax::CallableDefinition<'_, '_>,
+    operation: &str,
+) -> Vec<String> {
+    let mut widths: Vec<String> = definition
+        .instructions()
+        .filter_map(|instruction| data_memory_width(instruction, operation))
         .collect();
     widths.sort();
     widths
 }
 
-fn data_memory_width(line: &str, operation: &str) -> Option<String> {
-    let prefix = format!("{operation}.");
-    let mnemonic = line
-        .split_whitespace()
-        .find(|word| word.starts_with(&prefix))?
-        .trim_end_matches([';', ',']);
+fn data_memory_width(instruction: &ptx_syntax::Instruction<'_>, operation: &str) -> Option<String> {
+    if instruction.base_opcode() != operation {
+        return None;
+    }
+    let mnemonic = instruction.head();
     if mnemonic.contains(".param.") || mnemonic.contains(".shared.") || mnemonic.contains(".local.")
     {
         return None;
@@ -597,9 +611,20 @@ mod tests {
 
     #[test]
     fn ptx_control_flow_parser_handles_suffixes_and_inverted_predicates() {
-        let ptx = "@!%p1 bra L1;\n@%p2 bra.uni L2;\nbra.uni L3;\ncall.uni helper;";
-        assert_eq!(conditional_branches(ptx), 2);
-        assert!(is_branch_instruction("bra.uni L3;"));
-        assert!(is_call_instruction("call.uni helper;"));
+        let ptx = ".visible .entry test() {\n\
+                   @!%p1 bra L1;\n@%p2 bra.uni L2;\nbra.uni L3;\ncall.uni helper;\n}";
+        let document = ptx_syntax::Document::parse(ptx).unwrap();
+        let definition = entry(&document, "test").unwrap();
+        assert_eq!(conditional_branches(definition), 2);
+        assert!(
+            definition
+                .instructions()
+                .any(|instruction| instruction.head() == "bra.uni")
+        );
+        assert!(
+            definition
+                .instructions()
+                .any(|instruction| instruction.head() == "call.uni")
+        );
     }
 }

--- a/crates/rustc-codegen-cuda/examples/repr_transparent_abi/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/repr_transparent_abi/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -357,6 +358,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptx-syntax"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +406,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]

--- a/crates/rustc-codegen-cuda/examples/repr_transparent_abi/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/repr_transparent_abi/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
@@ -79,24 +79,23 @@ mod kernels {
     }
 }
 
-fn entry_header<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
-    let marker = format!(".visible .entry {name}(");
-    let start = ptx
-        .find(&marker)
-        .ok_or_else(|| format!("missing PTX entry `{name}`"))?;
-    let rest = &ptx[start..];
-    let end = rest
-        .find('{')
-        .ok_or_else(|| format!("unterminated PTX entry header `{name}`"))?;
-    Ok(&rest[..end])
+fn entry_header<'source>(
+    document: &ptx_syntax::Document<'source>,
+    name: &str,
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(ptx_syntax::Callable::definition_header_text)
+        .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
 fn require_scalar_header(
-    ptx: &str,
+    document: &ptx_syntax::Document<'_>,
     name: &str,
     scalar_token: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let header = entry_header(ptx, name)?;
+    let header = entry_header(document, name)?;
     if header.contains(".b8") {
         return Err(
             format!("kernel `{name}` still exposes an aggregate PTX parameter:\n{header}").into(),
@@ -114,14 +113,15 @@ fn require_scalar_header(
 fn verify_generated_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("repr_transparent_abi.ptx");
     let ptx = std::fs::read_to_string(&path)?;
+    let document = ptx_syntax::Document::parse(&ptx)?;
 
-    require_scalar_header(&ptx, "scalar", ".param .u32")?;
-    require_scalar_header(&ptx, "pointer", ".param .u64")?;
-    require_scalar_header(&ptx, "marked", ".param .u32")?;
-    require_scalar_header(&ptx, "nested", ".param .u32")?;
-    require_scalar_header(&ptx, "uniform", ".param .u32")?;
+    require_scalar_header(&document, "scalar", ".param .u32")?;
+    require_scalar_header(&document, "pointer", ".param .u64")?;
+    require_scalar_header(&document, "marked", ".param .u32")?;
+    require_scalar_header(&document, "nested", ".param .u32")?;
+    require_scalar_header(&document, "uniform", ".param .u32")?;
 
-    let ordinary = entry_header(&ptx, "ordinary")?;
+    let ordinary = entry_header(&document, "ordinary")?;
     if !ordinary.contains(".b8") {
         return Err(format!(
             "ordinary one-field struct was incorrectly scalarized at the kernel boundary:\n{ordinary}"

--- a/crates/rustc-codegen-cuda/examples/unchecked_indexing/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/unchecked_indexing/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -357,6 +358,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptx-syntax"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +481,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]

--- a/crates/rustc-codegen-cuda/examples/unchecked_indexing/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/unchecked_indexing/Cargo.toml
@@ -22,3 +22,4 @@ cuda-host = { path = "../../../cuda-host" }
 
 # Host-side CUDA runtime
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
@@ -284,8 +284,8 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         return Err("compile-time marker `__unchecked_indexing_config` leaked into PTX".into());
     }
 
-    let checked = entry_body(&document, "indexed_sum_checked")?;
-    let unchecked = entry_body(&document, "indexed_sum_unchecked")?;
+    let checked = entry(&document, "indexed_sum_checked")?;
+    let unchecked = entry(&document, "indexed_sum_unchecked")?;
 
     // Default behavior: the checked kernel keeps its bounds checks, meaning
     // at least one trap block plus a guarded branch that jumps around/into it.
@@ -309,7 +309,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     // Generic opted kernel: the entry wrapper (named `scaled_gather_TID_<hash>`
     // by the generic-kernel naming scheme) carries the marker, so its entry
     // must contain zero traps.
-    let gather = entry_body_by_prefix(&document, "scaled_gather")?;
+    let gather = entry_by_prefix(&document, "scaled_gather")?;
     let gather_traps = count_traps(gather);
     if gather_traps != 0 {
         return Err(format!(
@@ -322,7 +322,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     // user-named implementation helper, which rustc MIR-inlines into the
     // caller. The helper body must not carry the elision marker, so the
     // caller's own (and the inlined helper's) bounds checks must survive.
-    let caller = entry_body(&document, "gather_then_check")?;
+    let caller = entry(&document, "gather_then_check")?;
     let caller_traps = count_traps(caller);
     if caller_traps == 0 {
         return Err(
@@ -344,54 +344,52 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn entry_body<'source>(
-    document: &ptx_syntax::Document<'source>,
+fn entry<'document, 'source>(
+    document: &'document ptx_syntax::Document<'source>,
     name: &str,
-) -> Result<&'source str, Box<dyn std::error::Error>> {
-    entry_body_from(
+) -> Result<ptx_syntax::CallableDefinition<'document, 'source>, Box<dyn std::error::Error>> {
+    entry_from(
         document
-            .callables_named(name)
-            .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry),
+            .definitions_named(name)
+            .find(|definition| definition.callable().kind() == ptx_syntax::CallableKind::Entry),
         name,
     )
 }
 
-/// Like [`entry_body`], but matches on an entry-name prefix. Generic kernel
+/// Like [`entry`], but matches on an entry-name prefix. Generic kernel
 /// entries are exported as `<name>_TID_<hex32>`, where the hash depends on
 /// the concrete instantiation.
-fn entry_body_by_prefix<'source>(
-    document: &ptx_syntax::Document<'source>,
+fn entry_by_prefix<'document, 'source>(
+    document: &'document ptx_syntax::Document<'source>,
     prefix: &str,
-) -> Result<&'source str, Box<dyn std::error::Error>> {
-    entry_body_from(
-        document.callables().iter().find(|callable| {
-            callable.kind() == ptx_syntax::CallableKind::Entry
-                && callable.name().starts_with(prefix)
+) -> Result<ptx_syntax::CallableDefinition<'document, 'source>, Box<dyn std::error::Error>> {
+    entry_from(
+        document.definitions().find(|definition| {
+            definition.callable().kind() == ptx_syntax::CallableKind::Entry
+                && definition.callable().name().starts_with(prefix)
         }),
         prefix,
     )
 }
 
-fn entry_body_from<'source>(
-    callable: Option<&ptx_syntax::Callable<'source>>,
+fn entry_from<'document, 'source>(
+    definition: Option<ptx_syntax::CallableDefinition<'document, 'source>>,
     name: &str,
-) -> Result<&'source str, Box<dyn std::error::Error>> {
-    callable
-        .and_then(|callable| callable.body_text().map(|_| callable.text()))
-        .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
+) -> Result<ptx_syntax::CallableDefinition<'document, 'source>, Box<dyn std::error::Error>> {
+    definition.ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
-fn count_traps(body: &str) -> usize {
-    body.lines()
-        .filter(|line| line.trim_start().starts_with("trap;"))
+fn count_traps(definition: ptx_syntax::CallableDefinition<'_, '_>) -> usize {
+    definition
+        .instructions()
+        .filter(|instruction| instruction.base_opcode() == "trap")
         .count()
 }
 
 /// A predicated branch such as `@%p1 bra $L__BB0_4;`, the shape of a bounds
 /// guard (and of the `get_mut` Option branch).
-fn has_guarded_branch(body: &str) -> bool {
-    body.lines().any(|line| {
-        let line = line.trim_start();
-        line.starts_with("@%p") && line.split_whitespace().any(|word| word == "bra")
-    })
+fn has_guarded_branch(definition: ptx_syntax::CallableDefinition<'_, '_>) -> bool {
+    definition
+        .instructions()
+        .any(|instruction| instruction.base_opcode() == "bra" && instruction.predicate().is_some())
 }

--- a/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
@@ -276,6 +276,7 @@ fn main() {
 fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("unchecked_indexing.ptx");
     let ptx = std::fs::read_to_string(&path)?;
+    let document = ptx_syntax::Document::parse(&ptx)?;
 
     // The compiler marker must never survive into the generated module,
     // neither as a call nor as a stray declaration.
@@ -283,8 +284,8 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
         return Err("compile-time marker `__unchecked_indexing_config` leaked into PTX".into());
     }
 
-    let checked = entry_body(&ptx, "indexed_sum_checked")?;
-    let unchecked = entry_body(&ptx, "indexed_sum_unchecked")?;
+    let checked = entry_body(&document, "indexed_sum_checked")?;
+    let unchecked = entry_body(&document, "indexed_sum_unchecked")?;
 
     // Default behavior: the checked kernel keeps its bounds checks, meaning
     // at least one trap block plus a guarded branch that jumps around/into it.
@@ -308,7 +309,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     // Generic opted kernel: the entry wrapper (named `scaled_gather_TID_<hash>`
     // by the generic-kernel naming scheme) carries the marker, so its entry
     // must contain zero traps.
-    let gather = entry_body_by_prefix(&ptx, "scaled_gather")?;
+    let gather = entry_body_by_prefix(&document, "scaled_gather")?;
     let gather_traps = count_traps(gather);
     if gather_traps != 0 {
         return Err(format!(
@@ -321,7 +322,7 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     // user-named implementation helper, which rustc MIR-inlines into the
     // caller. The helper body must not carry the elision marker, so the
     // caller's own (and the inlined helper's) bounds checks must survive.
-    let caller = entry_body(&ptx, "gather_then_check")?;
+    let caller = entry_body(&document, "gather_then_check")?;
     let caller_traps = count_traps(caller);
     if caller_traps == 0 {
         return Err(
@@ -343,37 +344,41 @@ fn verify_ptx() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn entry_body<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
-    entry_body_from(ptx, &format!(".visible .entry {name}("), name)
+fn entry_body<'source>(
+    document: &ptx_syntax::Document<'source>,
+    name: &str,
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    entry_body_from(
+        document
+            .callables_named(name)
+            .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry),
+        name,
+    )
 }
 
 /// Like [`entry_body`], but matches on an entry-name prefix. Generic kernel
 /// entries are exported as `<name>_TID_<hex32>`, where the hash depends on
 /// the concrete instantiation.
-fn entry_body_by_prefix<'a>(
-    ptx: &'a str,
+fn entry_body_by_prefix<'source>(
+    document: &ptx_syntax::Document<'source>,
     prefix: &str,
-) -> Result<&'a str, Box<dyn std::error::Error>> {
-    entry_body_from(ptx, &format!(".visible .entry {prefix}"), prefix)
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    entry_body_from(
+        document.callables().iter().find(|callable| {
+            callable.kind() == ptx_syntax::CallableKind::Entry
+                && callable.name().starts_with(prefix)
+        }),
+        prefix,
+    )
 }
 
-fn entry_body_from<'a>(
-    ptx: &'a str,
-    needle: &str,
+fn entry_body_from<'source>(
+    callable: Option<&ptx_syntax::Callable<'source>>,
     name: &str,
-) -> Result<&'a str, Box<dyn std::error::Error>> {
-    let start = ptx
-        .find(needle)
-        .ok_or_else(|| format!("missing PTX entry `{name}`"))?;
-    let rest = &ptx[start..];
-    let open = rest
-        .find('{')
-        .ok_or_else(|| format!("PTX entry `{name}` has no body"))?;
-    let close = rest[open + 1..]
-        .find("\n}")
-        .map(|offset| open + 1 + offset + 2)
-        .ok_or_else(|| format!("PTX entry `{name}` has no closing brace"))?;
-    Ok(&rest[..close])
+) -> Result<&'source str, Box<dyn std::error::Error>> {
+    callable
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .ok_or_else(|| format!("missing or incomplete PTX entry `{name}`").into())
 }
 
 fn count_traps(body: &str) -> usize {

--- a/crates/rustc-codegen-cuda/examples/vectorization/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/vectorization/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cuda-core",
  "cuda-macros",
  "half",
+ "ptx-syntax",
  "sha2",
  "thiserror",
 ]
@@ -357,6 +358,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptx-syntax"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +476,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "ptx-syntax",
 ]
 
 [[package]]

--- a/crates/rustc-codegen-cuda/examples/vectorization/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/vectorization/Cargo.toml
@@ -22,3 +22,4 @@ cuda-host = { path = "../../../cuda-host" }
 
 # Host-side CUDA runtime
 cuda-core = { path = "../../../cuda-core" }
+ptx-syntax = { path = "../../../ptx-syntax" }

--- a/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/vectorization/src/main.rs
@@ -235,12 +235,13 @@ fn main() {
     }
 
     if let Some(ptx) = &ptx {
+        let document = ptx_syntax::Document::parse(ptx).expect("parse embedded PTX");
         println!(
             "{:<11} {:<14} {:>4} {:>5}  {:<22} vectorized",
             "rust", "cuda", "size", "align", "ptx load"
         );
         for r in &rows {
-            let body = kernel_body(ptx, r.kernel);
+            let body = kernel_body(&document, r.kernel);
             let load = first_mem_op(body);
             let vectorized =
                 load.contains(".v2.") || load.contains(".v4.") || load.contains(".v8.");
@@ -267,7 +268,7 @@ fn main() {
         // The in-kernel `as_vectors::<F32x4>` view over a flat `&[f32]` parameter
         // must reach the same 128-bit transactions as the over-aligned parameter
         // types above: this is the checked-view path the `vector` module ships.
-        let view_body = kernel_body(ptx, "f32x4_view_copy");
+        let view_body = kernel_body(&document, "f32x4_view_copy");
         for dir in ["ld", "st"] {
             match find_128bit_global(view_body, dir) {
                 Some(line) => println!("f32x4_view_copy: {line}"),
@@ -335,14 +336,13 @@ fn embedded_ptx_text() -> Option<String> {
     )
 }
 
-/// PTX text of a `.visible .entry <name>` kernel, header to closing `}`.
-fn kernel_body<'a>(ptx: &'a str, name: &str) -> &'a str {
-    let start = ptx
-        .find(&format!(".visible .entry {name}("))
-        .unwrap_or_else(|| panic!("kernel `{name}` not found in PTX"));
-    let body = &ptx[start..];
-    let end = body.find("\n}").map_or(body.len(), |e| e + 2);
-    &body[..end]
+/// PTX text of a `.entry <name>` kernel, header through closing brace.
+fn kernel_body<'source>(document: &ptx_syntax::Document<'source>, name: &str) -> &'source str {
+    document
+        .callables_named(name)
+        .find(|callable| callable.kind() == ptx_syntax::CallableKind::Entry)
+        .and_then(|callable| callable.body_text().map(|_| callable.text()))
+        .unwrap_or_else(|| panic!("kernel `{name}` not found or incomplete in PTX"))
 }
 
 /// First 128-bit vector global memory op of direction `dir` (`ld`/`st`) in a


### PR DESCRIPTION
## Summary

- expose exact opcode and top-level operand byte spans from structured instructions
- preserve the exact predicate-register span alongside its parsed spelling
- keep text and span iterators aligned for semantic consumers and edit planning

## Stack

14/18 — depends on #906. The commit introduced by this PR is 05324e62.

## Validation

- cargo +nightly-2026-04-03 test -p ptx-syntax
- cargo +nightly-2026-04-03 clippy -p ptx-syntax --all-targets -- -D warnings
- cargo +nightly-2026-04-03 test --workspace --locked --offline


