### PR TITLE
build(just): check-guards runs the naming guard too, and says it does not

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,10 +147,10 @@ doc-check:
 # is no longer required: `test-cuda` shadows the toolkit's libcuda stub itself.
 # `check-guards` covers the status-guard, naming-guard and cargo-deny workflows
 # in full, and `check-intrinsics` the generated-intrinsics job; see their
-# comments for prerequisites. Still CI-only: clippy's per-example pass (one run per example
-# workspace), examples-compile (needs the CUDA codegen backend), and CodeQL. The
-# book gate has a local mirror too, but `just book` stays out of `check` as the
-# one gate needing a Python virtualenv.
+# comments for prerequisites. Still CI-only: clippy's per-example pass (one run
+# per example workspace), examples-compile (needs the CUDA codegen backend),
+# and CodeQL. The book gate has a local mirror too, but `just book` stays out
+# of `check` as the one gate needing a Python virtualenv.
 # Run CI's gates minus examples-compile, book, CodeQL
 check: fmt-check clippy test test-cuda check-guards check-intrinsics doc-check
 
@@ -205,20 +205,21 @@ check-errors:
     scripts/check-error-example-status.sh
 
 # Every status-guard job (error* examples in STATUS.md, the smoketest example
-# contract, the README crate inventory, toolchain-pin parity, and the book's CLI
-# command reference) plus all three cargo-deny jobs: `cargo deny check` enforces
-# deny.toml over the root workspace's resolved graph and again over
-# crates/rustc-codegen-cuda, which resolves its own because it has its own
-# `[workspace]`; the license inventory covers what both declare; and deny.toml
-# holds over the example workspaces. These were only reachable by reading the
-# workflows, so `just
-# check` could pass while status-guard or cargo-deny failed. Keep this list in
-# step when a guard is added to either workflow -- the crate-inventory and
-# toolchain-parity jobs were added to CI without being added here, which is the
-# same drift this recipe exists to prevent. Prerequisites: `cargo-deny` on PATH
-# (`cargo install cargo-deny --locked`) and `python3` (most of the scripts drive
-# it). The scripts are invoked via `bash` as CI does, since not all of them
-# carry an exec bit.
+# contract, the README crate inventory, toolchain-pin parity, the book's CLI
+# command reference, the book's device-API names, and the device-only build),
+# the naming-guard's reserved-prefix search, and all four cargo-deny jobs:
+# `cargo deny check` enforces deny.toml over the root workspace's resolved
+# graph and again over crates/rustc-codegen-cuda, which resolves its own
+# because it has its own `[workspace]`; the license inventory covers what both
+# declare; deny.toml holds over the example workspaces; and every first-party
+# source file carries an SPDX header. These were only reachable by reading the
+# workflows, so `just check` could pass while status-guard or cargo-deny
+# failed. Keep this list in step when a guard is added to any of the three
+# workflows -- the crate-inventory and toolchain-parity jobs were added to CI
+# without being added here, which is the same drift this recipe exists to
+# prevent. Prerequisites: `cargo-deny` on PATH (`cargo install cargo-deny
+# --locked`) and `python3` (most of the scripts drive it). The scripts are
+# invoked via `bash` as CI does, since not all of them carry an exec bit.
 # Run the status-guard, naming-guard and cargo-deny CI jobs (needs cargo-deny, python3)
 check-guards:
     bash scripts/check-error-example-status.sh

--- a/Justfile
+++ b/Justfile
@@ -145,9 +145,9 @@ doc-check:
 # `clippy` and `doc-check` already build cuda-bindings, so this recipe needs a
 # CUDA toolkit either way. Machines without even a toolkit get `test`. A driver
 # is no longer required: `test-cuda` shadows the toolkit's libcuda stub itself.
-# `check-guards` covers the status-guard and cargo-deny workflows in full, and
-# `check-intrinsics` the generated-intrinsics job; see their comments for
-# prerequisites. Still CI-only: clippy's per-example pass (one run per example
+# `check-guards` covers the status-guard, naming-guard and cargo-deny workflows
+# in full, and `check-intrinsics` the generated-intrinsics job; see their
+# comments for prerequisites. Still CI-only: clippy's per-example pass (one run per example
 # workspace), examples-compile (needs the CUDA codegen backend), and CodeQL. The
 # book gate has a local mirror too, but `just book` stays out of `check` as the
 # one gate needing a Python virtualenv.
@@ -219,7 +219,7 @@ check-errors:
 # (`cargo install cargo-deny --locked`) and `python3` (most of the scripts drive
 # it). The scripts are invoked via `bash` as CI does, since not all of them
 # carry an exec bit.
-# Run the status-guard and cargo-deny CI jobs (needs cargo-deny, python3)
+# Run the status-guard, naming-guard and cargo-deny CI jobs (needs cargo-deny, python3)
 check-guards:
     bash scripts/check-error-example-status.sh
     bash scripts/check-example-smoketest-contract.sh


### PR DESCRIPTION
## The drift

`check-guards` has run `scripts/check-reserved-prefixes.sh` since #835, but both descriptions of its scope name only two workflows:

```
# Run the status-guard and cargo-deny CI jobs (needs cargo-deny, python3)
# `check-guards` covers the status-guard and cargo-deny workflows in full
```

That script is **naming-guard.yml**'s `reserved-symbols-guard` job, not a status-guard one.

The recipe is correct; the description undersells it, which is the direction that costs a round trip — a contributor touching a `cuda_oxide_*` literal reads this, concludes the reserved-prefix guard is CI-only, and finds out after pushing.

## After

The mapping now checks out job for job:

| workflow | jobs | mirrored by |
|---|---|---|
| status-guard.yml | 7 | 7 scripts |
| naming-guard.yml | 1 | `check-reserved-prefixes.sh` |
| cargo-deny.yml | 4 | 2 `cargo deny` runs + 2 scripts |

= the eleven scripts and two `cargo deny` invocations `check-guards` runs.

Comment-only; `just --list` and `just -n check-guards` are unchanged apart from the wording. No GPU.