### PR TITLE
feat(wgmma): pipeline two accumulator groups across counted K-loops

### DIFF
--- a/crates/cuda-oxide-codegen/tests/wgmma_pipelined_counted_loop_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_pipelined_counted_loop_ptx.rs
@@ -1,0 +1,454 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! End-to-end probe for the production two-slot BF16 WGMMA counted pipeline.
+//!
+//! The test starts from the canonical pointer-form MIR shape recognized by
+//! `mir-lower`: two distinct `[[f32; 8]; 4]` accumulator slots, four affine
+//! descriptor recurrences, two `MMA -> commit_group -> wait_group<1>` stages in
+//! the unique latch, and a final `wait_group<0>` in the exit. The fusion pass
+//! must replace that CFG with one value-form carrier, which then lowers to one
+//! convergent inline-PTX counted pipeline and survives `ptxas -arch=sm_90a`
+//! without stack or spill traffic.
+
+#![cfg(unix)]
+
+use cuda_oxide_codegen::experimental::{CodegenModule, CompileOptions, Compiler, Target};
+use dialect_mir::{
+    ops::{
+        MirAddOp, MirCondBranchOp, MirConstantOp, MirFuncOp, MirGotoOp, MirLtOp, MirNotOp,
+        MirReturnOp,
+    },
+    types::{MirArrayType, MirPtrType},
+};
+use dialect_nvvm::ops::{
+    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaM64N64K16F32Bf16Op,
+    WgmmaWaitGroupSyncAlignedOp,
+};
+use pliron::builtin::attributes::IntegerAttr;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        attributes::TypeAttr,
+        op_interfaces::{OperandSegmentInterface, SymbolOpInterface},
+        types::{FP32Type, FunctionType},
+    },
+    context::Context,
+    linked_list::ContainsLinkedList,
+    op::Op,
+    operation::Operation,
+    utils::apint::APInt,
+    value::Value,
+};
+use std::num::NonZeroUsize;
+
+const ACCUMULATOR_LEN: u32 = 32;
+const RESULT_COUNT: u32 = 64;
+const TRIP_COUNT: u64 = 4;
+const DESC_A0_STEP: u64 = 16;
+const DESC_B0_STEP: u64 = 32;
+const DESC_A1_STEP: u64 = 48;
+const DESC_B1_STEP: u64 = 64;
+
+fn append_unsigned_constant(
+    ctx: &mut Context,
+    block: pliron::context::Ptr<BasicBlock>,
+    ty: pliron::r#type::TypedHandle<IntegerType>,
+    value: u64,
+) -> Value {
+    let width = usize::try_from(ty.deref(ctx).width()).expect("integer width must fit usize");
+    let constant = Operation::new(
+        ctx,
+        MirConstantOp::get_concrete_op_info(),
+        vec![ty.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    MirConstantOp::new(constant).set_attr_value(
+        ctx,
+        IntegerAttr::new(
+            ty,
+            APInt::from_u64(
+                value,
+                NonZeroUsize::new(width).expect("nonzero integer width"),
+            ),
+        ),
+    );
+    constant.insert_at_back(block, ctx);
+    constant.deref(ctx).get_result(0)
+}
+
+fn append_wait_group(
+    ctx: &mut Context,
+    block: pliron::context::Ptr<BasicBlock>,
+    u64_ty: pliron::r#type::TypedHandle<IntegerType>,
+    pending: u64,
+) {
+    let value = append_unsigned_constant(ctx, block, u64_ty, pending);
+    WgmmaWaitGroupSyncAlignedOp::build(ctx, value).insert_at_back(block, ctx);
+}
+
+fn append_mma(
+    ctx: &mut Context,
+    block: pliron::context::Ptr<BasicBlock>,
+    accumulator: Value,
+    desc_a: Value,
+    desc_b: Value,
+) {
+    Operation::new(
+        ctx,
+        WgmmaMmaM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![],
+        vec![accumulator, desc_a, desc_b],
+        vec![],
+        0,
+    )
+    .insert_at_back(block, ctx);
+}
+
+fn append_u64_add(
+    ctx: &mut Context,
+    block: pliron::context::Ptr<BasicBlock>,
+    u64_ty: pliron::r#type::TypedHandle<IntegerType>,
+    value: Value,
+    step: u64,
+) -> Value {
+    let step = append_unsigned_constant(ctx, block, u64_ty, step);
+    let add = Operation::new(
+        ctx,
+        MirAddOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![value, step],
+        vec![],
+        0,
+    );
+    add.insert_at_back(block, ctx);
+    add.deref(ctx).get_result(0)
+}
+
+fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
+    module.edit(|ctx, module| {
+        let module_region = module.get_operation().deref(ctx).get_region(0);
+        let module_block = module_region
+            .deref(ctx)
+            .iter(ctx)
+            .next()
+            .expect("codegen module must contain its top-level block");
+
+        let f32_ty = FP32Type::get(ctx);
+        let row_ty = MirArrayType::get(ctx, f32_ty.into(), 8);
+        let accumulator_ty = MirArrayType::get(ctx, row_ty.into(), 4);
+        let accumulator_ptr_ty = MirPtrType::get_generic(ctx, accumulator_ty.into(), true);
+        let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+        let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+        let i1_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+
+        let argument_types: Vec<pliron::r#type::TypeHandle> = vec![
+            accumulator_ptr_ty.into(),
+            accumulator_ptr_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+        ];
+        let function_type = FunctionType::get(ctx, argument_types.clone(), vec![]);
+        let function_op = Operation::new(
+            ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let function = MirFuncOp::new(ctx, function_op, TypeAttr::new(function_type.into()));
+        function.set_symbol_name(
+            ctx,
+            "wgmma_pipelined_counted_loop_kernel".try_into().unwrap(),
+        );
+
+        let function_region = function.get_operation().deref(ctx).get_region(0);
+        let preheader = BasicBlock::new(ctx, None, argument_types);
+        preheader.insert_at_back(function_region, ctx);
+        let header = BasicBlock::new(
+            ctx,
+            None,
+            vec![
+                u32_ty.into(),
+                u64_ty.into(),
+                u64_ty.into(),
+                u64_ty.into(),
+                u64_ty.into(),
+            ],
+        );
+        header.insert_at_back(function_region, ctx);
+        let latch = BasicBlock::new(ctx, None, vec![]);
+        latch.insert_at_back(function_region, ctx);
+        let exit = BasicBlock::new(ctx, None, vec![]);
+        exit.insert_at_back(function_region, ctx);
+
+        let accumulator0 = preheader.deref(ctx).get_argument(0);
+        let accumulator1 = preheader.deref(ctx).get_argument(1);
+        let desc_a0_base = preheader.deref(ctx).get_argument(2);
+        let desc_b0_base = preheader.deref(ctx).get_argument(3);
+        let desc_a1_base = preheader.deref(ctx).get_argument(4);
+        let desc_b1_base = preheader.deref(ctx).get_argument(5);
+
+        WgmmaFenceSyncAlignedOp::build(ctx).insert_at_back(preheader, ctx);
+        let i0 = append_unsigned_constant(ctx, preheader, u32_ty, 0);
+        Operation::new(
+            ctx,
+            MirGotoOp::get_concrete_op_info(),
+            vec![],
+            vec![i0, desc_a0_base, desc_b0_base, desc_a1_base, desc_b1_base],
+            vec![header],
+            0,
+        )
+        .insert_at_back(preheader, ctx);
+
+        let i = header.deref(ctx).get_argument(0);
+        let desc_a0 = header.deref(ctx).get_argument(1);
+        let desc_b0 = header.deref(ctx).get_argument(2);
+        let desc_a1 = header.deref(ctx).get_argument(3);
+        let desc_b1 = header.deref(ctx).get_argument(4);
+        let bound = append_unsigned_constant(ctx, header, u32_ty, TRIP_COUNT);
+        let lt = Operation::new(
+            ctx,
+            MirLtOp::get_concrete_op_info(),
+            vec![i1_ty.into()],
+            vec![i, bound],
+            vec![],
+            0,
+        );
+        lt.insert_at_back(header, ctx);
+        let lt_value = lt.deref(ctx).get_result(0);
+        let not_lt = Operation::new(
+            ctx,
+            MirNotOp::get_concrete_op_info(),
+            vec![i1_ty.into()],
+            vec![lt_value],
+            vec![],
+            0,
+        );
+        not_lt.insert_at_back(header, ctx);
+        let not_lt_value = not_lt.deref(ctx).get_result(0);
+        let (branch_operands, segment_sizes) =
+            MirCondBranchOp::compute_segment_sizes(vec![vec![not_lt_value], vec![], vec![]]);
+        let branch = Operation::new(
+            ctx,
+            MirCondBranchOp::get_concrete_op_info(),
+            vec![],
+            branch_operands,
+            vec![exit, latch],
+            0,
+        );
+        Operation::get_op::<MirCondBranchOp>(branch, ctx)
+            .expect("MirCondBranchOp")
+            .set_operand_segment_sizes(ctx, segment_sizes);
+        branch.insert_at_back(header, ctx);
+
+        append_mma(ctx, latch, accumulator0, desc_a0, desc_b0);
+        WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
+        append_wait_group(ctx, latch, u64_ty, 1);
+
+        append_mma(ctx, latch, accumulator1, desc_a1, desc_b1);
+        WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
+        append_wait_group(ctx, latch, u64_ty, 1);
+
+        let one = append_unsigned_constant(ctx, latch, u32_ty, 1);
+        let i_next = Operation::new(
+            ctx,
+            MirAddOp::get_concrete_op_info(),
+            vec![u32_ty.into()],
+            vec![i, one],
+            vec![],
+            0,
+        );
+        i_next.insert_at_back(latch, ctx);
+        let i_next = i_next.deref(ctx).get_result(0);
+
+        let desc_a0_next = append_u64_add(ctx, latch, u64_ty, desc_a0, DESC_A0_STEP);
+        let desc_b0_next = append_u64_add(ctx, latch, u64_ty, desc_b0, DESC_B0_STEP);
+        let desc_a1_next = append_u64_add(ctx, latch, u64_ty, desc_a1, DESC_A1_STEP);
+        let desc_b1_next = append_u64_add(ctx, latch, u64_ty, desc_b1, DESC_B1_STEP);
+
+        Operation::new(
+            ctx,
+            MirGotoOp::get_concrete_op_info(),
+            vec![],
+            vec![
+                i_next,
+                desc_a0_next,
+                desc_b0_next,
+                desc_a1_next,
+                desc_b1_next,
+            ],
+            vec![header],
+            0,
+        )
+        .insert_at_back(latch, ctx);
+
+        append_wait_group(ctx, exit, u64_ty, 0);
+        Operation::new(
+            ctx,
+            MirReturnOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        )
+        .insert_at_back(exit, ctx);
+
+        function.get_operation().insert_at_back(module_block, ctx);
+    });
+
+    module
+        .mark_kernel_entry("wgmma_pipelined_counted_loop_kernel")
+        .expect("kernel entry must be marked");
+}
+
+fn find_ptxas() -> std::path::PathBuf {
+    ["CUDA_TOOLKIT_PATH", "CUDA_HOME"]
+        .iter()
+        .filter_map(|variable| std::env::var(variable).ok())
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| std::path::PathBuf::from(root).join("bin/ptxas"))
+        .chain(std::iter::once(std::path::PathBuf::from(
+            "/usr/local/cuda/bin/ptxas",
+        )))
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("ptxas"))
+}
+
+fn used_register_count(ptxas_stderr: &str) -> Option<u32> {
+    ptxas_stderr.lines().find_map(|line| {
+        let start = line.find("Used ")? + "Used ".len();
+        let remainder = &line[start..];
+        let end = remainder.find(" registers")?;
+        remainder[..end].trim().parse().ok()
+    })
+}
+
+#[test]
+fn pointer_form_two_slot_counted_pipeline_compiles_spill_free_for_sm_90a() {
+    let mut module = CodegenModule::new("wgmma_pipelined_counted_loop").unwrap();
+    build_wgmma_pipelined_counted_loop_kernel(&mut module);
+
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
+    let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
+    let ptx = compiler
+        .compile(&mut module, &options)
+        .expect("pointer-form two-slot counted WGMMA pipeline must compile to PTX")
+        .into_ptx();
+    let text = String::from_utf8(ptx.clone()).expect("PTX must be UTF-8");
+
+    assert!(
+        text.contains(".visible .entry"),
+        "kernel entry is missing:\n{text}"
+    );
+    assert!(
+        text.contains(".target sm_90a"),
+        "PTX must target sm_90a:\n{text}"
+    );
+    assert!(
+        text.contains("wgmma_pipelined_counted_loop_kernel"),
+        "counted-pipeline kernel is missing:\n{text}"
+    );
+    assert!(
+        text.contains("L__wgmma_pipeline_loop_") && text.contains("L__wgmma_pipeline_done_"),
+        "production counted-pipeline labels are missing; pointer-form MIR did not fuse:\n{text}"
+    );
+    assert!(
+        !text.contains("${:uid}"),
+        "llc must expand every ${{:uid}} escape into a unique label suffix:\n{text}"
+    );
+    assert_eq!(text.matches("bra.uni").count(), 2);
+    assert_eq!(text.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(
+        text.matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
+            .count(),
+        2
+    );
+    assert_eq!(text.matches("wgmma.commit_group.sync.aligned").count(), 2);
+    assert_eq!(text.matches("wgmma.wait_group.sync.aligned 1").count(), 2);
+    assert_eq!(text.matches("wgmma.wait_group.sync.aligned 0").count(), 1);
+
+    for recurrence in [
+        "add.u64 %desc_a0",
+        "add.u64 %desc_b0",
+        "add.u64 %desc_a1",
+        "add.u64 %desc_b1",
+    ] {
+        assert!(
+            text.contains(recurrence),
+            "descriptor recurrence `{recurrence}` is missing from the PTX loop:\n{text}"
+        );
+    }
+    assert!(
+        !text.contains(".local") && !text.contains("ld.local") && !text.contains("st.local"),
+        "the production counted pipeline unexpectedly materializes local memory:\n{text}"
+    );
+
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let directory = std::env::temp_dir().join(format!(
+        "wgmma_pipelined_counted_loop_ptx_{}_{}",
+        std::process::id(),
+        unique,
+    ));
+    std::fs::create_dir_all(&directory).unwrap();
+    let ptx_path = directory.join("pipelined_counted_loop.ptx");
+    let cubin_path = directory.join("pipelined_counted_loop.cubin");
+    std::fs::write(&ptx_path, &ptx).unwrap();
+
+    let ptxas = find_ptxas();
+    let ptxas_result = std::process::Command::new(&ptxas)
+        .arg("-arch=sm_90a")
+        .arg("--compile-only")
+        .arg("-v")
+        .arg(&ptx_path)
+        .arg("-o")
+        .arg(&cubin_path)
+        .output();
+    let _ = std::fs::remove_dir_all(&directory);
+
+    let output = ptxas_result.unwrap_or_else(|error| {
+        panic!(
+            "could not run {}: {error}\nSet CUDA_TOOLKIT_PATH or CUDA_HOME, or put ptxas on PATH.",
+            ptxas.display()
+        )
+    });
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "ptxas rejected the production two-slot counted WGMMA pipeline:\n{stderr}\n\nPTX:\n{text}"
+    );
+    assert!(
+        stderr.contains("0 bytes stack frame"),
+        "ptxas reported a nonzero stack frame or omitted the expected report:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("0 bytes spill stores"),
+        "ptxas reported spill stores:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("0 bytes spill loads"),
+        "ptxas reported spill loads:\n{stderr}"
+    );
+
+    let used_registers =
+        used_register_count(&stderr).expect("ptxas output must report register usage");
+    assert!(
+        used_registers >= RESULT_COUNT,
+        "the production path did not keep both accumulator slots live: ptxas used only {used_registers} registers\n{stderr}"
+    );
+    assert!(used_registers >= ACCUMULATOR_LEN);
+
+    eprintln!("{stderr}");
+}

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -42,6 +42,8 @@ use pliron_derive::{pliron_attr, pliron_op};
 
 const WGMMA_M64N64_F32_ACCUMULATOR_COUNT: usize = 32;
 const WGMMA_COUNTED_LOOP_CONTROL_COUNT: usize = 5;
+const WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT: usize = 2 * WGMMA_M64N64_F32_ACCUMULATOR_COUNT;
+const WGMMA_COUNTED_PIPELINE_CONTROL_COUNT: usize = 9;
 const WGMMA_MAX_PENDING_GROUPS: u8 = 7;
 
 // =============================================================================
@@ -452,6 +454,124 @@ impl Verify for WgmmaMmaLoopValuesM64N64K16F32Bf16Op {
     }
 }
 
+/// Value-form BF16 WGMMA counted loop with two independent accumulator slots.
+///
+/// This deliberately narrow carrier models a fixed `wait_group<1>` pipeline:
+/// each loop iteration issues one committed group into slot 0, throttles to at
+/// most one pending group, then repeats the sequence for slot 1. The four
+/// descriptors advance independently and a final `wait_group<0>` drains the
+/// asynchronous lifetime before either slot becomes visible to LLVM.
+///
+/// Operand layout:
+///
+/// ```text
+/// [
+///   slot0_acc_0, ..., slot0_acc_31,
+///   slot1_acc_0, ..., slot1_acc_31,
+///   desc_a0_base, desc_b0_base, desc_a1_base, desc_b1_base,
+///   desc_a0_step, desc_b0_step, desc_a1_step, desc_b1_step,
+///   trip_count,
+/// ]
+/// ```
+///
+/// Result layout mirrors the 64 flattened accumulator inputs.
+#[pliron_op(
+    name = "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16",
+    format
+)]
+pub struct WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op;
+
+impl WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+
+    /// Build the fixed two-slot counted-loop pipeline carrier.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        ctx: &mut Context,
+        accumulators: Vec<Value>,
+        desc_a0_base: Value,
+        desc_b0_base: Value,
+        desc_a1_base: Value,
+        desc_b1_base: Value,
+        desc_a0_step: Value,
+        desc_b0_step: Value,
+        desc_a1_step: Value,
+        desc_b1_step: Value,
+        trip_count: Value,
+    ) -> Ptr<Operation> {
+        let f32_ty = FP32Type::get(ctx);
+        let mut operands =
+            Vec::with_capacity(accumulators.len() + WGMMA_COUNTED_PIPELINE_CONTROL_COUNT);
+        operands.extend(accumulators);
+        operands.extend([
+            desc_a0_base,
+            desc_b0_base,
+            desc_a1_base,
+            desc_b1_base,
+            desc_a0_step,
+            desc_b0_step,
+            desc_a1_step,
+            desc_b1_step,
+            trip_count,
+        ]);
+
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![f32_ty.into(); WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT],
+            operands,
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let expected_operands =
+            WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT + WGMMA_COUNTED_PIPELINE_CONTROL_COUNT;
+
+        if op.get_num_operands() != expected_operands {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires 64 f32 accumulators and exactly nine u64 loop-control operands"
+            );
+        }
+        if op.get_num_results() != WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires exactly 64 f32 results"
+            );
+        }
+
+        for accumulator_index in 0..WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT {
+            if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx))
+                || !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx))
+            {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 accumulator operands and results must be f32"
+                );
+            }
+        }
+
+        for control_index in WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT..expected_operands {
+            if !is_u64(ctx, op.get_operand(control_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 descriptor bases, descriptor steps, and trip count must be u64"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// The statically known `wait_group<N>` bound carried by a
 /// [`WgmmaMmaPipelineValuesM64N64K16F32Bf16Op`].
 ///
@@ -622,5 +742,6 @@ pub(super) fn register(ctx: &mut Context) {
     WgmmaMmaGroupM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaLoopValuesM64N64K16F32Bf16Op::register(ctx);
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -38,8 +38,8 @@ use dialect_nvvm::ops::{
     ThreadfenceOp, ThreadfenceSystemOp, VoteSyncAllOp, VoteSyncAnyOp, VoteSyncBallotOp,
     VoteSyncUniOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMaxPendingAttr,
     WgmmaMmaGroupM64N64K16F32Bf16Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
+    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
 #[test]
@@ -92,6 +92,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("wgmma.rs", "WgmmaMmaGroupM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32Bf16Op"),
+        ("wgmma.rs", "WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaPipelineValuesM64N64K16F32Bf16Op"),
     ];
     expected.sort_unstable();
@@ -4720,6 +4721,100 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     );
     assert!(
         WgmmaMmaLoopValuesM64N64K16F32Bf16Op::new(wrong_loop_result_type)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let counted_pipeline_group = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 64],
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+    );
+    {
+        let counted_pipeline_ref = counted_pipeline_group.deref(&ctx);
+        assert_eq!(counted_pipeline_ref.get_num_operands(), 73);
+        assert_eq!(counted_pipeline_ref.get_num_results(), 64);
+    }
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(counted_pipeline_group)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let too_few_counted_pipeline_accumulators = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 63],
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(too_few_counted_pipeline_accumulators)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut wrong_counted_pipeline_control_operands = vec![f32_value; 64];
+    wrong_counted_pipeline_control_operands.extend([
+        u64_value, u64_value, u64_value, u64_value, u64_value, u64_value, u32_value, u64_value,
+        u64_value,
+    ]);
+    let wrong_counted_pipeline_control = Operation::new(
+        &mut ctx,
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 64],
+        wrong_counted_pipeline_control_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_control)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut valid_counted_pipeline_operands = vec![f32_value; 64];
+    valid_counted_pipeline_operands.extend([u64_value; 9]);
+    let wrong_counted_pipeline_result_count = Operation::new(
+        &mut ctx,
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 63],
+        valid_counted_pipeline_operands.clone(),
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_count)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let mut wrong_counted_pipeline_result_types = vec![f32_ty.into(); 64];
+    wrong_counted_pipeline_result_types[0] = u32_ty.into();
+    let wrong_counted_pipeline_result_type = Operation::new(
+        &mut ctx,
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
+        wrong_counted_pipeline_result_types,
+        valid_counted_pipeline_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_type)
             .verify(&ctx)
             .is_err()
     );

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -40,8 +40,9 @@ use dialect_nvvm::ops::{
     AssertFailOp, CvtaGenericToSharedOffsetOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicFenceOp,
     NvvmAtomicLoadOp, NvvmAtomicRmwOp, NvvmAtomicStoreOp, ReadPtxSregClusterIdxOp,
     ReadPtxSregNclusterIdOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
-    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
+    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -1096,6 +1097,23 @@ impl MirToLlvmConversion for WgmmaMmaLoopValuesM64N64K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma_loop_values(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma_loop_pipeline_values(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -6,7 +6,9 @@
 //! WGMMA conversion for Hopper `sm_90a`.
 
 use crate::convert::intrinsics::common::*;
-use dialect_nvvm::ops::WgmmaMmaPipelineValuesM64N64K16F32Bf16Op;
+use dialect_nvvm::ops::{
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+};
 use llvm_export::ops as llvm;
 use llvm_export::types::{self as llvm_types, VoidType};
 use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
@@ -22,6 +24,9 @@ use pliron::r#type::TypeHandle;
 
 const VALUE_ACCUMULATOR_COUNT: usize = 32;
 const COUNTED_LOOP_CONTROL_COUNT: usize = 5;
+const COUNTED_PIPELINE_SLOT_COUNT: usize = 2;
+const COUNTED_PIPELINE_RESULT_COUNT: usize = COUNTED_PIPELINE_SLOT_COUNT * VALUE_ACCUMULATOR_COUNT;
+const COUNTED_PIPELINE_CONTROL_COUNT: usize = 9;
 
 /// Convert WGMMA make_smem_desc to inline PTX.
 pub(crate) fn convert_make_smem_desc(
@@ -164,6 +169,73 @@ fn counted_loop_template() -> String {
     template.push_str("    wgmma.wait_group.sync.aligned 0;\n");
     template.push('}');
     template
+}
+
+fn counted_pipeline_template() -> String {
+    let slot0 = pipeline_accumulator_operand_list(0);
+    let slot1 = pipeline_accumulator_operand_list(1);
+    let control_base = COUNTED_PIPELINE_RESULT_COUNT * 2;
+    let desc_a0_base = control_base;
+    let desc_b0_base = control_base + 1;
+    let desc_a1_base = control_base + 2;
+    let desc_b1_base = control_base + 3;
+    let desc_a0_step = control_base + 4;
+    let desc_b0_step = control_base + 5;
+    let desc_a1_step = control_base + 6;
+    let desc_b1_step = control_base + 7;
+    let trip_count = control_base + 8;
+
+    let mut template = String::from(
+        "{\n    .reg .u64 %desc_a0;\n    .reg .u64 %desc_b0;\n    .reg .u64 %desc_a1;\n    .reg .u64 %desc_b1;\n    .reg .u64 %remaining;\n    .reg .pred %loop_more;\n",
+    );
+    template.push_str(&format!("    mov.u64 %desc_a0, ${desc_a0_base};\n"));
+    template.push_str(&format!("    mov.u64 %desc_b0, ${desc_b0_base};\n"));
+    template.push_str(&format!("    mov.u64 %desc_a1, ${desc_a1_base};\n"));
+    template.push_str(&format!("    mov.u64 %desc_b1, ${desc_b1_base};\n"));
+    template.push_str(&format!("    mov.u64 %remaining, ${trip_count};\n"));
+    template.push_str("    wgmma.fence.sync.aligned;\n");
+    template.push_str("    setp.eq.u64 %loop_more, %remaining, 0;\n");
+    template.push_str("    @%loop_more bra.uni L__wgmma_pipeline_done_${:uid};\n");
+    template.push_str("L__wgmma_pipeline_loop_${:uid}:\n");
+    template.push_str(&format!(
+        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+         {{{slot0}}}, %desc_a0, %desc_b0, 1, 1, 1, 0, 0;\n"
+    ));
+    template.push_str("    wgmma.commit_group.sync.aligned;\n");
+    template.push_str("    wgmma.wait_group.sync.aligned 1;\n");
+    template.push_str(&format!(
+        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+         {{{slot1}}}, %desc_a1, %desc_b1, 1, 1, 1, 0, 0;\n"
+    ));
+    template.push_str("    wgmma.commit_group.sync.aligned;\n");
+    template.push_str("    wgmma.wait_group.sync.aligned 1;\n");
+    template.push_str(&format!(
+        "    add.u64 %desc_a0, %desc_a0, ${desc_a0_step};\n"
+    ));
+    template.push_str(&format!(
+        "    add.u64 %desc_b0, %desc_b0, ${desc_b0_step};\n"
+    ));
+    template.push_str(&format!(
+        "    add.u64 %desc_a1, %desc_a1, ${desc_a1_step};\n"
+    ));
+    template.push_str(&format!(
+        "    add.u64 %desc_b1, %desc_b1, ${desc_b1_step};\n"
+    ));
+    template.push_str("    sub.u64 %remaining, %remaining, 1;\n");
+    template.push_str("    setp.ne.u64 %loop_more, %remaining, 0;\n");
+    template.push_str("    @%loop_more bra.uni L__wgmma_pipeline_loop_${:uid};\n");
+    template.push_str("L__wgmma_pipeline_done_${:uid}:\n");
+    template.push_str("    wgmma.wait_group.sync.aligned 0;\n");
+    template.push('}');
+    template
+}
+
+fn counted_pipeline_constraints() -> String {
+    let mut constraints = vec!["=f".to_owned(); COUNTED_PIPELINE_RESULT_COUNT];
+    constraints.extend((0..COUNTED_PIPELINE_RESULT_COUNT).map(|index| index.to_string()));
+    constraints.extend((0..COUNTED_PIPELINE_CONTROL_COUNT).map(|_| "l".to_owned()));
+    constraints.push("~{memory}".to_owned());
+    constraints.join(",")
 }
 
 fn pipeline_accumulator_operand_list(slot: usize) -> String {
@@ -393,6 +465,60 @@ pub(crate) fn convert_mma_loop_values(
     Ok(())
 }
 
+/// Lower the fixed two-slot counted WGMMA pipeline to one convergent inline-PTX scope.
+///
+/// Both 32-value accumulator slots are tied across the same asm statement. The
+/// four descriptor recurrences, trip counter, commits, partial waits, and final
+/// full drain all remain internal so LLVM never observes a live asynchronous
+/// accumulator value.
+pub(crate) fn convert_mma_loop_pipeline_values(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let loc = op.deref(ctx).loc();
+    let result_count = op.deref(ctx).get_num_results();
+    let operands: Vec<_> = op.deref(ctx).operands().collect();
+
+    Operation::get_op::<WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op>(op, ctx)
+        .expect("counted-pipeline conversion must be invoked for the counted-pipeline WGMMA op");
+
+    if result_count != COUNTED_PIPELINE_RESULT_COUNT {
+        return pliron::input_err_noloc!(
+            "counted-pipeline value-form WGMMA requires exactly 64 accumulator results"
+        );
+    }
+    if operands.len() != COUNTED_PIPELINE_RESULT_COUNT + COUNTED_PIPELINE_CONTROL_COUNT {
+        return pliron::input_err_noloc!(
+            "counted-pipeline value-form WGMMA requires 64 accumulator inputs and nine loop-control operands"
+        );
+    }
+
+    let template = counted_pipeline_template();
+    let constraints = counted_pipeline_constraints();
+    let f32_ty = FP32Type::get(ctx);
+    let struct_ty: TypeHandle = llvm_types::StructType::get_unnamed(
+        ctx,
+        vec![f32_ty.into(); COUNTED_PIPELINE_RESULT_COUNT],
+    )
+    .into();
+
+    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+    let aggregate = asm_op.deref(ctx).get_result(0);
+
+    let mut extracted_values = Vec::with_capacity(COUNTED_PIPELINE_RESULT_COUNT);
+    for index in 0..COUNTED_PIPELINE_RESULT_COUNT {
+        let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![index as u32])
+            .map_err(|error| pliron::input_error!(loc.clone(), "{}", error))?;
+        rewriter.insert_operation(ctx, extract.get_operation());
+        extracted_values.push(extract.get_operation().deref(ctx).get_result(0));
+    }
+
+    rewriter.replace_operation_with_values(ctx, op, extracted_values);
+    Ok(())
+}
+
 /// Lower a multi-slot BF16 WGMMA pipeline to one convergent inline-PTX scope.
 ///
 /// Each accumulator slot owns 32 tied `f32` registers. Groups are committed
@@ -491,15 +617,16 @@ pub(crate) fn convert_mma(
     _operands_info: &OperandsInfo,
 ) -> Result<()> {
     pliron::input_err_noloc!(
-        "WGMMA MMA reached lowering without deferred accumulator fusion; expected a supported linear wait_group<0> region, a proven partial-wait pipeline, or a canonical counted K-loop"
+        "WGMMA MMA reached lowering without deferred accumulator fusion; expected a supported linear wait_group<0> region, a proven partial-wait pipeline, a canonical counted K-loop, or the fixed two-slot counted pipeline"
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        counted_loop_constraints, counted_loop_template, deferred_group_template,
-        pipeline_constraints, pipeline_template, value_group_constraints, value_group_template,
+        counted_loop_constraints, counted_loop_template, counted_pipeline_constraints,
+        counted_pipeline_template, deferred_group_template, pipeline_constraints,
+        pipeline_template, value_group_constraints, value_group_template,
     };
 
     #[test]
@@ -603,6 +730,59 @@ mod tests {
         assert_eq!(
             constraints.split(',').filter(|value| *value == "l").count(),
             5
+        );
+        assert!(constraints.ends_with("~{memory}"));
+    }
+
+    #[test]
+    fn counted_pipeline_template_keeps_two_slots_and_partial_waits_inside_loop() {
+        let template = counted_pipeline_template();
+        assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+        assert_eq!(
+            template.matches("wgmma.commit_group.sync.aligned").count(),
+            2
+        );
+        assert_eq!(
+            template.matches("wgmma.wait_group.sync.aligned 1").count(),
+            2
+        );
+        assert_eq!(
+            template.matches("wgmma.wait_group.sync.aligned 0").count(),
+            1
+        );
+        assert!(template.contains("L__wgmma_pipeline_loop_${:uid}:"));
+        assert!(template.contains("L__wgmma_pipeline_done_${:uid}:"));
+        assert!(template.contains("{$0, $1, $2"));
+        assert!(template.contains("{$32, $33, $34"));
+        assert!(template.contains("mov.u64 %desc_a0, $128;"));
+        assert!(template.contains("mov.u64 %desc_b0, $129;"));
+        assert!(template.contains("mov.u64 %desc_a1, $130;"));
+        assert!(template.contains("mov.u64 %desc_b1, $131;"));
+        assert!(template.contains("add.u64 %desc_a0, %desc_a0, $132;"));
+        assert!(template.contains("add.u64 %desc_b0, %desc_b0, $133;"));
+        assert!(template.contains("add.u64 %desc_a1, %desc_a1, $134;"));
+        assert!(template.contains("add.u64 %desc_b1, %desc_b1, $135;"));
+        assert!(template.contains("mov.u64 %remaining, $136;"));
+        assert!(!template.contains("ld.f32"));
+        assert!(!template.contains("st.f32"));
+        assert!(!template.contains(".reg .f32"));
+        assert!(
+            !template.contains("\\\n"),
+            "counted-pipeline PTX must not contain a literal line-continuation backslash: {template}"
+        );
+
+        let constraints = counted_pipeline_constraints();
+        assert_eq!(
+            constraints
+                .split(',')
+                .filter(|value| *value == "=f")
+                .count(),
+            64
+        );
+        assert_eq!(
+            constraints.split(',').filter(|value| *value == "l").count(),
+            9
         );
         assert!(constraints.ends_with("~{memory}"));
     }

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -500,11 +500,22 @@ pub(crate) fn convert_mma_loop_pipeline_values(
     let f32_ty = FP32Type::get(ctx);
     let struct_ty: TypeHandle = llvm_types::StructType::get_unnamed(
         ctx,
-        vec![f32_ty.into(); COUNTED_PIPELINE_RESULT_COUNT],
+        (
+            vec![f32_ty.into(); COUNTED_PIPELINE_RESULT_COUNT],
+            llvm_types::StructLayout::Unpacked,
+        ),
     )
     .into();
 
-    let asm_op = inline_asm_convergent(ctx, rewriter, struct_ty, operands, &template, &constraints);
+    let asm_op = inline_asm_convergent(
+        ctx,
+        rewriter,
+        op,
+        struct_ty,
+        operands,
+        &template,
+        &constraints,
+    );
     let aggregate = asm_op.deref(ctx).get_result(0);
 
     let mut extracted_values = Vec::with_capacity(COUNTED_PIPELINE_RESULT_COUNT);

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -530,7 +530,7 @@ fn match_pipelined_counted_loop(
     let mut accumulators = Vec::with_capacity(2);
     let mut slot_types = Vec::with_capacity(2);
     let mut descriptor_args = Vec::with_capacity(4);
-    for mma in mmas.iter().copied() {
+    for &mma in &mmas {
         let mma_ref = mma.deref(ctx);
         let accumulator = mma_ref.get_operand(0);
         require_supported_accumulator(ctx, accumulator)?;

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -33,6 +33,12 @@
 //! Groups are committed and the slots are reused round-robin only after the
 //! corresponding partial wait has made the oldest slot safe. Every accepted
 //! pipeline ends with `wait_group<0>` before any accumulator value escapes.
+//!
+//! A second narrow loop form composes these properties for exactly two
+//! canonical accumulator slots. Its latch must contain two
+//! `MMA -> commit_group -> wait_group<1>` stages, followed by affine recurrences
+//! for four descriptor block arguments. The exit contains the final
+//! `wait_group<0>`. This form is selected before the single-slot counted loop.
 
 use dialect_mir::{
     ops::{
@@ -44,9 +50,9 @@ use dialect_mir::{
 };
 use dialect_nvvm::ops::{
     WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
-    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
-    WgmmaWaitGroupSyncAlignedOp,
+    WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32Bf16Op,
+    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 use mir_transforms::analyses::{induction, loop_info::LoopInfo};
 use pliron::{
@@ -130,6 +136,22 @@ struct CountedLoopPlan {
     trip_count: u64,
     row_type: TypeHandle,
     element_type: TypeHandle,
+}
+
+struct PipelinedCountedLoopPlan {
+    fence: Ptr<Operation>,
+    preheader: Ptr<BasicBlock>,
+    preheader_terminator: Ptr<Operation>,
+    exit: Ptr<BasicBlock>,
+    mmas: Vec<Ptr<Operation>>,
+    commits: Vec<Ptr<Operation>>,
+    partial_waits: Vec<Ptr<Operation>>,
+    final_wait: Ptr<Operation>,
+    accumulators: Vec<Value>,
+    desc_bases: Vec<Value>,
+    desc_steps: Vec<u64>,
+    trip_count: u64,
+    slot_types: Vec<(TypeHandle, TypeHandle)>,
 }
 
 fn collect_blocks(ctx: &Context, root: Ptr<Operation>) -> Vec<Ptr<BasicBlock>> {
@@ -246,6 +268,12 @@ fn counted_loop_operation_is_supported(ctx: &Context, operation: Ptr<Operation>)
         || Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some()
 }
 
+fn pipelined_counted_loop_operation_is_supported(ctx: &Context, operation: Ptr<Operation>) -> bool {
+    counted_loop_operation_is_supported(ctx, operation)
+        || Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some()
+        || Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some()
+}
+
 fn find_preheader_fence(
     ctx: &Context,
     preheader: Ptr<BasicBlock>,
@@ -315,6 +343,26 @@ fn find_exit_commit_wait(
     Ok(None)
 }
 
+fn find_exit_wait_zero(ctx: &Context, exit: Ptr<BasicBlock>) -> Result<Option<Ptr<Operation>>> {
+    for operation in exit.deref(ctx).iter(ctx).collect::<Vec<_>>() {
+        if is_ignorable(ctx, operation) {
+            continue;
+        }
+        if Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_none() {
+            return Ok(None);
+        }
+        require_wait_shape(ctx, operation)?;
+        let wait_operand = operation.deref(ctx).get_operand(0);
+        if integer_constant_u64(ctx, wait_operand) != Some(0) {
+            return pliron::input_err_noloc!(
+                "pipelined counted WGMMA loop requires a final wait_group<0>"
+            );
+        }
+        return Ok(Some(operation));
+    }
+    Ok(None)
+}
+
 fn affine_u64_step(ctx: &Context, argument: Value, next: Value) -> Option<u64> {
     if !is_u64_value(ctx, argument) || !is_u64_value(ctx, next) {
         return None;
@@ -339,6 +387,222 @@ fn affine_u64_step(ctx: &Context, argument: Value, next: Value) -> Option<u64> {
     } else {
         None
     }
+}
+
+fn match_pipelined_counted_loop(
+    ctx: &Context,
+    info: &LoopInfo,
+    region: Ptr<Region>,
+    loop_id: usize,
+) -> Result<Option<PipelinedCountedLoopPlan>> {
+    let r#loop = &info.loops()[loop_id];
+    if !r#loop.children.is_empty() || r#loop.latches.len() != 1 {
+        return Ok(None);
+    }
+
+    let Some(preheader) = info.preheader(ctx, region, loop_id) else {
+        return Ok(None);
+    };
+    let Some(fence) = find_preheader_fence(ctx, preheader)? else {
+        return Ok(None);
+    };
+
+    let exiting_blocks = info.exiting_blocks(ctx, region, loop_id);
+    if exiting_blocks.len() != 1 || exiting_blocks[0] != r#loop.header {
+        return Ok(None);
+    }
+    let exit_blocks = info.exit_blocks(ctx, region, loop_id);
+    if exit_blocks.len() != 1 {
+        return Ok(None);
+    }
+    let exit = exit_blocks[0];
+    if exit.deref(ctx).get_num_arguments() != 0 {
+        return Ok(None);
+    }
+    let Some(final_wait) = find_exit_wait_zero(ctx, exit)? else {
+        return Ok(None);
+    };
+
+    let preheader_terminator = preheader
+        .deref(ctx)
+        .get_terminator(ctx)
+        .expect("counted pipeline preheader must have a terminator");
+    if Operation::get_op::<MirGotoOp>(preheader_terminator, ctx).is_none() {
+        return Ok(None);
+    }
+
+    let latch = r#loop.latches[0];
+    let latch_terminator = latch
+        .deref(ctx)
+        .get_terminator(ctx)
+        .expect("counted pipeline latch must have a terminator");
+    if Operation::get_op::<MirGotoOp>(latch_terminator, ctx).is_none() {
+        return Ok(None);
+    }
+
+    let header = r#loop.header;
+    let header_args = header.deref(ctx).arguments().collect::<Vec<_>>();
+    let Some(init_operands) = edge_operands(ctx, preheader, header) else {
+        return Ok(None);
+    };
+    let Some(recurrence_operands) = edge_operands(ctx, latch, header) else {
+        return Ok(None);
+    };
+    if init_operands.len() != header_args.len() || recurrence_operands.len() != header_args.len() {
+        return Ok(None);
+    }
+
+    let recurrences = induction::analyze(ctx, info, loop_id, preheader);
+    let Some(primary_iv) = recurrences.primary_iv else {
+        return Ok(None);
+    };
+    let Some(trip_count) = recurrences.trip_count else {
+        return Ok(None);
+    };
+    if trip_count == 0 || primary_iv >= header_args.len() {
+        return Ok(None);
+    }
+
+    for &block in &r#loop.blocks {
+        for operation in block.deref(ctx).iter(ctx).collect::<Vec<_>>() {
+            if !pipelined_counted_loop_operation_is_supported(ctx, operation) {
+                return Ok(None);
+            }
+            let is_pipeline_control =
+                Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some()
+                    || Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some()
+                    || Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some();
+            if is_pipeline_control && block != latch {
+                return Ok(None);
+            }
+        }
+    }
+
+    let latch_operations = latch.deref(ctx).iter(ctx).collect::<Vec<_>>();
+    let mut pipeline_events = Vec::new();
+    for (index, operation) in latch_operations.iter().copied().enumerate() {
+        if Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some() {
+            require_pointer_mma_shape(ctx, operation)?;
+            pipeline_events.push((index, 0u8, operation));
+        } else if Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some() {
+            require_nullary_control_op(ctx, operation, "WGMMA commit_group")?;
+            pipeline_events.push((index, 1u8, operation));
+        } else if Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some() {
+            require_wait_shape(ctx, operation)?;
+            let wait_operand = operation.deref(ctx).get_operand(0);
+            if integer_constant_u64(ctx, wait_operand) != Some(1) {
+                return Ok(None);
+            }
+            pipeline_events.push((index, 2u8, operation));
+        }
+    }
+
+    if pipeline_events.len() != 6
+        || pipeline_events
+            .iter()
+            .map(|(_, kind, _)| *kind)
+            .collect::<Vec<_>>()
+            != [0, 1, 2, 0, 1, 2]
+    {
+        return Ok(None);
+    }
+
+    let first_event_index = pipeline_events[0].0;
+    let last_event_index = pipeline_events[5].0;
+    for operation in latch_operations
+        .iter()
+        .copied()
+        .take(last_event_index)
+        .skip(first_event_index + 1)
+    {
+        let is_event = Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some()
+            || Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some()
+            || Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some();
+        if !is_event && !is_ignorable(ctx, operation) {
+            return Ok(None);
+        }
+    }
+
+    let mmas = vec![pipeline_events[0].2, pipeline_events[3].2];
+    let commits = vec![pipeline_events[1].2, pipeline_events[4].2];
+    let partial_waits = vec![pipeline_events[2].2, pipeline_events[5].2];
+
+    let mut accumulators = Vec::with_capacity(2);
+    let mut slot_types = Vec::with_capacity(2);
+    let mut descriptor_args = Vec::with_capacity(4);
+    for mma in mmas.iter().copied() {
+        let mma_ref = mma.deref(ctx);
+        let accumulator = mma_ref.get_operand(0);
+        require_supported_accumulator(ctx, accumulator)?;
+        let Some(shape) = value_accumulator_shape(ctx, accumulator) else {
+            return Ok(None);
+        };
+        if accumulator
+            .defining_block()
+            .is_some_and(|block| r#loop.blocks.contains(&block))
+            || accumulator
+                .defining_op()
+                .and_then(|operation| operation.deref(ctx).get_parent_block())
+                .is_some_and(|block| r#loop.blocks.contains(&block))
+        {
+            return Ok(None);
+        }
+        accumulators.push(accumulator);
+        slot_types.push(shape);
+        descriptor_args.extend([mma_ref.get_operand(1), mma_ref.get_operand(2)]);
+    }
+    if accumulators[0] == accumulators[1] {
+        return Ok(None);
+    }
+
+    let mut descriptor_indices = Vec::with_capacity(4);
+    for descriptor in descriptor_args {
+        if !is_u64_value(ctx, descriptor) {
+            return Ok(None);
+        }
+        let Some(index) = header_args.iter().position(|value| *value == descriptor) else {
+            return Ok(None);
+        };
+        if index == primary_iv || descriptor_indices.contains(&index) {
+            return Ok(None);
+        }
+        descriptor_indices.push(index);
+    }
+
+    let mut desc_bases = Vec::with_capacity(4);
+    let mut desc_steps = Vec::with_capacity(4);
+    for index in descriptor_indices {
+        let base = init_operands[index];
+        if !is_u64_value(ctx, base) {
+            return Ok(None);
+        }
+        let Some(step) = affine_u64_step(ctx, header_args[index], recurrence_operands[index])
+        else {
+            return Ok(None);
+        };
+        desc_bases.push(base);
+        desc_steps.push(step);
+    }
+
+    if loop_values_escape(ctx, &r#loop.blocks) {
+        return Ok(None);
+    }
+
+    Ok(Some(PipelinedCountedLoopPlan {
+        fence,
+        preheader,
+        preheader_terminator,
+        exit,
+        mmas,
+        commits,
+        partial_waits,
+        final_wait,
+        accumulators,
+        desc_bases,
+        desc_steps,
+        trip_count,
+        slot_types,
+    }))
 }
 
 fn match_counted_loop(
@@ -850,6 +1114,103 @@ fn rewire_goto(
     for &operand in operands {
         Operation::push_operand(terminator, ctx, operand);
     }
+}
+
+fn apply_pipelined_counted_loop_plan(ctx: &mut Context, plan: PipelinedCountedLoopPlan) {
+    let PipelinedCountedLoopPlan {
+        fence,
+        preheader,
+        preheader_terminator,
+        exit,
+        mmas,
+        commits,
+        partial_waits,
+        final_wait,
+        accumulators,
+        desc_bases,
+        desc_steps,
+        trip_count,
+        slot_types,
+    } = plan;
+
+    debug_assert_eq!(accumulators.len(), 2);
+    debug_assert_eq!(desc_bases.len(), 4);
+    debug_assert_eq!(desc_steps.len(), 4);
+    debug_assert_eq!(slot_types.len(), 2);
+    debug_assert_eq!(
+        preheader.deref(ctx).get_terminator(ctx),
+        Some(preheader_terminator)
+    );
+    debug_assert_eq!(exit.deref(ctx).get_num_arguments(), 0);
+
+    let loc = fence.deref(ctx).loc();
+    let mut element_pointers = Vec::with_capacity(2);
+    let mut all_accumulator_values = Vec::with_capacity(2 * ACCUMULATOR_LEN);
+    for slot in 0..2 {
+        let (row_type, element_type) = slot_types[slot];
+        let (pointers, values) = load_accumulator_values_before(
+            ctx,
+            preheader_terminator,
+            accumulators[slot],
+            row_type,
+            element_type,
+            loc.clone(),
+        );
+        element_pointers.push(pointers);
+        all_accumulator_values.extend(values);
+    }
+
+    let step_values = desc_steps
+        .into_iter()
+        .map(|step| insert_u64_constant_before(ctx, step, preheader_terminator))
+        .collect::<Vec<_>>();
+    let trip_count = insert_u64_constant_before(ctx, trip_count, preheader_terminator);
+
+    let pipeline = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        ctx,
+        all_accumulator_values,
+        desc_bases[0],
+        desc_bases[1],
+        desc_bases[2],
+        desc_bases[3],
+        step_values[0],
+        step_values[1],
+        step_values[2],
+        step_values[3],
+        trip_count,
+    );
+    pipeline.deref_mut(ctx).set_loc(loc.clone());
+    let accumulator_results = (0..2 * ACCUMULATOR_LEN)
+        .map(|index| pipeline.deref(ctx).get_result(index))
+        .collect::<Vec<_>>();
+    pipeline.insert_before(ctx, preheader_terminator);
+
+    for slot in 0..2 {
+        let begin = slot * ACCUMULATOR_LEN;
+        let end = begin + ACCUMULATOR_LEN;
+        store_accumulator_values_before(
+            ctx,
+            preheader_terminator,
+            std::mem::take(&mut element_pointers[slot]),
+            accumulator_results[begin..end].to_vec(),
+            loc.clone(),
+        );
+    }
+
+    let mut rewriter = IRRewriter::<Recorder>::default();
+    rewriter.erase_operation(ctx, fence);
+    for mma in mmas {
+        rewriter.erase_operation(ctx, mma);
+    }
+    for commit in commits {
+        rewriter.erase_operation(ctx, commit);
+    }
+    for wait in partial_waits {
+        rewriter.erase_operation(ctx, wait);
+    }
+    rewriter.erase_operation(ctx, final_wait);
+
+    rewire_goto(ctx, preheader_terminator, exit, &[]);
 }
 
 fn apply_counted_loop_plan(ctx: &mut Context, plan: CountedLoopPlan) {
@@ -1525,6 +1886,11 @@ pub(crate) fn fuse_deferred_accumulators(
     module_op: Ptr<Operation>,
 ) -> Result<()> {
     loop {
+        enum CountedPlan {
+            Pipelined(PipelinedCountedLoopPlan),
+            Single(CountedLoopPlan),
+        }
+
         let mut counted_plan = None;
 
         'functions: for function in collect_functions(ctx, module_op) {
@@ -1545,8 +1911,12 @@ pub(crate) fn fuse_deferred_accumulators(
             };
 
             for loop_id in 0..info.loops().len() {
+                if let Some(plan) = match_pipelined_counted_loop(ctx, &info, region, loop_id)? {
+                    counted_plan = Some((function, CountedPlan::Pipelined(plan)));
+                    break 'functions;
+                }
                 if let Some(plan) = match_counted_loop(ctx, &info, region, loop_id)? {
-                    counted_plan = Some((function, plan));
+                    counted_plan = Some((function, CountedPlan::Single(plan)));
                     break 'functions;
                 }
             }
@@ -1556,7 +1926,10 @@ pub(crate) fn fuse_deferred_accumulators(
             break;
         };
 
-        apply_counted_loop_plan(ctx, plan);
+        match plan {
+            CountedPlan::Pipelined(plan) => apply_pipelined_counted_loop_plan(ctx, plan),
+            CountedPlan::Single(plan) => apply_counted_loop_plan(ctx, plan),
+        }
         let mut rewriter = IRRewriter::<Recorder>::default();
         remove_blocks_inside_op(function, ctx, &mut rewriter);
     }

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -9486,6 +9486,329 @@ fn test_pointer_form_wgmma_partial_wait_pipeline_keeps_multiple_groups_in_flight
 }
 
 #[test]
+fn test_pointer_form_wgmma_two_slot_counted_pipeline_stays_register_resident()
+-> Result<(), anyhow::Error> {
+    use dialect_mir::types::{MirArrayType, MirPtrType};
+    use pliron::basic_block::BasicBlock;
+    use pliron::builtin::op_interfaces::OperandSegmentInterface;
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    const SLOT_COUNT: usize = 2;
+    const ACCUMULATOR_LEN: usize = 32;
+    const RESULT_COUNT: usize = SLOT_COUNT * ACCUMULATOR_LEN;
+    const LOOP_CONTROL_COUNT: usize = 9;
+    const TRIP_COUNT: u64 = 4;
+    const DESC_A0_STEP: u64 = 16;
+    const DESC_B0_STEP: u64 = 32;
+    const DESC_A1_STEP: u64 = 48;
+    const DESC_B1_STEP: u64 = 64;
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let row_ty = MirArrayType::get(&mut ctx, f32_ty.into(), 8);
+    let accumulator_ty = MirArrayType::get(&mut ctx, row_ty.into(), 4);
+    let accumulator_ptr_ty = MirPtrType::get_generic(&mut ctx, accumulator_ty.into(), true);
+    let u32_ty = IntegerType::get(&ctx, 32, Signedness::Unsigned);
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    let i1_ty = IntegerType::get(&ctx, 1, Signedness::Signless);
+
+    let (module_ptr, preheader) = build_test_kernel(
+        &mut ctx,
+        vec![
+            accumulator_ptr_ty.into(),
+            accumulator_ptr_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+        ],
+    );
+    let accumulator0 = preheader.deref(&ctx).get_argument(0);
+    let accumulator1 = preheader.deref(&ctx).get_argument(1);
+    let desc_a0_base = preheader.deref(&ctx).get_argument(2);
+    let desc_b0_base = preheader.deref(&ctx).get_argument(3);
+    let desc_a1_base = preheader.deref(&ctx).get_argument(4);
+    let desc_b1_base = preheader.deref(&ctx).get_argument(5);
+
+    let module_region = module_ptr.deref(&ctx).get_region(0);
+    let module_block = module_region.deref(&ctx).iter(&ctx).next().unwrap();
+    let function = module_block.deref(&ctx).iter(&ctx).next().unwrap();
+    let function_region = function.deref(&ctx).get_region(0);
+
+    let header = BasicBlock::new(
+        &mut ctx,
+        None,
+        vec![
+            u32_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+            u64_ty.into(),
+        ],
+    );
+    header.insert_at_back(function_region, &ctx);
+    let latch = BasicBlock::new(&mut ctx, None, vec![]);
+    latch.insert_at_back(function_region, &ctx);
+    let exit = BasicBlock::new(&mut ctx, None, vec![]);
+    exit.insert_at_back(function_region, &ctx);
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(preheader, &ctx);
+    let i0 = append_mir_unsigned_constant(&mut ctx, preheader, u32_ty, 0);
+    Operation::new(
+        &mut ctx,
+        mir::MirGotoOp::get_concrete_op_info(),
+        vec![],
+        vec![i0, desc_a0_base, desc_b0_base, desc_a1_base, desc_b1_base],
+        vec![header],
+        0,
+    )
+    .insert_at_back(preheader, &ctx);
+
+    let i = header.deref(&ctx).get_argument(0);
+    let desc_a0 = header.deref(&ctx).get_argument(1);
+    let desc_b0 = header.deref(&ctx).get_argument(2);
+    let desc_a1 = header.deref(&ctx).get_argument(3);
+    let desc_b1 = header.deref(&ctx).get_argument(4);
+    let bound = append_mir_unsigned_constant(&mut ctx, header, u32_ty, TRIP_COUNT);
+    let lt = Operation::new(
+        &mut ctx,
+        mir::MirLtOp::get_concrete_op_info(),
+        vec![i1_ty.into()],
+        vec![i, bound],
+        vec![],
+        0,
+    );
+    lt.insert_at_back(header, &ctx);
+    let lt_value = lt.deref(&ctx).get_result(0);
+    let not_lt = Operation::new(
+        &mut ctx,
+        mir::MirNotOp::get_concrete_op_info(),
+        vec![i1_ty.into()],
+        vec![lt_value],
+        vec![],
+        0,
+    );
+    not_lt.insert_at_back(header, &ctx);
+    let not_lt_value = not_lt.deref(&ctx).get_result(0);
+    let (branch_operands, segment_sizes) =
+        mir::MirCondBranchOp::compute_segment_sizes(vec![vec![not_lt_value], vec![], vec![]]);
+    let branch = Operation::new(
+        &mut ctx,
+        mir::MirCondBranchOp::get_concrete_op_info(),
+        vec![],
+        branch_operands,
+        vec![exit, latch],
+        0,
+    );
+    Operation::get_op::<mir::MirCondBranchOp>(branch, &ctx)
+        .expect("MirCondBranchOp")
+        .set_operand_segment_sizes(&ctx, segment_sizes);
+    branch.insert_at_back(header, &ctx);
+
+    append_pointer_wgmma_mma(&mut ctx, latch, accumulator0, desc_a0, desc_b0);
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(latch, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, latch, 1);
+    append_pointer_wgmma_mma(&mut ctx, latch, accumulator1, desc_a1, desc_b1);
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(latch, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, latch, 1);
+
+    let one = append_mir_unsigned_constant(&mut ctx, latch, u32_ty, 1);
+    let i_next = Operation::new(
+        &mut ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![i, one],
+        vec![],
+        0,
+    );
+    i_next.insert_at_back(latch, &ctx);
+    let i_next = i_next.deref(&ctx).get_result(0);
+
+    let desc_a0_step = append_mir_unsigned_constant(&mut ctx, latch, u64_ty, DESC_A0_STEP);
+    let desc_a0_next = Operation::new(
+        &mut ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![desc_a0, desc_a0_step],
+        vec![],
+        0,
+    );
+    desc_a0_next.insert_at_back(latch, &ctx);
+    let desc_a0_next = desc_a0_next.deref(&ctx).get_result(0);
+
+    let desc_b0_step = append_mir_unsigned_constant(&mut ctx, latch, u64_ty, DESC_B0_STEP);
+    let desc_b0_next = Operation::new(
+        &mut ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![desc_b0, desc_b0_step],
+        vec![],
+        0,
+    );
+    desc_b0_next.insert_at_back(latch, &ctx);
+    let desc_b0_next = desc_b0_next.deref(&ctx).get_result(0);
+
+    let desc_a1_step = append_mir_unsigned_constant(&mut ctx, latch, u64_ty, DESC_A1_STEP);
+    let desc_a1_next = Operation::new(
+        &mut ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![desc_a1, desc_a1_step],
+        vec![],
+        0,
+    );
+    desc_a1_next.insert_at_back(latch, &ctx);
+    let desc_a1_next = desc_a1_next.deref(&ctx).get_result(0);
+
+    let desc_b1_step = append_mir_unsigned_constant(&mut ctx, latch, u64_ty, DESC_B1_STEP);
+    let desc_b1_next = Operation::new(
+        &mut ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u64_ty.into()],
+        vec![desc_b1, desc_b1_step],
+        vec![],
+        0,
+    );
+    desc_b1_next.insert_at_back(latch, &ctx);
+    let desc_b1_next = desc_b1_next.deref(&ctx).get_result(0);
+
+    Operation::new(
+        &mut ctx,
+        mir::MirGotoOp::get_concrete_op_info(),
+        vec![],
+        vec![
+            i_next,
+            desc_a0_next,
+            desc_b0_next,
+            desc_a1_next,
+            desc_b1_next,
+        ],
+        vec![header],
+        0,
+    )
+    .insert_at_back(latch, &ctx);
+
+    append_wgmma_wait_group_constant(&mut ctx, exit, 0);
+    append_return(&mut ctx, exit);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let body = lowered_kernel_body(&ctx, module_ptr);
+    let matching = body
+        .iter()
+        .copied()
+        .filter_map(|operation| {
+            Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx)
+                .map(|inline_asm| (operation, inline_asm))
+        })
+        .filter(|(_, asm)| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("L__wgmma_pipeline_loop_${:uid}:"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one fused two-slot counted WGMMA pipeline"
+    );
+
+    let (asm_operation, asm) = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("counted-pipeline WGMMA template");
+
+    assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+    assert_eq!(
+        template.matches("wgmma.commit_group.sync.aligned").count(),
+        2
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 1").count(),
+        2
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1
+    );
+    assert!(template.contains("{$0, $1"));
+    assert!(template.contains("{$32, $33"));
+    assert!(template.contains("mov.u64 %desc_a0, $128;"));
+    assert!(template.contains("mov.u64 %desc_b0, $129;"));
+    assert!(template.contains("mov.u64 %desc_a1, $130;"));
+    assert!(template.contains("mov.u64 %desc_b1, $131;"));
+    assert!(template.contains("add.u64 %desc_a0, %desc_a0, $132;"));
+    assert!(template.contains("add.u64 %desc_b0, %desc_b0, $133;"));
+    assert!(template.contains("add.u64 %desc_a1, %desc_a1, $134;"));
+    assert!(template.contains("add.u64 %desc_b1, %desc_b1, $135;"));
+    assert!(template.contains("mov.u64 %remaining, $136;"));
+    assert!(
+        !template.contains(".reg .f32")
+            && !template.contains("ld.f32")
+            && !template.contains("st.f32"),
+        "counted pipeline must keep accumulator memory outside asm: {template}"
+    );
+
+    let mut expected_constraints = vec!["=f".to_owned(); RESULT_COUNT];
+    expected_constraints.extend((0..RESULT_COUNT).map(|index| index.to_string()));
+    expected_constraints.extend((0..LOOP_CONTROL_COUNT).map(|_| "l".to_owned()));
+    expected_constraints.push("~{memory}".to_owned());
+    let expected_constraints = expected_constraints.join(",");
+    assert_eq!(
+        asm.get_attr_inline_asm_constraints(&ctx)
+            .map(|value| String::from((*value).clone()))
+            .as_deref(),
+        Some(expected_constraints.as_str())
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+    assert_eq!(
+        asm_operation.deref(&ctx).get_num_operands(),
+        RESULT_COUNT + LOOP_CONTROL_COUNT
+    );
+
+    let asm_position = body
+        .iter()
+        .position(|operation| operation == asm_operation)
+        .expect("counted-pipeline WGMMA asm must be in the lowered kernel body");
+    let load_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::LoadOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(load_positions.len(), RESULT_COUNT);
+    assert!(load_positions.iter().all(|index| *index < asm_position));
+
+    let store_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::StoreOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(store_positions.len(), RESULT_COUNT);
+    assert!(store_positions.iter().all(|index| *index > asm_position));
+    assert_eq!(
+        body.iter()
+            .filter(|operation| {
+                Operation::get_op::<llvm::ExtractValueOp>(**operation, &ctx).is_some()
+            })
+            .count(),
+        RESULT_COUNT
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_pointer_form_wgmma_counted_k_loop_stays_register_resident() -> Result<(), anyhow::Error> {
     use dialect_mir::types::{MirArrayType, MirPtrType};
     use pliron::basic_block::BasicBlock;


### PR DESCRIPTION
Fixes #934 

## Summary

Add production lowering for a conservative two-slot BF16 WGMMA pipeline inside canonical counted K-loops.

The new path combines the existing register-resident counted-loop model with the existing partial-wait pipeline model while keeping the complete asynchronous WGMMA lifetime inside one convergent inline-PTX scope.

## What changed

Add an internal value-form counted-pipeline carrier with:

```text
64 x f32 accumulator inputs
9 x u64 loop/control inputs
64 x f32 accumulator results
```

The nine control operands are:

```text
desc_a0_base
desc_b0_base
desc_a1_base
desc_b1_base

desc_a0_step
desc_b0_step
desc_a1_step
desc_b1_step

trip_count
```

The lowering emits the following static pipeline inside the counted PTX loop:

```text
mma slot0
commit_group
wait_group<1>

mma slot1
commit_group
wait_group<1>

advance four descriptors
decrement trip counter
branch
```

A final `wait_group<0>` drains the remaining asynchronous work before either accumulator becomes visible to LLVM.

## Recognition

The deferred-accumulator fusion pass recognizes this shape before falling back to the existing single-accumulator counted-loop matcher.

The accepted form is intentionally narrow:

* one canonical counted loop;
* one latch;
* one exit;
* compile-time positive trip count;
* two distinct canonical `[[f32; 8]; 4]` accumulators;
* exactly two pointer-form BF16 WGMMA operations in the latch;
* one commit and `wait_group<1>` after each MMA;
* four distinct `u64` descriptor block arguments;
* affine descriptor recurrences;
* final `wait_group<0>` in the exit;
* no loop values escaping the fused region.

## Validation

Validated with CUDA 13.3 `ptxas` targeting `sm_90a`.

The new end-to-end test starts from pointer-form MIR and exercises the complete production path:

```text
pointer-form MIR
    -> counted-pipeline recognition
    -> 64-value internal carrier
    -> convergent inline PTX
    -> LLVM NVPTX
    -> ptxas sm_90a
```

`ptxas` reports:

```text
Function properties for wgmma_pipelined_counted_loop_kernel
    0 bytes stack frame
    0 bytes spill stores
    0 bytes spill loads
Used 90 registers, used 0 barriers
```

For comparison:

```text
single-slot counted K-loop       58 registers, 0 spills
two-slot straight-line pipeline  90 registers, 0 spills
two-slot counted pipeline        90 registers, 0 spills
```

The combined counted pipeline therefore retains the same reported register count as the existing two-slot straight-line pipeline.

The affected test suites also pass:

```text
dialect-nvvm        50 passed
mir-lower unit     220 passed
mir-lower tests    106 passed
cuda-oxide-codegen all tests passed
```

Formatting and whitespace validation also pass:

```text
cargo fmt --all
cargo fmt --all -- --check
git diff --check
```

## Scope

This PR intentionally supports only:

```text
2 accumulator slots
wait_group<1>
canonical counted K-loop
BF16 m64n64k16 -> f32 accumulator
```

It does not generalize counted-loop scheduling to arbitrary wait depths, accumulator counts, CFG shapes, dynamic waits, or additional WGMMA data types.

Fixes #932