### PR TITLE
fix(mir-importer): admit thin-pointer union static relocations

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -8234,14 +8234,48 @@ fn validate_device_static_union_initializer(
     initializer: &GlobalInitializerData,
     loc: Location,
 ) -> TranslationResult<()> {
+    let relocation_slots: Vec<(u64, u32)> = initializer
+        .relocations
+        .iter()
+        .map(|relocation| (relocation.source_offset, relocation.width_bytes))
+        .collect();
+    validate_device_static_union_storage(
+        ctx,
+        union_ty,
+        rustc_public::target::MachineInfo::target_pointer_width().bytes(),
+        initializer.bytes.len() as u64,
+        initializer.alignment,
+        &relocation_slots,
+    )
+    .map_err(|message| {
+        input_error!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} contains {message}",
+                static_def.name()
+            ))
+        )
+    })
+}
+
+/// Pure storage gate behind [`validate_device_static_union_initializer`]:
+/// accept only a union that is one naturally aligned pointer word whose
+/// evaluated initializer is exactly one full-width relocation at byte zero.
+/// The caller attaches the static's name and source location to rejections.
+fn validate_device_static_union_storage(
+    ctx: &Context,
+    union_ty: TypeHandle,
+    pointer_width: usize,
+    initializer_len: u64,
+    initializer_align: u64,
+    relocation_slots: &[(u64, u32)],
+) -> Result<(), String> {
     let (union_name, union_size, union_align) = {
         let ty_ref = union_ty.deref(ctx);
         let union_ty = ty_ref
             .downcast_ref::<dialect_mir::types::MirUnionType>()
             .ok_or_else(|| {
-                input_error_noloc!(TranslationErr::unsupported(
-                    "validate_device_static_union_initializer called on non-union type"
-                ))
+                "a non-union type in the device-static union initializer gate".to_string()
             })?;
         (
             union_ty.name().to_string(),
@@ -8251,87 +8285,53 @@ fn validate_device_static_union_initializer(
     };
 
     let storage_kind = classify_union_constant_storage(ctx, union_ty).map_err(|message| {
-        input_error!(
-            loc.clone(),
-            TranslationErr::unsupported(format!(
-                "device static {} contains union `{union_name}` whose initializer cannot preserve pointer provenance: {message}",
-                static_def.name()
-            ))
+        format!(
+            "union `{union_name}` whose initializer cannot preserve pointer provenance: \
+             {message}"
         )
     })?;
     if !matches!(storage_kind, UnionConstantStorageKind::ThinPointer { .. }) {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} contains union `{union_name}` without thin-pointer storage; \
-                 device-global union initializers are supported only when every non-ZST \
-                 alternative is a representation-compatible thin pointer",
-                static_def.name()
-            ))
-        );
+        return Err(format!(
+            "union `{union_name}` without thin-pointer storage; device-global union \
+             initializers are supported only when every non-ZST alternative is a \
+             representation-compatible thin pointer"
+        ));
     }
 
-    let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
     if pointer_width != 8 {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} contains union `{union_name}`, but cuda-oxide currently \
-                 supports device-global union relocations only for 8-byte NVPTX pointers",
-                static_def.name()
-            ))
-        );
+        return Err(format!(
+            "union `{union_name}`, but cuda-oxide currently supports device-global union \
+             relocations only for 8-byte NVPTX pointers"
+        ));
     }
     let pointer_width_u64 = pointer_width as u64;
 
     if union_size != pointer_width_u64 || union_align != pointer_width_u64 {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} contains union `{union_name}` with size/alignment \
-                 {union_size}/{union_align}; device-global union relocations require exactly \
-                 one naturally aligned {pointer_width}-byte pointer word",
-                static_def.name()
-            ))
-        );
+        return Err(format!(
+            "union `{union_name}` with size/alignment {union_size}/{union_align}; \
+             device-global union relocations require exactly one naturally aligned \
+             {pointer_width}-byte pointer word"
+        ));
     }
-    if initializer.bytes.len() as u64 != pointer_width_u64
-        || initializer.alignment != pointer_width_u64
-    {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} union `{union_name}` has evaluated initializer \
-                 size/alignment {}/{}, expected {pointer_width}/{pointer_width}",
-                static_def.name(),
-                initializer.bytes.len(),
-                initializer.alignment
-            ))
-        );
+    if initializer_len != pointer_width_u64 || initializer_align != pointer_width_u64 {
+        return Err(format!(
+            "union `{union_name}` with evaluated initializer size/alignment \
+             {initializer_len}/{initializer_align}, expected {pointer_width}/{pointer_width}"
+        ));
     }
 
-    let [relocation] = initializer.relocations.as_slice() else {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} union `{union_name}` has {} initializer relocations; \
-                 exactly one thin-pointer relocation is required",
-                static_def.name(),
-                initializer.relocations.len()
-            ))
-        );
+    let [(source_offset, width_bytes)] = relocation_slots else {
+        return Err(format!(
+            "union `{union_name}` with {} initializer relocations; exactly one \
+             thin-pointer relocation is required",
+            relocation_slots.len()
+        ));
     };
-    if relocation.source_offset != 0 || u64::from(relocation.width_bytes) != pointer_width_u64 {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} union `{union_name}` relocation occupies byte {} with \
-                 width {}, expected one {pointer_width}-byte slot at byte zero",
-                static_def.name(),
-                relocation.source_offset,
-                relocation.width_bytes
-            ))
-        );
+    if *source_offset != 0 || u64::from(*width_bytes) != pointer_width_u64 {
+        return Err(format!(
+            "union `{union_name}` whose relocation occupies byte {source_offset} with \
+             width {width_bytes}, expected one {pointer_width}-byte slot at byte zero"
+        ));
     }
 
     Ok(())
@@ -13277,7 +13277,8 @@ mod aggregate_relocation_tests {
         UnionConstantStorageKind, classify_union_constant_storage, constant_type_contains_pointer,
         decode_relocation_addend, find_unconsumed_relocation, match_thin_pointer_relocation,
         provenance_starts_in_range, relocation_offsets_overlapping_range,
-        validate_array_value_element_type, validate_slice_relocation_shape,
+        validate_array_value_element_type, validate_device_static_union_storage,
+        validate_slice_relocation_shape,
     };
     use dialect_mir::types::{
         EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
@@ -13635,6 +13636,122 @@ mod aggregate_relocation_tests {
         assert!(
             validate_array_value_element_type(&ctx, ptr_ty, &Location::Unknown).is_err(),
             "direct pointer elements were never part of the bare array contract"
+        );
+    }
+
+    #[test]
+    fn device_static_union_storage_gate_admits_only_one_anchored_pointer_word() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let word_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
+        let byte_ptr_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u8_ty, false).into();
+        let thin_pointer_union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "ThinPointerWord".into(),
+            vec!["word".into(), "bytes".into()],
+            vec![word_ptr_ty, byte_ptr_ty],
+            8,
+            8,
+        )
+        .into();
+
+        assert_eq!(
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 8, 8, 8, &[(0, 8)]),
+            Ok(()),
+            "one naturally aligned pointer word with one anchored relocation is the \
+             accepted shape"
+        );
+
+        let byte_image_error =
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 4, 8, 8, &[(0, 8)])
+                .expect_err("a 32-bit pointer target must remain fail-closed");
+        assert!(
+            byte_image_error.contains("8-byte NVPTX pointers"),
+            "diagnostic must name the pointer-width restriction: {byte_image_error}"
+        );
+
+        let bytes_ty: TypeHandle = MirArrayType::get(&mut ctx, u8_ty, 4).into();
+        let pointer_free_union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "Bits".into(),
+            vec!["word".into(), "bytes".into()],
+            vec![u32_ty, bytes_ty],
+            4,
+            4,
+        )
+        .into();
+        let storage_error =
+            validate_device_static_union_storage(&ctx, pointer_free_union_ty, 8, 4, 4, &[(0, 8)])
+                .expect_err("byte-image unions take the literal-bytes path, not this gate");
+        assert!(
+            storage_error.contains("without thin-pointer storage"),
+            "diagnostic must explain the thin-pointer requirement: {storage_error}"
+        );
+
+        let wide_union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "TwoWords".into(),
+            vec!["first".into(), "second".into()],
+            vec![word_ptr_ty, byte_ptr_ty],
+            16,
+            8,
+        )
+        .into();
+        let size_error =
+            validate_device_static_union_storage(&ctx, wide_union_ty, 8, 16, 8, &[(0, 8)])
+                .expect_err("a union wider than one pointer word must remain fail-closed");
+        assert!(
+            size_error.contains("size/alignment 16/8"),
+            "diagnostic must report the rejected layout: {size_error}"
+        );
+
+        let initializer_error =
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 8, 16, 8, &[(0, 8)])
+                .expect_err("an over-sized evaluated initializer must remain fail-closed");
+        assert!(
+            initializer_error.contains("initializer size/alignment 16/8"),
+            "diagnostic must report the evaluated-initializer mismatch: {initializer_error}"
+        );
+
+        let uninit_error =
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 8, 8, 8, &[])
+                .expect_err("zero relocations (e.g. a ZST-field initializer) must fail closed");
+        assert!(
+            uninit_error.contains("0 initializer relocations"),
+            "diagnostic must count the missing relocation: {uninit_error}"
+        );
+
+        let multi_error = validate_device_static_union_storage(
+            &ctx,
+            thin_pointer_union_ty,
+            8,
+            8,
+            8,
+            &[(0, 4), (4, 4)],
+        )
+        .expect_err("two relocations cannot describe one pointer word");
+        assert!(
+            multi_error.contains("2 initializer relocations"),
+            "diagnostic must count the extra relocations: {multi_error}"
+        );
+
+        let offset_error =
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 8, 8, 8, &[(4, 8)])
+                .expect_err("a relocation off the word base must remain fail-closed");
+        assert!(
+            offset_error.contains("occupies byte 4"),
+            "diagnostic must locate the misplaced relocation: {offset_error}"
+        );
+
+        let width_error =
+            validate_device_static_union_storage(&ctx, thin_pointer_union_ty, 8, 8, 8, &[(0, 4)])
+                .expect_err("a narrow relocation cannot carry full pointer provenance");
+        assert!(
+            width_error.contains("width 4"),
+            "diagnostic must report the short relocation: {width_error}"
         );
     }
 }

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -7615,8 +7615,8 @@ fn translate_array_value_constant_inner(
 /// its fields.
 ///
 /// Aggregate **const** values with thin pointers to device statics are
-/// materialized per field; device-global *initializer* relocations remain a
-/// separate unsupported gap.
+/// materialized per field; device-global initializers use a separate
+/// allocation-level relocation path instead of this value reconstruction.
 fn translate_struct_constant(
     ctx: &mut Context,
     constant: &mir::ConstOperand,
@@ -8217,6 +8217,124 @@ fn classify_union_constant_storage(
         field_index,
         field_ty,
     })
+}
+
+/// Admit only the device-static union shape whose complete storage can be
+/// represented by one provenance-preserving thin-pointer relocation.
+///
+/// Device-global initializers do not retain a source-level active union field,
+/// so this path must prove the physical storage without guessing one. Keep the
+/// scope deliberately narrower than ordinary union SSA lowering: one top-level
+/// pointer-sized union, naturally aligned, one relocation at byte zero, and
+/// every non-ZST alternative a representation-compatible thin pointer.
+fn validate_device_static_union_initializer(
+    ctx: &Context,
+    static_def: &rustc_public::mir::mono::StaticDef,
+    union_ty: TypeHandle,
+    initializer: &GlobalInitializerData,
+    loc: Location,
+) -> TranslationResult<()> {
+    let (union_name, union_size, union_align) = {
+        let ty_ref = union_ty.deref(ctx);
+        let union_ty = ty_ref
+            .downcast_ref::<dialect_mir::types::MirUnionType>()
+            .ok_or_else(|| {
+                input_error_noloc!(TranslationErr::unsupported(
+                    "validate_device_static_union_initializer called on non-union type"
+                ))
+            })?;
+        (
+            union_ty.name().to_string(),
+            union_ty.total_size(),
+            union_ty.abi_align(),
+        )
+    };
+
+    let storage_kind = classify_union_constant_storage(ctx, union_ty).map_err(|message| {
+        input_error!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "device static {} contains union `{union_name}` whose initializer cannot preserve pointer provenance: {message}",
+                static_def.name()
+            ))
+        )
+    })?;
+    if !matches!(storage_kind, UnionConstantStorageKind::ThinPointer { .. }) {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} contains union `{union_name}` without thin-pointer storage; \
+                 device-global union initializers are supported only when every non-ZST \
+                 alternative is a representation-compatible thin pointer",
+                static_def.name()
+            ))
+        );
+    }
+
+    let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
+    if pointer_width != 8 {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} contains union `{union_name}`, but cuda-oxide currently \
+                 supports device-global union relocations only for 8-byte NVPTX pointers",
+                static_def.name()
+            ))
+        );
+    }
+    let pointer_width_u64 = pointer_width as u64;
+
+    if union_size != pointer_width_u64 || union_align != pointer_width_u64 {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} contains union `{union_name}` with size/alignment \
+                 {union_size}/{union_align}; device-global union relocations require exactly \
+                 one naturally aligned {pointer_width}-byte pointer word",
+                static_def.name()
+            ))
+        );
+    }
+    if initializer.bytes.len() as u64 != pointer_width_u64
+        || initializer.alignment != pointer_width_u64
+    {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} union `{union_name}` has evaluated initializer \
+                 size/alignment {}/{}, expected {pointer_width}/{pointer_width}",
+                static_def.name(),
+                initializer.bytes.len(),
+                initializer.alignment
+            ))
+        );
+    }
+
+    let [relocation] = initializer.relocations.as_slice() else {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} union `{union_name}` has {} initializer relocations; \
+                 exactly one thin-pointer relocation is required",
+                static_def.name(),
+                initializer.relocations.len()
+            ))
+        );
+    };
+    if relocation.source_offset != 0 || u64::from(relocation.width_bytes) != pointer_width_u64 {
+        return input_err!(
+            loc,
+            TranslationErr::unsupported(format!(
+                "device static {} union `{union_name}` relocation occupies byte {} with \
+                 width {}, expected one {pointer_width}-byte slot at byte zero",
+                static_def.name(),
+                relocation.source_offset,
+                relocation.width_bytes
+            ))
+        );
+    }
+
+    Ok(())
 }
 
 /// Verify that rustc and the MIR union agree on the exact stored size.
@@ -12142,19 +12260,33 @@ fn ensure_static_global_alloc(
     let allocation_size = initializer.bytes.len() as u64;
     let initializer_hex = bytes_to_hex(&initializer.bytes);
     let static_ty = static_def.ty();
-
-    if let Some(union_name) = stored_type_union_name(static_ty, &mut Vec::new()) {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "device static {} contains union `{union_name}`; initialized union storage is not yet supported",
-                static_def.name()
-            ))
-        );
-    }
-
     let is_constant = is_constant_wrapper_type(&static_ty);
     let global_ty = types::translate_type(ctx, &static_ty)?;
+
+    if let Some(union_name) = stored_type_union_name(static_ty, &mut Vec::new()) {
+        if global_ty
+            .deref(ctx)
+            .is::<dialect_mir::types::MirUnionType>()
+        {
+            validate_device_static_union_initializer(
+                ctx,
+                static_def,
+                global_ty,
+                &initializer,
+                loc.clone(),
+            )?;
+        } else {
+            return input_err!(
+                loc,
+                TranslationErr::unsupported(format!(
+                    "device static {} contains nested union `{union_name}`; device-global \
+                     union initializer relocations are supported only for a top-level \
+                     thin-pointer union",
+                    static_def.name()
+                ))
+            );
+        }
+    }
     let global_ptr_ty: TypeHandle = if is_constant {
         dialect_mir::types::MirPtrType::get_constant(ctx, global_ty, is_mutable).into()
     } else {

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -5024,6 +5024,27 @@ mod tests {
     }
 
     #[test]
+    fn relocated_initialized_global_layout_accepts_thin_pointer_union() {
+        let mut ctx = make_ctx();
+        let u32_ty = mir_uint(&mut ctx, 32);
+        let u8_ty = mir_uint(&mut ctx, 8);
+        let word_ptr: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
+        let byte_ptr: TypeHandle = MirPtrType::get_generic(&mut ctx, u8_ty, false).into();
+        let union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "RelocatedPointerUnion".into(),
+            vec!["word".into(), "byte".into()],
+            vec![word_ptr, byte_ptr],
+            8,
+            8,
+        )
+        .into();
+
+        validate_relocated_initialized_global_layout(&mut ctx, union_ty, 8, 8)
+            .expect("one pointer-word union must be valid relocated global storage");
+    }
+
+    #[test]
     fn relocated_initialized_global_layout_rejects_malformed_memory_order() {
         let mut ctx = make_ctx();
         let byte = mir_uint(&mut ctx, 8);

--- a/crates/rustc-codegen-cuda/examples/device_global/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_global/README.md
@@ -51,6 +51,14 @@ each slot with `getelementptr`, `addrspacecast`, and `ptrtoint` constant
 expressions, so the device linker sees an actual relocation rather than a null
 placeholder.
 
+A top-level union initializer is also supported when its complete storage is
+exactly one naturally aligned pointer word and every non-ZST union alternative
+is a representation-compatible thin pointer. The example initializes the union
+with `&UNION_RELOCATION_TARGETS[2]`, so the same check also covers an 8-byte
+non-zero target addend. Pointer/integer unions, fat or nested pointer storage,
+mixed pointer address spaces, nested unions, and padded, over-aligned, or
+under-aligned union storage remain fail-closed.
+
 Packed `repr(C, packed)` statics are also covered. When either the allocation
 alignment or a relocation's byte offset cannot satisfy the pointer carrier's
 natural alignment, cuda-oxide uses a packed LLVM struct only as the physical
@@ -67,6 +75,7 @@ The relocation coverage includes:
 - two fields sharing one target;
 - a second independently materialized target;
 - an interior pointer with a non-zero byte addend;
+- a top-level thin-pointer union occupying one pointer word;
 - packed/unaligned relocation slots, including literal prefix/suffix bytes;
 - targets reachable only through another static initializer;
 - modern opaque-pointer NVVM IR and legacy LLVM 7 typed-pointer NVVM IR.
@@ -110,8 +119,11 @@ producing a wrong value.
 
 The supported relocation scope is intentionally narrow: thin pointers from one
 device static to another device static in global or constant memory, including
-zero and non-zero byte addends. Anonymous promoted allocations, functions,
-vtables, trait-object metadata, slices and other fat pointers, unsized pointees,
-and relocation targets outside device static storage remain fail-closed. Packed
-or otherwise unaligned thin-pointer slots are supported when the containing
-top-level struct has an explicit, non-overlapping rustc layout.
+zero and non-zero byte addends. A top-level union is admitted only when the
+complete union is one naturally aligned pointer word and every non-ZST
+alternative is a representation-compatible thin pointer. Anonymous promoted
+allocations, functions, vtables, trait-object metadata, slices and other fat
+pointers, unsized pointees, nested unions, pointer/integer unions, and relocation
+targets outside device static storage remain fail-closed. Packed or otherwise
+unaligned thin-pointer slots are supported when the containing top-level struct
+has an explicit, non-overlapping rustc layout.

--- a/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
@@ -28,6 +28,18 @@ static RELOCATION_REFERENCE: &u32 = &RELOCATION_TARGET_A;
 static RELOCATION_REFERENCES: [&u32; 2] = [&RELOCATION_TARGET_A, &RELOCATION_TARGET_B];
 static INTERIOR_RELOCATION_REFERENCE: &f32 = &STATIC_WEIGHTS[2][1];
 
+static UNION_RELOCATION_TARGETS: [u32; 3] = [7, 11, 23];
+
+#[repr(C)]
+union RelocatedPointerUnion {
+    word: &'static u32,
+    byte: &'static u8,
+}
+
+static UNION_RELOCATION: RelocatedPointerUnion = RelocatedPointerUnion {
+    word: &UNION_RELOCATION_TARGETS[2],
+};
+
 #[repr(C, packed)]
 struct PackedRelocation {
     tag: u8,
@@ -169,6 +181,15 @@ mod kernels {
             *out.add(1) = *RELOCATION_REFERENCES[0];
             *out.add(2) = *RELOCATION_REFERENCES[1];
             *out.add(3) = (*INTERIOR_RELOCATION_REFERENCE).to_bits();
+        }
+    }
+
+    /// Read a top-level union whose complete static initializer is one
+    /// provenance-preserving pointer relocation with a non-zero target addend.
+    #[kernel]
+    pub unsafe fn union_static_initializer_relocation(out: *mut u32) {
+        unsafe {
+            *out = *UNION_RELOCATION.word;
         }
     }
 
@@ -344,6 +365,31 @@ fn main() {
         std::process::exit(1);
     }
 
+    let union_relocation_out_dev =
+        DeviceBuffer::<u32>::zeroed(&stream, 1).expect("Failed to allocate union relocation output");
+
+    unsafe {
+        module.union_static_initializer_relocation(
+            &stream,
+            LaunchConfig::for_num_elems(1),
+            union_relocation_out_dev.cu_deviceptr() as *mut u32,
+        )
+    }
+    .expect("Union static initializer relocation kernel launch failed");
+
+    let union_relocation_result = union_relocation_out_dev
+        .to_host_vec(&stream)
+        .expect("Failed to copy union relocation output")[0];
+
+    println!("Union static initializer relocation: result = {union_relocation_result}");
+
+    if union_relocation_result != 23 {
+        eprintln!(
+            "FAILED: expected union static initializer relocation 23, got {union_relocation_result}"
+        );
+        std::process::exit(1);
+    }
+
     let packed_relocation_out_dev = DeviceBuffer::<u32>::zeroed(&stream, 5)
         .expect("Failed to allocate packed relocation output");
 
@@ -394,6 +440,6 @@ fn main() {
     }
 
     println!(
-        "\nSUCCESS: device globals preserved storage, initializer bytes, aligned and packed pointer relocations, pointer addends, and subobject addresses."
+        "\nSUCCESS: device globals preserved storage, initializer bytes, aligned, packed, and union pointer relocations, pointer addends, and subobject addresses."
     );
 }

--- a/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
@@ -365,8 +365,8 @@ fn main() {
         std::process::exit(1);
     }
 
-    let union_relocation_out_dev =
-        DeviceBuffer::<u32>::zeroed(&stream, 1).expect("Failed to allocate union relocation output");
+    let union_relocation_out_dev = DeviceBuffer::<u32>::zeroed(&stream, 1)
+        .expect("Failed to allocate union relocation output");
 
     unsafe {
         module.union_static_initializer_relocation(


### PR DESCRIPTION
Closes #983 

## Summary

Allow a narrowly defined class of top-level union device-global initializers to reuse the existing provenance-preserving static relocation path.

Previously, `ensure_static_global_alloc` rejected any initialized static whose stored type contained a union before the initializer relocation metadata could be lowered.

This change admits the case where the complete union storage is provably one representation-compatible thin pointer.

## What changes

`mir-importer` now validates a top-level union initializer before creating the global allocation.

The accepted shape is intentionally strict:

- the static itself lowers to a MIR union type;
- the union is exactly one target pointer word in size;
- the union has natural pointer alignment;
- every non-ZST union field is a representation-compatible thin pointer;
- pointer alternatives use the same address space;
- the evaluated initializer contains exactly one pointer relocation;
- that relocation starts at byte zero and occupies the complete pointer word.

Once those conditions are proven, the implementation reuses the existing
device-global initializer relocation path unchanged.

Nested union storage remains rejected.

## Why this is safe

A device-global initializer does not retain a source-level notion of the active union field.

Therefore this patch does not attempt to infer or select one.

Instead, it only accepts unions for which all non-ZST alternatives describe the same physical pointer representation and the complete initialized storage is covered by one relocation. The relocation remains the source of pointer provenance, including its target addend.

Unsupported layouts continue to fail closed.

## Example

The `device_global` example now covers a union initialized with a pointer to an array subobject:

```rust
static UNION_RELOCATION_TARGETS: [u32; 3] = [7, 11, 23];

#[repr(C)]
union RelocatedPointerUnion {
    word: &'static u32,
    byte: &'static u8,
}

static UNION_RELOCATION: RelocatedPointerUnion = RelocatedPointerUnion {
    word: &UNION_RELOCATION_TARGETS[2],
};
```

The kernel dereferences the union pointer and returns `23`.

This also exercises a non-zero relocation addend, so the test verifies more than preservation of a pointer-shaped initializer.

## Tests

Passed locally:

```text
cargo fmt --all -- --check

cargo test -p mir-importer --lib
1089 passed; 0 failed

cargo clippy -p mir-importer --all-targets -- -D warnings

cargo test -p mir-lower --lib
247 passed; 0 failed

cargo clippy -p mir-lower --all-targets -- -D warnings

cargo oxide run device_global
PASS
Union static initializer relocation: result = 23

CUDA_OXIDE_NO_OPT=1 cargo oxide run device_global
PASS
Union static initializer relocation: result = 23

scripts/smoketest.sh --only '^device_global$' --no-color --keep-logs
1 passed; 0 failed

git diff --check
```

## Scope

This PR intentionally does not add support for:

* pointer/integer union storage;
* fat-pointer alternatives;
* nested pointer-bearing union fields;
* mixed address spaces;
* nested unions inside aggregate static storage;
* padded or non-naturally-aligned union layouts;
* multiple relocations within union storage.

Those cases require additional representation rules and should be handled separately.
