### PR TITLE
fix(mir-importer): preserve nested enum constant provenance

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -11651,13 +11651,15 @@ fn translate_constant_value_from_alloc(
     if is_enum {
         let size = rust_type_layout_size(*rust_ty, loc.clone())?;
         if alloc_has_provenance_in_range(alloc, absolute_byte_offset, size) {
-            return input_err!(
+            return translate_enum_constant_from_alloc(
+                ctx,
+                alloc,
+                absolute_byte_offset,
+                rust_ty,
+                ty_ptr,
+                block_ptr,
+                prev_op,
                 loc,
-                TranslationErr::unsupported(
-                    "Nested enum constant contains pointer relocation(s); cuda-oxide cannot yet \
-                     preserve nested enum pointer provenance"
-                        .to_string()
-                )
             );
         }
     }

--- a/crates/rustc-codegen-cuda/examples/enum_constant_provenance/README.md
+++ b/crates/rustc-codegen-cuda/examples/enum_constant_provenance/README.md
@@ -7,12 +7,16 @@ The example covers:
 - a niche-encoded `Option<&T>` pointing at an interior device-static element;
 - the niche variant without a pointer relocation;
 - a direct-tagged `#[repr(u8)]` enum without a payload;
-- a direct-tagged enum with a pointer payload.
+- a direct-tagged enum with a pointer payload;
+- a direct-tagged relocation-carrying enum nested at a non-zero offset in a
+  struct constant;
+- a niche-encoded `Option<&T>` nested in a tuple constant;
+- a relocation-carrying enum nested in an array constant.
 
-The importer must preserve the enum's outer allocation while reconstructing
-pointer fields from rustc relocation entries. The bytes stored under a
-relocation represent the addend into the target allocation, not an exposed
-pointer address.
+The importer must preserve the enclosing allocation while recursively
+reconstructing enum pointer fields from rustc relocation entries. The bytes
+stored under a relocation represent the addend into the target allocation, not
+an exposed pointer address.
 
 ```bash
 cargo oxide run enum_constant_provenance
@@ -24,6 +28,5 @@ Expected result:
 enum_constant_provenance: PASS
 ```
 
-Pointer/integer overlapping enum storage, address-space-3 pointer layouts,
-anonymous promoted allocations, and pointer relocations nested inside aggregate
-enum fields remain unsupported.
+Pointer/integer overlapping enum storage, address-space-3 pointer layouts, and
+anonymous promoted allocations remain unsupported.

--- a/crates/rustc-codegen-cuda/examples/enum_constant_provenance/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/enum_constant_provenance/src/main.rs
@@ -6,7 +6,8 @@
 //! Runtime regression for pointer provenance in enum constants.
 //!
 //! Covers niche-encoded enums pointing to a device static or an interior
-//! static subobject, plus direct-tagged enums.
+//! static subobject, direct-tagged enums, and relocation-carrying enums nested
+//! inside struct, tuple, and array constants.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
 use cuda_device::kernel;
@@ -27,8 +28,23 @@ enum TaggedReference {
     Present(&'static u64),
 }
 
+#[derive(Clone, Copy)]
+struct EnumHolder {
+    marker: u32,
+    item: TaggedReference,
+}
+
 const DIRECT_EMPTY: TaggedReference = TaggedReference::Empty;
 const DIRECT_TAGGED: TaggedReference = TaggedReference::Present(&TARGETS[0]);
+const NESTED_STRUCT: EnumHolder = EnumHolder {
+    marker: 17,
+    item: TaggedReference::Present(&TARGETS[1]),
+};
+const NESTED_TUPLE: (u32, Option<&'static u64>) = (23, Some(&TARGETS[0]));
+const NESTED_ARRAY: [TaggedReference; 2] = [
+    TaggedReference::Empty,
+    TaggedReference::Present(&TARGETS[1]),
+];
 
 #[inline(never)]
 fn niche_static() -> Option<&'static u64> {
@@ -51,6 +67,21 @@ fn direct_tagged() -> TaggedReference {
 }
 
 #[inline(never)]
+fn nested_struct() -> EnumHolder {
+    NESTED_STRUCT
+}
+
+#[inline(never)]
+fn nested_tuple() -> (u32, Option<&'static u64>) {
+    NESTED_TUPLE
+}
+
+#[inline(never)]
+fn nested_array() -> [TaggedReference; 2] {
+    NESTED_ARRAY
+}
+
+#[inline(never)]
 fn tagged_value(value: TaggedReference) -> u64 {
     match value {
         TaggedReference::Empty => 0,
@@ -64,7 +95,7 @@ mod kernels {
 
     /// # Safety
     ///
-    /// `output` must point to writable device memory for four `u64` values.
+    /// `output` must point to writable device memory for eight `u64` values.
     #[kernel]
     pub unsafe fn enum_pointer_constants(output: *mut u64) {
         let static_value = niche_static().map_or(0, |pointer| *pointer);
@@ -72,24 +103,37 @@ mod kernels {
         let direct_empty_value = tagged_value(direct_empty());
         let direct_tagged_value = tagged_value(direct_tagged());
 
+        let holder = nested_struct();
+        let nested_struct_marker = holder.marker as u64;
+        let nested_struct_value = tagged_value(holder.item);
+
+        let nested_tuple_value = nested_tuple().1.map_or(0, |pointer| *pointer);
+
+        let array_value = nested_array();
+        let nested_array_value = tagged_value(array_value[1]);
+
         unsafe {
             output.add(0).write(static_value);
             output.add(1).write(none_value);
             output.add(2).write(direct_empty_value);
             output.add(3).write(direct_tagged_value);
+            output.add(4).write(nested_struct_marker);
+            output.add(5).write(nested_struct_value);
+            output.add(6).write(nested_tuple_value);
+            output.add(7).write(nested_array_value);
         }
     }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const OUTPUT_COUNT: usize = 4;
+    const OUTPUT_COUNT: usize = 8;
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
     let module = kernels::load(&ctx)?;
     let output = DeviceBuffer::<u64>::zeroed(&stream, OUTPUT_COUNT)?;
 
-    // SAFETY: the output allocation contains four u64 values and exactly one
+    // SAFETY: the output allocation contains eight u64 values and exactly one
     // thread is launched.
     unsafe {
         module.enum_pointer_constants(
@@ -100,7 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }?;
 
     let actual = output.to_host_vec(&stream)?;
-    let expected = [SECOND, 0, 0, FIRST];
+    let expected = [SECOND, 0, 0, FIRST, 17, SECOND, FIRST, SECOND];
 
     assert_eq!(
         actual.as_slice(),

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -74,9 +74,9 @@ relocations in device-global union initializers remain rejected.
 Enum constants preserve payload relocations to device statics, including
 non-zero byte addends. This includes niche-encoded `Option<&T>` and
 direct-tagged enum layouts, both for direct thin-reference payloads and for
-pointers nested inside tuple, struct, or array payload fields. Anonymous
-promoted allocations remain unsupported, as does a relocation-carrying enum
-constant nested inside another constant's field.
+pointers nested inside tuple, struct, or array payload fields. Relocation-carrying
+enum constants can also be nested inside tuple, struct, and array constants.
+Anonymous promoted allocations remain unsupported.
 
 ## Compiler: Closures
 


### PR DESCRIPTION
Closes #989 

## Summary

Preserve pointer provenance for relocation-carrying enum constants nested inside aggregate constants.

Previously, `translate_constant_value_from_alloc` explicitly rejected a nested enum whenever relocation entries were present in the enum's byte range.

This change delegates that case to the existing allocation-aware enum decoder, using the nested field's absolute byte offset.

## Implementation

When an aggregate field is an enum:

- relocation-free enums continue through the existing path;
- if provenance exists within the enum storage range, the importer now calls `translate_enum_constant_from_alloc`;
- the enclosing allocation and `absolute_byte_offset` are preserved, allowing the existing enum decoder to reconstruct pointer fields from rustc relocation entries.

No new enum decoding mechanism is introduced.

## Regression coverage

Extend `enum_constant_provenance` with:

- a direct-tagged enum nested inside a struct at a non-zero offset;
- a niche-encoded `Option<&T>` nested inside a tuple;
- a relocation-carrying direct-tagged enum nested inside an array.

The runtime regression verifies both the enclosing aggregate values and the
pointer targets reconstructed from relocation provenance.

## Documentation

Update the supported-features documentation to record that relocation-carrying enum constants may now be nested inside tuple, struct, and array constants.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p mir-importer`
- `cargo clippy -p mir-importer --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/rustc-codegen-cuda/examples/enum_constant_provenance/Cargo.toml --all-targets -- -D warnings`
- `scripts/smoketest.sh --compile-only -o '^enum_constant_provenance$'`
- `cargo oxide run enum_constant_provenance`
- `just book`

The importer test suite completed with 1089 passing tests, and the documentation build completed successfully.

The `enum_constant_provenance` regression also passes both libNVVM compilation and GPU runtime validation.

## Non-goals

This PR does not change support for:

- anonymous promoted allocations;
- pointer/integer overlapping enum storage;
- unsupported address-space pointer layouts;
- unrelated enum or aggregate constant layouts.
