### PR TITLE
docs(examples): three READMEs state a minimum GPU below their own runtime gate

### DIFF
--- a/crates/rustc-codegen-cuda/examples/barrier/README.md
+++ b/crates/rustc-codegen-cuda/examples/barrier/README.md
@@ -77,8 +77,9 @@ cargo oxide run barrier
 
 - **Minimum GPU**: Ampere (sm_80) or newer. `main` skips cleanly below that
   (`if major < 8`), matching the `mbarrier requires sm_80+` message it
-  prints. Some mbarrier instructions are sm_70+, but sm_80 is the floor for
-  running this example.
+  prints. If you have seen `cuda::barrier` work on sm_70, that is libcu++'s
+  software fallback; the PTX `mbarrier` instructions this example emits
+  need sm_80+.
 - **CUDA Driver**: 11.0+
 
 ## Mbarrier Functions
@@ -131,7 +132,6 @@ while !mbarrier_test_wait(&raw const BAR, token) {}
 | Error                              | Cause                      | Solution                                    |
 |------------------------------------|----------------------------|---------------------------------------------|
 | Hang / deadlock                    | Mismatched arrival count   | Ensure init count matches actual arrivals   |
-| `CUDA_ERROR_ILLEGAL_INSTRUCTION`   | Pre-Volta GPU              | Use sync_threads() for older GPUs           |
 | Race condition                     | Missing fence after init   | Add `fence_proxy_async_shared_cta()` for TMA|
 
 ## Generated PTX

--- a/crates/rustc-codegen-cuda/examples/barrier/README.md
+++ b/crates/rustc-codegen-cuda/examples/barrier/README.md
@@ -75,7 +75,10 @@ cargo oxide run barrier
 
 ## Hardware Requirements
 
-- **Minimum GPU**: Volta (sm_70) or newer for full mbarrier support
+- **Minimum GPU**: Ampere (sm_80) or newer. `main` skips cleanly below that
+  (`if major < 8`), matching the `mbarrier requires sm_80+` message it
+  prints. Some mbarrier instructions are sm_70+, but sm_80 is the floor for
+  running this example.
 - **CUDA Driver**: 11.0+
 
 ## Mbarrier Functions

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
@@ -124,8 +124,10 @@ Output buffer layout for reduce/scan kernels:
 
 ## Hardware Requirements
 
-- **Minimum GPU**: Volta (sm_70+) — `match.any.sync`/`match.all.sync`
-  require sm_70.
+- **Minimum GPU**: Hopper (sm_90) or newer. `main` skips cleanly below that
+  (`if major < 9`) because the demo launches thread block clusters. The
+  `match.any.sync`/`match.all.sync` primitives it also exercises are sm_70+,
+  but the cluster launch is what sets the floor.
 - **Cooperative launch**: any GPU that reports
   `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH) == 1`
   (essentially all post-Pascal GPUs).

--- a/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
+++ b/crates/rustc-codegen-cuda/examples/coop_groups_demo/README.md
@@ -52,9 +52,10 @@ launches through the typed path: both kernels carry
 generated launch methods submit via `cuLaunchKernelEx` with
 `CU_LAUNCH_ATTRIBUTE_COOPERATIVE`. The same module also holds
 `test_cluster_coop_grid_sync`, which combines `#[cluster_launch(2, 1, 1)]`
-with `#[cooperative_launch]` and a `#[launch_contract]`. On Hopper+ that
-kernel is prepared and launched through the safe `PreparedLaunch` path;
-pre-Hopper devices print that the combined mode was not exercised.
+with `#[cooperative_launch]` and a `#[launch_contract]`. That kernel is
+prepared and launched through the safe `PreparedLaunch` path. Pre-Hopper
+devices never get this far: `main` prints its `thread block clusters
+require sm_90+` skip line and exits before launching anything.
 
 ### Layer 2 — typed cooperative-groups handles (5 checks)
 

--- a/crates/rustc-codegen-cuda/examples/future_apis/README.md
+++ b/crates/rustc-codegen-cuda/examples/future_apis/README.md
@@ -161,7 +161,7 @@ cargo oxide run future_apis
 - **Minimum GPU**: Hopper (sm_90) or newer. `ManagedBarrier::init_by` emits
   `fence.proxy.async`, which ptxas rejects below sm_90, so `main` skips
   cleanly on anything lower (`if major < 9`). The mbarrier instructions
-  themselves are sm_70+, but that is not the floor for running this example.
+  themselves only need sm_80+, but the fence is what sets the floor here.
 - **CUDA Driver**: 11.0+
 
 ## CuSimd API Reference

--- a/crates/rustc-codegen-cuda/examples/future_apis/README.md
+++ b/crates/rustc-codegen-cuda/examples/future_apis/README.md
@@ -158,7 +158,10 @@ cargo oxide run future_apis
 
 ## Hardware Requirements
 
-- **Minimum GPU**: Volta (sm_70) or newer for mbarrier
+- **Minimum GPU**: Hopper (sm_90) or newer. `ManagedBarrier::init_by` emits
+  `fence.proxy.async`, which ptxas rejects below sm_90, so `main` skips
+  cleanly on anything lower (`if major < 9`). The mbarrier instructions
+  themselves are sm_70+, but that is not the floor for running this example.
 - **CUDA Driver**: 11.0+
 
 ## CuSimd API Reference


### PR DESCRIPTION
## Summary

Fourteen examples gate `main` on compute capability. Three of them also state a **Minimum GPU** in their README, and **all three state one lower than the gate they ship with** — so the README says the example runs on hardware where it prints `skipping:` and returns.

| Example | README said | Gate in `main()` | The gate's own message |
|:--|:--|:--|:--|
| `future_apis` | Volta (sm_70) | `major < 9` | "fence.proxy.async … requires sm_90+" |
| `coop_groups_demo` | Volta (sm_70+) | `major < 9` | "thread block clusters require sm_90+" |
| `barrier` | Volta (sm_70) | `major < 8` | "mbarrier requires sm_80+" |

`future_apis` is the one with history: `8615368f` corrected that gate to `major < 9` during the **#666** review — the requirement is `fence.proxy.async`, emitted by `ManagedBarrier::init_by` for every barrier kind, which ptxas rejects below sm_90, and the `TmaBarrier` typestate is inert `PhantomData` that detects nothing. The gate moved; the README did not.

In all three cases the sm_70 figure is not invented — it is the floor of *one* instruction family the example touches (mbarrier, or `match.any.sync`) rather than the floor for running the example. Each entry now states the real floor, cites the gate that enforces it, and keeps the sm_70 fact as the aside it always was, so the next reader does not have to reconcile them.

Every gate here is in `main()` and returns immediately, so this is the whole example's floor, not one test's.

## Testing

Local, no GPU — documentation only.

- [x] Swept all 215 example READMEs: these three were the **only** ones whose stated Minimum GPU did not match a gate in their own `main`, and after this change none do
- [x] `check-error-example-status` and `check-example-smoketest-contract` pass
- [ ] `cargo oxide run <example>` — not applicable; verifying the floors themselves would need Hopper and Ampere parts, which is why this takes each example's own gate as the authority rather than re-deriving it