### PR TITLE
docs: three docs give three different rustup component lists, none matching the pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ nix run github:NVlabs/cuda-oxide#new my-project   # bootstrap a project
 # Toolchain installed automatically via rust-toolchain.toml
 # Manual install if needed:
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev llvm-tools --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev rust-analyzer clippy rustfmt llvm-tools --toolchain nightly-2026-04-03
 ```
 
 #### CUDA

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -45,7 +45,9 @@ rustup component add rust-src rustc-dev rust-analyzer clippy rustfmt llvm-tools 
 `rust-src` provides the standard library source for cross-compilation,
 `rustc-dev` exposes compiler internals that the codegen backend links against,
 and `llvm-tools` installs the toolchain-bundled `llc` used for PTX generation
-(also required by `cargo oxide doctor`).
+(also required by `cargo oxide doctor`). The other three are not needed to
+build: `rust-analyzer` powers IDE support, `clippy` is the lint gate CI runs,
+and `rustfmt` backs `cargo oxide fmt`.
 
 ## Install CUDA
 

--- a/cuda-oxide-book/appendix/building-from-source.md
+++ b/cuda-oxide-book/appendix/building-from-source.md
@@ -39,7 +39,7 @@ If you need to install manually:
 
 ```bash
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev llvm-tools --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev rust-analyzer clippy rustfmt llvm-tools --toolchain nightly-2026-04-03
 ```
 
 `rust-src` provides the standard library source for cross-compilation,

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -243,11 +243,13 @@ rustup toolchain install nightly-2026-04-03
 rustup component add rust-src rustc-dev rust-analyzer clippy rustfmt llvm-tools --toolchain nightly-2026-04-03
 ```
 
-These components are required by the codegen backend and doctor:
+Three of these components are what the codegen backend and doctor need:
 
 - `rust-src` -- source of the Rust standard library, needed for cross-compiling to the NVPTX target.
 - `rustc-dev` -- compiler internals that the backend links against.
 - `llvm-tools` -- toolchain-bundled `llc` used to lower LLVM IR to PTX (doctor's floor check).
+
+The other three are not needed to build: `rust-analyzer` powers IDE support, `clippy` is the lint gate CI runs, and `rustfmt` backs `cargo oxide fmt`.
 
 ---
 

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -240,7 +240,7 @@ If you need to install it manually:
 
 ```bash
 rustup toolchain install nightly-2026-04-03
-rustup component add rust-src rustc-dev rust-analyzer llvm-tools --toolchain nightly-2026-04-03
+rustup component add rust-src rustc-dev rust-analyzer clippy rustfmt llvm-tools --toolchain nightly-2026-04-03
 ```
 
 These components are required by the codegen backend and doctor:


### PR DESCRIPTION
## Summary

The same onboarding step — install the pinned toolchain and its components — appears in three places with three different answers, and the pin has a fourth:

| Location | Components | Count |
|:--|:--|--:|
| `README.md:183` | rust-src rustc-dev llvm-tools | 3 |
| `book/appendix/building-from-source.md:42` | rust-src rustc-dev llvm-tools | 3 |
| `book/getting-started/installation.md:243` | rust-src rustc-dev rust-analyzer llvm-tools | 4 |
| **`rust-toolchain.toml`** | + rust-analyzer **clippy rustfmt** | **6** |
| `cargo oxide new` scaffold | the same 6 | 6 |

`rustfmt` and `clippy` are missing from all three, and `rustfmt` is not optional: `cargo oxide fmt` shells out to `cargo fmt`, and `cuda-intrinsics-gen` runs `rustfmt_source` on every file it generates (`generate.rs:35`). #727 added it to the pin for exactly that reason.

## Why this bites despite the pin

Inside a checkout it doesn't — `rust-toolchain.toml` makes rustup install whatever the pin names, which is why `check-toolchain-parity.sh` deliberately leaves these command lines out of scope (*"the `rustup component add` command lines … are not quotes of it"*).

But `README.md:183` sits directly under `cargo +nightly-2026-04-03 install --git … cargo-oxide`, which is the **out-of-checkout** path: there is no `rust-toolchain.toml` there, so rustup installs exactly what the line names and the gap is real.

All three now name the pin's six, matching the scaffold `cargo oxide new` writes into user projects.

## Left alone deliberately

Three narrower lines that name a component because a *specific symptom* names it, not as the install step:

- `building-from-source.md:265` — `rustup component add rustc-dev …`
- `installation.md:371` — `rustup component add llvm-tools …` for a missing `llc`
- `installation.md:374` — `rustup component add rust-src llvm-tools …`

The devcontainer's five (`llvm-tools` omitted because the image ships LLVM 21 and sets `CUDA_OXIDE_LLC`) is also deliberate and already guarded, so it is unchanged.

## Testing

Local, no GPU.

- [x] All three lines now expand to exactly the pin's component list, compared programmatically against `rust-toolchain.toml`
- [x] `just book` (`sphinx-build -W --keep-going`) succeeds
- [x] `check-toolchain-parity.sh` and `check-crate-inventory.sh` pass
- [ ] `cargo oxide run <example>` — not applicable