### PR TITLE
docs(cuda-device): core atomics lower with system scope, not device scope

### DIFF
--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -121,7 +121,7 @@ Typestate-based async barrier for TMA and MMA synchronization (Hopper+). Tracks 
 Two kinds of atomics work on device:
 
 - **`cuda_device::atomic::*`** -- 21 scoped GPU atomic types across three scopes (`Device`/`.gpu`, `Block`/`.cta`, `System`/`.sys`) and seven value types (u32, i32, u64, i64, f16, f32, f64). These give explicit control over scope and ordering.
-- **`core::sync::atomic::*`** -- standard library atomics (`AtomicU32`, `AtomicBool`, etc.) also compile to GPU code, defaulting to device scope.
+- **`core::sync::atomic::*`** -- standard library atomics (`AtomicU32`, `AtomicBool`, etc.) also compile to GPU code. These always lower with **system scope** (`.sys`), not device scope, for safe host-device coherence -- matching CUDA C++ `cuda::atomic<T>` defaults. Reach for the `cuda_device::atomic` types above when you want `.gpu` or `.cta` instead.
 
 Both paths emit the same NVVM atomic ops and share the full lowering pipeline to PTX.
 


### PR DESCRIPTION
## Summary

The follow-up you flagged reviewing #973: the bullet next to the one that PR touched says `core::sync::atomic` types compile to GPU code "defaulting to **device** scope". They default to **system** scope, and the tree says so everywhere except here:

| Site | Says |
|:--|:--|
| `mir-importer .../intrinsics/atomic.rs:62` | "All `core::sync::atomic` operations are lowered with **system scope** (`.sys`) for safe host-device coherence, matching CUDA C++ `cuda::atomic<T>` defaults." |
| `.../atomic.rs:764` | "Core atomics always use system scope for safe host-device coherence." |
| `.../atomic.rs:814` | `scope: AtomicScope::System,` |
| book `supported-features.md:170` | "lowered to PTX `atom.sys`" |
| book `api-quick-reference.md:425` | "defaulting to system scope" |

So the README was the lone dissenter — and it is the file a reader lands on first for this crate.

The distinction is not cosmetic. `.gpu` and `.sys` differ in what is guaranteed and what it costs: a reader told "device scope" concludes host-visible coherence is *not* provided, and either adds synchronization that is already there or switches to `SystemAtomicU32` for a property they were getting for free.

The corrected bullet states the scope, the reason (matching CUDA C++ `cuda::atomic<T>`), and points at `cuda_device::atomic` as the way to ask for `.gpu` or `.cta` deliberately — which is what the paragraph is really about.

## Testing

Local, no GPU — documentation only.

- [x] No documentation anywhere in the tree now claims device scope for `core::sync::atomic`
- [x] This bullet agrees with all three code sites and both book pages
- [x] `check-crate-inventory` passes
- [ ] `cargo oxide run <example>` — not applicable