### PR TITLE
chore(backend): scope the codegen backend's blanket dead-code allows

### DIFF
--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -2439,7 +2439,6 @@ mod tests {
         DEVICE_PREFIX, KERNEL_PREFIX, LEGACY_DEVICE_PREFIX, LEGACY_KERNEL_PREFIX,
         PTX_MERGE_REQUIRED_PREFIX, is_ptx_merge_required_marker, ptx_merge_required_marker,
     };
-    use rustc_index::Idx;
     use rustc_middle::mir::BasicBlock;
 
     #[test]

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -280,21 +280,27 @@ fn rustc_ty_to_device_extern_type<'tcx>(
 /// Contains paths to generated artifacts and the payload selected for
 /// embedding in the host binary.
 ///
-/// `ptx_path`, `ll_path` and `ptx_content` are written by `run_device_codegen`
-/// and never read back inside this crate: they record what codegen produced,
-/// which is what the module diagram above documents. Nothing links this crate
-/// as a library -- it is a `dylib` rustc loads through `-Zcodegen-backend` --
-/// so `pub` does not make them reachable either.
-#[allow(
-    dead_code,
-    reason = "written as the recorded codegen result, not read back"
-)]
+/// `ptx_path`, `ll_path` and `ptx_content` are written by
+/// `generate_device_code` and never read back inside this crate: they record
+/// what codegen produced, which is what the module diagram above documents.
+/// Nothing links this crate as a library (it is a `dylib` rustc loads through
+/// `-Zcodegen-backend`), so `pub` does not make them reachable either. Those
+/// three fields carry their own suppressions below; the remaining fields are
+/// read in `lib.rs` and stay lint-checked.
 pub struct DeviceCodegenResult {
     /// Path to generated PTX assembly file.
     ///
     /// In NVVM IR modes this is the would-be PTX path and may not exist.
+    #[expect(
+        dead_code,
+        reason = "recorded codegen output, kept for future diagnostics"
+    )]
     pub ptx_path: PathBuf,
     /// Path to generated LLVM IR file.
+    #[expect(
+        dead_code,
+        reason = "recorded codegen output, kept for future diagnostics"
+    )]
     pub ll_path: PathBuf,
     /// GPU target architecture used (e.g., "sm_80", "sm_90a", "sm_100a").
     ///
@@ -304,6 +310,10 @@ pub struct DeviceCodegenResult {
     /// PTX content as a string, ready for embedding in the host binary.
     ///
     /// NVVM IR / LTOIR flows intentionally skip PTX generation.
+    #[expect(
+        dead_code,
+        reason = "recorded codegen output, kept for future diagnostics"
+    )]
     pub ptx_content: Option<String>,
     /// Device artifact payload selected for embedding.
     pub artifact: Option<DeviceCodegenArtifact>,
@@ -450,16 +460,16 @@ fn debug_position_from_span(tcx: TyCtxt<'_>, span: Span) -> Option<DebugSourcePo
 /// the variant set still mirrors the pipeline's, rather than deleted and
 /// re-added the next time it is needed.
 #[derive(Debug)]
-#[allow(
-    dead_code,
-    reason = "Translation mirrors PipelineError and is not constructed here"
-)]
 pub enum DeviceCodegenError {
     /// No kernels were found to compile.
     NoKernels,
     /// Failed to enter or exit stable_mir context.
     StableMirError(String),
     /// MIR to Pliron IR translation failed.
+    #[expect(
+        dead_code,
+        reason = "mirrors PipelineError's taxonomy, not constructed here"
+    )]
     Translation(String),
     /// PTX generation (llc invocation) failed.
     PtxGeneration(String),

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -279,6 +279,16 @@ fn rustc_ty_to_device_extern_type<'tcx>(
 ///
 /// Contains paths to generated artifacts and the payload selected for
 /// embedding in the host binary.
+///
+/// `ptx_path`, `ll_path` and `ptx_content` are written by `run_device_codegen`
+/// and never read back inside this crate: they record what codegen produced,
+/// which is what the module diagram above documents. Nothing links this crate
+/// as a library -- it is a `dylib` rustc loads through `-Zcodegen-backend` --
+/// so `pub` does not make them reachable either.
+#[allow(
+    dead_code,
+    reason = "written as the recorded codegen result, not read back"
+)]
 pub struct DeviceCodegenResult {
     /// Path to generated PTX assembly file.
     ///
@@ -433,7 +443,17 @@ fn debug_position_from_span(tcx: TyCtxt<'_>, span: Span) -> Option<DebugSourcePo
 }
 
 /// Errors that can occur during device code generation.
+///
+/// `Translation` is part of the taxonomy and has a `Display` arm, but nothing
+/// constructs it today: translation failures arrive as
+/// `cuda_oxide_codegen::PipelineError` and are reported through that. Kept so
+/// the variant set still mirrors the pipeline's, rather than deleted and
+/// re-added the next time it is needed.
 #[derive(Debug)]
+#[allow(
+    dead_code,
+    reason = "Translation mirrors PipelineError and is not constructed here"
+)]
 pub enum DeviceCodegenError {
     /// No kernels were found to compile.
     NoKernels,

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -301,8 +301,6 @@
 //!   artifacts
 
 #![feature(rustc_private)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
 
 // Import rustc internal crates
 extern crate rustc_abi;
@@ -344,7 +342,6 @@ use rustc_session::config::OutputFilenames;
 use std::any::Any;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// The CUDA codegen backend.


### PR DESCRIPTION
## Summary

`crates/rustc-codegen-cuda/src/lib.rs` suppresses two lints for the whole crate:

```rust
#![allow(unused_imports)]
#![allow(dead_code)]
```

That is the largest first-party crate in the tree, and those two lines mean no unused import and no dead item anywhere in it has been reported since they were added. #833 is the precedent for caring: *"stop exporting the translator, and drop what that hid: six items with no callers anywhere on main. This is the hygiene rustc and LLVM get from non-pub."*

Removing both surfaces exactly **four** items — small enough to resolve rather than re-suppress:

| Site | Item |
|:--|:--|
| `lib.rs:345` | unused import `std::sync::Arc` |
| `collector.rs:2442` | unused import `rustc_index::Idx` (inside `mod tests`) |
| `device_codegen.rs:286` | fields `ptx_path`, `ll_path`, `ptx_content` never read |
| `device_codegen.rs:443` | variant `Translation` never constructed |

## Two deletions, two reasoned keeps

The two unused imports are deleted. `collector.rs:2442` is the interesting one: `Idx` is already imported at the top of the file and the test module gets it via `use super::*;`, so the explicit import is redundant — and it is **only visible under `--all-targets`**, which is how CI's clippy runs but not how `cargo check --lib` does. I found it by running the real gate after `cargo check` reported clean.

The other two are kept with a local `#[allow(dead_code, reason = ...)]` each, because both are deliberate:

- **`DeviceCodegenResult`'s three fields** are *written* by `run_device_codegen` (`device_codegen.rs:826-829`) and documented in the module's own diagram at `:75-78`. They record what codegen produced. Nothing links this crate as a library — it is a `dylib` rustc loads via `-Zcodegen-backend` — so `pub` does not make them reachable from anywhere either.
- **`DeviceCodegenError::Translation`** has a `Display` arm at `:457` but no constructor: translation failures arrive as `cuda_oxide_codegen::PipelineError` and are reported through that. Keeping the variant keeps this taxonomy mirroring the pipeline's.

So two invisible crate-wide suppressions become one deletion pair and two local, reasoned decisions — and any *future* dead code in the backend is caught instead of absorbed.

## Testing

Local, no GPU, on the backend's own workspace with the gates CI runs there.

- [x] **Mutation:** adding an unused import and an uncalled fn now produces 2 warnings, and **3 errors under `-D warnings`** — where before both passed silently
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` 23/23
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes
- [x] `cargo fmt --all --check` clean
- [ ] `cargo oxide run <example>` — not applicable, no behaviour change