### PR TITLE
docs(book): refresh the dialect-nvvm counts the catalog stamp now invalidates

### DIFF
--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -1,11 +1,16 @@
 # Pliron Dialects
 
 cuda-oxide does not lower Rust to PTX in a single, heroic transformation. It
-works across three pliron dialects, each modeling a different level of
-abstraction: two defined locally (`dialect-mir`, `dialect-nvvm`) and the LLVM
-dialect provided by the upstream `pliron-llvm` crate. This chapter walks
-through all three -- their types, their operations, and how they fit together
-to form the compilation pipeline.
+works across three pliron dialects on the way down, each modeling a different
+level of abstraction: two defined locally (`dialect-mir`, `dialect-nvvm`) and
+the LLVM dialect provided by the upstream `pliron-llvm` crate. This chapter
+walks through all three -- their types, their operations, and how they fit
+together to form the compilation pipeline.
+
+Two further pliron dialects live in this tree off that path and are not covered
+here: `dialect-iket`, the compiler-facing form of in-kernel event tracing, and
+`dialect-ptx`, a structured terminal PTX dialect that can be built directly or
+projected from parsed PTX source. Each crate's README is the reference.
 
 If you have not read the [Pliron -- Pliron IR (MLIR-like)](pliron.md) chapter yet, now
 is a good time. The concepts there (operations, types, attributes, regions,
@@ -291,16 +296,16 @@ they become `call` instructions to `@llvm.nvvm.*` intrinsics.
 
 ### Architecture Coverage
 
-At catalog SHA-256 `df42ef97` (the stamp in every `ops/generated/` file
-header), the dialect holds 543 operations across 41 modules, and they come
+At catalog SHA-256 `20440c06` (the stamp in every `ops/generated/` file
+header), the dialect holds 560 operations across 42 modules, and they come
 from two different places. The split is the first thing to know about it,
 because it decides where -- and whether -- you would add one. If the header
-stamp no longer starts with `df42ef97`, the counts on this page predate the
+stamp no longer starts with `20440c06`, the counts on this page predate the
 catalog you are reading.
 
 **Hand-written**, directly under `crates/dialect-nvvm/src/ops/`. These are the
 ops with bespoke verification or lowering that the intrinsic catalog does not
-describe. There are seven modules and 18 operations:
+describe. There are seven modules and 19 operations:
 
 | Module    | Description                                                 | Ops |
 | :-------- | :---------------------------------------------------------- | --: |
@@ -310,12 +315,12 @@ describe. There are seven modules and 18 operations:
 | `debug`   | `assertfail`, `vprintf`                                     |   2 |
 | `grid`    | Cooperative `grid_sync`                                     |   1 |
 | `memory`  | Generic-to-shared address conversion with a byte offset     |   1 |
-| `wgmma`   | Warpgroup MMA descriptors and the m64n64k16 bf16 shapes     |   6 |
+| `wgmma`   | Warpgroup MMA descriptors and the m64n64k16 bf16 shapes     |   7 |
 
 **Generated**, under `ops/generated/`, from `intrinsics/catalog.json` by
 `cuda-intrinsics-gen`. Every file there opens with `// @generated ... DO NOT
 EDIT.`, and editing one by hand is undone by the next generator run. This is
-the large majority -- 34 modules and 525 operations, resolved from 986 catalog
+the large majority -- 35 modules and 541 operations, resolved from 1002 catalog
 entries, since several intrinsics can share one structural op:
 
 | Area                        | Modules                                                                       | Ops |
@@ -323,13 +328,14 @@ entries, since several intrinsics can share one structural op:
 | Tensor Core Gen 5 + TMEM    | `tcgen05`                                                                     | 210 |
 | Tensor Memory Accelerator   | `tma`                                                                         | 111 |
 | Special registers           | `sreg`                                                                        |  44 |
-| Packed (SIMD-in-register)   | `packed_alu`, `packed_conversion`, `packed_atomic`                            |  43 |
+| Packed (SIMD-in-register)   | `packed_alu`, `packed_conversion`, `packed_atomic`                            |  51 |
 | Async copy and barriers     | `cp_async`, `mbarrier_extended`, `mbarrier_basic`, `sync`                     |  34 |
 | Warp-level                  | `warp_shuffle`, `redux`, `vote`, `warp_match`, `warp_barrier`, `active_mask`, `elect` |  31 |
 | Matrix fragment movement    | `ldmatrix`, `register_mma`, `stmatrix`, `wgmma_control`, `movmatrix`, `sparse_mma` |  22 |
 | Execution and debug control | `execution_control`, `debug_control`                                          |  11 |
 | Cluster                     | `clc`, `cluster_barrier`, `cluster_memory`                                    |  10 |
 | Scalar math                 | `dotprod`, `scalar_arithmetic`, `scalar_conversion`, `scalar_math`, `extended_minmax`, `prmt` |   9 |
+| Integer min/max (DPX)       | `integer_minmax`                                                              |   8 |
 
 Architecture requirements live per intrinsic rather than per module -- the
 catalog records the PTX version and minimum SM for each, and


### PR DESCRIPTION
## Summary

The obligation #964's merge comment attached to #946 landing. #946 has landed (`d485edbb`), and it was not the only batch member to move these numbers.

The page carries the self-invalidating stamp your layered commit added:

> If the header stamp no longer starts with `df42ef97`, the counts on this page predate the catalog you are reading.

Every `ops/generated/` header now prints `20440c06...`, so it does.

## What moved, and which PR moved it

Recomputed at `d485edbb`, with each delta attributed per module via `git ls-tree` + `git show` rather than from a PR diff:

| Module | Before | After | From |
|:--|--:|--:|:--|
| `generated/integer_minmax.rs` | 0 | 8 | **#967** — new module, DPX min/max |
| `generated/packed_alu.rs` | 22 | 30 | **#946** — f32x2 arithmetic |
| `ops/wgmma.rs` | 6 | 7 | **#935** — counted-K pipeline op |

Which moves five figures and adds a row:

| Figure | Before | After |
|:--|:--|:--|
| catalog stamp | `df42ef97` | `20440c06` |
| total | 543 / 41 modules | **560 / 42** |
| hand-written | 18 ops | **19** (`wgmma` 6→7) |
| generated | 34 mods / 525 ops / 986 entries | **35 / 541 / 1002** |
| Packed (SIMD-in-register) | 43 | **51** |
| Integer min/max (DPX) | — | **new row, 8** |

`integer_minmax` gets its own row rather than joining Scalar math beside `extended_minmax`: six of its eight ops are `16x2` packed forms (`max_s16x2`, `min_relu_s16x2`, …) and two are scalar `s32`, so it reads as a feature area, not a scalar-math addition.

Checked and **unchanged** in the same pass: dialect-mir is still 62 ops / 12 modules / 9 types, and the `pliron` pin is still `8447aa42`, so the LLVM dialect's 69 stands.

## A correction to my own #964

That PR asserted #946 added no ops, on the strength of `gh pr diff 946 | grep -c pliron_op` returning `0`. As you noted, `gh pr diff` returns empty on a diff that large — so the grep was counting nothing rather than finding nothing. An unfalsifiable check that reads as a clean result, which is the same shape as the `rg || true` bug `check-reserved-prefixes.sh` documents. Every count here is derived from git objects in the tree instead.

## One editorial change on the same page

The chapter opened "works across three pliron dialects … two defined locally". Two more local pliron dialects exist and the book never mentions either: `dialect-iket` (7 ops, 2 types) and `dialect-ptx` (#917). The claim is now scoped to the lowering path — which is what this chapter covers — with a pointer to both crates' READMEs, rather than shoehorning an event-tracing dialect and a terminal PTX dialect into a "levels of abstraction" table where they do not belong.

The same count appears in `pliron.md` and `architecture-overview.md`; those are a companion PR, and this one touches neither file.

## Testing

Local, no GPU.

- [x] Every figure on the page recomputed by script against the tree (stamp, totals, all 7 hand-written rows, all 11 generated group rows summing to 541)
- [x] `just book` (`sphinx-build -W --keep-going`) succeeds
- [x] `check-book-api-names.sh` passes
- [ ] `cargo oxide run <example>` — not applicable, documentation only