### PR TITLE
ci: the license guard's CR handling explains itself with two false claims

### DIFF
--- a/scripts/check-dependency-licenses.sh
+++ b/scripts/check-dependency-licenses.sh
@@ -45,8 +45,16 @@ test -s "${CSV}"
 # Column 1 is the package name: always a bare crate name, never quoted and
 # never containing a comma, so a plain field split is safe.  Later columns do
 # use quoting (descriptions contain commas), which is why only column 1 is
-# read this way.  The file uses CRLF, hence the `tr -d '\r'`.
-recorded="$(tail -n +2 "${CSV}" | cut -d, -f1 | tr -d '\r' | LC_ALL=C sort -u)"
+# read this way.
+#
+# No CR handling is needed on this path, and the comment here used to claim
+# otherwise. Two reasons: the committed file is LF-only since 8eb0dcf2 (#917)
+# normalized it (111 CR bytes -> 0) while touching it for something else; and
+# even on a CRLF checkout the CR sits before the newline, which puts it in the
+# *last* field, never in the `cut -d, -f1` we read. Verified both ways -- CSV
+# converted to CRLF, with and without a `tr -d '\r'` here, all four
+# combinations agree.
+recorded="$(tail -n +2 "${CSV}" | cut -d, -f1 | LC_ALL=C sort -u)"
 
 # Self-test.  The failure mode a guard like this has to survive is "quietly
 # stops seeing anything", so prove the CSV still parses into a plausible set


### PR DESCRIPTION
## Summary

`check-dependency-licenses.sh` justifies a pipeline stage like this:

```bash
# The file uses CRLF, hence the `tr -d '\r'`.
recorded="$(tail -n +2 "${CSV}" | cut -d, -f1 | tr -d '\r' | ...)"
```

Both halves are wrong.

**1. The file is not CRLF.** `dependency-licenses.csv` has zero CR bytes. It *was* CRLF when the guard was written — 111 of them at `642eacf5` — and `8eb0dcf2` (#917) normalized it to LF while touching it for something unrelated, so the sentence has been stale since that landed.

**2. The `tr` would not be needed even if it were.** A CR sits immediately before the newline, which puts it in the CSV's **last** field. `cut -d, -f1` reads the **first**. The strip has never had anything to remove on this path.

So the stage goes, and the comment now records why no CR handling belongs there.

## How the second error came to light

I first wrote this PR claiming the opposite — that dropping the strip would make the guard report every crate as missing — and built a mutation to demonstrate it. **The mutation refused to reproduce it.** Converting the committed CSV to CRLF (117 CR bytes) and running the guard with the strip removed passes exactly as it does today. Both line endings, with and without the strip: all four combinations agree.

That is the whole finding, and I would not have got it right by reading.

## Scope

The same reasoning applies to the `.strip("\r")` in the example-workspace half further down, which reads `line.split(",")[0]`. That one is left alone — one concern per change.

Happy to keep the `tr` as belt-and-braces and only fix the comment; it costs nothing at runtime. I removed it because a line whose stated purpose is false and whose effect is nil teaches the next reader something untrue about the file format, which is how it survived this long.

## Testing

Local, no GPU.

- [x] Guard passes on the tree as committed (57 declared crates, plus the example-workspace half)
- [x] Guard passes identically with the CSV converted to CRLF
- [ ] `cargo oxide run <example>` — not applicable, CI script only