### PR TITLE
feat(mir): preserve Rust pointer and reference kind

### DIFF
--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -10,17 +10,17 @@ rustc MIR ──► mir-importer ──► dialect-mir ──► mir-lower ─�
 
 The dialect defines nine types that preserve Rust-level semantics:
 
-| Type                  | Description                                        | Example                               |
-|-----------------------|----------------------------------------------------|---------------------------------------|
-| `MirTupleType`        | Heterogeneous tuples                               | `mir.tuple<i32, f32, i64>`            |
-| `MirPtrType`          | Pointers with address space and mutability         | `mir.ptr<f32, mutable, addrspace: 3>` |
-| `MirSliceType`        | Fat pointers (`&[T]` = ptr + len)                  | `mir.slice<f32, addrspace: 1>`        |
-| `MirDisjointSliceType`| `DisjointSlice<T>` -- per-thread unique access     | `mir.disjoint_slice<f32, ...>`        |
-| `MirStructType`       | Named structs with layout metadata                 | `mir.struct<"Point", [f32, f32]>`     |
-| `MirUnionType`        | Rust unions -- each field a view of the same bytes | `mir.union<"Repr", [a, b], [i32, f32], 4, 4>` |
-| `MirEnumType`         | Rust enums with their exact rustc layout           | `mir.enum<"Ordering", i8, ...>`       |
-| `MirArrayType`        | Fixed-size arrays                                  | `mir.array<f32, 256>`                 |
-| `MirFP16Type`         | IEEE 754 binary16 -- Rust's `f16`                  | `mir.fp16`                            |
+| Type                  | Description                                                  | Example                                                               |
+|-----------------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `MirTupleType`        | Heterogeneous tuples                                         | `mir.tuple<i32, f32, i64>`                                            |
+| `MirPtrType`          | Thin pointers with address space, mutability, and source kind | `mir.ptr<f32, mutable: true, addrspace: 3, kind: UniqueRef>`           |
+| `MirSliceType`        | Fat pointers with retained source kind (ptr + len)           | `mir.slice<f32, kind: SharedRef>`                                     |
+| `MirDisjointSliceType`| `DisjointSlice<T>` -- per-thread unique access               | `mir.disjoint_slice<f32, ...>`                                        |
+| `MirStructType`       | Named structs with layout metadata                           | `mir.struct<"Point", [f32, f32]>`                                   |
+| `MirUnionType`        | Rust unions -- each field a view of the same bytes           | `mir.union<"Repr", [a, b], [i32, f32], 4, 4>`                       |
+| `MirEnumType`         | Rust enums with their exact rustc layout                     | `mir.enum<"Ordering", i8, ...>`                                     |
+| `MirArrayType`        | Fixed-size arrays                                            | `mir.array<f32, 256>`                                                 |
+| `MirFP16Type`         | IEEE 754 binary16 -- Rust's `f16`                            | `mir.fp16`                                                            |
 
 `MirEnumType` records the enum's layout the way rustc computed it: Direct,
 Niche, Single, or Empty; the physical integer/pointer carrier and absolute
@@ -47,9 +47,52 @@ For a niche layout such as `Option<&T>`, the carrier is the pointer itself:
 null encodes `None`, and a non-null pointer is the untagged `Some` variant.
 The device never adds a synthetic discriminant.
 
+### Pointer and reference kinds
+
+`MirPtrType` and `MirSliceType` retain the source-level category that produced a
+pointer-like Rust value:
+
+| Rust type | `MirPointerKind` | Meaning |
+|-----------|------------------|---------|
+| `&T` | `SharedRef` | Shared Rust reference |
+| `&mut T` | `UniqueRef` | Mutable/unique Rust reference |
+| `*const T` | `RawConst` | Immutable raw pointer |
+| `*mut T` | `RawMut` | Mutable raw pointer |
+| compiler-generated address | `Erased` | Storage/projection pointer with no Rust alias guarantee |
+
+The existing `is_mutable` bit remains part of `MirPtrType` because operations
+need writeability information, but it is not proof of uniqueness. In
+particular, `RawMut` and `UniqueRef` are both mutable while only the latter
+originates from `&mut T`.
+
+Pointer kind is preserved through Rust type import, references, raw-address
+formation, pointer-like local stores, slices, and compatible casts. Internal
+alloca/projection addresses are created as `Erased`; they acquire a Rust kind
+only when the importer reaches a Rust-typed semantic boundary. Generic pointer
+normalization may cross between `Erased` and a concrete kind, but it never
+switches directly between two distinct concrete Rust kinds; those transitions
+require an explicit Rust/MIR coercion or cast. A projection of an existing slice
+preserves the source kind, while an explicit reborrow or raw address is
+normalized to the new Rust result type.
+
+`Retag` remains a codegen no-op. The dialect records the static pointer category
+but does not attempt to model dynamic Stacked Borrows / Tree Borrows tags or
+retag epochs.
+
+MIR-to-LLVM lowering deliberately erases `MirPointerKind`. All four Rust source
+categories keep the same LLVM pointer/fat-pointer representation, and this
+change does not emit `noalias`, `readonly`, `dereferenceable`, or related
+metadata. Any future alias metadata requires a separate audited policy; it must
+not be inferred from `is_mutable` alone.
+
+For GPU-specific abstractions such as `SharedArray`, the Rust reference kind is
+still retained when the source type is a reference, while the CUDA address
+space remains an independent property. The compiler does not currently turn a
+`UniqueRef` to shared memory into cross-thread LLVM alias guarantees.
+
 ### Address Spaces
 
-Pointers and slices carry an NVPTX address space:
+Pointers carry an NVPTX address space independently of their source kind:
 
 | Space      | ID | PTX Qualifier | Use                           |
 |------------|----|---------------|-------------------------------|

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -185,10 +185,88 @@ pub mod address_space {
     pub const TMEM: u32 = 6;
 }
 
-/// A pointer type with mutability and address space tracking.
+/// Source-level pointer/reference category retained by `dialect-mir`.
+///
+/// This is semantic provenance, not a physical representation choice. In
+/// particular, [`MirPointerKind::RawMut`] and [`MirPointerKind::UniqueRef`]
+/// are both mutable pointers at the machine level, but only the latter came
+/// from an `&mut T`-typed Rust value. [`MirPointerKind::Erased`] is used for
+/// compiler-generated storage and temporary addresses that must not acquire
+/// Rust aliasing guarantees merely because they are mutable.
+///
+/// The MIR dialect deliberately does not translate this enum directly into
+/// LLVM `noalias`, `readonly`, or related attributes. It exists so any future
+/// use of Rust aliasing facts has an explicit, auditable source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+#[format]
+pub enum MirPointerKind {
+    /// Compiler-generated or intentionally forgotten pointer provenance.
+    #[default]
+    Erased,
+    /// Shared Rust reference: `&T`.
+    SharedRef,
+    /// Mutable/unique Rust reference: `&mut T`.
+    UniqueRef,
+    /// Immutable raw pointer: `*const T`.
+    RawConst,
+    /// Mutable raw pointer: `*mut T`.
+    RawMut,
+}
+
+impl MirPointerKind {
+    /// Kind for a Rust reference with the supplied source mutability.
+    pub fn from_reference_mutability(is_mutable: bool) -> Self {
+        if is_mutable {
+            Self::UniqueRef
+        } else {
+            Self::SharedRef
+        }
+    }
+
+    /// Kind for a Rust raw pointer with the supplied source mutability.
+    pub fn from_raw_mutability(is_mutable: bool) -> Self {
+        if is_mutable {
+            Self::RawMut
+        } else {
+            Self::RawConst
+        }
+    }
+
+    /// Whether the kind represents a Rust reference rather than a raw or
+    /// compiler-generated pointer.
+    pub fn is_reference(self) -> bool {
+        matches!(self, Self::SharedRef | Self::UniqueRef)
+    }
+
+    /// Whether the kind originated from `&mut T`.
+    ///
+    /// This is intentionally only a classification query. Downstream code
+    /// must not turn it into LLVM alias metadata without a separate, audited
+    /// policy for the operation/function boundary where the value is used.
+    pub fn is_unique_reference(self) -> bool {
+        self == Self::UniqueRef
+    }
+
+    /// Required `MirPtrType::is_mutable` value for source-level kinds.
+    /// `Erased` accepts either mutability because storage pointers may be
+    /// mutable even when they do not represent a Rust `&mut`/`*mut` value.
+    fn expected_mutability(self) -> Option<bool> {
+        match self {
+            Self::Erased => None,
+            Self::SharedRef | Self::RawConst => Some(false),
+            Self::UniqueRef | Self::RawMut => Some(true),
+        }
+    }
+}
+
+/// A pointer type with mutability, address space, and Rust pointer kind tracking.
 ///
 /// Represents a pointer to a value of a specific type in a specific memory space.
-/// Syntax: `mir.ptr <type, mutable: bool, addrspace: u32>`
+/// Syntax: `mir.ptr <type, mutable: bool, addrspace: u32, kind: MirPointerKind>`
+///
+/// `is_mutable` is a machine-level/source-mutability property only. It is not
+/// proof of uniqueness: `*mut T` is mutable but can alias, while `&mut T` is
+/// represented by the distinct [`MirPointerKind::UniqueRef`] kind.
 ///
 /// Address spaces are critical for GPU memory:
 /// - 0 (generic): Can point to any memory, resolved at runtime
@@ -200,36 +278,60 @@ pub mod address_space {
 ///
 /// # Verification
 /// * Pointee type must be valid.
+/// * Non-erased pointer kinds must agree with `is_mutable`.
 #[pliron_type(
     name = "mir.ptr",
-    format = "`<` $pointee `,` `mutable:` $is_mutable `,` `addrspace:` $address_space `>`"
+    format = "`<` $pointee `,` `mutable:` $is_mutable `,` `addrspace:` $address_space `,` `kind:` $kind `>`"
 )]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirPtrType {
     pub pointee: TypeHandle,
     pub is_mutable: bool,
     pub address_space: u32,
+    pub kind: MirPointerKind,
 }
 
 impl MirPtrType {
-    /// Create a pointer type with explicit address space.
+    /// Create a compiler/internal pointer with explicit address space.
+    ///
+    /// Existing synthetic-pointer call sites intentionally route through this
+    /// constructor and therefore receive `Erased` provenance. Rust-originated
+    /// pointers should use [`Self::get_with_kind`].
     pub fn get(
         ctx: &mut Context,
         pointee: TypeHandle,
         is_mutable: bool,
         address_space: u32,
     ) -> TypedHandle<Self> {
+        Self::get_with_kind(
+            ctx,
+            pointee,
+            is_mutable,
+            address_space,
+            MirPointerKind::Erased,
+        )
+    }
+
+    /// Create a pointer with explicit Rust/source-level pointer kind.
+    pub fn get_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        address_space: u32,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
         Type::instantiate(
             MirPtrType {
                 pointee,
                 is_mutable,
                 address_space,
+                kind,
             },
             ctx,
         )
     }
 
-    /// Create a pointer in generic address space (0).
+    /// Create a compiler/internal pointer in generic address space (0).
     pub fn get_generic(
         ctx: &mut Context,
         pointee: TypeHandle,
@@ -238,13 +340,33 @@ impl MirPtrType {
         Self::get(ctx, pointee, is_mutable, address_space::GENERIC)
     }
 
-    /// Create a pointer in shared memory address space (3).
+    /// Create a Rust/source-level pointer in generic address space (0).
+    pub fn get_generic_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Self::get_with_kind(ctx, pointee, is_mutable, address_space::GENERIC, kind)
+    }
+
+    /// Create a compiler/internal pointer in shared memory address space (3).
     pub fn get_shared(
         ctx: &mut Context,
         pointee: TypeHandle,
         is_mutable: bool,
     ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::SHARED)
+    }
+
+    /// Create a Rust/source-level pointer in shared memory address space (3).
+    pub fn get_shared_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Self::get_with_kind(ctx, pointee, is_mutable, address_space::SHARED, kind)
     }
 
     /// Create a pointer in global memory address space (1).
@@ -278,6 +400,10 @@ impl MirPtrType {
         self.address_space
     }
 
+    pub fn pointer_kind(&self) -> MirPointerKind {
+        self.kind
+    }
+
     /// Check if this pointer is in shared memory (addrspace 3).
     pub fn is_shared(&self) -> bool {
         self.address_space == address_space::SHARED
@@ -291,31 +417,60 @@ impl MirPtrType {
 
 impl Verify for MirPtrType {
     fn verify(&self, _ctx: &Context) -> Result<(), Error> {
-        // Pointer types are valid if their pointee type is valid.
+        if let Some(expected) = self.kind.expected_mutability()
+            && expected != self.is_mutable
+        {
+            return verify_err!(
+                Location::Unknown,
+                "MirPtrType pointer kind {:?} is inconsistent with mutable: {}",
+                self.kind,
+                self.is_mutable
+            );
+        }
         Ok(())
     }
 }
 
-/// A slice type: { ptr: *T, len: usize }
+/// A slice/fat-pointer type: `{ ptr: *T, len: usize }` plus source pointer kind.
 ///
-/// Represents a view into a contiguous sequence of elements.
-/// Syntax: `mir.slice <type>`
+/// Represents a view into a contiguous sequence of elements. References and
+/// raw pointers to `[T]` share the same physical `{ptr, len}` layout, but their
+/// Rust pointer category remains distinct in the MIR type.
+/// Syntax: `mir.slice <type, kind: MirPointerKind>`
+///
+/// Bare `[T]` carriers and compiler-generated fat pointers use
+/// [`MirPointerKind::Erased`].
 ///
 /// # Verification
 /// * Element type must be valid.
-#[pliron_type(name = "mir.slice", format = "`<` $element_ty `>`")]
+#[pliron_type(name = "mir.slice", format = "`<` $element_ty `,` `kind:` $kind `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirSliceType {
     pub element_ty: TypeHandle,
+    pub kind: MirPointerKind,
 }
 
 impl MirSliceType {
+    /// Create a slice carrier with intentionally erased pointer provenance.
     pub fn get(ctx: &mut Context, element_ty: TypeHandle) -> TypedHandle<Self> {
-        Type::instantiate(MirSliceType { element_ty }, ctx)
+        Self::get_with_kind(ctx, element_ty, MirPointerKind::Erased)
+    }
+
+    /// Create a slice/fat-pointer retaining its Rust/source-level pointer kind.
+    pub fn get_with_kind(
+        ctx: &mut Context,
+        element_ty: TypeHandle,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Type::instantiate(MirSliceType { element_ty, kind }, ctx)
     }
 
     pub fn element_type(&self) -> TypeHandle {
         self.element_ty
+    }
+
+    pub fn pointer_kind(&self) -> MirPointerKind {
+        self.kind
     }
 }
 

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -14,8 +14,8 @@ use dialect_mir::{
         MirPtrOffsetOp, MirRemOp, MirReturnOp, MirSetDiscriminantOp, MirStoreOp, MirSubOp,
     },
     types::{
-        EnumVariant, MirDisjointSliceType, MirEnumType, MirPtrType, MirSliceType, MirTupleType,
-        MirUnionType,
+        EnumVariant, MirDisjointSliceType, MirEnumType, MirPointerKind, MirPtrType, MirSliceType,
+        MirTupleType, MirUnionType,
     },
 };
 use pliron::{
@@ -189,6 +189,94 @@ fn test_mir_control_flow_verify() {
         MirAssertOp::new(op_assert_bad).verify(&ctx).is_err(),
         "Assert cond type mismatch"
     );
+}
+
+#[test]
+fn test_mir_pointer_kind_distinguishes_references_from_raw_pointers() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
+    let pointee: pliron::r#type::TypeHandle = i32_ty.into();
+
+    let shared_ref =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::SharedRef);
+    let raw_const =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::RawConst);
+    let unique_ref =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef);
+    let raw_mut =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::RawMut);
+
+    assert_ne!(
+        shared_ref, raw_const,
+        "&T must remain distinct from *const T"
+    );
+    assert_ne!(
+        unique_ref, raw_mut,
+        "&mut T must remain distinct from *mut T"
+    );
+    assert_ne!(
+        shared_ref, unique_ref,
+        "&T must remain distinct from &mut T"
+    );
+    assert_ne!(
+        raw_const, raw_mut,
+        "*const T must remain distinct from *mut T"
+    );
+
+    assert_eq!(
+        shared_ref.deref(&ctx).pointer_kind(),
+        MirPointerKind::SharedRef
+    );
+    assert_eq!(
+        unique_ref.deref(&ctx).pointer_kind(),
+        MirPointerKind::UniqueRef
+    );
+    assert_eq!(
+        raw_const.deref(&ctx).pointer_kind(),
+        MirPointerKind::RawConst
+    );
+    assert_eq!(raw_mut.deref(&ctx).pointer_kind(), MirPointerKind::RawMut);
+}
+
+#[test]
+fn test_mir_slice_preserves_pointer_kind() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let u8_ty = IntegerType::get(&ctx, 8, Signedness::Unsigned);
+    let element: pliron::r#type::TypeHandle = u8_ty.into();
+
+    let shared = MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef);
+    let raw = MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::RawConst);
+
+    assert_ne!(shared, raw, "&[T] must remain distinct from *const [T]");
+    assert_eq!(shared.deref(&ctx).pointer_kind(), MirPointerKind::SharedRef);
+    assert_eq!(raw.deref(&ctx).pointer_kind(), MirPointerKind::RawConst);
+}
+
+#[test]
+fn test_mir_pointer_kind_mutability_consistency_verify() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
+    let invalid_shared = MirPtrType {
+        pointee: i32_ty.into(),
+        is_mutable: true,
+        address_space: 0,
+        kind: MirPointerKind::SharedRef,
+    };
+    let invalid_raw_mut = MirPtrType {
+        pointee: i32_ty.into(),
+        is_mutable: false,
+        address_space: 0,
+        kind: MirPointerKind::RawMut,
+    };
+
+    assert!(invalid_shared.verify(&ctx).is_err());
+    assert!(invalid_raw_mut.verify(&ctx).is_err());
 }
 
 #[test]

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -32,7 +32,7 @@
 
 use super::types;
 use crate::error::{TranslationErr, TranslationResult};
-use crate::translator::values::ValueMap;
+use crate::translator::values::{ValueMap, pointer_kind_retype_allowed};
 use dialect_iket::{ops::IketSentinelTokenOp, types::IketRangeTokenType};
 use dialect_mir::attributes::MirCastKindAttr;
 use dialect_mir::attributes::MirFP16Attr;
@@ -43,7 +43,7 @@ use dialect_mir::ops::{
     MirInsertFieldOp, MirLeOp, MirLoadOp, MirLtOp, MirMulOp, MirNeOp, MirNegOp, MirNotOp,
     MirPtrOffsetOp, MirRefOp, MirRemOp, MirShlOp, MirShrOp, MirSubOp, MirUndefOp,
 };
-use dialect_mir::types::MirFP16Type;
+use dialect_mir::types::{MirFP16Type, MirPointerKind};
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -62,18 +62,22 @@ use rustc_public::ty::{AdtKind, ConstantKind};
 use rustc_public_bridge::IndexedVal;
 use std::num::NonZeroUsize;
 
-/// Cast a value to a target type if address spaces differ.
+/// Normalize a pointer-like value to the exact MIR type required by Rust.
 ///
-/// When constructing structs/enums, the field type uses generic address space (0)
-/// because Rust's type system doesn't carry address space info. But the actual
-/// value may have a specific address space (e.g., addrspace:3 for shared memory).
+/// Physical address computation deliberately uses compiler/internal pointer
+/// types (`MirPointerKind::Erased`) and can also retain a concrete CUDA address
+/// space. At the boundary where Rust supplies an exact result type, this helper
+/// restores that type with an explicit `mir.cast` while preserving the runtime
+/// pointer bits. This covers both thin `MirPtrType` values and fat
+/// `MirSliceType` values.
 ///
-/// This function inserts a MirCastOp to convert from the specific address space
-/// to the generic address space, following LLVM's model where generic pointers
-/// can hold any address space pointer.
-///
-/// Returns the (possibly casted) value and the last inserted operation.
-fn cast_to_generic_addrspace_if_needed(
+/// The helper only acts when source and destination are the same pointer shape:
+/// thin pointers must have the same pointee, and fat pointers must have the same
+/// element type. `Erased` may gain or forget a concrete Rust kind at an explicit
+/// typed boundary, but normalization never switches directly between two
+/// distinct concrete Rust pointer kinds. It does not invent thin/fat coercions
+/// or reinterpret pointees.
+fn cast_to_expected_pointer_type_if_needed(
     ctx: &mut Context,
     value: Value,
     expected_type: TypeHandle,
@@ -82,59 +86,58 @@ fn cast_to_generic_addrspace_if_needed(
     loc: Location,
 ) -> (Value, Option<Ptr<Operation>>) {
     let value_type = value.get_type(ctx);
-
-    // Check if both are pointer types
-    let value_ptr_info: Option<(TypeHandle, bool, u32)> = {
-        let ty_ref = value_type.deref(ctx);
-        ty_ref
-            .downcast_ref::<dialect_mir::types::MirPtrType>()
-            .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space))
-    };
-
-    let expected_ptr_info: Option<(TypeHandle, bool, u32)> = {
-        let ty_ref = expected_type.deref(ctx);
-        ty_ref
-            .downcast_ref::<dialect_mir::types::MirPtrType>()
-            .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space))
-    };
-
-    if let (
-        Some((val_pointee, val_mut, val_addrspace)),
-        Some((exp_pointee, exp_mut, exp_addrspace)),
-    ) = (value_ptr_info, expected_ptr_info)
-    {
-        // Both are pointers - check if address spaces differ
-        if val_addrspace != exp_addrspace && val_pointee == exp_pointee && val_mut == exp_mut {
-            // Need to insert an address space cast
-            // Create the target type (same pointer but with expected address space)
-            let target_ptr_ty =
-                dialect_mir::types::MirPtrType::get(ctx, exp_pointee, exp_mut, exp_addrspace);
-
-            let cast_op = Operation::new(
-                ctx,
-                MirCastOp::get_concrete_op_info(),
-                vec![target_ptr_ty.into()],
-                vec![value],
-                vec![],
-                0,
-            );
-            cast_op.deref_mut(ctx).set_loc(loc);
-            MirCastOp::new(cast_op).set_attr_cast_kind(ctx, MirCastKindAttr::PtrToPtr);
-
-            if let Some(prev) = prev_op {
-                cast_op.insert_after(ctx, prev);
-            } else {
-                cast_op.insert_at_front(block_ptr, ctx);
-            }
-
-            let casted_value = cast_op.deref(ctx).get_result(0);
-            return (casted_value, Some(cast_op));
-        }
+    if value_type == expected_type {
+        return (value, prev_op);
     }
 
-    // No cast needed
-    (value, prev_op)
+    let compatible = {
+        let value_ref = value_type.deref(ctx);
+        let expected_ref = expected_type.deref(ctx);
+
+        match (
+            value_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+            expected_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+        ) {
+            (Some(value_ptr), Some(expected_ptr)) => {
+                value_ptr.pointee == expected_ptr.pointee
+                    && pointer_kind_retype_allowed(value_ptr.kind, expected_ptr.kind)
+            }
+            _ => match (
+                value_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+                expected_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+            ) {
+                (Some(value_slice), Some(expected_slice)) => {
+                    value_slice.element_ty == expected_slice.element_ty
+                        && pointer_kind_retype_allowed(value_slice.kind, expected_slice.kind)
+                }
+                _ => false,
+            },
+        }
+    };
+
+    if !compatible {
+        return (value, prev_op);
+    }
+
+    let cast_op = Operation::new(
+        ctx,
+        MirCastOp::get_concrete_op_info(),
+        vec![expected_type],
+        vec![value],
+        vec![],
+        0,
+    );
+    cast_op.deref_mut(ctx).set_loc(loc);
+    MirCastOp::new(cast_op).set_attr_cast_kind(ctx, MirCastKindAttr::PtrToPtr);
+
+    match prev_op {
+        Some(prev) => cast_op.insert_after(ctx, prev),
+        None => cast_op.insert_at_front(block_ptr, ctx),
+    }
+
+    (cast_op.deref(ctx).get_result(0), Some(cast_op))
 }
+
 /// Coerce a raw data pointer so it points to `element_type` in the generic
 /// address space.
 ///
@@ -145,7 +148,7 @@ fn cast_to_generic_addrspace_if_needed(
 /// pointer to the slice element type (the same `get_generic` slot every other
 /// data-slot construction uses), so when the pointee differs, emit a `PtrToPtr`
 /// cast to that type. This also normalizes a non-generic address space, composing
-/// with `cast_to_generic_addrspace_if_needed`, which only fires when the pointee
+/// with `cast_to_expected_pointer_type_if_needed`, which only fires when the pointee
 /// already matched.
 fn coerce_slice_data_pointee(
     ctx: &mut Context,
@@ -215,7 +218,7 @@ fn cast_struct_fields_to_expected_types(
 
     for (i, value) in field_values.into_iter().enumerate() {
         if let Some(expected_type) = field_types.get(i) {
-            let (casted_value, new_prev_op) = cast_to_generic_addrspace_if_needed(
+            let (casted_value, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                 ctx,
                 value,
                 *expected_type,
@@ -270,7 +273,7 @@ fn cast_enum_fields_to_expected_types(
 
     for (i, value) in field_values.into_iter().enumerate() {
         if let Some(expected_type) = variant_field_types.get(i) {
-            let (casted_value, new_prev_op) = cast_to_generic_addrspace_if_needed(
+            let (casted_value, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                 ctx,
                 value,
                 *expected_type,
@@ -756,16 +759,34 @@ pub fn translate_rvalue(
             // no extra allocation is needed. `mem2reg` folds this back into
             // SSA when the borrow doesn't escape.
             //
-            // Mutability: slots are always allocated mutable (we may store
-            // into them regardless of the Rust mutability of the local).
-            // Callers that expect a `*const T` pointer handle the coercion
-            // via `MirCastOp::PointerCoercionMutToConst`; most consumers in
-            // the dialect (FieldAddr, ArrayElementAddr, Load, Store) are
-            // mutability-agnostic at the pliron level.
+            // Slots are always allocated mutable because the importer writes
+            // locals through them. They are compiler storage, not `&mut T`.
+            // The normalization below retypes the physical slot address to the
+            // exact Rust reference kind without treating slot mutability as
+            // evidence of uniqueness.
             let is_mutable = matches!(borrow_kind, mir::BorrowKind::Mut { .. });
+            let pointer_kind = MirPointerKind::from_reference_mutability(is_mutable);
             if place.projection.is_empty() {
                 if let Some(slot) = value_map.get_slot(place.local) {
-                    return Ok((None, slot, prev_op));
+                    // The slot is compiler storage (`Erased`) and is always
+                    // mutable. Taking a Rust borrow is the semantic boundary
+                    // where that physical address acquires the exact `&T` /
+                    // `&mut T` type recorded by rustc.
+                    let rust_result_type = rvalue.ty(body.locals()).map_err(|error| {
+                        input_error_noloc!(TranslationErr::unsupported(format!(
+                            "failed to determine reference rvalue type: {error:?}"
+                        )))
+                    })?;
+                    let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
+                    let (result, last_inserted) = cast_to_expected_pointer_type_if_needed(
+                        ctx,
+                        slot,
+                        expected_ptr_type,
+                        block_ptr,
+                        prev_op,
+                        loc.clone(),
+                    );
+                    return Ok((None, result, last_inserted));
                 }
                 // ZST local (no slot). Synthesise a pointer-to-ZST via
                 // MirRefOp as a fallback so callers still get a well-typed
@@ -789,7 +810,12 @@ pub fn translate_rvalue(
                             loc.clone(),
                         )?
                     };
-                let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, ty_ptr, is_mutable);
+                let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                    ctx,
+                    ty_ptr,
+                    is_mutable,
+                    pointer_kind,
+                );
                 let ref_op = Operation::new(
                     ctx,
                     MirRefOp::get_concrete_op_info(),
@@ -832,7 +858,7 @@ pub fn translate_rvalue(
                 })?;
                 let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
 
-                let (result_val, last_inserted) = cast_to_generic_addrspace_if_needed(
+                let (result_val, last_inserted) = cast_to_expected_pointer_type_if_needed(
                     ctx,
                     result_val,
                     expected_ptr_type,
@@ -872,7 +898,12 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let val_ty = val.get_type(ctx);
-            let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, val_ty, is_mutable);
+            let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                ctx,
+                val_ty,
+                is_mutable,
+                pointer_kind,
+            );
 
             let ref_op = Operation::new(
                 ctx,
@@ -896,12 +927,29 @@ pub fn translate_rvalue(
             // same unified address walker as `Rvalue::Ref` (which also gives
             // raw pointers the runtime-Index / ConstantIndex handling).
             let is_mutable = matches!(mutability, mir::RawPtrKind::Mut);
+            let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
 
-            // Bare local: the alloca slot IS the address.
+            // Bare local: the alloca slot is the physical address, but the
+            // result must carry the exact raw-pointer kind rather than the
+            // slot's compiler-only `Erased` provenance.
             if place.projection.is_empty()
                 && let Some(slot) = value_map.get_slot(place.local)
             {
-                return Ok((None, slot, prev_op));
+                let rust_result_type = rvalue.ty(body.locals()).map_err(|error| {
+                    input_error_noloc!(TranslationErr::unsupported(format!(
+                        "failed to determine address-of rvalue type: {error:?}"
+                    )))
+                })?;
+                let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
+                let (result, last_inserted) = cast_to_expected_pointer_type_if_needed(
+                    ctx,
+                    slot,
+                    expected_ptr_type,
+                    block_ptr,
+                    prev_op,
+                    loc.clone(),
+                );
+                return Ok((None, result, last_inserted));
             }
 
             // Unified address path: full projection walk from the slot
@@ -926,7 +974,7 @@ pub fn translate_rvalue(
                 })?;
                 let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
 
-                let (result_val, last_inserted) = cast_to_generic_addrspace_if_needed(
+                let (result_val, last_inserted) = cast_to_expected_pointer_type_if_needed(
                     ctx,
                     result_val,
                     expected_ptr_type,
@@ -962,7 +1010,12 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let val_ty = val.get_type(ctx);
-            let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, val_ty, is_mutable);
+            let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                ctx,
+                val_ty,
+                is_mutable,
+                pointer_kind,
+            );
 
             use dialect_mir::ops::MirRefOp;
             let ref_op = Operation::new(
@@ -1260,7 +1313,7 @@ pub fn translate_rvalue(
                             current_prev_op,
                             loc.clone(),
                         )?;
-                        let (val, new_prev_op) = cast_to_generic_addrspace_if_needed(
+                        let (val, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                             ctx,
                             val,
                             element_type,
@@ -1381,6 +1434,7 @@ pub fn translate_rvalue(
                     }
 
                     let is_mutable = matches!(mutability, Mutability::Mut);
+                    let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
 
                     match pointee_ty.kind() {
                         TyKind::RigidTy(RigidTy::Slice(elem_ty)) => {
@@ -1420,14 +1474,15 @@ pub fn translate_rvalue(
                                     is_mutable,
                                 )
                                 .into();
-                            let (data_val, current_prev_op) = cast_to_generic_addrspace_if_needed(
-                                ctx,
-                                data_val,
-                                expected_ptr_ty,
-                                block_ptr,
-                                prev_after_len,
-                                loc.clone(),
-                            );
+                            let (data_val, current_prev_op) =
+                                cast_to_expected_pointer_type_if_needed(
+                                    ctx,
+                                    data_val,
+                                    expected_ptr_ty,
+                                    block_ptr,
+                                    prev_after_len,
+                                    loc.clone(),
+                                );
 
                             // Coerce the data pointer to the slice element type: a
                             // reinterpret cast feeding `from_raw_parts` can leave it
@@ -1443,7 +1498,11 @@ pub fn translate_rvalue(
                                 loc.clone(),
                             );
 
-                            let slice_ty = dialect_mir::types::MirSliceType::get(ctx, element_type);
+                            let slice_ty = dialect_mir::types::MirSliceType::get_with_kind(
+                                ctx,
+                                element_type,
+                                pointer_kind,
+                            );
 
                             use dialect_mir::ops::MirConstructSliceOp;
                             let op = Operation::new(
@@ -2039,7 +2098,7 @@ pub fn translate_operand(
             // statics have already been intercepted above and remain addrspace 3.
             // Statics tagged `#[constant]` (detected by the mangled symbol
             // prefix) instead lower into constant memory (addrspace 4).
-            if let Some((pointee_ty, is_mutable)) = get_static_pointer_info(&rust_ty)
+            if let Some((pointee_ty, is_mutable, pointer_kind)) = get_static_pointer_info(&rust_ty)
                 && let Some(static_target) = static_target_from_constant(constant, loc.clone())?
             {
                 let static_ty = static_target.static_def.ty();
@@ -2077,6 +2136,7 @@ pub fn translate_operand(
                             elem_ty,
                             len,
                             is_mutable,
+                            pointer_kind,
                             0,
                             block_ptr,
                             prev_op,
@@ -2126,6 +2186,7 @@ pub fn translate_operand(
                         elem_ty,
                         len,
                         is_mutable,
+                        pointer_kind,
                         static_target.byte_offset,
                         block_ptr,
                         prev_op,
@@ -2583,7 +2644,7 @@ pub fn translate_operand(
 
                     // The shared materializer needs the pointee's Rust type for
                     // enum-layout queries and ZST detection.
-                    let Some((pointee_rust_ty, _)) = get_static_pointer_info(&rust_ty) else {
+                    let Some((pointee_rust_ty, _, _)) = get_static_pointer_info(&rust_ty) else {
                         return input_err!(
                             loc,
                             TranslationErr::unsupported(format!(
@@ -4373,6 +4434,17 @@ fn emit_slice_subslice_value(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> TranslationResult<(Value, Ptr<Operation>)> {
+    // Subslice is a projection of an existing fat pointer, not a new borrow.
+    // Preserve the source pointer category; callers that explicitly form a
+    // reborrow/raw address normalize the terminal result to their new Rust
+    // type afterwards.
+    let pointer_kind = slice_value
+        .get_type(ctx)
+        .deref(ctx)
+        .downcast_ref::<dialect_mir::types::MirSliceType>()
+        .map(|slice| slice.pointer_kind())
+        .unwrap_or(MirPointerKind::Erased);
+
     use dialect_mir::ops::MirConstructSliceOp;
 
     let Some(trim) = from.checked_add(to) else {
@@ -4444,7 +4516,7 @@ fn emit_slice_subslice_value(
     sub_op.insert_after(ctx, trim_op);
     let new_len = sub_op.deref(ctx).get_result(0);
 
-    let slice_ty = dialect_mir::types::MirSliceType::get(ctx, element_ty);
+    let slice_ty = dialect_mir::types::MirSliceType::get_with_kind(ctx, element_ty, pointer_kind);
     let construct = Operation::new(
         ctx,
         MirConstructSliceOp::get_concrete_op_info(),
@@ -5556,7 +5628,7 @@ fn construct_disjoint_slice_aggregate(
     // verifier expects.
     let expected_ptr_ty: TypeHandle =
         dialect_mir::types::MirPtrType::get_generic(ctx, element_type, true).into();
-    let (data_val, current_prev_op) = cast_to_generic_addrspace_if_needed(
+    let (data_val, current_prev_op) = cast_to_expected_pointer_type_if_needed(
         ctx,
         runtime_fields[0],
         expected_ptr_ty,
@@ -5806,12 +5878,12 @@ pub fn translate_place_iterative(
                     .is::<dialect_mir::types::MirSliceType>();
                 let pointer_info = get_static_pointer_info(&current_rust_ty);
                 let slice_deref_mutability =
-                    pointer_info.as_ref().and_then(|(pointee, is_mutable)| {
+                    pointer_info.as_ref().and_then(|(pointee, is_mutable, _)| {
                         rust_ty_is_slice(pointee).then_some(*is_mutable)
                     });
                 let current_is_slice_tail_ref = pointer_info
                     .as_ref()
-                    .is_some_and(|(pointee, _)| types::slice_tail_element_ty(pointee).is_some());
+                    .is_some_and(|(pointee, _, _)| types::slice_tail_element_ty(pointee).is_some());
 
                 if next_is_slice_subslice
                     && current_is_fat_slice
@@ -6606,7 +6678,7 @@ fn translate_ptr_to_array_constant(
     );
 
     let global_ptr = global_alloc.get_operation().deref(ctx).get_result(0);
-    let (ptr_val, last_op) = cast_to_generic_addrspace_if_needed(
+    let (ptr_val, last_op) = cast_to_expected_pointer_type_if_needed(
         ctx,
         global_ptr,
         const_ty_ptr,
@@ -9611,7 +9683,7 @@ fn translate_union_aggregate(
         prev_op,
         loc.clone(),
     )?;
-    let (active_value, current_prev_op) = cast_to_generic_addrspace_if_needed(
+    let (active_value, current_prev_op) = cast_to_expected_pointer_type_if_needed(
         ctx,
         active_value,
         expected_field_ty,
@@ -10952,6 +11024,7 @@ fn translate_static_array_as_slice(
     elem_ty: rustc_public::ty::Ty,
     len: u64,
     is_mutable: bool,
+    pointer_kind: MirPointerKind,
     byte_offset: u64,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -11030,7 +11103,7 @@ fn translate_static_array_as_slice(
     };
     let len_val = len_op.deref(ctx).get_result(0);
 
-    let slice_ty = MirSliceType::get(ctx, elem_mir_ty);
+    let slice_ty = MirSliceType::get_with_kind(ctx, elem_mir_ty, pointer_kind);
     let construct = Operation::new(
         ctx,
         MirConstructSliceOp::get_concrete_op_info(),
@@ -11330,7 +11403,7 @@ fn translate_slice_at_alloc_offset(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
-    let Some((pointee_ty, is_mutable)) = get_static_pointer_info(rust_ty) else {
+    let Some((pointee_ty, is_mutable, pointer_kind)) = get_static_pointer_info(rust_ty) else {
         return input_err!(
             loc,
             TranslationErr::unsupported(format!(
@@ -11394,6 +11467,7 @@ fn translate_slice_at_alloc_offset(
         elem_ty,
         len,
         is_mutable,
+        pointer_kind,
         static_target.byte_offset,
         block_ptr,
         prev_op,
@@ -12497,19 +12571,33 @@ fn set_global_initializer_relocations_attr(
 }
 
 /// Check if a type is a pointer/reference to a static allocation.
-/// Returns `(pointee_ty, is_mutable)` when the type can carry a static address.
+/// Returns `(pointee_ty, is_mutable, pointer_kind)` when the type can carry a
+/// static address. Keeping the kind here prevents constant materialization from
+/// collapsing `&T`/`&mut T` and raw pointers before they enter `dialect-mir`.
 use super::values::is_constant_wrapper_type;
 
-fn get_static_pointer_info(ty: &rustc_public::ty::Ty) -> Option<(rustc_public::ty::Ty, bool)> {
+fn get_static_pointer_info(
+    ty: &rustc_public::ty::Ty,
+) -> Option<(rustc_public::ty::Ty, bool, MirPointerKind)> {
     use rustc_public::mir::Mutability;
     use rustc_public::ty::{RigidTy, TyKind};
 
     match ty.kind() {
         TyKind::RigidTy(RigidTy::RawPtr(pointee_ty, mutability)) => {
-            Some((pointee_ty, mutability == Mutability::Mut))
+            let is_mutable = mutability == Mutability::Mut;
+            Some((
+                pointee_ty,
+                is_mutable,
+                MirPointerKind::from_raw_mutability(is_mutable),
+            ))
         }
         TyKind::RigidTy(RigidTy::Ref(_, pointee_ty, mutability)) => {
-            Some((pointee_ty, mutability == Mutability::Mut))
+            let is_mutable = mutability == Mutability::Mut;
+            Some((
+                pointee_ty,
+                is_mutable,
+                MirPointerKind::from_reference_mutability(is_mutable),
+            ))
         }
         _ => None,
     }
@@ -13730,6 +13818,45 @@ mod tests {
     }
 
     #[test]
+    fn expected_pointer_normalization_rejects_concrete_kind_change() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let pointee_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let source_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            false,
+            MirPointerKind::SharedRef,
+        )
+        .into();
+        let target_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            true,
+            MirPointerKind::UniqueRef,
+        )
+        .into();
+        let block = BasicBlock::new(&mut ctx, None, vec![source_ty]);
+        let source = block.deref(&ctx).get_argument(0);
+
+        let (normalized, last_op) = cast_to_expected_pointer_type_if_needed(
+            &mut ctx,
+            source,
+            target_ty,
+            block,
+            None,
+            Location::Unknown,
+        );
+
+        assert_eq!(normalized.get_type(&ctx), source_ty);
+        assert!(
+            last_op.is_none(),
+            "generic normalization must not strengthen SharedRef into UniqueRef"
+        );
+    }
+
+    #[test]
     fn projected_address_normalization_matches_expected_pointer_type() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
@@ -13738,15 +13865,20 @@ mod tests {
 
         let physical_ptr_ty: TypeHandle = MirPtrType::get(&mut ctx, pointee_ty, false, 1).into();
 
-        let expected_rust_ptr_ty: TypeHandle =
-            MirPtrType::get_generic(&mut ctx, pointee_ty, false).into();
+        let expected_rust_ptr_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            false,
+            MirPointerKind::SharedRef,
+        )
+        .into();
 
         let block = BasicBlock::new(&mut ctx, None, vec![physical_ptr_ty]);
         let physical_pointer = block.deref(&ctx).get_argument(0);
 
         // Rvalue::Ref and Rvalue::AddressOf both use this normalization after
         // computing a projected address in its physical address space.
-        let (normalized_pointer, last_op) = cast_to_generic_addrspace_if_needed(
+        let (normalized_pointer, last_op) = cast_to_expected_pointer_type_if_needed(
             &mut ctx,
             physical_pointer,
             expected_rust_ptr_ty,
@@ -13758,7 +13890,7 @@ mod tests {
         assert_eq!(
             normalized_pointer.get_type(&ctx),
             expected_rust_ptr_ty,
-            "projected addresses must be normalized to the exact Rust pointer type"
+            "projected addresses must be normalized to the exact Rust pointer type and kind"
         );
 
         let cast_op = last_op.expect(

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -872,10 +872,18 @@ pub fn translate_statement(
             Ok(prev_op)
         }
 
-        // Codegen-irrelevant statements: borrow-check / type-system / coverage
-        // hints that have no runtime effect. Skipping is correct.
+        // `Retag` refines rustc's dynamic alias/provenance model but has no
+        // runtime effect. `dialect-mir` preserves the static source category
+        // (`&T`, `&mut T`, `*const T`, `*mut T`) in its pointer types, but it
+        // does not model Stacked/Tree Borrows tags or retag epochs. Therefore
+        // Retag remains an intentional no-op. Any future LLVM alias metadata
+        // must be based on an explicit audited policy, never inferred from the
+        // fact that Retag was skipped or from `MirPtrType::is_mutable`.
+        mir::StatementKind::Retag(..) => Ok(prev_op),
+
+        // Other codegen-irrelevant borrow-check / type-system / coverage hints
+        // have no runtime effect and are intentionally skipped.
         mir::StatementKind::FakeRead(..)
-        | mir::StatementKind::Retag(..)
         | mir::StatementKind::PlaceMention(..)
         | mir::StatementKind::AscribeUserType { .. }
         | mir::StatementKind::Coverage(..)
@@ -1205,6 +1213,9 @@ pub(crate) fn emit_array_element_store(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> Ptr<Operation> {
+    // This is an address produced solely to perform the store, not a Rust
+    // reference/raw-pointer value. The legacy constructor intentionally gives
+    // it `MirPointerKind::Erased` provenance.
     let elem_ptr_ty =
         dialect_mir::types::MirPtrType::get(ctx, element_ty, true, address_space).into();
 
@@ -1243,7 +1254,8 @@ pub(crate) fn emit_array_element_store(
 /// callers of the statement module sometimes thread pointers coming from
 /// other sources (loads, field-addr ops, ...), which may be immutable.
 /// Derived addresses inherit the base pointer's mutability to keep pliron
-/// type checking consistent.
+/// type checking consistent. This bit is not an aliasing or uniqueness proof;
+/// source-level reference kind is tracked separately by `MirPointerKind`.
 pub(crate) fn pointer_is_mutable(ctx: &pliron::context::Context, ptr: Value) -> bool {
     let ty = ptr.get_type(ctx);
     let ty_ref = ty.deref(ctx);

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -17,8 +17,8 @@
 //! | `char`              | `ui32`                              |
 //! | `(A, B, C)`         | `MirTupleType`                      |
 //! | `[T; N]`            | `ArrayType`                         |
-//! | `*const T`, `*mut T`| `MirPtrType` (generic addrspace)    |
-//! | `[T]`, `&[T]`       | `MirSliceType`                      |
+//! | `*const T`, `*mut T`| `MirPtrType` + raw pointer kind     |
+//! | `[T]`, `&[T]`       | `MirSliceType` + pointer kind       |
 //! | `struct S { .. }`   | `MirStructType`                     |
 //! | `union U { .. }`    | `MirUnionType`                      |
 //! | `enum E { .. }`     | `MirEnumType`                       |
@@ -44,8 +44,8 @@ use rustc_public_bridge::IndexedVal;
 
 // Re-export types from dialect_mir for convenience
 pub use dialect_mir::types::{
-    EnumEncoding, EnumVariant, MirDisjointSliceType, MirEnumType, MirPtrType, MirSliceType,
-    MirTupleType, MirUnionType, StructAbiKind,
+    EnumEncoding, EnumVariant, MirDisjointSliceType, MirEnumType, MirPointerKind, MirPtrType,
+    MirSliceType, MirTupleType, MirUnionType, StructAbiKind,
 };
 use rustc_public::mir::Mutability;
 
@@ -314,15 +314,17 @@ pub(super) fn slice_tail_element_ty(ty: &rustc_public::ty::Ty) -> Option<rustc_p
 
 /// Translates a raw-pointer or reference type to its `dialect-mir` equivalent.
 ///
-/// Most pointers become generic-addrspace `MirPtrType`, but a few Rust-level
-/// types are stand-ins for shared-memory objects in a CUDA kernel. We detect
-/// those here and produce the correct `addrspace(3)` pointer so that the
-/// alloca slot for such a local matches the pointer value produced by
-/// shared-memory intrinsics (e.g. `MirSharedAllocOp`). See module docs.
+/// `pointer_kind` is the source-level distinction that must survive this
+/// boundary: `&T`, `&mut T`, `*const T`, and `*mut T` remain different MIR
+/// types even when their physical pointee, mutability bit, and address space
+/// match. Most pointers use the generic address space; CUDA stand-ins such as
+/// `SharedArray` and `Barrier` retain the same source pointer kind while using
+/// their concrete shared-memory address space.
 fn translate_pointer_like(
     ctx: &mut Context,
     pointee: &rustc_public::ty::Ty,
     is_mutable: bool,
+    pointer_kind: MirPointerKind,
 ) -> TranslationResult<TypeHandle> {
     match pointee.kind() {
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(elem_ty)) => {
@@ -333,7 +335,7 @@ fn translate_pointer_like(
             // the alloca slot even though Rust considers these freely
             // interconvertible.
             let elem = translate_type(ctx, &elem_ty)?;
-            Ok(MirSliceType::get(ctx, elem).into())
+            Ok(MirSliceType::get_with_kind(ctx, elem, pointer_kind).into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Str) => {
             // `&str` / `*const str` is a fat pointer (data ptr + length),
@@ -347,7 +349,7 @@ fn translate_pointer_like(
                 pliron::builtin::types::Signedness::Unsigned,
             )
             .into();
-            Ok(MirSliceType::get(ctx, u8_ty).into())
+            Ok(MirSliceType::get_with_kind(ctx, u8_ty, pointer_kind).into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, substs))
             if adt_def.trimmed_name() == "SharedArray" =>
@@ -357,7 +359,13 @@ fn translate_pointer_like(
             // `[T; N]`. Match the intrinsic-emitted shared-alloc pointer so
             // the alloca slot and the rvalue agree on type.
             let elem = shared_array_element_type(ctx, &substs, "SharedArray")?;
-            Ok(dialect_mir::types::MirPtrType::get_shared(ctx, elem, is_mutable).into())
+            Ok(dialect_mir::types::MirPtrType::get_shared_with_kind(
+                ctx,
+                elem,
+                is_mutable,
+                pointer_kind,
+            )
+            .into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, _substs))
             if adt_def.trimmed_name() == "Barrier" =>
@@ -370,7 +378,13 @@ fn translate_pointer_like(
                 pliron::builtin::types::Signedness::Unsigned,
             )
             .into();
-            Ok(dialect_mir::types::MirPtrType::get_shared(ctx, u64_ty, is_mutable).into())
+            Ok(dialect_mir::types::MirPtrType::get_shared_with_kind(
+                ctx,
+                u64_ty,
+                is_mutable,
+                pointer_kind,
+            )
+            .into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(..))
             if slice_tail_element_ty(pointee).is_some() =>
@@ -390,11 +404,11 @@ fn translate_pointer_like(
             // extracts the data pointer (the struct's address) first; see
             // the place-address walker in `rvalue.rs`.
             let struct_model = translate_type(ctx, pointee)?;
-            Ok(MirSliceType::get(ctx, struct_model).into())
+            Ok(MirSliceType::get_with_kind(ctx, struct_model, pointer_kind).into())
         }
         _ => {
             let pointee_ty = translate_type(ctx, pointee)?;
-            Ok(MirPtrType::get_generic(ctx, pointee_ty, is_mutable).into())
+            Ok(MirPtrType::get_generic_with_kind(ctx, pointee_ty, is_mutable, pointer_kind).into())
         }
     }
 }
@@ -652,7 +666,8 @@ pub fn translate_type(
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::RawPtr(ty, mutability)) => {
             let is_mutable = mutability == Mutability::Mut;
-            translate_pointer_like(ctx, &ty, is_mutable)
+            let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
+            translate_pointer_like(ctx, &ty, is_mutable, pointer_kind)
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Ref(
             _region,
@@ -660,7 +675,8 @@ pub fn translate_type(
             mutability,
         )) => {
             let is_mutable = mutability == Mutability::Mut;
-            translate_pointer_like(ctx, &ty, is_mutable)
+            let pointer_kind = MirPointerKind::from_reference_mutability(is_mutable);
+            translate_pointer_like(ctx, &ty, is_mutable, pointer_kind)
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, substs)) => {
             // Get the trimmed name (just the type name without path)

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -17,8 +17,8 @@
 //! # Slot address-space inference
 //!
 //! Rust's reference / raw-pointer types carry no address-space information
-//! (`&mut f32`, `*const u32` all translate to a generic `MirPtrType`). On
-//! GPU, however, intermediate locals frequently end up holding pointers in
+//! (`&mut f32`, `*const u32` are distinct pointer kinds but both default to a
+//! generic-address-space `MirPtrType`). On GPU, however, intermediate locals frequently end up holding pointers in
 //! a concrete address space — e.g. `let p = &mut TILE_A[i]` on a
 //! `SharedArray` produces an `addrspace(3)` pointer, yet the Rust local is
 //! typed `&mut f32` (generic).
@@ -37,7 +37,7 @@
 
 use dialect_mir::attributes::MirCastKindAttr;
 use dialect_mir::ops::{MirAllocaOp, MirCastOp, MirLoadOp, MirStoreOp};
-use dialect_mir::types::{MirPtrType, address_space};
+use dialect_mir::types::{MirPointerKind, MirPtrType, MirSliceType, address_space};
 use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
 use pliron::op::Op;
@@ -157,14 +157,12 @@ impl ValueMap {
     /// Emit `mir.store` of `value` into `local`'s slot. Returns `None` for ZST
     /// / unset locals.
     ///
-    /// When `value` is a pointer whose type differs from the slot's declared
-    /// pointee (mutability, address space, or underlying pointee shape), a
-    /// `mir.cast <PtrToPtr>` is inserted automatically. This bridges the
-    /// common case where an rvalue produces a pointer in a concrete address
-    /// space (e.g. `shared_alloc` returning `*mut T addrspace(3)`) while the
-    /// local's Rust-declared type translates to a generic-addrspace pointer
-    /// (e.g. `*mut SharedArray<T, N>` -> `*mut ()`). All pointers have the
-    /// same runtime layout after lowering, so the cast is free.
+    /// When `value` is pointer-like and its type differs from the slot's
+    /// declared pointee, a `mir.cast <PtrToPtr>` is inserted automatically.
+    /// This covers both thin [`MirPtrType`] values and fat [`MirSliceType`]
+    /// values. Besides address-space normalization, the cast restores the
+    /// exact Rust pointer/reference kind carried by the local's declared type.
+    /// No alias guarantee is inferred from this conversion.
     pub fn store_local(
         &self,
         ctx: &mut Context,
@@ -189,9 +187,23 @@ impl ValueMap {
     }
 }
 
-/// If `value` is a pointer whose type differs from `target_ty` (also a
-/// pointer), emit a `mir.cast <PtrToPtr>` that converts it. Returns the (new)
-/// value and the (new) anchor op. Otherwise this is a no-op.
+/// Whether generic pointer normalization may change `source` into `target`.
+///
+/// `Erased` is the bridge between compiler-generated physical addresses and
+/// Rust-typed semantic values, so gaining or forgetting a concrete kind at
+/// that boundary is allowed. Two distinct concrete Rust kinds must never be
+/// interconverted by generic normalization: such a transition needs an
+/// explicit Rust/MIR coercion or cast with its own audited semantics.
+pub(crate) fn pointer_kind_retype_allowed(source: MirPointerKind, target: MirPointerKind) -> bool {
+    source == target || source == MirPointerKind::Erased || target == MirPointerKind::Erased
+}
+
+/// If `value` and `target_ty` are compatible pointer-like MIR types, emit a
+/// `mir.cast <PtrToPtr>` to the exact target type. Thin pointers are compatible
+/// when their pointees agree and pointer-kind normalization is safe; fat slices
+/// follow the same rule for their element type. This is deliberately
+/// conservative: thin/fat conversions, pointee reinterpretation, and changes
+/// between distinct concrete Rust pointer kinds remain explicit elsewhere.
 pub(crate) fn maybe_ptr_coerce(
     ctx: &mut Context,
     value: Value,
@@ -204,12 +216,32 @@ pub(crate) fn maybe_ptr_coerce(
         return (value, prev_op);
     }
 
-    // Only auto-insert a PtrToPtr cast when both sides are already pointer
-    // types; anything else is a genuine translation mismatch and should be
-    // surfaced by the verifier, not papered over here.
-    let value_is_ptr = value_ty.deref(ctx).downcast_ref::<MirPtrType>().is_some();
-    let target_is_ptr = target_ty.deref(ctx).downcast_ref::<MirPtrType>().is_some();
-    if !(value_is_ptr && target_is_ptr) {
+    let compatible = {
+        let value_ref = value_ty.deref(ctx);
+        let target_ref = target_ty.deref(ctx);
+
+        match (
+            value_ref.downcast_ref::<MirPtrType>(),
+            target_ref.downcast_ref::<MirPtrType>(),
+        ) {
+            (Some(value_ptr), Some(target_ptr)) => {
+                value_ptr.pointee == target_ptr.pointee
+                    && pointer_kind_retype_allowed(value_ptr.kind, target_ptr.kind)
+            }
+            _ => match (
+                value_ref.downcast_ref::<MirSliceType>(),
+                target_ref.downcast_ref::<MirSliceType>(),
+            ) {
+                (Some(value_slice), Some(target_slice)) => {
+                    value_slice.element_ty == target_slice.element_ty
+                        && pointer_kind_retype_allowed(value_slice.kind, target_slice.kind)
+                }
+                _ => false,
+            },
+        }
+    };
+
+    if !compatible {
         return (value, prev_op);
     }
 
@@ -635,19 +667,21 @@ fn propagate_from_local(local: mir::Local, classes: &[SlotAddrSpace]) -> WriteCl
 /// current address space; otherwise return `elem_ty` unchanged.
 ///
 /// Used by `body::emit_entry_allocas` to override a Rust-declared pointer
-/// addrspace with the one inferred by [`SlotAddrSpaceMap`].
+/// addrspace with the one inferred by [`SlotAddrSpaceMap`]. The pointer kind
+/// is preserved exactly: address-space inference must never turn `&mut T` into
+/// an erased/raw pointer, or vice versa.
 pub fn align_pointer_addr_space(ctx: &mut Context, elem_ty: TypeHandle, target: u32) -> TypeHandle {
     let ptr_info = elem_ty
         .deref(ctx)
         .downcast_ref::<MirPtrType>()
-        .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space));
-    let Some((pointee, is_mutable, current)) = ptr_info else {
+        .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space, pt.kind));
+    let Some((pointee, is_mutable, current, kind)) = ptr_info else {
         return elem_ty;
     };
     if current == target {
         return elem_ty;
     }
-    MirPtrType::get(ctx, pointee, is_mutable, target).into()
+    MirPtrType::get_with_kind(ctx, pointee, is_mutable, target, kind).into()
 }
 
 /// Extract a pointer type's address space, or `None` if `elem_ty` is not a
@@ -663,6 +697,99 @@ pub fn pointer_addr_space(ctx: &Context, elem_ty: TypeHandle) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pointer_like_local_coercion_restores_fat_pointer_kind() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let element: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let physical: TypeHandle = MirSliceType::get(&mut ctx, element).into();
+        let expected: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef).into();
+
+        let block = BasicBlock::new(&mut ctx, None, vec![physical]);
+        let value = block.deref(&ctx).get_argument(0);
+        let (value, cast) = maybe_ptr_coerce(&mut ctx, value, expected, block, None);
+
+        assert_eq!(value.get_type(&ctx), expected);
+        assert!(
+            cast.is_some(),
+            "fat pointer kind restoration must be explicit in MIR"
+        );
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_rejects_concrete_kind_changes() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+
+        for (source_kind, source_mutable, target_kind, target_mutable) in [
+            (
+                MirPointerKind::SharedRef,
+                false,
+                MirPointerKind::UniqueRef,
+                true,
+            ),
+            (
+                MirPointerKind::RawConst,
+                false,
+                MirPointerKind::RawMut,
+                true,
+            ),
+            (
+                MirPointerKind::RawConst,
+                false,
+                MirPointerKind::SharedRef,
+                false,
+            ),
+        ] {
+            let source: TypeHandle =
+                MirPtrType::get_generic_with_kind(&mut ctx, pointee, source_mutable, source_kind)
+                    .into();
+            let target: TypeHandle =
+                MirPtrType::get_generic_with_kind(&mut ctx, pointee, target_mutable, target_kind)
+                    .into();
+            let block = BasicBlock::new(&mut ctx, None, vec![source]);
+            let value = block.deref(&ctx).get_argument(0);
+
+            let (coerced, cast) = maybe_ptr_coerce(&mut ctx, value, target, block, None);
+
+            assert_eq!(
+                coerced.get_type(&ctx),
+                source,
+                "generic normalization must not change {source_kind:?} into {target_kind:?}"
+            );
+            assert!(
+                cast.is_none(),
+                "generic normalization must not synthesize a concrete pointer-kind transition"
+            );
+        }
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_rejects_fat_pointer_kind_changes() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let element: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let source: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::RawConst).into();
+        let target: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef).into();
+        let block = BasicBlock::new(&mut ctx, None, vec![source]);
+        let value = block.deref(&ctx).get_argument(0);
+
+        let (coerced, cast) = maybe_ptr_coerce(&mut ctx, value, target, block, None);
+
+        assert_eq!(coerced.get_type(&ctx), source);
+        assert!(cast.is_none());
+    }
 
     #[test]
     fn reachable_unknown_pointer_write_prevents_concrete_narrowing() {
@@ -683,5 +810,27 @@ mod tests {
             propagate_from_local(source, &[SlotAddrSpace::Generic]),
             WriteClass::Classified(space) if space == address_space::GENERIC
         ));
+    }
+
+    #[test]
+    fn address_space_alignment_preserves_pointer_kind() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let unique: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef)
+                .into();
+
+        let aligned = align_pointer_addr_space(&mut ctx, unique, address_space::SHARED);
+        let aligned = aligned.deref(&ctx);
+        let aligned = aligned
+            .downcast_ref::<MirPtrType>()
+            .expect("aligned type must remain a MIR pointer");
+
+        assert_eq!(aligned.address_space, address_space::SHARED);
+        assert_eq!(aligned.kind, MirPointerKind::UniqueRef);
+        assert!(aligned.is_mutable);
     }
 }

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -572,7 +572,9 @@ pub(crate) fn convert_construct_tuple(
 /// `MirSliceType` lowers to the `{ ptr, i64 }` fat-pointer struct, where
 /// field 0 is the data pointer and field 1 is the element count by
 /// construction (the same layout the entry prologue's `reconstruct_slice`
-/// and the Unsize cast path build).
+/// and the Unsize cast path build). `MirSliceType::kind` is intentionally
+/// semantic-only: all reference/raw-pointer kinds share this physical layout
+/// and no LLVM alias metadata is inferred here.
 pub(crate) fn convert_construct_slice(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -111,6 +111,24 @@ pub fn convert(
     let llvm_ty = convert_type(ctx, mir_result_ty).map_err(|e| pliron::input_error!(loc, "{e}"))?;
     let val_ty = val.get_type(ctx);
 
+    // Rust pointer/reference kind is a MIR semantic distinction, not an LLVM
+    // representation distinction. With opaque LLVM pointers (and the canonical
+    // `{ptr, i64}` slice layout), changing only pointer kind can therefore
+    // produce identical lowered source/destination types. Forward the value
+    // directly instead of manufacturing a bitcast or a struct memory
+    // round-trip. Address-space-changing casts still take the normal path.
+    if val_ty == llvm_ty
+        && matches!(
+            &cast_kind,
+            MirCastKindAttr::PtrToPtr
+                | MirCastKindAttr::PointerCoercionMutToConst
+                | MirCastKindAttr::Subtype
+        )
+    {
+        rewriter.replace_operation_with_values(ctx, op, vec![val]);
+        return Ok(());
+    }
+
     let llvm_op = match &cast_kind {
         MirCastKindAttr::Transmute => emit_transmute(ctx, rewriter, val, val_ty, llvm_ty)?,
 
@@ -980,8 +998,8 @@ mod tests {
     use dialect_mir::attributes::MirCastKindAttr;
     use dialect_mir::ops as mir;
     use dialect_mir::types::{
-        EnumCarrierKind, EnumEncoding, EnumLayoutKind, EnumVariant, MirEnumType, MirPtrType,
-        MirStructType,
+        EnumCarrierKind, EnumEncoding, EnumLayoutKind, EnumVariant, MirEnumType, MirPointerKind,
+        MirPtrType, MirStructType,
     };
     use llvm_export::ops as llvm;
     use pliron::builtin::op_interfaces::{CallOpCallable, CallOpInterface, SymbolOpInterface};
@@ -1181,6 +1199,33 @@ mod tests {
                 lower_single_cast(&mut ctx, source, destination, MirCastKindAttr::Transmute);
             assert_physical_transmute_round_trip(&ctx, module);
         }
+    }
+
+    #[test]
+    fn pointer_kind_only_coercion_has_no_llvm_instruction() {
+        let mut ctx = make_ctx();
+        let pointee = int_ty(&mut ctx, 32, Signedness::Unsigned);
+        let unique: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef)
+                .into();
+        let shared: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::SharedRef)
+                .into();
+
+        let module = lower_single_cast(
+            &mut ctx,
+            unique,
+            shared,
+            MirCastKindAttr::PointerCoercionMutToConst,
+        );
+        let body = kernel_blocks(&ctx, module);
+
+        assert_eq!(count_ops::<mir::MirCastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::BitcastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::AllocaOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 0);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/type_interface_impls.rs
+++ b/crates/mir-lower/src/convert/type_interface_impls.rs
@@ -64,6 +64,8 @@ impl MirConvertibleType for MirSliceType {}
 #[type_interface_impl]
 impl MirTypeConversion for MirSliceType {
     fn converter(&self) -> ConvertMirTypeFn {
+        // `MirPointerKind` is semantic-only. `&[T]`, `&mut [T]`, and raw
+        // slice pointers all keep the same physical `{ptr, i64}` layout.
         |_ty, ctx| Ok(make_slice_struct(ctx))
     }
 }
@@ -75,6 +77,9 @@ impl MirConvertibleType for MirPtrType {}
 impl MirTypeConversion for MirPtrType {
     fn converter(&self) -> ConvertMirTypeFn {
         |ty, ctx| {
+            // Deliberately erase Rust pointer/reference kind here. It is not
+            // a physical LLVM pointer property and is not sufficient by
+            // itself to justify `noalias`, `readonly`, or related metadata.
             let address_space = ty
                 .deref(ctx)
                 .downcast_ref::<MirPtrType>()


### PR DESCRIPTION
## Summary

Preserve Rust pointer/reference kind through MIR import instead of collapsing
references and raw pointers that share the same pointee, mutability, and address
space.

Fixes #413.

This introduces `MirPointerKind` with the following categories:

- `SharedRef` for `&T`
- `UniqueRef` for `&mut T`
- `RawConst` for `*const T`
- `RawMut` for `*mut T`
- `Erased` for compiler-generated/internal addresses

The kind is carried by both `MirPtrType` and `MirSliceType`.

## What changed

### dialect-mir

- Added `MirPointerKind`.
- Added pointer kind to `MirPtrType`.
- Added pointer kind to `MirSliceType`.
- Added constructors that explicitly preserve source pointer kind.
- Existing synthetic/internal pointer constructors default to `Erased`.
- Added verification that concrete pointer kinds agree with the pointer
  mutability bit.
- Documented the distinction between mutability and Rust reference uniqueness.

### MIR importer

Rust types now map as follows:

| Rust type | MIR pointer kind |
|-----------|------------------|
| `&T` | `SharedRef` |
| `&mut T` | `UniqueRef` |
| `*const T` | `RawConst` |
| `*mut T` | `RawMut` |

Pointer kind is preserved through relevant importer paths, including:

- `Rvalue::Ref`
- `Rvalue::AddressOf`
- projected addresses
- slices and subslices
- pointer-like local stores
- static pointer materialization
- CUDA address-space alignment

Compiler-generated storage and temporary addresses remain `Erased`.

Pointer normalization is intentionally conservative. It may restore a concrete
Rust kind at an explicit Rust-typed semantic boundary, but generic coercion does
not silently convert one concrete Rust pointer category into another. For
example, it cannot synthesize:

- `SharedRef -> UniqueRef`
- `RawConst -> RawMut`
- raw pointer -> reference

### MIR lowering

`MirPointerKind` is semantic-only and is intentionally erased during MIR-to-LLVM
type conversion.

When a cast changes only MIR pointer kind and both sides lower to the same LLVM
type, lowering forwards the value directly instead of emitting an unnecessary
LLVM cast or memory round-trip.

This PR deliberately does not emit LLVM `noalias`, `readonly`,
`dereferenceable`, or related metadata.

`Retag` remains a codegen no-op; dynamic Stacked Borrows / Tree Borrows state is
outside the scope of this change.

## Tests

Added coverage for:

- distinguishing references from raw pointers
- preserving pointer kind in slices
- pointer-kind/mutability consistency
- preserving pointer kind during address-space alignment
- restoring fat-pointer kind at typed boundaries
- rejecting concrete pointer-kind changes during generic normalization
- erasing pointer-kind-only coercions without emitting LLVM instructions

Validation performed:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p dialect-mir --all-targets
cargo test -p mir-importer --all-targets
cargo test -p mir-lower --all-targets
```

All checks pass.
