### PR TITLE
fix(mir-importer): forward generated ldmatrix result bundles

### DIFF
--- a/crates/mir-importer/src/translator/terminator/helpers.rs
+++ b/crates/mir-importer/src/translator/terminator/helpers.rs
@@ -376,10 +376,11 @@ pub fn set_compiler_result_bundle_marker(ctx: &mut Context, op: Ptr<Operation>) 
 }
 
 /// Bundle a generated operation's independent `u32` results into the Rust
-/// array value expected by its raw ABI.
+/// array value expected by its raw ABI and mark the compiler-owned adapter
+/// for result forwarding.
 ///
-/// Keeping this adapter here lets later multi-result families reuse the same
-/// SSA-to-array boundary without introducing a stack temporary.
+/// This helper is only for compiler-generated multi-result carriers. Ordinary
+/// Rust arrays must never receive the forwarding marker.
 pub fn bundle_generated_u32_results_as_array(
     ctx: &mut Context,
     producer: Ptr<Operation>,
@@ -400,6 +401,7 @@ pub fn bundle_generated_u32_results_as_array(
         0,
     );
     array.deref_mut(ctx).set_loc(loc);
+    set_compiler_result_bundle_marker(ctx, array);
     array.insert_after(ctx, producer);
     (array.deref(ctx).get_result(0), array)
 }
@@ -655,5 +657,87 @@ pub fn emit_unit_noop_intrinsic(
                 intrinsic_name
             ))
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialect_mir::{
+        attributes::{COMPILER_RESULT_BUNDLE_ATTR_KEY, CompilerResultBundleAttr},
+        ops::MirFuncOp,
+    };
+    use pliron::{
+        builtin::{
+            attributes::{StringAttr, TypeAttr},
+            op_interfaces::{SingleBlockRegionInterface, SymbolOpInterface},
+            ops::ModuleOp,
+            types::FunctionType,
+        },
+        identifier::Identifier,
+        region::Region,
+        r#type::TypeHandle,
+    };
+
+    #[test]
+    fn generated_u32_result_array_is_marked_for_forwarding() {
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let module = ModuleOp::new(&mut ctx, "test".try_into().unwrap());
+        let function_type = FunctionType::get(&ctx, vec![], vec![]);
+        let function = Operation::new(
+            &mut ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let function_op = MirFuncOp::new(&mut ctx, function, TypeAttr::new(function_type.into()));
+        function_op.set_symbol_name(&mut ctx, "kernel".try_into().unwrap());
+        module.append_operation(&mut ctx, function, 0);
+
+        let region: Ptr<Region> = function.deref(&ctx).get_region(0);
+        let block = BasicBlock::new(&mut ctx, None, vec![]);
+        block.insert_at_back(region, &ctx);
+
+        let producer = Operation::new(
+            &mut ctx,
+            MirCallOp::get_concrete_op_info(),
+            vec![u32_ty; 2],
+            vec![],
+            vec![],
+            0,
+        );
+        MirCallOp::new(producer)
+            .set_attr_callee(&ctx, StringAttr::new("register_pair".to_string()));
+        producer.insert_at_back(block, &ctx);
+
+        let loc = producer.deref(&ctx).loc().clone();
+        let (_, bundle) = bundle_generated_u32_results_as_array(&mut ctx, producer, 2, loc);
+
+        let key = Identifier::try_from(COMPILER_RESULT_BUNDLE_ATTR_KEY).unwrap();
+        let is_marked = {
+            let bundle_op = bundle.deref(&ctx);
+            bundle_op
+                .attributes
+                .get::<CompilerResultBundleAttr>(&key)
+                .is_some_and(|marker| marker.0)
+        };
+
+        assert!(
+            is_marked,
+            "generated result bundle must carry the forwarding marker"
+        );
+        assert_eq!(
+            bundle.deref(&ctx).get_operand(0),
+            producer.deref(&ctx).get_result(0)
+        );
+        assert_eq!(
+            bundle.deref(&ctx).get_operand(1),
+            producer.deref(&ctx).get_result(1)
+        );
     }
 }


### PR DESCRIPTION
Closes #1002 

## Summary

Mark arrays produced by `bundle_generated_u32_results_as_array` as compiler-owned result bundles so the existing `forward_compiler_result_bundles` pass can forward generated multi-result `ldmatrix` values directly from their producer results.

This closes the remaining `ldmatrix` forwarding gap called out in #888.

## Changes

- attach the existing `mir.compiler_result_bundle` marker to generated `u32` result arrays
- document that the helper is restricted to compiler-generated multi-result carriers
- add a regression test verifying:

  - the generated array carries the forwarding marker
  - producer result ordering is preserved

No changes are made to the forwarding pass, generated intrinsic dispatcher, overlays, or generated files.

## Validation

All standard validation passes:

- `cargo fmt --all -- --check`
- `cargo test -p mir-importer --all-targets`
  - 1090 tests passed
- `cargo test -p mir-transforms --all-targets`
- `cargo run -p cuda-intrinsics-gen -- check`
- `cargo clippy -p mir-importer --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`

### PTX validation

Using the existing `generated_ldmatrix` example and an unmodified `HEAD` worktree as the baseline:

**Default pipeline**

```text
PASS: default PTX is byte-identical
```

**CUDA_OXIDE_NO_OPT=1**

Before:

```text
st.local=16
ld.local=15
```

After:

```text
st.local=0
ld.local=0
```

The resulting NO_OPT PTX keeps the `ldmatrix` results directly in registers for the x1/x2/x4 and transpose forms.

### Runtime oracle

On sm_120:

```text
PASS: all 128 ldmatrix x4 fragments matched on sm_120
```

The runtime oracle validates all 128 x4 fragments, while the regression test and NO_OPT PTX inspection verify result ordering and direct-register forwarding across the generated ldmatrix path.
