### PR TITLE
perf(mir-importer): promote struct array constants

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -6572,13 +6572,13 @@ fn struct_layout_matches_llvm_natural(
             continue;
         }
         let offset = field_offsets[decl_idx];
-        if offset % align != 0 || offset < end {
+        if !offset.is_multiple_of(align) || offset < end {
             return false;
         }
         end = offset + size;
         max_align = max_align.max(align);
     }
-    total_size >= end && total_size % max_align == 0
+    total_size >= end && total_size.is_multiple_of(max_align)
 }
 
 /// Natural size and alignment of the LLVM storage a dialect type converts to,

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -6421,13 +6421,13 @@ pub(crate) fn emit_promoted_immutable_global(
 /// bare-array value admission: an unpromotable bare value can fall back to
 /// element-wise materialization, while a pointer-to-array constant cannot.
 ///
-/// Admits primitive scalars, enums carrying no payload, tuples whose every field
-/// is itself admissible, and nested arrays of any of those. `ty` is the array
-/// type, and nesting is walked so an unsupported leaf cannot hide inside it. A
-/// zero-length array passes for any element type: its
-/// initializer is empty and nothing can ever be read through it, which is what
-/// admits a promoted empty-slice constant such as `&[]` (rustc promotes it to
-/// `&[T; 0]`) regardless of `T`.
+/// Admits primitive scalars, enums carrying no payload, tuples and structs whose
+/// every field is itself admissible, and nested arrays of any of those. `ty` is
+/// the array type, and nesting is walked so an unsupported leaf cannot hide
+/// inside it. A zero-length array passes for any element type: its initializer
+/// is empty and nothing can ever be read through it, which is what admits a
+/// promoted empty-slice constant such as `&[]` (rustc promotes it to `&[T; 0]`)
+/// regardless of `T`.
 ///
 /// Tuples are admitted when every field is itself promotable. That only became
 /// worth doing once a tuple field read stopped going through a copy of the whole
@@ -6436,14 +6436,13 @@ pub(crate) fn emit_promoted_immutable_global(
 /// read addressed in place, the promotion is what removes the depot — the two
 /// only pay off together.
 ///
-/// Structs remain outside immutable-global promotion in this change. Bare
-/// struct arrays have an element-wise fallback, but widening this predicate
-/// would also widen the pointer-to-array form, which is a separate change. A
-/// payload-carrying enum stays out because reading one back still round-trips
-/// the payload through memory: the address walker resolves enum payload fields
-/// for writes, not for reads.
+/// Structs are admitted recursively, so a struct containing a pointer, union,
+/// payload-carrying enum, or any other unsupported leaf remains outside this
+/// path. A payload-carrying enum stays out because reading one back still
+/// round-trips the payload through memory: the address walker resolves enum
+/// payload fields for writes, not for reads.
 fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
-    use dialect_mir::types::{MirArrayType, MirEnumType, MirTupleType};
+    use dialect_mir::types::{MirArrayType, MirEnumType, MirStructType, MirTupleType};
 
     let obj = ty.deref(ctx);
     if let Some(array) = obj.downcast_ref::<MirArrayType>() {
@@ -6456,6 +6455,23 @@ fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
     if let Some(tuple) = obj.downcast_ref::<MirTupleType>() {
         let fields = tuple.get_types().to_vec();
         drop(obj);
+        return fields
+            .into_iter()
+            .all(|field| promotable_array_element(ctx, field));
+    }
+    if let Some(structure) = obj.downcast_ref::<MirStructType>() {
+        let fields = structure.field_types().to_vec();
+        let has_zero_byte_over_alignment = structure.total_size == 0 && structure.abi_align > 1;
+        drop(obj);
+
+        // A zero-byte `repr(align(N))` struct can raise the alignment of an
+        // enclosing tuple without contributing storage to its LLVM shape. Keep
+        // that established alignment-sensitive path out of immutable-global
+        // promotion; ordinary stored structs still recurse through their fields.
+        if has_zero_byte_over_alignment {
+            return false;
+        }
+
         return fields
             .into_iter()
             .all(|field| promotable_array_element(ctx, field));
@@ -6627,7 +6643,7 @@ pub(crate) fn translate_array_constant_into_alloca(
     }
     // Elements whose whole-element read is a single scalar-like load, or whose
     // fields are each addressed in place: primitive scalars, field-less enums,
-    // tuples of those, and nested arrays of any of them.
+    // recursively promotable tuples and structs, and nested arrays of those.
     if !promotable_array_element(ctx, value_ty) {
         return Ok(None);
     }
@@ -6702,7 +6718,7 @@ pub(crate) fn translate_array_constant_into_alloca(
 /// used by the bare array value path's immutable-global optimization. A bare
 /// array that fails this gate can still fall back to element-wise materialization;
 /// a pointer-to-array constant has no such fallback, so failure here is an input
-/// error. Structs therefore remain outside this reference form in this change.
+/// error. Structs pass only when every field is recursively promotable.
 fn validate_ptr_to_array_constant_type(
     ctx: &Context,
     ty: TypeHandle,
@@ -6715,7 +6731,7 @@ fn validate_ptr_to_array_constant_type(
     input_err!(
         loc,
         TranslationErr::unsupported(format!(
-            "Array constant element type is not supported: {:?}. Supported array constants are primitive scalars (integers, f16, f32, f64), field-less enums, tuples of those, or nested arrays of those.",
+            "Array constant element type is not supported: {:?}. Supported array constants are primitive scalars (integers, f16, f32, f64), field-less enums, tuples and structs recursively composed of supported fields, or nested arrays of those.",
             ty.deref(ctx)
         ))
     )
@@ -11933,14 +11949,16 @@ mod tuple_constant_byte_image_tests {
 #[cfg(test)]
 mod pointer_array_constant_type_tests {
     use super::validate_ptr_to_array_constant_type;
-    use dialect_mir::types::{EnumVariant, MirArrayType, MirEnumType, MirStructType, MirTupleType};
+    use dialect_mir::types::{
+        EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
+    };
     use pliron::builtin::types::{IntegerType, Signedness};
     use pliron::context::Context;
     use pliron::location::Location;
     use pliron::r#type::TypeHandle;
 
     #[test]
-    fn pointer_array_constant_boundary_keeps_structs_out_and_promotable_tuples_in() {
+    fn pointer_array_constant_boundary_admits_recursive_promotable_aggregates() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
 
@@ -11963,26 +11981,22 @@ mod pointer_array_constant_type_tests {
         .into();
         let struct_array: TypeHandle = MirArrayType::get(&mut ctx, struct_ty, 2).into();
         assert!(
-            validate_ptr_to_array_constant_type(&ctx, struct_array, Location::Unknown).is_err(),
-            "pointer-to-array constants must not gain struct element support"
+            validate_ptr_to_array_constant_type(&ctx, struct_array, Location::Unknown).is_ok(),
+            "pointer-to-array constants admit structs whose fields are promotable"
         );
 
         let nested_struct_array: TypeHandle = MirArrayType::get(&mut ctx, struct_array, 2).into();
         assert!(
             validate_ptr_to_array_constant_type(&ctx, nested_struct_array, Location::Unknown)
-                .is_err(),
-            "nesting must not hide an unsupported struct leaf"
+                .is_ok(),
+            "nesting preserves a promotable struct leaf"
         );
 
-        // Widening the shared predicate to tuples deliberately widens this form
-        // too: `promotable_array_element` still gates both the value form's
-        // promotion and this reference form, and only bare-value *admission*
-        // is wider now (a struct table falls back to element-wise
-        // materialization, which this form does not have). Nothing here
-        // enumerates fields -- the initializer is rustc's evaluated byte image
-        // and the size-agreement check rejects any layout the dialect
-        // reproduces differently -- so a tuple element travels this path
-        // the same way a scalar does.
+        // The shared predicate gates both bare-value promotion and this
+        // reference form. The initializer is rustc's evaluated byte image and
+        // the size-agreement check rejects any layout the dialect reproduces
+        // differently, so recursive tuples and structs travel this path without
+        // rebuilding fields here.
         let tuple_ty: TypeHandle = MirTupleType::get(&mut ctx, vec![u32_ty]).into();
         let tuple_array: TypeHandle = MirArrayType::get(&mut ctx, tuple_ty, 2).into();
         assert!(
@@ -11990,15 +12004,33 @@ mod pointer_array_constant_type_tests {
             "const R: &[(u32,); N] = &TABLE must pass the same gate the bare table passes"
         );
 
-        // ... and a tuple is only as admissible as its fields, on this path too.
+        // A tuple containing a promotable struct is recursively admissible too.
         let tuple_with_struct_ty: TypeHandle =
             MirTupleType::get(&mut ctx, vec![u32_ty, struct_ty]).into();
         let tuple_with_struct_array: TypeHandle =
             MirArrayType::get(&mut ctx, tuple_with_struct_ty, 2).into();
         assert!(
             validate_ptr_to_array_constant_type(&ctx, tuple_with_struct_array, Location::Unknown)
+                .is_ok(),
+            "a promotable struct field keeps its tuple in the reference form"
+        );
+
+        // A struct is only as promotable as its fields. Pointer-bearing
+        // initializers need relocation/provenance support and must stay out.
+        let pointer_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
+        let pointer_struct_ty: TypeHandle = MirStructType::get(
+            &mut ctx,
+            "PointerBearingElement".into(),
+            vec!["pointer".into()],
+            vec![pointer_ty],
+        )
+        .into();
+        let pointer_struct_array: TypeHandle =
+            MirArrayType::get(&mut ctx, pointer_struct_ty, 2).into();
+        assert!(
+            validate_ptr_to_array_constant_type(&ctx, pointer_struct_array, Location::Unknown)
                 .is_err(),
-            "a struct field must keep its tuple out of the reference form as well"
+            "pointer-bearing structs must remain outside immutable-global promotion"
         );
     }
 
@@ -12087,7 +12119,9 @@ mod pointer_array_constant_type_tests {
 #[cfg(test)]
 mod promotable_array_element_tests {
     use super::promotable_array_element;
-    use dialect_mir::types::{EnumVariant, MirArrayType, MirEnumType, MirStructType, MirTupleType};
+    use dialect_mir::types::{
+        EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
+    };
     use pliron::builtin::types::{IntegerType, Signedness};
     use pliron::context::Context;
     use pliron::r#type::TypeHandle;
@@ -12128,7 +12162,7 @@ mod promotable_array_element_tests {
     }
 
     #[test]
-    fn promotion_admits_scalars_fieldless_enums_and_promotable_tuples() {
+    fn promotion_admits_recursive_promotable_aggregates() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
 
@@ -12157,10 +12191,8 @@ mod promotable_array_element_tests {
             "nested field-less enum arrays stay promotable"
         );
 
-        // Everything below is rejected for cost, not for correctness: reading one
-        // field of these elements out of a local array still copies the whole
-        // array, so a promoted global would be dead weight beside an unchanged
-        // depot.
+        // Payload-carrying enums still use a value path that round-trips their
+        // payload through memory, so they remain outside immutable-global promotion.
         let maybe_ty = payload_enum(&mut ctx, u32_ty);
         let maybe_array: TypeHandle = MirArrayType::get(&mut ctx, maybe_ty, 4).into();
         assert!(
@@ -12190,25 +12222,77 @@ mod promotable_array_element_tests {
         .into();
         let struct_array: TypeHandle = MirArrayType::get(&mut ctx, struct_ty, 4).into();
         assert!(
-            !promotable_array_element(&ctx, struct_array),
-            "struct elements remain outside immutable-global promotion in this change"
+            promotable_array_element(&ctx, struct_array),
+            "a struct of promotable fields is promotable"
         );
 
-        // A tuple is only as promotable as its fields: a struct field keeps the
-        // whole element out, at any depth.
+        // Recursive aggregates remain promotable when every leaf is promotable.
         let tuple_with_struct: TypeHandle =
             MirTupleType::get(&mut ctx, vec![u32_ty, struct_ty]).into();
         let tuple_with_struct_array: TypeHandle =
             MirArrayType::get(&mut ctx, tuple_with_struct, 4).into();
         assert!(
-            !promotable_array_element(&ctx, tuple_with_struct_array),
-            "a struct field must keep its tuple out"
+            promotable_array_element(&ctx, tuple_with_struct_array),
+            "a promotable struct field keeps its tuple promotable"
         );
-        let nested_excluded: TypeHandle =
+        let nested_struct_arrays: TypeHandle =
             MirArrayType::get(&mut ctx, tuple_with_struct_array, 2).into();
         assert!(
-            !promotable_array_element(&ctx, nested_excluded),
-            "nesting must not hide an excluded leaf"
+            promotable_array_element(&ctx, nested_struct_arrays),
+            "nesting preserves recursive promotability"
+        );
+
+        // A zero-byte over-aligned struct carries an ABI constraint that is not
+        // visible in the lowered storage shape. Preserve the established
+        // alignment-sensitive value path for aggregates containing such a leaf.
+        let over_aligned_zst_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "OverAlignedZst".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            0,
+            32,
+        )
+        .into();
+        let tuple_with_over_aligned_zst: TypeHandle =
+            MirTupleType::get(&mut ctx, vec![over_aligned_zst_ty, u32_ty]).into();
+        let over_aligned_zst_array: TypeHandle =
+            MirArrayType::get(&mut ctx, tuple_with_over_aligned_zst, 2).into();
+        assert!(
+            !promotable_array_element(&ctx, over_aligned_zst_array),
+            "a zero-byte over-aligned struct must keep its containing aggregate on the alignment-sensitive path"
+        );
+
+        // Unsupported leaves still poison the whole recursive aggregate.
+        let pointer_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
+        let pointer_struct_ty: TypeHandle = MirStructType::get(
+            &mut ctx,
+            "PointerBearingElement".into(),
+            vec!["pointer".into()],
+            vec![pointer_ty],
+        )
+        .into();
+        let pointer_struct_array: TypeHandle =
+            MirArrayType::get(&mut ctx, pointer_struct_ty, 4).into();
+        assert!(
+            !promotable_array_element(&ctx, pointer_struct_array),
+            "a pointer leaf must keep its containing struct out of promotion"
+        );
+
+        let struct_with_payload_enum: TypeHandle = MirStructType::get(
+            &mut ctx,
+            "PayloadEnumElement".into(),
+            vec!["value".into()],
+            vec![maybe_ty],
+        )
+        .into();
+        let payload_struct_array: TypeHandle =
+            MirArrayType::get(&mut ctx, struct_with_payload_enum, 4).into();
+        assert!(
+            !promotable_array_element(&ctx, payload_struct_array),
+            "a payload-enum leaf must keep its containing struct out of promotion"
         );
     }
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -6441,6 +6441,12 @@ pub(crate) fn emit_promoted_immutable_global(
 /// path. A payload-carrying enum stays out because reading one back still
 /// round-trips the payload through memory: the address walker resolves enum
 /// payload fields for writes, not for reads.
+///
+/// A struct whose recorded rustc layout the natural (non-packed) LLVM struct
+/// cannot honor, canonically `repr(C, packed)`, is also refused: the promoted
+/// global's bytes are rustc's packed image, but the destination local is
+/// storage of the diverged LLVM type, so the copy would land fields at the
+/// wrong bytes. See [`struct_layout_matches_llvm_natural`].
 fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
     use dialect_mir::types::{MirArrayType, MirEnumType, MirStructType, MirTupleType};
 
@@ -6461,7 +6467,10 @@ fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
     }
     if let Some(structure) = obj.downcast_ref::<MirStructType>() {
         let fields = structure.field_types().to_vec();
-        let has_zero_byte_over_alignment = structure.total_size == 0 && structure.abi_align > 1;
+        let field_offsets = structure.field_offsets().to_vec();
+        let mem_to_decl = structure.mem_to_decl.clone();
+        let total_size = structure.total_size;
+        let has_zero_byte_over_alignment = total_size == 0 && structure.abi_align > 1;
         drop(obj);
 
         // A zero-byte `repr(align(N))` struct can raise the alignment of an
@@ -6469,6 +6478,22 @@ fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
         // that established alignment-sensitive path out of immutable-global
         // promotion; ordinary stored structs still recurse through their fields.
         if has_zero_byte_over_alignment {
+            return false;
+        }
+
+        // A `repr(packed)` struct records field offsets the non-packed LLVM
+        // struct the lowering builds cannot reproduce: explicit `[N x i8]`
+        // padding slots can only push a field later, never below its natural
+        // alignment. Copying rustc's packed byte image over storage of that
+        // diverged type would put every later field at the wrong bytes, so
+        // such structs stay on the element-wise fallback.
+        if !struct_layout_matches_llvm_natural(
+            ctx,
+            &fields,
+            &field_offsets,
+            &mem_to_decl,
+            total_size,
+        ) {
             return false;
         }
 
@@ -6489,6 +6514,146 @@ fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
         || obj.is::<MirFP16Type>()
         || obj.is::<FP32Type>()
         || obj.is::<FP64Type>()
+}
+
+/// Whether rustc's recorded struct layout is one the lowering's non-packed
+/// LLVM struct actually reproduces at the byte level.
+///
+/// The lowering places fields at their recorded offsets by inserting explicit
+/// `[N x i8]` padding slots, which can only ADD bytes: a field can never land
+/// below its natural LLVM alignment, and LLVM still rounds the struct's size
+/// up to its natural alignment. So the built type agrees with rustc's byte
+/// image exactly when every stored field's offset is naturally aligned and
+/// non-overlapping in memory order, and `total_size` is a multiple of the
+/// struct's natural alignment. `repr(packed)` breaks the former (a `u32` at
+/// offset 1) and usually the latter (a 5-byte total), and either divergence
+/// makes a byte-image copy land fields at the wrong bytes.
+///
+/// A struct with no recorded layout (`field_offsets` empty or `total_size`
+/// zero) answers `true`: the lowering builds no padded layout to diverge
+/// from, and the promotion path's stored-size agreement check already fails
+/// closed on the unknown size. Any field whose natural size or alignment
+/// cannot be established answers `false`: no verdict means no promotion.
+fn struct_layout_matches_llvm_natural(
+    ctx: &Context,
+    field_types: &[TypeHandle],
+    field_offsets: &[u64],
+    mem_to_decl: &[usize],
+    total_size: u64,
+) -> bool {
+    if field_offsets.is_empty() || total_size == 0 {
+        return true;
+    }
+    if field_offsets.len() != field_types.len() {
+        return false;
+    }
+    // Empty `mem_to_decl` means identity (declaration order = memory order).
+    let identity: Vec<usize>;
+    let memory_order: &[usize] = if mem_to_decl.is_empty() {
+        identity = (0..field_types.len()).collect();
+        &identity
+    } else {
+        mem_to_decl
+    };
+
+    let mut end: u64 = 0;
+    let mut max_align: u64 = 1;
+    for &decl_idx in memory_order {
+        if decl_idx >= field_types.len() {
+            return false;
+        }
+        let Some((size, align)) = llvm_natural_size_align(ctx, field_types[decl_idx]) else {
+            return false;
+        };
+        // Zero-sized fields are stripped from the LLVM struct: no slot, no
+        // bytes, no alignment contribution (over-aligned ZSTs are refused
+        // before this walk runs).
+        if size == 0 {
+            continue;
+        }
+        let offset = field_offsets[decl_idx];
+        if offset % align != 0 || offset < end {
+            return false;
+        }
+        end = offset + size;
+        max_align = max_align.max(align);
+    }
+    total_size >= end && total_size % max_align == 0
+}
+
+/// Natural size and alignment of the LLVM storage a dialect type converts to,
+/// or `None` when the walk cannot establish them.
+///
+/// "Natural" means what LLVM's datalayout assigns the converted type with no
+/// packing: leaves are their own width and self-aligned, arrays inherit their
+/// element's alignment, and aggregates align to their most-aligned stored
+/// field because the padding slots between fields are `[N x i8]` with
+/// alignment one. Aggregates answer with rustc's `total_size` for their size;
+/// that matches the built LLVM type only when their own layout is natural,
+/// which [`struct_layout_matches_llvm_natural`] establishes recursively (via
+/// [`promotable_array_element`]) before the answer is trusted. A field-less
+/// enum stores only its discriminant, so it aligns as that integer does.
+fn llvm_natural_size_align(ctx: &Context, ty: TypeHandle) -> Option<(u64, u64)> {
+    use dialect_mir::types::{MirArrayType, MirEnumType, MirStructType, MirTupleType};
+
+    let obj = ty.deref(ctx);
+    if let Some(array) = obj.downcast_ref::<MirArrayType>() {
+        let element_ty = array.element_type();
+        let count = array.size();
+        drop(obj);
+        let (element_size, element_align) = llvm_natural_size_align(ctx, element_ty)?;
+        return Some((element_size.checked_mul(count)?, element_align));
+    }
+    if let Some(tuple) = obj.downcast_ref::<MirTupleType>() {
+        let fields = tuple.get_types().to_vec();
+        let total_size = tuple.total_size();
+        drop(obj);
+        let align = aggregate_natural_align(ctx, &fields)?;
+        return Some((total_size, align));
+    }
+    if let Some(structure) = obj.downcast_ref::<MirStructType>() {
+        let fields = structure.field_types().to_vec();
+        let total_size = structure.total_size;
+        drop(obj);
+        let align = aggregate_natural_align(ctx, &fields)?;
+        return Some((total_size, align));
+    }
+    if let Some(enumeration) = obj.downcast_ref::<MirEnumType>() {
+        let discriminant_ty = enumeration.discriminant_ty;
+        let total_size = enumeration.total_size();
+        drop(obj);
+        let (_, align) = llvm_natural_size_align(ctx, discriminant_ty)?;
+        return Some((total_size, align));
+    }
+    let size = if let Some(integer) = obj.downcast_ref::<IntegerType>() {
+        // `bool` arrives as `i1` and occupies a byte.
+        u64::from(integer.width().div_ceil(8)).max(1)
+    } else if obj.is::<MirFP16Type>() {
+        2
+    } else if obj.is::<FP32Type>() {
+        4
+    } else if obj.is::<FP64Type>() {
+        8
+    } else {
+        return None;
+    };
+    // Every scalar Rust hands this path is self-aligned at a power-of-two
+    // width; anything else has no natural alignment to report.
+    size.is_power_of_two().then_some((size, size))
+}
+
+/// Natural alignment of the LLVM struct built for an aggregate's fields:
+/// the maximum over the stored (non-zero-sized) fields, one when nothing is
+/// stored. `None` when some field's alignment cannot be established.
+fn aggregate_natural_align(ctx: &Context, fields: &[TypeHandle]) -> Option<u64> {
+    let mut align: u64 = 1;
+    for &field in fields {
+        let (field_size, field_align) = llvm_natural_size_align(ctx, field)?;
+        if field_size > 0 {
+            align = align.max(field_align);
+        }
+    }
+    Some(align)
 }
 
 /// Bytes a dialect type occupies, as the converted LLVM storage will lay it out,
@@ -12118,12 +12283,13 @@ mod pointer_array_constant_type_tests {
 
 #[cfg(test)]
 mod promotable_array_element_tests {
-    use super::promotable_array_element;
+    use super::{promotable_array_element, validate_array_value_element_type};
     use dialect_mir::types::{
         EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
     };
     use pliron::builtin::types::{IntegerType, Signedness};
     use pliron::context::Context;
+    use pliron::location::Location;
     use pliron::r#type::TypeHandle;
 
     /// A field-less enum with a recorded layout, as rustc gives a `#[repr(u32)]`
@@ -12293,6 +12459,71 @@ mod promotable_array_element_tests {
         assert!(
             !promotable_array_element(&ctx, payload_struct_array),
             "a payload-enum leaf must keep its containing struct out of promotion"
+        );
+    }
+
+    #[test]
+    fn a_packed_struct_is_not_promoted_but_keeps_its_fallback() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+
+        // `#[repr(C, packed)] struct Packed { tag: u8, value: u32 }`: rustc
+        // records `value` at offset 1 and a 5-byte total. The non-packed LLVM
+        // struct the lowering builds cannot place an `i32` below offset 4, so
+        // the recorded byte image and the converted type disagree.
+        let packed_struct_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "Packed".into(),
+            vec!["tag".into(), "value".into()],
+            vec![u8_ty, u32_ty],
+            vec![],
+            vec![0, 1],
+            5,
+            1,
+        )
+        .into();
+        let packed_struct_array: TypeHandle =
+            MirArrayType::get(&mut ctx, packed_struct_ty, 4).into();
+        assert!(
+            !promotable_array_element(&ctx, packed_struct_array),
+            "a packed struct's byte image diverges from its LLVM storage, so \
+             promotion must fail closed"
+        );
+        let empty_packed_array: TypeHandle =
+            MirArrayType::get(&mut ctx, packed_struct_ty, 0).into();
+        assert!(
+            promotable_array_element(&ctx, empty_packed_array),
+            "a zero-length array of packed structs has no bytes to diverge"
+        );
+
+        // The element-wise fallback decodes fields at rustc's recorded
+        // offsets, so it stays available to the shapes promotion refuses.
+        assert!(
+            validate_array_value_element_type(&ctx, packed_struct_ty, &Location::Unknown).is_ok(),
+            "the bare-array fallback must still admit the packed struct"
+        );
+
+        // The same fields with rustc's natural layout recorded stay promoted:
+        // the gate keys on divergence, not on layout presence.
+        let natural_struct_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "Natural".into(),
+            vec!["tag".into(), "value".into()],
+            vec![u8_ty, u32_ty],
+            vec![],
+            vec![0, 4],
+            8,
+            4,
+        )
+        .into();
+        let natural_struct_array: TypeHandle =
+            MirArrayType::get(&mut ctx, natural_struct_ty, 4).into();
+        assert!(
+            promotable_array_element(&ctx, natural_struct_array),
+            "a naturally laid out struct with full recorded layout stays promotable"
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
@@ -17,7 +17,7 @@
 //! - bare arrays of padded and nested struct constants,
 //! - bare arrays of over-aligned zero-sized struct constants,
 //! - direct padded tuple constants,
-//! - pointer-to-array constants (`&[T; N]`), which predate bare-array support,
+//! - pointer-to-array constants (`&[T; N]`), including padded and nested structs,
 //! - tuple arrays containing pointers to device statics,
 //! - tuple-array pointer relocations with non-zero static addends,
 //! - initialized union constants, including `[U; N]` runtime indexing,
@@ -81,6 +81,7 @@ const PADDED_STRUCT_TABLE: [PaddedStruct; 2] = [
         value: 0x99aa_bbcc,
     },
 ];
+const PADDED_STRUCT_REF: &[PaddedStruct; 2] = &PADDED_STRUCT_TABLE;
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -105,6 +106,7 @@ const NESTED_STRUCT_TABLE: [NestedStruct; 2] = [
         wide: 0x8182_8384_8586_8788,
     },
 ];
+const NESTED_STRUCT_REF: &[NestedStruct; 2] = &NESTED_STRUCT_TABLE;
 
 #[derive(Clone, Copy)]
 #[repr(align(32))]
@@ -264,6 +266,26 @@ mod kernels {
     }
 
     #[inline(never)]
+    fn padded_struct_ref_value(i: usize) -> u32 {
+        let idx = i & 1;
+        (PADDED_STRUCT_REF[idx].tag as u32)
+            .wrapping_mul(257)
+            .wrapping_add(PADDED_STRUCT_REF[idx].value)
+    }
+
+    #[inline(never)]
+    fn nested_struct_ref_value(i: usize) -> u32 {
+        let idx = i & 1;
+        (NESTED_STRUCT_REF[idx].inner.tag as u32)
+            .wrapping_mul(257)
+            .wrapping_add(NESTED_STRUCT_REF[idx].inner.value)
+            .wrapping_mul(257)
+            .wrapping_add(NESTED_STRUCT_REF[idx].wide as u32)
+            .wrapping_mul(257)
+            .wrapping_add((NESTED_STRUCT_REF[idx].wide >> 32) as u32)
+    }
+
+    #[inline(never)]
     fn zst_struct_array_value(i: usize) -> u32 {
         let value = ZST_STRUCT_TABLE[i & 1];
         ((&value as *const ZstStruct as usize) & 31) as u32
@@ -375,6 +397,8 @@ mod kernels {
             let overaligned_zst = overaligned_zst_tuple_array_value(i);
             let padded_struct = padded_struct_array_value(i);
             let nested_struct = nested_struct_array_value(i);
+            let padded_struct_ref = padded_struct_ref_value(i);
+            let nested_struct_ref = nested_struct_ref_value(i);
             let zst_struct = zst_struct_array_value(i);
 
             *slot = nested
@@ -398,6 +422,10 @@ mod kernels {
                 .wrapping_add(padded_struct)
                 .wrapping_mul(257)
                 .wrapping_add(nested_struct)
+                .wrapping_mul(257)
+                .wrapping_add(padded_struct_ref)
+                .wrapping_mul(257)
+                .wrapping_add(nested_struct_ref)
                 .wrapping_mul(257)
                 .wrapping_add(zst_struct);
         }
@@ -480,6 +508,9 @@ fn expected_u32(i: usize) -> u32 {
         .wrapping_mul(257)
         .wrapping_add((nested_value.wide >> 32) as u32);
 
+    let padded_struct_ref = padded_struct;
+    let nested_struct_ref = nested_struct;
+
     let zst_value = ZST_STRUCT_TABLE[i & 1];
     let zst_struct = ((&zst_value as *const ZstStruct as usize) & 31) as u32;
 
@@ -504,6 +535,10 @@ fn expected_u32(i: usize) -> u32 {
         .wrapping_add(padded_struct)
         .wrapping_mul(257)
         .wrapping_add(nested_struct)
+        .wrapping_mul(257)
+        .wrapping_add(padded_struct_ref)
+        .wrapping_mul(257)
+        .wrapping_add(nested_struct_ref)
         .wrapping_mul(257)
         .wrapping_add(zst_struct)
 }
@@ -580,7 +615,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if failures == 0 {
         println!(
-            "array_constants: PASS ({N} threads; primitive, enum, initialized union/MaybeUninit, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, padded/nested/ZST struct, pointer-to-array, and tuple-array static-pointer constants)"
+            "array_constants: PASS ({N} threads; primitive, enum, initialized union/MaybeUninit, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, padded/nested/ZST struct, pointer-to-array including struct references, and tuple-array static-pointer constants)"
         );
         Ok(())
     } else {

--- a/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
@@ -22,6 +22,19 @@ require_shape() {
     fi
 }
 
+require_shape_count() {
+    local description="$1"
+    local expected="$2"
+    local pattern="$3"
+    local actual
+
+    actual="$(grep -Ec "${pattern}" "${llvm_ir}" || true)"
+    if [[ "${actual}" -ne "${expected}" ]]; then
+        echo "error: expected ${expected} ${description} in ${llvm_ir}, found ${actual}" >&2
+        exit 1
+    fi
+}
+
 symbol_body() {
     local artifact="$1"
     local format="$2"
@@ -96,16 +109,46 @@ require_shape \
 # struct constants. `PaddedStruct` is `#[repr(C)] { u8, u32 }`, so the lowered
 # element contains an explicit three-byte padding slot before the u32.
 padded_struct_symbol='array_constants__kernels__padded_struct_array_value'
+padded_struct_ref_symbol='array_constants__kernels__padded_struct_ref_value'
+padded_struct_initializer='addrspace\(1\) constant \[16 x i8\] c"\\A5\\00\\00\\00\\44\\33\\22\\11\\5A\\00\\00\\00\\CC\\BB\\AA\\99"'
 require_symbol_shape "${llvm_ir}" llvm "${padded_struct_symbol}" \
     "padded bare-struct array storage" \
     'alloca \[2 x \{ i8, \[3 x i8\], i32 \}\]'
+require_shape \
+    "padded struct array immutable-global byte image" \
+    "${padded_struct_initializer}"
+require_symbol_shape "${llvm_ir}" llvm "${padded_struct_symbol}" \
+    "padded struct array filled from a read-only global" \
+    'llvm\.memcpy\.p0\.p1\.i64\(ptr %[A-Za-z0-9_.]+, ptr addrspace\(1\) @'
+reject_symbol_shape "${llvm_ir}" llvm "${padded_struct_ref_symbol}" \
+    "local padded struct table copy in pointer-to-array path" \
+    'alloca \[2 x \{ i8, \[3 x i8\], i32 \}\]'
+require_shape_count \
+    "padded struct immutable-global initializer" \
+    1 \
+    "${padded_struct_initializer}"
 
 # Recursive aggregate decoding must preserve the inner struct's padding while
 # placing the following u64 at its `#[repr(C)]` offset.
 nested_struct_symbol='array_constants__kernels__nested_struct_array_value'
+nested_struct_ref_symbol='array_constants__kernels__nested_struct_ref_value'
+nested_struct_initializer='addrspace\(1\) constant \[32 x i8\] c"\\33\\00\\00\\00\\04\\03\\02\\01\\18\\17\\16\\15\\14\\13\\12\\11\\CC\\00\\00\\00\\A4\\A3\\A2\\A1\\88\\87\\86\\85\\84\\83\\82\\81"'
 require_symbol_shape "${llvm_ir}" llvm "${nested_struct_symbol}" \
     "nested bare-struct array storage" \
     'alloca \[2 x \{ \{ i8, \[3 x i8\], i32 \}, i64 \}\]'
+require_shape \
+    "nested struct array immutable-global byte image" \
+    "${nested_struct_initializer}"
+require_symbol_shape "${llvm_ir}" llvm "${nested_struct_symbol}" \
+    "nested struct array filled from a read-only global" \
+    'llvm\.memcpy\.p0\.p1\.i64\(ptr %[A-Za-z0-9_.]+, ptr addrspace\(1\) @'
+reject_symbol_shape "${llvm_ir}" llvm "${nested_struct_ref_symbol}" \
+    "local nested struct table copy in pointer-to-array path" \
+    'alloca \[2 x \{ \{ i8, \[3 x i8\], i32 \}, i64 \}\]'
+require_shape_count \
+    "nested struct immutable-global initializer" \
+    1 \
+    "${nested_struct_initializer}"
 
 # The standalone over-aligned ZST struct array has no data bytes to pin in LLVM
 # IR. Runtime coverage in `array_constants` checks that indexing it still

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -47,9 +47,15 @@ guessing an active field: initialized bytes are preserved, uninitialized
 inactive bytes remain `undef`, and the byte image is transmuted into the
 layout-exact union type. This includes direct unions, unions nested in tuple or
 struct constants, runtime-indexed `[U; N]`, and `MaybeUninit<T>` constants.
-Bare arrays whose elements are structs are materialized element-wise
-through the same layout-aware struct decoders; promoting such tables to
-one immutable device global is a tracked follow-up.
+Bare arrays whose elements are recursively promotable structs use the same
+immutable-device-global path as scalar and tuple tables, avoiding a per-thread
+local table copy for read-only uses. Pointer-to-array constants such as
+`const R: &[Struct; N] = &TABLE` use the same promoted global when every struct
+field is recursively promotable and the converted storage size matches rustc's
+layout. Zero-byte over-aligned struct leaves (for example, `repr(align(N))` ZSTs)
+remain on the existing alignment-sensitive value path instead of this promotion
+path. Arrays of packed structs whose element stride diverges from LLVM's natural
+layout remain unsupported as described above.
 Thin pointer fields in array, tuple, and struct **const** values that relocate
 to device statics are materialized via `MirGlobalAllocOp` per field, including
 non-zero byte addends into a static (see `struct_constant_provenance`,


### PR DESCRIPTION
Closes #924

## Problem

- Constant tables of structs were rebuilt element by element in every kernel invocation instead of living in device memory as one read-only global:

```text
const TABLE: [Pair; 4] = [Pair { key: 1, val: 10 }, ...];

Before (per kernel, per thread):
  %slot = alloca [4 x { i32, i32 }]
  store ... x8                        // rebuild the table in local memory
After (once per module):
  @__const_table = addrspace(1) constant [32 x i8] c"\01\00\00\00\0A..."
  // kernels just index it; duplicate tables dedup to one global
```

- Scalar and tuple element types already promoted this way; struct elements did not.

## Fix

- `promotable_array_element` gains a struct arm: a struct element is promotable when all of its fields are
- `const R: &[Pair; N] = &TABLE` references the same promoted global; duplicates dedup to one initializer
- pointer-bearing, enum-payload, and over-aligned ZST cases stay excluded on purpose (relocation and alignment paths keep their existing behavior)
- review follow-up 3b173084: `repr(C, packed)` struct elements are also excluded. Their LLVM natural layout cannot reproduce rustc's offsets, so promotion would read wrong bytes:

```text
#[repr(C, packed)] struct P { a: u8, b: u32 }   // rustc: b at offset 1
natural LLVM layout of { i8, i32 }              // b at offset 4
// promoted global + natural layout = reads b from the wrong place
// now: fails the layout-agreement check, falls back, still compiles
```

## Gotchas

- the exclusion check recurses, so a packed struct nested anywhere in the element type also blocks promotion
- a shared benefit: pointer-to-array constants of packed structs now get a hard diagnostic instead of quietly using the wrong layout

## Testing and validation

- mir-importer suite green (1069 tests), including new promote, dedup, reference-sharing, and packed-fails-closed tests
- GPU (sm_120): `array_constants` PASS, `verify-code-shape.sh` confirms the promoted byte-image global in the IR
- CI green (43/43)
