### PR TITLE
docs(ptx-parse): the one published crate with no README

### DIFF
--- a/crates/ptx-parse/Cargo.toml
+++ b/crates/ptx-parse/Cargo.toml
@@ -8,5 +8,6 @@ repository.workspace = true
 # Published because cuda-host depends on it (name verified free on crates.io).
 publish = true
 description = "Lossless structural views over PTX source text"
+readme = "README.md"
 
 [dependencies]

--- a/crates/ptx-parse/README.md
+++ b/crates/ptx-parse/README.md
@@ -1,0 +1,91 @@
+# ptx-parse
+
+Lossless structural views over PTX source text.
+
+`Document::parse` borrows the source and owns only structural indices into it,
+so every byte of the input -- including comments, whitespace and syntax this
+crate does not recognise -- is still reachable through the original `&str`.
+Nothing is reformatted, and nothing is discarded.
+
+```text
+PTX source text
+     │  Document::parse
+     ▼
+Document<'source>        tokens, statements, scopes, diagnostics, coverage
+     │                   labels, directives, callables, instructions
+     │  EditScript
+     ▼
+edited PTX + byte lineage (AppliedEdits)
+```
+
+## What it deliberately does not do
+
+This crate does not type-check the PTX ISA. Instructions are discovered
+structurally, so an opcode introduced by a newer PTX version is retained with
+the same source spans as one this crate has seen before. Consumers that need
+ISA semantics layer that policy over `Instruction::head`.
+
+That choice is what keeps the crate useful against a moving target: a PTX file
+from a toolkit newer than this checkout still parses, and the parts a caller
+does understand keep exact spans.
+
+## The two representations
+
+`dialect-ptx` is the sibling crate, and the split between them is deliberate:
+
+| Crate         | Owns                                                                       |
+|---------------|----------------------------------------------------------------------------|
+| `ptx-parse`   | Exact external source, trivia, unknown syntax, byte-preserving edits       |
+| `dialect-ptx` | Canonical structure for analysis, construction, transformation, emission   |
+
+Use `EditScript::apply_with_map` when the requirement is to patch real source
+and keep every untouched byte; use `dialect-ptx`'s `emit_canonical_module`
+when the module was constructed or transformed in IR and normalised formatting
+is acceptable.
+
+## Structure
+
+Every statement is one of six kinds -- `Directive`, `Instruction`,
+`CallableHeader`, `Label`, `Preprocessor`, `Unknown` -- and each carries exact
+source and token ranges. `Unknown` is a first-class outcome rather than an
+error: it is how unrecognised syntax keeps its bytes and its spans.
+
+`Document` indexes those statements several ways so callers do not re-scan:
+
+- by scope (`statements_in_scope`, `scopes`)
+- by span (`labels_in`, `directives_in`)
+- by statement (`labels_for_statement`, `directive_for_statement`,
+  `callable_for_statement`)
+- by name (`callables_named`), plus `definitions()` for callables with bodies
+
+`diagnostics()` reports what the parse noticed without failing, and
+`coverage()` reports how much of the source was structurally classified.
+`ParseError` is reserved for input the crate cannot index at all.
+
+## Editing
+
+`EditScript` collects `insert`, `delete` and `replace` operations against
+original offsets and applies them in one pass:
+
+- `apply` returns the edited string.
+- `apply_with_map` returns `AppliedEdits`, which maps offsets in both
+  directions (`original_to_output`, `output_to_original`,
+  `original_range_to_output`) with an explicit `MapBias` at edit boundaries.
+
+The mapping is the reason to prefer `apply_with_map`: a caller that recorded
+spans against the original text can move them onto the edited text without
+re-parsing.
+
+## Consumers
+
+| Crate                 | Uses it for                                                |
+|-----------------------|------------------------------------------------------------|
+| `cuda-oxide-codegen`  | Reading and patching emitted PTX (`export.rs`, `ptx.rs`)   |
+| `cuda-host`           | Editing embedded PTX artifacts (`embedded.rs`)             |
+| `cuda-intrinsics-gen` | Checking the PTX each generated intrinsic emits            |
+| `cargo-oxide`         | Inspecting PTX for the CLI                                 |
+| `dialect-ptx`         | Projecting parsed source into the structured dialect       |
+
+## License
+
+Apache-2.0. See [LICENSE](../../LICENSE).

--- a/crates/ptx-parse/README.md
+++ b/crates/ptx-parse/README.md
@@ -88,4 +88,4 @@ re-parsing.
 
 ## License
 
-Apache-2.0. See [LICENSE](../../LICENSE).
+Apache-2.0. See [LICENSE](https://github.com/NVlabs/cuda-oxide/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Every workspace member except `ptx-parse` ships a `README.md` **and** declares `readme = "README.md"` — 26 of 27 with both, and `ptx-parse` with neither.

It is the wrong crate to have missed. `ptx-parse` is the **only member that sets `publish = true`**:

```toml
# Published because cuda-host depends on it (name verified free on crates.io).
publish = true
description = "Lossless structural views over PTX source text"
```

So it is the one crate here whose crates.io page renders from a README — and that page would render with the one-line description and nothing else.

Its sibling `dialect-ptx`, from the same #914–#917 stack, has both, and its README sends readers here:

> `ptx-parse::Document` owns exact external source, trivia, unknown syntax, and byte-preserving edits.

Following that pointer currently lands on nothing.

## What the README says, and where each claim comes from

Written from the crate's own sources, not from an impression of them:

| Section | Source |
|:--|:--|
| Framing, and the deliberate no-ISA-type-checking rule | the `lib.rs` crate doc |
| Six `StatementKind` variants, `Document` accessors, `diagnostics`, `coverage`, `ParseError` | `lib.rs`, `syntax.rs` |
| `EditScript` surface, `apply_with_map`/`AppliedEdits`, `MapBias` at edit boundaries | `edit.rs` |
| The `ptx-parse` / `dialect-ptx` split | restated in the same terms `dialect-ptx`'s README already uses, so the two agree rather than drift |
| Consumer table | the actual `ptx_parse::` call sites in `cuda-oxide-codegen`, `cuda-host`, `cuda-intrinsics-gen`, `cargo-oxide`, `dialect-ptx` |

`readme = "README.md"` is added alongside, matching the other 26 manifests, so the packaged crate carries it too.

Happy to cut or reshape any of it — this is the one PR in this batch that adds prose rather than correcting it, and you or @lucifer1004 may have a different idea of what belongs on that page.

## Testing

Local, no GPU.

- [x] Every backticked API name in the new README resolves in `crates/ptx-parse/src/`
- [x] All 27 members now have both the file and the manifest field
- [x] `cargo metadata --locked` still parses; `cargo test -p ptx-parse` green (35 passed)
- [x] `check-crate-inventory`, `check-dependency-licenses`, `check-spdx-headers` pass
- [ ] `cargo oxide run <example>` — not applicable