### PR TITLE
docs(cuda-async): the scheduling tables list async_on beside four safe methods

### DIFF
--- a/crates/cuda-async/src/device_operation.rs
+++ b/crates/cuda-async/src/device_operation.rs
@@ -17,7 +17,7 @@
 //! | [`schedule`] | Pairs the operation with a stream, returns a [`DeviceFuture`].    |
 //! | [`sync`]     | Shorthand: schedule + execute + synchronize on the default device.|
 //! | [`sync_on`]  | Execute and synchronize on a specific stream.                     |
-//! | [`async_on`] | Execute on a specific stream **without** synchronizing.           |
+//! | [`async_on`] | `unsafe`: execute on a specific stream **without** synchronizing.  |
 //!
 //! [`schedule`]: DeviceOperation::schedule
 //! [`sync`]: DeviceOperation::sync
@@ -105,13 +105,18 @@ impl ExecutionContext {
 ///
 /// # Executing operations
 ///
-/// | Method       | Picks stream via         | Blocks? | Async? |
-/// |--------------|--------------------------|---------|--------|
-/// | [`schedule`] | `SchedulingPolicy`       | No      | Yes    |
-/// | `.await`     | Default policy           | No      | Yes    |
-/// | [`sync`]     | Default policy           | Yes     | No     |
-/// | [`sync_on`]  | Caller-provided stream   | Yes     | No     |
-/// | [`async_on`] | Caller-provided stream   | No      | No     |
+/// | Method       | Picks stream via         | Blocks? | Async? | `unsafe`? |
+/// |--------------|--------------------------|---------|--------|-----------|
+/// | [`schedule`] | `SchedulingPolicy`       | No      | Yes    | No        |
+/// | `.await`     | Default policy           | No      | Yes    | No        |
+/// | [`sync`]     | Default policy           | Yes     | No     | No        |
+/// | [`sync_on`]  | Caller-provided stream   | Yes     | No     | No        |
+/// | [`async_on`] | Caller-provided stream   | No      | No     | **`unsafe`** |
+///
+/// [`async_on`] is the only one that is `unsafe`, and it is the only one that
+/// returns while GPU work may still be in flight: the caller must synchronize
+/// the stream before consuming device-side outputs. The other four either block
+/// or hand back a future that does the waiting.
 ///
 /// # Implementors
 ///


### PR DESCRIPTION
## Summary

`DeviceOperation` has exactly one `unsafe` method, `async_on`, and **both** tables that compare the scheduling entry points present it as a peer of the safe ones.

The crate-level table said only:

```
//! | [`async_on`] | Execute on a specific stream **without** synchronizing. |
```

and the trait-level table compares the five on *Picks stream via / Blocks? / Async?* with no column for it at all — so `async_on` reads as the natural choice for anyone scanning for non-blocking behaviour, which is exactly what those columns invite.

Its own doc comment already carries the contract:

```rust
/// # Safety
///
/// GPU work may still be in flight when this returns. The caller must
/// synchronize `stream` before consuming device-side outputs.
```

That is the one fact the comparison tables omitted, and it is the reason the method is `unsafe` rather than a performance note. In a repository whose whole device-side story is about marking unsafe surfaces precisely — `DisjointSlice`, `ThreadIndex`, `#[launch_contract]` unlocking a safe launch — a table that hides it in the API a caller picks from is the wrong place to be quiet.

The trait-level table gains an explicit `unsafe?` column rather than a footnote, because the point is the comparison: it is the only `unsafe` entry **and** the only one that returns with work in flight, and those two facts are the same fact. A sentence below the table says so.

## Testing

Local, no GPU.

- [x] Swept the tree for the same shape — a doc-table row naming an `unsafe fn` without saying so — and these two rows were the only instances; **none remain**. (The row names `unsafe` directly rather than just marking a column, so the sweep confirms it rather than tripping on my own formatting.)
- [x] `cargo doc --no-deps -p cuda-async` and the same with `--document-private-items` both pass under `-D warnings`
- [x] fmt and `clippy --all-targets -- -D warnings` clean
- [ ] `cargo oxide run <example>` — not applicable, doc comments only