### PR TITLE
feat(wgmma): support three-slot counted pipelines

### DIFF
--- a/crates/cuda-oxide-codegen/tests/wgmma_pipelined_counted_loop_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_pipelined_counted_loop_ptx.rs
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! End-to-end probe for the production two-slot BF16 WGMMA counted pipeline.
+//! End-to-end probes for production BF16 WGMMA counted pipelines.
 //!
-//! The test starts from the canonical pointer-form MIR shape recognized by
-//! `mir-lower`: two distinct `[[f32; 8]; 4]` accumulator slots, four affine
-//! descriptor recurrences, two `MMA -> commit_group -> wait_group<1>` stages in
-//! the unique latch, and a final `wait_group<0>` in the exit. The fusion pass
-//! must replace that CFG with one value-form carrier, which then lowers to one
-//! convergent inline-PTX counted pipeline and survives `ptxas -arch=sm_90a`
-//! without stack or spill traffic.
+//! The tests start from the canonical pointer-form MIR shape recognized by
+//! `mir-lower` and cover both supported production depths: two distinct
+//! `[[f32; 8]; 4]` accumulator slots with `wait_group<1>` and three slots with
+//! `wait_group<2>`. Each slot owns one affine descriptor pair. The fusion pass
+//! must replace the counted CFG with one value-form carrier, which then lowers
+//! to one convergent inline-PTX counted pipeline and survives
+//! `ptxas -arch=sm_90a` without stack or spill traffic.
 
 #![cfg(unix)]
 
@@ -47,11 +47,8 @@ use std::num::NonZeroUsize;
 
 const ACCUMULATOR_LEN: u32 = 32;
 const RESULT_COUNT: u32 = 64;
+const THREE_SLOT_RESULT_COUNT: u32 = 96;
 const TRIP_COUNT: u64 = 4;
-const DESC_A0_STEP: u64 = 16;
-const DESC_B0_STEP: u64 = 32;
-const DESC_A1_STEP: u64 = 48;
-const DESC_B1_STEP: u64 = 64;
 
 fn append_unsigned_constant(
     ctx: &mut Context,
@@ -130,7 +127,12 @@ fn append_u64_add(
     add.deref(ctx).get_result(0)
 }
 
-fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
+fn build_wgmma_pipelined_counted_loop_kernel(
+    module: &mut CodegenModule,
+    kernel_name: &str,
+    slot_count: usize,
+    max_pending_groups: u64,
+) {
     module.edit(|ctx, module| {
         let module_region = module.get_operation().deref(ctx).get_region(0);
         let module_block = module_region
@@ -146,15 +148,11 @@ fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
         let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
         let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
         let i1_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+        let u64_type: pliron::r#type::TypeHandle = u64_ty.into();
 
-        let argument_types: Vec<pliron::r#type::TypeHandle> = vec![
-            accumulator_ptr_ty.into(),
-            accumulator_ptr_ty.into(),
-            u64_ty.into(),
-            u64_ty.into(),
-            u64_ty.into(),
-            u64_ty.into(),
-        ];
+        let mut argument_types: Vec<pliron::r#type::TypeHandle> =
+            vec![accumulator_ptr_ty.into(); slot_count];
+        argument_types.extend(vec![u64_type; slot_count * 2]);
         let function_type = FunctionType::get(ctx, argument_types.clone(), vec![]);
         let function_op = Operation::new(
             ctx,
@@ -165,55 +163,46 @@ fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
             1,
         );
         let function = MirFuncOp::new(ctx, function_op, TypeAttr::new(function_type.into()));
-        function.set_symbol_name(
-            ctx,
-            "wgmma_pipelined_counted_loop_kernel".try_into().unwrap(),
-        );
+        function.set_symbol_name(ctx, kernel_name.try_into().unwrap());
 
         let function_region = function.get_operation().deref(ctx).get_region(0);
         let preheader = BasicBlock::new(ctx, None, argument_types);
         preheader.insert_at_back(function_region, ctx);
-        let header = BasicBlock::new(
-            ctx,
-            None,
-            vec![
-                u32_ty.into(),
-                u64_ty.into(),
-                u64_ty.into(),
-                u64_ty.into(),
-                u64_ty.into(),
-            ],
-        );
+
+        let mut header_types: Vec<pliron::r#type::TypeHandle> = vec![u32_ty.into()];
+        header_types.extend(vec![u64_type; slot_count * 2]);
+        let header = BasicBlock::new(ctx, None, header_types);
         header.insert_at_back(function_region, ctx);
         let latch = BasicBlock::new(ctx, None, vec![]);
         latch.insert_at_back(function_region, ctx);
         let exit = BasicBlock::new(ctx, None, vec![]);
         exit.insert_at_back(function_region, ctx);
 
-        let accumulator0 = preheader.deref(ctx).get_argument(0);
-        let accumulator1 = preheader.deref(ctx).get_argument(1);
-        let desc_a0_base = preheader.deref(ctx).get_argument(2);
-        let desc_b0_base = preheader.deref(ctx).get_argument(3);
-        let desc_a1_base = preheader.deref(ctx).get_argument(4);
-        let desc_b1_base = preheader.deref(ctx).get_argument(5);
+        let accumulators = (0..slot_count)
+            .map(|slot| preheader.deref(ctx).get_argument(slot))
+            .collect::<Vec<_>>();
+        let desc_bases = (0..slot_count * 2)
+            .map(|index| preheader.deref(ctx).get_argument(slot_count + index))
+            .collect::<Vec<_>>();
 
         WgmmaFenceSyncAlignedOp::build(ctx).insert_at_back(preheader, ctx);
         let i0 = append_unsigned_constant(ctx, preheader, u32_ty, 0);
+        let mut initial_values = vec![i0];
+        initial_values.extend(desc_bases.iter().copied());
         Operation::new(
             ctx,
             MirGotoOp::get_concrete_op_info(),
             vec![],
-            vec![i0, desc_a0_base, desc_b0_base, desc_a1_base, desc_b1_base],
+            initial_values,
             vec![header],
             0,
         )
         .insert_at_back(preheader, ctx);
 
         let i = header.deref(ctx).get_argument(0);
-        let desc_a0 = header.deref(ctx).get_argument(1);
-        let desc_b0 = header.deref(ctx).get_argument(2);
-        let desc_a1 = header.deref(ctx).get_argument(3);
-        let desc_b1 = header.deref(ctx).get_argument(4);
+        let descriptors = (0..slot_count * 2)
+            .map(|index| header.deref(ctx).get_argument(1 + index))
+            .collect::<Vec<_>>();
         let bound = append_unsigned_constant(ctx, header, u32_ty, TRIP_COUNT);
         let lt = Operation::new(
             ctx,
@@ -250,13 +239,17 @@ fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
             .set_operand_segment_sizes(ctx, segment_sizes);
         branch.insert_at_back(header, ctx);
 
-        append_mma(ctx, latch, accumulator0, desc_a0, desc_b0);
-        WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
-        append_wait_group(ctx, latch, u64_ty, 1);
-
-        append_mma(ctx, latch, accumulator1, desc_a1, desc_b1);
-        WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
-        append_wait_group(ctx, latch, u64_ty, 1);
+        for slot in 0..slot_count {
+            append_mma(
+                ctx,
+                latch,
+                accumulators[slot],
+                descriptors[slot * 2],
+                descriptors[slot * 2 + 1],
+            );
+            WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
+            append_wait_group(ctx, latch, u64_ty, max_pending_groups);
+        }
 
         let one = append_unsigned_constant(ctx, latch, u32_ty, 1);
         let i_next = Operation::new(
@@ -270,22 +263,22 @@ fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
         i_next.insert_at_back(latch, ctx);
         let i_next = i_next.deref(ctx).get_result(0);
 
-        let desc_a0_next = append_u64_add(ctx, latch, u64_ty, desc_a0, DESC_A0_STEP);
-        let desc_b0_next = append_u64_add(ctx, latch, u64_ty, desc_b0, DESC_B0_STEP);
-        let desc_a1_next = append_u64_add(ctx, latch, u64_ty, desc_a1, DESC_A1_STEP);
-        let desc_b1_next = append_u64_add(ctx, latch, u64_ty, desc_b1, DESC_B1_STEP);
+        let mut next_values = vec![i_next];
+        for (index, descriptor) in descriptors.iter().copied().enumerate() {
+            next_values.push(append_u64_add(
+                ctx,
+                latch,
+                u64_ty,
+                descriptor,
+                16 * (index as u64 + 1),
+            ));
+        }
 
         Operation::new(
             ctx,
             MirGotoOp::get_concrete_op_info(),
             vec![],
-            vec![
-                i_next,
-                desc_a0_next,
-                desc_b0_next,
-                desc_a1_next,
-                desc_b1_next,
-            ],
+            next_values,
             vec![header],
             0,
         )
@@ -306,7 +299,7 @@ fn build_wgmma_pipelined_counted_loop_kernel(module: &mut CodegenModule) {
     });
 
     module
-        .mark_kernel_entry("wgmma_pipelined_counted_loop_kernel")
+        .mark_kernel_entry(kernel_name)
         .expect("kernel entry must be marked");
 }
 
@@ -335,7 +328,12 @@ fn used_register_count(ptxas_stderr: &str) -> Option<u32> {
 #[test]
 fn pointer_form_two_slot_counted_pipeline_compiles_spill_free_for_sm_90a() {
     let mut module = CodegenModule::new("wgmma_pipelined_counted_loop").unwrap();
-    build_wgmma_pipelined_counted_loop_kernel(&mut module);
+    build_wgmma_pipelined_counted_loop_kernel(
+        &mut module,
+        "wgmma_pipelined_counted_loop_kernel",
+        2,
+        1,
+    );
 
     let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
     let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
@@ -447,6 +445,134 @@ fn pointer_form_two_slot_counted_pipeline_compiles_spill_free_for_sm_90a() {
     assert!(
         used_registers >= RESULT_COUNT,
         "the production path did not keep both accumulator slots live: ptxas used only {used_registers} registers\n{stderr}"
+    );
+    assert!(used_registers >= ACCUMULATOR_LEN);
+
+    eprintln!("{stderr}");
+}
+
+#[test]
+fn pointer_form_three_slot_counted_pipeline_compiles_spill_free_for_sm_90a() {
+    let mut module = CodegenModule::new("wgmma_three_slot_pipelined_counted_loop").unwrap();
+    build_wgmma_pipelined_counted_loop_kernel(
+        &mut module,
+        "wgmma_three_slot_pipelined_counted_loop_kernel",
+        3,
+        2,
+    );
+
+    let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
+    let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
+    let ptx = compiler
+        .compile(&mut module, &options)
+        .expect("pointer-form three-slot counted WGMMA pipeline must compile to PTX")
+        .into_ptx();
+    let text = String::from_utf8(ptx.clone()).expect("PTX must be UTF-8");
+
+    assert!(
+        text.contains(".visible .entry"),
+        "kernel entry is missing:\n{text}"
+    );
+    assert!(
+        text.contains(".target sm_90a"),
+        "PTX must target sm_90a:\n{text}"
+    );
+    assert!(
+        text.contains("wgmma_three_slot_pipelined_counted_loop_kernel"),
+        "three-slot counted-pipeline kernel is missing:\n{text}"
+    );
+    assert!(
+        text.contains("L__wgmma_pipeline_loop_") && text.contains("L__wgmma_pipeline_done_"),
+        "production three-slot counted-pipeline labels are missing; pointer-form MIR did not fuse:\n{text}"
+    );
+    assert!(
+        !text.contains("${:uid}"),
+        "llc must expand every ${{:uid}} escape into a unique label suffix:\n{text}"
+    );
+    assert_eq!(text.matches("bra.uni").count(), 2);
+    assert_eq!(text.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(
+        text.matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
+            .count(),
+        3
+    );
+    assert_eq!(text.matches("wgmma.commit_group.sync.aligned").count(), 3);
+    assert_eq!(text.matches("wgmma.wait_group.sync.aligned 2").count(), 3);
+    assert_eq!(text.matches("wgmma.wait_group.sync.aligned 0").count(), 1);
+
+    for recurrence in [
+        "add.u64 %desc_a0",
+        "add.u64 %desc_b0",
+        "add.u64 %desc_a1",
+        "add.u64 %desc_b1",
+        "add.u64 %desc_a2",
+        "add.u64 %desc_b2",
+    ] {
+        assert!(
+            text.contains(recurrence),
+            "descriptor recurrence `{recurrence}` is missing from the three-slot PTX loop:\n{text}"
+        );
+    }
+    assert!(
+        !text.contains(".local") && !text.contains("ld.local") && !text.contains("st.local"),
+        "the production three-slot counted pipeline unexpectedly materializes local memory:\n{text}"
+    );
+
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let directory = std::env::temp_dir().join(format!(
+        "wgmma_three_slot_pipelined_counted_loop_ptx_{}_{}",
+        std::process::id(),
+        unique,
+    ));
+    std::fs::create_dir_all(&directory).unwrap();
+    let ptx_path = directory.join("three_slot_pipelined_counted_loop.ptx");
+    let cubin_path = directory.join("three_slot_pipelined_counted_loop.cubin");
+    std::fs::write(&ptx_path, &ptx).unwrap();
+
+    let ptxas = find_ptxas();
+    let ptxas_result = std::process::Command::new(&ptxas)
+        .arg("-arch=sm_90a")
+        .arg("--compile-only")
+        .arg("-v")
+        .arg(&ptx_path)
+        .arg("-o")
+        .arg(&cubin_path)
+        .output();
+    let _ = std::fs::remove_dir_all(&directory);
+
+    let output = ptxas_result.unwrap_or_else(|error| {
+        panic!(
+            "could not run {}: {error}\nSet CUDA_TOOLKIT_PATH or CUDA_HOME, or put ptxas on PATH.",
+            ptxas.display()
+        )
+    });
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "ptxas rejected the production three-slot counted WGMMA pipeline:\n{stderr}\n\nPTX:\n{text}"
+    );
+    assert!(
+        stderr.contains("0 bytes stack frame"),
+        "ptxas reported a nonzero stack frame or omitted the expected report:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("0 bytes spill stores"),
+        "ptxas reported spill stores:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("0 bytes spill loads"),
+        "ptxas reported spill loads:\n{stderr}"
+    );
+
+    let used_registers =
+        used_register_count(&stderr).expect("ptxas output must report register usage");
+    assert!(
+        used_registers >= THREE_SLOT_RESULT_COUNT,
+        "the production path did not keep all three accumulator slots live: ptxas used only {used_registers} registers\n{stderr}"
     );
     assert!(used_registers >= ACCUMULATOR_LEN);
 

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -42,9 +42,8 @@ use pliron_derive::{pliron_attr, pliron_op};
 
 const WGMMA_M64N64_F32_ACCUMULATOR_COUNT: usize = 32;
 const WGMMA_COUNTED_LOOP_CONTROL_COUNT: usize = 5;
-const WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT: usize = 2 * WGMMA_M64N64_F32_ACCUMULATOR_COUNT;
-const WGMMA_COUNTED_PIPELINE_CONTROL_COUNT: usize = 9;
 const WGMMA_MAX_PENDING_GROUPS: u8 = 7;
+const WGMMA_COUNTED_PIPELINE_MAX_PENDING_GROUPS: u8 = 2;
 
 // =============================================================================
 // Descriptor Operations
@@ -454,30 +453,41 @@ impl Verify for WgmmaMmaLoopValuesM64N64K16F32Bf16Op {
     }
 }
 
-/// Value-form BF16 WGMMA counted loop with two independent accumulator slots.
+/// Value-form BF16 WGMMA counted loop with independent accumulator slots.
 ///
-/// This deliberately narrow carrier models a fixed `wait_group<1>` pipeline:
-/// each loop iteration issues one committed group into slot 0, throttles to at
-/// most one pending group, then repeats the sequence for slot 1. The four
-/// descriptors advance independently and a final `wait_group<0>` drains the
-/// asynchronous lifetime before either slot becomes visible to LLVM.
+/// This deliberately narrow carrier supports the production counted-loop
+/// pipeline depths validated for Hopper:
+///
+/// ```text
+/// wait_group<1> -> 2 accumulator slots
+/// wait_group<2> -> 3 accumulator slots
+/// ```
+///
+/// For `max_pending_groups = N`, the operation carries `N + 1` independent
+/// 32-value accumulator slots. Each slot owns one descriptor pair and one affine
+/// descriptor-step pair. The loop issues one committed group per slot, throttles
+/// each stage with `wait_group<N>`, advances all descriptor recurrences, and
+/// performs a final `wait_group<0>` before any accumulator becomes visible to
+/// LLVM.
 ///
 /// Operand layout:
 ///
 /// ```text
 /// [
 ///   slot0_acc_0, ..., slot0_acc_31,
-///   slot1_acc_0, ..., slot1_acc_31,
-///   desc_a0_base, desc_b0_base, desc_a1_base, desc_b1_base,
-///   desc_a0_step, desc_b0_step, desc_a1_step, desc_b1_step,
+///   ...
+///   slotN_acc_0, ..., slotN_acc_31,
+///   desc_a0_base, desc_b0_base, ..., desc_aN_base, desc_bN_base,
+///   desc_a0_step, desc_b0_step, ..., desc_aN_step, desc_bN_step,
 ///   trip_count,
 /// ]
 /// ```
 ///
-/// Result layout mirrors the 64 flattened accumulator inputs.
+/// Result layout mirrors the flattened accumulator inputs.
 #[pliron_op(
     name = "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16",
-    format
+    format,
+    attributes = (counted_max_pending_groups: WgmmaMaxPendingAttr)
 )]
 pub struct WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op;
 
@@ -487,68 +497,86 @@ impl WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
         Self { op }
     }
 
-    /// Build the fixed two-slot counted-loop pipeline carrier.
-    #[allow(clippy::too_many_arguments)]
+    /// Build a counted-loop WGMMA pipeline for a validated partial-wait depth.
     pub fn build(
         ctx: &mut Context,
         accumulators: Vec<Value>,
-        desc_a0_base: Value,
-        desc_b0_base: Value,
-        desc_a1_base: Value,
-        desc_b1_base: Value,
-        desc_a0_step: Value,
-        desc_b0_step: Value,
-        desc_a1_step: Value,
-        desc_b1_step: Value,
+        desc_bases: Vec<Value>,
+        desc_steps: Vec<Value>,
         trip_count: Value,
+        max_pending_groups: u8,
     ) -> Ptr<Operation> {
         let f32_ty = FP32Type::get(ctx);
+        let result_count = accumulators.len();
         let mut operands =
-            Vec::with_capacity(accumulators.len() + WGMMA_COUNTED_PIPELINE_CONTROL_COUNT);
+            Vec::with_capacity(result_count + desc_bases.len() + desc_steps.len() + 1);
         operands.extend(accumulators);
-        operands.extend([
-            desc_a0_base,
-            desc_b0_base,
-            desc_a1_base,
-            desc_b1_base,
-            desc_a0_step,
-            desc_b0_step,
-            desc_a1_step,
-            desc_b1_step,
-            trip_count,
-        ]);
+        operands.extend(desc_bases);
+        operands.extend(desc_steps);
+        operands.push(trip_count);
 
-        Operation::new(
+        let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),
-            vec![f32_ty.into(); WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT],
+            vec![f32_ty.into(); result_count],
             operands,
             vec![],
             0,
-        )
+        );
+        Self::new(op)
+            .set_attr_counted_max_pending_groups(ctx, WgmmaMaxPendingAttr(max_pending_groups));
+        op
+    }
+
+    /// Return the statically known `wait_group<N>` bound.
+    pub fn max_pending_groups(&self, ctx: &Context) -> Option<u8> {
+        self.get_attr_counted_max_pending_groups(ctx)
+            .map(|attribute| attribute.0)
     }
 }
 
 impl Verify for WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
     fn verify(&self, ctx: &Context) -> Result<(), Error> {
         let op = self.get_operation().deref(ctx);
-        let expected_operands =
-            WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT + WGMMA_COUNTED_PIPELINE_CONTROL_COUNT;
+        let Some(max_pending_attr) = self.get_attr_counted_max_pending_groups(ctx) else {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires an nvvm.wgmma_max_pending_groups attribute"
+            );
+        };
+        max_pending_attr.verify(ctx)?;
+        let max_pending_groups = max_pending_attr.0;
+        drop(max_pending_attr);
+
+        if max_pending_groups > WGMMA_COUNTED_PIPELINE_MAX_PENDING_GROUPS {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 supports only max_pending_groups 1 or 2"
+            );
+        }
+
+        let slot_count = usize::from(max_pending_groups) + 1;
+        let expected_results = slot_count * WGMMA_M64N64_F32_ACCUMULATOR_COUNT;
+        let expected_controls = slot_count * 4 + 1;
+        let expected_operands = expected_results + expected_controls;
 
         if op.get_num_operands() != expected_operands {
             return verify_err!(
                 op.loc(),
-                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires 64 f32 accumulators and exactly nine u64 loop-control operands"
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires {} f32 accumulators and exactly {} u64 loop-control operands",
+                expected_results,
+                expected_controls
             );
         }
-        if op.get_num_results() != WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT {
+        if op.get_num_results() != expected_results {
             return verify_err!(
                 op.loc(),
-                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires exactly 64 f32 results"
+                "nvvm.wgmma_mma_loop_pipeline_values_m64n64k16_f32_bf16 requires exactly {} f32 results",
+                expected_results
             );
         }
 
-        for accumulator_index in 0..WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT {
+        for accumulator_index in 0..expected_results {
             if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx))
                 || !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx))
             {
@@ -559,7 +587,7 @@ impl Verify for WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
             }
         }
 
-        for control_index in WGMMA_COUNTED_PIPELINE_ACCUMULATOR_COUNT..expected_operands {
+        for control_index in expected_results..expected_operands {
             if !is_u64(ctx, op.get_operand(control_index).get_type(ctx)) {
                 return verify_err!(
                     op.loc(),
@@ -572,8 +600,8 @@ impl Verify for WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op {
     }
 }
 
-/// The statically known `wait_group<N>` bound carried by a
-/// [`WgmmaMmaPipelineValuesM64N64K16F32Bf16Op`].
+/// The statically known `wait_group<N>` bound carried by value-form WGMMA
+/// pipeline operations.
 ///
 /// PTX `wgmma.wait_group.sync.aligned N;` throttles at most `N` pending
 /// groups, with `N` in `1..=7` for a partial wait. `0` is the full drain the

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -4728,58 +4728,91 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     let counted_pipeline_group = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
         &mut ctx,
         vec![f32_value; 64],
+        vec![u64_value; 4],
+        vec![u64_value; 4],
         u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
+        1,
     );
     {
         let counted_pipeline_ref = counted_pipeline_group.deref(&ctx);
         assert_eq!(counted_pipeline_ref.get_num_operands(), 73);
         assert_eq!(counted_pipeline_ref.get_num_results(), 64);
     }
-    assert!(
-        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(counted_pipeline_group)
-            .verify(&ctx)
-            .is_ok()
-    );
+    let counted_pipeline =
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(counted_pipeline_group);
+    assert_eq!(counted_pipeline.max_pending_groups(&ctx), Some(1));
+    assert!(counted_pipeline.verify(&ctx).is_ok());
 
-    let too_few_counted_pipeline_accumulators = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+    let three_slot_counted_pipeline = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
         &mut ctx,
-        vec![f32_value; 63],
+        vec![f32_value; 96],
+        vec![u64_value; 6],
+        vec![u64_value; 6],
         u64_value,
+        2,
+    );
+    {
+        let counted_pipeline_ref = three_slot_counted_pipeline.deref(&ctx);
+        assert_eq!(counted_pipeline_ref.get_num_operands(), 109);
+        assert_eq!(counted_pipeline_ref.get_num_results(), 96);
+    }
+    let three_slot_counted_pipeline =
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(three_slot_counted_pipeline);
+    assert_eq!(
+        three_slot_counted_pipeline.max_pending_groups(&ctx),
+        Some(2)
+    );
+    assert!(three_slot_counted_pipeline.verify(&ctx).is_ok());
+
+    let too_many_accumulators_for_wait_one = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 96],
+        vec![u64_value; 4],
+        vec![u64_value; 4],
         u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
-        u64_value,
+        1,
     );
     assert!(
-        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(too_few_counted_pipeline_accumulators)
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(too_many_accumulators_for_wait_one)
             .verify(&ctx)
             .is_err()
     );
 
-    let mut wrong_counted_pipeline_control_operands = vec![f32_value; 64];
-    wrong_counted_pipeline_control_operands.extend([
-        u64_value, u64_value, u64_value, u64_value, u64_value, u64_value, u32_value, u64_value,
-        u64_value,
-    ]);
-    let wrong_counted_pipeline_control = Operation::new(
+    let too_few_accumulators_for_wait_two = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
         &mut ctx,
-        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::get_concrete_op_info(),
-        vec![f32_ty.into(); 64],
-        wrong_counted_pipeline_control_operands,
-        vec![],
-        0,
+        vec![f32_value; 64],
+        vec![u64_value; 6],
+        vec![u64_value; 6],
+        u64_value,
+        2,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(too_few_accumulators_for_wait_two)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let unsupported_wait_three = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 128],
+        vec![u64_value; 8],
+        vec![u64_value; 8],
+        u64_value,
+        3,
+    );
+    assert!(
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(unsupported_wait_three)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let wrong_counted_pipeline_control = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
+        &mut ctx,
+        vec![f32_value; 64],
+        vec![u64_value; 4],
+        vec![u64_value, u64_value, u32_value, u64_value],
+        u64_value,
+        1,
     );
     assert!(
         WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_control)
@@ -4797,11 +4830,11 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
         vec![],
         0,
     );
-    assert!(
-        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_count)
-            .verify(&ctx)
-            .is_err()
-    );
+    let wrong_counted_pipeline_result_count =
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_count);
+    wrong_counted_pipeline_result_count
+        .set_attr_counted_max_pending_groups(&ctx, WgmmaMaxPendingAttr(1));
+    assert!(wrong_counted_pipeline_result_count.verify(&ctx).is_err());
 
     let mut wrong_counted_pipeline_result_types = vec![f32_ty.into(); 64];
     wrong_counted_pipeline_result_types[0] = u32_ty.into();
@@ -4813,11 +4846,11 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
         vec![],
         0,
     );
-    assert!(
-        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_type)
-            .verify(&ctx)
-            .is_err()
-    );
+    let wrong_counted_pipeline_result_type =
+        WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::new(wrong_counted_pipeline_result_type);
+    wrong_counted_pipeline_result_type
+        .set_attr_counted_max_pending_groups(&ctx, WgmmaMaxPendingAttr(1));
+    assert!(wrong_counted_pipeline_result_type.verify(&ctx).is_err());
 
     let pipeline_group = WgmmaMmaPipelineValuesM64N64K16F32Bf16Op::build(
         &mut ctx,

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -24,9 +24,7 @@ use pliron::r#type::TypeHandle;
 
 const VALUE_ACCUMULATOR_COUNT: usize = 32;
 const COUNTED_LOOP_CONTROL_COUNT: usize = 5;
-const COUNTED_PIPELINE_SLOT_COUNT: usize = 2;
-const COUNTED_PIPELINE_RESULT_COUNT: usize = COUNTED_PIPELINE_SLOT_COUNT * VALUE_ACCUMULATOR_COUNT;
-const COUNTED_PIPELINE_CONTROL_COUNT: usize = 9;
+const COUNTED_PIPELINE_MAX_PENDING_GROUPS: u8 = 2;
 
 /// Convert WGMMA make_smem_desc to inline PTX.
 pub(crate) fn convert_make_smem_desc(
@@ -171,56 +169,54 @@ fn counted_loop_template() -> String {
     template
 }
 
-fn counted_pipeline_template() -> String {
-    let slot0 = pipeline_accumulator_operand_list(0);
-    let slot1 = pipeline_accumulator_operand_list(1);
-    let control_base = COUNTED_PIPELINE_RESULT_COUNT * 2;
-    let desc_a0_base = control_base;
-    let desc_b0_base = control_base + 1;
-    let desc_a1_base = control_base + 2;
-    let desc_b1_base = control_base + 3;
-    let desc_a0_step = control_base + 4;
-    let desc_b0_step = control_base + 5;
-    let desc_a1_step = control_base + 6;
-    let desc_b1_step = control_base + 7;
-    let trip_count = control_base + 8;
+fn counted_pipeline_template(slot_count: usize, max_pending_groups: u8) -> String {
+    let result_count = slot_count * VALUE_ACCUMULATOR_COUNT;
+    let control_base = result_count * 2;
+    let step_base = control_base + slot_count * 2;
+    let trip_count = control_base + slot_count * 4;
 
-    let mut template = String::from(
-        "{\n    .reg .u64 %desc_a0;\n    .reg .u64 %desc_b0;\n    .reg .u64 %desc_a1;\n    .reg .u64 %desc_b1;\n    .reg .u64 %remaining;\n    .reg .pred %loop_more;\n",
-    );
-    template.push_str(&format!("    mov.u64 %desc_a0, ${desc_a0_base};\n"));
-    template.push_str(&format!("    mov.u64 %desc_b0, ${desc_b0_base};\n"));
-    template.push_str(&format!("    mov.u64 %desc_a1, ${desc_a1_base};\n"));
-    template.push_str(&format!("    mov.u64 %desc_b1, ${desc_b1_base};\n"));
+    let mut template = String::from("{\n");
+    for slot in 0..slot_count {
+        template.push_str(&format!("    .reg .u64 %desc_a{slot};\n"));
+        template.push_str(&format!("    .reg .u64 %desc_b{slot};\n"));
+    }
+    template.push_str("    .reg .u64 %remaining;\n    .reg .pred %loop_more;\n");
+
+    for slot in 0..slot_count {
+        let desc_a_base = control_base + slot * 2;
+        let desc_b_base = desc_a_base + 1;
+        template.push_str(&format!("    mov.u64 %desc_a{slot}, ${desc_a_base};\n"));
+        template.push_str(&format!("    mov.u64 %desc_b{slot}, ${desc_b_base};\n"));
+    }
     template.push_str(&format!("    mov.u64 %remaining, ${trip_count};\n"));
     template.push_str("    wgmma.fence.sync.aligned;\n");
     template.push_str("    setp.eq.u64 %loop_more, %remaining, 0;\n");
     template.push_str("    @%loop_more bra.uni L__wgmma_pipeline_done_${:uid};\n");
     template.push_str("L__wgmma_pipeline_loop_${:uid}:\n");
-    template.push_str(&format!(
-        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
-         {{{slot0}}}, %desc_a0, %desc_b0, 1, 1, 1, 0, 0;\n"
-    ));
-    template.push_str("    wgmma.commit_group.sync.aligned;\n");
-    template.push_str("    wgmma.wait_group.sync.aligned 1;\n");
-    template.push_str(&format!(
-        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
-         {{{slot1}}}, %desc_a1, %desc_b1, 1, 1, 1, 0, 0;\n"
-    ));
-    template.push_str("    wgmma.commit_group.sync.aligned;\n");
-    template.push_str("    wgmma.wait_group.sync.aligned 1;\n");
-    template.push_str(&format!(
-        "    add.u64 %desc_a0, %desc_a0, ${desc_a0_step};\n"
-    ));
-    template.push_str(&format!(
-        "    add.u64 %desc_b0, %desc_b0, ${desc_b0_step};\n"
-    ));
-    template.push_str(&format!(
-        "    add.u64 %desc_a1, %desc_a1, ${desc_a1_step};\n"
-    ));
-    template.push_str(&format!(
-        "    add.u64 %desc_b1, %desc_b1, ${desc_b1_step};\n"
-    ));
+
+    for slot in 0..slot_count {
+        let accumulators = pipeline_accumulator_operand_list(slot);
+        template.push_str(&format!(
+            "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+             {{{accumulators}}}, %desc_a{slot}, %desc_b{slot}, 1, 1, 1, 0, 0;\n"
+        ));
+        template.push_str("    wgmma.commit_group.sync.aligned;\n");
+        template.push_str(&format!(
+            "    wgmma.wait_group.sync.aligned {max_pending_groups};\n"
+        ));
+    }
+
+    for slot in 0..slot_count {
+        let desc_a_step = step_base + slot * 2;
+        let desc_b_step = desc_a_step + 1;
+        template.push_str(&format!(
+            "    add.u64 %desc_a{slot}, %desc_a{slot}, ${desc_a_step};\n"
+        ));
+        template.push_str(&format!(
+            "    add.u64 %desc_b{slot}, %desc_b{slot}, ${desc_b_step};\n"
+        ));
+    }
+
     template.push_str("    sub.u64 %remaining, %remaining, 1;\n");
     template.push_str("    setp.ne.u64 %loop_more, %remaining, 0;\n");
     template.push_str("    @%loop_more bra.uni L__wgmma_pipeline_loop_${:uid};\n");
@@ -230,10 +226,10 @@ fn counted_pipeline_template() -> String {
     template
 }
 
-fn counted_pipeline_constraints() -> String {
-    let mut constraints = vec!["=f".to_owned(); COUNTED_PIPELINE_RESULT_COUNT];
-    constraints.extend((0..COUNTED_PIPELINE_RESULT_COUNT).map(|index| index.to_string()));
-    constraints.extend((0..COUNTED_PIPELINE_CONTROL_COUNT).map(|_| "l".to_owned()));
+fn counted_pipeline_constraints(result_count: usize, control_count: usize) -> String {
+    let mut constraints = vec!["=f".to_owned(); result_count];
+    constraints.extend((0..result_count).map(|index| index.to_string()));
+    constraints.extend((0..control_count).map(|_| "l".to_owned()));
     constraints.push("~{memory}".to_owned());
     constraints.join(",")
 }
@@ -465,12 +461,12 @@ pub(crate) fn convert_mma_loop_values(
     Ok(())
 }
 
-/// Lower the fixed two-slot counted WGMMA pipeline to one convergent inline-PTX scope.
+/// Lower a counted WGMMA pipeline to one convergent inline-PTX scope.
 ///
-/// Both 32-value accumulator slots are tied across the same asm statement. The
-/// four descriptor recurrences, trip counter, commits, partial waits, and final
-/// full drain all remain internal so LLVM never observes a live asynchronous
-/// accumulator value.
+/// The production counted-loop carrier supports the validated `wait_group<1>`
+/// two-slot and `wait_group<2>` three-slot forms. Every accumulator slot is tied
+/// across the same asm statement together with its descriptor recurrence and the
+/// trip counter, so LLVM never observes a live asynchronous accumulator value.
 pub(crate) fn convert_mma_loop_pipeline_values(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -481,27 +477,38 @@ pub(crate) fn convert_mma_loop_pipeline_values(
     let result_count = op.deref(ctx).get_num_results();
     let operands: Vec<_> = op.deref(ctx).operands().collect();
 
-    Operation::get_op::<WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op>(op, ctx)
+    let pipeline = Operation::get_op::<WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op>(op, ctx)
         .expect("counted-pipeline conversion must be invoked for the counted-pipeline WGMMA op");
-
-    if result_count != COUNTED_PIPELINE_RESULT_COUNT {
+    let Some(max_pending_groups) = pipeline.max_pending_groups(ctx) else {
+        return pliron::input_err_noloc!("counted-pipeline WGMMA is missing max_pending_groups");
+    };
+    if !(1..=COUNTED_PIPELINE_MAX_PENDING_GROUPS).contains(&max_pending_groups) {
         return pliron::input_err_noloc!(
-            "counted-pipeline value-form WGMMA requires exactly 64 accumulator results"
-        );
-    }
-    if operands.len() != COUNTED_PIPELINE_RESULT_COUNT + COUNTED_PIPELINE_CONTROL_COUNT {
-        return pliron::input_err_noloc!(
-            "counted-pipeline value-form WGMMA requires 64 accumulator inputs and nine loop-control operands"
+            "counted-pipeline WGMMA supports only max_pending_groups 1 or 2"
         );
     }
 
-    let template = counted_pipeline_template();
-    let constraints = counted_pipeline_constraints();
+    let slot_count = usize::from(max_pending_groups) + 1;
+    let expected_result_count = slot_count * VALUE_ACCUMULATOR_COUNT;
+    let control_count = slot_count * 4 + 1;
+    if result_count != expected_result_count {
+        return pliron::input_err_noloc!(
+            "counted-pipeline WGMMA requires max_pending_groups + 1 accumulator slots"
+        );
+    }
+    if operands.len() != result_count + control_count {
+        return pliron::input_err_noloc!(
+            "counted-pipeline WGMMA requires two descriptor bases and two descriptor steps per accumulator slot plus one trip count"
+        );
+    }
+
+    let template = counted_pipeline_template(slot_count, max_pending_groups);
+    let constraints = counted_pipeline_constraints(result_count, control_count);
     let f32_ty = FP32Type::get(ctx);
     let struct_ty: TypeHandle = llvm_types::StructType::get_unnamed(
         ctx,
         (
-            vec![f32_ty.into(); COUNTED_PIPELINE_RESULT_COUNT],
+            vec![f32_ty.into(); result_count],
             llvm_types::StructLayout::Unpacked,
         ),
     )
@@ -518,8 +525,8 @@ pub(crate) fn convert_mma_loop_pipeline_values(
     );
     let aggregate = asm_op.deref(ctx).get_result(0);
 
-    let mut extracted_values = Vec::with_capacity(COUNTED_PIPELINE_RESULT_COUNT);
-    for index in 0..COUNTED_PIPELINE_RESULT_COUNT {
+    let mut extracted_values = Vec::with_capacity(result_count);
+    for index in 0..result_count {
         let extract = llvm::ExtractValueOp::new(ctx, aggregate, vec![index as u32])
             .map_err(|error| pliron::input_error!(loc.clone(), "{}", error))?;
         rewriter.insert_operation(ctx, extract.get_operation());
@@ -628,7 +635,7 @@ pub(crate) fn convert_mma(
     _operands_info: &OperandsInfo,
 ) -> Result<()> {
     pliron::input_err_noloc!(
-        "WGMMA MMA reached lowering without deferred accumulator fusion; expected a supported linear wait_group<0> region, a proven partial-wait pipeline, a canonical counted K-loop, or the fixed two-slot counted pipeline"
+        "WGMMA MMA reached lowering without deferred accumulator fusion; expected a supported linear wait_group<0> region, a proven partial-wait pipeline, a canonical counted K-loop, or a supported counted pipeline"
     )
 }
 
@@ -746,56 +753,104 @@ mod tests {
     }
 
     #[test]
-    fn counted_pipeline_template_keeps_two_slots_and_partial_waits_inside_loop() {
-        let template = counted_pipeline_template();
-        assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
-        assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+    fn counted_pipeline_template_supports_two_and_three_slot_wait_depths() {
+        let two_slot = counted_pipeline_template(2, 1);
+        assert_eq!(two_slot.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(two_slot.matches("wgmma.mma_async").count(), 2);
         assert_eq!(
-            template.matches("wgmma.commit_group.sync.aligned").count(),
+            two_slot.matches("wgmma.commit_group.sync.aligned").count(),
             2
         );
         assert_eq!(
-            template.matches("wgmma.wait_group.sync.aligned 1").count(),
+            two_slot.matches("wgmma.wait_group.sync.aligned 1").count(),
             2
         );
         assert_eq!(
-            template.matches("wgmma.wait_group.sync.aligned 0").count(),
+            two_slot.matches("wgmma.wait_group.sync.aligned 0").count(),
             1
         );
-        assert!(template.contains("L__wgmma_pipeline_loop_${:uid}:"));
-        assert!(template.contains("L__wgmma_pipeline_done_${:uid}:"));
-        assert!(template.contains("{$0, $1, $2"));
-        assert!(template.contains("{$32, $33, $34"));
-        assert!(template.contains("mov.u64 %desc_a0, $128;"));
-        assert!(template.contains("mov.u64 %desc_b0, $129;"));
-        assert!(template.contains("mov.u64 %desc_a1, $130;"));
-        assert!(template.contains("mov.u64 %desc_b1, $131;"));
-        assert!(template.contains("add.u64 %desc_a0, %desc_a0, $132;"));
-        assert!(template.contains("add.u64 %desc_b0, %desc_b0, $133;"));
-        assert!(template.contains("add.u64 %desc_a1, %desc_a1, $134;"));
-        assert!(template.contains("add.u64 %desc_b1, %desc_b1, $135;"));
-        assert!(template.contains("mov.u64 %remaining, $136;"));
-        assert!(!template.contains("ld.f32"));
-        assert!(!template.contains("st.f32"));
-        assert!(!template.contains(".reg .f32"));
-        assert!(
-            !template.contains("\\\n"),
-            "counted-pipeline PTX must not contain a literal line-continuation backslash: {template}"
-        );
+        assert!(two_slot.contains("{$0, $1, $2"));
+        assert!(two_slot.contains("{$32, $33, $34"));
+        assert!(two_slot.contains("mov.u64 %desc_a0, $128;"));
+        assert!(two_slot.contains("mov.u64 %desc_b1, $131;"));
+        assert!(two_slot.contains("add.u64 %desc_a0, %desc_a0, $132;"));
+        assert!(two_slot.contains("add.u64 %desc_b1, %desc_b1, $135;"));
+        assert!(two_slot.contains("mov.u64 %remaining, $136;"));
 
-        let constraints = counted_pipeline_constraints();
+        let three_slot = counted_pipeline_template(3, 2);
+        assert_eq!(three_slot.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(three_slot.matches("wgmma.mma_async").count(), 3);
         assert_eq!(
-            constraints
+            three_slot
+                .matches("wgmma.commit_group.sync.aligned")
+                .count(),
+            3
+        );
+        assert_eq!(
+            three_slot
+                .matches("wgmma.wait_group.sync.aligned 2")
+                .count(),
+            3
+        );
+        assert_eq!(
+            three_slot
+                .matches("wgmma.wait_group.sync.aligned 0")
+                .count(),
+            1
+        );
+        assert!(three_slot.contains("{$0, $1, $2"));
+        assert!(three_slot.contains("{$32, $33, $34"));
+        assert!(three_slot.contains("{$64, $65, $66"));
+        assert!(three_slot.contains("mov.u64 %desc_a0, $192;"));
+        assert!(three_slot.contains("mov.u64 %desc_b2, $197;"));
+        assert!(three_slot.contains("add.u64 %desc_a0, %desc_a0, $198;"));
+        assert!(three_slot.contains("add.u64 %desc_b2, %desc_b2, $203;"));
+        assert!(three_slot.contains("mov.u64 %remaining, $204;"));
+
+        for template in [&two_slot, &three_slot] {
+            assert!(template.contains("L__wgmma_pipeline_loop_${:uid}:"));
+            assert!(template.contains("L__wgmma_pipeline_done_${:uid}:"));
+            assert!(!template.contains("ld.f32"));
+            assert!(!template.contains("st.f32"));
+            assert!(!template.contains(".reg .f32"));
+            assert!(
+                !template.contains("\\\n"),
+                "counted-pipeline PTX must not contain a literal line-continuation backslash: {template}"
+            );
+        }
+
+        let two_slot_constraints = counted_pipeline_constraints(64, 9);
+        assert_eq!(
+            two_slot_constraints
                 .split(',')
                 .filter(|value| *value == "=f")
                 .count(),
             64
         );
         assert_eq!(
-            constraints.split(',').filter(|value| *value == "l").count(),
+            two_slot_constraints
+                .split(',')
+                .filter(|value| *value == "l")
+                .count(),
             9
         );
-        assert!(constraints.ends_with("~{memory}"));
+
+        let three_slot_constraints = counted_pipeline_constraints(96, 13);
+        assert_eq!(
+            three_slot_constraints
+                .split(',')
+                .filter(|value| *value == "=f")
+                .count(),
+            96
+        );
+        assert_eq!(
+            three_slot_constraints
+                .split(',')
+                .filter(|value| *value == "l")
+                .count(),
+            13
+        );
+        assert!(three_slot_constraints.ends_with("~{memory}"));
     }
 
     #[test]

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -34,11 +34,13 @@
 //! corresponding partial wait has made the oldest slot safe. Every accepted
 //! pipeline ends with `wait_group<0>` before any accumulator value escapes.
 //!
-//! A second narrow loop form composes these properties for exactly two
-//! canonical accumulator slots. Its latch must contain two
-//! `MMA -> commit_group -> wait_group<1>` stages, followed by affine recurrences
-//! for four descriptor block arguments. The exit contains the final
-//! `wait_group<0>`. This form is selected before the single-slot counted loop.
+//! A second narrow loop form composes these properties for the production
+//! counted-pipeline depths validated on Hopper: two canonical accumulator slots
+//! with `wait_group<1>` or three slots with `wait_group<2>`. Its latch must
+//! contain one `MMA -> commit_group -> wait_group<N>` stage per slot, followed
+//! by affine recurrences for two descriptor block arguments per slot. The exit
+//! contains the final `wait_group<0>`. This form is selected before the
+//! single-slot counted loop.
 
 use dialect_mir::{
     ops::{
@@ -152,6 +154,7 @@ struct PipelinedCountedLoopPlan {
     desc_steps: Vec<u64>,
     trip_count: u64,
     slot_types: Vec<(TypeHandle, TypeHandle)>,
+    max_pending_groups: u8,
 }
 
 fn collect_blocks(ctx: &Context, root: Ptr<Operation>) -> Vec<Ptr<BasicBlock>> {
@@ -483,32 +486,57 @@ fn match_pipelined_counted_loop(
     for (index, operation) in latch_operations.iter().copied().enumerate() {
         if Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some() {
             require_pointer_mma_shape(ctx, operation)?;
-            pipeline_events.push((index, 0u8, operation));
+            pipeline_events.push((index, 0u8, operation, 0u64));
         } else if Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some() {
             require_nullary_control_op(ctx, operation, "WGMMA commit_group")?;
-            pipeline_events.push((index, 1u8, operation));
+            pipeline_events.push((index, 1u8, operation, 0u64));
         } else if Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some() {
             require_wait_shape(ctx, operation)?;
             let wait_operand = operation.deref(ctx).get_operand(0);
-            if integer_constant_u64(ctx, wait_operand) != Some(1) {
+            let Some(max_pending) = integer_constant_u64(ctx, wait_operand) else {
+                return Ok(None);
+            };
+            if !(1..=2).contains(&max_pending) {
                 return Ok(None);
             }
-            pipeline_events.push((index, 2u8, operation));
+            pipeline_events.push((index, 2u8, operation, max_pending));
         }
     }
 
-    if pipeline_events.len() != 6
-        || pipeline_events
-            .iter()
-            .map(|(_, kind, _)| *kind)
-            .collect::<Vec<_>>()
-            != [0, 1, 2, 0, 1, 2]
+    let wait_depths = pipeline_events
+        .iter()
+        .filter(|(_, kind, _, _)| *kind == 2)
+        .map(|(_, _, _, max_pending)| *max_pending)
+        .collect::<Vec<_>>();
+    let Some(&max_pending_groups) = wait_depths.first() else {
+        return Ok(None);
+    };
+    if wait_depths
+        .iter()
+        .any(|wait_depth| *wait_depth != max_pending_groups)
     {
         return Ok(None);
     }
 
-    let first_event_index = pipeline_events[0].0;
-    let last_event_index = pipeline_events[5].0;
+    let max_pending_groups = u8::try_from(max_pending_groups)
+        .expect("supported counted-pipeline wait depth must fit u8");
+    let slot_count = usize::from(max_pending_groups) + 1;
+    if pipeline_events.len() != slot_count * 3
+        || !pipeline_events
+            .chunks_exact(3)
+            .all(|chunk| chunk[0].1 == 0 && chunk[1].1 == 1 && chunk[2].1 == 2)
+    {
+        return Ok(None);
+    }
+
+    let first_event_index = pipeline_events
+        .first()
+        .expect("counted pipeline has at least one stage")
+        .0;
+    let last_event_index = pipeline_events
+        .last()
+        .expect("counted pipeline has at least one stage")
+        .0;
     for operation in latch_operations
         .iter()
         .copied()
@@ -523,13 +551,22 @@ fn match_pipelined_counted_loop(
         }
     }
 
-    let mmas = vec![pipeline_events[0].2, pipeline_events[3].2];
-    let commits = vec![pipeline_events[1].2, pipeline_events[4].2];
-    let partial_waits = vec![pipeline_events[2].2, pipeline_events[5].2];
+    let mmas = pipeline_events
+        .chunks_exact(3)
+        .map(|chunk| chunk[0].2)
+        .collect::<Vec<_>>();
+    let commits = pipeline_events
+        .chunks_exact(3)
+        .map(|chunk| chunk[1].2)
+        .collect::<Vec<_>>();
+    let partial_waits = pipeline_events
+        .chunks_exact(3)
+        .map(|chunk| chunk[2].2)
+        .collect::<Vec<_>>();
 
-    let mut accumulators = Vec::with_capacity(2);
-    let mut slot_types = Vec::with_capacity(2);
-    let mut descriptor_args = Vec::with_capacity(4);
+    let mut accumulators = Vec::with_capacity(slot_count);
+    let mut slot_types = Vec::with_capacity(slot_count);
+    let mut descriptor_args = Vec::with_capacity(slot_count * 2);
     for &mma in &mmas {
         let mma_ref = mma.deref(ctx);
         let accumulator = mma_ref.get_operand(0);
@@ -547,15 +584,15 @@ fn match_pipelined_counted_loop(
         {
             return Ok(None);
         }
+        if accumulators.contains(&accumulator) {
+            return Ok(None);
+        }
         accumulators.push(accumulator);
         slot_types.push(shape);
         descriptor_args.extend([mma_ref.get_operand(1), mma_ref.get_operand(2)]);
     }
-    if accumulators[0] == accumulators[1] {
-        return Ok(None);
-    }
 
-    let mut descriptor_indices = Vec::with_capacity(4);
+    let mut descriptor_indices = Vec::with_capacity(slot_count * 2);
     for descriptor in descriptor_args {
         if !is_u64_value(ctx, descriptor) {
             return Ok(None);
@@ -569,8 +606,8 @@ fn match_pipelined_counted_loop(
         descriptor_indices.push(index);
     }
 
-    let mut desc_bases = Vec::with_capacity(4);
-    let mut desc_steps = Vec::with_capacity(4);
+    let mut desc_bases = Vec::with_capacity(slot_count * 2);
+    let mut desc_steps = Vec::with_capacity(slot_count * 2);
     for index in descriptor_indices {
         let base = init_operands[index];
         if !is_u64_value(ctx, base) {
@@ -602,6 +639,7 @@ fn match_pipelined_counted_loop(
         desc_steps,
         trip_count,
         slot_types,
+        max_pending_groups,
     }))
 }
 
@@ -1131,12 +1169,18 @@ fn apply_pipelined_counted_loop_plan(ctx: &mut Context, plan: PipelinedCountedLo
         desc_steps,
         trip_count,
         slot_types,
+        max_pending_groups,
     } = plan;
 
-    debug_assert_eq!(accumulators.len(), 2);
-    debug_assert_eq!(desc_bases.len(), 4);
-    debug_assert_eq!(desc_steps.len(), 4);
-    debug_assert_eq!(slot_types.len(), 2);
+    let slot_count = usize::from(max_pending_groups) + 1;
+    debug_assert!((1..=2).contains(&max_pending_groups));
+    debug_assert_eq!(accumulators.len(), slot_count);
+    debug_assert_eq!(desc_bases.len(), slot_count * 2);
+    debug_assert_eq!(desc_steps.len(), slot_count * 2);
+    debug_assert_eq!(slot_types.len(), slot_count);
+    debug_assert_eq!(mmas.len(), slot_count);
+    debug_assert_eq!(commits.len(), slot_count);
+    debug_assert_eq!(partial_waits.len(), slot_count);
     debug_assert_eq!(
         preheader.deref(ctx).get_terminator(ctx),
         Some(preheader_terminator)
@@ -1144,9 +1188,9 @@ fn apply_pipelined_counted_loop_plan(ctx: &mut Context, plan: PipelinedCountedLo
     debug_assert_eq!(exit.deref(ctx).get_num_arguments(), 0);
 
     let loc = fence.deref(ctx).loc();
-    let mut element_pointers = Vec::with_capacity(2);
-    let mut all_accumulator_values = Vec::with_capacity(2 * ACCUMULATOR_LEN);
-    for slot in 0..2 {
+    let mut element_pointers = Vec::with_capacity(slot_count);
+    let mut all_accumulator_values = Vec::with_capacity(slot_count * ACCUMULATOR_LEN);
+    for slot in 0..slot_count {
         let (row_type, element_type) = slot_types[slot];
         let (pointers, values) = load_accumulator_values_before(
             ctx,
@@ -1169,23 +1213,18 @@ fn apply_pipelined_counted_loop_plan(ctx: &mut Context, plan: PipelinedCountedLo
     let pipeline = WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::build(
         ctx,
         all_accumulator_values,
-        desc_bases[0],
-        desc_bases[1],
-        desc_bases[2],
-        desc_bases[3],
-        step_values[0],
-        step_values[1],
-        step_values[2],
-        step_values[3],
+        desc_bases,
+        step_values,
         trip_count,
+        max_pending_groups,
     );
     pipeline.deref_mut(ctx).set_loc(loc.clone());
-    let accumulator_results = (0..2 * ACCUMULATOR_LEN)
+    let accumulator_results = (0..slot_count * ACCUMULATOR_LEN)
         .map(|index| pipeline.deref(ctx).get_result(index))
         .collect::<Vec<_>>();
     pipeline.insert_before(ctx, preheader_terminator);
 
-    for slot in 0..2 {
+    for slot in 0..slot_count {
         let begin = slot * ACCUMULATOR_LEN;
         let end = begin + ACCUMULATOR_LEN;
         store_accumulator_values_before(

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -9617,6 +9617,168 @@ fn test_pointer_form_wgmma_partial_wait_pipeline_keeps_multiple_groups_in_flight
     Ok(())
 }
 
+fn build_pointer_form_wgmma_counted_pipeline_case(
+    ctx: &mut Context,
+    slot_count: usize,
+    wait_depths: &[i64],
+    repeat_last_accumulator: bool,
+) -> pliron::context::Ptr<Operation> {
+    use dialect_mir::types::{MirArrayType, MirPtrType};
+    use pliron::basic_block::BasicBlock;
+    use pliron::builtin::op_interfaces::OperandSegmentInterface;
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+
+    assert_eq!(wait_depths.len(), slot_count);
+
+    let f32_ty = FP32Type::get(ctx);
+    let row_ty = MirArrayType::get(ctx, f32_ty.into(), 8);
+    let accumulator_ty = MirArrayType::get(ctx, row_ty.into(), 4);
+    let accumulator_ptr_ty = MirPtrType::get_generic(ctx, accumulator_ty.into(), true);
+    let u32_ty = IntegerType::get(ctx, 32, Signedness::Unsigned);
+    let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+    let i1_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+    let u64_type: pliron::r#type::TypeHandle = u64_ty.into();
+
+    let mut argument_types: Vec<pliron::r#type::TypeHandle> =
+        vec![accumulator_ptr_ty.into(); slot_count];
+    argument_types.extend(vec![u64_type; slot_count * 2]);
+    let (module_ptr, preheader) = build_test_kernel(ctx, argument_types);
+
+    let accumulators = (0..slot_count)
+        .map(|slot| preheader.deref(ctx).get_argument(slot))
+        .collect::<Vec<_>>();
+    let desc_bases = (0..slot_count * 2)
+        .map(|index| preheader.deref(ctx).get_argument(slot_count + index))
+        .collect::<Vec<_>>();
+
+    let module_region = module_ptr.deref(ctx).get_region(0);
+    let module_block = module_region.deref(ctx).iter(ctx).next().unwrap();
+    let function = module_block.deref(ctx).iter(ctx).next().unwrap();
+    let function_region = function.deref(ctx).get_region(0);
+
+    let mut header_types: Vec<pliron::r#type::TypeHandle> = vec![u32_ty.into()];
+    header_types.extend(vec![u64_type; slot_count * 2]);
+    let header = BasicBlock::new(ctx, None, header_types);
+    header.insert_at_back(function_region, ctx);
+    let latch = BasicBlock::new(ctx, None, vec![]);
+    latch.insert_at_back(function_region, ctx);
+    let exit = BasicBlock::new(ctx, None, vec![]);
+    exit.insert_at_back(function_region, ctx);
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(ctx).insert_at_back(preheader, ctx);
+    let i0 = append_mir_unsigned_constant(ctx, preheader, u32_ty, 0);
+    let mut initial_values = vec![i0];
+    initial_values.extend(desc_bases.iter().copied());
+    Operation::new(
+        ctx,
+        mir::MirGotoOp::get_concrete_op_info(),
+        vec![],
+        initial_values,
+        vec![header],
+        0,
+    )
+    .insert_at_back(preheader, ctx);
+
+    let i = header.deref(ctx).get_argument(0);
+    let descriptors = (0..slot_count * 2)
+        .map(|index| header.deref(ctx).get_argument(1 + index))
+        .collect::<Vec<_>>();
+    let bound = append_mir_unsigned_constant(ctx, header, u32_ty, 4);
+    let lt = Operation::new(
+        ctx,
+        mir::MirLtOp::get_concrete_op_info(),
+        vec![i1_ty.into()],
+        vec![i, bound],
+        vec![],
+        0,
+    );
+    lt.insert_at_back(header, ctx);
+    let lt_value = lt.deref(ctx).get_result(0);
+    let not_lt = Operation::new(
+        ctx,
+        mir::MirNotOp::get_concrete_op_info(),
+        vec![i1_ty.into()],
+        vec![lt_value],
+        vec![],
+        0,
+    );
+    not_lt.insert_at_back(header, ctx);
+    let not_lt_value = not_lt.deref(ctx).get_result(0);
+    let (branch_operands, segment_sizes) =
+        mir::MirCondBranchOp::compute_segment_sizes(vec![vec![not_lt_value], vec![], vec![]]);
+    let branch = Operation::new(
+        ctx,
+        mir::MirCondBranchOp::get_concrete_op_info(),
+        vec![],
+        branch_operands,
+        vec![exit, latch],
+        0,
+    );
+    Operation::get_op::<mir::MirCondBranchOp>(branch, ctx)
+        .expect("MirCondBranchOp")
+        .set_operand_segment_sizes(ctx, segment_sizes);
+    branch.insert_at_back(header, ctx);
+
+    for slot in 0..slot_count {
+        let accumulator = if repeat_last_accumulator && slot + 1 == slot_count {
+            accumulators[0]
+        } else {
+            accumulators[slot]
+        };
+        append_pointer_wgmma_mma(
+            ctx,
+            latch,
+            accumulator,
+            descriptors[slot * 2],
+            descriptors[slot * 2 + 1],
+        );
+        nvvm::WgmmaCommitGroupSyncAlignedOp::build(ctx).insert_at_back(latch, ctx);
+        append_wgmma_wait_group_constant(ctx, latch, wait_depths[slot]);
+    }
+
+    let one = append_mir_unsigned_constant(ctx, latch, u32_ty, 1);
+    let i_next = Operation::new(
+        ctx,
+        mir::MirAddOp::get_concrete_op_info(),
+        vec![u32_ty.into()],
+        vec![i, one],
+        vec![],
+        0,
+    );
+    i_next.insert_at_back(latch, ctx);
+    let i_next = i_next.deref(ctx).get_result(0);
+
+    let mut next_values = vec![i_next];
+    for (index, descriptor) in descriptors.iter().copied().enumerate() {
+        let step = append_mir_unsigned_constant(ctx, latch, u64_ty, 16 * (index as u64 + 1));
+        let next = Operation::new(
+            ctx,
+            mir::MirAddOp::get_concrete_op_info(),
+            vec![u64_ty.into()],
+            vec![descriptor, step],
+            vec![],
+            0,
+        );
+        next.insert_at_back(latch, ctx);
+        next_values.push(next.deref(ctx).get_result(0));
+    }
+
+    Operation::new(
+        ctx,
+        mir::MirGotoOp::get_concrete_op_info(),
+        vec![],
+        next_values,
+        vec![header],
+        0,
+    )
+    .insert_at_back(latch, ctx);
+
+    append_wgmma_wait_group_constant(ctx, exit, 0);
+    append_return(ctx, exit);
+
+    module_ptr
+}
+
 #[test]
 fn test_pointer_form_wgmma_two_slot_counted_pipeline_stays_register_resident()
 -> Result<(), anyhow::Error> {
@@ -9938,6 +10100,170 @@ fn test_pointer_form_wgmma_two_slot_counted_pipeline_stays_register_resident()
     );
 
     Ok(())
+}
+
+#[test]
+fn test_pointer_form_wgmma_three_slot_counted_pipeline_stays_register_resident()
+-> Result<(), anyhow::Error> {
+    const RESULT_COUNT: usize = 96;
+    const LOOP_CONTROL_COUNT: usize = 13;
+
+    let mut ctx = make_test_ctx();
+    let module_ptr = build_pointer_form_wgmma_counted_pipeline_case(&mut ctx, 3, &[2, 2, 2], false);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let body = lowered_kernel_body(&ctx, module_ptr);
+    let matching = body
+        .iter()
+        .copied()
+        .filter_map(|operation| {
+            Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx)
+                .map(|inline_asm| (operation, inline_asm))
+        })
+        .filter(|(_, asm)| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("L__wgmma_pipeline_loop_${:uid}:"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one fused three-slot counted WGMMA pipeline"
+    );
+
+    let (asm_operation, asm) = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("three-slot counted-pipeline WGMMA template");
+
+    assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(template.matches("wgmma.mma_async").count(), 3);
+    assert_eq!(
+        template.matches("wgmma.commit_group.sync.aligned").count(),
+        3
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 2").count(),
+        3
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1
+    );
+    assert!(template.contains("{$0, $1"));
+    assert!(template.contains("{$32, $33"));
+    assert!(template.contains("{$64, $65"));
+    assert!(template.contains("mov.u64 %desc_a0, $192;"));
+    assert!(template.contains("mov.u64 %desc_b0, $193;"));
+    assert!(template.contains("mov.u64 %desc_a1, $194;"));
+    assert!(template.contains("mov.u64 %desc_b1, $195;"));
+    assert!(template.contains("mov.u64 %desc_a2, $196;"));
+    assert!(template.contains("mov.u64 %desc_b2, $197;"));
+    assert!(template.contains("add.u64 %desc_a0, %desc_a0, $198;"));
+    assert!(template.contains("add.u64 %desc_b0, %desc_b0, $199;"));
+    assert!(template.contains("add.u64 %desc_a1, %desc_a1, $200;"));
+    assert!(template.contains("add.u64 %desc_b1, %desc_b1, $201;"));
+    assert!(template.contains("add.u64 %desc_a2, %desc_a2, $202;"));
+    assert!(template.contains("add.u64 %desc_b2, %desc_b2, $203;"));
+    assert!(template.contains("mov.u64 %remaining, $204;"));
+    assert!(
+        !template.contains(".reg .f32")
+            && !template.contains("ld.f32")
+            && !template.contains("st.f32"),
+        "three-slot counted pipeline must keep accumulator memory outside asm: {template}"
+    );
+
+    let mut expected_constraints = vec!["=f".to_owned(); RESULT_COUNT];
+    expected_constraints.extend((0..RESULT_COUNT).map(|index| index.to_string()));
+    expected_constraints.extend((0..LOOP_CONTROL_COUNT).map(|_| "l".to_owned()));
+    expected_constraints.push("~{memory}".to_owned());
+    let expected_constraints = expected_constraints.join(",");
+    assert_eq!(
+        asm.get_attr_inline_asm_constraints(&ctx)
+            .map(|value| String::from((*value).clone()))
+            .as_deref(),
+        Some(expected_constraints.as_str())
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+    assert_eq!(
+        asm_operation.deref(&ctx).get_num_operands(),
+        RESULT_COUNT + LOOP_CONTROL_COUNT
+    );
+
+    let asm_position = body
+        .iter()
+        .position(|operation| operation == asm_operation)
+        .expect("three-slot counted-pipeline WGMMA asm must be in the lowered kernel body");
+    let load_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::LoadOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(load_positions.len(), RESULT_COUNT);
+    assert!(load_positions.iter().all(|index| *index < asm_position));
+
+    let store_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::StoreOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(store_positions.len(), RESULT_COUNT);
+    assert!(store_positions.iter().all(|index| *index > asm_position));
+    assert_eq!(
+        body.iter()
+            .filter(|operation| {
+                Operation::get_op::<llvm::ExtractValueOp>(**operation, &ctx).is_some()
+            })
+            .count(),
+        RESULT_COUNT
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_pointer_form_wgmma_counted_pipeline_rejects_wait_two_with_two_slots() {
+    let mut ctx = make_test_ctx();
+    let module_ptr = build_pointer_form_wgmma_counted_pipeline_case(&mut ctx, 2, &[2, 2], false);
+
+    assert!(
+        mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).is_err(),
+        "wait_group<2> must require three counted-pipeline accumulator slots"
+    );
+}
+
+#[test]
+fn test_pointer_form_wgmma_counted_pipeline_rejects_mixed_partial_waits() {
+    let mut ctx = make_test_ctx();
+    let module_ptr = build_pointer_form_wgmma_counted_pipeline_case(&mut ctx, 3, &[2, 1, 2], false);
+
+    assert!(
+        mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).is_err(),
+        "all counted-pipeline stages must use the same partial-wait depth"
+    );
+}
+
+#[test]
+fn test_pointer_form_wgmma_counted_pipeline_rejects_reused_accumulator_slot() {
+    let mut ctx = make_test_ctx();
+    let module_ptr = build_pointer_form_wgmma_counted_pipeline_case(&mut ctx, 3, &[2, 2, 2], true);
+
+    assert!(
+        mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr).is_err(),
+        "counted-pipeline accumulator slots must be pairwise distinct"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1020 

## Summary

Extend the production BF16 WGMMA counted-loop pipeline from the existing two-slot `wait_group<1>` form to also support a three-slot `wait_group<2>` form.

The counted carrier, recognizer, and lowering now derive the accumulator-slot count from the partial-wait depth while deliberately restricting the production contract to:

```text
2 slots + wait_group<1>
3 slots + wait_group<2>
```

The straight-line WGMMA pipeline continues to support its broader `wait_group<N>` range independently.

## Implementation

The counted-loop carrier now models a variable number of accumulator slots and carries the corresponding partial-wait depth.

The production layout is derived from:

```text
slot_count        = max_pending_groups + 1
accumulator_count = slot_count * 32
descriptor_count  = slot_count * 2
control_count     = slot_count * 4 + 1
```

This gives:

```text
wait_group<1>:
  2 slots
  64 accumulator values
  9 control values

wait_group<2>:
  3 slots
  96 accumulator values
  13 control values
```

The counted inline-PTX template now emits one `MMA -> commit_group -> wait_group<N>` stage per slot, advances all descriptor recurrences inside the same counted loop, and performs a final `wait_group<0>` before any accumulator result becomes visible to LLVM.

## Recognition

The counted-loop recognizer remains fail-closed.

It now requires:

* one canonical accumulator pointer per slot
* pairwise-distinct accumulator pointers
* homogeneous partial-wait depths
* exactly one `MMA -> commit_group -> wait_group<N>` stage per slot
* `N` equal to either 1 or 2
* two affine descriptor recurrences per slot
* one final `wait_group<0>`

Malformed counted pipelines are rejected rather than partially fused.

Negative coverage includes:

* mixed `wait_group<1>` / `wait_group<2>` stages
* `wait_group<2>` with only two slots
* reused accumulator slots

## Validation

```text
cargo test -p dialect-nvvm
cargo test -p mir-lower

cargo test -p cuda-oxide-codegen \
  --test wgmma_pipelined_counted_loop_ptx -- --nocapture

cargo fmt --all -- --check
git diff --check
```

Results:

```text
dialect-nvvm:
  50 passed

mir-lower unit tests:
  246 passed

mir-lower lowering tests:
  111 passed

counted-pipeline codegen:
  2 passed
```

`ptxas` results on `sm_90a`:

```text
two-slot production path:
  0 bytes stack frame
  0 bytes spill stores
  0 bytes spill loads
  Used 90 registers

three-slot production path:
  0 bytes stack frame
  0 bytes spill stores
  0 bytes spill loads
  Used 122 registers
```

The three-slot production path therefore keeps all 96 tied accumulator values register-resident without introducing stack or spill traffic.

## Scope

This PR modifies the counted WGMMA production path only.

It does not extend counted pipelines beyond `wait_group<2>` and does not change the existing broader straight-line WGMMA pipeline support.
