### PR TITLE
fix: carry slice-tail metadata through nested DST fields

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -2976,11 +2976,15 @@ fn classify_place_read_strategy(
 
                     match &place.projection[proj_idx + 1] {
                         mir::ProjectionElem::Field(_, field_rust_ty) => {
-                            if rust_ty_is_slice(field_rust_ty) {
-                                // Borrow/read of an unsized tail constructs a
-                                // fat value, not a thin final address.
+                            if rust_ty_is_slice(field_rust_ty)
+                                || types::slice_tail_element_ty(field_rust_ty).is_some()
+                            {
+                                // A direct slice tail or a nested slice-tailed DST needs
+                                // fat-pointer metadata that the address read path does not carry
+                                // across fields. Keep it on the value path.
                                 return Ok(PlaceReadStrategy::ValueFallback);
                             }
+
                             current_ptr_ty = dialect_mir::types::MirPtrType::get_generic(
                                 ctx, elem_ty, /* is_mutable */ false,
                             )
@@ -4604,6 +4608,10 @@ fn translate_place_addr_from_slot(
     // a following Index/ConstantIndex.
     let mut consumed_slice_subslice = false;
     let mut current_slice_len: Option<Value> = None;
+    // A fat reference to a slice-tailed struct carries the runtime length of
+    // its final slice field. Preserve that metadata while walking nested
+    // slice-tailed struct fields until the actual `[T]` field is reached.
+    let mut carried_slice_tail_len: Option<Value> = None;
     // Set by a `Downcast` and consumed by the `Field` that follows it, which
     // is the only projection pair that can name an enum payload.
     let mut pending_variant: Option<usize> = None;
@@ -4859,8 +4867,22 @@ fn translate_place_addr_from_slot(
 
                         match &projection[proj_idx + 1] {
                             // Sized field access: hand the data pointer to
-                            // the field arm below.
-                            mir::ProjectionElem::Field(..) => {
+                            // the field arm below. If the field is itself a
+                            // slice-tailed DST, preserve the fat reference's
+                            // metadata until the walk reaches the actual `[T]`
+                            // tail field.
+                            mir::ProjectionElem::Field(_, field_rust_ty) => {
+                                if types::slice_tail_element_ty(field_rust_ty).is_some() {
+                                    let (len, len_op) = emit_slice_len_extract(
+                                        ctx,
+                                        fat_val,
+                                        block_ptr,
+                                        current_prev_op,
+                                        loc.clone(),
+                                    );
+                                    current_prev_op = Some(len_op);
+                                    carried_slice_tail_len = Some(len);
+                                }
                                 current = data_ptr;
                                 continue;
                             }
@@ -4934,6 +4956,77 @@ fn translate_place_addr_from_slot(
             }
 
             mir::ProjectionElem::Field(field_idx, field_ty) => {
+                let tail_elem_rust_ty = match field_ty.kind() {
+                    rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(elem)) => {
+                        Some(elem)
+                    }
+                    _ => None,
+                };
+
+                if let Some(tail_len) = carried_slice_tail_len.take() {
+                    if let Some(tail_elem_rust_ty) = tail_elem_rust_ty {
+                        // Element-address traversal through an unsized tail is
+                        // intentionally left to #881. For #880 the address path
+                        // only needs to materialize the whole nested slice tail.
+                        if proj_idx + 1 != projection.len() || pending_variant.is_some() {
+                            return Ok(None);
+                        }
+
+                        let tail_elem_ty = types::translate_type(ctx, &tail_elem_rust_ty)?;
+                        let Some(tail_ptr_ty) = projected_pointer_type(
+                            ctx,
+                            current.get_type(ctx),
+                            tail_elem_ty,
+                            is_mutable,
+                        ) else {
+                            return Ok(None);
+                        };
+
+                        // The physical struct stores an unsized slice tail as
+                        // its element type, so the field address must be `*T`,
+                        // not `*[T]`.
+                        let tail_addr = Operation::new(
+                            ctx,
+                            MirFieldAddrOp::get_concrete_op_info(),
+                            vec![tail_ptr_ty],
+                            vec![current],
+                            vec![],
+                            0,
+                        );
+                        tail_addr.deref_mut(ctx).set_loc(loc.clone());
+                        MirFieldAddrOp::new(tail_addr).set_attr_field_index(
+                            ctx,
+                            dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                        );
+                        match current_prev_op {
+                            Some(previous) => tail_addr.insert_after(ctx, previous),
+                            None => tail_addr.insert_at_front(block_ptr, ctx),
+                        }
+                        let tail_ptr = tail_addr.deref(ctx).get_result(0);
+
+                        let slice_ty = dialect_mir::types::MirSliceType::get(ctx, tail_elem_ty);
+                        use dialect_mir::ops::MirConstructSliceOp;
+                        let construct = Operation::new(
+                            ctx,
+                            MirConstructSliceOp::get_concrete_op_info(),
+                            vec![slice_ty.into()],
+                            vec![tail_ptr, tail_len],
+                            vec![],
+                            0,
+                        );
+                        construct.deref_mut(ctx).set_loc(loc.clone());
+                        construct.insert_after(ctx, tail_addr);
+                        return Ok(Some((construct.deref(ctx).get_result(0), Some(construct))));
+                    }
+
+                    // Metadata remains relevant only while descending through
+                    // another slice-tailed DST field. A sized field projects
+                    // away from the unsized tail, so discard it there.
+                    if types::slice_tail_element_ty(field_ty).is_some() {
+                        carried_slice_tail_len = Some(tail_len);
+                    }
+                }
+
                 let field_type = types::translate_type(ctx, field_ty)?;
 
                 // After a `Downcast`, the field belongs to that variant, and an
@@ -5199,7 +5292,7 @@ fn translate_place_addr_from_slot(
     // A chain that ENDS on a `Downcast` never occurs in valid MIR (the
     // validator requires a `Field` after it). Punt rather than hand back the
     // enum's own address as if it were the variant's payload place.
-    if pending_variant.is_some() {
+    if pending_variant.is_some() || carried_slice_tail_len.is_some() {
         return Ok(None);
     }
 
@@ -5629,9 +5722,11 @@ pub fn translate_place_iterative(
     let mut preserved_slice_deref_mutability: Option<bool> = None;
 
     // A fat reference to a slice-tailed struct carries the runtime length of
-    // that tail in field 1. Deref scalarizes the fat value to the struct data
-    // pointer, so preserve the length for the immediately following tail Field.
-    let mut preserved_slice_tail_len: Option<Value> = None;
+    // that tail in field 1. Keep the metadata alongside the projected address
+    // until the walk reaches the actual slice field. This mirrors rustc's
+    // `llextra` model and lets metadata survive through nested slice-tailed
+    // struct fields such as `outer.inner.tail[k]`.
+    let mut carried_slice_tail_len: Option<Value> = None;
 
     // Process each projection element iteratively
     for (proj_idx, projection) in place.projection.iter().enumerate() {
@@ -5653,10 +5748,6 @@ pub fn translate_place_iterative(
                 let current_is_slice_tail_ref = pointer_info
                     .as_ref()
                     .is_some_and(|(pointee, _)| types::slice_tail_element_ty(pointee).is_some());
-                let next_is_slice_tail_field = matches!(
-                    place.projection.get(proj_idx + 1),
-                    Some(ProjectionElem::Field(_, field_ty)) if rust_ty_is_slice(field_ty)
-                );
 
                 if next_is_slice_subslice
                     && current_is_fat_slice
@@ -5665,16 +5756,16 @@ pub fn translate_place_iterative(
                     // Preserve the fat pair. The following Subslice consumes
                     // both data and len and advances `current_rust_ty` normally.
                     preserved_slice_deref_mutability = slice_deref_mutability;
-                    preserved_slice_tail_len = None;
+                    carried_slice_tail_len = None;
                 } else {
                     // `&S<[T]>` uses the same fat-pair carrier as a slice, but
                     // field 0 points at the struct prefix while field 1 is the
-                    // trailing slice length. Save that metadata before Deref
-                    // reduces the value to the struct data pointer.
-                    preserved_slice_tail_len = if next_is_slice_tail_field
-                        && current_is_fat_slice
-                        && current_is_slice_tail_ref
-                    {
+                    // trailing slice length. Extract that metadata before Deref
+                    // reduces the value to the struct data pointer. Unlike the
+                    // old one-step handoff, keep it alive across any nested
+                    // slice-tailed struct fields until the real `[T]` field is
+                    // reached.
+                    carried_slice_tail_len = if current_is_fat_slice && current_is_slice_tail_ref {
                         let (len, len_op) = emit_slice_len_extract(
                             ctx,
                             current_value,
@@ -5701,9 +5792,19 @@ pub fn translate_place_iterative(
             }
 
             ProjectionElem::Field(field_idx, field_ty) => {
-                // Check if this is a field access on an enum (preceded by Downcast)
+                // Check if this is a field access on an enum (preceded by Downcast).
                 if let Some(variant_idx) = pending_downcast.take() {
-                    // Enum variant field access - use MirEnumPayloadOp
+                    if carried_slice_tail_len.is_some() {
+                        return input_err!(
+                            loc,
+                            TranslationErr::unsupported(
+                                "slice-tail metadata cannot cross an enum Downcast/Field projection"
+                                    .to_string()
+                            )
+                        );
+                    }
+
+                    // Enum variant field access - use MirEnumPayloadOp.
                     (current_value, current_prev_op) = apply_enum_field_projection(
                         ctx,
                         current_value,
@@ -5715,105 +5816,165 @@ pub fn translate_place_iterative(
                         current_prev_op,
                         loc.clone(),
                     )?;
-                } else if let Some(tail_len) = preserved_slice_tail_len.take() {
-                    let rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(
-                        tail_elem_rust_ty,
-                    )) = field_ty.kind()
-                    else {
-                        return input_err!(
-                            loc,
-                            TranslationErr::unsupported(
-                                "preserved slice-tail metadata was not consumed by a slice Field"
-                                    .to_string()
-                            )
-                        );
-                    };
-                    let tail_elem_ty = types::translate_type(ctx, &tail_elem_rust_ty)?;
-
-                    // The struct model stores an unsized `[T]` tail as the
-                    // element type `T`, because the elements live inline after
-                    // the sized prefix. Address the field as `*T`, not `*[T]`.
-                    use dialect_mir::ops::{MirConstructSliceOp, MirFieldAddrOp};
-                    let tail_ptr_ty: TypeHandle =
-                        dialect_mir::types::MirPtrType::get_generic(ctx, tail_elem_ty, false)
-                            .into();
-                    let tail_addr = Operation::new(
-                        ctx,
-                        MirFieldAddrOp::get_concrete_op_info(),
-                        vec![tail_ptr_ty],
-                        vec![current_value],
-                        vec![],
-                        0,
-                    );
-                    tail_addr.deref_mut(ctx).set_loc(loc.clone());
-                    MirFieldAddrOp::new(tail_addr).set_attr_field_index(
-                        ctx,
-                        dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
-                    );
-                    match current_prev_op {
-                        Some(prev) => tail_addr.insert_after(ctx, prev),
-                        None => tail_addr.insert_at_front(block_ptr, ctx),
-                    }
-                    let tail_ptr = tail_addr.deref(ctx).get_result(0);
-
-                    // Reconstruct the semantic `[T]` value from the inline tail
-                    // address plus the metadata saved from the outer fat reference.
-                    // A following Index or ConstantIndex can scalarize this
-                    // MirSliceType to field 0 and reuse the existing pointer-offset
-                    // + load path.
-                    let tail_slice_ty = dialect_mir::types::MirSliceType::get(ctx, tail_elem_ty);
-                    let construct_tail = Operation::new(
-                        ctx,
-                        MirConstructSliceOp::get_concrete_op_info(),
-                        vec![tail_slice_ty.into()],
-                        vec![tail_ptr, tail_len],
-                        vec![],
-                        0,
-                    );
-                    construct_tail.deref_mut(ctx).set_loc(loc.clone());
-                    construct_tail.insert_after(ctx, tail_addr);
-                    current_value = construct_tail.deref(ctx).get_result(0);
-                    current_prev_op = Some(construct_tail);
                 } else {
-                    let current_is_ptr = current_value
-                        .get_type(ctx)
-                        .deref(ctx)
-                        .is::<dialect_mir::types::MirPtrType>();
-                    if current_is_ptr {
-                        // `current_value` is an ADDRESS, not an aggregate
-                        // value. This happens after dereferencing a fat
-                        // pointer: `apply_deref_projection` cannot load an
-                        // unsized pointee, so it hands back the data
-                        // pointer instead (e.g. reading
-                        // `(*iter).alive.start` through the fat
-                        // `&mut PolymorphicIter<[MaybeUninit<T>]>` inside
-                        // `core::array::IntoIter::next`, issue #138).
-                        // Compute the field's address and load the field.
-                        (current_value, current_prev_op) = apply_field_addr_and_load(
+                    let tail_elem_rust_ty = match field_ty.kind() {
+                        rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(
+                            elem,
+                        )) => Some(elem),
+                        _ => None,
+                    };
+                    let field_is_slice_tailed_adt =
+                        types::slice_tail_element_ty(field_ty).is_some();
+
+                    if let Some(tail_elem_rust_ty) = tail_elem_rust_ty
+                        && let Some(tail_len) = carried_slice_tail_len.take()
+                    {
+                        let tail_elem_ty = types::translate_type(ctx, &tail_elem_rust_ty)?;
+
+                        // The struct model stores an unsized `[T]` tail as the
+                        // element type `T`, because the elements live inline after
+                        // the sized prefix. Address the field as `*T`, not `*[T]`.
+                        use dialect_mir::ops::{MirConstructSliceOp, MirFieldAddrOp};
+                        let tail_ptr_ty: TypeHandle =
+                            dialect_mir::types::MirPtrType::get_generic(ctx, tail_elem_ty, false)
+                                .into();
+                        let tail_addr = Operation::new(
                             ctx,
-                            current_value,
-                            *field_idx,
-                            field_ty,
-                            block_ptr,
-                            current_prev_op,
-                            loc.clone(),
-                        )?;
+                            MirFieldAddrOp::get_concrete_op_info(),
+                            vec![tail_ptr_ty],
+                            vec![current_value],
+                            vec![],
+                            0,
+                        );
+                        tail_addr.deref_mut(ctx).set_loc(loc.clone());
+                        MirFieldAddrOp::new(tail_addr).set_attr_field_index(
+                            ctx,
+                            dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                        );
+                        match current_prev_op {
+                            Some(prev) => tail_addr.insert_after(ctx, prev),
+                            None => tail_addr.insert_at_front(block_ptr, ctx),
+                        }
+                        let tail_ptr = tail_addr.deref(ctx).get_result(0);
+
+                        // Reconstruct the semantic `[T]` value from the inline tail
+                        // address plus the metadata carried from the outer fat reference.
+                        // A following Index or ConstantIndex can scalarize this
+                        // MirSliceType to field 0 and reuse the existing pointer-offset
+                        // + load path.
+                        let tail_slice_ty =
+                            dialect_mir::types::MirSliceType::get(ctx, tail_elem_ty);
+                        let construct_tail = Operation::new(
+                            ctx,
+                            MirConstructSliceOp::get_concrete_op_info(),
+                            vec![tail_slice_ty.into()],
+                            vec![tail_ptr, tail_len],
+                            vec![],
+                            0,
+                        );
+                        construct_tail.deref_mut(ctx).set_loc(loc.clone());
+                        construct_tail.insert_after(ctx, tail_addr);
+                        current_value = construct_tail.deref(ctx).get_result(0);
+                        current_prev_op = Some(construct_tail);
+                    } else if carried_slice_tail_len.is_some() && field_is_slice_tailed_adt {
+                        // The selected field is itself an unsized struct whose final
+                        // field eventually contains the same slice tail. Such a field
+                        // cannot be loaded as an SSA aggregate. Advance only the
+                        // address and keep the metadata riding alongside it for the
+                        // next projection step.
+                        if !current_value
+                            .get_type(ctx)
+                            .deref(ctx)
+                            .is::<dialect_mir::types::MirPtrType>()
+                        {
+                            return input_err!(
+                                loc,
+                                TranslationErr::unsupported(format!(
+                                    "slice-tail metadata reached nested DST field {:?}, but the current value is not an address",
+                                    field_ty
+                                ))
+                            );
+                        }
+
+                        use dialect_mir::ops::MirFieldAddrOp;
+                        let field_type = types::translate_type(ctx, field_ty)?;
+                        let field_ptr_ty: TypeHandle =
+                            dialect_mir::types::MirPtrType::get_generic(ctx, field_type, false)
+                                .into();
+                        let field_addr = Operation::new(
+                            ctx,
+                            MirFieldAddrOp::get_concrete_op_info(),
+                            vec![field_ptr_ty],
+                            vec![current_value],
+                            vec![],
+                            0,
+                        );
+                        field_addr.deref_mut(ctx).set_loc(loc.clone());
+                        MirFieldAddrOp::new(field_addr).set_attr_field_index(
+                            ctx,
+                            dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
+                        );
+                        match current_prev_op {
+                            Some(prev) => field_addr.insert_after(ctx, prev),
+                            None => field_addr.insert_at_front(block_ptr, ctx),
+                        }
+                        current_value = field_addr.deref(ctx).get_result(0);
+                        current_prev_op = Some(field_addr);
                     } else {
-                        // Regular struct/tuple field access
-                        (current_value, current_prev_op) = apply_field_projection(
-                            ctx,
-                            current_value,
-                            *field_idx,
-                            field_ty,
-                            block_ptr,
-                            current_prev_op,
-                            loc.clone(),
-                        )?;
+                        // A sized field does not inherit DST metadata. Once the
+                        // projection leaves the unsized-tail path, drop the
+                        // metadata and lower the field normally.
+                        carried_slice_tail_len = None;
+
+                        let current_is_ptr = current_value
+                            .get_type(ctx)
+                            .deref(ctx)
+                            .is::<dialect_mir::types::MirPtrType>();
+                        if current_is_ptr {
+                            // `current_value` is an ADDRESS, not an aggregate
+                            // value. This happens after dereferencing a fat
+                            // pointer: `apply_deref_projection` cannot load an
+                            // unsized pointee, so it hands back the data
+                            // pointer instead (e.g. reading
+                            // `(*iter).alive.start` through the fat
+                            // `&mut PolymorphicIter<[MaybeUninit<T>]>` inside
+                            // `core::array::IntoIter::next`, issue #138).
+                            // Compute the field's address and load the field.
+                            (current_value, current_prev_op) = apply_field_addr_and_load(
+                                ctx,
+                                current_value,
+                                *field_idx,
+                                field_ty,
+                                block_ptr,
+                                current_prev_op,
+                                loc.clone(),
+                            )?;
+                        } else {
+                            // Regular struct/tuple field access.
+                            (current_value, current_prev_op) = apply_field_projection(
+                                ctx,
+                                current_value,
+                                *field_idx,
+                                field_ty,
+                                block_ptr,
+                                current_prev_op,
+                                loc.clone(),
+                            )?;
+                        }
                     }
                 }
             }
 
             ProjectionElem::Downcast(variant_idx) => {
+                if carried_slice_tail_len.is_some() {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(
+                            "slice-tail metadata reached Downcast before the unsized slice field"
+                                .to_string()
+                        )
+                    );
+                }
                 // Downcast is a no-op - it just narrows the type for the next Field access
                 // Store the variant index for use by the next Field projection
                 pending_downcast = Some(*variant_idx);
@@ -5821,6 +5982,15 @@ pub fn translate_place_iterative(
             }
 
             ProjectionElem::Index(index_local) => {
+                if carried_slice_tail_len.is_some() {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(
+                            "slice-tail metadata reached Index before the unsized slice field"
+                                .to_string()
+                        )
+                    );
+                }
                 let index_place = mir::Place {
                     local: *index_local,
                     projection: vec![],
@@ -5965,6 +6135,15 @@ pub fn translate_place_iterative(
                 min_length: _,
                 from_end,
             } => {
+                if carried_slice_tail_len.is_some() {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(
+                            "slice-tail metadata reached ConstantIndex before the unsized slice field"
+                                .to_string()
+                        )
+                    );
+                }
                 if *from_end {
                     return input_err!(
                         loc,
@@ -6133,6 +6312,15 @@ pub fn translate_place_iterative(
             }
 
             ProjectionElem::Subslice { from, to, from_end } => {
+                if carried_slice_tail_len.is_some() {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(
+                            "slice-tail metadata reached Subslice before the unsized slice field"
+                                .to_string()
+                        )
+                    );
+                }
                 if *from_end {
                     let Some(is_mutable) = preserved_slice_deref_mutability.take() else {
                         return input_err!(
@@ -6245,6 +6433,16 @@ pub fn translate_place_iterative(
                 ))
             )
         })?;
+    }
+
+    if carried_slice_tail_len.is_some() {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(
+                "place projection ended on a slice-tailed DST before its metadata was attached to the slice field"
+                    .to_string()
+            )
+        );
     }
 
     Ok((current_value, current_prev_op))

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -330,6 +330,36 @@ fn convert_float_to_int(
     Ok(llvm_call.get_operation())
 }
 
+/// Return the element count of the sized array that becomes a slice tail
+/// during an unsize coercion.
+///
+/// The array may be the direct pointee (`&[T; N] -> &[T]`) or may sit behind
+/// one or more trailing struct fields (`&Outer<Inner<[T; N]>> ->
+/// &Outer<Inner<[T]>>`). Rust DST unsizing follows that trailing-field chain,
+/// so mirror it here instead of assuming the array is only one field deep.
+fn unsize_array_tail_len(ctx: &Context, mut ty: pliron::r#type::TypeHandle) -> Option<u64> {
+    loop {
+        let next = {
+            let ty_ref = ty.deref(ctx);
+
+            if let Some(array_ty) = ty_ref.downcast_ref::<MirArrayType>() {
+                return Some(array_ty.size());
+            }
+
+            let struct_ty = ty_ref.downcast_ref::<dialect_mir::types::MirStructType>()?;
+            let field_types = struct_ty.field_types();
+            let last_decl_idx = match struct_ty.memory_order().last().copied() {
+                Some(idx) => idx,
+                None => field_types.len().checked_sub(1)?,
+            };
+
+            *field_types.get(last_decl_idx)?
+        };
+
+        ty = next;
+    }
+}
+
 /// Emit an Unsize coercion: `&[T; N]` → `&[T]` (or `*[T; N]` → `[T]`).
 ///
 /// When the MIR source is a pointer to an array and the LLVM destination is a
@@ -349,33 +379,9 @@ fn emit_unsize_cast(
 ) -> Result<Ptr<Operation>> {
     let array_len = {
         let mir_ref = mir_opd_ty.deref(ctx);
-        mir_ref.downcast_ref::<MirPtrType>().and_then(|ptr_ty| {
-            let pointee_ref = ptr_ty.pointee.deref(ctx);
-            if let Some(arr) = pointee_ref.downcast_ref::<MirArrayType>() {
-                // `&[T; N] -> &[T]`: the classic array unsize.
-                Some(arr.size())
-            } else if let Some(struct_ty) =
-                pointee_ref.downcast_ref::<dialect_mir::types::MirStructType>()
-            {
-                // `&S<[T; N]> -> &S<[T]>` where the struct's LAST field is
-                // the array that becomes the unsized tail (e.g. the
-                // `PolymorphicIter` inside `core::array::IntoIter`, which
-                // every `for x in arr` loop unsizes; issue #138). The fat
-                // pointer's metadata is that array's element count.
-                let field_types = struct_ty.field_types();
-                let last_decl_idx = match struct_ty.memory_order().last().copied() {
-                    Some(idx) => idx,
-                    None => field_types.len().checked_sub(1)?,
-                };
-                field_types.get(last_decl_idx).and_then(|t| {
-                    t.deref(ctx)
-                        .downcast_ref::<MirArrayType>()
-                        .map(|a| a.size())
-                })
-            } else {
-                None
-            }
-        })
+        mir_ref
+            .downcast_ref::<MirPtrType>()
+            .and_then(|ptr_ty| unsize_array_tail_len(ctx, ptr_ty.pointee))
     };
 
     if let Some(len) = array_len {

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -44,14 +44,17 @@ raw-pointer shapes the unified `translate_place_address` walker must lower:
 | 19 | `test_inline_never_node_fn`          | Exact issue #120 `node()` MIR shape            |
 | 20 | `test_holder_deref_tail`             | `&hr.0[k]` with Deref inside the tail          |
 
-plus **3 slice-value regression kernels** that pin the two indexing forms on
-a projected unsized slice tail, and the tail byte offset behind padding:
+plus **6 slice-value regression kernels** that pin direct and nested indexing
+of projected unsized slice tails, including padded layouts:
 
-| #  | Variant                              | Shape pinned                                   |
-|:---|:-------------------------------------|:-----------------------------------------------|
-| 21 | `test_slice_tail_constant_index`     | `Field(tail) -> MirSliceType -> ConstantIndex` |
-| 22 | `test_slice_tail_runtime_index`      | `Field(tail) -> MirSliceType -> Index`         |
-| 23 | `test_slice_tail_padded_offset`      | `[u16]` tail at byte offset 10 behind padding  |
+| #  | Variant                                  | Shape pinned                                           |
+|:---|:-----------------------------------------|:-------------------------------------------------------|
+| 21 | `test_slice_tail_constant_index`         | `Field(tail) -> MirSliceType -> ConstantIndex`         |
+| 22 | `test_slice_tail_runtime_index`          | `Field(tail) -> MirSliceType -> Index`                 |
+| 23 | `test_slice_tail_padded_offset`          | `[u16]` tail at byte offset 10 behind padding          |
+| 24 | `test_nested_slice_tail_constant_index`  | `Field(inner) -> Field(tail) -> ConstantIndex`         |
+| 25 | `test_nested_slice_tail_runtime_index`   | `Field(inner) -> Field(tail) -> Index`                 |
+| 26 | `test_nested_slice_tail_padded_offset`   | Nested padded DST tail with constant + runtime indexes |
 
 Each kernel writes a difference (`r1 - r0`, or original-local readback for
 the write-through variants) for inputs chosen so a correct implementation
@@ -59,18 +62,27 @@ must produce `+5.0` for every element. The harness prints `PASS` per kernel,
 tracks failures, prints a final `SUCCESS` marker when every kernel passes,
 and exits non-zero if any kernel reports a wrong diff.
 
-The slice-value regressions construct a `SliceTail<[f32; 2]>` and unsize it to
-`&SliceTail<[f32]>`. Deref of the fat struct reference must preserve the
-runtime tail length long enough for `Field(tail)` to reconstruct a
-`MirSliceType` value. `test_slice_tail_constant_index` then exercises a literal
-`ConstantIndex`, while `test_slice_tail_runtime_index` uses a data-derived
-runtime `Index`. Both normalize the semantic slice value to its data pointer
-before reusing the existing pointer-offset + load lowering.
-`test_slice_tail_padded_offset` repeats both indexing forms on the
-issue #870 repro layout (`head: u64`, `tag: u8`, `tail: [u16]`), whose
-tail sits at byte offset 10 behind a padding byte: `SliceTail` places its
-tail at offset 4 with no padding, so only the padded variant can catch a
-wrong-tail-offset bug in the `Field(tail)` address computation.
+The direct slice-value regressions construct a `SliceTail<[f32; 2]>` and
+unsize it to `&SliceTail<[f32]>`. Deref of the fat struct reference must
+preserve the runtime tail length long enough for `Field(tail)` to reconstruct
+a `MirSliceType` value. `test_slice_tail_constant_index` then exercises a
+literal `ConstantIndex`, while `test_slice_tail_runtime_index` uses a
+data-derived runtime `Index`. Both normalize the semantic slice value to its
+data pointer before reusing the existing pointer-offset + load lowering.
+`test_slice_tail_padded_offset` repeats both indexing forms on the issue #870
+repro layout (`head: u64`, `tag: u8`, `tail: [u16]`), whose tail sits at byte
+offset 10 behind a padding byte: `SliceTail` places its tail at offset 4 with
+no padding, so only the padded variant can catch a wrong-tail-offset bug in the
+`Field(tail)` address computation.
+
+The nested issue #880 regressions push that same slice tail one struct field
+deeper. `NestedOuter<T>` ends in `NestedInner<T>`, so a value read walks
+`Deref -> Field(inner) -> Field(tail) -> Index/ConstantIndex`. The outer fat
+pointer's length metadata must remain paired with the projected address across
+`Field(inner)` instead of being handed only to the immediately following
+field. `test_nested_slice_tail_padded_offset` nests `PaddedTail<T>` as the final
+field of another struct so the walk must preserve metadata while also honoring
+both aggregate field offsets.
 
 ## Trigger conditions
 
@@ -120,8 +132,17 @@ the fix, the same MIR lowers to
 %v9 = load float, ptr %v8                                              ; correct
 ```
 
-and all 23 kernels report `PASS` (the harness prints a final `SUCCESS`
-marker and exits non-zero if any kernel reports a wrong diff).
+and all 26 kernels report `PASS` (the harness prints a final `SUCCESS` marker
+and exits non-zero if any kernel reports a wrong diff).
+
+Issue #880 exposes a separate value-walker gap after the direct DST-tail
+support from #873. The old `preserved_slice_tail_len` logic used a one-step
+lookahead at `Deref`, so `Field(inner)` caused the fat pointer's length to be
+dropped before `Field(tail)` could reconstruct the slice. The updated walker
+carries that metadata alongside the projected address through nested
+slice-tailed struct fields, only consuming it when the actual `[T]` tail field
+is reached. Sized fields drop the metadata, and structurally inconsistent
+projection shapes fail loudly.
 
 ## Build & run
 

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -751,10 +751,7 @@ mod kernels {
     /// `NestedOuter<[f32]>`, while the indexed slice lives one struct field
     /// deeper at `inner.tail`. Metadata must survive `Field(inner)`.
     #[kernel]
-    pub fn test_nested_slice_tail_constant_index(
-        input: &[[f32; 2]],
-        mut out: DisjointSlice<f32>,
-    ) {
+    pub fn test_nested_slice_tail_constant_index(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
         let idx = thread::index_1d();
         let i = idx.get();
         if i >= input.len() {
@@ -781,10 +778,7 @@ mod kernels {
     /// Issue #880 runtime-index repro. The data-derived index prevents MIR
     /// from folding the final projection into a ConstantIndex.
     #[kernel]
-    pub fn test_nested_slice_tail_runtime_index(
-        input: &[[f32; 2]],
-        mut out: DisjointSlice<f32>,
-    ) {
+    pub fn test_nested_slice_tail_runtime_index(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
         let idx = thread::index_1d();
         let i = idx.get();
         if i >= input.len() {
@@ -814,10 +808,7 @@ mod kernels {
     /// `NestedPaddedOuter`. Both constant and runtime indexing must retain
     /// the outer fat pointer's length while computing the two field offsets.
     #[kernel]
-    pub fn test_nested_slice_tail_padded_offset(
-        input: &[[f32; 2]],
-        mut out: DisjointSlice<f32>,
-    ) {
+    pub fn test_nested_slice_tail_padded_offset(input: &[[f32; 2]], mut out: DisjointSlice<f32>) {
         let idx = thread::index_1d();
         let i = idx.get();
         if i >= input.len() {

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/src/main.rs
@@ -16,6 +16,8 @@
  *     value.tail[1]                                      // DST slice tail + const index
  *     value.tail[k]                                      // DST slice tail + runtime index
  *     padded.tail[k]                                     // DST slice tail behind padding
+ *     outer.inner.tail[1]                                // nested DST tail + const index
+ *     outer.inner.tail[k]                                // nested DST tail + runtime index
  *
  * Each kernel writes the difference compute(1) - compute(0), with inputs
  * designed so the two slots differ: a dropped index reads slot 0 twice
@@ -101,6 +103,31 @@ pub struct PaddedTail<T: ?Sized> {
     pub head: u64,
     pub tag: u8,
     pub tail: T,
+}
+
+/// Slice-tailed inner struct used to pin issue #880's nested projection:
+/// `Deref -> Field(inner) -> Field(tail) -> Index`.
+#[repr(C)]
+pub struct NestedInner<T: ?Sized> {
+    pub head: u32,
+    pub tail: T,
+}
+
+/// A DST whose unsized tail is inherited through its final `NestedInner<T>`
+/// field. The outer fat pointer carries the metadata needed by `inner.tail`.
+#[repr(C)]
+pub struct NestedOuter<T: ?Sized> {
+    pub id: u64,
+    pub inner: NestedInner<T>,
+}
+
+/// Nested padded variant. `PaddedTail<[u16]>` places its tail at byte offset
+/// 10 inside `inner`; `marker` also forces `inner` away from offset zero.
+/// Together they catch both lost metadata and a naive nested field offset.
+#[repr(C)]
+pub struct NestedPaddedOuter<T: ?Sized> {
+    pub marker: u32,
+    pub inner: PaddedTail<T>,
 }
 
 /// Out-of-line accessor pinning the `[Deref, Field(0), Deref, Index(k)]`
@@ -719,6 +746,107 @@ mod kernels {
             *slot = (c1 as f32 - c0 as f32) + (r1 as f32 - r0 as f32);
         }
     }
+
+    /// Issue #880 constant-index repro. The fat reference belongs to
+    /// `NestedOuter<[f32]>`, while the indexed slice lives one struct field
+    /// deeper at `inner.tail`. Metadata must survive `Field(inner)`.
+    #[kernel]
+    pub fn test_nested_slice_tail_constant_index(
+        input: &[[f32; 2]],
+        mut out: DisjointSlice<f32>,
+    ) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let concrete = NestedOuter {
+            id: u64::MAX,
+            inner: NestedInner {
+                head: u32::MAX,
+                tail: input[i],
+            },
+        };
+        let value: &NestedOuter<[f32]> = &concrete;
+
+        let r0 = value.inner.tail[0];
+        let r1 = value.inner.tail[1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = r1 - r0;
+        }
+    }
+
+    /// Issue #880 runtime-index repro. The data-derived index prevents MIR
+    /// from folding the final projection into a ConstantIndex.
+    #[kernel]
+    pub fn test_nested_slice_tail_runtime_index(
+        input: &[[f32; 2]],
+        mut out: DisjointSlice<f32>,
+    ) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let concrete = NestedOuter {
+            id: u64::MAX,
+            inner: NestedInner {
+                head: u32::MAX,
+                tail: input[i],
+            },
+        };
+        let value: &NestedOuter<[f32]> = &concrete;
+
+        let k = (input[0][0] as usize) & 1;
+        let r0 = value.inner.tail[k];
+        let r1 = value.inner.tail[k + 1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = r1 - r0;
+        }
+    }
+
+    /// Nested padded issue #880 regression. The `[u16]` tail is ten bytes
+    /// into `PaddedTail`, and that whole DST is itself the final field of
+    /// `NestedPaddedOuter`. Both constant and runtime indexing must retain
+    /// the outer fat pointer's length while computing the two field offsets.
+    #[kernel]
+    pub fn test_nested_slice_tail_padded_offset(
+        input: &[[f32; 2]],
+        mut out: DisjointSlice<f32>,
+    ) {
+        let idx = thread::index_1d();
+        let i = idx.get();
+        if i >= input.len() {
+            return;
+        }
+
+        let a = input[i][0] as u16;
+        let b = input[i][1] as u16;
+        let concrete = NestedPaddedOuter {
+            marker: u32::MAX,
+            inner: PaddedTail {
+                head: u64::MAX,
+                tag: 0xFF,
+                tail: [a, b, b, b],
+            },
+        };
+        let value: &NestedPaddedOuter<[u16]> = &concrete;
+
+        let c0 = value.inner.tail[0];
+        let c1 = value.inner.tail[1];
+
+        let k = ((input[0][0] as usize) & 1) + 2;
+        let r0 = value.inner.tail[k];
+        let r1 = value.inner.tail[k + 1];
+
+        if let Some(slot) = out.get_mut(idx) {
+            *slot = (c1 as f32 - c0 as f32) + (r1 as f32 - r0 as f32);
+        }
+    }
 }
 
 const N: usize = 4;
@@ -900,6 +1028,30 @@ fn main() {
         // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
         unsafe { module.test_slice_tail_padded_offset(s, cfg, i, o) }.expect("launch")
     });
+    all_pass &= run_and_report(
+        "test_nested_slice_tail_constant_index",
+        &stream,
+        |s, cfg, i, o| {
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_nested_slice_tail_constant_index(s, cfg, i, o) }.expect("launch")
+        },
+    );
+    all_pass &= run_and_report(
+        "test_nested_slice_tail_runtime_index",
+        &stream,
+        |s, cfg, i, o| {
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_nested_slice_tail_runtime_index(s, cfg, i, o) }.expect("launch")
+        },
+    );
+    all_pass &= run_and_report(
+        "test_nested_slice_tail_padded_offset",
+        &stream,
+        |s, cfg, i, o| {
+            // SAFETY: launch shape/resources match the kernel; buffers cover its accesses.
+            unsafe { module.test_nested_slice_tail_padded_offset(s, cfg, i, o) }.expect("launch")
+        },
+    );
 
     if all_pass {
         println!("\nSUCCESS: all kernels passed");


### PR DESCRIPTION
Closes #880

## Summary

Fix nested DST slice-tail reads such as:

```rust
let value: &Outer<[f32]> = &concrete;
let x = value.inner.tail[k];
```

The MIR value walker previously preserved slice-tail metadata only when the slice field immediately followed `Deref`. A nested `Field(inner)` therefore dropped the length before `Field(tail)` could reconstruct the slice.

This change carries the slice-tail length alongside the projected address through nested slice-tailed fields, following the same general model as rustc's `llextra` handling.

## Changes

* carry slice-tail metadata through nested fields in the MIR value walker
* route nested slice-tailed reads through the value fallback path
* reconstruct generated whole-tail `AddressOf` projections while preserving the existing boundary for indexed address lowering
* recursively recover the concrete array length for nested DST unsize coercions so fat-pointer metadata is initialized correctly
* add constant-index, runtime-index, and padded-layout GPU regressions for nested slice tails

Indexed element writes and borrows remain unsupported and are intentionally left to #881.

## Validation

* `cargo oxide run ref_index_projections`

  * 26/26 kernels pass
* `CUDA_OXIDE_NO_OPT=1 cargo oxide run ref_index_projections`

  * 26/26 kernels pass
* `cargo oxide pipeline ref_index_projections`
* `scripts/smoketest.sh -o '^ref_index_projections$'`
* `scripts/smoketest.sh --compile-only -o '^ref_index_projections$'`
* `cargo clippy -p mir-importer --all-targets -- -D warnings`
* `cargo clippy -p mir-lower --all-targets -- -D warnings`
* `cargo test -p mir-importer`
* `cargo test -p mir-lower`
* `git diff --check`