### PR TITLE
docs(cuda-macros): seven rustdoc errors the docs gate cannot see

### DIFF
--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -2458,8 +2458,8 @@ fn render_requires_expr(expr: &Expr) -> String {
 ///
 /// Every operand is widened to `u64` and every `+`/`-`/`*` goes through the
 /// corresponding checked operation, so a relation whose arithmetic leaves the
-/// `u64` range fails with [`SizeRequirementOverflow`] instead of wrapping. A
-/// relation that evaluates to false fails with [`SizeRequirementViolated`]
+/// `u64` range fails with `LaunchContractError::SizeRequirementOverflow` instead of wrapping. A
+/// relation that evaluates to false fails with `LaunchContractError::SizeRequirementViolated`
 /// carrying the relation's source text and both evaluated sides.
 fn generate_requires_checks(
     kernel: &CudaModuleKernel,
@@ -4650,7 +4650,7 @@ fn is_thread_index_path(path: &Path, name: &str) -> bool {
 /// import as unused. Instead, we splice `__internal` in front of the
 /// last segment and keep everything before it intact:
 ///
-/// ```ignore
+/// ```text
 /// thread::index_1d()                   →  thread::__internal::index_1d(&scope)
 /// cuda_device::thread::index_1d()      →  cuda_device::thread::__internal::index_1d(&scope)
 /// ::cuda_device::thread::index_1d()    →  ::cuda_device::thread::__internal::index_1d(&scope)
@@ -4661,7 +4661,7 @@ fn is_thread_index_path(path: &Path, name: &str) -> bool {
 /// anything to import; see the bare-ident case in `is_thread_index_path`'s
 /// doc-comment for why we still rewrite those):
 ///
-/// ```ignore
+/// ```text
 /// index_1d()                           →  ::cuda_device::thread::__internal::index_1d(&scope)
 /// ```
 fn internal_thread_path(user_path: &Path, name: &str, arguments: syn::PathArguments) -> Path {
@@ -7661,14 +7661,14 @@ fn expand_cuda_launch(input: CudaLaunchInput) -> TokenStream2 {
 /// Parsed input for the [`cuda_launch_async!`] macro.
 ///
 /// Unlike [`CudaLaunchInput`], this struct has no `stream` field. The stream
-/// is assigned later by the [`SchedulingPolicy`] when the returned
-/// [`AsyncKernelLaunch`] is `.sync()`'d or `.await`'d.
+/// is assigned later by the `SchedulingPolicy` when the returned
+/// `AsyncKernelLaunch` is `.sync()`'d or `.await`'d.
 struct CudaLaunchAsyncInput {
     /// Path to the `#[kernel]` function, possibly with generic arguments.
     kernel: syn::Path,
     /// Expression resolving to an `Arc<CudaModule>` that contains the compiled PTX.
     module: syn::Expr,
-    /// Expression resolving to a [`LaunchConfig`] (grid/block dims, shared mem).
+    /// Expression resolving to a [`LaunchConfig`](https://docs.rs/cuda-core/latest/cuda_core/struct.LaunchConfig.html) (grid/block dims, shared mem).
     config: syn::Expr,
     /// Kernel arguments: `slice(x)`, `slice_mut(x)`, direct values, or closures.
     args: Vec<CudaLaunchArg>,


### PR DESCRIPTION
## Summary

`cargo doc --no-deps --document-private-items -p cuda-macros` reports **seven errors** under `-D warnings`. The CI gate omits `--document-private-items`, so it reports none of them:

```
lib.rs:2461  unresolved link to `SizeRequirementOverflow`
lib.rs:2462  unresolved link to `SizeRequirementViolated`
lib.rs:7664  unresolved link to `SchedulingPolicy`
lib.rs:7665  unresolved link to `AsyncKernelLaunch`
lib.rs:7671  unresolved link to `LaunchConfig`
lib.rs:4653  could not parse code block as Rust code
lib.rs:4664  could not parse code block as Rust code
```

### The five links

All five name types in crates this one does not depend on — `cuda-macros` takes only `quote`, `syn`, `proc-macro2` and `reserved-oxide-symbols`, while `SizeRequirement*` are `cuda_core::LaunchContractError` variants, `SchedulingPolicy`/`AsyncKernelLaunch` are `cuda-async`, and `LaunchConfig` is `cuda-core`. Rustdoc has nothing to resolve them against, so the brackets render as literal text.

**The file already contains both correct idioms and uses them elsewhere**, so this matches the local convention rather than inventing one:

| Idiom | Already used at | For |
|:--|:--|:--|
| plain code span | `lib.rs:6012`, `:6014` | the *same two* `SizeRequirement*` variants, 3,500 lines above the broken links |
| explicit docs.rs URL | `lib.rs:508`, `:5927` | the *same* `LaunchConfig` type as the broken link at `:7671` |

### The two code blocks

Both are ```` ```ignore ```` fences whose contents are path-rewrite illustrations, not Rust:

```
index_1d()   →  ::cuda_device::thread::__internal::index_1d(&scope)
```

`ignore` still asks rustdoc to parse the block for `invalid_rust_codeblocks`, and it stops on the `→` (U+2192) with "unknown start of token". These are ```` ```text ```` now, which is what the file's two existing ```` ```text ```` blocks are for. The other 27 ```` ```ignore ```` blocks are real Rust and are untouched.

## Not proposing the gate change here

Three other crates have private-doc errors too — `llvm-export`, `mir-importer`, `mir-lower`, six between them — and two of the four files involved are being edited by open PRs right now. Adding `--document-private-items` to the docs gate is its own change once the tree is clean, and worth doing, since this class is otherwise only found by looking.

## Testing

Local, no GPU.

- [x] `--document-private-items` on `cuda-macros` now passes under `-D warnings` where it reported seven errors
- [x] The CI docs gate still passes; `--lib` tests unchanged (99 passed)
- [x] Counts move exactly as intended — ```` ```ignore ```` 29→27, ```` ```text ```` 2→4. Both fences edited **by line number** after a text-match replace hit the wrong block on my first attempt
- [ ] `cargo oxide run <example>` — not applicable, doc comments only