### PR TITLE
docs: the f16 scoped atomics are public API and documented nowhere

### DIFF
--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -120,7 +120,7 @@ Typestate-based async barrier for TMA and MMA synchronization (Hopper+). Tracks 
 
 Two kinds of atomics work on device:
 
-- **`cuda_device::atomic::*`** -- 18 scoped GPU atomic types across three scopes (`Device`/`.gpu`, `Block`/`.cta`, `System`/`.sys`) and six value types (u32, i32, u64, i64, f32, f64). These give explicit control over scope and ordering.
+- **`cuda_device::atomic::*`** -- 21 scoped GPU atomic types across three scopes (`Device`/`.gpu`, `Block`/`.cta`, `System`/`.sys`) and seven value types (u32, i32, u64, i64, f16, f32, f64). These give explicit control over scope and ordering.
 - **`core::sync::atomic::*`** -- standard library atomics (`AtomicU32`, `AtomicBool`, etc.) also compile to GPU code, defaulting to device scope.
 
 Both paths emit the same NVVM atomic ops and share the full lowering pipeline to PTX.

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -410,11 +410,16 @@ COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
 let old = COUNTER.load(AtomicOrdering::Acquire);
 ```
 
-| Scope                                    | Types                         |
-|:-----------------------------------------|:------------------------------|
-| `DeviceAtomic{U32,I32,U64,I64,F32,F64}`  | `.gpu` scope                  |
-| `BlockAtomic{U32,I32,U64,I64,F32,F64}`   | `.cta` scope                  |
-| `SystemAtomic{U32,I32,U64,I64,F32,F64}`  | `.sys` scope (CPU-GPU shared) |
+| Scope                                        | Types                         |
+|:---------------------------------------------|:------------------------------|
+| `DeviceAtomic{U32,I32,U64,I64,F16,F32,F64}`  | `.gpu` scope                  |
+| `BlockAtomic{U32,I32,U64,I64,F16,F32,F64}`   | `.cta` scope                  |
+| `SystemAtomic{U32,I32,U64,I64,F16,F32,F64}`  | `.sys` scope (CPU-GPU shared) |
+
+Twenty-one types: seven value widths in each of the three scopes. The `F16`
+variants take the same surface as `F32`/`F64` -- `load`, `store`, `fetch_add`,
+`fetch_sub`, `swap` -- with `fetch_add`/`fetch_sub` lowering to hardware
+`atom.add.noftz.f16`.
 
 `core::sync::atomic` types (`AtomicU32`, `AtomicBool`, etc.) also compile to
 GPU code, defaulting to system scope.

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -164,9 +164,9 @@ constant nested inside another constant's field.
 
 | Feature | Status | Description |
 |:--------|:-------|:------------|
-| Device-Scope Atomics | **Full** | `DeviceAtomic{U32,I32,U64,I64,F32,F64}` with `.gpu` scope. All 5 orderings. |
-| Block-Scope Atomics | **Full** | `BlockAtomic{U32,I32,U64,I64,F32,F64}` with `.cta` scope. |
-| System-Scope Atomics | **Full** | `SystemAtomic{U32,I32,U64,I64,F32,F64}` with `.sys` scope. For CPU-GPU shared data. |
+| Device-Scope Atomics | **Full** | `DeviceAtomic{U32,I32,U64,I64,F16,F32,F64}` with `.gpu` scope. All 5 orderings. |
+| Block-Scope Atomics | **Full** | `BlockAtomic{U32,I32,U64,I64,F16,F32,F64}` with `.cta` scope. |
+| System-Scope Atomics | **Full** | `SystemAtomic{U32,I32,U64,I64,F16,F32,F64}` with `.sys` scope. For CPU-GPU shared data. |
 | `core::sync::atomic` Support | **Full** | Standard library atomic types lowered to PTX `atom.sys` instructions. |
 
 ## Runtime Library: Shared Memory


### PR DESCRIPTION
## Summary

`cuda-device` exports **21** scoped atomic types — three scopes × seven value widths, `{U32,I32,U64,I64,F16,F32,F64}` for each of `Device`/`Block`/`System`. Every place in the tree that lists them omits the `F16` entry:

| File | Says |
|:--|:--|
| `crates/cuda-device/README.md:123` | "**18** scoped GPU atomic types across three scopes … and **six** value types (u32, i32, u64, i64, f32, f64)" |
| `cuda-oxide-book/appendix/api-quick-reference.md` | `DeviceAtomic{U32,I32,U64,I64,F32,F64}` and the Block/System rows |
| `cuda-oxide-book/appendix/supported-features.md:167-169` | the same three brace lists, each marked **Full** |

So `DeviceAtomicF16`, `BlockAtomicF16` and `SystemAtomicF16` are reachable today — `pub mod atomic`, generated by the same `define_float_atomic!` invocation as `F32` and `F64`, with the identical surface (`new`, `from_ptr`, `load`, `store`, `fetch_add`, `fetch_sub`, `swap`) — and a reader has no way to learn they exist short of reading `atomic.rs`. They landed in `f5e9af62` ("Add scalar f16 atomic support") and the docs never followed.

`18` and `six value types` were also mutually consistent (3 × 6), which is why the number reads as deliberate rather than stale.

## Changes

- The three lists gain `F16`; the README's counts become 21 and seven.
- One sentence in the quick reference on what the `F16` variants support, since "same as F32/F64" is the useful fact and `fetch_add`/`fetch_sub` lowering to hardware `atom.add.noftz.f16` is the part worth naming.

No arch caveat is added: that instruction wants sm_70+ and the book's documented floor is sm_80, so it is always satisfied here.

Not caught by `check-book-api-names.sh` by design — its scope is free functions in `warp`/`thread`/`grid`/`cluster`, and these are type names in `atomic`.

## Testing

Local, no GPU.

- [x] By script: every `XAtomic{...}` brace list in both book pages expands to exactly the set of `pub struct (Device|Block|System)Atomic*` declarations in `crates/cuda-device/src/atomic.rs` — nothing missing, nothing invented, across all six lists
- [x] `just book` (`sphinx-build -W --keep-going`) succeeds
- [x] `check-book-api-names.sh` passes
- [ ] `cargo oxide run <example>` — not applicable, documentation only