### PR TITLE
ci: nothing checks the formatting of the device-only fixture

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -28,6 +28,16 @@ jobs:
         run: cargo fmt --all -- --check
         working-directory: crates/rustc-codegen-cuda
 
+      # `crates/cuda-macros/tests/device-only` is a workspace of its own, so the
+      # root `cargo fmt --all` above stops at it, and the examples glob below
+      # only covers `examples/`. It is the fixture that proves the #701/#702
+      # device-only property, and `check-device-only-build.sh` runs `cargo check`
+      # on it but never rustfmt -- so unformatted code there has never failed
+      # anything.
+      - name: Check the cuda-macros device-only fixture formatting
+        run: cargo fmt --all -- --check
+        working-directory: crates/cuda-macros/tests/device-only
+
       - name: Check example crate formatting
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

`crates/cuda-macros/tests/device-only` is a Cargo workspace of its own, and it falls outside every formatting scope this job has:

- `cargo fmt --all` at the repository root stops at the workspace boundary;
- the `crates/rustc-codegen-cuda` step is a different workspace;
- the examples step globs `crates/rustc-codegen-cuda/examples/**/Cargo.toml`, and the fixture lives under `crates/cuda-macros/tests/`.

`check-device-only-build.sh` runs `cargo check --locked` on it, so it compiles, but nothing has ever run rustfmt over it.

That matters slightly more than for an ordinary fixture: this is the crate that proves the #701/#702 property — a kernel-only crate taking `cuda-macros = { default-features = false }` needs no host surface and no `cuda.h` — so it is a file contributors will edit when that gating changes, and the one file where a formatting drift would not be caught.

## Testing

Local, no GPU. It is formatted correctly today, so this step fails nothing now. Verified both directions:

| | Result |
|:--|:--|
| clean tree | new step passes |
| fixture deliberately unformatted | new step **fails**; `cargo fmt --all --check` at the root **still passes** — the gap in one line |

clippy has the same blind spot on this fixture plus three nested example workspaces; that is a separate change to `clippy.yml` and does not touch this file.

- [x] `fmt.yml` still parses, 5 steps
- [ ] `cargo oxide run <example>` — not applicable