### PR TITLE
ci: both license guards still defer to #663, which is closed

### DIFF
--- a/scripts/check-dependency-licenses.sh
+++ b/scripts/check-dependency-licenses.sh
@@ -141,10 +141,18 @@ echo "OK: ${CSV} records all $(printf '%s\n' "${required}" | grep -c .) declared
 # Examples whose third-party dependencies are deliberately out of inventory
 # scope.  cutile_inter_kernel links cutile-rs by git, which resolves a further
 # ~60 crates (wasm-bindgen, wit-bindgen, wasmparser, windows-targets) that exist
-# in this tree only to build one interop example.  Whether those belong in the
-# inventory is the open question in #663; until it is settled the example is
-# listed here rather than left silently uncovered.  Delete the entry to require
-# the rows.
+# in this tree only to build one interop example.
+#
+# Be clear about what this withholds: the same example is also on
+# check-example-license-policy.sh's POLICY_EXEMPT_EXAMPLES, so those crates get
+# neither a CSV row nor a `cargo deny check`.  Every other example workspace is
+# covered by both since #664 and #681.  This one is the single hole, and it is
+# open deliberately -- see that script for the two blockers.
+#
+# Tracked in #953.  (This comment used to cite #663, which is closed; the
+# general gap it tracked was fixed, but the decisions keeping this example
+# exempt were not, so they moved to their own issue.)  Delete the entry to
+# require the rows.
 #
 # Every name here is checked against the examples on disk below, so a typo or a
 # rename fails the run instead of quietly exempting nothing -- or everything.

--- a/scripts/check-example-license-policy.sh
+++ b/scripts/check-example-license-policy.sh
@@ -44,11 +44,17 @@ EXAMPLES_ROOT=crates/rustc-codegen-cuda/examples
 #   error[source-not-allowed]: detected 'git' source not explicitly allowed  (x7)
 #   error[unlicensed]: cuda-bindings = 0.1.0 is unlicensed
 #
-# The first needs cutile-rs added to `[sources] allow-git`, the second needs a
-# license field on a crate this repository does not own.  Both are policy calls
-# for a maintainer, and they are the open question in #663 -- the same reason
-# the example is already exempt from the inventory guard.  Delete the entry once
-# that is settled.
+# The first needs cutile-rs added to `[sources] allow-git`; `deny.toml`'s
+# allow-git still lists only pliron.  The second is not ours to fix: that
+# `cuda-bindings` is cutile-rs's own vendored copy at 0.1.0, not this
+# repository's crate of the same name (ours is 0.2.1 and inherits the workspace
+# license).  Both are policy calls for a maintainer.
+#
+# Tracked in #953.  (This comment used to cite #663, which is closed; that
+# issue's general gap was fixed by #664 and #681, but neither of these two
+# decisions was, so they moved to their own issue.)  The example is exempt from
+# the inventory guard for the same reason, so these crates are governed by
+# neither -- the one such hole in the tree.  Delete the entry once settled.
 #
 # Every name here is checked against the examples on disk below, so a typo or a
 # rename fails the run instead of quietly exempting nothing -- or everything.


### PR DESCRIPTION
Closes the documentation half of #953.

## The drift

Each license guard exempts `cutile_inter_kernel` and justifies it by pointing at #663:

```
check-dependency-licenses.sh:
  Whether those belong in the inventory is the open question in #663

check-example-license-policy.sh:
  Both are policy calls for a maintainer, and they are the open question
  in #663 ... Delete the entry once that is settled.
```

**#663 closed on 2026-08-10.** I closed it, saying both halves were enforced in CI — and that was overstated. #664 and #681 did cover every *other* example workspace, but this one is on **both** exemption lists, so its ~60 git-pulled crates get neither a CSV row nor a `cargo deny check`. Two readers are now sent to a resolved thread to find a decision that was never made.

## What is actually still open

Unchanged, and still yours:

| blocker | state |
|---|---|
| `error[source-not-allowed]` (x7) | `deny.toml`'s `allow-git` lists only pliron, not cutile-rs |
| `error[unlicensed]: cuda-bindings = 0.1.0` | that is cutile-rs's own vendored crate, **not** this repo's — ours is `0.2.1` with `license.workspace = true`, so the fix is not ours to make |

## The change

Comment-only. Repoints both at #953, and states plainly what the exemption withholds: not just the inventory rows but the policy check too, making this the one such hole in the tree. The previous wording let a reader of the inventory guard assume `cargo deny` still covered these crates — I made that assumption myself while writing this, and had to correct the patch.

Neither exemption list is touched.

## Verified

Both guards pass unchanged: 55 declared crates recorded, every example workspace's third-party crates covered, and `deny.toml` holding over every example outside `POLICY_EXEMPT_EXAMPLES`. No GPU.