### PR TITLE
docs(devcontainer): the README names two of the five components the image installs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,9 +7,10 @@ This dev container provides the toolchain expected by cuda-oxide:
 - LLVM 21 with NVPTX support
 - Clang 21 resource headers for `bindgen`
 - Rust `nightly-2026-04-03` with `rust-src`, `rustc-dev`, `rust-analyzer`,
-  `rustfmt` and `clippy`. `llvm-tools` is deliberately left out: the image
-  ships LLVM 21 and sets `CUDA_OXIDE_LLC`, so `rust-toolchain.toml` pulls it
-  only if something asks for it.
+  `rustfmt` and `clippy`. `llvm-tools` is not preinstalled in the image;
+  rustup adds it on your first cargo command in the checkout, because
+  `rust-toolchain.toml` names it. The image ships LLVM 21 and
+  `CUDA_OXIDE_LLC` already points at `llc-21`, so nothing waits on it.
 
 Open the repository in a devcontainer-aware editor and choose "Reopen in
 Container". The container requests GPU access with `--gpus=all` and uses

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -6,7 +6,10 @@ This dev container provides the toolchain expected by cuda-oxide:
 - CUDA Toolkit 13.0
 - LLVM 21 with NVPTX support
 - Clang 21 resource headers for `bindgen`
-- Rust `nightly-2026-04-03` with `rust-src` and `rustc-dev`
+- Rust `nightly-2026-04-03` with `rust-src`, `rustc-dev`, `rust-analyzer`,
+  `rustfmt` and `clippy`. `llvm-tools` is deliberately left out: the image
+  ships LLVM 21 and sets `CUDA_OXIDE_LLC`, so `rust-toolchain.toml` pulls it
+  only if something asks for it.
 
 Open the repository in a devcontainer-aware editor and choose "Reopen in
 Container". The container requests GPU access with `--gpus=all` and uses


### PR DESCRIPTION
## Summary

`.devcontainer/README.md` describes what the container provides:

```
- Rust `nightly-2026-04-03` with `rust-src` and `rustc-dev`
```

`devcontainer.json` installs five:

```json
"components": "rust-src,rustc-dev,rust-analyzer,rustfmt,clippy"
```

So the README understates the image by three, including **`rustfmt`** — which `cargo oxide fmt` and `cuda-intrinsics-gen` both need — and **`clippy`**, which is a CI gate a contributor will want to run before pushing. Someone reading this page concludes the container is barer than it is and installs components that are already there.

## The one absence worth explaining

`llvm-tools` looks like an omission and is not: the image ships LLVM 21 (`Dockerfile:41`) and sets `CUDA_OXIDE_LLC=/usr/bin/llc-21` (both `Dockerfile:11` and `devcontainer.json`), so the toolchain-bundled `llc` is redundant there. `check-toolchain-parity.sh` already encodes that as a deliberate warm-cache subset; this just says it where a reader looking at the container will see it.

## Testing

Local, no GPU.

- [x] The README now names exactly the five components `devcontainer.json` installs, compared programmatically, and its `llvm-tools` claim agrees with the JSON
- [x] `check-toolchain-parity.sh` and `check-spdx-headers.sh` pass
- [ ] `cargo oxide run <example>` — not applicable