### PR TITLE
fix(mir-lower): scalarize repr(transparent) device returns

### DIFF
--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -63,7 +63,7 @@
 
 use crate::convert::types::{
     StructLayoutInfo, build_struct_slot_map, convert_function_type, convert_type, is_kernel_func,
-    is_zero_sized_type,
+    is_zero_sized_type, transparent_scalar_abi_info,
 };
 use crate::helpers;
 use dialect_mir::ops::{MirCallOp, MirFuncOp};
@@ -639,6 +639,7 @@ pub fn convert(
     };
 
     let mut zst_replacement_type = None;
+    let mut transparent_result_abi = None;
     let result_type = if let Some(mir_ty) = mir_result_ty_ptr {
         // Only the empty tuple `()` is the unit type. `is::<MirTupleType>()`
         // also matches `(T, U, ...)`, so we have to peek at the field count.
@@ -648,7 +649,20 @@ pub fn convert(
             .deref(ctx)
             .downcast_ref::<MirTupleType>()
             .is_some_and(|t| t.get_types().is_empty());
-        let converted = convert_type(ctx, mir_ty).map_err(anyhow_to_pliron)?;
+        let is_transparent_scalar = {
+            let ty_ref = mir_ty.deref(ctx);
+            ty_ref
+                .downcast_ref::<MirStructType>()
+                .is_some_and(MirStructType::is_transparent_scalar)
+        };
+        let converted = if is_transparent_scalar {
+            let abi = transparent_scalar_abi_info(ctx, mir_ty).map_err(anyhow_to_pliron)?;
+            let scalar_ty = abi.scalar_ty;
+            transparent_result_abi = Some(abi);
+            scalar_ty
+        } else {
+            convert_type(ctx, mir_ty).map_err(anyhow_to_pliron)?
+        };
         if is_unit || is_zero_sized_type(ctx, converted) {
             // NVPTX cannot carry a ZST in a function signature, so the call
             // itself returns void. Keep the converted ZST type so any MIR uses
@@ -718,7 +732,27 @@ pub fn convert(
 
     let is_void = result_type.deref(ctx).is::<llvm_types::VoidType>();
     if has_result && !is_void && llvm_call.get_operation().deref(ctx).get_num_results() > 0 {
-        rewriter.replace_operation(ctx, op, llvm_call.get_operation());
+        if let Some(abi) = transparent_result_abi {
+            // The ABI call returns only the underlying scalar, but MIR users
+            // still operate on the ordinary converted wrapper aggregate.
+            // Rebuild nested transparent layers from inner to outer so the
+            // replacement result has exactly the MIR op's converted type.
+            let mut value = llvm_call.get_operation().deref(ctx).get_result(0);
+            let mut replacement = llvm_call.get_operation();
+            for layer in abi.layers.iter().rev() {
+                let undef = llvm::UndefOp::new(ctx, layer.llvm_struct_ty);
+                rewriter.insert_operation(ctx, undef.get_operation());
+                let aggregate = undef.get_operation().deref(ctx).get_result(0);
+                let insert =
+                    llvm::InsertValueOp::new(ctx, aggregate, value, vec![layer.field_slot]);
+                rewriter.insert_operation(ctx, insert.get_operation());
+                value = insert.get_operation().deref(ctx).get_result(0);
+                replacement = insert.get_operation();
+            }
+            rewriter.replace_operation(ctx, op, replacement);
+        } else {
+            rewriter.replace_operation(ctx, op, llvm_call.get_operation());
+        }
     } else if op.deref(ctx).has_use()
         && let Some(zst_type) = zst_replacement_type
     {

--- a/crates/mir-lower/src/convert/ops/control_flow.rs
+++ b/crates/mir-lower/src/convert/ops/control_flow.rs
@@ -23,6 +23,7 @@
 //! With `DialectConversion` + `inline_region`, blocks are the ORIGINALS (moved,
 //! not copied). Successor pointers are already valid — no block map lookup needed.
 
+use dialect_mir::types::MirStructType;
 use llvm_export::ops as llvm;
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::op_interfaces::CallOpCallable;
@@ -45,21 +46,47 @@ pub(crate) fn convert_return(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
-    _operands_info: &OperandsInfo,
+    operands_info: &OperandsInfo,
 ) -> Result<()> {
     let operands: Vec<_> = op.deref(ctx).operands().collect();
 
     let ret_val = match operands.as_slice() {
         [] => None,
         [val] => {
-            let ty = val.get_type(ctx);
+            let mir_ty = operands_info.lookup_most_recent_type(*val);
+            let is_transparent_scalar = mir_ty.is_some_and(|mir_ty| {
+                let ty_ref = mir_ty.deref(ctx);
+                ty_ref
+                    .downcast_ref::<MirStructType>()
+                    .is_some_and(MirStructType::is_transparent_scalar)
+            });
 
-            if ty.deref(ctx).is::<llvm_export::types::VoidType>()
-                || crate::convert::types::is_zero_sized_type(ctx, ty)
-            {
-                None
+            if is_transparent_scalar {
+                let mir_ty = mir_ty.expect("transparent scalar check requires a MIR type");
+                let abi = match crate::convert::types::transparent_scalar_abi_info(ctx, mir_ty) {
+                    Ok(abi) => abi,
+                    Err(error) => {
+                        return pliron::input_err_noloc!(
+                            "failed to lower transparent scalar return ABI: {error}"
+                        );
+                    }
+                };
+                let mut scalar = *val;
+                for layer in &abi.layers {
+                    let extract = llvm::ExtractValueOp::new(ctx, scalar, vec![layer.field_slot])?;
+                    rewriter.insert_operation(ctx, extract.get_operation());
+                    scalar = extract.get_operation().deref(ctx).get_result(0);
+                }
+                Some(scalar)
             } else {
-                Some(*val)
+                let ty = val.get_type(ctx);
+                if ty.deref(ctx).is::<llvm_export::types::VoidType>()
+                    || crate::convert::types::is_zero_sized_type(ctx, ty)
+                {
+                    None
+                } else {
+                    Some(*val)
+                }
             }
         }
         _ => {
@@ -267,17 +294,34 @@ mod tests {
 
     use crate::convert::ops::test_util::*;
     use dialect_mir::ops as mir;
-    use dialect_mir::types::MirTupleType;
+    use dialect_mir::types::{MirStructType, MirTupleType, StructAbiKind};
     use llvm_export::ops as llvm;
     use pliron::builtin::op_interfaces::{
         BranchOpInterface, CallOpCallable, CallOpInterface, OperandSegmentInterface,
         SymbolOpInterface,
     };
     use pliron::builtin::types::{IntegerType, Signedness};
+    use pliron::context::Context;
     use pliron::linked_list::ContainsLinkedList;
     use pliron::op::Op;
     use pliron::operation::Operation;
-    use pliron::r#type::TypeHandle;
+    use pliron::r#type::{TypeHandle, Typed};
+
+    fn transparent_u32(ctx: &mut Context, name: &str) -> TypeHandle {
+        let u32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        MirStructType::get_with_full_layout_and_abi(
+            ctx,
+            name.into(),
+            vec!["value".into()],
+            vec![u32_ty],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into()
+    }
 
     #[test]
     fn convert_return_void_lowers_to_llvm_return_without_value() {
@@ -314,6 +358,120 @@ mod tests {
             1,
             "scalar return must carry one value operand"
         );
+    }
+
+    #[test]
+    fn convert_return_transparent_scalar_extracts_underlying_value() {
+        let mut ctx = make_ctx();
+        let wrapper = transparent_u32(&mut ctx, "Scalar");
+        let (module_ptr, entry) = build_kernel(&mut ctx, vec![], vec![wrapper]);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, wrapper);
+        undef.get_operation().insert_at_back(entry, &ctx);
+        let value = undef.get_operation().deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, entry, vec![value]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let ret = find_first::<llvm::ReturnOp>(&ctx, &body).expect("expected llvm.return");
+        let operand = ret
+            .get_operation()
+            .deref(&ctx)
+            .operands()
+            .next()
+            .expect("transparent return must carry the scalar");
+        let operand_ty = operand.get_type(&ctx);
+        let operand_ty_ref = operand_ty.deref(&ctx);
+        let integer = operand_ty_ref
+            .downcast_ref::<IntegerType>()
+            .expect("transparent u32 return must become i32");
+        assert_eq!(integer.width(), 32);
+        assert_eq!(count_ops::<llvm::ExtractValueOp>(&ctx, &body), 1);
+    }
+
+    #[test]
+    fn convert_return_nested_transparent_scalar_extracts_all_layers() {
+        let mut ctx = make_ctx();
+        let inner = transparent_u32(&mut ctx, "Inner");
+        let outer: TypeHandle = MirStructType::get_with_full_layout_and_abi(
+            &mut ctx,
+            "Outer".into(),
+            vec!["inner".into()],
+            vec![inner],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into();
+        let (module_ptr, entry) = build_kernel(&mut ctx, vec![], vec![outer]);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, outer);
+        undef.get_operation().insert_at_back(entry, &ctx);
+        let value = undef.get_operation().deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, entry, vec![value]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let ret = find_first::<llvm::ReturnOp>(&ctx, &body).expect("expected llvm.return");
+        let operand = ret
+            .get_operation()
+            .deref(&ctx)
+            .operands()
+            .next()
+            .expect("nested transparent return must carry the scalar");
+        let operand_ty = operand.get_type(&ctx);
+        let operand_ty_ref = operand_ty.deref(&ctx);
+        let integer = operand_ty_ref
+            .downcast_ref::<IntegerType>()
+            .expect("nested transparent u32 return must become i32");
+        assert_eq!(integer.width(), 32);
+        assert_eq!(count_ops::<llvm::ExtractValueOp>(&ctx, &body), 2);
+    }
+
+    #[test]
+    fn convert_return_ordinary_one_field_struct_stays_aggregate() {
+        let mut ctx = make_ctx();
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let ordinary: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "Ordinary".into(),
+            vec!["value".into()],
+            vec![u32_ty],
+            vec![0],
+            vec![0],
+            4,
+            4,
+        )
+        .into();
+        let (module_ptr, entry) = build_kernel(&mut ctx, vec![], vec![ordinary]);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, ordinary);
+        undef.get_operation().insert_at_back(entry, &ctx);
+        let value = undef.get_operation().deref(&ctx).get_result(0);
+        append_mir_return(&mut ctx, entry, vec![value]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let ret = find_first::<llvm::ReturnOp>(&ctx, &body).expect("expected llvm.return");
+        let operand = ret
+            .get_operation()
+            .deref(&ctx)
+            .operands()
+            .next()
+            .expect("ordinary aggregate return must keep its value");
+        assert!(
+            operand
+                .get_type(&ctx)
+                .deref(&ctx)
+                .is::<llvm_export::types::StructType>(),
+            "ordinary one-field struct return must remain aggregate"
+        );
+        assert_eq!(count_ops::<llvm::ExtractValueOp>(&ctx, &body), 0);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -219,16 +219,17 @@ pub fn convert_type(ctx: &mut Context, ty: TypeHandle) -> Result<TypeHandle, any
     ))
 }
 
-/// Return the single non-ZST field of a rustc-proven transparent scalar struct.
+/// Return the declaration index and type of the single non-ZST field of a
+/// rustc-proven transparent scalar struct.
 ///
 /// The importer marks the outer ABI from rustc rather than inferring it from
 /// source field count. We still validate the MIR shape here so malformed or
 /// hand-written dialect input cannot turn an arbitrary aggregate into a scalar
-/// kernel parameter.
-pub(crate) fn transparent_scalar_field(
+/// ABI value.
+fn transparent_scalar_field_with_index(
     ctx: &mut Context,
     struct_ty: TypeHandle,
-) -> Result<TypeHandle, anyhow::Error> {
+) -> Result<(usize, TypeHandle), anyhow::Error> {
     let (name, field_types, mem_to_decl, is_transparent_scalar) = {
         let ty_ref = struct_ty.deref(ctx);
         let s = ty_ref
@@ -256,7 +257,7 @@ pub(crate) fn transparent_scalar_field(
         if is_zero_sized_type(ctx, converted) {
             continue;
         }
-        if scalar_field.replace(field_ty).is_some() {
+        if scalar_field.replace((decl_idx, field_ty)).is_some() {
             return Err(anyhow::anyhow!(
                 "transparent scalar struct `{}` has more than one non-ZST field",
                 name
@@ -268,7 +269,90 @@ pub(crate) fn transparent_scalar_field(
         .ok_or_else(|| anyhow::anyhow!("transparent scalar struct `{}` has no non-ZST field", name))
 }
 
-/// LLVM parameter type for a rustc-proven transparent scalar struct.
+/// Return the single non-ZST field of a rustc-proven transparent scalar struct.
+pub(crate) fn transparent_scalar_field(
+    ctx: &mut Context,
+    struct_ty: TypeHandle,
+) -> Result<TypeHandle, anyhow::Error> {
+    Ok(transparent_scalar_field_with_index(ctx, struct_ty)?.1)
+}
+
+/// One aggregate layer traversed when a transparent scalar wrapper crosses an
+/// ABI boundary. `field_slot` is the LLVM struct slot containing the next
+/// nested wrapper or the final scalar.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TransparentScalarLayer {
+    pub llvm_struct_ty: TypeHandle,
+    pub field_slot: u32,
+}
+
+/// Complete ABI projection for a rustc-proven transparent scalar wrapper.
+///
+/// `layers` are ordered outermost to innermost. A return lowers by extracting
+/// those slots in order; a call result is rebuilt by inserting the scalar into
+/// the same layers in reverse order.
+#[derive(Clone, Debug)]
+pub(crate) struct TransparentScalarAbiInfo {
+    pub scalar_ty: TypeHandle,
+    pub layers: Vec<TransparentScalarLayer>,
+}
+
+/// Build the scalar ABI projection, including the exact LLVM slot used at every
+/// wrapper layer.
+///
+/// Slot indices come from [`build_struct_slot_map`], so ZST markers, explicit
+/// padding, and rustc memory order cannot make the return/call paths disagree
+/// with ordinary aggregate conversion.
+pub(crate) fn transparent_scalar_abi_info(
+    ctx: &mut Context,
+    struct_ty: TypeHandle,
+) -> Result<TransparentScalarAbiInfo, anyhow::Error> {
+    let mut current = struct_ty;
+    let mut layers = Vec::new();
+
+    loop {
+        let (decl_idx, field_ty) = transparent_scalar_field_with_index(ctx, current)?;
+        let layout = {
+            let ty_ref = current.deref(ctx);
+            let s = ty_ref.downcast_ref::<MirStructType>().ok_or_else(|| {
+                anyhow::anyhow!("transparent scalar ABI requires a MirStructType")
+            })?;
+            StructLayoutInfo::of_struct(s)
+        };
+        let map = build_struct_slot_map(ctx, &layout)?;
+        let field_slot = map.decl_to_llvm[decl_idx].ok_or_else(|| {
+            anyhow::anyhow!(
+                "transparent scalar field {} unexpectedly lowered as a ZST",
+                decl_idx
+            )
+        })?;
+        layers.push(TransparentScalarLayer {
+            llvm_struct_ty: map.llvm_struct_ty,
+            field_slot,
+        });
+
+        let nested_transparent = {
+            let field_ref = field_ty.deref(ctx);
+            field_ref
+                .downcast_ref::<MirStructType>()
+                .is_some_and(MirStructType::is_transparent_scalar)
+        };
+        if nested_transparent {
+            current = field_ty;
+            continue;
+        }
+
+        let scalar_ty = convert_type(ctx, field_ty)?;
+        if is_zero_sized_type(ctx, scalar_ty) {
+            return Err(anyhow::anyhow!(
+                "transparent scalar ABI resolved to a zero-sized field"
+            ));
+        }
+        return Ok(TransparentScalarAbiInfo { scalar_ty, layers });
+    }
+}
+
+/// LLVM ABI type for a rustc-proven transparent scalar struct.
 ///
 /// Transparent wrappers can nest (`Outer(Inner(u32))`). rustc still reports
 /// the outer ADT as one scalar, so recurse through transparent scalar fields
@@ -277,18 +361,7 @@ pub(crate) fn transparent_scalar_llvm_type(
     ctx: &mut Context,
     struct_ty: TypeHandle,
 ) -> Result<TypeHandle, anyhow::Error> {
-    let field_ty = transparent_scalar_field(ctx, struct_ty)?;
-    let nested_transparent = {
-        let field_ref = field_ty.deref(ctx);
-        field_ref
-            .downcast_ref::<MirStructType>()
-            .is_some_and(MirStructType::is_transparent_scalar)
-    };
-    if nested_transparent {
-        transparent_scalar_llvm_type(ctx, field_ty)
-    } else {
-        convert_type(ctx, field_ty)
-    }
+    Ok(transparent_scalar_abi_info(ctx, struct_ty)?.scalar_ty)
 }
 
 /// Convert a MIR function type to an LLVM function type.
@@ -332,6 +405,7 @@ pub(crate) fn transparent_scalar_llvm_type(
 ///
 /// - Empty tuple `()` becomes `void`
 /// - Empty struct `struct {}` becomes `void`
+/// - Rustc-proven `repr(transparent)` scalar ADTs return the underlying scalar
 /// - Other types are converted normally
 ///
 /// # Arguments
@@ -473,13 +547,25 @@ pub fn convert_function_type(
         }
     }
 
-    // Convert return type, treating empty tuple/struct as void
+    // Convert return type. A rustc-proven transparent scalar wrapper uses
+    // the underlying scalar at the function ABI boundary, while its body
+    // continues to use the ordinary converted aggregate representation.
     let ret_ty = if results_ptr.is_empty() {
         llvm_types::VoidType::get(ctx).into()
     } else {
-        let ty = convert_type(ctx, results_ptr[0])?;
-        // Check if zero-sized (empty struct or struct with only ZST fields)
-        // Note: convert_type already strips ZST fields, so we just check for empty
+        let mir_ret_ty = results_ptr[0];
+        let is_transparent_scalar = {
+            let ty_ref = mir_ret_ty.deref(ctx);
+            ty_ref
+                .downcast_ref::<MirStructType>()
+                .is_some_and(MirStructType::is_transparent_scalar)
+        };
+        let ty = if is_transparent_scalar {
+            transparent_scalar_llvm_type(ctx, mir_ret_ty)?
+        } else {
+            convert_type(ctx, mir_ret_ty)?
+        };
+        // Check if zero-sized (empty struct or struct with only ZST fields).
         if is_zero_sized_type(ctx, ty) {
             llvm_types::VoidType::get(ctx).into()
         } else {
@@ -2543,7 +2629,7 @@ mod tests {
     use super::*;
     use dialect_mir::types::{
         EnumEncoding, EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType,
-        MirTupleType, MirUnionType,
+        MirTupleType, MirUnionType, StructAbiKind,
     };
 
     fn make_ctx() -> Context {
@@ -2579,6 +2665,93 @@ mod tests {
             .expect("expected an LLVM struct type")
             .fields()
             .collect()
+    }
+
+    fn transparent_u32(ctx: &mut Context, name: &str) -> TypeHandle {
+        let u32_ty = mir_uint(ctx, 32);
+        MirStructType::get_with_full_layout_and_abi(
+            ctx,
+            name.into(),
+            vec!["value".into()],
+            vec![u32_ty],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into()
+    }
+
+    #[test]
+    fn transparent_scalar_return_type_uses_underlying_scalar() {
+        let mut ctx = make_ctx();
+        let wrapper = transparent_u32(&mut ctx, "Scalar");
+        let func_ty = FunctionType::get(&ctx, vec![], vec![wrapper]);
+
+        let lowered = convert_function_type(&mut ctx, func_ty, false).unwrap();
+        let result_ty = lowered.deref(&ctx).result_type();
+        let result_ty_ref = result_ty.deref(&ctx);
+        let integer = result_ty_ref
+            .downcast_ref::<IntegerType>()
+            .expect("transparent u32 return must lower to an integer");
+        assert_eq!(integer.width(), 32);
+    }
+
+    #[test]
+    fn nested_transparent_scalar_abi_records_each_rebuild_layer() {
+        let mut ctx = make_ctx();
+        let inner = transparent_u32(&mut ctx, "Inner");
+        let outer: TypeHandle = MirStructType::get_with_full_layout_and_abi(
+            &mut ctx,
+            "Outer".into(),
+            vec!["inner".into()],
+            vec![inner],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into();
+
+        let info = transparent_scalar_abi_info(&mut ctx, outer).unwrap();
+        let scalar_ty_ref = info.scalar_ty.deref(&ctx);
+        let integer = scalar_ty_ref
+            .downcast_ref::<IntegerType>()
+            .expect("nested transparent wrapper must resolve to u32");
+        assert_eq!(integer.width(), 32);
+        assert_eq!(info.layers.len(), 2);
+        assert_eq!(info.layers[0].field_slot, 0);
+        assert_eq!(info.layers[1].field_slot, 0);
+    }
+
+    #[test]
+    fn ordinary_one_field_return_remains_aggregate() {
+        let mut ctx = make_ctx();
+        let u32_ty = mir_uint(&mut ctx, 32);
+        let ordinary: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "Ordinary".into(),
+            vec!["value".into()],
+            vec![u32_ty],
+            vec![0],
+            vec![0],
+            4,
+            4,
+        )
+        .into();
+        let func_ty = FunctionType::get(&ctx, vec![], vec![ordinary]);
+
+        let lowered = convert_function_type(&mut ctx, func_ty, false).unwrap();
+        assert!(
+            lowered
+                .deref(&ctx)
+                .result_type()
+                .deref(&ctx)
+                .is::<llvm_types::StructType>(),
+            "ordinary one-field structs must not be scalarized"
+        );
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Kernel-boundary ABI regression coverage for `#[repr(transparent)]` scalar ADTs.
+//! Kernel-boundary and device-return ABI regression coverage for
+//! `#[repr(transparent)]` scalar ADTs.
 //!
-//! The device entry must expose the underlying scalar/pointer parameter rather
-//! than an aggregate `.param .b8[...]`. An ordinary one-field struct is kept as
-//! the negative control and must remain aggregate at the kernel boundary.
+//! Kernel entries must expose the underlying scalar/pointer parameter rather
+//! than an aggregate `.param .b8[...]`. Device helper returns must likewise use
+//! the underlying scalar ABI while callers reconstruct the Rust wrapper value.
+//! An ordinary one-field struct is kept as the negative control on both paths.
 
 use core::marker::PhantomData;
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{Uniform, cuda_module, kernel};
+use cuda_device::{Uniform, cuda_module, device, kernel};
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
@@ -36,6 +38,36 @@ pub struct Outer(pub Inner);
 
 #[derive(Clone, Copy)]
 pub struct Ordinary(pub u32);
+
+#[inline(never)]
+#[device]
+pub fn return_scalar(value: u32) -> Scalar {
+    Scalar(value)
+}
+
+#[inline(never)]
+#[device]
+pub fn return_pointer(value: *const u32) -> Pointer {
+    Pointer(value)
+}
+
+#[inline(never)]
+#[device]
+pub fn return_marked(value: u32) -> Marked {
+    Marked(value, PhantomData)
+}
+
+#[inline(never)]
+#[device]
+pub fn return_nested(value: u32) -> Outer {
+    Outer(Inner(value))
+}
+
+#[inline(never)]
+#[device]
+pub fn return_ordinary(value: u32) -> Ordinary {
+    Ordinary(value)
+}
 
 #[cuda_module]
 mod kernels {
@@ -77,6 +109,42 @@ mod kernels {
         // SAFETY: the host launch passes one writable u32 in `out`.
         unsafe { out.write(value.0) };
     }
+
+    #[kernel]
+    pub unsafe fn scalar_return(value: u32, out: *mut u32) {
+        let wrapped = return_scalar(value);
+        // SAFETY: the host launch passes one writable u32 in `out`.
+        unsafe { out.write(wrapped.0) };
+    }
+
+    #[kernel]
+    pub unsafe fn pointer_return(value: *const u32, out: *mut u32) {
+        let wrapped = return_pointer(value);
+        // SAFETY: the host launch keeps `value` readable and `out` writable
+        // through synchronization.
+        unsafe { out.write(wrapped.0.read()) };
+    }
+
+    #[kernel]
+    pub unsafe fn marked_return(value: u32, out: *mut u32) {
+        let wrapped = return_marked(value);
+        // SAFETY: the host launch passes one writable u32 in `out`.
+        unsafe { out.write(wrapped.0) };
+    }
+
+    #[kernel]
+    pub unsafe fn nested_return(value: u32, out: *mut u32) {
+        let wrapped = return_nested(value);
+        // SAFETY: the host launch passes one writable u32 in `out`.
+        unsafe { out.write(wrapped.0.0) };
+    }
+
+    #[kernel]
+    pub unsafe fn ordinary_return(value: u32, out: *mut u32) {
+        let wrapped = return_ordinary(value);
+        // SAFETY: the host launch passes one writable u32 in `out`.
+        unsafe { out.write(wrapped.0) };
+    }
 }
 
 fn entry_header<'a>(ptx: &'a str, name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
@@ -111,6 +179,38 @@ fn require_scalar_header(
     Ok(())
 }
 
+fn require_llvm_return_shape(
+    llvm_ir: &str,
+    name_fragment: &str,
+    return_tokens: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let header = llvm_ir
+        .lines()
+        .find(|line| line.trim_start().starts_with("define ") && line.contains(name_fragment))
+        .ok_or_else(|| format!("missing LLVM definition containing `{name_fragment}`"))?;
+    if !return_tokens.iter().any(|token| header.contains(token)) {
+        return Err(format!(
+            "device helper `{name_fragment}` does not expose any expected return token {:?}:\n{header}",
+            return_tokens
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn verify_generated_llvm_ir() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("repr_transparent_abi.ll");
+    let llvm_ir = std::fs::read_to_string(&path)?;
+
+    require_llvm_return_shape(&llvm_ir, "return_scalar", &["i32 @"])?;
+    require_llvm_return_shape(&llvm_ir, "return_pointer", &["ptr @", "* @"])?;
+    require_llvm_return_shape(&llvm_ir, "return_marked", &["i32 @"])?;
+    require_llvm_return_shape(&llvm_ir, "return_nested", &["i32 @"])?;
+    require_llvm_return_shape(&llvm_ir, "return_ordinary", &["{ i32 } @"])?;
+
+    Ok(())
+}
+
 fn verify_generated_ptx() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("repr_transparent_abi.ptx");
     let ptx = std::fs::read_to_string(&path)?;
@@ -134,11 +234,13 @@ fn verify_generated_ptx() -> Result<(), Box<dyn std::error::Error>> {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if std::env::args().any(|arg| arg == "--verify-ptx") {
+        verify_generated_llvm_ir()?;
         verify_generated_ptx()?;
-        println!("repr_transparent_abi: PASS (PTX parameter shapes)");
+        println!("repr_transparent_abi: PASS (LLVM return ABI and PTX parameter shapes)");
         return Ok(());
     }
 
+    verify_generated_llvm_ir()?;
     verify_generated_ptx()?;
 
     let context = CudaContext::new(0)?;
@@ -157,9 +259,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let nested_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
     let uniform_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
     let ordinary_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
+    let scalar_return_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
+    let pointer_return_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
+    let marked_return_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
+    let nested_return_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
+    let ordinary_return_out = DeviceBuffer::<u32>::zeroed(&stream, 1)?;
 
     // SAFETY: every kernel launches one thread. Each output buffer owns one
-    // writable u32, and `input` owns the readable u32 used by `pointer`.
+    // writable u32, and `input` owns the readable u32 used by pointer tests.
     unsafe {
         module.scalar(
             &stream,
@@ -199,6 +306,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ordinary(37),
             ordinary_out.cu_deviceptr() as *mut u32,
         )?;
+
+        module.scalar_return(
+            &stream,
+            config,
+            41u32,
+            scalar_return_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.pointer_return(
+            &stream,
+            config,
+            input.cu_deviceptr() as *const u32,
+            pointer_return_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.marked_return(
+            &stream,
+            config,
+            43u32,
+            marked_return_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.nested_return(
+            &stream,
+            config,
+            47u32,
+            nested_return_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.ordinary_return(
+            &stream,
+            config,
+            53u32,
+            ordinary_return_out.cu_deviceptr() as *mut u32,
+        )?;
     }
 
     assert_eq!(scalar_out.to_host_vec(&stream)?, [11]);
@@ -207,7 +345,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(nested_out.to_host_vec(&stream)?, [29]);
     assert_eq!(uniform_out.to_host_vec(&stream)?, [31]);
     assert_eq!(ordinary_out.to_host_vec(&stream)?, [37]);
+    assert_eq!(scalar_return_out.to_host_vec(&stream)?, [41]);
+    assert_eq!(pointer_return_out.to_host_vec(&stream)?, [17]);
+    assert_eq!(marked_return_out.to_host_vec(&stream)?, [43]);
+    assert_eq!(nested_return_out.to_host_vec(&stream)?, [47]);
+    assert_eq!(ordinary_return_out.to_host_vec(&stream)?, [53]);
 
-    println!("repr_transparent_abi: PASS (runtime values and PTX parameter shapes)");
+    println!(
+        "repr_transparent_abi: PASS (kernel parameters, device returns, and runtime values)"
+    );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/repr_transparent_abi/src/main.rs
@@ -351,8 +351,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(nested_return_out.to_host_vec(&stream)?, [47]);
     assert_eq!(ordinary_return_out.to_host_vec(&stream)?, [53]);
 
-    println!(
-        "repr_transparent_abi: PASS (kernel parameters, device returns, and runtime values)"
-    );
+    println!("repr_transparent_abi: PASS (kernel parameters, device returns, and runtime values)");
     Ok(())
 }


### PR DESCRIPTION
Closes #942 

## Summary

Extend `repr(transparent)` scalar ABI lowering to device function returns.

Rustc-proven transparent scalar ADTs now use their underlying scalar or pointer type at the LLVM function ABI boundary, while preserving the aggregate wrapper representation inside MIR lowering.

## Changes

- classify transparent scalar device return types using their underlying scalar LLVM type
- extract the underlying scalar when lowering transparent return values
- reconstruct transparent wrappers after scalar-returning device calls
- preserve exact struct field slots, including nested transparent wrappers and ZST marker fields
- keep ordinary one-field structs aggregate
- extend `repr_transparent_abi` with scalar, pointer, marked, nested, and ordinary return cases

## Implementation

Transparent return ABI information records each wrapper layer together with its actual LLVM field slot.

When lowering a return, the transparent wrapper is recursively unwrapped with `extractvalue` until the ABI scalar is reached.

At a call site, the scalar result is rebuilt into the MIR-visible wrapper representation using `undef` plus `insertvalue`, from the innermost transparent layer back to the outermost one.

This keeps ABI scalarization localized to function boundaries rather than changing the internal representation of transparent structs.

## Validation

- `cargo test -p mir-lower`
  - 225 unit tests passed
  - 105 integration tests passed
- `cargo clippy -p mir-lower --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo oxide run repr_transparent_abi`
  - `repr_transparent_abi: PASS (kernel parameters, device returns, and runtime values)`

## Scope

This PR intentionally does not change device extern ABI handling.
That should be addressed separately.
