### PR TITLE
docs(mir-importer): three doc links in statement.rs resolve to nothing

### DIFF
--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -1156,7 +1156,7 @@ fn store_through_place_address(
 /// to an array.
 ///
 /// Used by the statement-level element write helpers. Returns a structured
-/// error when the pointer's pointee isn't a [`MirArrayType`], which signals
+/// error when the pointer's pointee isn't a [`MirArrayType`](dialect_mir::types::MirArrayType), which signals
 /// a structural mismatch (most likely the wrong MIR projection reaching
 /// this path).
 pub(crate) fn slot_array_element_ty(
@@ -1237,7 +1237,7 @@ pub(crate) fn emit_array_element_store(
     store_op
 }
 
-/// Return `true` if the pointer value's type is a mutable [`MirPtrType`].
+/// Return `true` if the pointer value's type is a mutable [`MirPtrType`](dialect_mir::types::MirPtrType).
 ///
 /// Slots emitted by the entry-block alloca loop are always mutable, but
 /// callers of the statement module sometimes thread pointers coming from
@@ -1253,7 +1253,7 @@ pub(crate) fn pointer_is_mutable(ctx: &pliron::context::Context, ptr: Value) -> 
 }
 
 /// Return the address space of a pointer value. Defaults to 0 (the generic
-/// address space) if the value is not a [`MirPtrType`].
+/// address space) if the value is not a [`MirPtrType`](dialect_mir::types::MirPtrType).
 pub(crate) fn pointer_address_space(ctx: &pliron::context::Context, ptr: Value) -> u32 {
     let ty = ptr.get_type(ctx);
     let ty_ref = ty.deref(ctx);


### PR DESCRIPTION
## Summary

Same class as the `cuda-macros` fix: `cargo doc --document-private-items` under `-D warnings` reports these, and the CI gate omits that flag so it reports none.

```
statement.rs:1159  unresolved link to `MirArrayType`
statement.rs:1240  unresolved link to `MirPtrType`
statement.rs:1256  unresolved link to `MirPtrType`
```

Unlike the `cuda-macros` case these are fixable as **real links** rather than demoted to plain spans: `mir-importer` does depend on `dialect-mir`, so the types are reachable — they are simply not in scope in this module, which imports `dialect_mir::types::MirEnumType` and not these two. Each link now carries the full path, so a reader gets a working jump rather than literal brackets.

Worth noting why the file's fourth `[`MirFieldAddrOp`]` is not in that list: it sits in a `//` comment at `:228`, not a `///` doc comment, so rustdoc never looks at it. Only doc comments are checked — part of why this class hides.

## What I deliberately did not touch

Two errors remain in this crate after this change, both in `src/translator/rvalue.rs` (`MirFieldAddrOp` at `:4552`, `MirArrayElementAddrOp` at `:4556`). That file is being edited by open PRs right now, so it is untouched here. **The crate is not clean yet**, and I would rather say so than take a conflict.

## Testing

Local, no GPU.

- [x] No `--document-private-items` error remains in `statement.rs`
- [x] CI docs gate and `cargo test -p mir-importer` (1090 tests) unchanged
- [ ] `cargo oxide run <example>` — not applicable