### PR TITLE
ci: no workspace member can be silently absent from the test matrix

### DIFF
--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -109,6 +109,24 @@ jobs:
       - name: Verify every device call the book shows resolves
         run: bash scripts/check-book-api-names.sh
 
+  # `unit-tests.yml`'s matrix is the only thing deciding which crates get
+  # `cargo test`, and a member missing from it fails nothing: the workflow is
+  # green, `just check` is green, and the tests never ran. #971 found four
+  # crates in that state holding 107 tests between them, two of them for
+  # months. The workflow's own "intentionally not in this matrix" comment
+  # reading as complete is what hid them.
+  test-matrix-coverage:
+    name: test-matrix coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # Reads Cargo.toml, unit-tests.yml and the Justfile: no cargo, no network.
+      - name: Verify every workspace member is tested or declared untested
+        run: bash scripts/check-test-matrix-coverage.sh
+
   # #702 let a kernel-only crate drop the host surface (and with it `cuda.h`) via
   # `cuda-macros = { default-features = false }`, which is what #701 asked for.
   # Nothing exercised it: no example takes that configuration, and every other

--- a/Justfile
+++ b/Justfile
@@ -207,7 +207,8 @@ check-errors:
 
 # Every status-guard job (error* examples in STATUS.md, the smoketest example
 # contract, the README crate inventory, toolchain-pin parity, the book's CLI
-# command reference, the book's device-API names, and the device-only build),
+# command reference, the book's device-API names, the device-only build, and
+# test-matrix coverage),
 # the naming-guard's reserved-prefix search, and all four cargo-deny jobs:
 # `cargo deny check` enforces deny.toml over the root workspace's resolved
 # graph and again over crates/rustc-codegen-cuda, which resolves its own
@@ -231,6 +232,7 @@ check-guards:
     bash scripts/check-book-api-names.sh
     bash scripts/check-reserved-prefixes.sh
     bash scripts/check-device-only-build.sh
+    bash scripts/check-test-matrix-coverage.sh
     cargo deny --locked check
     cargo deny --manifest-path crates/rustc-codegen-cuda/Cargo.toml --locked check
     bash scripts/check-dependency-licenses.sh

--- a/scripts/check-test-matrix-coverage.sh
+++ b/scripts/check-test-matrix-coverage.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Verify every workspace member is either tested by CI or declared untested.
+#
+# `unit-tests.yml`'s matrix decides which crates get `cargo test`.  A member
+# absent from it is not reported anywhere: the workflow passes, `just check`
+# passes, and the crate's tests simply never run.  #971 found four in that
+# state holding 107 `#[test]` functions between them -- `dialect-ptx` (43),
+# `ptx-parse` (35), `iket-lower` (22) and `dialect-iket` (7).  `dialect-iket`
+# and `iket-lower` had been uncovered for months.
+#
+# The workflow already carries the intent, as a comment listing what is out of
+# scope on purpose:
+#
+#     # Crates intentionally not in this matrix:
+#     #   * `cuda-bindings` - generated sys bindings covered transitively.
+#     #   * `fuzzer` - differential-testing infra with no unit tests.
+#     #   * `rustc-codegen-cuda` - its own [workspace] ...
+#
+# That comment reading as complete is what made the four invisible.  This guard
+# makes it complete: a member must appear in the matrix or be named in that
+# list, and anything in neither fails the run.  Adding a crate to the exclusion
+# list stays a one-line, reviewable act -- which is the point.  Removing the
+# guesswork, not the choice.
+#
+# Also checked, because a stale list is as bad as a short one: every name in the
+# exclusion comment must still be a real member (or `rustc-codegen-cuda`, which
+# is deliberately not one), so a renamed or deleted crate cannot leave a
+# permanent hole behind.
+#
+# The Justfile's `test` and `test-cuda` recipes are checked against the same
+# matrix, since their own comment is the contract -- "Mirrors
+# .github/workflows/unit-tests.yml; keep the two in step" -- and nothing
+# enforced it.
+#
+# Reads three text files: no cargo, no network, no toolchain.
+#
+# Run this after adding a workspace member or editing the matrix.
+set -euo pipefail
+
+export LC_ALL=C
+
+cd "$(dirname "$0")/.."
+
+MANIFEST=Cargo.toml
+WORKFLOW=.github/workflows/unit-tests.yml
+JUSTFILE=Justfile
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: python3 is required to verify test-matrix coverage" >&2
+    echo "       refusing to report success from a check that cannot run" >&2
+    exit 1
+fi
+
+test -s "${MANIFEST}"
+test -s "${WORKFLOW}"
+test -s "${JUSTFILE}"
+
+python3 - "${MANIFEST}" "${WORKFLOW}" "${JUSTFILE}" <<'PY'
+import re
+import sys
+
+manifest_path, workflow_path, justfile_path = sys.argv[1:4]
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+manifest, workflow, justfile = (
+    read(manifest_path),
+    read(workflow_path),
+    read(justfile_path),
+)
+
+# Workspace members, read from the manifest for the reason
+# check-crate-inventory.sh gives: the question is what the workspace declares,
+# and reading it needs no cargo and no lockfile.
+members_block = re.search(r"^members\s*=\s*\[(.*?)\]", manifest, re.M | re.S)
+if not members_block:
+    sys.exit(
+        f"parse self-test failed: no `members = [...]` list in {manifest_path}; "
+        "fix this script before trusting it"
+    )
+paths = re.findall(r'"([^"]+)"', members_block.group(1))
+globbed = [path for path in paths if "*" in path]
+if globbed:
+    sys.exit(
+        "unsupported glob in workspace members: "
+        + " ".join(globbed)
+        + "; this guard resolves explicit paths only, so extend it before adding globs"
+    )
+members = sorted({path.rstrip("/").rsplit("/", 1)[-1] for path in paths})
+if len(members) < 20:
+    sys.exit(
+        f"parse self-test failed: read {len(members)} members from {manifest_path}"
+    )
+
+# The matrix entries.  `- package: <name>` is the only shape the workflow uses.
+matrix = set(re.findall(r"^\s+- package:\s*([a-z0-9-]+)\s*$", workflow, re.M))
+if len(matrix) < 15:
+    sys.exit(
+        f"parse self-test failed: read {len(matrix)} matrix packages from "
+        f"{workflow_path}; the entry shape changed, fix this script"
+    )
+
+# The exclusion comment.  Only backticked names on a `#   * ` bullet count, so
+# prose in the surrounding paragraphs cannot silently exempt a crate.
+excluded_block = re.search(
+    r"Crates intentionally not in this matrix:(.*?)\n\s+include:", workflow, re.S
+)
+if not excluded_block:
+    sys.exit(
+        "parse self-test failed: no `Crates intentionally not in this matrix:` "
+        f"comment found before `include:` in {workflow_path}; it moved or was "
+        "reworded, so fix this script rather than trusting an empty exclusion set"
+    )
+excluded = set(re.findall(r"^\s*#\s+\*\s+`([a-z0-9-]+)`", excluded_block.group(1), re.M))
+if not excluded:
+    sys.exit(
+        "parse self-test failed: the exclusion comment in "
+        f"{workflow_path} yielded no names; the bullet shape changed"
+    )
+
+failures = []
+
+# 1. Every member is tested or declared untested.
+uncovered = [m for m in members if m not in matrix and m not in excluded]
+if uncovered:
+    failures.append(
+        "these workspace members are neither in the unit-tests matrix nor named\n"
+        "  in its exclusion comment, so their tests never run:\n    "
+        + "\n    ".join(uncovered)
+        + "\n  Add a `- package: <name>` entry to .github/workflows/unit-tests.yml,\n"
+        "  or name the crate in the `Crates intentionally not in this matrix:`\n"
+        "  comment with the reason."
+    )
+
+# 2. The exclusion list names real crates.  `rustc-codegen-cuda` is excluded and
+#    is deliberately not a member (its own [workspace] for the rustc_private
+#    dylibs), so it is the one accepted non-member.
+known = set(members) | {"rustc-codegen-cuda"}
+phantom = sorted(name for name in excluded if name not in known)
+if phantom:
+    failures.append(
+        "the exclusion comment names crates that are not workspace members:\n    "
+        + "\n    ".join(phantom)
+        + "\n  A renamed or deleted crate left behind here is a permanent hole;\n"
+        "  drop the bullet."
+    )
+
+# 3. A matrix entry must be a real member too, or the job runs `cargo test -p`
+#    on a name cargo cannot resolve.
+unknown = sorted(name for name in matrix if name not in members)
+if unknown:
+    failures.append(
+        "the matrix names packages that are not workspace members:\n    "
+        + "\n    ".join(unknown)
+    )
+
+# 4. The Justfile mirrors the matrix, which its own comment promises.
+recipes = {}
+for name in ("test", "test-cuda"):
+    body = re.search(rf"^{name}:\n(.*?)(?=\n^[a-z@#]|\Z)", justfile, re.M | re.S)
+    if not body:
+        sys.exit(
+            f"parse self-test failed: no `{name}:` recipe in {justfile_path}; "
+            "it was renamed, so fix this script"
+        )
+    # `[a-z]` first, deliberately: `test-cuda` contains `ldconfig -p 2>/dev/null`,
+    # and a looser `[a-z0-9-]+` reads that redirect as a package named "2".
+    recipes[name] = set(re.findall(r"-p ([a-z][a-z0-9-]*)", body.group(1)))
+just = recipes["test"] | recipes["test-cuda"]
+if len(just) < 15:
+    sys.exit(
+        f"parse self-test failed: read {len(just)} packages from {justfile_path}'s "
+        "test recipes; the `-p` spelling changed"
+    )
+only_ci = sorted(matrix - just)
+only_just = sorted(just - matrix)
+if only_ci or only_just:
+    detail = []
+    if only_ci:
+        detail.append("in the matrix but not in `just test`/`test-cuda`: " + " ".join(only_ci))
+    if only_just:
+        detail.append("in `just test`/`test-cuda` but not in the matrix: " + " ".join(only_just))
+    failures.append(
+        "the Justfile no longer mirrors the matrix, which its own comment\n"
+        '  promises ("Mirrors .github/workflows/unit-tests.yml; keep the two in\n'
+        '  step"):\n    ' + "\n    ".join(detail)
+    )
+
+if failures:
+    print("error: test-matrix coverage is incomplete", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+        print(file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"OK: all {len(members)} workspace members are covered -- {len(matrix)} in the "
+    f"unit-tests matrix, {len(excluded)} declared untested -- and the Justfile's "
+    "test recipes mirror the matrix."
+)
+PY


### PR DESCRIPTION
## Summary

The follow-up named in the #971 merge note.

`unit-tests.yml`'s matrix decides which crates get `cargo test`, and a member missing from it fails nothing — the workflow is green, `just check` is green, and the tests never ran. #971 found four crates in exactly that state holding **107 `#[test]` functions** between them, two of them uncovered for months.

The workflow already carried the intent, as a comment:

```
# Crates intentionally not in this matrix:
#   * `cuda-bindings` - generated sys bindings covered transitively.
#   * `fuzzer` - differential-testing infra with no unit tests.
#   * `rustc-codegen-cuda` - its own [workspace] ...
```

**That list reading as complete is precisely what hid the four.** This guard makes it complete: every member must be in the matrix or named in that comment, and a crate in neither fails the run. Excluding one stays a one-line reviewable act with a written reason — the guesswork goes, the choice stays.

## Four assertions, each with a failure this has already had

1. **Member in neither the matrix nor the exclusion list.** The #971 case.
2. **Exclusion list names a non-member.** A renamed or deleted crate left behind there is a permanent hole. `rustc-codegen-cuda` is the one accepted non-member, since its own `[workspace]` keeps it out by design.
3. **Matrix names a non-member**, which would make the job run `cargo test -p` on a name cargo cannot resolve.
4. **The Justfile mirrors the matrix**, which its own comment already promises (*"Mirrors .github/workflows/unit-tests.yml; keep the two in step"*) and nothing enforced.

Parse self-tests on all three inputs, in the house style: the member list, the matrix entry shape, the exclusion comment, and the Justfile `-p` spelling each fail loudly rather than yielding an empty set that would pass vacuously.

One thing the guard caught **in its own first run**, worth keeping: a naive `-p ([a-z0-9-]+)` reads `ldconfig -p 2>/dev/null` in `test-cuda` as a package named `2`. The pattern requires a leading letter, and the comment says why.

## Testing

Local, no GPU. Each mutation against an otherwise clean tree:

| Mutation | Result |
|:--|:--|
| drop `dialect-ptx` from the matrix | exit 1, names it |
| drop it **and** declare it excluded, Justfile untouched | exit 1, mirror broken |
| drop it, declare it, **and** drop it from the Justfile | **OK** — the real exclusion flow |
| exclusion list names `ghost-crate` | exit 1, names it |
| Justfile drops a package the matrix keeps | exit 1, reports both directions |
| reword the exclusion heading | self-test fires |
| rename `- package:` → `- pkg:` | self-test fires |
| clean tree | OK, 27 = 25 matrix + 3 declared |

- [x] Wired into `status-guard.yml` as a new job and into the Justfile's `check-guards`, whose docstring lists the status-guard jobs and now names this one — the drift that recipe exists to prevent
- [x] All ten guards, the docs gate, the book gate and every workflow parse clean on the merged tree
- [ ] `cargo oxide run <example>` — not applicable, CI script only