### PR TITLE
docs(dialect-mir): the crate README's type and operation tables are behind the code

### DIFF
--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -8,7 +8,7 @@ rustc MIR ──► mir-importer ──► dialect-mir ──► mir-lower ─�
 
 ## Types
 
-The dialect defines seven types that preserve Rust-level semantics:
+The dialect defines nine types that preserve Rust-level semantics:
 
 | Type                  | Description                                        | Example                               |
 |-----------------------|----------------------------------------------------|---------------------------------------|
@@ -17,8 +17,10 @@ The dialect defines seven types that preserve Rust-level semantics:
 | `MirSliceType`        | Fat pointers (`&[T]` = ptr + len)                  | `mir.slice<f32, addrspace: 1>`        |
 | `MirDisjointSliceType`| `DisjointSlice<T>` -- per-thread unique access     | `mir.disjoint_slice<f32, ...>`        |
 | `MirStructType`       | Named structs with layout metadata                 | `mir.struct<"Point", [f32, f32]>`     |
+| `MirUnionType`        | Rust unions -- each field a view of the same bytes | `mir.union<"Repr", [a, b], [i32, f32], 4, 4>` |
 | `MirEnumType`         | Rust enums with their exact rustc layout           | `mir.enum<"Ordering", i8, ...>`       |
 | `MirArrayType`        | Fixed-size arrays                                  | `mir.array<f32, 256>`                 |
+| `MirFP16Type`         | IEEE 754 binary16 -- Rust's `f16`                  | `mir.fp16`                            |
 
 `MirEnumType` records the enum's layout the way rustc computed it: Direct,
 Niche, Single, or Empty; the physical integer/pointer carrier and absolute
@@ -60,21 +62,22 @@ Pointers and slices carry an NVPTX address space:
 
 ## Operations
 
-55 operations across 11 modules:
+62 operations across 12 modules, one row per file in `src/ops/`:
 
-| Module         | Ops | Description                                                                             |
-|----------------|-----|-----------------------------------------------------------------------------------------|
-| `function`     | 1   | `MirFuncOp` -- function definition                                                      |
-| `control_flow` | 5   | return, goto, cond_branch, assert, unreachable                                          |
-| `memory`       | 9   | alloca, load, store, ref, assign, ptr_offset, shared_alloc, global_alloc, extern_shared |
-| `constants`    | 3   | integer, float, and undef constants                                                     |
-| `arithmetic`   | 15  | add/sub/mul/div/rem, checked variants, bitwise, shifts                                  |
-| `comparison`   | 6   | lt, le, gt, ge, eq, ne                                                                  |
-| `aggregate`    | 8   | construct/extract/insert for structs, tuples, and arrays; field and element address     |
-| `enum_ops`     | 4   | construct_enum, get_discriminant, set_discriminant, enum_payload                        |
-| `cast`         | 1   | type conversions (kind tracked via `MirCastKindAttr`)                                   |
-| `storage`      | 2   | storage_live, storage_dead (lifetime markers)                                           |
-| `call`         | 1   | function calls                                                                          |
+| Module         | Ops | Description                                                                                              |
+|----------------|-----|----------------------------------------------------------------------------------------------------------|
+| `function`     | 1   | `MirFuncOp` -- function definition                                                                       |
+| `control_flow` | 6   | return, goto, cond_branch, assert, unreachable, unroll_hint                                              |
+| `memory`       | 11  | alloca, load, store, ref, assign, ptr_offset, memcpy, memmove, shared_alloc, global_alloc, extern_shared |
+| `constants`    | 3   | integer, float, and undef constants                                                                      |
+| `arithmetic`   | 15  | add/sub/mul/div/rem, checked variants, bitwise, shifts                                                   |
+| `comparison`   | 7   | lt, le, gt, ge, eq, ne, cmp                                                                              |
+| `aggregate`    | 10  | construct/extract/insert for structs, tuples, arrays, slices and disjoint slices; field and element address |
+| `enum_ops`     | 4   | construct_enum, get_discriminant, set_discriminant, enum_payload                                          |
+| `cast`         | 1   | type conversions (kind tracked via `MirCastKindAttr`)                                                    |
+| `storage`      | 2   | storage_live, storage_dead (lifetime markers)                                                            |
+| `call`         | 1   | function calls                                                                                           |
+| `debug`        | 1   | dbg_value -- binds a value to a source-level variable                                                    |
 
 `MirAllocaOp` implements `PromotableAllocationInterface` and `MirLoadOp` / `MirStoreOp` implement `PromotableOpInterface`, so pliron's `mem2reg` pass can promote scalar stack slots back into SSA. `MirUndefOp` is the default reaching definition the pass materialises when a load is not dominated by any store.
 


### PR DESCRIPTION
## Summary

Both inventories in `crates/dialect-mir/README.md` are hand-maintained and nothing checks them. Counts recomputed from the tree at `a766fc26`.

### Types: "seven" → **nine**

Two types have `#[pliron_type(...)]` declarations in `src/types.rs` and no row:

- `MirUnionType` — Rust unions, every field a view of the same bytes. Not a corner case: #857 and #927 are both about union constants, so a reader who came to this README to understand that work found no mention of the type carrying it.
- `MirFP16Type` — IEEE 754 binary16, Rust's `f16`.

### Operations: 55 across 11 modules → **62 across 12**

| Module | README | Tree | Missing |
|:--|--:|--:|:--|
| `control_flow` | 5 | 6 | `unroll_hint` |
| `memory` | 9 | 11 | `memcpy`, `memmove` |
| `comparison` | 6 | 7 | `cmp` |
| `aggregate` | 8 | 10 | `construct_slice`, `construct_disjoint_slice` |
| **`debug`** | — | 1 | `dbg_value` — no row at all |

The header now says "one row per file in `src/ops/`", since that is the invariant that makes the table checkable at a glance.

## Note on the neighbouring PR

The book keeps a second copy of this same operation inventory in `cuda-oxide-book/compiler/mlir-dialects.md`. It is stale too, and by a **different amount** — it says 54 where this file says 55, because it never picked up `set_discriminant` which this one already had. Two hand-kept copies drifting apart at different rates is the argument for reading `src/ops/` rather than trusting either. That file is fixed separately; the two changes share no files, and each stands alone.

## Testing

Local, no GPU.

- [x] Every row recomputed from `src/types.rs` and `src/ops/`; both tables now match the tree exactly (9/9 types, 62 ops across 12 modules, per-module counts all equal)
- [x] `check-crate-inventory.sh` and `check-toolchain-parity.sh` pass
- [ ] `cargo oxide run <example>` — not applicable, documentation only