### PR TITLE
perf(mir-importer): promote pointer-bearing constant tables

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -6592,16 +6592,21 @@ fn translate_ptr_to_array_constant(
             ))
         );
     }
-    let (bytes, alignment) =
-        promoted_array_initializer(constant, expected_size, "array", loc.clone())?;
+    let initializer = promoted_array_initializer(constant, expected_size, "array", loc.clone())?;
+    let promoted_anchor = materialize_promoted_initializer_targets(
+        ctx,
+        &initializer.relocations,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
 
     let global_alloc = emit_promoted_immutable_global(
         ctx,
         array_ty,
-        &bytes,
-        alignment,
+        &initializer,
         block_ptr,
-        prev_op,
+        promoted_anchor,
         loc.clone(),
     );
 
@@ -6617,23 +6622,21 @@ fn translate_ptr_to_array_constant(
     Ok((ptr_val, last_op))
 }
 
-/// Materialize `bytes` as an immutable device global holding a `value_ty`.
+/// Materialize an evaluated constant allocation as an immutable device global.
 ///
-/// Deduplicated by (type, bytes), so the same table spelled several ways — or
-/// reached from several functions — is emitted once.
+/// Deduplicated by type, bytes, and relocation identity. Pointer placeholder
+/// bytes alone are not enough: two constants can have identical byte images and
+/// addends while their rustc provenance targets different statics.
 ///
 /// The global is marked immutable, which is what makes it useful beyond simply
 /// having an address: the exporter writes LLVM `constant`, so `opt` may treat
-/// reads of it as invariant. That is what lets a copy of the data into a stack
-/// slot be deleted (`isOnlyCopiedFromConstantMemory`) and what makes `llc`
-/// select `ld.global.nc`. The claim is sound here and only here: the bytes are
-/// an evaluated Rust constant, the name is compiler-generated so no host setter
-/// can reach it, and nothing is handed a mutable path to the storage.
+/// reads of it as invariant. Pointer slots remain symbolic relocation metadata
+/// all the way to the exporter instead of being reconstructed from placeholder
+/// integer bytes.
 pub(crate) fn emit_promoted_immutable_global(
     ctx: &mut Context,
     value_ty: TypeHandle,
-    bytes: &[u8],
-    alignment: u64,
+    initializer: &GlobalInitializerData,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
@@ -6641,8 +6644,8 @@ pub(crate) fn emit_promoted_immutable_global(
     use dialect_mir::types::MirPtrType;
     use pliron::builtin::attributes::{StringAttr, TypeAttr};
 
-    let initializer_hex = bytes_to_hex(bytes);
-    let global_key = promoted_constant_dedup_key(ctx, value_ty, bytes);
+    let initializer_hex = bytes_to_hex(&initializer.bytes);
+    let global_key = promoted_constant_dedup_key(ctx, value_ty, initializer);
     let global_ptr_ty = MirPtrType::get_global(ctx, value_ty, false);
 
     let global_op = Operation::new(
@@ -6659,8 +6662,12 @@ pub(crate) fn emit_promoted_immutable_global(
     global_alloc.set_attr_global_type(ctx, TypeAttr::new(value_ty));
     global_alloc.set_attr_global_key(ctx, StringAttr::new(global_key));
     set_global_initializer_hex_attr(ctx, global_alloc.get_operation(), &initializer_hex);
-    if alignment > 0 {
-        global_alloc.set_alignment_value(ctx, alignment);
+    if !initializer.relocations.is_empty() {
+        let encoded = encode_global_initializer_relocations(&initializer.relocations);
+        set_global_initializer_relocations_attr(ctx, global_alloc.get_operation(), &encoded);
+    }
+    if initializer.alignment > 0 {
+        global_alloc.set_alignment_value(ctx, initializer.alignment);
     }
     global_alloc.mark_immutable(ctx);
 
@@ -6673,6 +6680,35 @@ pub(crate) fn emit_promoted_immutable_global(
     global_alloc
 }
 
+/// Ensure every Rust static referenced by a promoted initializer exists as a
+/// MIR global before the promoted table is emitted.
+///
+/// Without this step the old element-wise pointer decoder used to materialize
+/// the targets as a side effect. Once the entire table stays in one global, the
+/// relocation metadata is the only reference and the targets must be made
+/// explicit here.
+fn materialize_promoted_initializer_targets(
+    ctx: &mut Context,
+    relocations: &[GlobalInitializerRelocation],
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> TranslationResult<Option<Ptr<Operation>>> {
+    let mut state = StaticGlobalMaterializationState {
+        globals: std::collections::HashMap::new(),
+        last_op: prev_op,
+    };
+    ensure_initializer_relocation_targets(
+        ctx,
+        relocations,
+        "promoted constant table",
+        block_ptr,
+        loc,
+        &mut state,
+    )?;
+    Ok(state.last_op)
+}
+
 /// Whether an array's elements are cheap enough to be worth promoting the whole
 /// array to an immutable global and copying it in.
 ///
@@ -6683,8 +6719,11 @@ pub(crate) fn emit_promoted_immutable_global(
 /// bare-array value admission: an unpromotable bare value can fall back to
 /// element-wise materialization, while a pointer-to-array constant cannot.
 ///
-/// Admits primitive scalars, enums carrying no payload, tuples and structs whose
-/// every field is itself admissible, and nested arrays of any of those. `ty` is
+/// Admits primitive scalars, thin pointers, enums carrying no payload, tuples
+/// and structs whose every field is itself admissible, and nested arrays of any
+/// of those. Pointer admission is still relocation-gated later: only provenance
+/// that can be represented by [`GlobalInitializerRelocation`] reaches promotion.
+/// `ty` is
 /// the array type, and nesting is walked so an unsupported leaf cannot hide
 /// inside it. A zero-length array passes for any element type: its initializer
 /// is empty and nothing can ever be read through it, which is what admits a
@@ -6698,9 +6737,10 @@ pub(crate) fn emit_promoted_immutable_global(
 /// read addressed in place, the promotion is what removes the depot — the two
 /// only pay off together.
 ///
-/// Structs are admitted recursively, so a struct containing a pointer, union,
-/// payload-carrying enum, or any other unsupported leaf remains outside this
-/// path. A payload-carrying enum stays out because reading one back still
+/// Structs are admitted recursively, including thin pointer fields. Unions,
+/// fat-pointer storage, payload-carrying enums, and any other unsupported leaf
+/// remain outside this path. A payload-carrying enum stays out because reading
+/// one back still
 /// round-trips the payload through memory: the address walker resolves enum
 /// payload fields for writes, not for reads.
 ///
@@ -6772,7 +6812,8 @@ fn promotable_array_element(ctx: &Context, ty: TypeHandle) -> bool {
                 .iter()
                 .all(|&count| count == 0);
     }
-    obj.is::<IntegerType>()
+    obj.is::<dialect_mir::types::MirPtrType>()
+        || obj.is::<IntegerType>()
         || obj.is::<MirFP16Type>()
         || obj.is::<FP32Type>()
         || obj.is::<FP64Type>()
@@ -6856,7 +6897,7 @@ fn struct_layout_matches_llvm_natural(
 /// [`promotable_array_element`]) before the answer is trusted. A field-less
 /// enum stores only its discriminant, so it aligns as that integer does.
 fn llvm_natural_size_align(ctx: &Context, ty: TypeHandle) -> Option<(u64, u64)> {
-    use dialect_mir::types::{MirArrayType, MirEnumType, MirStructType, MirTupleType};
+    use dialect_mir::types::{MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType};
 
     let obj = ty.deref(ctx);
     if let Some(array) = obj.downcast_ref::<MirArrayType>() {
@@ -6887,7 +6928,11 @@ fn llvm_natural_size_align(ctx: &Context, ty: TypeHandle) -> Option<(u64, u64)> 
         let (_, align) = llvm_natural_size_align(ctx, discriminant_ty)?;
         return Some((total_size, align));
     }
-    let size = if let Some(integer) = obj.downcast_ref::<IntegerType>() {
+    let size = if obj.is::<MirPtrType>() {
+        // cuda-oxide lowers device code for 64-bit NVPTX. Keep this helper
+        // independent of rustc's session TLS so it remains unit-testable.
+        8
+    } else if let Some(integer) = obj.downcast_ref::<IntegerType>() {
         // `bool` arrives as `i1` and occupies a byte.
         u64::from(integer.width().div_ceil(8)).max(1)
     } else if obj.is::<MirFP16Type>() {
@@ -6930,7 +6975,7 @@ fn aggregate_natural_align(ctx: &Context, fields: &[TypeHandle]) -> Option<u64> 
 /// for a genuine zero-sized type and for a size it does not know, and only the
 /// caller's own size comparison could tell them apart.
 fn dialect_stored_size(ctx: &Context, ty: TypeHandle) -> Option<u64> {
-    use dialect_mir::types::{MirArrayType, MirEnumType, MirStructType, MirTupleType};
+    use dialect_mir::types::{MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType};
 
     let obj = ty.deref(ctx);
     let size = if let Some(array) = obj.downcast_ref::<MirArrayType>() {
@@ -6942,6 +6987,10 @@ fn dialect_stored_size(ctx: &Context, ty: TypeHandle) -> Option<u64> {
         structure.total_size()
     } else if let Some(enumeration) = obj.downcast_ref::<MirEnumType>() {
         enumeration.total_size()
+    } else if obj.is::<MirPtrType>() {
+        // cuda-oxide lowers device code for 64-bit NVPTX. Keep this helper
+        // independent of rustc's session TLS so it remains unit-testable.
+        8
     } else if let Some(integer) = obj.downcast_ref::<IntegerType>() {
         // `bool` arrives as `i1` and occupies a byte.
         u64::from(integer.width().div_ceil(8)).max(1)
@@ -7086,23 +7135,28 @@ pub(crate) fn translate_array_constant_into_alloca(
     if dialect_stored_size(ctx, value_ty) != Some(expected_size as u64) {
         return Ok(None);
     }
-    // Rejects pointer relocations, and any byte image that is not exactly the
-    // Rust size — so the global cannot disagree with the local it fills.
-    let Ok((bytes, alignment)) =
-        promoted_array_initializer(constant, expected_size, "array", loc.clone())
+    // Preserve both the evaluated byte image and any supported pointer
+    // relocations. Unsupported relocation targets keep the existing element-wise
+    // fallback rather than partially promoting the table.
+    let Ok(initializer) = promoted_array_initializer(constant, expected_size, "array", loc.clone())
     else {
         return Ok(None);
     };
+    let promoted_anchor = materialize_promoted_initializer_targets(
+        ctx,
+        &initializer.relocations,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
 
-    // Past every bail-out: nothing below can fail, so no half-built global is
-    // left behind in the block.
+    // Past every promotion bail-out: emit one immutable global and copy it into the local.
     let global_alloc = emit_promoted_immutable_global(
         ctx,
         value_ty,
-        &bytes,
-        alignment,
+        &initializer,
         block_ptr,
-        prev_op,
+        promoted_anchor,
         loc.clone(),
     );
     let src = global_alloc.get_operation().deref(ctx).get_result(0);
@@ -7158,7 +7212,7 @@ fn validate_ptr_to_array_constant_type(
     input_err!(
         loc,
         TranslationErr::unsupported(format!(
-            "Array constant element type is not supported: {:?}. Supported array constants are primitive scalars (integers, f16, f32, f64), field-less enums, tuples and structs recursively composed of supported fields, or nested arrays of those.",
+            "Array constant element type is not supported: {:?}. Supported promoted array constants are primitive scalars (integers, f16, f32, f64), thin pointers/references with supported static relocations, field-less enums, tuples and structs recursively composed of supported fields, or nested arrays of those.",
             ty.deref(ctx)
         ))
     )
@@ -10365,7 +10419,7 @@ struct GlobalInitializerRelocation {
 /// Literal bytes remain byte-exact. Pointer slots are carried separately so
 /// lowering can replace their placeholder addend bytes with LLVM relocation
 /// expressions without changing padding, NaN payloads, or field offsets.
-struct GlobalInitializerData {
+pub(crate) struct GlobalInitializerData {
     bytes: Vec<u8>,
     alignment: u64,
     relocations: Vec<GlobalInitializerRelocation>,
@@ -10518,50 +10572,128 @@ fn allocation_initializer_data(
     })
 }
 
-/// Follow the one outer pointer used for a promoted array, then copy the
-/// referenced array allocation into global storage.
+/// Build the byte-exact, relocation-aware initializer used by array promotion.
+///
+/// Bare `[T; N]` constants own their allocation directly, so provenance entries
+/// inside that allocation belong to pointer fields in the table. Pointer-to-array
+/// constants (`&[T; N]` / `*const [T; N]`) instead contain one outer relocation
+/// to the backing allocation; that relocation is followed once and any
+/// relocations inside the selected table range are preserved and rebased.
 fn promoted_array_initializer(
     constant: &mir::ConstOperand,
     expected_size: usize,
     kind_name: &str,
     loc: Location,
-) -> TranslationResult<(Vec<u8>, u64)> {
+) -> TranslationResult<GlobalInitializerData> {
     use rustc_public::mir::alloc::GlobalAlloc;
-    use rustc_public::ty::TyConstKind;
+    use rustc_public::ty::{RigidTy, TyConstKind, TyKind};
 
-    fn initializer_from_allocation(
+    fn direct_initializer(
         alloc: &rustc_public::ty::Allocation,
         expected_size: usize,
         kind_name: &str,
         loc: Location,
-    ) -> TranslationResult<(Vec<u8>, u64)> {
-        let Some(&(provenance_offset, provenance)) = alloc.provenance.ptrs.first() else {
-            let data = allocation_initializer_data(
-                alloc,
-                &format!("promoted {kind_name} initializer"),
-                loc.clone(),
-            )?;
-            if !data.relocations.is_empty() {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "promoted {kind_name} initializer contains {} pointer relocation(s); promoted array provenance is not part of device-global static relocation support",
-                        data.relocations.len()
-                    ))
-                );
-            }
-            if data.bytes.len() != expected_size {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "promoted {kind_name} initializer is {} bytes, expected {expected_size}",
-                        data.bytes.len()
-                    ))
-                );
-            }
-            return Ok((data.bytes, data.alignment));
-        };
+    ) -> TranslationResult<GlobalInitializerData> {
+        let data = allocation_initializer_data(
+            alloc,
+            &format!("promoted {kind_name} initializer"),
+            loc.clone(),
+        )?;
+        if data.bytes.len() != expected_size {
+            return input_err!(
+                loc,
+                TranslationErr::unsupported(format!(
+                    "promoted {kind_name} initializer is {} bytes, expected {expected_size}",
+                    data.bytes.len()
+                ))
+            );
+        }
+        Ok(data)
+    }
 
+    fn project_initializer_range(
+        data: GlobalInitializerData,
+        target_offset: usize,
+        expected_size: usize,
+        kind_name: &str,
+        loc: Location,
+    ) -> TranslationResult<GlobalInitializerData> {
+        let end = target_offset.checked_add(expected_size).ok_or_else(|| {
+            input_error_noloc!(TranslationErr::unsupported(format!(
+                "promoted {kind_name} initializer offset overflows its allocation"
+            )))
+        })?;
+        let bytes = data
+            .bytes
+            .get(target_offset..end)
+            .ok_or_else(|| {
+                input_error_noloc!(TranslationErr::unsupported(format!(
+                    "promoted {kind_name} initializer needs bytes {target_offset}..{end}, but its backing allocation is only {} bytes",
+                    data.bytes.len()
+                )))
+            })?
+            .to_vec();
+        let alignment = data.alignment;
+
+        let mut relocations = Vec::new();
+        for relocation in data.relocations {
+            let source_start = usize::try_from(relocation.source_offset).map_err(|_| {
+                input_error_noloc!(TranslationErr::unsupported(format!(
+                    "promoted {kind_name} relocation source offset {} does not fit usize",
+                    relocation.source_offset
+                )))
+            })?;
+            let width = usize::try_from(relocation.width_bytes).map_err(|_| {
+                input_error_noloc!(TranslationErr::unsupported(format!(
+                    "promoted {kind_name} relocation width {} does not fit usize",
+                    relocation.width_bytes
+                )))
+            })?;
+            let source_end = source_start.checked_add(width).ok_or_else(|| {
+                input_error_noloc!(TranslationErr::unsupported(format!(
+                    "promoted {kind_name} relocation at byte {source_start} overflows"
+                )))
+            })?;
+            let overlaps = source_start < end && source_end > target_offset;
+            if !overlaps {
+                continue;
+            }
+            if source_start < target_offset || source_end > end {
+                return input_err!(
+                    loc,
+                    TranslationErr::unsupported(format!(
+                        "promoted {kind_name} relocation bytes {source_start}..{source_end} cross selected initializer range {target_offset}..{end}"
+                    ))
+                );
+            }
+
+            relocations.push(GlobalInitializerRelocation {
+                source_offset: u64::try_from(source_start - target_offset).map_err(|_| {
+                    input_error_noloc!(TranslationErr::unsupported(format!(
+                        "promoted {kind_name} rebased relocation offset does not fit u64"
+                    )))
+                })?,
+                width_bytes: relocation.width_bytes,
+                target_address_space: relocation.target_address_space,
+                target_addend: relocation.target_addend,
+                target_key: relocation.target_key,
+                target_static: relocation.target_static,
+            });
+        }
+
+        Ok(GlobalInitializerData {
+            bytes,
+            alignment,
+            relocations,
+        })
+    }
+
+    fn pointer_initializer(
+        alloc: &rustc_public::ty::Allocation,
+        expected_size: usize,
+        kind_name: &str,
+        loc: Location,
+    ) -> TranslationResult<GlobalInitializerData> {
         if alloc.provenance.ptrs.len() != 1 {
             return input_err!(
                 loc,
@@ -10571,10 +10703,19 @@ fn promoted_array_initializer(
                 ))
             );
         }
+        let &(provenance_offset, provenance) =
+            alloc.provenance.ptrs.first().expect("length checked above");
 
         let pointer_width = rustc_public::target::MachineInfo::target_pointer_width().bytes();
+        let pointer_end = provenance_offset
+            .checked_add(pointer_width)
+            .ok_or_else(|| {
+                input_error_noloc!(TranslationErr::unsupported(format!(
+                    "promoted {kind_name} outer pointer range overflows"
+                )))
+            })?;
         let target_offset = alloc
-            .read_partial_uint(provenance_offset..provenance_offset + pointer_width)
+            .read_partial_uint(provenance_offset..pointer_end)
             .map_err(|e| {
                 input_error_noloc!(TranslationErr::unsupported(format!(
                     "Failed to read promoted {kind_name} pointer offset: {e:?}"
@@ -10604,38 +10745,35 @@ fn promoted_array_initializer(
             &format!("promoted {kind_name} backing allocation"),
             loc.clone(),
         )?;
-        if !data.relocations.is_empty() {
-            return input_err!(
-                loc,
-                TranslationErr::unsupported(format!(
-                    "promoted {kind_name} backing allocation contains {} pointer relocation(s); promoted array provenance is not part of device-global static relocation support",
-                    data.relocations.len()
-                ))
-            );
-        }
-        let end = target_offset.checked_add(expected_size).ok_or_else(|| {
-            input_error_noloc!(TranslationErr::unsupported(format!(
-                "promoted {kind_name} initializer offset overflows its allocation"
-            )))
-        })?;
-        let bytes = data.bytes.get(target_offset..end).ok_or_else(|| {
-            input_error_noloc!(TranslationErr::unsupported(format!(
-                "promoted {kind_name} initializer needs bytes {target_offset}..{end}, but its backing allocation is only {} bytes",
-                data.bytes.len()
-            )))
-        })?;
-        Ok((bytes.to_vec(), data.alignment))
+        project_initializer_range(data, target_offset, expected_size, kind_name, loc)
     }
+
+    let pointer_form = matches!(
+        constant.const_.ty().kind(),
+        TyKind::RigidTy(RigidTy::RawPtr(_, _)) | TyKind::RigidTy(RigidTy::Ref(_, _, _))
+    );
 
     match constant.const_.kind() {
         ConstantKind::Allocated(alloc) => {
-            initializer_from_allocation(alloc, expected_size, kind_name, loc)
+            if pointer_form {
+                pointer_initializer(alloc, expected_size, kind_name, loc)
+            } else {
+                direct_initializer(alloc, expected_size, kind_name, loc)
+            }
         }
         ConstantKind::Ty(ty_const) => match ty_const.kind() {
             TyConstKind::Value(_, alloc) => {
-                initializer_from_allocation(alloc, expected_size, kind_name, loc)
+                if pointer_form {
+                    pointer_initializer(alloc, expected_size, kind_name, loc)
+                } else {
+                    direct_initializer(alloc, expected_size, kind_name, loc)
+                }
             }
-            TyConstKind::ZSTValue(_) if expected_size == 0 => Ok((Vec::new(), 1)),
+            TyConstKind::ZSTValue(_) if expected_size == 0 => Ok(GlobalInitializerData {
+                bytes: Vec::new(),
+                alignment: 1,
+                relocations: Vec::new(),
+            }),
             other => input_err!(
                 loc,
                 TranslationErr::unsupported(format!(
@@ -10643,7 +10781,11 @@ fn promoted_array_initializer(
                 ))
             ),
         },
-        ConstantKind::ZeroSized if expected_size == 0 => Ok((Vec::new(), 1)),
+        ConstantKind::ZeroSized if expected_size == 0 => Ok(GlobalInitializerData {
+            bytes: Vec::new(),
+            alignment: 1,
+            relocations: Vec::new(),
+        }),
         other => input_err!(
             loc,
             TranslationErr::unsupported(format!(
@@ -10677,17 +10819,32 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
     hex
 }
 
-fn promoted_constant_dedup_key(ctx: &Context, ty: TypeHandle, bytes: &[u8]) -> String {
+fn promoted_constant_dedup_key(
+    ctx: &Context,
+    ty: TypeHandle,
+    initializer: &GlobalInitializerData,
+) -> String {
+    let relocations = encode_global_initializer_relocations(&initializer.relocations);
+    promoted_constant_dedup_key_from_parts(ctx, ty, &initializer.bytes, &relocations)
+}
+
+fn promoted_constant_dedup_key_from_parts(
+    ctx: &Context,
+    ty: TypeHandle,
+    bytes: &[u8],
+    relocations: &str,
+) -> String {
     // This string is only an in-pass map key; it never becomes the emitted
-    // symbol name. Keep the full type and byte image so deduplication is exact.
-    // A short hash would make a collision silently alias two different Rust
-    // constants to the same device global.
+    // symbol name. Keep the full type, byte image, and relocation encoding so
+    // constants with identical placeholder bytes but different provenance
+    // targets cannot alias.
     let ty = ty.deref(ctx).disp(ctx).to_string();
     let bytes = bytes_to_hex(bytes);
     format!(
-        "__cuda_oxide_promoted_type{}:{ty}:bytes{}:{bytes}",
+        "__cuda_oxide_promoted_type{}:{ty}:bytes{}:{bytes}:relocs{}:{relocations}",
         ty.len(),
-        bytes.len() / 2
+        bytes.len() / 2,
+        relocations.len()
     )
 }
 
@@ -12200,7 +12357,33 @@ fn ensure_static_global_alloc(
     };
     state.globals.insert(global_key, materialized);
 
-    for relocation in &initializer.relocations {
+    let owner_description = format!("device static {}", static_def.name());
+    ensure_initializer_relocation_targets(
+        ctx,
+        &initializer.relocations,
+        &owner_description,
+        block_ptr,
+        loc,
+        state,
+    )?;
+
+    Ok(materialized)
+}
+
+/// Materialize and validate every static referenced by an initializer.
+///
+/// The owner is already registered by [`ensure_static_global_alloc`] before
+/// recursion reaches this helper, so self-references and mutually recursive
+/// static graphs remain finite.
+fn ensure_initializer_relocation_targets(
+    ctx: &mut Context,
+    relocations: &[GlobalInitializerRelocation],
+    owner_description: &str,
+    block_ptr: Ptr<BasicBlock>,
+    loc: Location,
+    state: &mut StaticGlobalMaterializationState,
+) -> TranslationResult<()> {
+    for relocation in relocations {
         let target = ensure_static_global_alloc(
             ctx,
             &relocation.target_static,
@@ -12213,8 +12396,7 @@ fn ensure_static_global_alloc(
             return input_err!(
                 loc,
                 TranslationErr::unsupported(format!(
-                    "device static {} relocation at byte {} points {} bytes into {}, but the target allocation is only {} bytes",
-                    static_def.name(),
+                    "{owner_description} relocation at byte {} points {} bytes into {}, but the target allocation is only {} bytes",
                     relocation.source_offset,
                     relocation.target_addend,
                     relocation.target_static.name(),
@@ -12223,8 +12405,7 @@ fn ensure_static_global_alloc(
             );
         }
     }
-
-    Ok(materialized)
+    Ok(())
 }
 
 fn translate_static_global_pointer(
@@ -12768,22 +12949,27 @@ mod pointer_array_constant_type_tests {
             "a promotable struct field keeps its tuple in the reference form"
         );
 
-        // A struct is only as promotable as its fields. Pointer-bearing
-        // initializers need relocation/provenance support and must stay out.
+        // Pointer-bearing structs are promotable now that immutable globals
+        // preserve rustc relocation metadata instead of flattening pointer
+        // placeholder bytes.
         let pointer_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
-        let pointer_struct_ty: TypeHandle = MirStructType::get(
+        let pointer_struct_ty: TypeHandle = MirStructType::get_with_full_layout(
             &mut ctx,
             "PointerBearingElement".into(),
             vec!["pointer".into()],
             vec![pointer_ty],
+            vec![],
+            vec![0],
+            8,
+            8,
         )
         .into();
         let pointer_struct_array: TypeHandle =
             MirArrayType::get(&mut ctx, pointer_struct_ty, 2).into();
         assert!(
             validate_ptr_to_array_constant_type(&ctx, pointer_struct_array, Location::Unknown)
-                .is_err(),
-            "pointer-bearing structs must remain outside immutable-global promotion"
+                .is_ok(),
+            "pointer-bearing structs are admitted by relocation-aware promotion"
         );
     }
 
@@ -12871,7 +13057,7 @@ mod pointer_array_constant_type_tests {
 
 #[cfg(test)]
 mod promotable_array_element_tests {
-    use super::{promotable_array_element, validate_array_value_element_type};
+    use super::{dialect_stored_size, promotable_array_element, validate_array_value_element_type};
     use dialect_mir::types::{
         EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
     };
@@ -13019,20 +13205,41 @@ mod promotable_array_element_tests {
             "a zero-byte over-aligned struct must keep its containing aggregate on the alignment-sensitive path"
         );
 
-        // Unsupported leaves still poison the whole recursive aggregate.
+        // Thin pointers are scalar load leaves once their initializer
+        // provenance is preserved as relocation metadata. Pin their concrete
+        // storage size too, so admission cannot later fail the byte-size gate.
         let pointer_ty: TypeHandle = MirPtrType::get_generic(&mut ctx, u32_ty, false).into();
-        let pointer_struct_ty: TypeHandle = MirStructType::get(
+        let pointer_array: TypeHandle = MirArrayType::get(&mut ctx, pointer_ty, 4).into();
+        assert!(
+            promotable_array_element(&ctx, pointer_array),
+            "a thin pointer is itself a promotable scalar load leaf"
+        );
+        assert_eq!(
+            dialect_stored_size(&ctx, pointer_array),
+            Some(32),
+            "four NVPTX64 pointers occupy 32 bytes"
+        );
+
+        // Use a full rustc-style layout so this assertion exercises
+        // struct_layout_matches_llvm_natural instead of its unknown-layout
+        // early return.
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointer_struct_ty: TypeHandle = MirStructType::get_with_full_layout(
             &mut ctx,
             "PointerBearingElement".into(),
-            vec!["pointer".into()],
-            vec![pointer_ty],
+            vec!["pointer".into(), "tag".into()],
+            vec![pointer_ty, u8_ty],
+            vec![],
+            vec![0, 8],
+            16,
+            8,
         )
         .into();
         let pointer_struct_array: TypeHandle =
             MirArrayType::get(&mut ctx, pointer_struct_ty, 4).into();
         assert!(
-            !promotable_array_element(&ctx, pointer_struct_array),
-            "a pointer leaf must keep its containing struct out of promotion"
+            promotable_array_element(&ctx, pointer_struct_array),
+            "a naturally laid out struct containing a thin pointer is promotable"
         );
 
         let struct_with_payload_enum: TypeHandle = MirStructType::get(
@@ -13801,7 +14008,7 @@ mod checked_binary_op_tests {
     }
 
     #[test]
-    fn promoted_immutable_globals_are_marked_and_dedup_by_type_and_bytes() {
+    fn promoted_immutable_globals_are_marked_and_dedup_by_type_and_initializer() {
         use dialect_mir::types::MirArrayType;
         use pliron::builtin::ops::ModuleOp;
         use pliron::linked_list::ContainsLinkedList;
@@ -13825,13 +14032,17 @@ mod checked_binary_op_tests {
 
         let f32_ty: TypeHandle = FP32Type::get(&ctx).into();
         let table_ty: TypeHandle = MirArrayType::get(&mut ctx, f32_ty, 2).into();
-        let bytes = [0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40]; // [1.0f32, 2.0f32]
+        let bytes = vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40]; // [1.0f32, 2.0f32]
+        let initializer = GlobalInitializerData {
+            bytes,
+            alignment: 4,
+            relocations: Vec::new(),
+        };
 
         let first = emit_promoted_immutable_global(
             &mut ctx,
             table_ty,
-            &bytes,
-            4,
+            &initializer,
             block,
             None,
             Location::Unknown,
@@ -13845,34 +14056,62 @@ mod checked_binary_op_tests {
         );
         let first_key = String::from(first.get_attr_global_key(&ctx).expect("dedup key").clone());
 
-        // The same table reached again — another function, another spelling —
-        // must produce the same key, which is what convert_global_alloc_dc
-        // collapses into a single emitted global.
+        // The same table reached again, through another function or spelling,
+        // must produce the same key.
         let again = emit_promoted_immutable_global(
             &mut ctx,
             table_ty,
-            &bytes,
-            4,
+            &initializer,
             block,
             None,
             Location::Unknown,
         );
         let again_key = String::from(again.get_attr_global_key(&ctx).expect("dedup key").clone());
-        assert_eq!(first_key, again_key, "same (type, bytes) must share a key");
+        assert_eq!(
+            first_key, again_key,
+            "same type, bytes, and relocations must share a key"
+        );
 
-        // A different byte image must not alias: a short or lossy key would
-        // silently hand two different Rust constants one device global.
-        let other_bytes = [0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f];
+        // A different byte image must not alias.
+        let other_initializer = GlobalInitializerData {
+            bytes: vec![0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f],
+            alignment: 4,
+            relocations: Vec::new(),
+        };
         let other = emit_promoted_immutable_global(
             &mut ctx,
             table_ty,
-            &other_bytes,
-            4,
+            &other_initializer,
             block,
             None,
             Location::Unknown,
         );
         let other_key = String::from(other.get_attr_global_key(&ctx).expect("dedup key").clone());
         assert_ne!(first_key, other_key, "distinct bytes must not share a key");
+    }
+
+    #[test]
+    fn promoted_dedup_key_distinguishes_relocation_identity() {
+        use dialect_mir::types::MirArrayType;
+
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let i64_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Unsigned).into();
+        let table_ty: TypeHandle = MirArrayType::get(&mut ctx, i64_ty, 1).into();
+        let bytes = [0u8; 8];
+
+        // Pointer placeholder bytes and addends may be identical. The target key
+        // is rustc's provenance identity and must therefore participate in the
+        // promoted-global dedup key.
+        let target_a = "v1 1 0 8 1 0 8 target_a ";
+        let target_b = "v1 1 0 8 1 0 8 target_b ";
+
+        let key_a = promoted_constant_dedup_key_from_parts(&ctx, table_ty, &bytes, target_a);
+        let key_b = promoted_constant_dedup_key_from_parts(&ctx, table_ty, &bytes, target_b);
+        assert_ne!(
+            key_a, key_b,
+            "identical bytes with different relocation targets must not alias"
+        );
     }
 }

--- a/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
@@ -279,17 +279,30 @@ require_symbol_shape "${llvm_ir}" llvm "${maybe_uninit_symbol}" \
 
 pointer_tuple_symbol='array_constants__kernels__pointer_tuple_array_value'
 
-# Device globals use backend-generated internal symbols, so source-level static
-# names are not stable in LLVM IR. Runtime coverage checks the zero-addend
-# whole-static case. This assertion pins the non-zero interior-static
-# projection and ensures provenance is not reconstructed from placeholder bytes.
+# Pointer-bearing tuple tables now take the same immutable-global promotion as
+# pointer-free tables. The source local is filled from addrspace(1) constant
+# storage before optimization; `opt` then removes the depot. The initializer
+# keeps both pointer identities as symbolic relocations, including the
+# POINTER_VALUES[2] eight-byte addend.
 require_symbol_shape "${llvm_ir}" llvm "${pointer_tuple_symbol}" \
-    "eight-byte device-static subobject projection" \
-    'getelementptr( inbounds)? i8,.*i64 8([^0-9]|$)'
+    "pointer tuple table filled from a relocation-aware read-only global" \
+    'llvm\.memcpy\.p0\.p1\.i64\(ptr %[A-Za-z0-9_.]+, ptr addrspace\(1\) @'
+
+require_shape \
+    "relocation-aware immutable pointer-table initializer" \
+    'addrspace\(1\) constant .*ptrtoint.*ptrtoint'
+
+require_shape \
+    "non-zero promoted pointer-table relocation addend" \
+    'addrspace\(1\) constant .*ptrtoint.*getelementptr.*i64 8'
 
 reject_symbol_shape "${llvm_ir}" llvm "${pointer_tuple_symbol}" \
     "placeholder-byte inttoptr reconstruction" \
     'inttoptr'
+
+reject_symbol_shape "${optimized_llvm_ir}" llvm "${pointer_tuple_symbol}" \
+    "per-thread pointer tuple table depot after optimization" \
+    'alloca \[2 x '
 
 # A non-empty tuple made entirely of ZST fields must still be decoded by the
 # tuple path. Its stripped LLVM representation leaves the outer u32 intact.

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -49,27 +49,47 @@ layout-exact union type. This includes direct unions, unions nested in tuple or
 struct constants, runtime-indexed `[U; N]`, and `MaybeUninit<T>` constants.
 Bare arrays whose elements are recursively promotable structs use the same
 immutable-device-global path as scalar and tuple tables, avoiding a per-thread
-local table copy for read-only uses. Pointer-to-array constants such as
-`const R: &[Struct; N] = &TABLE` use the same promoted global when every struct
-field is recursively promotable and the converted storage size matches rustc's
-layout. Zero-byte over-aligned struct leaves (for example, `repr(align(N))` ZSTs)
-remain on the existing alignment-sensitive value path instead of this promotion
-path. Arrays of packed structs whose element stride diverges from LLVM's natural
-layout remain unsupported as described above.
-Thin pointer fields in array, tuple, and struct **const** values that relocate
-to device statics are materialized via `MirGlobalAllocOp` per field, including
-non-zero byte addends into a static (see `struct_constant_provenance`,
-`tuple_constant_provenance`, `tuple_array_provenance`). Slice fat-pointer fields
-in aggregate constants are also supported when their data pointer relocates to
-a device static and the pointee is a same-element array-to-slice view. Their
-literal `usize` length metadata is decoded independently, including non-zero
-static byte addends and nested aggregate field offsets. Thin-pointer-only
-union constants preserve the same relocation provenance, including non-zero
-addends, by reconstructing one typed pointer carrier instead of transmuting
-placeholder bytes. Pointer/integer overlapping unions, fat or nested pointer
-storage in unions, over-aligned/padded pointer unions, unsupported fat-pointer
-metadata, pointer-to-array union constants (`&[U; N]`), and pointer
-relocations in device-global union initializers remain rejected.
+local table copy for read-only uses. This promotion also admits supported thin
+pointer/reference leaves. Their evaluated byte image remains byte-exact while
+pointer slots are preserved as symbolic device-global relocations, including
+non-zero byte addends into referenced device statics. Relocation targets are
+materialized explicitly, and promoted-global deduplication includes relocation
+identity as well as type and bytes so byte-identical tables that point at
+different statics cannot alias.
+
+Pointer-to-array constants such as `const R: &[Struct; N] = &TABLE` use the same
+promoted immutable global when every element is recursively promotable and the
+converted storage size matches rustc's layout. When the outer pointer selects a
+subrange of a backing allocation, relocation source offsets inside that range
+are rebased into the promoted initializer while preserving their target and
+addend. Unsupported bare array constants retain the existing element-wise
+fallback where available; pointer-to-array constants continue to fail closed
+when no correct fallback exists. Zero-byte over-aligned struct leaves (for
+example, `repr(align(N))` ZSTs) remain on the existing alignment-sensitive value
+path instead of this promotion path. Arrays of packed structs whose element
+stride diverges from LLVM's natural layout remain unsupported as described
+above.
+
+Thin pointer fields in array, tuple, and struct **const** values that do not take
+the immutable-table promotion path are materialized via `MirGlobalAllocOp` per
+field, including non-zero byte addends into a static (see
+`struct_constant_provenance`, `tuple_constant_provenance`,
+`tuple_array_provenance`). The `array_constants` regression also covers a
+promoted pointer-bearing tuple table with both a zero-addend static reference
+and a non-zero static-subobject addend, and verifies that optimized code does
+not retain a per-thread table depot.
+
+Slice fat-pointer fields in aggregate constants are also supported when their
+data pointer relocates to a device static and the pointee is a same-element
+array-to-slice view. Their literal `usize` length metadata is decoded
+independently, including non-zero static byte addends and nested aggregate field
+offsets. Thin-pointer-only union constants preserve the same relocation
+provenance, including non-zero addends, by reconstructing one typed pointer
+carrier instead of transmuting placeholder bytes. Pointer/integer overlapping
+unions, fat or nested pointer storage in unions, over-aligned/padded pointer
+unions, unsupported fat-pointer metadata, pointer-to-array union constants
+(`&[U; N]`), and pointer relocations in device-global union initializers remain
+rejected.
 
 Enum constants preserve payload relocations to device statics, including
 non-zero byte addends. This includes niche-encoded `Option<&T>` and


### PR DESCRIPTION
Closes #991 

## Summary

Promote supported constant tables containing thin pointer/reference fields into relocation-aware immutable device globals.

Previously, pointer-bearing aggregates were excluded from the constant-table promotion path and fell back to element-wise reconstruction. This change preserves their evaluated byte image together with symbolic pointer relocations, allowing the whole table to live in one read-only device global.

## What changed

### Relocation-aware promoted initializers

`promoted_array_initializer` now produces the full initializer representation rather than only raw bytes and alignment.

For promoted tables it preserves:

- initializer bytes;
- alignment;
- relocation source offsets;
- relocation targets;
- target address spaces;
- relocation addends;
- static identity/provenance.

For pointer/reference-to-array constants, relocations from the selected backing allocation range are rebased into the promoted table.

### Pointer-bearing aggregates

Thin MIR pointer types are now accepted as promotable leaves inside supported array element layouts.

Existing exclusions remain in place for layouts that cannot safely use this promotion path, including packed/unsupported aggregate layouts and unsupported enum cases.

### Relocation target materialization

Promoted globals now explicitly ensure that static globals referenced by their initializer relocations are materialized.

This reuses the same relocation-target materialization logic used by ordinary static-global initializers.

### Provenance-aware deduplication

The promoted-global deduplication key now includes relocation metadata in addition to the byte image.

This prevents two byte-identical initializers with different relocation targets from incorrectly aliasing the same promoted global.

### Code-shape regression

The `array_constants` regression now checks that the pointer tuple table:

- is sourced from an immutable `addrspace(1)` global;
- contains symbolic `ptrtoint` relocation expressions;
- preserves the non-zero `+8` static-subobject relocation;
- does not leave a per-thread pointer-table depot after optimization;
- does not reconstruct pointers through `inttoptr`.

## Example LLVM shape

The promoted table is emitted in the form:

```llvm
@__device_global_* = addrspace(1) constant ... {
    i64 ptrtoint (... @__device_global_* ... to i64),
    ...,
    i64 ptrtoint (
        ptr addrspacecast (
            ptr addrspace(1) getelementptr (
                i8,
                ptr addrspace(1) @__device_global_*,
                i64 8
            ) to ptr
        ) to i64
    ),
    ...
}
```

This keeps the relocation symbolic through the device-global initializer instead of rebuilding the pointer value in each thread.

## Validation

Validated with:

```text
cargo fmt --all -- --check
git diff --check
cargo check -p mir-importer

cargo test -p mir-importer pointer_array_constant_type_tests
cargo test -p mir-importer promotable_array_element_tests
cargo test -p mir-importer promoted_immutable_globals_are_marked_and_dedup_by_type_and_initializer
cargo test -p mir-importer promoted_dedup_key_distinguishes_relocation_identity
cargo test -p mir-importer

cargo clippy -p mir-importer --all-targets --all-features -- -D warnings

./scripts/check-error-example-status.sh

cargo oxide build array_constants
./crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
cargo oxide run array_constants

./scripts/smoketest.sh
```

Results:

```text
array_constants code shape: PASS
array_constants: PASS
```

Full smoketest:

```text
Pass: 214 / 214
Fail: 0 / 214
```

The GPU runtime validation was performed on the `array_constants` regression and the full repository smoketest completed with no failures. 

## Scope

This PR intentionally limits promotion to relocation forms already representable by the existing device-global relocation infrastructure.

Unsupported relocation targets and aggregate layouts retain their existing behavior rather than being partially promoted. Bare array constants may fall back to element-wise materialization; pointer-to-array constants continue to fail closed where no correct fallback exists.
