### PR TITLE
docs(mir-importer): TMA is the Tensor Memory Accelerator, and three translator rows were missing

### DIFF
--- a/crates/mir-importer/README.md
+++ b/crates/mir-importer/README.md
@@ -102,7 +102,7 @@ file:
 | `layout`      | Rust dynamic-layout intrinsics for slices, `str`, and slice-tailed structs  |
 | `memory`      | Memory access and conversion intrinsics                                     |
 | `saturating`  | Rust compiler saturating integer intrinsics                                 |
-| `tma`         | Tensor Memory Access (TMA) intrinsics                                       |
+| `tma`         | Tensor Memory Accelerator (TMA) intrinsics                                  |
 | `wgmma`       | Hopper WGMMA (Warpgroup Matrix Multiply-Accumulate) intrinsics              |
 
 Per-intrinsic PTX and minimum-SM requirements live in the catalog and are

--- a/crates/mir-importer/src/translator/mod.rs
+++ b/crates/mir-importer/src/translator/mod.rs
@@ -19,6 +19,9 @@
 //! | [`rvalue`]     | Expression translation (binops, casts, etc.)      |
 //! | [`types`]      | Rust type → `dialect-mir` type conversion         |
 //! | [`values`]     | MIR local → alloca slot mapping                   |
+//! | [`layout`]     | Shared readers over rustc's aggregate layout       |
+//! | [`location`]   | Source-location helpers for MIR translation       |
+//! | [`payload_store`] | Enum-payload stores whose storage type differs  |
 //!
 //! # Translation Flow
 //!

--- a/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/mod.rs
@@ -15,7 +15,7 @@
 //! | `memory`     | `SharedArray`, `stmatrix_*`, type conversions                                |
 //! | `atomic`     | Atomic read-modify-write and compare-exchange                                |
 //! | `wgmma`      | Hopper WGMMA matrix operations                                               |
-//! | `tma`        | Tensor Memory Access (TMA) operations                                        |
+//! | `tma`        | Tensor Memory Accelerator (TMA) operations                                   |
 //! | `debug`      | `clock`, `clock64`, `globaltimer`, `trap`, `breakpoint`                      |
 //! | `asm`        | Inline PTX marker calls                                                      |
 //! | `iket`       | `cuda_device::iket` compiler markers                                         |

--- a/crates/mir-importer/src/translator/terminator/intrinsics/tma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/tma.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Tensor Memory Access (TMA) intrinsics.
+//! Tensor Memory Accelerator (TMA) intrinsics.
 //!
 //! Handles asynchronous bulk data movement between global and shared memory.
 
@@ -31,7 +31,7 @@ use rustc_public::mir;
 /// Emits `cp_async_bulk_tensor_Nd_g2s`: Async tensor copy global → shared via TMA.
 ///
 /// Initiates an asynchronous bulk tensor copy from global memory to shared memory
-/// using the Tensor Memory Access (TMA) hardware unit. The copy is tracked by
+/// using the Tensor Memory Accelerator (TMA) hardware unit. The copy is tracked by
 /// an mbarrier for completion notification.
 ///
 /// # Arguments


### PR DESCRIPTION
## Summary

Two follow-ups from the #978 merge note.

### The TMA expansion

You flagged that #978's `tma` row was copied verbatim from `tma.rs`, whose own doc comment says "Tensor Memory **Access**". The unit is the Tensor Memory **Accelerator**, and the tree already says so in 22 places — including `cuda-device/src/tma.rs`, `dialect-nvvm/src/ops/generated/tma.rs`, and the book chapter of that name. mir-importer was the holdout, in four places:

```
src/translator/terminator/intrinsics/tma.rs:6    module doc
src/translator/terminator/intrinsics/tma.rs:34   fn doc prose
src/translator/terminator/intrinsics/mod.rs:18   table row
README.md:105                                    table row
```

All four now read "Accelerator", and `Tensor Memory Access` no longer appears anywhere under `crates/mir-importer/`. Fixing the source alone would have left the README I just landed disagreeing with it, so both move together.

This is the cost of the verbatim-from-doc-comment rule #977 and #978 adopted: it cannot drift from the source, which also means it faithfully reproduces the source's mistakes. Worth the trade — but the fix has to land in the source.

### The three translator rows

`src/translator/mod.rs` carries the same module table as the README and was short the same three modules #978 added there: `layout`, `location`, `payload_store`.

## One claim I checked and am *not* making

Unlike #977's table, making these rows intra-doc links does **not** put them under the docs gate. `translator` is `pub(crate) mod` since `4c1d5838` (#833, "stop exporting the translator"), so `cargo doc --no-deps` never documents it and an unresolved link there is not an error. Verified by adding a `[`ghost_module`]` row and watching the gate pass.

It *does* fail under `--document-private-items` — but that flag also surfaces three pre-existing unresolved links elsewhere in the crate (`MirFieldAddrOp`, `MirArrayElementAddrOp`, `MirArrayType`), so turning it on is its own piece of work, not a free win here. The rows are links because the seven around them are; the enforcement claim belongs only to #977's table.

## Testing

Local, no GPU.

- [x] The translator table is exactly the 9 files in `translator/` plus the `terminator` subdirectory it also lists
- [x] The README's `tma` row and `tma.rs`'s doc comment are byte-identical again
- [x] `cargo test -p mir-importer` (1090 tests) and the docs gate clean
- [ ] `cargo oxide run <example>` — not applicable