### PR TITLE
feat(codegen): forward bounded dynamic result-bundle indexing

### DIFF
--- a/crates/cuda-oxide-codegen/src/prep.rs
+++ b/crates/cuda-oxide-codegen/src/prep.rs
@@ -101,6 +101,28 @@ pub fn prepare_mir_module(
     })?;
     verify_operation(ctx, module, "module post-mem2reg")?;
 
+    // Source-level dynamic indices commonly pass through temporary MIR slots.
+    // After mem2reg, bounded forms such as `index % C` are direct SSA values,
+    // while result-bundle allocas blocked by dynamic array projections remain.
+    // Re-run the same fail-closed forwarding proof here so those bundles can
+    // be recovered without teaching the pass to trace arbitrary stack slots.
+    mir_transforms::forward_compiler_result_bundles::forward_compiler_result_bundles(
+        module,
+        ctx,
+        &mut analyses,
+        preparation.verbose,
+    )
+    .map_err(|error| PipelineError::Verification {
+        name: "post-mem2reg compiler-result forwarding".to_string(),
+        message: error.disp(ctx).to_string(),
+        operation: None,
+    })?;
+    verify_operation(
+        ctx,
+        module,
+        "module post-mem2reg-compiler-result-forwarding",
+    )?;
+
     // Formation passes that need promoted SSA values but must still see the
     // original loop CFG run here. In particular, a reduction formation pass
     // cannot safely infer a source loop once generic unrolling has cloned it.

--- a/crates/mir-transforms/src/forward_compiler_result_bundles.rs
+++ b/crates/mir-transforms/src/forward_compiler_result_bundles.rs
@@ -20,7 +20,9 @@
 //! * the construct tree contains every result of exactly one producer, in order;
 //! * the outer bundle has one non-volatile store to one local alloca;
 //! * the alloca has no other stores, copies, escapes, or unknown pointer users;
-//! * every read is a non-volatile load through constant field/array projections;
+//! * every read is a non-volatile load through constant projections, or through
+//!   one terminal array projection whose unsigned runtime index is proven to be
+//!   `value % C` with a small constant candidate set;
 //! * the producer/store dominate every rewritten load.
 //!
 //! Any failed proof leaves the IR untouched.  Ordinary Rust aggregates are
@@ -29,12 +31,15 @@
 use dialect_mir::{
     attributes::{COMPILER_RESULT_BUNDLE_ATTR_KEY, CompilerResultBundleAttr},
     ops::{
-        MirAllocaOp, MirArrayElementAddrOp, MirConstantOp, MirConstructArrayOp,
-        MirConstructStructOp, MirConstructTupleOp, MirFieldAddrOp, MirLoadOp, MirStoreOp,
+        MAX_SCALARIZED_CANDIDATES, MirAllocaOp, MirArrayElementAddrOp, MirConstantOp,
+        MirConstructArrayOp, MirConstructStructOp, MirConstructTupleOp, MirExtractArrayElementOp,
+        MirFieldAddrOp, MirLoadOp, MirRemOp, MirStoreOp,
     },
+    types::MirArrayType,
 };
 use pliron::{
     basic_block::BasicBlock,
+    builtin::types::{IntegerType, Signedness},
     context::{Context, Ptr},
     graph::dominance::DomInfo,
     irbuild::{
@@ -42,18 +47,30 @@ use pliron::{
         rewriter::{IRRewriter, Rewriter},
     },
     linked_list::ContainsLinkedList,
+    location::Located,
+    op::Op,
     operation::Operation,
     pass::AnalysisManager,
     result::Result,
-    r#type::Typed,
+    r#type::{TypeHandle, Typed},
     value::Value,
 };
 use rustc_hash::FxHashSet;
 
 #[derive(Clone, Copy)]
+enum LoadReplacement {
+    Direct(Value),
+    BoundedArrayElement {
+        array: Value,
+        index: Value,
+        result_type: TypeHandle,
+    },
+}
+
+#[derive(Clone, Copy)]
 struct LoadForwarding {
     load: Ptr<Operation>,
-    replacement: Value,
+    replacement: LoadReplacement,
 }
 struct ForwardingPlan {
     store: Ptr<Operation>,
@@ -248,16 +265,38 @@ fn analyze_projection(
         return None;
     }
 
-    if let Some(field) = Operation::get_op::<MirFieldAddrOp>(projection, ctx) {
+    // Static projections continue to extend `path`. A non-constant array
+    // projection is accepted only as the terminal projection into one of this
+    // compiler-owned bundle's constructed arrays, and only when its candidate
+    // set is already explicit as an unsigned `value % C`.
+    let bounded_array = if let Some(field) = Operation::get_op::<MirFieldAddrOp>(projection, ctx) {
         path.push(field.get_attr_field_index(ctx)?.0 as usize);
+        None
     } else if Operation::get_op::<MirArrayElementAddrOp>(projection, ctx).is_some() {
-        path.push(integer_constant_usize(
-            ctx,
-            projection.deref(ctx).get_operand(1),
-        )?);
+        let index = projection.deref(ctx).get_operand(1);
+        if let Some(constant_index) = integer_constant_usize(ctx, index) {
+            path.push(constant_index);
+            None
+        } else {
+            let array = resolve_construct_path(ctx, bundle, &path)?;
+            let array_definer = array.defining_op()?;
+            if !bundle_nodes.contains(&array_definer)
+                || Operation::get_op::<MirConstructArrayOp>(array_definer, ctx).is_none()
+            {
+                return None;
+            }
+
+            let array_type = array.get_type(ctx);
+            let array_type_ref = array_type.deref(ctx);
+            let array_info = array_type_ref.downcast_ref::<MirArrayType>()?;
+            let element_type = array_info.element_type();
+            validate_bounded_dynamic_index(ctx, index, array_info.size())?;
+
+            Some((array, index, element_type))
+        }
     } else {
         return None;
-    }
+    };
 
     projection_nodes.push(projection);
     let pointer = projection.deref(ctx).get_result(0);
@@ -273,26 +312,50 @@ fn analyze_projection(
             if load.is_volatile(ctx) {
                 return None;
             }
-            let replacement = resolve_construct_path(ctx, bundle, &path)?;
-            // A whole-subaggregate read (e.g. loading the array field of a
-            // struct-wrapped bundle in one piece) resolves to one of the
-            // bundle's own construct results.  Forwarding it would leave live
-            // uses of an operation this pass erases, so fail closed and keep
-            // the memory path.
-            if replacement
-                .defining_op()
-                .is_some_and(|definer| bundle_nodes.contains(&definer))
-            {
-                return None;
-            }
-            if replacement.get_type(ctx) != user.deref(ctx).get_result(0).get_type(ctx) {
-                return None;
-            }
+
+            let result_type = user.deref(ctx).get_result(0).get_type(ctx);
+            let replacement = if let Some((array, index, element_type)) = bounded_array {
+                if result_type != element_type {
+                    return None;
+                }
+                LoadReplacement::BoundedArrayElement {
+                    array,
+                    index,
+                    result_type,
+                }
+            } else {
+                let replacement = resolve_construct_path(ctx, bundle, &path)?;
+                // A whole-subaggregate read (e.g. loading the array field of a
+                // struct-wrapped bundle in one piece) resolves to one of the
+                // bundle's own construct results. Forwarding it would leave live
+                // uses of an operation this pass erases, so fail closed and keep
+                // the memory path.
+                if replacement
+                    .defining_op()
+                    .is_some_and(|definer| bundle_nodes.contains(&definer))
+                {
+                    return None;
+                }
+                if replacement.get_type(ctx) != result_type {
+                    return None;
+                }
+                LoadReplacement::Direct(replacement)
+            };
+
             loads.push(LoadForwarding {
                 load: user,
                 replacement,
             });
             continue;
+        }
+
+        // Once a runtime array element has been selected, no further pointer
+        // projection is supported. Compiler result bundles are flat register
+        // packs (possibly behind static struct/tuple wrappers); allowing a
+        // dynamic projection into another aggregate would require a separate
+        // proof about the selected subaggregate.
+        if bounded_array.is_some() {
+            return None;
         }
         if Operation::get_op::<MirFieldAddrOp>(user, ctx).is_none()
             && Operation::get_op::<MirArrayElementAddrOp>(user, ctx).is_none()
@@ -322,6 +385,36 @@ fn integer_constant_usize(ctx: &Context, value: Value) -> Option<usize> {
         return None;
     }
     usize::try_from(integer.to_u64()).ok()
+}
+
+fn integer_constant_u64(ctx: &Context, value: Value) -> Option<u64> {
+    let operation = value.defining_op()?;
+    let constant = Operation::get_op::<MirConstantOp>(operation, ctx)?;
+    let attribute = constant.get_attr_value(ctx)?;
+    let integer = attribute.value();
+    (integer.bw() <= 64).then(|| integer.to_u64())
+}
+
+fn validate_bounded_dynamic_index(ctx: &Context, index: Value, array_size: u64) -> Option<()> {
+    let index_type = index.get_type(ctx);
+    let index_type_ref = index_type.deref(ctx);
+    let integer_type = index_type_ref.downcast_ref::<IntegerType>()?;
+    if integer_type.signedness() != Signedness::Unsigned {
+        return None;
+    }
+
+    let remainder = index.defining_op()?;
+    Operation::get_op::<MirRemOp>(remainder, ctx)?;
+    let divisor = remainder.deref(ctx).get_operand(1);
+    if divisor.get_type(ctx) != index_type {
+        return None;
+    }
+
+    let candidate_count = integer_constant_u64(ctx, divisor)?;
+    (candidate_count > 0
+        && candidate_count <= array_size
+        && candidate_count <= MAX_SCALARIZED_CANDIDATES)
+        .then_some(())
 }
 
 fn resolve_construct_path(ctx: &Context, mut value: Value, path: &[usize]) -> Option<Value> {
@@ -394,16 +487,47 @@ fn rewrite_plan(ctx: &mut Context, plan: ForwardingPlan) -> usize {
     let mut rewriter = IRRewriter::<Recorder>::default();
 
     for forwarding in plan.loads {
+        let replacement = match forwarding.replacement {
+            LoadReplacement::Direct(replacement) => replacement,
+            LoadReplacement::BoundedArrayElement {
+                array,
+                index,
+                result_type,
+            } => {
+                let location = forwarding.load.deref(ctx).loc().clone();
+                let extract = Operation::new(
+                    ctx,
+                    MirExtractArrayElementOp::get_concrete_op_info(),
+                    vec![result_type],
+                    vec![array, index],
+                    vec![],
+                    0,
+                );
+                extract.deref_mut(ctx).set_loc(location);
+                extract.insert_before(ctx, forwarding.load);
+                extract.deref(ctx).get_result(0)
+            }
+        };
+
         let old_result = forwarding.load.deref(ctx).get_result(0);
-        old_result.replace_all_uses_with(ctx, &forwarding.replacement);
+        old_result.replace_all_uses_with(ctx, &replacement);
         rewriter.erase_operation(ctx, forwarding.load);
     }
     for projection in plan.projection_nodes.into_iter().rev() {
         rewriter.erase_operation(ctx, projection);
     }
     rewriter.erase_operation(ctx, plan.store);
+
+    // Static forwarding makes the complete construct tree dead. Bounded
+    // dynamic extraction deliberately keeps the selected array constructor in
+    // SSA, so erase only constructors whose result is actually unused after
+    // the store/projection boundary has been removed. `bundle_nodes` is
+    // preorder (outer before inner), which also releases inner constructors
+    // when an otherwise-dead wrapper is erased.
     for constructor in plan.bundle_nodes {
-        rewriter.erase_operation(ctx, constructor);
+        if constructor.deref(ctx).get_result(0).num_uses(ctx) == 0 {
+            rewriter.erase_operation(ctx, constructor);
+        }
     }
     count
 }
@@ -437,7 +561,25 @@ mod tests {
         return_op: Ptr<Operation>,
     }
 
+    #[derive(Clone, Copy)]
+    enum IndexShape {
+        ConstantLast,
+        Dynamic,
+        BoundedRem { divisor: u64 },
+        SignedRem { divisor: u64 },
+    }
+
     fn build_fixture(ctx: &mut Context, marked: bool, extra_store: bool, width: usize) -> Fixture {
+        build_fixture_with_index(ctx, marked, extra_store, width, IndexShape::ConstantLast)
+    }
+
+    fn build_fixture_with_index(
+        ctx: &mut Context,
+        marked: bool,
+        extra_store: bool,
+        width: usize,
+        index_shape: IndexShape,
+    ) -> Fixture {
         dialect_mir::register(ctx);
 
         let element_type: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
@@ -475,8 +617,9 @@ mod tests {
         alloca.insert_at_back(entry, ctx);
         let slot = alloca.deref(ctx).get_result(0);
 
-        // A call is sufficient as a typed, independent two-result producer for
-        // this pass test.  The forwarding proof does not depend on its opcode.
+        // A call is sufficient as a typed, independent multi-result producer
+        // for this pass test. The forwarding proof does not depend on its
+        // opcode.
         let producer = Operation::new(
             ctx,
             MirCallOp::get_concrete_op_info(),
@@ -539,26 +682,105 @@ mod tests {
         );
         goto.insert_at_back(entry, ctx);
 
-        let index_type = IntegerType::get(ctx, 64, Signedness::Unsigned);
-        let index = Operation::new(
-            ctx,
-            MirConstantOp::get_concrete_op_info(),
-            vec![index_type.into()],
-            vec![],
-            vec![],
-            0,
-        );
-        MirConstantOp::new(index).set_attr_value(
-            ctx,
-            IntegerAttr::new(
-                index_type,
-                APInt::from_u64((width - 1) as u64, NonZeroUsize::new(64).unwrap()),
-            ),
-        );
-        index.insert_at_back(body, ctx);
+        let signedness = match index_shape {
+            IndexShape::SignedRem { .. } => Signedness::Signed,
+            _ => Signedness::Unsigned,
+        };
+        let index_type = IntegerType::get(ctx, 64, signedness);
+        let index_handle: TypeHandle = index_type.into();
 
+        let index_value = match index_shape {
+            IndexShape::ConstantLast => {
+                let index = Operation::new(
+                    ctx,
+                    MirConstantOp::get_concrete_op_info(),
+                    vec![index_handle],
+                    vec![],
+                    vec![],
+                    0,
+                );
+                MirConstantOp::new(index).set_attr_value(
+                    ctx,
+                    IntegerAttr::new(
+                        index_type,
+                        APInt::from_u64((width - 1) as u64, NonZeroUsize::new(64).unwrap()),
+                    ),
+                );
+                index.insert_at_back(body, ctx);
+                index.deref(ctx).get_result(0)
+            }
+            IndexShape::Dynamic | IndexShape::BoundedRem { .. } | IndexShape::SignedRem { .. } => {
+                let raw_index = Operation::new(
+                    ctx,
+                    MirCallOp::get_concrete_op_info(),
+                    vec![index_handle],
+                    vec![],
+                    vec![],
+                    0,
+                );
+                MirCallOp::new(raw_index)
+                    .set_attr_callee(ctx, StringAttr::new("runtime_index".to_string()));
+                raw_index.insert_at_back(body, ctx);
+                let raw_index_value = raw_index.deref(ctx).get_result(0);
+
+                match index_shape {
+                    IndexShape::Dynamic => raw_index_value,
+                    IndexShape::BoundedRem { divisor } | IndexShape::SignedRem { divisor } => {
+                        let constant = Operation::new(
+                            ctx,
+                            MirConstantOp::get_concrete_op_info(),
+                            vec![index_handle],
+                            vec![],
+                            vec![],
+                            0,
+                        );
+                        MirConstantOp::new(constant).set_attr_value(
+                            ctx,
+                            IntegerAttr::new(
+                                index_type,
+                                APInt::from_u64(divisor, NonZeroUsize::new(64).unwrap()),
+                            ),
+                        );
+                        constant.insert_at_back(body, ctx);
+                        let divisor_value = constant.deref(ctx).get_result(0);
+
+                        let remainder = Operation::new(
+                            ctx,
+                            MirRemOp::get_concrete_op_info(),
+                            vec![index_handle],
+                            vec![raw_index_value, divisor_value],
+                            vec![],
+                            0,
+                        );
+                        remainder.insert_at_back(body, ctx);
+                        remainder.deref(ctx).get_result(0)
+                    }
+                    IndexShape::ConstantLast => unreachable!(),
+                }
+            }
+        };
+
+        finish_fixture(
+            ctx,
+            module.get_operation(),
+            producer,
+            body,
+            slot,
+            element_type,
+            index_value,
+        )
+    }
+
+    fn finish_fixture(
+        ctx: &mut Context,
+        module: Ptr<Operation>,
+        producer: Ptr<Operation>,
+        body: Ptr<BasicBlock>,
+        slot: Value,
+        element_type: TypeHandle,
+        index_value: Value,
+    ) -> Fixture {
         let element_pointer: TypeHandle = MirPtrType::get_generic(ctx, element_type, false).into();
-        let index_value = index.deref(ctx).get_result(0);
         let address = Operation::new(
             ctx,
             MirArrayElementAddrOp::get_concrete_op_info(),
@@ -569,6 +791,7 @@ mod tests {
         );
         address.insert_at_back(body, ctx);
         let address_value = address.deref(ctx).get_result(0);
+
         let load = Operation::new(
             ctx,
             MirLoadOp::get_concrete_op_info(),
@@ -591,7 +814,7 @@ mod tests {
         return_op.insert_at_back(body, ctx);
 
         Fixture {
-            module: module.get_operation(),
+            module,
             producer,
             return_op,
         }
@@ -798,6 +1021,146 @@ mod tests {
             fixture.return_op.deref(&ctx).get_operand(0),
             fixture.producer.deref(&ctx).get_result(63)
         );
+    }
+
+    #[test]
+    fn bounded_dynamic_index_forwards_to_ssa_extraction() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(
+            &mut ctx,
+            true,
+            false,
+            32,
+            IndexShape::BoundedRem { divisor: 4 },
+        );
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 1);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirArrayElementAddrOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirStoreOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 1);
+        assert_eq!(
+            count::<MirConstructArrayOp>(&ctx, fixture.module),
+            1,
+            "the SSA array constructor must remain live for dynamic extraction"
+        );
+
+        let result = fixture.return_op.deref(&ctx).get_operand(0);
+        let result_definer = result
+            .defining_op()
+            .expect("bounded result must be produced by an extraction op");
+        assert!(Operation::get_op::<MirExtractArrayElementOp>(result_definer, &ctx).is_some());
+    }
+
+    #[test]
+    fn maximum_bounded_candidate_count_is_forwarded() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(
+            &mut ctx,
+            true,
+            false,
+            64,
+            IndexShape::BoundedRem {
+                divisor: MAX_SCALARIZED_CANDIDATES,
+            },
+        );
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 1);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 1);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 0);
+    }
+
+    #[test]
+    fn oversized_bounded_candidate_count_fails_closed() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(
+            &mut ctx,
+            true,
+            false,
+            64,
+            IndexShape::BoundedRem {
+                divisor: MAX_SCALARIZED_CANDIDATES + 1,
+            },
+        );
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 0);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 1);
+        assert_eq!(count::<MirArrayElementAddrOp>(&ctx, fixture.module), 1);
+        assert_eq!(count::<MirStoreOp>(&ctx, fixture.module), 1);
+    }
+
+    #[test]
+    fn bounded_candidate_count_larger_than_array_fails_closed() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(
+            &mut ctx,
+            true,
+            false,
+            4,
+            IndexShape::BoundedRem { divisor: 5 },
+        );
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 0);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 1);
+    }
+
+    #[test]
+    fn unbounded_dynamic_index_fails_closed() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(&mut ctx, true, false, 8, IndexShape::Dynamic);
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 0);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 1);
+        assert_eq!(count::<MirStoreOp>(&ctx, fixture.module), 1);
+    }
+
+    #[test]
+    fn signed_remainder_index_fails_closed() {
+        let mut ctx = Context::new();
+        let fixture = build_fixture_with_index(
+            &mut ctx,
+            true,
+            false,
+            8,
+            IndexShape::SignedRem { divisor: 4 },
+        );
+        let mut analyses = AnalysisManager::default();
+
+        let forwarded =
+            forward_compiler_result_bundles(fixture.module, &mut ctx, &mut analyses, false)
+                .unwrap();
+
+        assert_eq!(forwarded, 0);
+        assert_eq!(count::<MirExtractArrayElementOp>(&ctx, fixture.module), 0);
+        assert_eq!(count::<MirLoadOp>(&ctx, fixture.module), 1);
     }
 
     /// Regression test: a whole-array field load out of a struct-wrapped

--- a/crates/rustc-codegen-cuda/examples/generated_ldmatrix/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/generated_ldmatrix/src/main.rs
@@ -8,7 +8,9 @@
 //! One warp fills four distinct 8x8 b16 matrices in shared memory. Every lane
 //! then supplies one 16-byte row address to `ldmatrix`; the host checks all 128
 //! returned register fragments against their exact source matrix, row, and
-//! column pair.
+//! column pair. A second kernel selects one returned register with a source-
+//! level bounded dynamic index to exercise compiler-owned bundle forwarding
+//! through the real rustc-to-PTX pipeline.
 //!
 //! Build and run with:
 //!   cargo oxide run generated_ldmatrix
@@ -28,6 +30,7 @@ const COLUMNS: usize = 8;
 const WORDS_PER_ROW: usize = COLUMNS / 2;
 const SHARED_WORDS: usize = MATRICES * ROWS * WORDS_PER_ROW;
 const OUTPUT_WORDS: usize = LANES * MATRICES;
+const DYNAMIC_OUTPUT_WORDS: usize = LANES;
 const LEGACY_REGISTERS: usize = 14;
 
 /// A distinct nonzero value for every matrix element.
@@ -107,6 +110,44 @@ mod kernels {
             *output.get_unchecked_mut(output_word + 1) = registers[1];
             *output.get_unchecked_mut(output_word + 2) = registers[2];
             *output.get_unchecked_mut(output_word + 3) = registers[3];
+        }
+    }
+
+    /// Exercise bounded dynamic indexing of a compiler-owned x4 result bundle.
+    #[kernel]
+    pub fn ldmatrix_x4_dynamic_index_oracle(mut output: DisjointSlice<u32>) {
+        static mut INPUT: SharedArray<u32, SHARED_WORDS, 16> = SharedArray::UNINIT;
+
+        let lane = thread_idx_x() as usize;
+        if lane >= LANES {
+            return;
+        }
+
+        let source_matrix = lane / ROWS;
+        let source_row = lane % ROWS;
+        let row_word = lane * WORDS_PER_ROW;
+        let shared = core::ptr::addr_of_mut!(INPUT) as *mut u32;
+        unsafe {
+            shared
+                .add(row_word)
+                .write(matrix_word(source_matrix, source_row, 0));
+            shared
+                .add(row_word + 1)
+                .write(matrix_word(source_matrix, source_row, 1));
+            shared
+                .add(row_word + 2)
+                .write(matrix_word(source_matrix, source_row, 2));
+            shared
+                .add(row_word + 3)
+                .write(matrix_word(source_matrix, source_row, 3));
+        }
+        thread::sync_threads();
+
+        let registers = unsafe { ldmatrix_m8n8_x4_b16(shared.add(row_word).cast_const()) };
+        let register_index = lane % MATRICES;
+
+        unsafe {
+            *output.get_unchecked_mut(lane) = registers[register_index];
         }
     }
 
@@ -217,5 +258,47 @@ fn main() {
         }
     }
 
+    let mut dynamic_output = DeviceBuffer::<u32>::zeroed(&stream, DYNAMIC_OUTPUT_WORDS)
+        .expect("failed to allocate bounded dynamic-index output");
+
+    // SAFETY: one complete warp executes the convergent ldmatrix operation and
+    // every lane writes exactly one word to its own output slot.
+    unsafe {
+        module
+            .ldmatrix_x4_dynamic_index_oracle(
+                &stream,
+                LaunchConfig {
+                    grid_dim: (1, 1, 1),
+                    block_dim: (LANES as u32, 1, 1),
+                    shared_mem_bytes: 0,
+                },
+                &mut dynamic_output,
+            )
+            .expect("failed to launch bounded dynamic-index ldmatrix oracle");
+    }
+
+    let dynamic_actual = dynamic_output
+        .to_host_vec(&stream)
+        .expect("failed to copy bounded dynamic-index results to the host");
+
+    for (lane, &observed) in dynamic_actual.iter().enumerate() {
+        let register = lane % MATRICES;
+        let row = lane / WORDS_PER_ROW;
+        let pair = lane % WORDS_PER_ROW;
+        let expected = matrix_word(register, row, pair);
+
+        assert_eq!(
+            observed,
+            expected,
+            "lane {lane}, dynamic register {register}: expected row {row}, columns {}..{} = \
+            {expected:#010x}, got {observed:#010x}",
+            pair * 2,
+            pair * 2 + 1,
+        );
+    }
+
     println!("PASS: all {OUTPUT_WORDS} ldmatrix x4 fragments matched on sm_{major}{minor}");
+    println!(
+        "PASS: all {DYNAMIC_OUTPUT_WORDS} bounded dynamic ldmatrix selections matched on sm_{major}{minor}"
+    );
 }


### PR DESCRIPTION
Closes #1004

## Summary

Extend compiler-result bundle forwarding to handle bounded dynamic array indexing.

`forward_compiler_result_bundles` previously required every array projection to use a constant index. As a result, accesses such as:

```rust
let regs = intrinsic_returning_array();
let value = regs[index % 4];
```

kept the importer-created aggregate on the memory path even though the bundle boundary had already been proven safe.

This PR recognizes a narrow bounded dynamic form and rewrites it to the existing SSA aggregate extraction operation.

## What changed

`forward_compiler_result_bundles` now accepts a terminal dynamic array projection when:

* the result bundle passes the existing compiler-owned boundary proof;
* the index type is unsigned;
* the index is produced by `mir.rem(value, constant)`;
* the constant is non-zero;
* the constant does not exceed the array length;
* the constant does not exceed `MAX_SCALARIZED_CANDIDATES`.

For accepted accesses, the pass emits:

```text
mir.extract_array_element %array, %index
```

instead of preserving the `alloca -> store -> array_element_addr -> load` path.

The existing `mir.extract_array_element` lowering already recognizes bounded unsigned remainder indices and lowers them to fixed `extractvalue` candidates plus a select chain when profitable.

No second scalarization implementation is introduced here.

Source-level dynamic indices may initially reach this transform through temporary MIR slots, so the direct `mir.rem` shape is not always visible before mem2reg.

To make the optimization reachable from real compiler output, the same fail-closed compiler-result forwarding pass is run again immediately after mem2reg. At that point, promotable index temporaries have been converted to SSA and bounded forms such as `index % C` are directly visible to the existing recognition logic.

The original pre-mem2reg invocation remains in place for constant/static result bundle forwarding.

## Fail-closed behavior

The pass still leaves the complete memory path untouched for:

* arbitrary dynamic indices;
* signed remainder indices;
* candidate sets larger than `MAX_SCALARIZED_CANDIDATES`;
* bounds larger than the source array;
* volatile loads;
* additional stores or escaping/unknown pointer users;
* unsupported projection shapes.

Constant-index forwarding is unchanged.

## Constructor lifetime

Dynamic extraction retains the SSA `mir.construct_array` needed by `mir.extract_array_element`.

Bundle constructors are now erased only when their result has no remaining uses, while constant forwarding continues to eliminate the complete aggregate construction when possible.

## Tests

Added transform coverage for:

* bounded dynamic indexing;
* the maximum 16-candidate boundary;
* candidate count greater than 16;
* candidate count greater than the array length;
* unbounded dynamic indexing;
* signed remainder indexing.

Added an end-to-end `generated_ldmatrix` regression using a source-level bounded dynamic access:

```rust
let register_index = lane % 4;
let value = registers[register_index];
```

This exercises the complete rustc -> MIR -> mem2reg -> compiler-result forwarding -> LLVM/PTX pipeline.

Validation performed:

```text
cargo test -p mir-transforms
25 passed

cargo test -p mir-lower
252 unit tests passed
117 lowering tests passed

cargo test -p cuda-oxide-codegen --all-targets
176 unit tests passed
integration tests passed

cargo clippy \
  -p mir-transforms \
  -p mir-lower \
  -p cuda-oxide-codegen \
  --all-targets \
  -- \
  -D warnings

cargo fmt --all -- --check
git diff --check
```

End-to-end validation on sm_120:

```text
cargo oxide run generated_ldmatrix

PASS: all 128 ldmatrix x4 fragments matched on sm_120
PASS: all 32 bounded dynamic ldmatrix selections matched on sm_120
```

With LLVM optimization disabled:

```text
CUDA_OXIDE_NO_OPT=1 cargo oxide run generated_ldmatrix

PASS: all 128 ldmatrix x4 fragments matched on sm_120
PASS: all 32 bounded dynamic ldmatrix selections matched on sm_120
```

The generated PTX for the bounded dynamic result-bundle path contains no local memory round trip:

```text
st.local = 0
ld.local = 0
```