### PR TITLE
ci: the SPDX header guard does not look at the book's CSS/JS or flake.nix

### DIFF
--- a/scripts/check-spdx-headers.sh
+++ b/scripts/check-spdx-headers.sh
@@ -13,11 +13,19 @@
 # had to be fixed again. New files fail here now instead of in the next
 # license audit.
 #
-# Scope: tracked *.rs *.sh *.py *.cu *.c *.h *.ll files. Measured when this
-# guard was written that is 1789 files, and the header always sits within the
-# first four lines; the check reads the first 15 so a longer shebang/attribute
-# preamble cannot push a real header out of view, while a stray SPDX string in
-# the body of a generator or test still cannot satisfy it.
+# Scope: tracked *.rs *.sh *.py *.cu *.c *.h *.ll *.js *.css *.html *.nix
+# files -- 1803 of them, and the header always sits within the first four
+# lines; the check reads the first 15 so a longer shebang/attribute preamble
+# cannot push a real header out of view, while a stray SPDX string in the body
+# of a generator or test still cannot satisfy it.
+#
+# The last four extensions were outside the glob until this guard was extended,
+# and the eight files they cover -- the book's `_static` CSS and JS, its two
+# `_templates` HTML fragments, and `flake.nix` -- all carry the standard header
+# already. That is the point: someone wrote them correctly, and nothing was
+# checking, so the next one could arrive without a header exactly as #819 and
+# #835 did for shell scripts. Every one of the eight passes unchanged, so this
+# only closes the hole.
 #
 # Two kinds of files are deliberately not held to the standard header:
 #
@@ -101,7 +109,8 @@ while IFS= read -r f; do
     elif ! grep -Eq "${license_re}" <<<"${w}"; then
         violations="${violations}  ${f}: missing 'SPDX-License-Identifier: Apache-2.0' line"$'\n'
     fi
-done < <(git ls-files -- '*.rs' '*.sh' '*.py' '*.cu' '*.c' '*.h' '*.ll' |
+done < <(git ls-files -- '*.rs' '*.sh' '*.py' '*.cu' '*.c' '*.h' '*.ll' \
+    '*.js' '*.css' '*.html' '*.nix' |
     grep -v '^crates/fuzzer/rustlantis/' |
     grep -vxF -f <(printf '%s\n' "${BSD_EXEMPT_FILES[@]}"))
 


### PR DESCRIPTION
## Summary

`scripts/check-spdx-headers.sh` globs `*.rs *.sh *.py *.cu *.c *.h *.ll`. Eight tracked first-party files fall outside that list, so nothing checks their headers:

```
cuda-oxide-book/_static/css/custom.css
cuda-oxide-book/_static/css/lightbox.css
cuda-oxide-book/_static/css/nvidia-sphinx-theme.css
cuda-oxide-book/_static/js/lightbox.js
cuda-oxide-book/_static/js/spa-nav.js
cuda-oxide-book/_templates/footer.html
cuda-oxide-book/_templates/globaltoc.html
flake.nix
```

All eight already carry the standard two-line header, so **this changes no file and fails nothing today**. That is the point: someone wrote them correctly and nothing was watching, which is precisely the hazard the guard's own header describes — the OSRB review fixed 32 files in #812, and the next two scripts to land (#819, #835) arrived bare and had to be fixed again. A new book stylesheet or Sphinx template can land the same way now and CI stays green.

These files are in policy scope, not out of it: CONTRIBUTING's "License Headers" section already names HTML's comment form. Only the guard's glob was short.

## Changes

- Add `*.js *.css *.html *.nix` to the `git ls-files` glob.
- Update the scope comment (file count 1795 → 1803) and record why the four extensions are there.

## Testing

Local, no GPU and no toolkit — this guard reads text and runs in under a second.

| Case | Before | After |
|:--|:--|:--|
| clean tree | `OK` (1795 files) | `OK` (1803 files) |
| header stripped from `flake.nix` | **`OK` — passed** | `error: flake.nix: missing SPDX-FileCopyrightText line`, exit 1 |
| header stripped from `_static/js/spa-nav.js` | **`OK` — passed** | `error: ... spa-nav.js: missing SPDX-FileCopyrightText line`, exit 1 |

`nvidia-sphinx-theme.css` carries `Copyright (c) 2023-2024`, which the existing regex's optional year-range branch already accepts, and its header sits on lines 2–3 of a minified file — inside the 15-line window.

- [x] Guards pass (`check-spdx-headers.sh` plus the eight status-guard scripts)
- [ ] `cargo oxide run <example>` — not applicable, no code path changes
- [ ] New example added — not applicable