### PR TITLE
fix(mir-lower): support packed address-space 3 aggregates across the internal device ABI

### DIFF
--- a/crates/mir-lower/src/convert/enum_payload_storage.rs
+++ b/crates/mir-lower/src/convert/enum_payload_storage.rs
@@ -20,17 +20,13 @@
 //! the same contract. Pointer vectors remain fail-closed because they require
 //! separate ABI and address-space-cast semantics.
 
-use llvm_export::op_interfaces::{CastOpInterface, CastOpWithNNegInterface};
-use llvm_export::ops as llvm;
-use llvm_export::types as llvm_types;
-use llvm_export::types::PointerTypeExt;
-use pliron::builtin::types::{IntegerType, Signedness};
+use crate::convert::target_stable_storage::{
+    StorageRewriteOptions, coerce_target_stable_value, target_stable_storage_type,
+};
 use pliron::context::Context;
 use pliron::irbuild::dialect_conversion::DialectConversionRewriter;
-use pliron::irbuild::inserter::Inserter;
-use pliron::op::Op;
 use pliron::result::Result;
-use pliron::r#type::{TypeHandle, Typed};
+use pliron::r#type::TypeHandle;
 use pliron::value::Value;
 
 /// Maximum number of array-expanded shared-pointer leaves one payload rewrite
@@ -44,49 +40,23 @@ use pliron::value::Value;
 /// `build_enum_slot_map`, keeping one contract for every payload shape.
 pub(crate) const MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES: u64 = 16;
 
-#[derive(Clone)]
-struct StorageRewrite {
-    ty: TypeHandle,
-    /// Shared-pointer leaves anywhere in the rewritten type.
-    shared_pointer_leaves: u64,
-    /// Shared-pointer leaves reached through at least one array. Only these
-    /// count against [`MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES`], checked once
-    /// at the payload root by [`enum_payload_storage_type`].
-    array_shared_pointer_leaves: u64,
-}
-
-enum TypeShape {
-    Bool,
-    Pointer(u32),
-    Array(TypeHandle, u64),
-    Vector(TypeHandle),
-    Struct {
-        fields: Vec<TypeHandle>,
-        layout: llvm_types::StructLayout,
-    },
-    Identity,
-}
-
 /// Return the physical LLVM type used to store one semantic enum payload.
 ///
-/// The transformation is recursive through LLVM structs, which cover MIR
-/// structs and tuples after ordinary type conversion:
-///
-/// - `ptr addrspace(3)` becomes a CUDA generic pointer;
-/// - `i1` becomes the canonical one-byte `i8` memory representation;
-/// - structs are rebuilt field by field;
-/// - arrays are rebuilt recursively while the payload's total array-expanded
-///   shared-pointer leaves stay within
-///   [`MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES`];
-/// - vectors containing shared pointers are rejected.
+/// Shared pointers are genericized and bool leaves are canonicalized to bytes.
+/// The implementation is shared with other target-stable physical ABI carriers,
+/// while this wrapper retains the enum-specific bounded-array contract.
 pub(crate) fn enum_payload_storage_type(
     ctx: &mut Context,
     semantic_ty: TypeHandle,
 ) -> std::result::Result<TypeHandle, anyhow::Error> {
-    let rewrite = rewrite_storage_type(ctx, semantic_ty)?;
-    // One bound for every payload shape, enforced at the root: a single
-    // oversized array and a struct of several smaller arrays are both counted
-    // by their total array-expanded shared-pointer leaves.
+    let rewrite = target_stable_storage_type(
+        ctx,
+        semantic_ty,
+        StorageRewriteOptions {
+            canonicalize_bool: true,
+        },
+        "enum payload storage",
+    )?;
     if rewrite.array_shared_pointer_leaves > MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES {
         return Err(anyhow::anyhow!(
             "enum payload storage: arrays containing shared-memory pointers are not supported above the bounded rewrite limit; rewrite requires {} pointer conversions, supported bound is {MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES}",
@@ -96,276 +66,16 @@ pub(crate) fn enum_payload_storage_type(
     Ok(rewrite.ty)
 }
 
-fn rewrite_storage_type(
-    ctx: &mut Context,
-    semantic_ty: TypeHandle,
-) -> std::result::Result<StorageRewrite, anyhow::Error> {
-    let shape = {
-        let ty_ref = semantic_ty.deref(ctx);
-        if ty_ref
-            .downcast_ref::<IntegerType>()
-            .is_some_and(|integer| integer.width() == 1)
-        {
-            TypeShape::Bool
-        } else if let Some(pointer) = ty_ref.downcast_ref::<llvm_types::PointerType>() {
-            TypeShape::Pointer(pointer.address_space())
-        } else if let Some(array) = ty_ref.downcast_ref::<llvm_types::ArrayType>() {
-            TypeShape::Array(array.elem_type(), array.size())
-        } else if let Some(vector) = ty_ref.downcast_ref::<llvm_types::VectorType>() {
-            TypeShape::Vector(vector.elem_type())
-        } else if let Some(struct_ty) = ty_ref.downcast_ref::<llvm_types::StructType>() {
-            TypeShape::Struct {
-                fields: struct_ty.fields().collect(),
-                layout: struct_ty.layout(),
-            }
-        } else {
-            TypeShape::Identity
-        }
-    };
-
-    match shape {
-        TypeShape::Bool => Ok(StorageRewrite {
-            ty: IntegerType::get(ctx, 8, Signedness::Signless).into(),
-            shared_pointer_leaves: 0,
-            array_shared_pointer_leaves: 0,
-        }),
-        TypeShape::Pointer(address_space) if address_space == llvm_types::address_space::SHARED => {
-            Ok(StorageRewrite {
-                ty: llvm_types::PointerType::get_generic(ctx).into(),
-                shared_pointer_leaves: 1,
-                array_shared_pointer_leaves: 0,
-            })
-        }
-        TypeShape::Pointer(_) | TypeShape::Identity => Ok(StorageRewrite {
-            ty: semantic_ty,
-            shared_pointer_leaves: 0,
-            array_shared_pointer_leaves: 0,
-        }),
-        TypeShape::Array(element_ty, count) => {
-            let element = rewrite_storage_type(ctx, element_ty)?;
-            let shared_pointer_leaves = element
-                .shared_pointer_leaves
-                .checked_mul(count)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "enum payload storage: shared-pointer array rewrite size overflow"
-                    )
-                })?;
-            let ty = if element.ty == element_ty {
-                semantic_ty
-            } else {
-                llvm_types::ArrayType::get(ctx, element.ty, count).into()
-            };
-            Ok(StorageRewrite {
-                ty,
-                shared_pointer_leaves,
-                // The array multiplies everything below it, so every shared
-                // leaf it contains is array-expanded, including leaves nested
-                // through structs inside the element.
-                array_shared_pointer_leaves: shared_pointer_leaves,
-            })
-        }
-        TypeShape::Vector(element_ty) => {
-            let element = rewrite_storage_type(ctx, element_ty)?;
-            if element.ty != element_ty || element.shared_pointer_leaves != 0 {
-                return Err(anyhow::anyhow!(
-                    "enum payload storage: vectors containing bool or shared-memory pointer elements are not supported"
-                ));
-            }
-            Ok(StorageRewrite {
-                ty: semantic_ty,
-                shared_pointer_leaves: 0,
-                array_shared_pointer_leaves: 0,
-            })
-        }
-        TypeShape::Struct { fields, layout } => {
-            let mut storage_fields = Vec::with_capacity(fields.len());
-            let mut changed = false;
-            let mut shared_pointer_leaves = 0_u64;
-            let mut array_shared_pointer_leaves = 0_u64;
-            for field in fields {
-                let storage = rewrite_storage_type(ctx, field)?;
-                changed |= storage.ty != field;
-                shared_pointer_leaves = shared_pointer_leaves
-                    .checked_add(storage.shared_pointer_leaves)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "enum payload storage: shared-pointer leaf count overflow while rewriting a struct payload"
-                        )
-                    })?;
-                array_shared_pointer_leaves = array_shared_pointer_leaves
-                    .checked_add(storage.array_shared_pointer_leaves)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "enum payload storage: shared-pointer leaf count overflow while rewriting a struct payload"
-                        )
-                    })?;
-                storage_fields.push(storage.ty);
-            }
-            let ty = if changed {
-                llvm_types::StructType::get_unnamed(ctx, (storage_fields, layout)).into()
-            } else {
-                semantic_ty
-            };
-            Ok(StorageRewrite {
-                ty,
-                shared_pointer_leaves,
-                array_shared_pointer_leaves,
-            })
-        }
-    }
-}
-
-enum ValueCoercion {
-    BoolToByte,
-    ByteToBool,
-    SharedToGeneric,
-    GenericToShared,
-    Array {
-        target_element: TypeHandle,
-        count: u64,
-    },
-    Struct(Vec<TypeHandle>),
-    Unsupported,
-}
-
 /// Convert an enum payload value between its semantic and physical types.
 ///
-/// This is the value-level counterpart of [`enum_payload_storage_type`]. It
-/// recursively rebuilds structs/tuples, inserts the required address-space
-/// casts for shared pointer leaves, and canonicalizes/decanonicalizes bool
-/// bytes. The conversion is symmetric and is used both when constructing an
-/// enum and when extracting its payload.
+/// This is symmetric and recursively rebuilds aggregates, inserting explicit
+/// address-space casts for shared pointer leaves and widening/narrowing bool
+/// leaves to/from their canonical storage byte representation.
 pub(crate) fn coerce_enum_payload_value(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     value: Value,
     target_ty: TypeHandle,
 ) -> Result<Value> {
-    let source_ty = value.get_type(ctx);
-    if source_ty == target_ty {
-        return Ok(value);
-    }
-
-    let coercion = {
-        let source_ref = source_ty.deref(ctx);
-        let target_ref = target_ty.deref(ctx);
-
-        let source_integer = source_ref
-            .downcast_ref::<IntegerType>()
-            .map(IntegerType::width);
-        let target_integer = target_ref
-            .downcast_ref::<IntegerType>()
-            .map(IntegerType::width);
-        if source_integer == Some(1) && target_integer == Some(8) {
-            ValueCoercion::BoolToByte
-        } else if source_integer == Some(8) && target_integer == Some(1) {
-            ValueCoercion::ByteToBool
-        } else if let (Some(source_pointer), Some(target_pointer)) = (
-            source_ref.downcast_ref::<llvm_types::PointerType>(),
-            target_ref.downcast_ref::<llvm_types::PointerType>(),
-        ) {
-            match (
-                source_pointer.address_space(),
-                target_pointer.address_space(),
-            ) {
-                (llvm_types::address_space::SHARED, llvm_types::address_space::GENERIC) => {
-                    ValueCoercion::SharedToGeneric
-                }
-                (llvm_types::address_space::GENERIC, llvm_types::address_space::SHARED) => {
-                    ValueCoercion::GenericToShared
-                }
-                _ => ValueCoercion::Unsupported,
-            }
-        } else if let (Some(source_array), Some(target_array)) = (
-            source_ref.downcast_ref::<llvm_types::ArrayType>(),
-            target_ref.downcast_ref::<llvm_types::ArrayType>(),
-        ) {
-            if source_array.size() == target_array.size() {
-                ValueCoercion::Array {
-                    target_element: target_array.elem_type(),
-                    count: source_array.size(),
-                }
-            } else {
-                ValueCoercion::Unsupported
-            }
-        } else if let (Some(source_struct), Some(target_struct)) = (
-            source_ref.downcast_ref::<llvm_types::StructType>(),
-            target_ref.downcast_ref::<llvm_types::StructType>(),
-        ) {
-            if source_struct.num_fields() == target_struct.num_fields() {
-                ValueCoercion::Struct(target_struct.fields().collect())
-            } else {
-                ValueCoercion::Unsupported
-            }
-        } else {
-            ValueCoercion::Unsupported
-        }
-    };
-
-    match coercion {
-        ValueCoercion::BoolToByte => {
-            let zext = llvm::ZExtOp::new_with_nneg(ctx, value, target_ty, false);
-            rewriter.insert_operation(ctx, zext.get_operation());
-            Ok(zext.get_operation().deref(ctx).get_result(0))
-        }
-        ValueCoercion::ByteToBool => {
-            let trunc = llvm::TruncOp::new(ctx, value, target_ty);
-            rewriter.insert_operation(ctx, trunc.get_operation());
-            Ok(trunc.get_operation().deref(ctx).get_result(0))
-        }
-        ValueCoercion::SharedToGeneric | ValueCoercion::GenericToShared => {
-            let cast = llvm::AddrSpaceCastOp::new(ctx, value, target_ty);
-            rewriter.insert_operation(ctx, cast.get_operation());
-            Ok(cast.get_operation().deref(ctx).get_result(0))
-        }
-        ValueCoercion::Array {
-            target_element,
-            count,
-        } => {
-            let undef = llvm::UndefOp::new(ctx, target_ty);
-            rewriter.insert_operation(ctx, undef.get_operation());
-            let mut current = undef.get_operation().deref(ctx).get_result(0);
-            for index in 0..count {
-                let index = u32::try_from(index).map_err(|_| {
-                    pliron::input_error_noloc!(
-                        "enum payload storage array has more than u32::MAX elements"
-                    )
-                })?;
-                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
-                rewriter.insert_operation(ctx, extract.get_operation());
-                let element = extract.get_operation().deref(ctx).get_result(0);
-                let converted = coerce_enum_payload_value(ctx, rewriter, element, target_element)?;
-                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
-                rewriter.insert_operation(ctx, insert.get_operation());
-                current = insert.get_operation().deref(ctx).get_result(0);
-            }
-            Ok(current)
-        }
-        ValueCoercion::Struct(fields) => {
-            let undef = llvm::UndefOp::new(ctx, target_ty);
-            rewriter.insert_operation(ctx, undef.get_operation());
-            let mut current = undef.get_operation().deref(ctx).get_result(0);
-            for (index, target_field) in fields.into_iter().enumerate() {
-                let index = u32::try_from(index).map_err(|_| {
-                    pliron::input_error_noloc!(
-                        "enum payload storage struct has more than u32::MAX fields"
-                    )
-                })?;
-                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
-                rewriter.insert_operation(ctx, extract.get_operation());
-                let field = extract.get_operation().deref(ctx).get_result(0);
-                let converted = coerce_enum_payload_value(ctx, rewriter, field, target_field)?;
-                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
-                rewriter.insert_operation(ctx, insert.get_operation());
-                current = insert.get_operation().deref(ctx).get_result(0);
-            }
-            Ok(current)
-        }
-        ValueCoercion::Unsupported => pliron::input_err_noloc!(
-            "enum payload storage type mismatch: {} cannot be adapted to {}",
-            source_ty.deref(ctx).disp(ctx),
-            target_ty.deref(ctx).disp(ctx)
-        ),
-    }
+    coerce_target_stable_value(ctx, rewriter, value, target_ty, "enum payload storage")
 }

--- a/crates/mir-lower/src/convert/mod.rs
+++ b/crates/mir-lower/src/convert/mod.rs
@@ -47,5 +47,6 @@ mod generated_intrinsics;
 pub mod interface_impls;
 pub mod intrinsics;
 pub mod ops;
+pub(crate) mod target_stable_storage;
 pub mod type_interface_impls;
 pub mod types;

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -42,6 +42,7 @@ use crate::convert::types::{
     build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
     llvm_packed_struct_contains_pointer_in_address_space, llvm_type_contains_i1,
     llvm_type_size_align, make_slice_struct, mir_element_stride, mir_type_abi_align,
+    packed_shared_internal_abi_info,
 };
 use dialect_mir::ops::{
     MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
@@ -462,14 +463,18 @@ pub(crate) fn convert_construct_struct(
         );
     }
 
-    // Shared pointers are the one target-dependent packed exception: their
-    // physical width is 32 bits in modern NVVM p3:32 but 64 bits in PTX/legacy
-    // mode, and lowering runs before that target mode is selected.
+    // A packed struct containing AS3 remains target-dependent as a physical
+    // memory image. The narrow internal-call ABI exception is safe to construct
+    // in SSA because its return boundary rebuilds the value into a target-stable
+    // generic-pointer carrier before the aggregate crosses the function ABI.
     if llvm_packed_struct_contains_pointer_in_address_space(
         ctx,
         map.llvm_struct_ty,
         llvm_types::address_space::SHARED,
-    ) {
+    ) && packed_shared_internal_abi_info(ctx, result_ty)
+        .map_err(anyhow_to_pliron)?
+        .is_none()
+    {
         return pliron::input_err_noloc!(
             "constructing a packed aggregate containing a shared-memory pointer by value is \
              target-mode dependent and is not yet supported"
@@ -2894,7 +2899,7 @@ mod tests {
     }
 
     #[test]
-    fn packed_struct_construction_with_shared_pointer_fails_closed() {
+    fn packed_struct_construction_with_one_direct_shared_pointer_stays_semantic_in_ssa() {
         use dialect_mir::ops::MirConstructStructOp;
 
         let mut ctx = make_ctx();
@@ -2927,11 +2932,45 @@ mod tests {
         construct.insert_at_back(block, &ctx);
         append_mir_return(&mut ctx, block, vec![]);
 
-        let err = crate::lower_mir_to_llvm(&mut ctx, module)
-            .expect_err("packed construction containing AS3 must remain fail-closed");
-        assert!(
-            format!("{err:?}").contains("target-mode dependent"),
-            "the refusal must identify the target-dependent packed AS3 image: {err:?}"
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("one direct AS3 pointer in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        assert_eq!(
+            insert_indices(&ctx, &inserts),
+            vec![vec![0], vec![1]],
+            "packed AS3 construction must preserve the semantic packed field slots"
+        );
+
+        let result_ty = inserts
+            .last()
+            .expect("packed AS3 construction must emit insertvalue")
+            .get_operation()
+            .deref(&ctx)
+            .get_result(0)
+            .get_type(&ctx);
+        let result_ty_ref = result_ty.deref(&ctx);
+        let struct_ty = result_ty_ref
+            .downcast_ref::<llvm_types::StructType>()
+            .expect("packed AS3 construction result must be an LLVM struct");
+        assert_eq!(struct_ty.layout(), llvm_types::StructLayout::Packed);
+        assert_eq!(llvm_type_size_align(&ctx, result_ty), Some((9, 1)));
+
+        let pointer_ty = struct_ty.field_type(1);
+        let pointer_ty_ref = pointer_ty.deref(&ctx);
+        let pointer = pointer_ty_ref
+            .downcast_ref::<llvm_types::PointerType>()
+            .expect("second packed field must remain a pointer");
+        assert_eq!(
+            pointer.address_space(),
+            llvm_types::address_space::SHARED,
+            "construction must keep the semantic pointer in AS3"
+        );
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "construction itself must not genericize the shared pointer"
         );
     }
 

--- a/crates/mir-lower/src/convert/ops/call.rs
+++ b/crates/mir-lower/src/convert/ops/call.rs
@@ -61,9 +61,11 @@
 //! callee declaration carried `addrspace(3)`. The verifier rejected the
 //! mismatch.
 
+use crate::convert::target_stable_storage::coerce_target_stable_value;
 use crate::convert::types::{
     StructLayoutInfo, TransparentScalarAbiInfo, build_struct_slot_map, convert_function_type,
-    convert_type, is_kernel_func, is_zero_sized_type, transparent_scalar_abi_info,
+    convert_type, is_kernel_func, is_zero_sized_type, packed_shared_internal_abi_info,
+    transparent_scalar_abi_info,
 };
 use crate::helpers;
 use dialect_mir::ops::{MirCallOp, MirFuncOp};
@@ -640,6 +642,7 @@ pub fn convert(
 
     let mut zst_replacement_type = None;
     let mut transparent_result_abi = None;
+    let mut packed_shared_result_abi = None;
     let result_type = if let Some(mir_ty) = mir_result_ty_ptr {
         // Only the empty tuple `()` is the unit type. `is::<MirTupleType>()`
         // also matches `(T, U, ...)`, so we have to peek at the field count.
@@ -660,6 +663,12 @@ pub fn convert(
             let scalar_ty = abi.scalar_ty;
             transparent_result_abi = Some(abi);
             scalar_ty
+        } else if let Some(abi) =
+            packed_shared_internal_abi_info(ctx, mir_ty).map_err(anyhow_to_pliron)?
+        {
+            let storage_ty = abi.storage_ty;
+            packed_shared_result_abi = Some(abi);
+            storage_ty
         } else {
             convert_type(ctx, mir_ty).map_err(anyhow_to_pliron)?
         };
@@ -751,6 +760,16 @@ pub fn convert(
                 replacement = insert.get_operation();
             }
             rewriter.replace_operation(ctx, op, replacement);
+        } else if let Some(abi) = packed_shared_result_abi {
+            let value = llvm_call.get_operation().deref(ctx).get_result(0);
+            let semantic = coerce_target_stable_value(
+                ctx,
+                rewriter,
+                value,
+                abi.semantic_ty,
+                "packed shared internal ABI",
+            )?;
+            rewriter.replace_operation_with_values(ctx, op, vec![semantic]);
         } else {
             rewriter.replace_operation(ctx, op, llvm_call.get_operation());
         }

--- a/crates/mir-lower/src/convert/ops/control_flow.rs
+++ b/crates/mir-lower/src/convert/ops/control_flow.rs
@@ -23,6 +23,8 @@
 //! With `DialectConversion` + `inline_region`, blocks are the ORIGINALS (moved,
 //! not copied). Successor pointers are already valid — no block map lookup needed.
 
+use crate::convert::target_stable_storage::coerce_target_stable_value;
+use crate::convert::types::packed_shared_internal_abi_info;
 use dialect_mir::types::MirStructType;
 use llvm_export::ops as llvm;
 use pliron::basic_block::BasicBlock;
@@ -79,13 +81,36 @@ pub(crate) fn convert_return(
                 }
                 Some(scalar)
             } else {
-                let ty = val.get_type(ctx);
-                if ty.deref(ctx).is::<llvm_export::types::VoidType>()
-                    || crate::convert::types::is_zero_sized_type(ctx, ty)
-                {
-                    None
+                let packed_shared_abi = if let Some(mir_ty) = mir_ty {
+                    match packed_shared_internal_abi_info(ctx, mir_ty) {
+                        Ok(abi) => abi,
+                        Err(error) => {
+                            return pliron::input_err_noloc!(
+                                "failed to lower packed shared internal return ABI: {error}"
+                            );
+                        }
+                    }
                 } else {
-                    Some(*val)
+                    None
+                };
+
+                if let Some(abi) = packed_shared_abi {
+                    Some(coerce_target_stable_value(
+                        ctx,
+                        rewriter,
+                        *val,
+                        abi.storage_ty,
+                        "packed shared internal ABI",
+                    )?)
+                } else {
+                    let ty = val.get_type(ctx);
+                    if ty.deref(ctx).is::<llvm_export::types::VoidType>()
+                        || crate::convert::types::is_zero_sized_type(ctx, ty)
+                    {
+                        None
+                    } else {
+                        Some(*val)
+                    }
                 }
             }
         }

--- a/crates/mir-lower/src/convert/target_stable_storage.rs
+++ b/crates/mir-lower/src/convert/target_stable_storage.rs
@@ -1,0 +1,335 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Target-stable physical storage for values whose semantic LLVM type contains
+//! address-space-sensitive leaves.
+//!
+//! Modern NVVM represents address-space-3 pointers as 32-bit values while the
+//! legacy/PTX paths use 64-bit pointers. Any physical aggregate image that must
+//! be identical before the backend mode is selected therefore uses CUDA generic
+//! pointers as the stable carrier and converts shared pointers at value
+//! boundaries. Enum payload storage also uses this module for its bool-byte
+//! canonicalization.
+
+use llvm_export::op_interfaces::{CastOpInterface, CastOpWithNNegInterface};
+use llvm_export::ops as llvm;
+use llvm_export::types as llvm_types;
+use llvm_export::types::PointerTypeExt;
+use pliron::builtin::types::{IntegerType, Signedness};
+use pliron::context::Context;
+use pliron::irbuild::dialect_conversion::DialectConversionRewriter;
+use pliron::irbuild::inserter::Inserter;
+use pliron::op::Op;
+use pliron::result::Result;
+use pliron::r#type::{TypeHandle, Typed};
+use pliron::value::Value;
+
+#[derive(Clone, Copy)]
+pub(crate) struct StorageRewriteOptions {
+    pub canonicalize_bool: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct StorageRewrite {
+    pub ty: TypeHandle,
+    pub shared_pointer_leaves: u64,
+    pub array_shared_pointer_leaves: u64,
+}
+
+enum TypeShape {
+    Bool,
+    Pointer(u32),
+    Array(TypeHandle, u64),
+    Vector(TypeHandle),
+    Struct {
+        fields: Vec<TypeHandle>,
+        layout: llvm_types::StructLayout,
+    },
+    Identity,
+}
+
+/// Rewrite a semantic LLVM value type into a backend-independent physical
+/// storage type.
+///
+/// Shared pointers become generic pointers recursively. Bool leaves may also
+/// be canonicalized to `i8` when requested by the caller, which is required by
+/// enum byte storage but not by the internal packed-aggregate call ABI.
+pub(crate) fn target_stable_storage_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+    options: StorageRewriteOptions,
+    role: &str,
+) -> std::result::Result<StorageRewrite, anyhow::Error> {
+    rewrite_storage_type(ctx, semantic_ty, options, role)
+}
+
+fn rewrite_storage_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+    options: StorageRewriteOptions,
+    role: &str,
+) -> std::result::Result<StorageRewrite, anyhow::Error> {
+    let shape = {
+        let ty_ref = semantic_ty.deref(ctx);
+        if options.canonicalize_bool
+            && ty_ref
+                .downcast_ref::<IntegerType>()
+                .is_some_and(|integer| integer.width() == 1)
+        {
+            TypeShape::Bool
+        } else if let Some(pointer) = ty_ref.downcast_ref::<llvm_types::PointerType>() {
+            TypeShape::Pointer(pointer.address_space())
+        } else if let Some(array) = ty_ref.downcast_ref::<llvm_types::ArrayType>() {
+            TypeShape::Array(array.elem_type(), array.size())
+        } else if let Some(vector) = ty_ref.downcast_ref::<llvm_types::VectorType>() {
+            TypeShape::Vector(vector.elem_type())
+        } else if let Some(struct_ty) = ty_ref.downcast_ref::<llvm_types::StructType>() {
+            TypeShape::Struct {
+                fields: struct_ty.fields().collect(),
+                layout: struct_ty.layout(),
+            }
+        } else {
+            TypeShape::Identity
+        }
+    };
+
+    match shape {
+        TypeShape::Bool => Ok(StorageRewrite {
+            ty: IntegerType::get(ctx, 8, Signedness::Signless).into(),
+            shared_pointer_leaves: 0,
+            array_shared_pointer_leaves: 0,
+        }),
+        TypeShape::Pointer(address_space) if address_space == llvm_types::address_space::SHARED => {
+            Ok(StorageRewrite {
+                ty: llvm_types::PointerType::get_generic(ctx).into(),
+                shared_pointer_leaves: 1,
+                array_shared_pointer_leaves: 0,
+            })
+        }
+        TypeShape::Pointer(_) | TypeShape::Identity => Ok(StorageRewrite {
+            ty: semantic_ty,
+            shared_pointer_leaves: 0,
+            array_shared_pointer_leaves: 0,
+        }),
+        TypeShape::Array(element_ty, count) => {
+            let element = rewrite_storage_type(ctx, element_ty, options, role)?;
+            let shared_pointer_leaves = element
+                .shared_pointer_leaves
+                .checked_mul(count)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("{role}: shared-pointer array rewrite size overflow")
+                })?;
+            let ty = if element.ty == element_ty {
+                semantic_ty
+            } else {
+                llvm_types::ArrayType::get(ctx, element.ty, count).into()
+            };
+            Ok(StorageRewrite {
+                ty,
+                shared_pointer_leaves,
+                array_shared_pointer_leaves: shared_pointer_leaves,
+            })
+        }
+        TypeShape::Vector(element_ty) => {
+            let element = rewrite_storage_type(ctx, element_ty, options, role)?;
+            if element.ty != element_ty || element.shared_pointer_leaves != 0 {
+                return Err(anyhow::anyhow!(
+                    "{role}: vectors containing bool or shared-memory pointer elements are not supported"
+                ));
+            }
+            Ok(StorageRewrite {
+                ty: semantic_ty,
+                shared_pointer_leaves: 0,
+                array_shared_pointer_leaves: 0,
+            })
+        }
+        TypeShape::Struct { fields, layout } => {
+            let mut storage_fields = Vec::with_capacity(fields.len());
+            let mut changed = false;
+            let mut shared_pointer_leaves = 0_u64;
+            let mut array_shared_pointer_leaves = 0_u64;
+            for field in fields {
+                let storage = rewrite_storage_type(ctx, field, options, role)?;
+                changed |= storage.ty != field;
+                shared_pointer_leaves = shared_pointer_leaves
+                    .checked_add(storage.shared_pointer_leaves)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "{role}: shared-pointer leaf count overflow while rewriting a struct payload"
+                        )
+                    })?;
+                array_shared_pointer_leaves = array_shared_pointer_leaves
+                    .checked_add(storage.array_shared_pointer_leaves)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "{role}: shared-pointer leaf count overflow while rewriting a struct payload"
+                        )
+                    })?;
+                storage_fields.push(storage.ty);
+            }
+            let ty = if changed {
+                llvm_types::StructType::get_unnamed(ctx, (storage_fields, layout)).into()
+            } else {
+                semantic_ty
+            };
+            Ok(StorageRewrite {
+                ty,
+                shared_pointer_leaves,
+                array_shared_pointer_leaves,
+            })
+        }
+    }
+}
+
+enum ValueCoercion {
+    BoolToByte,
+    ByteToBool,
+    SharedToGeneric,
+    GenericToShared,
+    Array {
+        target_element: TypeHandle,
+        count: u64,
+    },
+    Struct(Vec<TypeHandle>),
+    Unsupported,
+}
+
+/// Convert a value between its semantic type and a target-stable storage type.
+///
+/// The conversion is symmetric and recursively rebuilds arrays and structs so
+/// pointer address-space conversions remain explicit SSA operations rather than
+/// bit reinterpretations.
+pub(crate) fn coerce_target_stable_value(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    value: Value,
+    target_ty: TypeHandle,
+    role: &str,
+) -> Result<Value> {
+    let source_ty = value.get_type(ctx);
+    if source_ty == target_ty {
+        return Ok(value);
+    }
+
+    let coercion = {
+        let source_ref = source_ty.deref(ctx);
+        let target_ref = target_ty.deref(ctx);
+
+        let source_integer = source_ref
+            .downcast_ref::<IntegerType>()
+            .map(IntegerType::width);
+        let target_integer = target_ref
+            .downcast_ref::<IntegerType>()
+            .map(IntegerType::width);
+        if source_integer == Some(1) && target_integer == Some(8) {
+            ValueCoercion::BoolToByte
+        } else if source_integer == Some(8) && target_integer == Some(1) {
+            ValueCoercion::ByteToBool
+        } else if let (Some(source_pointer), Some(target_pointer)) = (
+            source_ref.downcast_ref::<llvm_types::PointerType>(),
+            target_ref.downcast_ref::<llvm_types::PointerType>(),
+        ) {
+            match (
+                source_pointer.address_space(),
+                target_pointer.address_space(),
+            ) {
+                (llvm_types::address_space::SHARED, llvm_types::address_space::GENERIC) => {
+                    ValueCoercion::SharedToGeneric
+                }
+                (llvm_types::address_space::GENERIC, llvm_types::address_space::SHARED) => {
+                    ValueCoercion::GenericToShared
+                }
+                _ => ValueCoercion::Unsupported,
+            }
+        } else if let (Some(source_array), Some(target_array)) = (
+            source_ref.downcast_ref::<llvm_types::ArrayType>(),
+            target_ref.downcast_ref::<llvm_types::ArrayType>(),
+        ) {
+            if source_array.size() == target_array.size() {
+                ValueCoercion::Array {
+                    target_element: target_array.elem_type(),
+                    count: source_array.size(),
+                }
+            } else {
+                ValueCoercion::Unsupported
+            }
+        } else if let (Some(source_struct), Some(target_struct)) = (
+            source_ref.downcast_ref::<llvm_types::StructType>(),
+            target_ref.downcast_ref::<llvm_types::StructType>(),
+        ) {
+            if source_struct.num_fields() == target_struct.num_fields() {
+                ValueCoercion::Struct(target_struct.fields().collect())
+            } else {
+                ValueCoercion::Unsupported
+            }
+        } else {
+            ValueCoercion::Unsupported
+        }
+    };
+
+    match coercion {
+        ValueCoercion::BoolToByte => {
+            let zext = llvm::ZExtOp::new_with_nneg(ctx, value, target_ty, false);
+            rewriter.insert_operation(ctx, zext.get_operation());
+            Ok(zext.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::ByteToBool => {
+            let trunc = llvm::TruncOp::new(ctx, value, target_ty);
+            rewriter.insert_operation(ctx, trunc.get_operation());
+            Ok(trunc.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::SharedToGeneric | ValueCoercion::GenericToShared => {
+            let cast = llvm::AddrSpaceCastOp::new(ctx, value, target_ty);
+            rewriter.insert_operation(ctx, cast.get_operation());
+            Ok(cast.get_operation().deref(ctx).get_result(0))
+        }
+        ValueCoercion::Array {
+            target_element,
+            count,
+        } => {
+            let undef = llvm::UndefOp::new(ctx, target_ty);
+            rewriter.insert_operation(ctx, undef.get_operation());
+            let mut current = undef.get_operation().deref(ctx).get_result(0);
+            for index in 0..count {
+                let index = u32::try_from(index).map_err(|_| {
+                    pliron::input_error_noloc!("{role} array has more than u32::MAX elements")
+                })?;
+                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
+                rewriter.insert_operation(ctx, extract.get_operation());
+                let element = extract.get_operation().deref(ctx).get_result(0);
+                let converted =
+                    coerce_target_stable_value(ctx, rewriter, element, target_element, role)?;
+                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
+                rewriter.insert_operation(ctx, insert.get_operation());
+                current = insert.get_operation().deref(ctx).get_result(0);
+            }
+            Ok(current)
+        }
+        ValueCoercion::Struct(fields) => {
+            let undef = llvm::UndefOp::new(ctx, target_ty);
+            rewriter.insert_operation(ctx, undef.get_operation());
+            let mut current = undef.get_operation().deref(ctx).get_result(0);
+            for (index, target_field) in fields.into_iter().enumerate() {
+                let index = u32::try_from(index).map_err(|_| {
+                    pliron::input_error_noloc!("{role} struct has more than u32::MAX fields")
+                })?;
+                let extract = llvm::ExtractValueOp::new(ctx, value, vec![index])?;
+                rewriter.insert_operation(ctx, extract.get_operation());
+                let field = extract.get_operation().deref(ctx).get_result(0);
+                let converted =
+                    coerce_target_stable_value(ctx, rewriter, field, target_field, role)?;
+                let insert = llvm::InsertValueOp::new(ctx, current, converted, vec![index]);
+                rewriter.insert_operation(ctx, insert.get_operation());
+                current = insert.get_operation().deref(ctx).get_result(0);
+            }
+            Ok(current)
+        }
+        ValueCoercion::Unsupported => pliron::input_err_noloc!(
+            "{role} type mismatch: {} cannot be adapted to {}",
+            source_ty.deref(ctx).disp(ctx),
+            target_ty.deref(ctx).disp(ctx)
+        ),
+    }
+}

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -113,6 +113,7 @@ use pliron::r#type::{TypeHandle, type_cast};
 use super::enum_payload_storage::{
     MAX_ENUM_PAYLOAD_ARRAY_REWRITE_LEAVES, enum_payload_storage_type,
 };
+use super::target_stable_storage::{StorageRewriteOptions, target_stable_storage_type};
 use crate::type_conversion_interface::MirTypeConversion;
 
 // =============================================================================
@@ -364,6 +365,100 @@ pub(crate) fn transparent_scalar_llvm_type(
     Ok(transparent_scalar_abi_info(ctx, struct_ty)?.scalar_ty)
 }
 
+/// Target-stable ABI projection for the deliberately narrow packed-AS3
+/// internal device return case.
+///
+/// The function body continues to use the semantic packed LLVM struct with a
+/// shared pointer. Only the physical return value replaces that direct AS3
+/// pointer with a generic pointer, whose width is stable across the legacy/PTX
+/// and modern NVVM data layouts.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PackedSharedInternalAbiInfo {
+    pub semantic_ty: TypeHandle,
+    pub storage_ty: TypeHandle,
+}
+
+/// Recognize the first supported packed-AS3 internal ABI shape.
+///
+/// Scope is intentionally fail-closed: one direct shared-pointer field in a
+/// byte-faithful packed struct, with every other non-ZST field scalar. Nested
+/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain out
+/// of scope even though the generic storage utility can represent broader
+/// shapes for enum payloads.
+pub(crate) fn packed_shared_internal_abi_info(
+    ctx: &mut Context,
+    mir_ty: TypeHandle,
+) -> Result<Option<PackedSharedInternalAbiInfo>, anyhow::Error> {
+    let layout = {
+        let ty_ref = mir_ty.deref(ctx);
+        let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() else {
+            return Ok(None);
+        };
+        StructLayoutInfo::of_struct(struct_ty)
+    };
+
+    let map = build_struct_slot_map(ctx, &layout)?;
+    if !map.by_value_layout_faithful {
+        return Ok(None);
+    }
+    let is_packed = map
+        .llvm_struct_ty
+        .deref(ctx)
+        .downcast_ref::<llvm_types::StructType>()
+        .is_some_and(|struct_ty| struct_ty.layout() == llvm_types::StructLayout::Packed);
+    if !is_packed {
+        return Ok(None);
+    }
+
+    let mut direct_shared_pointers = 0_u64;
+    for field_ty in &map.field_llvm_types {
+        if is_zero_sized_type(ctx, *field_ty) {
+            continue;
+        }
+        let field_ref = field_ty.deref(ctx);
+        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
+            if pointer.address_space() == llvm_types::address_space::SHARED {
+                direct_shared_pointers += 1;
+            }
+            continue;
+        }
+        if field_ref.is::<IntegerType>()
+            || field_ref.is::<llvm_types::HalfType>()
+            || field_ref.is::<FP32Type>()
+            || field_ref.is::<FP64Type>()
+        {
+            continue;
+        }
+        return Ok(None);
+    }
+    if direct_shared_pointers != 1 {
+        return Ok(None);
+    }
+
+    let rewrite = target_stable_storage_type(
+        ctx,
+        map.llvm_struct_ty,
+        StorageRewriteOptions {
+            canonicalize_bool: false,
+        },
+        "packed shared internal ABI",
+    )?;
+    if rewrite.shared_pointer_leaves != 1 || rewrite.array_shared_pointer_leaves != 0 {
+        return Ok(None);
+    }
+    let Some((storage_size, _)) = llvm_type_size_align(ctx, rewrite.ty) else {
+        return Ok(None);
+    };
+    if layout.total_size > 0 && storage_size != layout.total_size {
+        return Ok(None);
+    }
+
+    Ok(Some(PackedSharedInternalAbiInfo {
+        semantic_ty: map.llvm_struct_ty,
+        storage_ty: rewrite.ty,
+    }))
+}
+
 /// Convert a type that crosses a function boundary as one LLVM value.
 ///
 /// A struct with a natural-layout divergence is legal by value only when
@@ -612,6 +707,11 @@ pub fn convert_function_type(
         };
         let ty = if is_transparent_scalar {
             transparent_scalar_llvm_type(ctx, mir_ret_ty)?
+        } else if !is_kernel_entry {
+            match packed_shared_internal_abi_info(ctx, mir_ret_ty)? {
+                Some(abi) => abi.storage_ty,
+                None => convert_by_value_abi_type(ctx, mir_ret_ty, "by-value function return")?,
+            }
         } else {
             convert_by_value_abi_type(ctx, mir_ret_ty, "by-value function return")?
         };
@@ -4904,6 +5004,83 @@ mod tests {
                 llvm_types::address_space::SHARED,
             ),
             "an AS3 pointer under a packed struct must be rejected by by-value paths"
+        );
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_genericizes_one_direct_shared_pointer() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedShared".into(),
+            vec!["tag".into(), "ptr".into()],
+            vec![tag, shared],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, packed)
+            .expect("ABI classification must succeed")
+            .expect("one direct packed AS3 pointer must use the internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((9, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((9, 1)));
+        assert!(llvm_packed_struct_contains_pointer_in_address_space(
+            &ctx,
+            abi.semantic_ty,
+            llvm_types::address_space::SHARED,
+        ));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+        assert!(llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::GENERIC,
+        ));
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_rejects_nested_shared_pointer() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let inner: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "InnerShared".into(),
+            vec!["ptr".into()],
+            vec![shared],
+            vec![0],
+            vec![0],
+            8,
+            8,
+        )
+        .into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedNestedShared".into(),
+            vec!["tag".into(), "inner".into()],
+            vec![tag, inner],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_internal_abi_info(&mut ctx, outer)
+                .expect("classification must not error")
+                .is_none(),
+            "the first internal ABI lane intentionally accepts only a direct AS3 field"
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -5,11 +5,13 @@
 
 //! End-to-end ABI regression coverage for packed aggregates.
 //!
-//! This example exercises four paths that must agree on the same rustc byte
+//! This example exercises five paths that must agree on the same rustc byte
 //! layout:
 //!
 //! - packed structs passed by value across the host -> kernel boundary;
 //! - packed structs passed to and returned from an internal device helper;
+//! - packed structs containing a shared pointer returned from an internal
+//!   device helper through a target-stable generic-pointer carrier;
 //! - whole-value stores of packed structs to device memory;
 //! - whole-value loads of packed structs from device memory.
 //!
@@ -19,7 +21,7 @@
 //! Rust does not guarantee a stable value for padding bytes.
 
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig};
-use cuda_device::{cuda_module, kernel};
+use cuda_device::{SharedArray, cuda_module, device, kernel};
 
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
@@ -33,6 +35,13 @@ pub struct Packed1 {
 pub struct Packed2 {
     pub a: u8,
     pub b: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedShared {
+    pub tag: u8,
+    pub ptr: *mut SharedArray<u32, 1>,
 }
 
 #[cuda_module]
@@ -56,6 +65,26 @@ mod kernels {
         Packed2 {
             a: a.wrapping_add(2),
             b: b.wrapping_add(0x1112_1314),
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    fn bounce_packed_shared(value: PackedShared) -> PackedShared {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_shared(
+        _value: PackedShared,
+        shared: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *shared)[0] = (&*shared)[0].wrapping_add(0x0102_0304);
+            out.write(0x22);
+            out.add(1).write((&*shared)[0]);
         }
     }
 
@@ -83,6 +112,25 @@ mod kernels {
             out.write(u32::from(a));
             out.add(1).write(b);
         }
+    }
+
+    #[kernel]
+    pub unsafe fn packed_shared(out: *mut u32) {
+        static mut SHARED: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let raw = &raw mut SHARED;
+        unsafe { (&mut *raw)[0] = 0x1020_3040 };
+
+        let value = bounce_packed_shared(PackedShared {
+            tag: 0x21,
+            ptr: raw,
+        });
+
+        // Keep the packed AS3 aggregate in SSA across both internal device ABI
+        // boundaries. The raw shared pointer is passed separately for the
+        // observable runtime check so this regression does not require a
+        // target-dependent whole-value packed store/load.
+        unsafe { consume_packed_shared(value, raw, out) };
     }
 
     #[kernel]
@@ -197,6 +245,11 @@ fn assert_host_layout() {
     assert_eq!(core::mem::align_of::<Packed2>(), 2);
     assert_eq!(core::mem::offset_of!(Packed2, a), 0);
     assert_eq!(core::mem::offset_of!(Packed2, b), 2);
+
+    assert_eq!(core::mem::size_of::<PackedShared>(), 1 + core::mem::size_of::<usize>());
+    assert_eq!(core::mem::align_of::<PackedShared>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedShared, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedShared, ptr), 1);
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -221,6 +274,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let by_value1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let by_value2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
+    let packed_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let storage1 = DeviceBuffer::<u8>::zeroed(&stream, core::mem::size_of::<Packed1>())?;
@@ -247,7 +301,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // SAFETY: every kernel launches one thread. The u32 output buffers contain
     // two writable elements. The byte buffers are CUDA allocations, so their
     // base addresses satisfy Packed1/Packed2 alignment and have exact storage
-    // for one value of the corresponding type.
+    // for one value of the corresponding type. The packed-shared kernel creates
+    // its AS3 pointer on device and never exposes it through the host ABI.
     unsafe {
         module.packed1(
             &stream,
@@ -260,6 +315,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             config,
             input2,
             by_value2_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.packed_shared(
+            &stream,
+            config,
+            packed_shared_out.cu_deviceptr() as *mut u32,
         )?;
 
         module.store_packed1(
@@ -291,6 +351,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(by_value1_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
     assert_eq!(by_value2_out.to_host_vec(&stream)?, [0x33, 0x6172_8394]);
+    assert_eq!(packed_shared_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
     assert_eq!(load1_out.to_host_vec(&stream)?, [0x41, 0x90a0_b0c0]);
     assert_eq!(load2_out.to_host_vec(&stream)?, [0x51, 0xd0e0_f001]);
 
@@ -304,7 +365,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&bytes2[2..6], &0xd0e0_f001u32.to_le_bytes());
 
     println!(
-        "packed_aggregate_abi: PASS (runtime values, whole-value load/store, and PTX parameter shapes)"
+        "packed_aggregate_abi: PASS (runtime values, packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
     );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -246,7 +246,10 @@ fn assert_host_layout() {
     assert_eq!(core::mem::offset_of!(Packed2, a), 0);
     assert_eq!(core::mem::offset_of!(Packed2, b), 2);
 
-    assert_eq!(core::mem::size_of::<PackedShared>(), 1 + core::mem::size_of::<usize>());
+    assert_eq!(
+        core::mem::size_of::<PackedShared>(),
+        1 + core::mem::size_of::<usize>()
+    );
     assert_eq!(core::mem::align_of::<PackedShared>(), 1);
     assert_eq!(core::mem::offset_of!(PackedShared, tag), 0);
     assert_eq!(core::mem::offset_of!(PackedShared, ptr), 1);


### PR DESCRIPTION
Closes #1000 

## Summary

Adds support for the first packed aggregate shape containing an AS3/shared-memory pointer across the internal device ABI.

The implementation keeps the packed aggregate's semantic representation unchanged inside device-function SSA, but uses a target-stable packed carrier containing a generic pointer when the value crosses an internal return boundary.

This extends the aggregate ABI work from #867, the scalar AS3 representation strategy from #884, and the packed aggregate support from #941.

## Problem

#941 intentionally kept packed aggregates containing shared-memory pointers unsupported by value because their physical representation depends on the selected NVPTX target mode.

That restriction is still correct for:

- kernel parameters;
- whole-value memory loads;
- whole-value memory stores.

It is unnecessarily restrictive for an internal device-function return, where the compiler controls both sides of the ABI boundary.

A packed semantic value such as:

```llvm
<{ i8, ptr addrspace(3) }>
```

can cross that boundary through a target-stable carrier:

```llvm
<{ i8, ptr }>
```

and be reconstructed back to the semantic AS3 representation at the caller.

## Design

The new internal return path is:

```text
semantic packed aggregate
<{ scalar, p3 }>
        ↓ target-stable coercion
internal ABI carrier
<{ scalar, p0 }>
        ↓ call / return
internal ABI carrier
<{ scalar, p0 }>
        ↓ target-stable coercion
semantic packed aggregate
<{ scalar, p3 }>
```

The AS3 ↔ generic conversion is represented explicitly with `addrspacecast`.

The function body itself continues to use the semantic packed AS3 type.

## Target-stable aggregate storage

This PR factors the recursive physical-storage rewrite previously used by enum payload storage into a shared helper.

The helper supports:

* shared pointer → generic pointer rewriting;
* optional bool `i1` ↔ `i8` canonicalization;
* recursive structs;
* recursive arrays where allowed by the caller;
* symmetric value reconstruction.

Enum payload storage retains its existing bounded-array and bool-canonicalization policy on top of the shared implementation.

## Packed AS3 internal ABI classification

The new packed-AS3 ABI path is intentionally narrow.

It accepts only:

* a byte-faithful packed struct;
* exactly one direct AS3/shared pointer field;
* scalar non-ZST sibling fields.

It rejects:

* nested aggregate AS3 leaves;
* arrays;
* vectors;
* multiple AS3 pointer leaves;
* layouts that cannot be represented faithfully.

The target-stable carrier must preserve the recorded aggregate size.

## Arguments and returns

Internal aggregate arguments already use the existing flattened field ABI path, so no new aggregate argument carrier is required.

For eligible packed-AS3 returns:

* the callee rebuilds the semantic packed value into the generic-pointer carrier before `llvm.return`;
* the call result is typed as the carrier;
* the caller reconstructs the semantic packed AS3 aggregate after the call.

Kernel entry returns and parameters are unchanged.

## Memory behavior

Whole-value packed AS3 loads and stores remain fail closed.

This PR does not make the target-dependent packed memory image legal.

The new exception applies only to semantic SSA construction and the controlled internal device ABI boundary.

## End-to-end coverage

`packed_aggregate_abi` now includes a device-only packed shared-pointer case:

```rust
#[repr(C, packed)]
struct PackedShared {
    tag: u8,
    ptr: *mut SharedArray<u32, 1>,
}
```

The value crosses internal device-function boundaries while remaining in SSA.

The shared pointer is created on device and is never exposed through the host/kernel parameter ABI.

Runtime validation confirms that the shared-memory pointer survives the round trip.

## Validation

```text
cargo fmt --all -- --check
git diff --check

cargo test -p mir-lower packed_struct_construction -- --nocapture
cargo test -p mir-lower packed_shared -- --nocapture
cargo test -p mir-lower --all-targets

cargo clippy -p mir-lower --all-targets -- -D warnings
```

Results:

```text
mir-lower unit tests:        248 passed
mir-lower integration tests: 107 passed
```

End-to-end:

```text
cargo oxide build packed_aggregate_abi
cargo oxide run packed_aggregate_abi
cargo oxide run addressof_sharedarray
```

Results:

```text
packed_aggregate_abi: PASS
(runtime values, packed shared internal ABI, whole-value load/store, and PTX parameter shapes)

PASS addressof_sharedarray:
shared address is non-null, enum storage and struct/tuple/array/enum
device-call round trips preserved shared pointers
```

## Out of scope

This PR intentionally does not support:

* packed AS3 kernel parameters;
* whole-value packed AS3 memory loads or stores;
* nested AS3 aggregates;
* arrays containing AS3 pointers;
* vectors containing AS3 pointers;
* multiple AS3 pointer leaves;
* broader recursive packed-AS3 ABI legalization.
