### PR TITLE
ci: clippy skips three nested example workspaces and the device-only fixture

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -86,13 +86,18 @@ jobs:
             dir="$(dirname "${manifest}")"
             parent="$(dirname "${dir}")"
             sub="$(basename "${dir}")"
+            # Skip anything the parent lists as a member: the loop above
+            # already lints it through the parent. Two assumptions baked in:
+            # members really are covered by that parent run, and no parent
+            # carries a `[workspace] exclude` list, whose quoted names this
+            # grep would match just like members and wrongly skip.
             if [ -f "${parent}/Cargo.toml" ] &&
                sed -n "/^\[workspace\]/,/^\[/p" "${parent}/Cargo.toml" |
                grep -q "\"${sub}\""; then
               continue
             fi
             echo "::group::clippy: ${dir#crates/rustc-codegen-cuda/examples/}"
-            (cd "${dir}" && cargo clippy --all-targets -- -D warnings)
+            (cd "${dir}" && cargo clippy --locked --all-targets -- -D warnings)
             echo "::endgroup::"
           done < <(
             find crates/rustc-codegen-cuda/examples -mindepth 3 -name Cargo.toml \
@@ -106,5 +111,5 @@ jobs:
           # surface, and check-device-only-build.sh runs `cargo check` on it but
           # never a lint.
           echo "::group::clippy: cuda-macros device-only fixture"
-          (cd crates/cuda-macros/tests/device-only && cargo clippy --all-targets -- -D warnings)
+          (cd crates/cuda-macros/tests/device-only && cargo clippy --locked --all-targets -- -D warnings)
           echo "::endgroup::"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -72,3 +72,39 @@ jobs:
             (cd "$ex" && cargo clippy --all-targets -- -D warnings)
             echo "::endgroup::"
           done
+
+          # The loop above is one level deep. A few examples nest a second
+          # manifest that the parent's `--all-targets` cannot reach either,
+          # because the parent does not list it in `[workspace] members`:
+          # `cutile_inter_kernel/simt` and `interop_cubin_identity/device`
+          # carry their own `[workspace]`, and `mathdx_ffi_test/libmathdx-sys`
+          # is a plain path dependency, which cargo builds but never lints.
+          # fmt.yml already reaches all three through its `**/Cargo.toml` glob;
+          # this closes the same gap for clippy. Membership is the test rather
+          # than a hardcoded list, so a new nesting is picked up automatically.
+          while IFS= read -r manifest; do
+            dir="$(dirname "${manifest}")"
+            parent="$(dirname "${dir}")"
+            sub="$(basename "${dir}")"
+            if [ -f "${parent}/Cargo.toml" ] &&
+               sed -n "/^\[workspace\]/,/^\[/p" "${parent}/Cargo.toml" |
+               grep -q "\"${sub}\""; then
+              continue
+            fi
+            echo "::group::clippy: ${dir#crates/rustc-codegen-cuda/examples/}"
+            (cd "${dir}" && cargo clippy --all-targets -- -D warnings)
+            echo "::endgroup::"
+          done < <(
+            find crates/rustc-codegen-cuda/examples -mindepth 3 -name Cargo.toml \
+              -not -path '*/target/*' | sort
+          )
+
+          # The `#[cuda_module]` device-only fixture is a workspace of its own
+          # outside examples/, so neither loop above nor the root
+          # `cargo clippy --workspace` reaches it. It is the only thing proving
+          # the #701/#702 property that a kernel-only crate needs no host
+          # surface, and check-device-only-build.sh runs `cargo check` on it but
+          # never a lint.
+          echo "::group::clippy: cuda-macros device-only fixture"
+          (cd crates/cuda-macros/tests/device-only && cargo clippy --all-targets -- -D warnings)
+          echo "::endgroup::"


### PR DESCRIPTION
## Summary

`clippy.yml`'s per-example loop is one level deep:

```bash
for ex in crates/rustc-codegen-cuda/examples/*/; do
```

Three manifests sit below that and are not reachable from their parent either, because the parent does not list them in `[workspace] members`:

| Manifest | Why the parent run misses it |
|:--|:--|
| `cutile_inter_kernel/simt` | own `[workspace]` |
| `interop_cubin_identity/device` | own `[workspace]` |
| `mathdx_ffi_test/libmathdx-sys` | plain path dependency |

cargo *builds* the third as a dependency of its parent but never lints it, and the first two are separate workspace roots the parent run stops at. So none of the three has ever been linted — while **`fmt.yml` reaches all three** through its `**/Cargo.toml` glob. That asymmetry is what makes this a gap rather than a policy.

Membership is the test rather than a hardcoded list of three, so a future nesting is picked up without editing this file again.

## A fourth, outside `examples/` entirely

`crates/cuda-macros/tests/device-only` is its own workspace, so the root `cargo clippy --workspace` stops at it and the examples loop never sees it. It is also the only thing proving the #701/#702 property that a kernel-only crate needs no host surface, and `check-device-only-build.sh` runs `cargo check` on it but never a lint. Added explicitly.

## Testing

Local, no GPU. All four are clean today, so this fails nothing now — verified by running `cargo clippy --all-targets -- -D warnings` in each:

```
cutile_inter_kernel/simt        Finished, no warnings (needs CUDA_TOOLKIT_PATH)
interop_cubin_identity/device   Finished, no warnings
mathdx_ffi_test/libmathdx-sys   Finished, no warnings
cuda-macros/tests/device-only   Finished, no warnings
```

- [x] Verified the step itself by extracting its `run` block from the parsed YAML and executing it with `cargo clippy` stubbed to `echo`: it visits **219** directories — the 215 top-level examples it visited before, plus the three nested manifests and the fixture — and the three parents are still visited separately, so nothing is lost
- [x] `clippy.yml` still parses
- [ ] `cargo oxide run <example>` — not applicable, CI workflow only