### PR TITLE
docs(book): the safety model's atomics example calls a constructor that takes no pointer

### DIFF
--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -490,8 +490,12 @@ from a raw pointer requires the caller to guarantee that the pointer is
 valid and properly aligned:
 
 ```rust
-let atom = unsafe { DeviceAtomicU32::new(ptr) };
-atom.fetch_add(1, Ordering::Relaxed);  // safe call
+use cuda_device::atomic::{AtomicOrdering, DeviceAtomicU32};
+
+// `from_ptr` is the unsafe constructor: it reinterprets existing memory.
+// `DeviceAtomicU32::new(value)` is the safe one, for an owned static.
+let atom = unsafe { DeviceAtomicU32::from_ptr(ptr) };
+atom.fetch_add(1, AtomicOrdering::Relaxed);  // safe call
 ```
 
 ### Unchecked slice access


### PR DESCRIPTION
## Summary

`cuda-oxide-book/gpu-safety/the-safety-model.md` shows this under **Atomics**:

```rust
let atom = unsafe { DeviceAtomicU32::new(ptr) };
atom.fetch_add(1, Ordering::Relaxed);  // safe call
```

Every line is wrong against `cuda-device`, and the snippet contradicts the paragraph directly above it — which correctly says the unsafe surface is "creating a `DeviceAtomicU32` **from a raw pointer**":

| In the book | Actually |
|:--|:--|
| `DeviceAtomicU32::new(ptr)` inside `unsafe` | `pub const fn new(val: u32) -> Self` — **safe**, takes an initial *value*. `crates/cuda-device/src/atomic.rs:181` |
| — | The pointer constructor the prose describes is `pub const unsafe fn from_ptr<'a>(ptr: *mut u32) -> &'a Self`, `atomic.rs:207` |
| `Ordering::Relaxed` | These take `cuda_device::atomic::AtomicOrdering`, not `core::sync::atomic::Ordering` |

So the `unsafe` block sits on the one call in the snippet that does not need it, and the API the section exists to teach is never named. A reader who pastes this gets three compiler errors.

The tree's own uses are the correct form — `crates/cuda-device/src/grid.rs:145` and `crates/rustc-codegen-cuda/examples/scoped_atomic_load_store/src/main.rs:72` both call `from_ptr`. The API quick reference also spells `AtomicOrdering` correctly; only this page does not.

## Changes

- `new` → `from_ptr`, `Ordering` → `AtomicOrdering`.
- Add the `use` line so the snippet stands alone, and one comment marking which of the two constructors is the unsafe one — the distinction this section is about.

## Why no guard caught it

`scripts/check-book-api-names.sh` is scoped, by design, to free functions in the `warp`/`thread`/`grid`/`cluster` modules; its header says so. `new` also resolves as a name regardless of which type carries it, so a name-existence check cannot see this class of error. I did sweep every `Type::method(` call in the book's 274 Rust blocks against `cuda-device`'s exports for the same shape and found no others.

## Testing

Local, no GPU.

- [x] `just book` (`sphinx-build -W --keep-going`) succeeds
- [x] `check-book-api-names.sh`, `check-toolchain-parity.sh`, `check-cli-doc-coverage.sh` pass
- [x] Corrected signatures read directly from `crates/cuda-device/src/atomic.rs`
- [ ] `cargo oxide run <example>` — not applicable, documentation only