### PR TITLE
docs(examples): ref_index_projections says 14 kernel variants and lists 32

### DIFF
--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -12,8 +12,8 @@ which later optimisation could then fold into a single path.
 
 ## What the example does
 
-`src/main.rs` contains **14 kernel variants** that bisect the trigger
-conditions:
+`src/main.rs` contains **32 kernel variants** that bisect the trigger
+conditions -- one per row of the table below:
 
 | #  | Variant                              | Purpose                                        |
 |:---|:-------------------------------------|:-----------------------------------------------|


### PR DESCRIPTION
## Summary

The sentence introducing the variant table:

> `src/main.rs` contains **14 kernel variants** that bisect the trigger conditions:

The table immediately below it has **32 rows**, numbered 1 to 32, and `src/main.rs` defines exactly those 32 kernels. So the number contradicts the table it introduces, one line apart.

The table has been kept current; only the sentence was missed. It grew past 14 across three PRs that each added rows for a new slice-tail case — #873 (`Index` on slice-tailed DST values), #950 (slice-tail metadata through nested DST fields) and #952 (indexed slice-tail elements) — and none of the three touched this line.

Corrected to 32, with "one per row of the table below" so the number has a visible invariant instead of being a second copy of a count kept elsewhere. A reader can now check it without opening `main.rs`.

## Testing

Local, no GPU.

- [x] The prose claim, the table's row count, and the `#[kernel]` definitions in `src/main.rs` all read **32**; row numbering is 1..32 with no gaps; the table's kernel names are exactly the set defined in the source, none missing and none invented
- [x] Swept the other 209 example READMEs for the same shape — a stated kernel/variant count disagreeing with its source — and **this is the only one**
- [x] `check-error-example-status.sh` and `check-example-smoketest-contract.sh` pass
- [ ] `cargo oxide run <example>` — not applicable, documentation only