### PR TITLE
ci(examples): the failure-log upload drops the iket_trace build log

### DIFF
--- a/.github/workflows/examples-compile.yml
+++ b/.github/workflows/examples-compile.yml
@@ -18,8 +18,7 @@ jobs:
   examples-compile:
     name: compile all examples (device pipeline, GPU-less)
     runs-on: ubuntu-latest
-    # 145 example crates as of the scoped-cache repair:
-    # backend build + shared dep tree + per-example
+    # 210 example crates: backend build + shared dep tree + per-example
     # device codegen. Typically well under an hour with the shared
     # CARGO_TARGET_DIR; the timeout leaves headroom for cold runners.
     # Leave job-level headroom around the 50-minute full compile and the
@@ -67,7 +66,7 @@ jobs:
           opt-21 --version | head -2
 
       - name: Compile every example (smoketest --compile-only)
-        # Step-level timeout, below the job's 60: a job-level timeout
+        # Step-level timeout, below the job's 75: a job-level timeout
         # CANCELS the job and `if: failure()` never fires, losing the
         # logs. A step timeout fails the step, so the upload still runs.
         timeout-minutes: 50
@@ -216,9 +215,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: smoketest-compile-logs
+          # One glob per log the artifact-modes step writes. `iket-trace-*`
+          # matched neither of the other two, so the one assertion that
+          # exercises the full libNVVM + nvJitLink path -- and the only one
+          # that can fail on internalization dropping `__iket_meta_info` from
+          # the cubin -- was the one whose log never reached the artifact.
+          # `if-no-files-found: ignore` below made that silent.
           path: |
             ${{ runner.temp }}/smoketest-logs/
             ${{ runner.temp }}/vecadd-*-build.log
+            ${{ runner.temp }}/iket-trace-*-build.log
             ${{ runner.temp }}/cross-crate-*-build.log
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary

The "Artifact modes keep shared Cargo dependencies fresh" step writes six build logs. The failure-upload step globs only two families:

```yaml
${{ runner.temp }}/vecadd-*-build.log
${{ runner.temp }}/cross-crate-*-build.log
```

| Log | Covered? |
|:--|:--|
| `vecadd-ptx-build.log` | yes |
| `vecadd-cubin-build.log` | yes |
| **`iket-trace-cubin-build.log`** | **no** |
| `vecadd-ptx-return-build.log` | yes |
| `cross-crate-sm86-build.log` | yes |
| `cross-crate-sm90-build.log` | yes |

`iket-trace-*` matches neither glob, and `if-no-files-found: ignore` makes the omission silent.

That is the worst one to lose. The other five assertions build PTX or a cubin and check the artifact header; the `iket_trace` one is the only step that drives the complete libNVVM + nvJitLink path, and its own comment says why it exists — *"an IR-only assertion would miss internalization dropping these globals from the cubin"*. When it fails, the reason is inside that log: which of `__iket_meta_info` or the long kernel name went missing, or whether nvJitLink failed earlier. Whoever picks up the red build currently gets the other five logs and a bare `test` exit status for the one that broke.

Adding the glob costs nothing when the step passes — the upload only runs `if: failure()`.

## Changes

- Add `${{ runner.temp }}/iket-trace-*-build.log` to the upload path, with a comment on the invariant (one glob per log the step writes).
- Two stale numbers in the same file's comments, found while checking this and fixed here rather than left to need a second PR:
  - the compile step says its timeout is "below the job's **60**" — the job's `timeout-minutes` is **75**. The reasoning is right and still holds (a job-level timeout cancels the job so `if: failure()` never fires); only the figure is wrong.
  - "**145** example crates as of the scoped-cache repair" — there are **210** directories with a `Cargo.toml` under `examples/` today.

## Testing

Local; this workflow needs a runner with the CUDA toolkit and LLVM 21, so the change is verified statically rather than by executing the job.

- [x] All six written logs are matched by the four globs (checked by `fnmatch` against the filenames the step actually `tee`s)
- [x] Every file in `.github/workflows/` still parses as YAML, and the upload step reads back with `if: failure()`, `if-no-files-found: ignore`, and four paths
- [x] Example-directory count recomputed from the tree
- [ ] `cargo oxide run <example>` — not applicable, workflow only