### PR TITLE
docs(book): the Crate Map says "every one" and lists 15 of 28

### DIFF
--- a/cuda-oxide-book/compiler/architecture-overview.md
+++ b/cuda-oxide-book/compiler/architecture-overview.md
@@ -141,6 +141,19 @@ cuda-oxide is split into focused crates. Here is every one and its role:
 | `cuda-core`          | Safe bindings to the CUDA Driver API (`CudaContext`, `DeviceBuffer`, `CudaStream`)     |
 | `cuda-async`         | Async GPU programming: `DeviceOperation`, combinators, stream pool scheduling          |
 | `cuda-bindings`      | Low-level FFI bindings to CUDA driver (`libcuda.so`)                                   |
+| `cuda-intrinsics`    | Generated low-level CUDA intrinsic declarations                                        |
+| `cuda-intrinsics-gen`| Extractor and deterministic source generator for the intrinsics                        |
+| `cuda-artifact-finalizer` | Driver-independent NVVM IR, LTOIR, and PTX finalization                           |
+| `oxide-artifacts`    | Architecture-neutral embedded device artifact metadata                                 |
+| `dialect-iket`       | pliron dialect modelling in-kernel event tracing                                       |
+| `iket-lower`         | `dialect-iket` profiles + instrumentation lowering                                     |
+| `dialect-ptx`        | pliron dialect modelling structured PTX                                                |
+| `ptx-parse`          | Lossless structural views over PTX source text                                         |
+| `cuda-oxide-codegen` | Experimental rustc-independent PTX backend                                             |
+| `libnvvm-sys`        | `dlopen` bindings to libNVVM (used by `cuda-host::ltoir`)                              |
+| `nvjitlink-sys`      | `dlopen` bindings to nvJitLink (used by `cuda-host::ltoir`)                             |
+| `reserved-oxide-symbols` | Workspace-private `cuda_oxide_*` symbol-name contract                              |
+| `fuzzer`             | Differential codegen fuzzer support (rustlantis adapter)                               |
 
 ### Dependency flow
 
@@ -185,10 +198,12 @@ add build complexity, slow down CI, and make contributor onboarding painful.
 With pliron, dialects are defined using standard Rust traits and derive macros,
 and the IR can be inspected with any Rust debugger.
 
-cuda-oxide defines two dialects on top of pliron: `dialect-mir` (models
-Rust MIR) and `dialect-nvvm` (NVIDIA GPU intrinsics). The LLVM dialect comes
-from the upstream `pliron-llvm` crate; cuda-oxide's `llvm-export` crate
-re-exports it and adds the textual `.ll` exporter.
+cuda-oxide defines four dialects on top of pliron. Two carry the lowering
+path: `dialect-mir` (models Rust MIR) and `dialect-nvvm` (NVIDIA GPU
+intrinsics). Two sit off it: `dialect-iket` (in-kernel event tracing) and
+`dialect-ptx` (structured terminal PTX). The LLVM dialect comes from the
+upstream `pliron-llvm` crate; cuda-oxide's `llvm-export` crate re-exports it
+and adds the textual `.ll` exporter.
 
 :::{seealso}
 For a deeper dive into pliron's architecture, see

--- a/cuda-oxide-book/compiler/pliron.md
+++ b/cuda-oxide-book/compiler/pliron.md
@@ -349,9 +349,12 @@ function signature.
 
 ## How cuda-oxide uses pliron
 
-cuda-oxide works with three dialects: it defines `dialect-mir` and
-`dialect-nvvm` locally (each as its own crate) and consumes the LLVM dialect
-from the upstream `pliron-llvm` crate. Registration is automatic: every
+The lowering path works with three dialects: cuda-oxide defines `dialect-mir`
+and `dialect-nvvm` locally (each as its own crate) and consumes the LLVM
+dialect from the upstream `pliron-llvm` crate. Two further local dialects sit
+off that path -- `dialect-iket` for in-kernel event tracing and `dialect-ptx`
+for structured terminal PTX -- and the sections below cover only the three
+above. Registration is automatic: every
 dialect, op, type, and attribute linked into the binary registers itself when
 a `Context` is created (`Context::default` runs all link-time registrations),
 so kernel authors and pass authors never have to think about dialect setup --


### PR DESCRIPTION
## The Crate Map

`architecture-overview.md`'s Crate Map opens:

> cuda-oxide is split into focused crates. **Here is every one and its role**:

and then lists 15. The workspace has 27 members plus `rustc-codegen-cuda`, so 13 are absent:

```
cuda-intrinsics          cuda-intrinsics-gen    cuda-artifact-finalizer
cuda-oxide-codegen       oxide-artifacts        reserved-oxide-symbols
dialect-iket             iket-lower             dialect-ptx
ptx-parse                libnvvm-sys            nvjitlink-sys
fuzzer
```

This is the same gap `scripts/check-crate-inventory.sh` exists to prevent, one document over. That guard was written because `dialect-iket` and `iket-lower` were missing from README.md's Crate Overview — *"1,700 lines of compiler across two crates, with no row between them."* **Both are missing here too**, and the guard cannot see this table: it only reads README.md.

Roles are copied verbatim from README.md's Crate Overview rather than written fresh, so the two inventories agree word for word and the guarded one stays the single source of truth.

## The dialect count

Two pages state how many pliron dialects cuda-oxide defines, and both predate `dialect-iket` and `dialect-ptx` (#917):

| Location | Says |
|:--|:--|
| `architecture-overview.md:188` | "cuda-oxide defines **two** dialects on top of pliron" |
| `pliron.md:352` | "cuda-oxide works with **three** dialects" |

Neither is a count of everything; both are counts of the lowering path, which is what the surrounding prose goes on to describe. Rather than fold two off-path dialects into a "levels of abstraction" narrative where they do not belong, each claim is now scoped to the lowering path and names the other two so a reader knows they exist.

`mlir-dialects.md` carries the same claim in its opening and is fixed in a companion PR; this one does not touch that file, so the two do not overlap.

## Testing

Local, no GPU.

- [x] The Crate Map matches the member list exactly by script — **28 listed, 28 actual, none missing and none extra**
- [x] `just book` (`sphinx-build -W --keep-going`) succeeds
- [x] `check-crate-inventory.sh` and `check-book-api-names.sh` pass
- [ ] `cargo oxide run <example>` — not applicable, documentation only