### PR TITLE
docs(dialect-mir): the attributes table and source tree are the two halves #965 missed

### DIFF
--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -102,14 +102,17 @@ This catches mismatches immediately after `mir-importer` translates from rustc, 
 
 ## Attributes
 
-The dialect defines four domain-specific attribute types (following the pliron best practice of avoiding overloaded `IntegerAttr`):
+The dialect defines seven domain-specific attribute types (following the pliron best practice of avoiding overloaded `IntegerAttr`), one row per `#[pliron_attr(...)]` in `src/attributes.rs`:
 
-| Attribute           | Rust Type          | Description                                                                                                          |
-|---------------------|--------------------|----------------------------------------------------------------------------------------------------------------------|
-| `mir.cast_kind`     | `MirCastKindAttr`  | Preserves Rust cast intent (e.g. `IntToFloat`, `PtrToPtr`, `Transmute`) so lowering picks the right LLVM instruction |
-| `mir.mutability`    | `MutabilityAttr`   | Boolean: `&` vs `&mut` for `mir.ref`                                                                                 |
-| `mir.field_index`   | `FieldIndexAttr`   | Structural field index for `extract_field`, `insert_field`, `field_addr`, `enum_payload`                             |
-| `mir.variant_index` | `VariantIndexAttr` | Enum variant index for `construct_enum`, `enum_payload`                                                              |
+| Attribute                     | Rust Type                   | Description                                                                                                          |
+|-------------------------------|-----------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `mir.cast_kind`               | `MirCastKindAttr`           | Preserves Rust cast intent (e.g. `IntToFloat`, `PtrToPtr`, `Transmute`) so lowering picks the right LLVM instruction |
+| `mir.mutability`              | `MutabilityAttr`            | Boolean: `&` vs `&mut` for `mir.ref`                                                                                 |
+| `mir.field_index`             | `FieldIndexAttr`            | Structural field index for `extract_field`, `insert_field`, `field_addr`, `enum_payload`                             |
+| `mir.variant_index`           | `VariantIndexAttr`          | Enum variant index for `construct_enum`, `enum_payload`                                                              |
+| `mir.fp16_attr`               | `MirFP16Attr`               | IEEE 754 binary16 value for `f16` constants, paired with `MirFP16Type`                                               |
+| `mir.unroll`                  | `UnrollAttr`                | Unroll factor carried by `mir.unroll_hint` -- `0` means full unroll, `n >= 2` means `n` body copies per trip          |
+| `mir.compiler_result_bundle`  | `CompilerResultBundleAttr`  | Marks an aggregate that exists only to adapt a compiler-owned multi-result op to a Rust aggregate return ABI          |
 
 ## Registration
 
@@ -126,19 +129,23 @@ register(&mut ctx);  // Registers all ops, types, and attributes
 ```text
 src/
 ├── lib.rs                       # Dialect registration
-├── types.rs                     # 7 MIR types + address_space constants
-├── attributes.rs                # 4 domain-specific attributes
+├── types.rs                     # 9 MIR types + address_space constants
+├── attributes.rs                # 7 domain-specific attributes
+├── const_fold.rs                # Constant folding over dialect-mir ops
+├── rust_intrinsics.rs           # Recognised core/std intrinsic calls
+├── side_effects.rs              # Per-op side-effect classification
 ├── ops/
 │   ├── mod.rs                   # Op module registry + re-exports
 │   ├── function.rs              # MirFuncOp
-│   ├── control_flow.rs          # Terminators and branches
-│   ├── memory.rs                # Load, store, alloc, shared memory
+│   ├── control_flow.rs          # Terminators, branches, unroll hints
+│   ├── memory.rs                # Load, store, alloc, memcpy, shared memory
 │   ├── constants.rs             # Integer and float literals
 │   ├── arithmetic.rs            # Math, bitwise, shifts, checked ops
 │   ├── comparison.rs            # Relational and equality
-│   ├── aggregate.rs             # Struct, tuple, array manipulation
+│   ├── aggregate.rs             # Struct, tuple, array, slice manipulation
 │   ├── enum_ops.rs              # Enum construction and inspection
 │   ├── cast.rs                  # Type conversions
+│   ├── debug.rs                 # dbg_value source-variable bindings
 │   ├── storage.rs               # Lifetime markers
 │   └── call.rs                  # Function calls
 ```


### PR DESCRIPTION
## Summary

#965 corrected this README's type and operation tables. It left the other two inventories on the same page, and both are stale in the same way — one of them now **contradicting the tables #965 just fixed**.

## Attributes: "four" → seven

`src/attributes.rs` has seven `#[pliron_attr(...)]` declarations; the table lists four. The three missing ones are all recent, and two pair directly with ops the README already lists:

| Attribute | Rust type | Pairs with |
|:--|:--|:--|
| `mir.fp16_attr` | `MirFP16Attr` | `MirFP16Type`, already in the Types table |
| `mir.unroll` | `UnrollAttr` | `mir.unroll_hint` — **added to the ops table by #965** |
| `mir.compiler_result_bundle` | `CompilerResultBundleAttr` | the multi-result return ABI from #888 |

`mir.unroll` is the clearest case: #965 added `mir.unroll_hint` to the operations table, and the attribute that op exists to carry sat three rows below, undocumented.

## Source Layout tree

It contradicts the page above it:

| Tree entry | Says | Page says |
|:--|:--|:--|
| `types.rs` | `# 7 MIR types` | the Types table lists **nine** |
| `attributes.rs` | `# 4 ... attributes` | see above — **seven** |
| `ops/` | no `debug.rs` | the Operations table lists it |
| `src/` | — | no `const_fold.rs`, `rust_intrinsics.rs`, `side_effects.rs` |

So a reader who trusted the tree came away with different numbers than one who trusted the tables, on a single page. Three module comments were also narrower than their files (`control_flow` also carries unroll hints, `memory` also `memcpy`/`memmove`, `aggregate` also slices) — all ops #965 added to the table without the tree following.

Both inventories now state the rule that makes them checkable, as the operations table does: one row per `#[pliron_attr(...)]`, one tree entry per file.

## Testing

Local, no GPU.

- [x] The attributes table matches all seven `(name, Rust type)` pairs exactly by script — `MirCastKindAttr` is a `pub enum`, the rest `pub struct`
- [x] The Source Layout tree matches `src/*.rs` plus `src/ops/*.rs` exactly: **19 listed, 19 on disk**, none missing and none invented
- [x] `check-crate-inventory.sh` passes
- [ ] `cargo oxide run <example>` — not applicable, documentation only