### PR TITLE
ci: four workspace members carry 107 tests that no CI job runs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,23 @@ jobs:
         #   * `fuzzer` — differential-testing infra with no unit tests.
         #   * `rustc-codegen-cuda` — its own [workspace] that links against
         #     `rustc-private` dylibs; covered by the separate job below.
+        #
+        # Everything else is here on purpose. This list is the whole
+        # justification for a member being absent, so a member that is neither
+        # in the matrix below nor named above is an omission, not a decision —
+        # which is how `dialect-iket`, `iket-lower`, `dialect-ptx` and
+        # `ptx-parse` came to carry 107 tests that no CI job ran.
         include:
+          # In-kernel event tracing: the semantic dialect and its lowering to a
+          # runtime compatibility profile. Pure pliron, no CUDA.
+          - package: dialect-iket
+          - package: iket-lower
+          # The PTX stack from #914-#917: a lossless CST over PTX source and the
+          # structured dialect projected from it. Pure Rust, no CUDA, and the
+          # dialect's CFG verification is exactly the kind of invariant a unit
+          # test is the only cheap way to keep.
+          - package: ptx-parse
+          - package: dialect-ptx
           - package: cuda-intrinsics-gen
           - package: cuda-intrinsics
           - package: llvm-export

--- a/Justfile
+++ b/Justfile
@@ -62,7 +62,8 @@ test:
         -p dialect-mir -p dialect-nvvm -p mir-importer -p mir-lower \
         -p mir-transforms -p nvvm-transforms -p reserved-oxide-symbols \
         -p cuda-device -p libnvvm-sys -p nvjitlink-sys \
-        -p cuda-artifact-finalizer -p cargo-oxide
+        -p cuda-artifact-finalizer -p cargo-oxide \
+        -p dialect-iket -p iket-lower -p ptx-parse -p dialect-ptx
     # `default = []`, but every consumer turns the object features on, and the
     # default set alone skips the eight ELF emit/extract tests.
     cargo test -p oxide-artifacts --all-targets --features object


### PR DESCRIPTION
## Summary

`unit-tests.yml`'s matrix covers 21 of the 27 workspace members. Its own comment block names the intended exclusions:

```
# Crates intentionally not in this matrix:
#   * `cuda-bindings` — generated sys bindings covered transitively.
#   * `fuzzer` — differential-testing infra with no unit tests.
#   * `rustc-codegen-cuda` — its own [workspace] ...
```

Four members are in **neither** list. They are not declared out; they were left out, and between them they hold 107 `#[test]` functions that nothing executes:

| Crate | Tests | What |
|:--|--:|:--|
| `dialect-ptx` | 43 | structured terminal PTX dialect (#917) |
| `ptx-parse` | 35 | lossless CST over PTX source (#917) |
| `iket-lower` | 22 | `dialect-iket` → runtime compatibility profile |
| `dialect-iket` | 7 | in-kernel event tracing dialect |

`dialect-iket` and `iket-lower` have been uncovered for a long time — they are the same two crates whose absence from README.md motivated `check-crate-inventory.sh`. `dialect-ptx` and `ptx-parse` arrived with #914–#917 last batch. The PTX pair is the one that stings: `dialect-ptx` verifies native CFG invariants, which is precisely the sort of property a unit test is the only cheap way to hold, and 43 of them have never gated a merge.

## Why no `needs_cuda`

None of the four touches `cuda-bindings`. Their full dependency sets are `pliron`, `pliron-derive`, `thiserror`, `combine`, `dyn-clone`, `linkme` — and `ptx-parse` has no dependencies at all. They go in the plain matrix with the default `--all-targets`, and add about a second of runtime between them.

The exclusion comment now also says what the list is *for* — that a member absent from both the matrix and the list is an omission rather than a decision — since the list reading as complete is what made this invisible.

`just test` gets the same four, because its own comment is the contract: *"Mirrors .github/workflows/unit-tests.yml; keep the two in step."* `test-cuda` is unchanged; nothing here links the driver.

## Testing

Local, pinned toolchain, no GPU.

```
dialect-iket    7 passed; 0 failed
iket-lower     22 passed; 0 failed
ptx-parse      35 passed; 0 failed
dialect-ptx    43 passed; 0 failed
```

So this turns green-on-nothing into green-on-107 without changing a test.

- [x] `just test` passes end to end on the merged tree with the four added
- [x] By script: the CI matrix and the Justfile package lists are now identical, and **every** workspace member is either in the matrix or named in the exclusion comment — none silently uncovered
- [x] `unit-tests.yml` still parses (25 matrix entries)
- [ ] `cargo oxide run <example>` — not applicable, no code path changes