### PR TITLE
fix(device-ffi): preserve repr(transparent) scalar ABI

### DIFF
--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -62,8 +62,8 @@
 //! mismatch.
 
 use crate::convert::types::{
-    StructLayoutInfo, build_struct_slot_map, convert_function_type, convert_type, is_kernel_func,
-    is_zero_sized_type, transparent_scalar_abi_info,
+    StructLayoutInfo, TransparentScalarAbiInfo, build_struct_slot_map, convert_function_type,
+    convert_type, is_kernel_func, is_zero_sized_type, transparent_scalar_abi_info,
 };
 use crate::helpers;
 use dialect_mir::ops::{MirCallOp, MirFuncOp};
@@ -1541,11 +1541,63 @@ fn cast_integer_value_to_type(
     Ok((cast_op.deref(ctx).get_result(0), Some(cast_op)))
 }
 
+/// Recover the transparent scalar ABI projection required by the callee's
+/// declared LLVM parameter type.
+///
+/// A `mir.call` to a `#[device] extern` can already carry the final link symbol,
+/// so the reserved source-level extern prefix is not a reliable discriminator at
+/// this stage. Instead, use the callee declaration as the ABI authority: when an
+/// operand's MIR type history contains a rustc-proven transparent scalar wrapper
+/// whose final scalar type exactly matches the next declared LLVM parameter, that
+/// wrapper must cross this call boundary as the scalar.
+///
+/// Nested wrapper histories can contain both `Outer` and `Inner`. Prefer the
+/// candidate with the most projection layers so the live outer aggregate is
+/// fully unwrapped instead of stopping after the innermost recorded wrapper.
+fn transparent_scalar_abi_matching_param(
+    ctx: &mut Context,
+    arg: Value,
+    operands_info: &OperandsInfo,
+    expected_ty: Option<TypeHandle>,
+) -> Result<Option<TransparentScalarAbiInfo>> {
+    let Some(expected_ty) = expected_ty else {
+        return Ok(None);
+    };
+
+    let mut best: Option<TransparentScalarAbiInfo> = None;
+    for mir_ty in operands_info.lookup_operand_history(arg) {
+        let is_transparent_scalar = {
+            let ty_ref = mir_ty.deref(ctx);
+            ty_ref
+                .downcast_ref::<MirStructType>()
+                .is_some_and(MirStructType::is_transparent_scalar)
+        };
+        if !is_transparent_scalar {
+            continue;
+        }
+
+        let abi = transparent_scalar_abi_info(ctx, mir_ty).map_err(anyhow_to_pliron)?;
+        if abi.scalar_ty != expected_ty {
+            continue;
+        }
+
+        let replace = best
+            .as_ref()
+            .is_none_or(|current| abi.layers.len() > current.layers.len());
+        if replace {
+            best = Some(abi);
+        }
+    }
+
+    Ok(best)
+}
+
 /// Flatten arguments according to ABI rules and coerce each one to the
 /// callee's expected parameter type.
 ///
 /// - Slice types → (ptr, len) pair
 /// - Struct types → individual field values (in MEMORY ORDER)
+/// - `repr(transparent)` scalar structs at device-extern boundaries → underlying scalar
 /// - Other types → pass through
 ///
 /// `expected_param_tys`, when present, is the LLVM-level (post-flatten)
@@ -1585,10 +1637,20 @@ fn flatten_arguments(
             Struct {
                 layout: StructLayoutInfo,
             },
+            TransparentScalar(TransparentScalarAbiInfo),
             None,
         }
 
-        let flatten_kind = if let Some(mir_ty) = operands_info.lookup_most_recent_type(*arg) {
+        let transparent_abi = transparent_scalar_abi_matching_param(
+            ctx,
+            *arg,
+            operands_info,
+            take_expected(&flattened_arg_types),
+        )?;
+
+        let flatten_kind = if let Some(abi) = transparent_abi {
+            FlattenKind::TransparentScalar(abi)
+        } else if let Some(mir_ty) = operands_info.lookup_most_recent_type(*arg) {
             let ty_ref = mir_ty.deref(ctx);
             if ty_ref.is::<MirSliceType>() {
                 FlattenKind::Slice {
@@ -1673,6 +1735,28 @@ fn flatten_arguments(
                     flattened_args.push(space_val);
                     flattened_arg_types.push(space_ty);
                 }
+            }
+            FlattenKind::TransparentScalar(abi) => {
+                let mut scalar = *arg;
+
+                // Layers are recorded outer-to-inner. Extract through every
+                // wrapper so nested transparent ADTs reach the exact scalar
+                // type declared by the device extern.
+                for layer in &abi.layers {
+                    let extract = llvm::ExtractValueOp::new(ctx, scalar, vec![layer.field_slot])?;
+                    rewriter.insert_operation(ctx, extract.get_operation());
+                    scalar = extract.get_operation().deref(ctx).get_result(0);
+                }
+
+                let (scalar, scalar_ty) = coerce_arg_to_param_ty(
+                    ctx,
+                    rewriter,
+                    scalar,
+                    abi.scalar_ty,
+                    take_expected(&flattened_arg_types),
+                )?;
+                flattened_args.push(scalar);
+                flattened_arg_types.push(scalar_ty);
             }
             FlattenKind::Struct { layout } => {
                 // Walk in memory order (the order `convert_function_type`
@@ -1901,6 +1985,76 @@ mod tests {
         assert!(flags.contains(FastmathFlags::REASSOC));
         assert!(flags.contains(FastmathFlags::NNAN));
         assert!(flags.contains(FastmathFlags::NINF));
+    }
+
+    #[test]
+    fn nested_transparent_arg_uses_scalar_when_callee_param_is_scalar() {
+        use dialect_mir::types::StructAbiKind;
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        crate::register(&mut ctx);
+
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let inner: TypeHandle = MirStructType::get_with_full_layout_and_abi(
+            &mut ctx,
+            "Inner".into(),
+            vec!["value".into()],
+            vec![u32_ty],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into();
+        let outer: TypeHandle = MirStructType::get_with_full_layout_and_abi(
+            &mut ctx,
+            "Outer".into(),
+            vec!["inner".into()],
+            vec![inner],
+            vec![0],
+            vec![0],
+            4,
+            4,
+            StructAbiKind::TransparentScalar,
+        )
+        .into();
+
+        // Model the real conversion pipeline: the live value gets its LLVM
+        // type from ordinary aggregate conversion, while OperandsInfo retains
+        // the MIR wrapper history separately.
+        let live_outer_ty = convert_type(&mut ctx, outer).unwrap();
+        let undef = llvm::UndefOp::new(&mut ctx, live_outer_ty);
+        let arg = undef.get_operation().deref(&ctx).get_result(0);
+        let operands_info = OperandsInfo::new(vec![(arg, vec![outer, inner])]);
+
+        let outer_abi = transparent_scalar_abi_info(&mut ctx, outer).unwrap();
+        let selected = transparent_scalar_abi_matching_param(
+            &mut ctx,
+            arg,
+            &operands_info,
+            Some(outer_abi.scalar_ty),
+        )
+        .unwrap()
+        .expect("scalar callee parameter must select the outer transparent ABI");
+        assert_eq!(selected.layers.len(), 2);
+        assert_eq!(selected.scalar_ty, outer_abi.scalar_ty);
+
+        // An ordinary Rust device-function boundary for `Outer(Inner(T))`
+        // still expects the inner aggregate after one-level struct flattening,
+        // so the transparent scalar projection must not activate there.
+        let inner_aggregate_ty = convert_type(&mut ctx, inner).unwrap();
+        assert!(
+            transparent_scalar_abi_matching_param(
+                &mut ctx,
+                arg,
+                &operands_info,
+                Some(inner_aggregate_ty),
+            )
+            .unwrap()
+            .is_none()
+        );
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/examples/extern_libdevice/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/extern_libdevice/src/main.rs
@@ -5,29 +5,40 @@
 
 //! Hand-written `__nv_*` libdevice externs called straight from a kernel.
 //!
-//! Regression test for two declaration paths that must coexist:
+//! Regression test for device-extern declaration paths and transparent ABI:
 //!
 //! - A plain `extern "C" { fn __nv_asinf(...) }` block (no `#[device]`).
 //!   The foreign item has no MIR body, so the importer must emit the call
 //!   under the link symbol and mir-lower must declare it at the call site.
-//!   Before this worked, the call failed module verification with
-//!   "Symbol __nv_asinf not found".
-//! - The `#[device] extern "C"` form of the same shape (`__nv_acosf`).
-//!   The pipeline's device-extern declaration step also declares this
-//!   symbol, so it must skip symbols the call-site path already declared
-//!   instead of producing a multiple-definition error.
+//! - The `#[device] extern "C"` scalar form (`__nv_acosf`) exercises the
+//!   pipeline's device-extern declaration path and declaration idempotence.
+//! - `#[repr(transparent)]` scalar wrappers around `f32` exercise the same
+//!   external `float -> float` ABI for nested and ZST-marked wrappers.
 //!
-//! Both symbols resolve against `libdevice.10.bc` when the NVVM IR is
-//! linked via libNVVM + nvJitLink (same flow as `math_atan`).
+//! All symbols resolve against `libdevice.10.bc` when the NVVM IR is linked
+//! via libNVVM + nvJitLink (same flow as `math_atan`).
 //!
 //! Run:
 //!     cargo oxide run extern_libdevice
 //!
 //! Exits 0 on SUCCESS, 1 on FAIL.
 
+use core::marker::PhantomData;
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::{DisjointSlice, device, kernel, thread};
 use cuda_host::{cuda_module, ltoir};
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct InnerF32(f32);
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct OuterF32(InnerF32);
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct MarkedF32(f32, PhantomData<()>);
 
 // Plain extern block: the original motivating shape. No macro support;
 // the kernel calls libdevice directly.
@@ -35,11 +46,13 @@ unsafe extern "C" {
     fn __nv_asinf(x: f32) -> f32;
 }
 
-// #[device] extern route for a libdevice symbol: also declared by the
-// pipeline's device-extern step, exercising declaration idempotence.
+// #[device] extern route for libdevice symbols. The transparent declarations
+// intentionally use Rust wrapper types whose C ABI must still be `float(float)`.
 #[device]
 unsafe extern "C" {
     fn __nv_acosf(x: f32) -> f32;
+    fn __nv_sinf(x: OuterF32) -> OuterF32;
+    fn __nv_cosf(x: MarkedF32) -> MarkedF32;
 }
 
 #[cuda_module]
@@ -64,10 +77,34 @@ mod kernels {
             }
         }
     }
+
+    #[kernel]
+    pub fn transparent_sin_cos(
+        xs: &[f32],
+        mut out_sin: DisjointSlice<f32>,
+        mut out_cos: DisjointSlice<f32>,
+    ) {
+        let i = thread::index_1d().get();
+        if i < xs.len() {
+            let x = xs[i];
+
+            if let Some(slot) = out_sin.get_mut(thread::index_1d()) {
+                let wrapped = OuterF32(InnerF32(x));
+                let result = unsafe { __nv_sinf(wrapped) };
+                *slot = result.0.0;
+            }
+
+            if let Some(slot) = out_cos.get_mut(thread::index_1d()) {
+                let wrapped = MarkedF32(x, PhantomData);
+                let result = unsafe { __nv_cosf(wrapped) };
+                *slot = result.0;
+            }
+        }
+    }
 }
 
-/// IEEE-754 ULP distance for finite f32 operands. `asin`/`acos` of inputs
-/// in `[-1, 1]` land in `[-pi/2, pi]`, so NaN/Inf handling is not needed.
+/// IEEE-754 ULP distance for finite f32 operands. All tested transcendental
+/// results are finite, so NaN/Inf handling is not needed here.
 fn ulp_diff_f32(a: f32, b: f32) -> u64 {
     const SIGN: u64 = 0x8000_0000;
     const BODY: u64 = 0x7FFF_FFFF;
@@ -82,7 +119,7 @@ fn ulp_diff_f32(a: f32, b: f32) -> u64 {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== extern_libdevice: direct __nv_asinf/__nv_acosf calls ===\n");
+    println!("=== extern_libdevice: direct and repr(transparent) device extern calls ===\n");
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
@@ -91,22 +128,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module = ltoir::load_kernel_module(&ctx, "extern_libdevice")?;
     let module = kernels::from_module(module)?;
 
-    // Full asin/acos domain including both endpoints.
+    // Full asin/acos domain including both endpoints. The same inputs are also
+    // well inside the finite sin/cos domain used by the transparent ABI cases.
     let xs: Vec<f32> = vec![
         -1.0, -0.9, -0.75, -0.5, -0.25, -0.1, 0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0,
     ];
     let n = xs.len();
-    let cfg = LaunchConfig::for_num_elems(n as u32);
+    let cfg_asin_acos = LaunchConfig::for_num_elems(n as u32);
+    let cfg_transparent = LaunchConfig::for_num_elems(n as u32);
 
     let xs_dev = DeviceBuffer::from_host(&stream, &xs)?;
     let mut out_asin = DeviceBuffer::<f32>::zeroed(&stream, n)?;
     let mut out_acos = DeviceBuffer::<f32>::zeroed(&stream, n)?;
+    let mut out_sin = DeviceBuffer::<f32>::zeroed(&stream, n)?;
+    let mut out_cos = DeviceBuffer::<f32>::zeroed(&stream, n)?;
 
-    // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
-    unsafe { module.asin_acos(&stream, cfg, &xs_dev, &mut out_asin, &mut out_acos) }?;
+    // SAFETY: launch shapes/resources match the kernels; buffers cover their accesses.
+    unsafe {
+        module.asin_acos(
+            &stream,
+            cfg_asin_acos,
+            &xs_dev,
+            &mut out_asin,
+            &mut out_acos,
+        )
+    }?;
+    unsafe {
+        module.transparent_sin_cos(
+            &stream,
+            cfg_transparent,
+            &xs_dev,
+            &mut out_sin,
+            &mut out_cos,
+        )
+    }?;
 
     let got_asin = out_asin.to_host_vec(&stream)?;
     let got_acos = out_acos.to_host_vec(&stream)?;
+    let got_sin = out_sin.to_host_vec(&stream)?;
+    let got_cos = out_cos.to_host_vec(&stream)?;
 
     // libdevice transcendentals are typically within 1 ULP of host libm;
     // 2 ULP matches the bound math_atan / primitive_stress use.
@@ -114,36 +174,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut failures = 0usize;
     for i in 0..n {
-        let exp_asin = xs[i].asin();
-        let exp_acos = xs[i].acos();
-        let d_asin = ulp_diff_f32(got_asin[i], exp_asin);
-        let d_acos = ulp_diff_f32(got_acos[i], exp_acos);
-        if d_asin > ULP_LIMIT || d_acos > ULP_LIMIT {
-            failures += 1;
-            eprintln!(
-                "[{i}] x={:>6.3} | asin ulp={d_asin} (gpu={:e} cpu={exp_asin:e}) | \
-                 acos ulp={d_acos} (gpu={:e} cpu={exp_acos:e})",
-                xs[i], got_asin[i], got_acos[i],
-            );
+        let expected = [xs[i].asin(), xs[i].acos(), xs[i].sin(), xs[i].cos()];
+        let actual = [got_asin[i], got_acos[i], got_sin[i], got_cos[i]];
+        let labels = ["asin", "acos", "sin(transparent)", "cos(marked)"];
+
+        for j in 0..actual.len() {
+            let ulp = ulp_diff_f32(actual[j], expected[j]);
+            if ulp > ULP_LIMIT {
+                failures += 1;
+                eprintln!(
+                    "[{i}] x={:>6.3} | {} ulp={ulp} (gpu={:e} cpu={:e})",
+                    xs[i], labels[j], actual[j], expected[j],
+                );
+            }
         }
     }
 
     for &i in &[0usize, 6, 12] {
         println!(
-            "[{i}] x={x:>6.3}  asin gpu={ga} cpu={ea}  acos gpu={gc} cpu={ec}",
+            "[{i}] x={x:>6.3}  asin={asin}  acos={acos}  \
+             sin(transparent)={sin}  cos(marked)={cos}",
             x = xs[i],
-            ga = got_asin[i],
-            ea = xs[i].asin(),
-            gc = got_acos[i],
-            ec = xs[i].acos(),
+            asin = got_asin[i],
+            acos = got_acos[i],
+            sin = got_sin[i],
+            cos = got_cos[i],
         );
     }
 
     if failures == 0 {
-        println!("\nSUCCESS: {n} cases x 2 functions within {ULP_LIMIT} ULP of host libm");
+        println!(
+            "\nSUCCESS: {n} cases x 4 functions within {ULP_LIMIT} ULP; \
+             repr(transparent) device extern ABI preserved"
+        );
         Ok(())
     } else {
-        eprintln!("\nFAILED: {failures}/{n} cases out of tolerance");
+        eprintln!("\nFAILED: {failures} function results out of tolerance");
         std::process::exit(1);
     }
 }

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -98,6 +98,7 @@ use llvm_export::ops::{
     DebugInlinedScope, DebugSourcePosition, DebugSourceScope, DebugSourceScopeLocation,
     DebugSourceScopeMap,
 };
+use rustc_middle::ty::layout::{LayoutCx, LayoutOf};
 use rustc_middle::ty::{EarlyBinder, InstanceKind, TypingEnv};
 use rustc_middle::ty::{Ty, TyCtxt, TyKind};
 use rustc_session::config::DebugInfo;
@@ -115,8 +116,11 @@ enum DeviceExternTypePosition {
 /// Convert a Rust device-extern type to the LLVM type supported at the
 /// external function boundary.
 ///
-/// Raw-pointer pointees are preserved recursively. Unsupported C ABI types
-/// return an error instead of being treated as an arbitrary pointer.
+/// Raw-pointer pointees are preserved recursively. Rustc-proven
+/// `#[repr(transparent)]` wrappers are recursively peeled to their ABI-relevant
+/// field before classification, so scalar and pointer wrappers preserve the
+/// same external ABI as their underlying value. Unsupported C ABI types return
+/// an error instead of being treated as an arbitrary pointer.
 ///
 /// Integer types smaller than 32 bits keep their NARROW IR type (`i8`,
 /// `i16`, `i1` for `bool`) and carry a `signext`/`zeroext` ABI attribute,
@@ -197,6 +201,28 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 Err("f128 device externs are not supported".to_string())
             }
         },
+        TyKind::Adt(adt_def, _) if adt_def.repr().transparent() => {
+            // Do not infer the transparent field from source syntax here.
+            // Rustc's layout engine already knows which field is ABI-relevant,
+            // including nested wrappers and 1-ZST marker fields.
+            let layout_cx = LayoutCx::new(tcx, TypingEnv::fully_monomorphized());
+            let layout = layout_cx.layout_of(ty).map_err(|err| {
+                format!(
+                    "failed to compute layout for repr(transparent) device-extern type `{ty}`: {err:?}"
+                )
+            })?;
+            let peeled = layout.peel_transparent_wrappers(&layout_cx);
+
+            // A transparent type with no peelable non-1ZST field is not a
+            // scalar/pointer wrapper that this device-extern ABI can represent.
+            if peeled.ty == ty {
+                return Err(format!(
+                    "`{ty}` is repr(transparent) but has no ABI-relevant field supported by device externs"
+                ));
+            }
+
+            rustc_ty_to_device_extern_type(tcx, peeled.ty, position)
+        }
         TyKind::RawPtr(pointee, _) | TyKind::Ref(_, pointee, _) => {
             let pointee = if matches!(pointee.kind(), TyKind::Tuple(fields) if fields.is_empty()) {
                 // Rust's `*mut ()` is its common spelling for a void pointer.


### PR DESCRIPTION
Closes #944 

Depends on #943.

This branch is currently stacked on #943, so GitHub's diff also includes the transparent device-return changes from that PR. The #945-specific delta is the final commit and touches only:

- `crates/mir-lower/src/convert/ops/call.rs`
- `crates/rustc-codegen-cuda/src/device_codegen.rs`
- `crates/rustc-codegen-cuda/examples/extern_libdevice/src/main.rs`

After #943 lands, this branch will be rebased onto `main`.

## Summary

Preserve the underlying scalar or pointer ABI of rustc-proven `#[repr(transparent)]` wrappers in `#[device] extern "C"` declarations and calls.

This extends transparent scalar ABI support to the device-extern boundary while keeping the aggregate wrapper representation inside MIR.

## Changes

- resolve rustc-proven transparent ADTs in device-extern signatures to their underlying scalar or pointer ABI type
- use rustc layout information rather than inferring transparency from source field count
- support nested transparent wrappers
- support transparent wrappers containing ZST marker fields
- project transparent call arguments recursively when the declared LLVM parameter expects the underlying scalar ABI
- select the outermost matching transparent wrapper from operand type history so nested wrappers are fully projected
- reuse the transparent return reconstruction introduced by #943
- extend `extern_libdevice` with nested and ZST-marker transparent ABI coverage
- preserve existing behavior for ordinary one-field structs

## Implementation

Device-extern signature classification uses rustc layout information to peel `repr(transparent)` wrappers recursively until the ABI-relevant scalar or pointer type is reached.

At call sites, transparent argument lowering is driven by the declared LLVM parameter type rather than by symbol-name classification.

For a nested wrapper such as:

```text
OuterF32(InnerF32(f32))
````

with an external parameter of `f32`, lowering selects the outermost transparent ABI projection whose scalar type matches the declared parameter and emits:

```text
OuterF32
  -> extractvalue
InnerF32
  -> extractvalue
f32
  -> external call
```

The scalar result is then reconstructed into the MIR-visible wrapper using the transparent return ABI machinery from #943.

This keeps scalarization localized to ABI boundaries and avoids changing the internal representation of transparent structs.

## Validation

* `cargo test -p mir-lower`

  * 226 unit tests passed
  * 105 integration tests passed
* `cargo clippy -p mir-lower --all-targets -- -D warnings`
* `cargo test --manifest-path crates/rustc-codegen-cuda/Cargo.toml`

  * 22 tests passed
* `cargo clippy --manifest-path crates/rustc-codegen-cuda/Cargo.toml --all-targets -- -D warnings`
* `cargo fmt --all -- --check`
* `git diff --check`
* `cargo oxide run extern_libdevice`

  * nested `OuterF32(InnerF32(f32))` device-extern argument/return
  * `MarkedF32(f32, PhantomData<()>)` ZST-marker wrapper
  * successful execution against libdevice on GPU
  * 13 cases × 4 functions within 2 ULP

Final E2E result:

```text
SUCCESS: 13 cases x 4 functions within 2 ULP; repr(transparent) device extern ABI preserved
```

## Scope

This PR is limited to device-extern ABI handling.

Transparent device-function return ABI lowering is handled by #943.
