### PR TITLE
ci: pin the entry-point workflow's token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ concurrency:
   group: ci-gate-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Every other workflow in the repo pins this rather than inheriting whatever the
+# repository default happens to be. This one is a pure caller today, so the four
+# called workflows' own `contents: read` already bounds the token and this
+# changes nothing. It matters for the next job added here directly: a `uses:`
+# job carries the callee's permissions, an inline `steps:` job would carry the
+# default instead, and that difference is invisible in review.
+permissions:
+  contents: read
+
 jobs:
   fmt:
     uses: ./.github/workflows/fmt.yml


### PR DESCRIPTION
`ci.yml` is the only workflow of the eleven that declares no `permissions`, so it inherits whatever the repository default is set to.

## This is a no-op today, and the comment says so

Every job in `ci.yml` is a `uses:` caller, and all four called workflows declare `contents: read` themselves, which already bounds the token:

```
fmt.yml         permissions: contents: read
clippy.yml      permissions: contents: read
unit-tests.yml  permissions: contents: read
cargo-deny.yml  permissions: contents: read
```

I'd rather state that than imply a hardening that isn't happening.

## Why it is still worth pinning

For the next job added here directly. A `uses:` job carries the callee's permissions; an inline `steps:` job carries the repository default. Nothing in review distinguishes them, and `ci.yml` is the natural place to add a job that is not a reusable-workflow call.

## What I deliberately did not touch

`codeql.yml` also has no top-level block, and that is correct: it scopes `security-events: write`, `packages: read`, `actions: read`, `contents: read` to the `analyze` job, which is **tighter** than a workflow-level grant, not looser. Moving it up would widen it.

No GPU, no behaviour change.