### PR TITLE
docs(cargo-oxide): the CLI crate's own README is missing two of its commands

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -324,6 +324,10 @@ cargo oxide pipeline vecadd
 cargo oxide pipeline device_ffi_test --emit-nvvm-ir --arch sm_120
 ```
 
+### `cargo oxide inspect [example]`
+
+Builds the example or project and prints the generated PTX to stdout. Where `pipeline` shows every stage verbosely, this prints just the finished device code, which makes it the quick way to diff codegen across a change. Takes `--arch`, `--features`, `--materialize-cubin`, `--no-fmad`, `--lineinfo` and `-v`. The example name is required inside the workspace and optional for a standalone project.
+
 ### `cargo oxide debug <example>`
 
 Builds with debug info (`-C debuginfo=2`) and launches cuda-gdb. Supports
@@ -343,6 +347,10 @@ cargo oxide new my_kernel
 cd my_kernel
 cargo oxide run
 ```
+
+### `cargo oxide clean`
+
+Removes project-local build outputs and the generated cuda-oxide artifacts beside them. This is the `cargo clean` equivalent that also knows about the device-side files the backend writes, so a stale `.ptx`, `.ll` or embedded artifact cannot survive into the next build.
 
 ### `cargo oxide fmt [--check]`
 
@@ -434,6 +442,7 @@ crates/cargo-oxide/
 └── src/
     ├── main.rs       # CLI definitions (clap) + dispatch
     ├── backend.rs    # Backend discovery + build logic
+    ├── artifact_identity.rs  # Embedded artifact identity/provenance
     └── commands.rs   # All command implementations
 ```
 

--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -326,7 +326,7 @@ cargo oxide pipeline device_ffi_test --emit-nvvm-ir --arch sm_120
 
 ### `cargo oxide inspect [example]`
 
-Builds the example or project and prints the generated PTX to stdout. Where `pipeline` shows every stage verbosely, this prints just the finished device code, which makes it the quick way to diff codegen across a change. Takes `--arch`, `--features`, `--materialize-cubin`, `--no-fmad`, `--lineinfo` and `-v`. The example name is required inside the workspace and optional for a standalone project.
+Builds the example or project and prints the generated PTX to stdout. Where `pipeline` shows every stage verbosely, this prints just the finished device code, which makes it the quick way to diff codegen across a change. Takes `--arch`, `--features`, `--no-fmad`, `--lineinfo`, `--device-debug`, `--unchecked-indexing` and `-v`. The example name is required inside the workspace and optional for a standalone project.
 
 ### `cargo oxide debug <example>`
 


### PR DESCRIPTION
## Summary

`crates/cargo-oxide/README.md` has a `### cargo oxide <cmd>` section for **13 of the 15** user-facing subcommands. Two have none:

```
inspect   Build an example or project and print the generated PTX
clean     Remove project-local build outputs and generated cuda-oxide artifacts
```

Both are in `cargo oxide --help`, so the CLI advertises them and its own documentation does not explain them. `inspect` is the one worth having: it is the quick way to see the finished PTX, which is what most people opening this README are trying to do, and `pipeline` — the verbose whole-pipeline dump — is the only nearby thing documented.

This is the gap `scripts/check-cli-doc-coverage.sh` exists to prevent, one file over. That guard reads the **book's** command reference; this README is outside its scope, exactly as `check-crate-inventory.sh` reads README.md and could not see the book's Crate Map in #970.

Both new sections are in the existing house style, with flags taken from `--help` rather than from the clap source, so what is documented is what a user sees.

`materializer-handshake` stays undocumented on purpose: it is `#[command(name = "__materializer-handshake", hide = true)]`, and the book guard already accounts for it as *"1 hidden one(s) correctly excluded"*.

Also: the Architecture section's source tree lists three files and `src/` has four — `artifact_identity.rs` was missing.

## Checked and deliberately not changed

- `cargo oxide bench` appears in this file but under a **`## Future Commands`** heading, and is correctly absent from clap.
- `CUDA_OXIDE_MATERIALIZE_CUBIN` is real (`MATERIALIZE_CUBIN_ENV` in `reserved-oxide-symbols`) and correctly described as internal.

## Testing

Local, no GPU — documentation only.

- [x] By script: the README's `###` command sections are now **exactly** the set of non-hidden `Commands` variants (15 and 15, no missing and no ghost)
- [x] The source tree matches `src/` exactly
- [x] `check-cli-doc-coverage.sh` passes
- [ ] `cargo oxide run <example>` — not applicable