### PR TITLE
docs(github): ask bug reports for `cargo oxide doctor`, not four hand-collected facts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,20 @@ What should happen.
 What actually happens (error message, wrong output, panic, etc.).
 
 **Environment**
+Paste the output of `cargo oxide doctor`. It reports the GPU and driver, the
+toolchain and its components, the resolved `llc`, libNVVM, nvJitLink and
+libdevice, and the backend it would load -- which is most of what a triage
+question would otherwise ask for one field at a time.
+
+<details><summary><code>cargo oxide doctor</code></summary>
+
+```text
+
+```
+
+</details>
+
+If `doctor` itself is what fails, the individual facts still help:
 - GPU: <!-- e.g. RTX 4090, H100 -->
 - CUDA driver version:
 - `rustc --version --verbose`:

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -4632,9 +4632,12 @@ pub fn doctor(ctx: &Context) {
     // CI boxes are supported workflows (`build`/`pipeline` work fine), and
     // the examples-compile CI job is exactly that.
     print!("NVIDIA driver / GPU... ");
-    match query_gpu_name_and_compute_cap() {
-        Some((name, (major, minor))) => {
-            println!("✓ {} (compute capability {}.{})", name, major, minor);
+    match query_gpu_name_cap_and_driver() {
+        Some((name, (major, minor), driver)) => {
+            println!(
+                "✓ {} (compute capability {}.{}, driver {})",
+                name, major, minor, driver
+            );
         }
         None => {
             // Some containers mount the kernel driver without shipping
@@ -6295,25 +6298,37 @@ fn parse_compute_cap_field(field: &str) -> Option<(u32, u32)> {
     Some((major.parse().ok()?, minor.parse().ok()?))
 }
 
-/// Query the name and compute capability of the first GPU via `nvidia-smi`,
-/// for doctor's driver / GPU report. Same trust rules as
-/// [`query_device_compute_cap`].
-fn query_gpu_name_and_compute_cap() -> Option<(String, (u32, u32))> {
+/// Query the name, compute capability, and driver version of the first GPU
+/// via `nvidia-smi`, for doctor's driver / GPU report. Same trust rules as
+/// [`query_device_compute_cap`]. The driver version matters for triage:
+/// PTX-JIT and driver-API compatibility bugs are driver-version-specific,
+/// and the bug-report template points reporters at this line.
+fn query_gpu_name_cap_and_driver() -> Option<(String, (u32, u32), String)> {
     let output = Command::new("nvidia-smi")
-        .args(["--query-gpu=name,compute_cap", "--format=csv,noheader"])
+        .args([
+            "--query-gpu=name,compute_cap,driver_version",
+            "--format=csv,noheader",
+        ])
         .output()
         .ok()
         .filter(|o| o.status.success())?;
-    parse_gpu_name_and_compute_cap(&String::from_utf8_lossy(&output.stdout))
+    parse_gpu_name_cap_and_driver(&String::from_utf8_lossy(&output.stdout))
 }
 
-/// Parse the first line of `nvidia-smi --query-gpu=name,compute_cap` output
-/// into the GPU name and `(major, minor)` pair. Splits on the LAST comma:
-/// GPU names may contain commas in principle, `compute_cap` never does.
-fn parse_gpu_name_and_compute_cap(stdout: &str) -> Option<(String, (u32, u32))> {
+/// Parse the first line of `nvidia-smi
+/// --query-gpu=name,compute_cap,driver_version` output into the GPU name,
+/// `(major, minor)` pair, and driver version. Splits on the LAST two commas:
+/// GPU names may contain commas in principle, `compute_cap` and
+/// `driver_version` never do.
+fn parse_gpu_name_cap_and_driver(stdout: &str) -> Option<(String, (u32, u32), String)> {
     let line = stdout.lines().next()?;
-    let (name, cap) = line.rsplit_once(',')?;
-    Some((name.trim().to_string(), parse_compute_cap_field(cap)?))
+    let (rest, driver) = line.rsplit_once(',')?;
+    let (name, cap) = rest.rsplit_once(',')?;
+    Some((
+        name.trim().to_string(),
+        parse_compute_cap_field(cap)?,
+        driver.trim().to_string(),
+    ))
 }
 
 /// Format a `(major, minor)` compute-capability tuple as the `sm_XX` /
@@ -9570,17 +9585,21 @@ device-owner = { path = "../device-owner" }
     }
 
     #[test]
-    fn parse_gpu_name_and_compute_cap_splits_on_last_comma() {
+    fn parse_gpu_name_cap_and_driver_splits_on_last_two_commas() {
         assert_eq!(
-            parse_gpu_name_and_compute_cap("NVIDIA GeForce RTX 5090, 12.0\n"),
-            Some(("NVIDIA GeForce RTX 5090".to_string(), (12, 0)))
+            parse_gpu_name_cap_and_driver("NVIDIA GeForce RTX 5090, 12.0, 580.65.06\n"),
+            Some((
+                "NVIDIA GeForce RTX 5090".to_string(),
+                (12, 0),
+                "580.65.06".to_string()
+            ))
         );
-        // Failure banner: no comma-separated cc field.
+        // Failure banner: no comma-separated cc/driver fields.
         assert_eq!(
-            parse_gpu_name_and_compute_cap("NVIDIA-SMI has failed.\n"),
+            parse_gpu_name_cap_and_driver("NVIDIA-SMI has failed.\n"),
             None
         );
-        assert_eq!(parse_gpu_name_and_compute_cap(""), None);
+        assert_eq!(parse_gpu_name_cap_and_driver(""), None);
     }
 
     #[test]


### PR DESCRIPTION
## The gap

`bug_report.md` asks reporters to assemble the environment by hand:

```
- GPU:
- CUDA driver version:
- `rustc --version --verbose`:
- `llc --version` (or `llc-22 --version`):
```

`cargo oxide doctor` already prints all four — and it appears **nowhere** outside a CI job name: not in the template, not in CONTRIBUTING, not in the book.

## What it adds over the four fields

Real output from this machine:

```
Pinned toolchain active... ✓ nightly-2026-04-03-... (overridden by '.../rust-toolchain.toml')
Codegen backend... ✓ /.../librustc_codegen_cuda.so
Shared cache (external projects)... ⚠ /home/.../librustc_codegen_cuda.so
  Older than the backend built here, so projects outside this
  repository would load a different one.
libNVVM (libnvvm.so)... ✓ libNVVM 2.0
llc (LLVM)... ✓ LLVM version 22.1.2-rust-... (/.../bin/llc)
```

Several of those separate "the compiler is broken" from "this checkout loads a different backend than you think" — a common enough answer to want in the first message rather than the third.

## Scope

The four fields stay, under *"If `doctor` itself is what fails"* — an environment broken enough to stop `doctor` is exactly when they are still needed. The output goes in a `<details>` block so a long paste does not bury the reproducer.

No GPU, no code change.