### PR TITLE
Add full debug info for Rust enums

### DIFF
--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -398,6 +398,10 @@ impl<'a> ModuleExportState<'a> {
             return id;
         }
 
+        if matches!(ty, DebugLocalTypeKind::Enum { .. }) {
+            return self.ensure_enum_debug_type(ty);
+        }
+
         let node = match ty {
             DebugLocalTypeKind::Basic {
                 name,
@@ -471,6 +475,9 @@ impl<'a> ModuleExportState<'a> {
                      size: {size_bits}, elements: !{elements_id})"
                 )
             }
+            DebugLocalTypeKind::Enum { .. } => {
+                unreachable!("enum debug types use ensure_enum_debug_type")
+            }
         };
 
         let id = self.alloc_metadata_id();
@@ -478,6 +485,148 @@ impl<'a> ModuleExportState<'a> {
         self.debug_types.insert(ty.clone(), id);
 
         id
+    }
+
+    /// Emit a Rust enum using the same parent/child scope relationships rustc
+    /// gives LLVM's native DWARF enum builder.
+    ///
+    /// Reserving the top-level and variant-part metadata IDs first lets child
+    /// nodes reference their semantic parents even though LLVM metadata is
+    /// serialized as a flat numbered list. This matters for discriminator
+    /// members at non-zero offsets: the member must be tied to the enum object
+    /// whose address `llvm.dbg.declare` describes, not emitted as an orphan.
+    fn ensure_enum_debug_type(&mut self, ty: &DebugLocalTypeKind) -> usize {
+        if let Some(id) = self.debug_types.get(ty).copied() {
+            return id;
+        }
+
+        let DebugLocalTypeKind::Enum {
+            name,
+            size_bits,
+            discriminant,
+            variants,
+        } = ty
+        else {
+            unreachable!("ensure_enum_debug_type requires an enum")
+        };
+
+        // rustc creates a recursive metadata graph. Reserve the parent IDs and
+        // cache the top-level type before emitting children so forward metadata
+        // references are well-defined and recursive type discovery terminates.
+        let enum_type_id = self.alloc_metadata_id();
+        let variant_part_id = self.alloc_metadata_id();
+        self.debug_types.insert(ty.clone(), enum_type_id);
+
+        let discriminator_member_id = discriminant.as_ref().map(|discriminant| {
+            let base = self.ensure_debug_type(&discriminant.ty);
+            let id = self.alloc_metadata_id();
+            self.debug_nodes.push((
+                id,
+                format!(
+                    "!DIDerivedType(tag: DW_TAG_member, scope: !{enum_type_id}, \
+                     baseType: !{base}, size: {}, offset: {}, flags: DIFlagArtificial)",
+                    discriminant.ty.size_bits(),
+                    discriminant.offset_bits
+                ),
+            ));
+            id
+        });
+        let discriminant_width = discriminant
+            .as_ref()
+            .map(|discriminant| discriminant.ty.size_bits())
+            .unwrap_or(64);
+
+        let mut variant_member_ids = Vec::with_capacity(variants.len());
+        for variant in variants {
+            // The variant struct is a sibling of the variant part under the
+            // enum type. Reserve its ID before its fields so each field can
+            // carry the correct struct scope, matching rustc native debuginfo.
+            let variant_struct_id = self.alloc_metadata_id();
+            let mut payload_member_ids = Vec::with_capacity(variant.members.len());
+            for member in &variant.members {
+                let base = self.ensure_debug_type(&member.ty);
+                let member_name = escape_debug_string(&member.name);
+                let member_size = member.ty.size_bits();
+                let id = self.alloc_metadata_id();
+                self.debug_nodes.push((
+                    id,
+                    format!(
+                        "!DIDerivedType(tag: DW_TAG_member, name: \"{member_name}\", \
+                         scope: !{variant_struct_id}, baseType: !{base}, \
+                         size: {member_size}, offset: {})",
+                        member.offset_bits
+                    ),
+                ));
+                payload_member_ids.push(id);
+            }
+
+            let payload_elements = payload_member_ids
+                .iter()
+                .map(|id| format!("!{id}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let payload_elements_id = self.alloc_metadata_id();
+            self.debug_nodes
+                .push((payload_elements_id, format!("!{{{payload_elements}}}")));
+
+            let variant_name = escape_debug_string(&variant.name);
+            self.debug_nodes.push((
+                variant_struct_id,
+                format!(
+                    "!DICompositeType(tag: DW_TAG_structure_type, name: \"{variant_name}\", \
+                     scope: !{enum_type_id}, size: {size_bits}, elements: !{payload_elements_id})"
+                ),
+            ));
+
+            let extra_data = variant
+                .discriminant
+                .map(|value| format!(", extraData: i{discriminant_width} {value}"))
+                .unwrap_or_default();
+            let variant_member_id = self.alloc_metadata_id();
+            self.debug_nodes.push((
+                variant_member_id,
+                format!(
+                    "!DIDerivedType(tag: DW_TAG_member, name: \"{variant_name}\", \
+                     scope: !{variant_part_id}, baseType: !{variant_struct_id}, \
+                     size: {size_bits}, offset: 0{extra_data})"
+                ),
+            ));
+            variant_member_ids.push(variant_member_id);
+        }
+
+        let variant_elements = variant_member_ids
+            .iter()
+            .map(|id| format!("!{id}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let variant_elements_id = self.alloc_metadata_id();
+        self.debug_nodes
+            .push((variant_elements_id, format!("!{{{variant_elements}}}")));
+
+        let discriminator = discriminator_member_id
+            .map(|id| format!(", discriminator: !{id}"))
+            .unwrap_or_default();
+        self.debug_nodes.push((
+            variant_part_id,
+            format!(
+                "!DICompositeType(tag: DW_TAG_variant_part, scope: !{enum_type_id}, \
+                 size: {size_bits}, elements: !{variant_elements_id}{discriminator})"
+            ),
+        ));
+
+        let enum_elements_id = self.alloc_metadata_id();
+        self.debug_nodes
+            .push((enum_elements_id, format!("!{{!{variant_part_id}}}")));
+        let name = escape_debug_string(name);
+        self.debug_nodes.push((
+            enum_type_id,
+            format!(
+                "!DICompositeType(tag: DW_TAG_structure_type, name: \"{name}\", \
+                 size: {size_bits}, elements: !{enum_elements_id})"
+            ),
+        ));
+
+        enum_type_id
     }
 
     fn debug_location_for_scope(&mut self, scope: usize, loc: &Location) -> Option<usize> {

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -505,6 +505,19 @@ pub mod ops {
             size_bits: u64,
             members: Vec<DebugTypeMember>,
         },
+        /// A Rust enum represented with DWARF variant-part metadata.
+        ///
+        /// The top-level enum is a `DW_TAG_structure_type` containing one
+        /// `DW_TAG_variant_part`. Each source variant is described by an
+        /// artificial struct containing its payload fields. `discriminant` is
+        /// absent for single/empty layouts and is the physical tag or niche
+        /// carrier for multi-variant layouts.
+        Enum {
+            name: String,
+            size_bits: u64,
+            discriminant: Option<DebugEnumDiscriminant>,
+            variants: Vec<DebugEnumVariant>,
+        },
         /// A fixed-length array `DICompositeType` (`DW_TAG_array_type`).
         Array {
             name: String,
@@ -523,6 +536,29 @@ pub mod ops {
         pub ty: DebugLocalTypeKind,
     }
 
+    /// Physical enum tag/niche carrier used by `DW_TAG_variant_part`.
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    pub struct DebugEnumDiscriminant {
+        /// Bit offset of the physical carrier within the enum storage.
+        pub offset_bits: u64,
+        /// The physical carrier type. Niche pointer carriers are intentionally
+        /// represented as an unsigned integer of the same width, matching
+        /// rustc's native DWARF strategy.
+        pub ty: Box<DebugLocalTypeKind>,
+    }
+
+    /// One Rust enum source variant.
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    pub struct DebugEnumVariant {
+        pub name: String,
+        /// Physical discriminant value selecting this variant. `None` is used
+        /// for single/empty layouts and for the untagged niche variant.
+        pub discriminant: Option<u64>,
+        /// Payload members at their rustc-reported offsets within the complete
+        /// enum object.
+        pub members: Vec<DebugTypeMember>,
+    }
+
     impl DebugLocalTypeKind {
         /// Size of this type in bits, used to fill `DIDerivedType`/member sizes.
         pub fn size_bits(&self) -> u64 {
@@ -530,6 +566,7 @@ pub mod ops {
                 DebugLocalTypeKind::Basic { size_bits, .. }
                 | DebugLocalTypeKind::Pointer { size_bits, .. }
                 | DebugLocalTypeKind::Struct { size_bits, .. }
+                | DebugLocalTypeKind::Enum { size_bits, .. }
                 | DebugLocalTypeKind::Array { size_bits, .. } => *size_bits,
             }
         }
@@ -590,6 +627,41 @@ pub mod ops {
                     put_str(out, &member.name);
                     put_u64(out, member.offset_bits);
                     serialize_debug_type(&member.ty, out);
+                }
+            }
+            DebugLocalTypeKind::Enum {
+                name,
+                size_bits,
+                discriminant,
+                variants,
+            } => {
+                out.push('e');
+                put_u64(out, *size_bits);
+                put_str(out, name);
+                match discriminant {
+                    Some(discriminant) => {
+                        put_u64(out, 1);
+                        put_u64(out, discriminant.offset_bits);
+                        serialize_debug_type(&discriminant.ty, out);
+                    }
+                    None => put_u64(out, 0),
+                }
+                put_u64(out, variants.len() as u64);
+                for variant in variants {
+                    put_str(out, &variant.name);
+                    match variant.discriminant {
+                        Some(value) => {
+                            put_u64(out, 1);
+                            put_u64(out, value);
+                        }
+                        None => put_u64(out, 0),
+                    }
+                    put_u64(out, variant.members.len() as u64);
+                    for member in &variant.members {
+                        put_str(out, &member.name);
+                        put_u64(out, member.offset_bits);
+                        serialize_debug_type(&member.ty, out);
+                    }
                 }
             }
             DebugLocalTypeKind::Array {
@@ -669,6 +741,52 @@ pub mod ops {
                     name,
                     size_bits,
                     members,
+                })
+            }
+            b'e' => {
+                let size_bits = take_u64(bytes, pos)?;
+                let name = take_str(bytes, pos)?;
+                let discriminant = match take_u64(bytes, pos)? {
+                    0 => None,
+                    1 => {
+                        let offset_bits = take_u64(bytes, pos)?;
+                        let ty = Box::new(deserialize_debug_type(bytes, pos)?);
+                        Some(DebugEnumDiscriminant { offset_bits, ty })
+                    }
+                    _ => return None,
+                };
+                let variant_count = take_u64(bytes, pos)? as usize;
+                let mut variants = Vec::with_capacity(variant_count);
+                for _ in 0..variant_count {
+                    let variant_name = take_str(bytes, pos)?;
+                    let discriminant_value = match take_u64(bytes, pos)? {
+                        0 => None,
+                        1 => Some(take_u64(bytes, pos)?),
+                        _ => return None,
+                    };
+                    let member_count = take_u64(bytes, pos)? as usize;
+                    let mut members = Vec::with_capacity(member_count);
+                    for _ in 0..member_count {
+                        let member_name = take_str(bytes, pos)?;
+                        let offset_bits = take_u64(bytes, pos)?;
+                        let ty = deserialize_debug_type(bytes, pos)?;
+                        members.push(DebugTypeMember {
+                            name: member_name,
+                            offset_bits,
+                            ty,
+                        });
+                    }
+                    variants.push(DebugEnumVariant {
+                        name: variant_name,
+                        discriminant: discriminant_value,
+                        members,
+                    });
+                }
+                Some(DebugLocalTypeKind::Enum {
+                    name,
+                    size_bits,
+                    discriminant,
+                    variants,
                 })
             }
             b'a' => {
@@ -1437,9 +1555,9 @@ pub mod ops {
     #[cfg(test)]
     mod tests {
         use super::{
-            DebugLocalTypeKind, DebugTypeMember, GlobalInitializerRelocation,
-            decode_global_initializer_relocations, deserialize_debug_type,
-            encode_global_initializer_relocations, serialize_debug_type,
+            DebugEnumDiscriminant, DebugEnumVariant, DebugLocalTypeKind, DebugTypeMember,
+            GlobalInitializerRelocation, decode_global_initializer_relocations,
+            deserialize_debug_type, encode_global_initializer_relocations, serialize_debug_type,
         };
 
         fn round_trip(ty: &DebugLocalTypeKind) -> DebugLocalTypeKind {
@@ -1493,6 +1611,43 @@ pub mod ops {
                     },
                 ],
             };
+            assert_eq!(round_trip(&ty), ty);
+        }
+
+        #[test]
+        fn round_trips_enum_variant_metadata() {
+            let ty = DebugLocalTypeKind::Enum {
+                name: "Option<&u32>".to_string(),
+                size_bits: 64,
+                discriminant: Some(DebugEnumDiscriminant {
+                    offset_bits: 0,
+                    ty: Box::new(DebugLocalTypeKind::Basic {
+                        name: "usize".to_string(),
+                        size_bits: 64,
+                        encoding: "DW_ATE_unsigned",
+                    }),
+                }),
+                variants: vec![
+                    DebugEnumVariant {
+                        name: "None".to_string(),
+                        discriminant: Some(0),
+                        members: vec![],
+                    },
+                    DebugEnumVariant {
+                        name: "Some".to_string(),
+                        discriminant: None,
+                        members: vec![DebugTypeMember {
+                            name: "0".to_string(),
+                            offset_bits: 0,
+                            ty: DebugLocalTypeKind::Pointer {
+                                name: "&u32".to_string(),
+                                size_bits: 64,
+                            },
+                        }],
+                    },
+                ],
+            };
+
             assert_eq!(round_trip(&ty), ty);
         }
 

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -14,10 +14,11 @@ use llvm_export::{
     op_interfaces::CastOpInterface,
     ops::{
         AddrSpaceCastOp, AddressOfOp, AllocaOp, BitcastOp, BrOp, CallOp, CondBrOp, ConstantOp,
-        DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourcePosition, DebugSourceScope,
-        DebugSourceScopeLocation, DebugSourceScopeMap, DebugValueOp, FuncOp, GepIndex,
-        GetElementPtrOp, GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp, LoadOp,
-        ReturnOp, SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
+        DebugEnumDiscriminant, DebugEnumVariant, DebugLocalTypeKind, DebugLocalVariableInfo,
+        DebugSourcePosition, DebugSourceScope, DebugSourceScopeLocation, DebugSourceScopeMap,
+        DebugValueOp, FuncOp, GepIndex, GetElementPtrOp, GlobalInitializerRelocation, GlobalOp,
+        GlobalOpExt, InlineAsmOp, LoadOp, ReturnOp, SelectOp, StoreOp, UndefOp,
+        encode_global_initializer_relocations,
     },
     types::{ArrayType, FuncType, HalfType, PointerType, StructType, VoidType},
 };
@@ -2690,6 +2691,188 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
             "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*mut f32\", baseType: null, size: 64)"
         ),
         "pointer variables should get a pointer DIType:\n{ir}"
+    );
+}
+
+#[test]
+fn full_debug_metadata_emits_rust_enum_variant_parts() {
+    let mut ctx = Context::new();
+
+    let module = ModuleOp::new(&mut ctx, "enum_debug".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.to_handle(), vec![], false);
+    let func = FuncOp::new(&mut ctx, "enum_debug_kernel".try_into().unwrap(), func_ty);
+    let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/enum.rs", 10, 1);
+    func.get_operation().deref_mut(&ctx).set_loc(func_loc);
+    let entry = func.get_or_create_entry_block(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let one_attr = IntegerAttr::new(i32_ty, APInt::from_u32(1, NonZero::new(32).unwrap()));
+    let one = ConstantOp::new(&mut ctx, one_attr.into());
+    one.get_operation().insert_at_back(entry, &ctx);
+    let one_val = one.get_operation().deref(&ctx).get_result(0);
+
+    let direct = AllocaOp::new(&mut ctx, i64_ty.into(), one_val);
+    let direct_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/enum.rs", 11, 9);
+    direct.get_operation().deref_mut(&ctx).set_loc(direct_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        direct.get_operation(),
+        DebugLocalVariableInfo {
+            name: "direct".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::Enum {
+                name: "Direct".to_string(),
+                size_bits: 64,
+                discriminant: Some(DebugEnumDiscriminant {
+                    offset_bits: 0,
+                    ty: Box::new(DebugLocalTypeKind::Basic {
+                        name: "u8".to_string(),
+                        size_bits: 8,
+                        encoding: "DW_ATE_unsigned",
+                    }),
+                }),
+                variants: vec![
+                    DebugEnumVariant {
+                        name: "Small".to_string(),
+                        discriminant: Some(3),
+                        members: vec![llvm_export::ops::DebugTypeMember {
+                            name: "0".to_string(),
+                            offset_bits: 32,
+                            ty: DebugLocalTypeKind::Basic {
+                                name: "u32".to_string(),
+                                size_bits: 32,
+                                encoding: "DW_ATE_unsigned",
+                            },
+                        }],
+                    },
+                    DebugEnumVariant {
+                        name: "Empty".to_string(),
+                        discriminant: Some(9),
+                        members: vec![],
+                    },
+                ],
+            },
+        },
+    );
+    direct.get_operation().insert_at_back(entry, &ctx);
+
+    let niche = AllocaOp::new(&mut ctx, i64_ty.into(), one_val);
+    let niche_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/enum.rs", 12, 9);
+    niche.get_operation().deref_mut(&ctx).set_loc(niche_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        niche.get_operation(),
+        DebugLocalVariableInfo {
+            name: "niche".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::Enum {
+                name: "OptionRef".to_string(),
+                size_bits: 64,
+                discriminant: Some(DebugEnumDiscriminant {
+                    offset_bits: 0,
+                    ty: Box::new(DebugLocalTypeKind::Basic {
+                        name: "usize".to_string(),
+                        size_bits: 64,
+                        encoding: "DW_ATE_unsigned",
+                    }),
+                }),
+                variants: vec![
+                    DebugEnumVariant {
+                        name: "None".to_string(),
+                        discriminant: Some(0),
+                        members: vec![],
+                    },
+                    DebugEnumVariant {
+                        name: "Some".to_string(),
+                        discriminant: None,
+                        members: vec![llvm_export::ops::DebugTypeMember {
+                            name: "0".to_string(),
+                            offset_bits: 0,
+                            ty: DebugLocalTypeKind::Pointer {
+                                name: "&u32".to_string(),
+                                size_bits: 64,
+                            },
+                        }],
+                    },
+                ],
+            },
+        },
+    );
+    niche.get_operation().insert_at_back(entry, &ctx);
+
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = DebugConfig {
+        inner: PtxExportConfig,
+        debug_kind: DebugKind::Full,
+    };
+    let ir =
+        export_module_to_string_with_config(&ctx, &module, &config).expect("enum debug export");
+
+    assert!(
+        ir.contains("!DICompositeType(tag: DW_TAG_variant_part"),
+        "Rust enums must contain a DW_TAG_variant_part:\n{ir}"
+    );
+    assert!(
+        ir.contains("flags: DIFlagArtificial"),
+        "the physical enum carrier must be marked artificial:\n{ir}"
+    );
+    let discriminator_member = ir
+        .lines()
+        .find(|line| {
+            line.contains("!DIDerivedType(tag: DW_TAG_member")
+                && line.contains("flags: DIFlagArtificial")
+        })
+        .expect("enum discriminator member");
+    assert!(
+        discriminator_member.contains("scope: !"),
+        "the physical enum carrier must be scoped to its enum object:\n{discriminator_member}\n{ir}"
+    );
+    let variant_part = ir
+        .lines()
+        .find(|line| line.contains("!DICompositeType(tag: DW_TAG_variant_part"))
+        .expect("enum variant part");
+    assert!(
+        variant_part.contains("scope: !"),
+        "the variant part must be scoped to its enum object:\n{variant_part}\n{ir}"
+    );
+    let direct_variant_member = ir
+        .lines()
+        .find(|line| {
+            line.contains("!DIDerivedType(tag: DW_TAG_member, name: \"Small\"")
+                && line.contains("extraData: i8 3")
+        })
+        .expect("direct enum variant member");
+    assert!(
+        direct_variant_member.contains("scope: !"),
+        "variant members must be scoped to their DW_TAG_variant_part:\n{direct_variant_member}\n{ir}"
+    );
+    assert!(
+        ir.contains("extraData: i8 3") && ir.contains("extraData: i8 9"),
+        "direct-tag variants must carry their physical discriminant values:\n{ir}"
+    );
+    assert!(
+        ir.contains("extraData: i64 0"),
+        "the tagged niche variant must carry the niche value:\n{ir}"
+    );
+
+    let some_variant_member = ir
+        .lines()
+        .find(|line| {
+            line.contains("!DIDerivedType(tag: DW_TAG_member, name: \"Some\"")
+                && line.contains("baseType:")
+        })
+        .expect("Some variant member");
+    assert!(
+        !some_variant_member.contains("extraData:"),
+        "the untagged niche variant must be the default branch:\n{some_variant_member}\n{ir}"
     );
 }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -28,8 +28,8 @@ use dialect_mir::ops::MirFuncOp;
 use dialect_mir::types::address_space;
 use llvm_export::export::DebugKind;
 use llvm_export::ops::{
-    DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourceScopeMap, DebugTypeMember,
-    LocalMemoryProvenanceAttr,
+    DebugEnumDiscriminant, DebugEnumVariant, DebugLocalTypeKind, DebugLocalVariableInfo,
+    DebugSourceScopeMap, DebugTypeMember, LocalMemoryProvenanceAttr,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::op_interfaces::SymbolOpInterface;
@@ -46,6 +46,7 @@ use rustc_public::CrateDef;
 use rustc_public::mir;
 use rustc_public::mir::mono;
 use rustc_public::ty::{ConstantKind, FloatTy, IntTy, RigidTy, Ty, TyKind, UintTy};
+use rustc_public_bridge::IndexedVal;
 
 /// Cluster dimensions extracted from `#[cluster(x,y,z)]` attribute.
 ///
@@ -789,21 +790,22 @@ fn debug_type_for_ty_at(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
             debug_struct_type(ty, name, fields, depth)
         }
         TyKind::RigidTy(RigidTy::Adt(adt_def, substs)) if depth < MAX_DEBUG_TYPE_DEPTH => {
-            // Only plain structs (one variant) are described as composites here;
-            // enums and unions need DWARF variant parts (deferred).
-            if !matches!(adt_def.kind(), rustc_public::ty::AdtKind::Struct) {
-                return None;
+            match adt_def.kind() {
+                rustc_public::ty::AdtKind::Struct => {
+                    let variants = adt_def.variants();
+                    if variants.len() != 1 {
+                        return None;
+                    }
+                    let name = adt_def.trimmed_name();
+                    let fields = variants[0]
+                        .fields()
+                        .into_iter()
+                        .map(|field| (field.name.to_string(), field.ty_with_args(&substs)));
+                    debug_struct_type(ty, name, fields, depth)
+                }
+                rustc_public::ty::AdtKind::Enum => debug_enum_type(ty, depth),
+                rustc_public::ty::AdtKind::Union => None,
             }
-            let variants = adt_def.variants();
-            if variants.len() != 1 {
-                return None;
-            }
-            let name = adt_def.trimmed_name();
-            let fields = variants[0]
-                .fields()
-                .into_iter()
-                .map(|field| (field.name.to_string(), field.ty_with_args(&substs)));
-            debug_struct_type(ty, name, fields, depth)
         }
         TyKind::RigidTy(RigidTy::Array(elem_ty, len_const)) if depth < MAX_DEBUG_TYPE_DEPTH => {
             let count = array_len_const(&len_const)?;
@@ -867,6 +869,238 @@ fn debug_struct_type(
         size_bits,
         members,
     })
+}
+
+/// Build a Rust enum debug type using rustc's physical layout.
+///
+/// This mirrors rustc's native DWARF representation rather than guessing from
+/// source-level `Option`/`Result` shapes: a top-level structure contains a
+/// variant part, whose discriminator is either the direct integer tag or the
+/// integer-normalized niche carrier. Variant payload fields use rustc's exact
+/// per-variant offsets. For niche layouts the untagged variant deliberately has
+/// no discriminant value, so the debugger treats it as the default branch.
+fn debug_enum_type(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
+    let TyKind::RigidTy(RigidTy::Adt(adt_def, substs)) = ty.kind() else {
+        return None;
+    };
+    if !matches!(adt_def.kind(), rustc_public::ty::AdtKind::Enum) {
+        return None;
+    }
+
+    #[derive(Clone, Copy)]
+    enum DebugEnumLayout {
+        Direct {
+            width: u64,
+        },
+        Niche {
+            width: u64,
+            niche_variant_start: usize,
+            niche_start: u128,
+            untagged_variant: usize,
+        },
+        Single,
+        Empty,
+    }
+
+    let layout_shape = ty.layout().ok()?.shape();
+    let size_bits = layout_shape.size.bytes() as u64 * 8;
+
+    let (discriminant, debug_layout) = match &layout_shape.variants {
+        rustc_public::abi::VariantsShape::Multiple {
+            tag,
+            tag_encoding: rustc_public::abi::TagEncoding::Direct,
+            tag_field,
+            ..
+        } => {
+            let primitive = match tag {
+                rustc_public::abi::Scalar::Initialized { value, .. }
+                | rustc_public::abi::Scalar::Union { value } => *value,
+            };
+            let rustc_public::abi::Primitive::Int { length, signed } = primitive else {
+                return None;
+            };
+            let width = length.bits() as u64;
+            if width == 0 || width > 64 {
+                return None;
+            }
+            let offset_bits = crate::translator::layout::enum_tag_offset(
+                &layout_shape.fields,
+                *tag_field,
+                pliron::location::Location::Unknown,
+            )
+            .ok()? as u64
+                * 8;
+            let tag_ty = DebugLocalTypeKind::Basic {
+                name: format!("{}{}", if signed { "i" } else { "u" }, width),
+                size_bits: width,
+                encoding: if signed {
+                    "DW_ATE_signed"
+                } else {
+                    "DW_ATE_unsigned"
+                },
+            };
+            (
+                Some(DebugEnumDiscriminant {
+                    offset_bits,
+                    ty: Box::new(tag_ty),
+                }),
+                DebugEnumLayout::Direct { width },
+            )
+        }
+        rustc_public::abi::VariantsShape::Multiple {
+            tag,
+            tag_encoding:
+                rustc_public::abi::TagEncoding::Niche {
+                    untagged_variant,
+                    niche_variants,
+                    niche_start,
+                },
+            tag_field,
+            ..
+        } => {
+            let primitive = match tag {
+                rustc_public::abi::Scalar::Initialized { value, .. }
+                | rustc_public::abi::Scalar::Union { value } => *value,
+            };
+            let width = primitive
+                .size(&rustc_public::target::MachineInfo::target())
+                .bits() as u64;
+            if width == 0 || width > 64 {
+                return None;
+            }
+            let offset_bits = crate::translator::layout::enum_tag_offset(
+                &layout_shape.fields,
+                *tag_field,
+                pliron::location::Location::Unknown,
+            )
+            .ok()? as u64
+                * 8;
+
+            // rustc normalizes niche carriers, including pointer niches, to an
+            // unsigned integer of the same physical width for DWARF.
+            let tag_name = match primitive {
+                rustc_public::abi::Primitive::Pointer(_) if width == 64 => "usize".to_string(),
+                _ => format!("u{width}"),
+            };
+            let tag_ty = DebugLocalTypeKind::Basic {
+                name: tag_name,
+                size_bits: width,
+                encoding: "DW_ATE_unsigned",
+            };
+            (
+                Some(DebugEnumDiscriminant {
+                    offset_bits,
+                    ty: Box::new(tag_ty),
+                }),
+                DebugEnumLayout::Niche {
+                    width,
+                    niche_variant_start: niche_variants.start().to_index(),
+                    niche_start: *niche_start,
+                    untagged_variant: untagged_variant.to_index(),
+                },
+            )
+        }
+        rustc_public::abi::VariantsShape::Single { .. } => (None, DebugEnumLayout::Single),
+        rustc_public::abi::VariantsShape::Empty => (None, DebugEnumLayout::Empty),
+    };
+
+    let source_variants = adt_def.variants();
+    let mut variants = Vec::with_capacity(source_variants.len());
+
+    for (variant_index, variant) in source_variants.iter().enumerate() {
+        let fields = variant.fields();
+        let field_offsets: Vec<u64> = match &layout_shape.variants {
+            rustc_public::abi::VariantsShape::Single { index }
+                if index.to_index() != variant_index =>
+            {
+                vec![0; fields.len()]
+            }
+            rustc_public::abi::VariantsShape::Empty => vec![0; fields.len()],
+            _ => crate::translator::layout::enum_variant_field_offsets(
+                &layout_shape,
+                variant_index,
+                pliron::location::Location::Unknown,
+            )
+            .ok()?
+            .into_iter()
+            .map(|offset| offset as u64)
+            .collect(),
+        };
+
+        let mut members = Vec::new();
+        for (field_index, field) in fields.into_iter().enumerate() {
+            let field_ty = field.ty_with_args(&substs);
+            let Some(member_ty) = debug_type_for_ty_at(&field_ty, depth + 1) else {
+                continue;
+            };
+            if member_ty.size_bits() == 0 {
+                continue;
+            }
+            let offset_bytes = *field_offsets.get(field_index)?;
+            let source_name = field.name.to_string();
+            let member_name = if source_name.parse::<usize>().ok() == Some(field_index) {
+                format!("__{field_index}")
+            } else {
+                source_name
+            };
+            members.push(DebugTypeMember {
+                name: member_name,
+                offset_bits: offset_bytes * 8,
+                ty: member_ty,
+            });
+        }
+
+        let discriminant_value = match debug_layout {
+            DebugEnumLayout::Direct { width } => {
+                let variant_idx = rustc_public::ty::VariantIdx::to_val(variant_index);
+                let raw = adt_def.discriminant_for_variant(variant_idx).val;
+                truncate_debug_discriminant(raw, width)
+            }
+            DebugEnumLayout::Niche {
+                width,
+                niche_variant_start,
+                niche_start,
+                untagged_variant,
+            } => {
+                if variant_index == untagged_variant {
+                    None
+                } else {
+                    let raw = (variant_index as u128)
+                        .wrapping_sub(niche_variant_start as u128)
+                        .wrapping_add(niche_start);
+                    truncate_debug_discriminant(raw, width)
+                }
+            }
+            DebugEnumLayout::Single | DebugEnumLayout::Empty => None,
+        };
+
+        variants.push(DebugEnumVariant {
+            name: variant.name().to_string(),
+            discriminant: discriminant_value,
+            members,
+        });
+    }
+
+    Some(DebugLocalTypeKind::Enum {
+        name: adt_def.trimmed_name(),
+        size_bits,
+        discriminant,
+        variants,
+    })
+}
+
+/// Truncate a physical discriminant to the width LLVM will attach as
+/// `extraData` on the corresponding variant member.
+fn truncate_debug_discriminant(value: u128, width: u64) -> Option<u64> {
+    if width == 0 || width > 64 {
+        return None;
+    }
+    let mask = if width == 64 {
+        u128::from(u64::MAX)
+    } else {
+        (1u128 << width) - 1
+    };
+    Some((value & mask) as u64)
 }
 
 /// Total size of `ty` in bits from its layout, or `None` if unavailable.

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -14,6 +14,7 @@
 //! - 64-bit arithmetic
 //! - Parallel for loop patterns
 //! - Full-debug closure environments
+//! - Full-debug Rust enum variants (direct and niche layouts)
 //!
 //! Run: cargo oxide run compiler_features
 
@@ -28,6 +29,13 @@ use cuda_host::cuda_module;
 #[cuda_module]
 mod kernels {
     use super::*;
+
+    /// Direct-tag enum used by the full-debug DWARF smoke test.
+    #[repr(u8)]
+    enum DebugDirectEnum {
+        Small(u32) = 3,
+        Wide(u64) = 9,
+    }
 
     /// Test multi-way match on u32
     #[kernel]
@@ -56,6 +64,47 @@ mod kernels {
             let maybe: Option<u32> = if val > 0 { Some(val) } else { None };
             let result = maybe.unwrap_or_default();
             *out_elem = result;
+        }
+    }
+
+    /// Full-debug fixture for direct-tag and niche-layout Rust enums.
+    ///
+    /// The breakpoint is after all four locals are initialized so cuda-gdb can
+    /// inspect both the active variant and its payload.
+    #[kernel]
+    pub fn test_enum_debug(seed: u32, mut out: DisjointSlice<u32>) {
+        let idx = thread::index_1d();
+        if let Some(out_elem) = out.get_mut(idx) {
+            let option_value: Option<u32> = Some(seed + 1);
+            let result_value: Result<u32, u64> = Err(0x1_0000_0009u64);
+            let direct_value = if seed == 0 {
+                DebugDirectEnum::Small(17)
+            } else {
+                DebugDirectEnum::Wide(0x2_0000_000Bu64)
+            };
+            let pointee = seed + 5;
+            let niche_value: Option<&u32> = Some(&pointee);
+
+            *out_elem = seed; // CUDA_OXIDE_DEBUG_ENUM_BREAKPOINT
+
+            let option_part = match option_value {
+                Some(value) => value,
+                None => 0,
+            };
+            let result_part = match result_value {
+                Ok(value) => value,
+                Err(value) => value as u32,
+            };
+            let direct_part = match direct_value {
+                DebugDirectEnum::Small(value) => value,
+                DebugDirectEnum::Wide(value) => value as u32,
+            };
+            let niche_part = match niche_value {
+                Some(value) => *value,
+                None => 0,
+            };
+
+            *out_elem = option_part + result_part + direct_part + niche_part;
         }
     }
 
@@ -580,6 +629,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             assert_eq!(result[0], expected, "test_option({}) failed", val);
             println!("  ✓ val={}: {} (expected {})", val, result[0], expected);
         }
+    }
+
+    // Test enum lowering and keep deterministic direct/niche debug fixtures live.
+    println!("Testing: test_enum_debug");
+    {
+        let mut out_dev = DeviceBuffer::<u32>::zeroed(&stream, N)?;
+        // seed=7: Some(8) + Err(...09) + Wide(...0B) + Some(&12) = 40.
+        // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+        unsafe { module.test_enum_debug((stream).as_ref(), cfg, 7u32, &mut out_dev) }?;
+        let result = out_dev.to_host_vec(&stream)?;
+        assert_eq!(result[0], 40, "test_enum_debug failed");
+        println!("  ✓ Result: {} (expected 40)", result[0]);
     }
 
     // Test closure lowering and keep a deterministic full-debug fixture live.

--- a/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/compiler_features/src/main.rs
@@ -71,6 +71,9 @@ mod kernels {
     ///
     /// The breakpoint is after all four locals are initialized so cuda-gdb can
     /// inspect both the active variant and its payload.
+    // The explicit match on each enum is the fixture: all four variant
+    // reads stay spelled out the same way for cuda-gdb inspection.
+    #[allow(clippy::manual_unwrap_or, clippy::manual_unwrap_or_default)]
     #[kernel]
     pub fn test_enum_debug(seed: u32, mut out: DisjointSlice<u32>) {
         let idx = thread::index_1d();

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -126,7 +126,7 @@ remain unsupported.
 | Local Clean | **Full** | `cargo oxide clean` removes project-local `target/` directories and generated device artifacts (`.ptx`, `.ll`, `.opt.ll`, `.ltoir`, `.cubin`, `.target`, `.options`, `.cubin.target`), never the shared `~/.cargo/cuda-oxide/` cache. |
 | Compute Sanitizer Wrapper | **Full** | `cargo oxide sanitize <example>` builds the example and runs the host binary under NVIDIA Compute Sanitizer (`memcheck`, `racecheck`, `initcheck`, or `synccheck`). |
 | cuda-gdb Source Debugging | **Full** | `cargo oxide debug` builds device debug information on the PTX path and launches `cuda-gdb`. Legacy NVVM IR does not yet support debug metadata. |
-| cuda-gdb Local / Argument Inspection | **Partial** | `CUDA_OXIDE_DEBUG=full` is a `-G`-style build (optimization off, locals kept in memory) so `info args`/`info locals` show real values for scalars, pointers/references, and structs/tuples/arrays with their fields. Enums, ABI-split bare slices, closures, and projections (`x.0`) are not yet described. |
+| cuda-gdb Local / Argument Inspection | **Partial** | `CUDA_OXIDE_DEBUG=full` is a `-G`-style build (optimization off, locals kept in memory) so `info args`/`info locals` show real values for scalars, pointers/references, structs/tuples/arrays, closure environments, and Rust enums with direct-tag or niche layouts, including active variants and payload fields. ABI-split bare slices and projections (`x.0`) are not yet described. |
 
 ## Compiler: Inline PTX
 

--- a/scripts/debug-smoketest.sh
+++ b/scripts/debug-smoketest.sh
@@ -8,13 +8,13 @@
 # Builds an example with full device debug info and drives cuda-gdb in batch
 # mode to prove that source debugging actually works on a real GPU: a source
 # breakpoint binds, the backtrace is correct, and `info args` / `info locals`
-# show real values (scalars, pointers, and struct fields), not just metadata
-# in the emitted IR.
+# show real values (scalars, pointers, structs, and Rust enums), not just
+# metadata in the emitted IR.
 #
-# For compiler_features, a second debugger pass validates closure-environment
-# DWARF specifically: the source breakpoint stops after a `move` closure has
-# been initialized, and cuda-gdb must expose `capture_0` and `capture_1` as
-# inspectable members of the closure local.
+# For compiler_features, dedicated debugger passes additionally validate
+# closure-environment and Rust-enum DWARF. The closure pass checks that both
+# captures are inspectable; the enum pass checks direct-tag and niche-layout
+# values after they have been initialized.
 #
 # This complements scripts/smoketest.sh (which validates the compile pipeline)
 # by validating debugger *consumption* of the DWARF we emit.
@@ -69,7 +69,8 @@ export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIB
 # Drive cuda-gdb: stop at a kernel, walk to the kernel frame, dump args/locals.
 GDB_LOG="$(mktemp)"
 CLOSURE_GDB_LOG="$(mktemp)"
-trap 'rm -f "$GDB_LOG" "$CLOSURE_GDB_LOG"' EXIT
+ENUM_GDB_LOG="$(mktemp)"
+trap 'rm -f "$GDB_LOG" "$CLOSURE_GDB_LOG" "$ENUM_GDB_LOG"' EXIT
 
 # Run from the example dir: the host binary resolves its embedded device
 # artifact relative to the working directory.
@@ -90,19 +91,20 @@ tail -25 "$GDB_LOG"
 echo "----------------------------------"
 
 # Verdict: a device breakpoint must have bound and fired, and at least one
-# concrete value (scalar, pointer, or struct field) must be visible.
+# concrete value (scalar, pointer, struct field, or enum payload) must be visible.
 fail=0
 grep -qiE "CUDA thread hit .*Breakpoint" "$GDB_LOG" || { echo "debug-smoketest: FAIL (no device breakpoint hit)"; fail=1; }
 grep -qE "= [0-9]|0x[0-9a-f]|\{.*:" "$GDB_LOG"        || { echo "debug-smoketest: FAIL (no inspectable args/locals)"; fail=1; }
 grep -qiE "INVALID_PTX|JIT compilation failed|No device code" "$GDB_LOG" && { echo "debug-smoketest: FAIL (PTX did not load under cuda-gdb)"; fail=1; }
 
-# compiler_features contains a dedicated closure-environment fixture. Break on
-# the source line immediately after the closure is created, then require
-# cuda-gdb to describe and print both captured fields.
+# compiler_features contains dedicated full-debug fixtures. Break on the source
+# line immediately after each value is initialized, then require cuda-gdb to
+# consume the generated DWARF rather than merely accepting the LLVM metadata.
 if [ "$EXAMPLE" = "compiler_features" ]; then
-    CLOSURE_SOURCE="$EXAMPLE_DIR/src/main.rs"
+    DEBUG_SOURCE="$EXAMPLE_DIR/src/main.rs"
+
     CLOSURE_MARKER="CUDA_OXIDE_DEBUG_CLOSURE_BREAKPOINT"
-    CLOSURE_LINE="$(grep -nF "$CLOSURE_MARKER" "$CLOSURE_SOURCE" | head -1 | cut -d: -f1)"
+    CLOSURE_LINE="$(grep -nF "$CLOSURE_MARKER" "$DEBUG_SOURCE" | head -1 | cut -d: -f1)"
 
     if [ -z "$CLOSURE_LINE" ]; then
         echo "debug-smoketest: FAIL (closure debug breakpoint marker not found)"
@@ -111,7 +113,7 @@ if [ "$EXAMPLE" = "compiler_features" ]; then
         ( cd "$EXAMPLE_DIR" && timeout 300 "$CUDA_GDB" --batch \
             -ex 'set pagination off' \
             -ex 'set breakpoint pending on' \
-            -ex "break $CLOSURE_SOURCE:$CLOSURE_LINE" \
+            -ex "break $DEBUG_SOURCE:$CLOSURE_LINE" \
             -ex 'run' \
             -ex 'frame 0' \
             -ex 'ptype closure' \
@@ -129,11 +131,49 @@ if [ "$EXAMPLE" = "compiler_features" ]; then
         grep -qE "capture_1[[:space:]]*:[[:space:]]*(0x[[:xdigit:]]+|[0-9]+)" "$CLOSURE_GDB_LOG" || { echo "debug-smoketest: FAIL (closure capture_1 is not inspectable)"; fail=1; }
         grep -qiE "INVALID_PTX|JIT compilation failed|No device code" "$CLOSURE_GDB_LOG" && { echo "debug-smoketest: FAIL (closure-debug PTX did not load under cuda-gdb)"; fail=1; }
     fi
+
+    ENUM_MARKER="CUDA_OXIDE_DEBUG_ENUM_BREAKPOINT"
+    ENUM_LINE="$(grep -nF "$ENUM_MARKER" "$DEBUG_SOURCE" | head -1 | cut -d: -f1)"
+
+    if [ -z "$ENUM_LINE" ]; then
+        echo "debug-smoketest: FAIL (enum debug breakpoint marker not found)"
+        fail=1
+    else
+        ( cd "$EXAMPLE_DIR" && timeout 300 "$CUDA_GDB" --batch \
+            -ex 'set pagination off' \
+            -ex 'set breakpoint pending on' \
+            -ex "break $DEBUG_SOURCE:$ENUM_LINE" \
+            -ex 'run' \
+            -ex 'frame 0' \
+            -ex 'ptype option_value' \
+            -ex 'print option_value' \
+            -ex 'ptype result_value' \
+            -ex 'print result_value' \
+            -ex 'ptype direct_value' \
+            -ex 'print direct_value' \
+            -ex 'ptype niche_value' \
+            -ex 'print niche_value' \
+            -ex 'backtrace' \
+            -ex 'kill' \
+            "./target/release/$EXAMPLE" ) >"$ENUM_GDB_LOG" 2>&1
+
+        echo "----- cuda-gdb enum output (tail) -----"
+        tail -45 "$ENUM_GDB_LOG"
+        echo "---------------------------------------"
+
+        grep -qiE "CUDA thread hit .*Breakpoint" "$ENUM_GDB_LOG" || { echo "debug-smoketest: FAIL (enum source breakpoint did not hit)"; fail=1; }
+        grep -qE '\$[0-9]+ = ([^[:space:]]+::)?Some \(8\)' "$ENUM_GDB_LOG" || { echo "debug-smoketest: FAIL (Option<u32> active variant/payload is not inspectable)"; fail=1; }
+        grep -qE '\$[0-9]+ = ([^[:space:]]+::)?Err \(4294967305\)' "$ENUM_GDB_LOG" || { echo "debug-smoketest: FAIL (Result<u32,u64> active Err variant/payload is not inspectable)"; fail=1; }
+        grep -qE '\$[0-9]+ = ([^[:space:]]+::)?Wide \(8589934603\)' "$ENUM_GDB_LOG" || { echo "debug-smoketest: FAIL (direct-tag custom enum active variant/payload is not inspectable)"; fail=1; }
+        grep -qE '\$[0-9]+ = ([^[:space:]]+::)?Some \(0x[[:xdigit:]]+\)' "$ENUM_GDB_LOG" || { echo "debug-smoketest: FAIL (niche Option<&u32> active variant/payload is not inspectable)"; fail=1; }
+        grep -qF '<No data fields>' "$ENUM_GDB_LOG" && { echo "debug-smoketest: FAIL (enum value resolved without an active variant payload)"; fail=1; }
+        grep -qiE "INVALID_PTX|JIT compilation failed|No device code" "$ENUM_GDB_LOG" && { echo "debug-smoketest: FAIL (enum-debug PTX did not load under cuda-gdb)"; fail=1; }
+    fi
 fi
 
 if [ "$fail" -eq 0 ]; then
     if [ "$EXAMPLE" = "compiler_features" ]; then
-        echo "debug-smoketest: PASS (source debugging + closure environments verified on $ARCH)"
+        echo "debug-smoketest: PASS (source debugging + closure environments + Rust enums verified on $ARCH)"
     else
         echo "debug-smoketest: PASS (source debugging + info args/locals verified on $ARCH)"
     fi


### PR DESCRIPTION
Closes #936 

## Summary

Adds full device debug metadata for Rust enums so `cuda-gdb` can identify the active variant and inspect its payload.

This implements the enum-debug portion of #226. Projected source variables remain out of scope for this PR.

## What changed

### MIR debug type import

Adds enum support to `DebugLocalTypeKind` and imports rustc enum layout information for debug metadata.

The importer now records:

- enum size
- physical discriminant location and type
- variant names
- variant discriminant values
- variant payload members and their byte offsets

Both direct-tag and niche-encoded layouts are supported.

For niche layouts, the untagged variant is emitted without a discriminant value, while tagged niche variants use the physical niche value.

### LLVM debug metadata

Emits Rust enums using the DWARF variant-part representation:

```text
enum DICompositeType
├── DW_TAG_variant_part
│   ├── artificial discriminant member
│   ├── variant member
│   └── variant member
└── variant payload structures
```

The metadata preserves the parent/scope relationships used by rustc's native LLVM debuginfo implementation, allowing debuggers to resolve both the active variant and its payload.

### End-to-end coverage

Adds enum debug coverage to `compiler_features`, including:

* `Option<u32>`
* `Result<u32, u64>`
* a direct-tag custom enum
* niche-encoded `Option<&u32>`

The CUDA GDB smoketest now verifies the actual printed variant and payload and explicitly rejects `<No data fields>` regressions.

## Validation

Focused LLVM exporter test:

```text
full_debug_metadata_emits_rust_enum_variant_parts ... ok
```

Full workspace:

```text
cargo test --workspace
```

passes.

End-to-end CUDA GDB validation on `sm_120`:

```text
$1 = Option::Some (8)
$2 = Result::Err (4294967305)
$3 = DebugDirectEnum::Wide (8589934603)
$4 = Option::Some (0x...)
```

and:

```text
debug-smoketest: PASS (source debugging + closure environments + Rust enums verified on sm_120)
```

## Out of scope

Debug declarations for source variables backed by MIR place projections are not included here and will be handled separately.
