### PR TITLE
docs(mir-importer): five of twelve intrinsic modules in the README do not exist

### DIFF
--- a/crates/mir-importer/README.md
+++ b/crates/mir-importer/README.md
@@ -77,24 +77,37 @@ artifact; a missing required sidecar is an error rather than a silent fallback.
 | `rvalue`    | Expression translation (binops, casts, etc.)   |
 | `types`     | Rust type → `dialect-mir` type conversion      |
 | `values`    | MIR local → alloca-slot mapping + load/store   |
+| `layout`    | Shared readers over rustc's aggregate layout   |
+| `location`  | Source-location helpers for MIR translation    |
+| `payload_store` | Enum-payload stores whose storage type differs from its usage |
 
-### `terminator/intrinsics/` — GPU Intrinsics
+### `terminator/intrinsics/` — intrinsic handlers
 
-| Module     | Intrinsics                                         | GPU       |
-|------------|----------------------------------------------------|-----------|
-| `generated`| Admitted generated intrinsics, including barriers  | Varies    |
-| `indexing` | `threadIdx`, `blockIdx`, `blockDim`, `gridDim`,    | All       |
-|            | `index_1d`/`index_2d`, DisjointSlice helpers       |           |
-| `sync`     | mbarrier ops and fences                            | All       |
-| `warp`     | Shuffle operations, `lane_id`, warp vote           | All       |
-| `atomic`   | Scoped GPU atomics, `core::sync::atomic` support   | sm_70+    |
-| `memory`   | Shared memory, address space casts, stmatrix       | All       |
-| `debug`    | `vprintf`, clock, trap, breakpoint                 | All       |
-| `cluster`  | Thread Block Clusters, DSMEM                       | sm_90+    |
-| `tma`      | Tensor Memory Accelerator bulk copies              | sm_90+    |
-| `wgmma`    | Warpgroup MMA                                      | sm_90     |
-| `tcgen05`  | 5th-gen Tensor Cores, TMEM                         | sm_100+   |
-| `clc`      | Cluster Launch Control                             | sm_100+   |
+Anything `intrinsics/catalog.json` describes is dispatched by `generated`;
+the modules beside it hold the cases the catalog does not cover. One row per
+file:
+
+| Module        | Purpose (from each module's own doc comment)                                |
+|---------------|-----------------------------------------------------------------------------|
+| `asm`         | Inline PTX marker-call translation                                          |
+| `atomic`      | Atomic operation intrinsic handlers                                         |
+| `bigint`      | Rust compiler bigint helper intrinsics                                      |
+| `bitops`      | Rust compiler bit-manipulation intrinsics                                   |
+| `debug`       | Debug and profiling intrinsics                                              |
+| `exact_div`   | Rust compiler `exact_div` intrinsic                                         |
+| `float_math`  | Rust compiler floating-point math intrinsics                                |
+| `generated`   | Generated raw/compatibility path dispatch for CUDA intrinsics               |
+| `iket`        | Translation of `cuda_device::iket` compiler markers                         |
+| `indexing`    | Thread and block indexing intrinsics                                        |
+| `layout`      | Rust dynamic-layout intrinsics for slices, `str`, and slice-tailed structs  |
+| `memory`      | Memory access and conversion intrinsics                                     |
+| `saturating`  | Rust compiler saturating integer intrinsics                                 |
+| `tma`         | Tensor Memory Access (TMA) intrinsics                                       |
+| `wgmma`       | Hopper WGMMA (Warpgroup Matrix Multiply-Accumulate) intrinsics              |
+
+Per-intrinsic PTX and minimum-SM requirements live in the catalog and are
+rendered into `intrinsics/generated-reference.md`, so they are not restated
+here.
 
 ### `pipeline.rs` — Compilation Orchestration
 
@@ -161,6 +174,13 @@ let result = run_pipeline(&functions, &device_externs, &config)?;
 
 ### Error Types
 
+`PipelineError` is defined in `cuda-oxide-codegen` and re-exported here
+(`pipeline.rs`), so this is the full set of variants `run_pipeline` can
+return. The crate's own `TranslationErr` (`error.rs`) is the narrower
+per-function error the translator raises: `Unsupported`, `TypeError` and
+`InvalidOp`.
+
+
 | Variant          | When                                             |
 |------------------|--------------------------------------------------|
 | `NoBody`         | Function has no MIR body                         |
@@ -170,6 +190,11 @@ let result = run_pipeline(&functions, &device_externs, &config)?;
 | `LoweredVerification` | Lowered LLVM-dialect invariant failed       |
 | `Export`         | LLVM IR export failed                            |
 | `PtxGeneration`  | `llc` invocation failed                          |
+| `Optimization`   | `opt` invocation failed                          |
+| `TargetSelection` | No target satisfied the module's requirements   |
+| `UnsupportedLinking` | Device symbols could not be linked           |
+| `LibdeviceUnavailable` | libdevice was needed but not found         |
+| `InvalidMirPassPipeline` | `CUDA_OXIDE_MIR_PASSES` named an unknown pass |
 
 ## Translation Flow
 


### PR DESCRIPTION
## Summary

`README.md`'s **"`terminator/intrinsics/` — GPU Intrinsics"** table has 12 rows. Only 7 name a module that exists:

| Row | Deleted in |
|:--|:--|
| `intrinsics/sync.rs` | `6a9a6373` (#406) |
| `intrinsics/cluster.rs` | `6a9a6373` (#406) |
| `intrinsics/tcgen05.rs` | `6a9a6373` (#406) |
| `intrinsics/clc.rs` | `6a9a6373` (#406) |
| `intrinsics/warp.rs` | `4c1d5838` (#833) |

#406 moved those families onto the catalog path and #833 dropped the last of them, so all five are handled by `generated.rs` today. Meanwhile **eight** modules that do exist had no row: `asm`, `bigint`, `bitops`, `exact_div`, `float_math`, `iket`, `layout`, `saturating`.

Between the two, the table describes a directory that has not existed for a long time — and it is the one place a contributor looks to find where an intrinsic is translated.

The book's `compiler/mir-importer.md` **already describes the current model correctly** ("`intrinsics/catalog.json` has its arm generated into … `generated.rs`"), so this README was the last copy still on the old one. Rewritten to match: one row per file, each description verbatim from that module's own `//!` doc comment. The per-module "GPU" column is dropped for the reason #964 dropped its equivalent — minimum-SM is a per-intrinsic property the catalog already records.

## Two smaller gaps on the same page

- The `translator/` table was missing `layout`, `location` and `payload_store`.
- The **Error Types** table lists 7 of `PipelineError`'s 12 variants, missing `Optimization`, `TargetSelection`, `UnsupportedLinking`, `LibdeviceUnavailable` and `InvalidMirPassPipeline`. It also never says that `PipelineError` is defined in `cuda-oxide-codegen` and re-exported here, nor that the crate's own `TranslationErr` — `Unsupported`, `TypeError`, `InvalidOp` — is a different, narrower error. Both are now stated.

> A note on that last one: I first read the table against `error.rs`, found none of the seven, and thought the whole table was fictional. It is not — the variants are real, just defined a crate away. Checking before writing is why this PR says "5 missing of 12" rather than something wrong.

## Testing

Local, no GPU — documentation only.

- [x] By script, no ghost and no missing row in any of the three tables: intrinsics = exactly the 15 files in `terminator/intrinsics/`; translator = exactly the 9 files in `translator/` plus the `terminator` subdirectory it also lists; errors = exactly the 12 `PipelineError` variants
- [x] Guards pass on the merged tree
- [ ] `cargo oxide run <example>` — not applicable