### PR TITLE
fix(mir-importer): preserve slice provenance in aggregate constants

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -10228,7 +10228,94 @@ fn interior_array_to_slice_unsize_info(
         .map(|remaining_len| (slice_elem, remaining_len)))
 }
 
-/// Read the slice length from a fat-pointer constant's metadata word.
+/// Validate the relocation shape of one slice fat pointer stored inside an
+/// allocation.
+///
+/// A slice occupies two pointer-width words. Exactly one relocation must back
+/// the data word at `fat_ptr_offset`; the metadata word is a literal `usize`
+/// and therefore must not overlap another relocation. Sibling relocations that
+/// end exactly at the field start or begin exactly at the field end are fine.
+///
+/// Returns `(metadata_offset, fat_pointer_end)` on success. Generic over the
+/// provenance payload so the boundary rules are unit testable without a rustc
+/// session.
+fn validate_slice_relocation_shape<P>(
+    ptrs: &[(usize, P)],
+    fat_ptr_offset: usize,
+    pointer_width: usize,
+) -> Result<(usize, usize), String> {
+    if pointer_width == 0 {
+        return Err("slice fat pointer has zero-width target pointers".to_string());
+    }
+
+    let metadata_offset = fat_ptr_offset
+        .checked_add(pointer_width)
+        .ok_or_else(|| "slice fat-pointer data-word end overflowed".to_string())?;
+    let fat_pointer_end = metadata_offset
+        .checked_add(pointer_width)
+        .ok_or_else(|| "slice fat-pointer metadata-word end overflowed".to_string())?;
+
+    let anchored = ptrs
+        .iter()
+        .filter(|(offset, _)| *offset == fat_ptr_offset)
+        .count();
+    if anchored != 1 {
+        return Err(format!(
+            "Slice fat pointer at byte {fat_ptr_offset} has {anchored} provenance entries at its \
+             data-word start; expected exactly one"
+        ));
+    }
+
+    let overlapping =
+        relocation_offsets_overlapping_range(ptrs, fat_ptr_offset, fat_pointer_end, pointer_width);
+    if let Some(other_offset) = overlapping
+        .into_iter()
+        .find(|offset| *offset != fat_ptr_offset)
+    {
+        return Err(format!(
+            "Slice fat pointer at byte {fat_ptr_offset} has an additional relocation at byte \
+             {other_offset}; the metadata word must remain literal usize bytes"
+        ));
+    }
+
+    Ok((metadata_offset, fat_pointer_end))
+}
+
+/// Read the slice length from a fat-pointer image stored at an arbitrary
+/// allocation offset.
+fn slice_len_from_alloc_at(
+    alloc: &rustc_public::ty::Allocation,
+    fat_ptr_offset: usize,
+    loc: Location,
+) -> TranslationResult<u64> {
+    let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
+    let (metadata_offset, fat_pointer_end) =
+        validate_slice_relocation_shape(&alloc.provenance.ptrs, fat_ptr_offset, pointer_width)
+            .map_err(|message| input_error!(loc.clone(), TranslationErr::unsupported(message)))?;
+
+    if fat_pointer_end > alloc.bytes.len() {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Slice fat pointer at byte {fat_ptr_offset} needs bytes through \
+                 {fat_pointer_end}, but the allocation is only {} bytes",
+                alloc.bytes.len()
+            ))
+        );
+    }
+
+    alloc
+        .read_partial_uint(metadata_offset..fat_pointer_end)
+        .map(|len| len as u64)
+        .map_err(|error| {
+            input_error_noloc!(TranslationErr::unsupported(format!(
+                "Failed to read slice length metadata at byte {metadata_offset}: {error:?}"
+            )))
+        })
+}
+
+/// Read the slice length from a standalone fat-pointer constant's metadata
+/// word.
 ///
 /// A `&[T]` / `*const [T]` constant is a two-word image: the data word (which
 /// carries the provenance to the static, read by `static_target_from_constant`)
@@ -10246,35 +10333,23 @@ fn slice_len_from_constant(constant: &mir::ConstOperand, loc: Location) -> Trans
     };
 
     let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
-    let Some(&(provenance_offset, _)) = alloc.provenance.ptrs.first() else {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(
-                "static slice unsize constant has no provenance for its data pointer".to_string()
-            )
-        );
-    };
-    if provenance_offset != 0 || alloc.bytes.len() != 2 * pointer_width {
+    let expected_size = pointer_width.checked_mul(2).ok_or_else(|| {
+        input_error_noloc!(TranslationErr::unsupported(
+            "static slice unsize constant pointer width overflowed".to_string()
+        ))
+    })?;
+    if alloc.bytes.len() != expected_size {
         return input_err!(
             loc,
             TranslationErr::unsupported(format!(
-                "static slice unsize constant has an unexpected fat-pointer image \
-                 (provenance at byte {}, {} bytes total; expected the data word at 0 \
-                 followed by one usize length word)",
-                provenance_offset,
+                "static slice unsize constant has {} bytes; expected exactly two \
+                 pointer-width words ({expected_size} bytes)",
                 alloc.bytes.len()
             ))
         );
     }
 
-    let len = alloc
-        .read_partial_uint(pointer_width..2 * pointer_width)
-        .map_err(|e| {
-            input_error_noloc!(TranslationErr::unsupported(format!(
-                "Failed to read static slice unsize length metadata: {e:?}"
-            )))
-        })? as u64;
-    Ok(len)
+    slice_len_from_alloc_at(alloc, 0, loc)
 }
 
 /// Materialize a region of a device static as a fat `&[T]` / `*const [T]`.
@@ -10430,8 +10505,8 @@ fn match_thin_pointer_relocation<P: Copy>(
         ));
     }
 
-    // A fat pointer spans two pointer-sized words; reject any additional
-    // provenance that lands inside this thin field's byte range.
+    // A thin pointer occupies one pointer-sized word; reject any additional
+    // provenance that lands inside this field's byte range.
     if let Some(&(interior_pos, _)) = ptrs
         .iter()
         .find(|(pos, _)| *pos > pointer_offset && *pos < field_end)
@@ -10649,6 +10724,95 @@ fn translate_thin_pointer_at_alloc_offset(
     Ok((cast_op.deref(ctx).get_result(0), Some(cast_op)))
 }
 
+/// Materialize a slice fat-pointer field from an aggregate constant allocation.
+///
+/// The data word keeps rustc provenance and may carry a non-zero byte addend
+/// into a device static. The metadata word is decoded independently as the
+/// stored slice length. This deliberately supports only same-element
+/// array-to-slice views over Rust statics, matching the standalone constant
+/// path; anonymous promoted allocations and other DST metadata remain
+/// fail-closed.
+#[allow(clippy::too_many_arguments)]
+fn translate_slice_at_alloc_offset(
+    ctx: &mut Context,
+    alloc: &rustc_public::ty::Allocation,
+    fat_ptr_offset: usize,
+    rust_ty: &rustc_public::ty::Ty,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
+    let Some((pointee_ty, is_mutable)) = get_static_pointer_info(rust_ty) else {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Aggregate slice constant at byte {fat_ptr_offset} has unexpected Rust type \
+                 {rust_ty:?}; expected a reference or raw pointer to a slice"
+            ))
+        );
+    };
+
+    let len = slice_len_from_alloc_at(alloc, fat_ptr_offset, loc.clone())?;
+    let Some(static_target) = static_target_from_allocation_at(alloc, fat_ptr_offset)? else {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Aggregate slice constant at byte {fat_ptr_offset} points at an anonymous or \
+                 unsupported allocation; slice provenance currently requires a Rust device static"
+            ))
+        );
+    };
+
+    let static_ty = static_target.static_def.ty();
+    let slice_region = if static_target.byte_offset == 0 {
+        array_to_slice_unsize_info(&static_ty, &pointee_ty, loc.clone())?
+    } else {
+        interior_array_to_slice_unsize_info(
+            &static_ty,
+            &pointee_ty,
+            static_target.byte_offset,
+            loc.clone(),
+        )?
+    };
+
+    let Some((elem_ty, available_len)) = slice_region else {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Aggregate slice constant at byte {fat_ptr_offset} points into device static {} \
+                 at byte addend {}, but its pointee type {pointee_ty:?} is not a supported \
+                 same-element array-to-slice view of static type {static_ty:?}",
+                static_target.static_def.name(),
+                static_target.byte_offset
+            ))
+        );
+    };
+
+    if len > available_len {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "Aggregate slice constant at byte {fat_ptr_offset} stores length {len}, which \
+                 exceeds the selected region's remaining length {available_len} in device \
+                 static {}",
+                static_target.static_def.name()
+            ))
+        );
+    }
+
+    translate_static_array_as_slice(
+        ctx,
+        &static_target.static_def,
+        elem_ty,
+        len,
+        is_mutable,
+        static_target.byte_offset,
+        block_ptr,
+        prev_op,
+        loc,
+    )
+}
+
 /// Slice `size` bytes from `alloc` at `offset`, treating uninit as zero.
 fn alloc_slice_bytes_zeroing_uninit(
     alloc: &rustc_public::ty::Allocation,
@@ -10770,8 +10934,9 @@ fn constant_field_byte_size(
 }
 
 /// Decode one typed value from an allocation at an absolute byte offset,
-/// resolving thin-pointer relocations to device statics via
-/// [`translate_thin_pointer_at_alloc_offset`].
+/// preserving supported pointer provenance. Thin pointer fields resolve through
+/// [`translate_thin_pointer_at_alloc_offset`]; slice fields pair the relocated
+/// data word with their literal length metadata.
 fn translate_constant_value_from_alloc(
     ctx: &mut Context,
     alloc: &rustc_public::ty::Allocation,
@@ -10800,14 +10965,30 @@ fn translate_constant_value_from_alloc(
     let is_slice = ty_ptr.deref(ctx).is::<dialect_mir::types::MirSliceType>();
     if is_slice {
         let size = rust_type_layout_size(*rust_ty, loc.clone())?;
-        if alloc_has_provenance_in_range(alloc, absolute_byte_offset, size) {
-            return input_err!(
+        let field_end = absolute_byte_offset.checked_add(size).ok_or_else(|| {
+            input_error!(
+                loc.clone(),
+                TranslationErr::unsupported(format!(
+                    "Slice field at byte {absolute_byte_offset} with size {size} overflowed"
+                ))
+            )
+        })?;
+        let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
+        let overlaps = relocation_offsets_overlapping_range(
+            &alloc.provenance.ptrs,
+            absolute_byte_offset,
+            field_end,
+            pointer_width,
+        );
+        if !overlaps.is_empty() {
+            return translate_slice_at_alloc_offset(
+                ctx,
+                alloc,
+                absolute_byte_offset,
+                rust_ty,
+                block_ptr,
+                prev_op,
                 loc,
-                TranslationErr::unsupported(
-                    "Aggregate constant contains a fat pointer (slice) with provenance; \
-                     only thin pointers to device statics are supported in aggregate constants"
-                        .to_string()
-                )
             );
         }
         let bytes = alloc_slice_bytes_zeroing_uninit(
@@ -10902,8 +11083,8 @@ fn translate_constant_value_from_alloc(
             loc,
             TranslationErr::unsupported(format!(
                 "Constant field of type {rust_ty:?} at byte offset {absolute_byte_offset} \
-                 overlaps a pointer relocation; only thin pointer fields can carry \
-                 provenance in aggregate constants"
+                 overlaps a pointer relocation; only supported pointer or slice fields can \
+                 carry provenance in aggregate constants"
             ))
         );
     }
@@ -12242,6 +12423,7 @@ mod aggregate_relocation_tests {
         constant_type_contains_pointer, decode_relocation_addend, find_unconsumed_relocation,
         match_thin_pointer_relocation, provenance_starts_in_range,
         relocation_offsets_overlapping_range, validate_array_value_element_type,
+        validate_slice_relocation_shape,
     };
     use dialect_mir::types::{
         EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
@@ -12269,6 +12451,57 @@ mod aggregate_relocation_tests {
         assert!(
             relocation_offsets_overlapping_range(&ptrs, 16, 24, 8).is_empty(),
             "touching a range boundary is not an overlap"
+        );
+    }
+
+    #[test]
+    fn aggregate_slice_relocation_accepts_nonzero_field_offset_with_siblings() {
+        let ptrs = [(0usize, ()), (8, ()), (24, ())];
+        assert_eq!(
+            validate_slice_relocation_shape(&ptrs, 8, 8),
+            Ok((16, 24)),
+            "sibling relocations outside the fat-pointer bytes must not interfere"
+        );
+    }
+
+    #[test]
+    fn aggregate_slice_relocation_rejects_metadata_provenance() {
+        let ptrs = [(8usize, ()), (16, ())];
+        let error = validate_slice_relocation_shape(&ptrs, 8, 8)
+            .expect_err("the metadata word must remain literal usize bytes");
+        assert!(
+            error.contains("additional relocation at byte 16"),
+            "diagnostic must identify metadata provenance: {error}"
+        );
+    }
+
+    #[test]
+    fn aggregate_slice_relocation_requires_data_word_provenance_at_field_start() {
+        let ptrs = [(12usize, ())];
+        let error = validate_slice_relocation_shape(&ptrs, 8, 8)
+            .expect_err("interior provenance cannot stand in for the slice data word");
+        assert!(
+            error.contains("0 provenance entries at its data-word start"),
+            "diagnostic must require an anchored data relocation: {error}"
+        );
+
+        let duplicate = [(8usize, 1u8), (8, 2u8)];
+        let error = validate_slice_relocation_shape(&duplicate, 8, 8)
+            .expect_err("two data-word provenance entries are ambiguous");
+        assert!(
+            error.contains("2 provenance entries at its data-word start"),
+            "diagnostic must count duplicate anchored relocations: {error}"
+        );
+    }
+
+    #[test]
+    fn aggregate_slice_relocation_rejects_left_crossing_pointer_storage() {
+        let ptrs = [(4usize, ()), (8, ())];
+        let error = validate_slice_relocation_shape(&ptrs, 8, 8)
+            .expect_err("a relocation from the preceding bytes must not overlap the slice");
+        assert!(
+            error.contains("additional relocation at byte 4"),
+            "diagnostic must identify the crossing relocation: {error}"
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/struct_constant_provenance/README.md
+++ b/crates/rustc-codegen-cuda/examples/struct_constant_provenance/README.md
@@ -1,15 +1,21 @@
 # struct_constant_provenance
 
-Positive regression for pointer provenance in a direct struct constant.
+Positive regression for pointer provenance in direct and nested struct constants.
 
-The example defines a constant struct containing a reference to a Rust static.
-The MIR importer must resolve the pointer relocation through the allocation's
-provenance table and materialize a pointer to the corresponding device global.
+The example covers two related constant representations:
 
-The pointer field must not be reconstructed from its placeholder bytes because
-those bytes contain only the addend into the target allocation. The relocation
-side table identifies the static allocation that provides the pointer's
-provenance.
+- a thin reference field that points to a Rust static;
+- a slice fat-pointer field whose data word points into a Rust static while its
+  second word carries the slice length.
+
+For both forms, the stored pointer bytes contain only the byte addend into the
+target allocation. Rustc's provenance table identifies the static allocation
+that provides the pointer provenance. The MIR importer must combine those
+pieces instead of reconstructing a pointer from placeholder bytes.
+
+The slice regression additionally checks a non-zero target addend and a nested
+struct field offset. Its length metadata must remain independent from the data
+pointer relocation.
 
 Run with:
 
@@ -20,5 +26,5 @@ cargo oxide run struct_constant_provenance
 Expected output:
 
 ```text
-PASS: struct constant pointer provenance preserved at runtime
+PASS: struct constant pointer and slice provenance preserved at runtime
 ```

--- a/crates/rustc-codegen-cuda/examples/struct_constant_provenance/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/struct_constant_provenance/src/main.rs
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Runtime regression for pointer provenance in a direct struct constant.
+//! Runtime regression for pointer provenance in direct and nested struct constants.
 //!
-//! The pointer field's stored bytes contain the addend into the target
-//! allocation, while the allocation's provenance table identifies the Rust
-//! static being referenced. The importer must combine both pieces, materialize
-//! a pointer to the corresponding device global, and preserve that pointer when
-//! the struct constant is consumed by GPU code.
+//! Thin pointer fields and slice fat-pointer fields both store pointer addends
+//! in the allocation bytes while rustc's provenance table identifies the Rust
+//! static being referenced. Slice fields additionally carry a literal `usize`
+//! metadata word. The importer must preserve both pieces when the constant is
+//! materialized for GPU code.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, cuda_module, kernel};
 
 static FIRST: [u8; 16] = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+static TABLE: [[u32; 4]; 3] = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33]];
 
 pub struct Holder {
     pub pointer: &'static [u8; 16],
@@ -24,6 +25,31 @@ const DIRECT: Holder = Holder {
     flag: true,
 };
 
+#[repr(C)]
+pub struct View {
+    pub tag: u32,
+    pub values: &'static [u32],
+}
+
+const DIRECT_SLICE: View = View {
+    tag: 7,
+    values: &TABLE[1],
+};
+
+#[repr(C)]
+pub struct NestedView {
+    pub prefix: u16,
+    pub view: View,
+}
+
+const NESTED_SLICE: NestedView = NestedView {
+    prefix: 3,
+    view: View {
+        tag: 11,
+        values: &TABLE[2],
+    },
+};
+
 #[cuda_module]
 mod kernels {
     use super::*;
@@ -33,6 +59,27 @@ mod kernels {
         if let Some((slot, index)) = output.get_mut_indexed() {
             let holder = DIRECT;
             *slot = holder.pointer[index.get() & 15] + holder.flag as u8;
+        }
+    }
+
+    #[kernel]
+    pub fn aggregate_slice_provenance(mut output: DisjointSlice<u32>) {
+        if let Some((slot, index)) = output.get_mut_indexed() {
+            let direct = DIRECT_SLICE;
+            let nested = NESTED_SLICE;
+
+            *slot = match index.get() {
+                0 => direct.tag,
+                1 => direct.values.len() as u32,
+                2 => direct.values[0],
+                3 => direct.values[3],
+                4 => nested.prefix as u32,
+                5 => nested.view.tag,
+                6 => nested.view.values.len() as u32,
+                7 => nested.view.values[0],
+                8 => nested.view.values[3],
+                _ => 0,
+            };
         }
     }
 }
@@ -68,5 +115,30 @@ fn main() {
         "struct constant pointer provenance produced incorrect GPU output"
     );
 
-    println!("PASS: struct constant pointer provenance preserved at runtime");
+    let mut slice_output = DeviceBuffer::<u32>::zeroed(&stream, 9)
+        .expect("Failed to allocate aggregate-slice output buffer");
+
+    // SAFETY: the launch is one-dimensional and the output buffer contains one
+    // element for every launched thread.
+    unsafe {
+        module.aggregate_slice_provenance(
+            &stream,
+            LaunchConfig::for_num_elems(9),
+            &mut slice_output,
+        )
+    }
+    .expect("aggregate_slice_provenance launch failed");
+
+    let slice_actual = slice_output
+        .to_host_vec(&stream)
+        .expect("Failed to copy aggregate-slice output to host");
+    let slice_expected = [7, 4, 20, 23, 3, 11, 4, 30, 33];
+
+    assert_eq!(
+        slice_actual.as_slice(),
+        slice_expected.as_slice(),
+        "aggregate slice constant provenance produced incorrect GPU output"
+    );
+
+    println!("PASS: struct constant pointer and slice provenance preserved at runtime");
 }

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -61,10 +61,12 @@ static byte addends and nested aggregate field offsets. Pointer relocations
 inside union constants, unsupported fat-pointer metadata, and pointer-to-array
 union constants (`&[U; N]`) remain rejected.
 
-Enum constants with direct thin-reference payloads preserve relocations to
-device statics, including non-zero byte addends. This includes niche-encoded
-`Option<&T>` and direct-tagged enum layouts. Anonymous promoted allocations and
-pointer relocations nested inside enum payload fields remain unsupported.
+Enum constants preserve payload relocations to device statics, including
+non-zero byte addends. This includes niche-encoded `Option<&T>` and
+direct-tagged enum layouts, both for direct thin-reference payloads and for
+pointers nested inside tuple, struct, or array payload fields. Anonymous
+promoted allocations remain unsupported, as does a relocation-carrying enum
+constant nested inside another constant's field.
 
 ## Compiler: Closures
 

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -53,16 +53,18 @@ one immutable device global is a tracked follow-up.
 Thin pointer fields in array, tuple, and struct **const** values that relocate
 to device statics are materialized via `MirGlobalAllocOp` per field, including
 non-zero byte addends into a static (see `struct_constant_provenance`,
-`tuple_constant_provenance`, `tuple_array_provenance`). Pointer relocations
-inside union constants, fat pointers, enum constants with relocations,
-pointer-to-array union constants (`&[U; N]`), and device-global *initializer*
-relocations remain rejected.
+`tuple_constant_provenance`, `tuple_array_provenance`). Slice fat-pointer fields
+in aggregate constants are also supported when their data pointer relocates to
+a device static and the pointee is a same-element array-to-slice view. Their
+literal `usize` length metadata is decoded independently, including non-zero
+static byte addends and nested aggregate field offsets. Pointer relocations
+inside union constants, unsupported fat-pointer metadata, and pointer-to-array
+union constants (`&[U; N]`) remain rejected.
 
 Enum constants with direct thin-reference payloads preserve relocations to
 device statics, including non-zero byte addends. This includes niche-encoded
 `Option<&T>` and direct-tagged enum layouts. Anonymous promoted allocations and
-pointer relocations nested inside array, tuple, struct, or enum payload fields
-remain unsupported.
+pointer relocations nested inside enum payload fields remain unsupported.
 
 ## Compiler: Closures
 


### PR DESCRIPTION
Closes #928

## Problem

- A slice stored in a struct constant lost its pointer identity:

```text
static TABLE: [u32; 8] = [...];

struct View { name: u32, data: &'static [u32] }
const V: View = View { name: 7, data: &TABLE[2..5] };

Before:  error: aggregate constant contains a fat pointer (slice) with
         provenance; only thin pointers to device statics are supported
After:   data.ptr  -> relocation to TABLE + 8 bytes   (provenance kept)
         data.len  -> 3                               (decoded from the metadata word)
```

- A slice is two words: a data pointer (a relocation, must stay symbolic) and a length (a literal, must be read as a number). The old path refused any aggregate constant containing one.

## Fix

- slice fields in aggregate constants now route to a dedicated decoder: the data word resolves through the existing addend-aware relocation path, the length word is read independently as an integer
- works at any nesting depth (a slice inside a struct inside a struct) and with non-zero addends into the target static
- malformed layouts are rejected with specific errors: provenance on the metadata word, duplicate relocation anchors, relocations crossing field boundaries; each has a unit test
- doc follow-up d2a3ecca: while verifying, the supported-features wording turned out stale in both directions; it now states the boundary the code actually implements (enum payload relocations work, including tuple/struct/array nesting; a relocation-carrying enum nested inside another constant stays rejected)

## Gotchas

- pointer-bearing union constants are the mirror-image case and belong to #927, not this PR
- device-global initializer relocations were already supported on main; the old doc line claiming otherwise was removed

## Testing and validation

- mir-importer suite green (1072 tests, four new slice-relocation tests)
- GPU (sm_120): `struct_constant_provenance` prints PASS with pointer and slice provenance verified at runtime, including a nested field at a non-zero offset
- full compile smoketest 208/208
- CI green (43/43)
