### PR TITLE
ci(book): stop uploading a Pages artifact that pull requests cannot deploy

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -56,7 +56,13 @@ jobs:
           sphinx-build -W --keep-going -b html
           cuda-oxide-book cuda-oxide-book/_build/html
 
-      - uses: actions/upload-pages-artifact@v3
+      # Only `deploy` consumes this, and `deploy` is skipped on pull requests,
+      # so uploading it there produces an artifact nothing can ever read. A PR's
+      # job is to prove `sphinx-build -W` succeeds, which the step above already
+      # did; gate the upload on the same condition `deploy` uses so the two
+      # cannot drift apart.
+      - if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
         with:
           path: cuda-oxide-book/_build/html
 


### PR DESCRIPTION
## The waste

`deploy` is gated on `github.event_name != 'pull_request'`, and it is the **only** consumer of the artifact `build` uploads — nothing else in the repo runs `download-pages-artifact` or `deploy-pages`. So on every pull request, `actions/upload-pages-artifact@v3` produces something nothing can read.

## What does not change

The PR run's purpose is untouched. What proves the book is sound is the step above:

```yaml
- name: Build Sphinx site
  run: >-
    sphinx-build -W --keep-going -b html
    cuda-oxide-book cuda-oxide-book/_build/html
```

which still runs on PRs and still fails the job on any warning. The upload only hands the finished result to Pages.

## The change

Gates the upload on the same expression `deploy` uses, verbatim rather than a paraphrase, so the two cannot drift into a state where main builds an artifact it never publishes, or a PR publishes one:

```
upload gate : github.event_name != 'pull_request'
deploy gate : github.event_name != 'pull_request'
identical   : True
```

No GPU.