### PR TITLE
ci(book): apply the stated pin policy to all seven requirements, not one

### DIFF
--- a/cuda-oxide-book/requirements.txt
+++ b/cuda-oxide-book/requirements.txt
@@ -1,10 +1,21 @@
 # Upper-bounded on the major: the build runs warnings-as-errors (-W), and a
-# new Sphinx major routinely introduces warnings, which would redden every PR
-# and the main-branch deploy overnight. Bump the bound deliberately instead.
+# new major routinely introduces warnings, which would redden every PR and the
+# main-branch deploy overnight. Bump a bound deliberately instead.
+#
+# Every requirement carries one, not just Sphinx. The rationale is not
+# Sphinx-specific: myst-parser decides what counts as a malformed directive or
+# an unresolved cross-reference, and the theme emits its own warnings, so
+# either can fail `-W` on a release nobody asked for. myst-parser had already
+# crossed two majors past its floor (3.x -> 5.x) while unbounded.
+#
+# Each bound is the next major above what resolves today, so this changes no
+# installed version.
 sphinx>=7.0,<10
-pydata-sphinx-theme>=0.15
-myst-parser>=3.0
-sphinx-copybutton>=0.5
-sphinx-design>=0.6
-sphinx-sitemap>=2.5
-sphinx-autobuild>=2024.10
+pydata-sphinx-theme>=0.15,<1
+myst-parser>=3.0,<6
+sphinx-copybutton>=0.5,<1
+sphinx-design>=0.6,<1
+sphinx-sitemap>=2.5,<3
+# Local live-reload only (`sphinx-autobuild cuda-oxide-book <out>`); no build
+# path in this repo invokes it, and `just book` uses sphinx-build.
+sphinx-autobuild>=2024.10,<2027


### PR DESCRIPTION
## Summary

`cuda-oxide-book/requirements.txt` opens by explaining why a bound is needed:

> Upper-bounded on the major: the build runs warnings-as-errors (-W), and a new Sphinx major routinely introduces warnings, which would redden every PR and the main-branch deploy overnight. Bump the bound deliberately instead.

Then **only `sphinx` carries one.** The other six are open-ended, and the rationale is not Sphinx-specific: under `-W` any dependency that decides what counts as a warning can fail the build on a release nobody in this repo asked for.

`myst-parser` is the clearest case — it is the markdown parser, it decides what a malformed directive or an unresolved cross-reference *is*, and it had already crossed **two majors** past its floor while unbounded (`>=3.0` resolving 5.1.0). `pydata-sphinx-theme` emits its own warnings and had moved five minors past its floor, which for a 0.x is the breaking axis.

## The bounds

Each is the next major above what resolves today, so **no installed version changes**:

| Requirement | Bound | Resolves |
|:--|:--|:--|
| `sphinx` | `>=7.0,<10` (unchanged) | 9.1.0 |
| `myst-parser` | `>=3.0,<6` | 5.1.0 |
| `pydata-sphinx-theme` | `>=0.15,<1` | 0.20.0 |
| `sphinx-design` | `>=0.6,<1` | 0.7.0 |
| `sphinx-copybutton` | `>=0.5,<1` | 0.5.2 |
| `sphinx-sitemap` | `>=2.5,<3` | 2.9.0 |
| `sphinx-autobuild` | `>=2024.10,<2027` | 2025.8.25 |

Note how little headroom `sphinx` itself has left: `<10` against **9.1.0**. That is the bound doing its job, and it is the only one that was.

The comment is rewritten to say the policy applies to every line, and drops "Sphinx" from the rationale since it was never the reason.

`sphinx-autobuild` gets a bound and a note rather than removal: nothing in the repo invokes it (`just book` and `book.yml` both use `sphinx-build`), so it is there for local live-reload — worth saying out loud rather than leaving a reader to wonder why CI installs it.

## Testing

Local, no GPU.

- [x] A **fresh** virtualenv built from this file resolves **byte-identical** versions to one built from the unbounded file — diffed package-by-package, no difference
- [x] `sphinx-build -W --keep-going -b html` from that fresh venv builds the book clean, which is exactly what the book gate runs
- [ ] `cargo oxide run <example>` — not applicable