### PR TITLE
ci: the device-only guard re-resolves the lock file it is judging

### DIFF
--- a/scripts/check-device-only-build.sh
+++ b/scripts/check-device-only-build.sh
@@ -81,9 +81,21 @@ no_cuda_env() {
     env -u CUDA_HOME -u CUDA_TOOLKIT_PATH -u CUDA_TOOLKIT_TARGET_DIR "$@"
 }
 
-graph="$(no_cuda_env cargo metadata --format-version 1 \
+# `--locked` on both cargo invocations below, for the reason
+# check-dependency-licenses.sh gives for its own `cargo metadata`: a check that
+# can rewrite its own input is not a check. The fixture's Cargo.lock is
+# tracked, and without the flag this guard re-resolves it in passing --
+# verified by deleting the cuda-device package block from the committed lock,
+# after which the guard still printed "OK: device-only graph is host-free
+# (8 packages)" and left the lock silently repaired. That matters more here
+# than elsewhere: the assertion is about the *resolved* graph, so a resolution
+# free to move is not the one the repository committed.
+graph="$(no_cuda_env cargo metadata --locked --format-version 1 \
     --manifest-path "${MANIFEST}" 2>/dev/null)" || {
     echo "error: cargo metadata failed for ${MANIFEST}" >&2
+    echo "       if it reports a stale lock file, commit the updated" >&2
+    echo "       ${FIXTURE}/Cargo.lock rather than letting the guard" >&2
+    echo "       re-resolve it" >&2
     exit 1
 }
 
@@ -113,11 +125,11 @@ if present:
 print(f"OK: device-only graph is host-free ({len(names)} packages).")
 '
 
-if ! no_cuda_env cargo check --quiet --manifest-path "${MANIFEST}" 2>/dev/null; then
+if ! no_cuda_env cargo check --locked --quiet --manifest-path "${MANIFEST}" 2>/dev/null; then
     echo "error: the device-only fixture does not type-check without a CUDA" \
         "toolkit" >&2
     echo "       re-run without --quiet for the diagnostic:" >&2
-    echo "       cargo check --manifest-path ${MANIFEST}" >&2
+    echo "       cargo check --locked --manifest-path ${MANIFEST}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

`scripts/check-device-only-build.sh` is the only guard in `scripts/` that resolves a Cargo graph without `--locked`. Its sibling states the rule it is missing:

> `--locked` so the guard reads the committed resolution rather than silently updating Cargo.lock to satisfy itself: **a check that can rewrite its own input is not a check.**
> — `scripts/check-dependency-licenses.sh`

`check-example-license-policy.sh` passes it too, and #806 added it to all three executable `cargo deny` invocations for the same reason.

It matters more here than in either of those. This guard's whole assertion is about the **resolved** graph — "cuda-host, cuda-core and cuda-bindings are absent from it" — and `crates/cuda-macros/tests/device-only/Cargo.lock` is tracked. A resolution free to move is not the one the repository committed.

## Reproduction

On a clean tree, delete the `cuda-device` package block from that committed lock, then run the guard exactly as `cargo-deny.yml` does:

**Before**
```
OK: device-only graph is host-free (8 packages).
OK: crates/cuda-macros/tests/device-only type-checks with the CUDA environment unset.
exit=0
```
…and `git diff` on the lock came back **empty** — cargo had quietly resolved it back to the committed content on the way past. The guard passed on a corrupt input *and* repaired that input, which is the failure mode that leaves nobody a reason to look.

**After**
```
error: cargo metadata failed for crates/cuda-macros/tests/device-only/Cargo.toml
       if it reports a stale lock file, commit the updated
       crates/cuda-macros/tests/device-only/Cargo.lock rather than letting the guard
       re-resolve it
exit=1
```
…and the lock is left exactly as the mutation made it (`1 file changed, 7 deletions(-)`).

For reference, `cargo metadata --locked` on the mutated lock reports:

```
error: cannot update the lock file .../device-only/Cargo.lock because --locked was passed to prevent this
```

## Changes

- `--locked` on `cargo metadata` and on `cargo check`, so the two invocations cannot disagree about which resolution is under test.
- The `cargo metadata` error path now names the lock file, since "commit the updated lock" is the fix and re-resolving is what we just stopped doing silently.

## Testing

Local, no GPU and no CUDA toolkit — the guard unsets the CUDA environment itself.

- [x] Clean tree passes unchanged (`8 packages`, fixture type-checks)
- [x] The mutation above now fails, and leaves the lock alone
- [x] Restoring the lock passes again
- [ ] `cargo oxide run <example>` — not applicable, CI script only