### PR TITLE
docs(examples): state the ref_index_projections kernel total up front

### DIFF
--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -12,8 +12,8 @@ which later optimisation could then fold into a single path.
 
 ## What the example does
 
-`src/main.rs` contains **14 kernel variants** that bisect the trigger
-conditions:
+`src/main.rs` contains **32 kernels in four groups**. The first group's
+**14 variants** bisect the trigger conditions:
 
 | #  | Variant                              | Purpose                                        |
 |:---|:-------------------------------------|:-----------------------------------------------|


### PR DESCRIPTION
The README's "What the example does" section opens with the first table's 14 variants; the three "plus 6" regression groups only appear further down. Readers who compare the opening sentence against the 32 `#[kernel]` functions in src/main.rs conclude the count is stale and file corrections (#974).

- Open the section with the total: 32 kernels in four groups.
- Keep the first group's 14-variant framing; per-group counts are unchanged.
- No table rows change; the document's own "all 32 kernels report PASS" line now has a matching opener.