### PR TITLE
docs(rustc-codegen-cuda): four env vars the backend reads are not in its table

### DIFF
--- a/crates/rustc-codegen-cuda/README.md
+++ b/crates/rustc-codegen-cuda/README.md
@@ -88,7 +88,7 @@ These are set automatically by `cargo oxide`. For manual invocations, all four a
 | `CUDA_OXIDE_SHOW_RUSTC_MIR`          | Dump raw rustc MIR                          |
 | `CUDA_OXIDE_EMIT_NVVM_IR`            | Emit NVVM IR for libNVVM                    |
 | `CUDA_OXIDE_DEVICE_CODEGEN_CRATE`    | Comma-separated device owner crate filter   |
-| `CUDA_OXIDE_DEVICE_ARCH`             | Detected GPU arch, used as a floor hint     |
+| `CUDA_OXIDE_DEVICE_ARCH`             | Detected GPU arch; advisory (see below)     |
 | `CUDA_OXIDE_DEBUG`                   | Device DWARF level override                 |
 | `CUDA_OXIDE_NO_FMA`                  | Disable FMA contraction (presence only)     |
 | `CUDA_OXIDE_NO_SPILL_WARN`           | Silence the register-spill warning          |
@@ -101,10 +101,12 @@ in `cuda-artifact-finalizer` so the build policy and the emitted DWARF cannot
 disagree about what a value means.
 
 `CUDA_OXIDE_DEVICE_ARCH` is a hint rather than an override: `cargo oxide`
-sets it to the detected GPU's arch only when `--arch` was *not* passed, and
-the backend raises the target above it when a kernel needs more (tcgen05 or
-cta_group TMA multicast need `sm_100a`, which a consumer `sm_120` lacks). An
-explicit `--arch` goes to `CUDA_OXIDE_TARGET` instead and wins.
+sets it to the detected GPU's arch only when `--arch` was *not* passed. The
+backend uses it as the build target when that GPU can run the kernel;
+otherwise it builds for the architecture the kernel's features require
+(tcgen05 and cta_group TMA multicast need `sm_100a`, which a consumer
+`sm_120` lacks). An explicit `--arch` goes to `CUDA_OXIDE_TARGET` instead
+and wins.
 
 `CUDA_OXIDE_NO_FMA` and `CUDA_OXIDE_NO_SPILL_WARN` are presence-only: any
 value, including the empty string, enables them. The first backs

--- a/crates/rustc-codegen-cuda/README.md
+++ b/crates/rustc-codegen-cuda/README.md
@@ -88,6 +88,28 @@ These are set automatically by `cargo oxide`. For manual invocations, all four a
 | `CUDA_OXIDE_SHOW_RUSTC_MIR`          | Dump raw rustc MIR                          |
 | `CUDA_OXIDE_EMIT_NVVM_IR`            | Emit NVVM IR for libNVVM                    |
 | `CUDA_OXIDE_DEVICE_CODEGEN_CRATE`    | Comma-separated device owner crate filter   |
+| `CUDA_OXIDE_DEVICE_ARCH`             | Detected GPU arch, used as a floor hint     |
+| `CUDA_OXIDE_DEBUG`                   | Device DWARF level override                 |
+| `CUDA_OXIDE_NO_FMA`                  | Disable FMA contraction (presence only)     |
+| `CUDA_OXIDE_NO_SPILL_WARN`           | Silence the register-spill warning          |
+
+`CUDA_OXIDE_DEBUG` overrides the DWARF level rustc's `-C debuginfo` would
+imply: `0`/`off`/`none`, `1`/`line`/`lines`/`line-tables`/`line-tables-only`,
+or `2`/`full` (case-insensitive). Any other value is ignored and the rustc
+level applies. `cargo oxide --device-debug` sets it, and the alias table lives
+in `cuda-artifact-finalizer` so the build policy and the emitted DWARF cannot
+disagree about what a value means.
+
+`CUDA_OXIDE_DEVICE_ARCH` is a hint rather than an override: `cargo oxide`
+sets it to the detected GPU's arch only when `--arch` was *not* passed, and
+the backend raises the target above it when a kernel needs more (tcgen05 or
+cta_group TMA multicast need `sm_100a`, which a consumer `sm_120` lacks). An
+explicit `--arch` goes to `CUDA_OXIDE_TARGET` instead and wins.
+
+`CUDA_OXIDE_NO_FMA` and `CUDA_OXIDE_NO_SPILL_WARN` are presence-only: any
+value, including the empty string, enables them. The first backs
+`cargo oxide --no-fmad`; the second suppresses the post-`ptxas` register-spill
+warning, which only fires when a native cubin is materialized.
 
 `cargo oxide --arch <sm_XX>` sets `CUDA_OXIDE_TARGET`. When it is unset,
 PTX output auto-detects the required target from generated LLVM IR.


### PR DESCRIPTION
## Summary

The README's **Environment Variables** table is the only place the backend's environment surface is written down. It lists 9; the crate reads 11, and the two it omits are joined by two more that shape output just as much:

| Variable | Read at | Effect |
|:--|:--|:--|
| `CUDA_OXIDE_DEVICE_ARCH` | `device_codegen.rs:765` | detected GPU arch, used as a floor hint |
| `CUDA_OXIDE_DEBUG` | `device_codegen.rs:851` | device DWARF level override |
| `CUDA_OXIDE_NO_FMA` | `device_codegen.rs:766` | disables FMA contraction |
| `CUDA_OXIDE_NO_SPILL_WARN` | `lib.rs:1041` | silences the register-spill warning |

None is internal plumbing. Three are the env half of documented `cargo oxide` flags — `--device-debug`, `--no-fmad`, and the arch detection behind a bare `cargo oxide run` — so a user who reads the CLI docs and then goes looking for the variable to set in a script, a Makefile, or CI finds nothing.

`CUDA_OXIDE_NO_SPILL_WARN` is the worse case: **it is the off switch for a warning the compiler prints at you, and the warning does not name it.**

## Semantics, taken from the code

The notes below the table now record the parts that are easy to get wrong:

- **`CUDA_OXIDE_DEBUG`** accepts `0`/`off`/`none`, `1`/`line`/`lines`/`line-tables`/`line-tables-only`, `2`/`full`, case-insensitively. Anything else is ignored and rustc's `-C debuginfo` level applies. The alias table lives in `cuda-artifact-finalizer` so the build policy and the emitted DWARF cannot disagree about a value.
- **`CUDA_OXIDE_DEVICE_ARCH`** is a *hint*, not an override. `cargo oxide` sets it to the detected GPU arch **only when `--arch` was not passed**, and the backend still raises the target above it when a kernel needs more (tcgen05 and cta_group TMA multicast need `sm_100a`, which a consumer `sm_120` lacks). An explicit `--arch` goes to `CUDA_OXIDE_TARGET` and wins.
- **`CUDA_OXIDE_NO_FMA`** and **`CUDA_OXIDE_NO_SPILL_WARN`** are presence-only (`var_os(..).is_some()`), so any value including the empty string enables them — setting either to `0` does **not** turn it off.

The two rows already present that this crate does not itself read (`CUDA_OXIDE_LLC`, `CUDA_OXIDE_DEVICE_CODEGEN_CRATE`) are left alone: they are read further down the same pipeline and belong on this page.

## Testing

Local, no GPU — documentation only.

- [x] By script: every `env::var`/`env::var_os` on a `CUDA_OXIDE_*` name anywhere under `crates/rustc-codegen-cuda/src/` now has a table row (11 read, 11 documented, none missing)
- [x] Guards pass on the merged tree
- [ ] `cargo oxide run <example>` — not applicable