### PR TITLE
Preserve map_shared_rank results in cluster-shared addrspace(7)

### DIFF
--- a/crates/cuda-device/src/generated/cluster_memory.rs
+++ b/crates/cuda-device/src/generated/cluster_memory.rs
@@ -27,7 +27,7 @@ pub unsafe fn dsmem_read_u32(local_ptr: *const u32, target_rank: u32) -> u32 {
 ///
 /// # Safety
 /// `local_ptr` must point into CTA shared memory, and `target_rank` must name a rank in the same live cluster.
-/// The result is a cluster address carrier. Do not use an ordinary pointer dereference for a remote load.
+/// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access; the target CTA must remain live and synchronization must make the access race-free.
 #[must_use]
 #[inline(never)]
 pub unsafe fn map_shared_rank<T>(local_ptr: *const T, target_rank: u32) -> *const T {
@@ -38,7 +38,7 @@ pub unsafe fn map_shared_rank<T>(local_ptr: *const T, target_rank: u32) -> *cons
 /// Maps a mutable CTA-shared address to another cluster rank.
 ///
 /// # Safety
-/// The mapping requirements above apply, and writes must not race.
+/// The mapping requirements above apply. The target CTA must remain live, and remote writes must be synchronized and race-free.
 #[must_use]
 #[inline(never)]
 pub unsafe fn map_shared_rank_mut<T>(local_ptr: *mut T, target_rank: u32) -> *mut T {

--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -5730,7 +5730,7 @@ fn render_compat_cluster_memory(catalog: &CatalogFile, hash: &str) -> String {
             ClusterMemoryOperation::MapSharedRank => {
                 output.push_str(
                     "/// `local_ptr` must point into CTA shared memory, and `target_rank` must name a rank in the same live cluster.\n\
-                     /// The result is a cluster address carrier. Do not use an ordinary pointer dereference for a remote load.\n",
+                     /// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access; the target CTA must remain live and synchronization must make the access race-free.\n",
                 );
                 output.push_str("#[must_use]\n#[inline(never)]\n");
                 output.push_str(
@@ -5743,7 +5743,7 @@ fn render_compat_cluster_memory(catalog: &CatalogFile, hash: &str) -> String {
                     "/// Maps a mutable CTA-shared address to another cluster rank.\n\
                      ///\n\
                      /// # Safety\n\
-                     /// The mapping requirements above apply, and writes must not race.\n\
+                     /// The mapping requirements above apply. The target CTA must remain live, and remote writes must be synchronized and race-free.\n\
                      #[must_use]\n#[inline(never)]\n\
                      pub unsafe fn map_shared_rank_mut<T>(local_ptr: *mut T, target_rank: u32) -> *mut T {\n\
                              let _ = (local_ptr, target_rank);\n\
@@ -10893,11 +10893,19 @@ impl MapaSharedClusterOp {
     pub fn new(op: Ptr<Operation>) -> Self { Self { op } }
 
     pub fn build(ctx: &mut Context, source: Value, rank: Value) -> Ptr<Operation> {
-        let result_ty = source.get_type(ctx);
+        let source_ty = source.get_type(ctx);
+        let (pointee, is_mutable) = {
+            let source_ty_obj = source_ty.deref(ctx);
+            let source_ptr = source_ty_obj
+                .downcast_ref::<MirPtrType>()
+                .expect("nvvm.mapa_shared_cluster source must be a MIR pointer");
+            (source_ptr.pointee, source_ptr.is_mutable())
+        };
+        let result_ty = MirPtrType::get_cluster_shared(ctx, pointee, is_mutable);
         Operation::new(
             ctx,
             Self::get_concrete_op_info(),
-            vec![result_ty],
+            vec![result_ty.into()],
             vec![source, rank],
             vec![],
             0,
@@ -10910,8 +10918,25 @@ impl Verify for MapaSharedClusterOp {
         let operation = self.get_operation();
         verify_pointer_rank(ctx, operation, "nvvm.mapa_shared_cluster")?;
         let op = operation.deref(ctx);
-        if op.get_result(0).get_type(ctx) != op.get_operand(0).get_type(ctx) {
-            return verify_err!(op.loc(), "nvvm.mapa_shared_cluster must preserve the pointer type");
+        let source_ty = op.get_operand(0).get_type(ctx);
+        let result_ty = op.get_result(0).get_type(ctx);
+        let source_ty_obj = source_ty.deref(ctx);
+        let result_ty_obj = result_ty.deref(ctx);
+        let source_ptr = source_ty_obj.downcast_ref::<MirPtrType>().unwrap();
+        let Some(result_ptr) = result_ty_obj.downcast_ref::<MirPtrType>() else {
+            return verify_err!(
+                op.loc(),
+                "nvvm.mapa_shared_cluster result must be a MIR pointer"
+            );
+        };
+        if result_ptr.pointee != source_ptr.pointee
+            || result_ptr.is_mutable() != source_ptr.is_mutable()
+            || !result_ptr.is_cluster_shared()
+        {
+            return verify_err!(
+                op.loc(),
+                "nvvm.mapa_shared_cluster must preserve pointee and mutability and return addrspace(7)"
+            );
         }
         Ok(())
     }
@@ -16279,7 +16304,7 @@ fn convert_generated_tcgen05_load(
             ClusterMemoryOperation::MapSharedRank => {
                 writeln!(
                     output,
-                    "        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, op, i64_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        let mapped = asm.deref(ctx).get_result(0);\n        let shared_pointer_ty = llvm_types::PointerType::get(ctx, 3);\n        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, shared_pointer_ty.into());\n        rewriter.insert_operation(ctx, int_to_ptr.get_operation());\n        rewriter.replace_operation(ctx, op, int_to_ptr.get_operation());\n        Ok(())"
+                    "        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signless);\n        let asm = inline_asm_convergent(\n            ctx, rewriter, op, i64_ty.into(), vec![shared_pointer, rank], {template:?}, {constraints:?},\n        );\n        let mapped = asm.deref(ctx).get_result(0);\n        let cluster_shared_pointer_ty = llvm_types::PointerType::get(ctx, 7);\n        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, cluster_shared_pointer_ty.into());\n        rewriter.insert_operation(ctx, int_to_ptr.get_operation());\n        rewriter.replace_operation(ctx, op, int_to_ptr.get_operation());\n        Ok(())"
                 )
                 .unwrap();
             }
@@ -18688,7 +18713,7 @@ pub(crate) fn render_probe(catalog: &CatalogFile, record: &CatalogIntrinsic, has
             ClusterMemoryOperation::MapSharedRank => {
                 writeln!(
                     output,
-                    "define ptr addrspace(3) @probe_{}(ptr %source_generic, i32 %rank) #0 {{",
+                    "define ptr addrspace(7) @probe_{}(ptr %source_generic, i32 %rank) #0 {{",
                     record.id
                 )
                 .unwrap();
@@ -18701,7 +18726,7 @@ pub(crate) fn render_probe(catalog: &CatalogFile, record: &CatalogIntrinsic, has
                 )
                 .unwrap();
                 output.push_str(
-                    "  %mapped = inttoptr i64 %mapped_integer to ptr addrspace(3)\n  ret ptr addrspace(3) %mapped\n}\n\nattributes #0 = { convergent }\n",
+                    "  %mapped = inttoptr i64 %mapped_integer to ptr addrspace(7)\n  ret ptr addrspace(7) %mapped\n}\n\nattributes #0 = { convergent }\n",
                 );
             }
             ClusterMemoryOperation::ReadU32 => {
@@ -20161,7 +20186,7 @@ fn render_reference(catalog: &CatalogFile, hash: &str) -> String {
                 ClusterMemorySourceContract::LlvmMapaSharedClusterAs7IdentityInlinePtx => {
                     writeln!(
                         output,
-                        "- `{}` keeps LLVM 22's address-space-7 result as source identity only. Both backends use exact convergent `mapa.shared::cluster.u64` inline PTX and preserve the established shared-address carrier; an ordinary pointer dereference is not a remote cluster load.",
+                        "- `{}` preserves LLVM 22's address-space-7 result. Both backends use exact convergent `mapa.shared::cluster.u64` inline PTX, and ordinary Rust dereference of the mapped pointer lowers through cluster shared memory.",
                         record.id
                     )
                     .unwrap();
@@ -23579,7 +23604,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_memory_rendering_preserves_pointer_carrier_and_composite_load() {
+    fn cluster_memory_rendering_preserves_cluster_shared_addrspace_and_composite_load() {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         let catalog = crate::resolve::resolve(&repo_root).unwrap();
         validate_renderable(&catalog).unwrap();
@@ -23594,7 +23619,7 @@ mod tests {
         ] {
             assert!(compatibility.contains(signature), "missing {signature}");
         }
-        assert!(compatibility.contains("ordinary pointer dereference"));
+        assert!(compatibility.contains("cluster-shared pointer in address space 7"));
 
         let dialect_mod = render_dialect_mod(&catalog, "test-hash");
         assert!(dialect_mod.contains("mod cluster_memory;"));
@@ -23604,7 +23629,7 @@ mod tests {
         let dialect = render_dialect_cluster_memory(&catalog, "test-hash");
         assert!(dialect.contains("pub struct MapaSharedClusterOp"));
         assert!(dialect.contains("pub struct DsmemReadU32Op"));
-        assert!(dialect.contains("nvvm.mapa_shared_cluster must preserve the pointer type"));
+        assert!(dialect.contains("nvvm.mapa_shared_cluster must preserve pointee and mutability and return addrspace(7)"));
         assert!(dialect.contains("nvvm.dsmem_read_u32 result must be u32"));
         assert!(dialect.contains("MapaSharedClusterOp::register(ctx);"));
         assert!(dialect.contains("DsmemReadU32Op::register(ctx);"));
@@ -23623,7 +23648,7 @@ mod tests {
         let lowering = render_lowering(&catalog, "test-hash");
         assert!(lowering.contains("cast_to_shared_addrspace"));
         assert!(lowering.contains("llvm_ops::IntToPtrOp::new"));
-        assert!(lowering.contains("llvm_types::PointerType::get(ctx, 3)"));
+        assert!(lowering.contains("llvm_types::PointerType::get(ctx, 7)"));
         assert!(lowering.contains("mapa.shared::cluster.u64 $0, $1, $2;"));
         assert!(lowering.contains(
             "{ .reg .u64 %mapped; mapa.shared::cluster.u64 %mapped, $1, $2; ld.shared::cluster.u32 $0, [%mapped]; }"
@@ -23637,7 +23662,7 @@ mod tests {
             .unwrap();
         assert_eq!(map.llvm.as_ref().unwrap().results, ["shared_cluster_ptr"]);
         let map_probe = render_probe(&catalog, map, "test-hash");
-        assert!(map_probe.contains("define ptr addrspace(3)"));
+        assert!(map_probe.contains("define ptr addrspace(7)"));
         assert!(map_probe.contains("inttoptr i64"));
         assert!(map_probe.contains("asm sideeffect"));
         assert!(!map_probe.contains("~{memory}"));
@@ -23660,7 +23685,7 @@ mod tests {
 
         let reference = render_reference(&catalog, "test-hash");
         assert!(reference.contains("## Cluster-memory contracts"));
-        assert!(reference.contains("address-space-7 result as source identity only"));
+        assert!(reference.contains("preserves LLVM 22's address-space-7 result"));
         assert!(reference.contains("has no one-to-one LLVM intrinsic"));
 
         let outputs = all_outputs(&catalog, "{}\n".into(), "test-hash").unwrap();

--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -4916,7 +4916,7 @@ fn render_raw_abi(catalog: &CatalogFile, hash: &str) -> String {
                 match cluster.operation {
                     ClusterMemoryOperation::MapSharedRank => output.push_str(
                         "/// `_arg0` must point into CTA shared memory, and `_arg1` must name a rank in the same live cluster.\n\
-                         /// The result is a cluster shared-address carrier; an ordinary pointer dereference is not a remote shared-memory access.\n",
+                         /// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access; ordinary loads and stores compile to `ld.shared::cluster` and `st.shared::cluster`. The target CTA must remain live and synchronization must make the access race-free.\n",
                     ),
                     ClusterMemoryOperation::ReadU32 => output.push_str(
                         "/// `_arg0` must point to an aligned readable `u32` in CTA shared memory, and `_arg1` must name a rank in the same live cluster.\n\
@@ -23629,7 +23629,9 @@ mod tests {
         let dialect = render_dialect_cluster_memory(&catalog, "test-hash");
         assert!(dialect.contains("pub struct MapaSharedClusterOp"));
         assert!(dialect.contains("pub struct DsmemReadU32Op"));
-        assert!(dialect.contains("nvvm.mapa_shared_cluster must preserve pointee and mutability and return addrspace(7)"));
+        assert!(dialect.contains(
+            "nvvm.mapa_shared_cluster must preserve pointee and mutability and return addrspace(7)"
+        ));
         assert!(dialect.contains("nvvm.dsmem_read_u32 result must be u32"));
         assert!(dialect.contains("MapaSharedClusterOp::register(ctx);"));
         assert!(dialect.contains("DsmemReadU32Op::register(ctx);"));
@@ -23681,7 +23683,9 @@ mod tests {
         let raw = render_raw_abi(&catalog, "test-hash");
         assert!(raw.contains("pub unsafe fn i0320(_arg0: *const u8, _arg1: u32) -> *const u8"));
         assert!(raw.contains("pub unsafe fn i0321(_arg0: *const u32, _arg1: u32) -> u32"));
-        assert!(raw.contains("ordinary pointer dereference is not a remote shared-memory access"));
+        assert!(raw.contains(
+            "ordinary loads and stores compile to `ld.shared::cluster` and `st.shared::cluster`"
+        ));
 
         let reference = render_reference(&catalog, "test-hash");
         assert!(reference.contains("## Cluster-memory contracts"));

--- a/crates/cuda-intrinsics/src/generated/abi_v1.rs
+++ b/crates/cuda-intrinsics/src/generated/abi_v1.rs
@@ -4563,7 +4563,7 @@ pub fn i0787(_arg0: f32) -> f32 {
 ///
 /// # Safety
 /// `_arg0` must point into CTA shared memory, and `_arg1` must name a rank in the same live cluster.
-/// The result is a cluster shared-address carrier; an ordinary pointer dereference is not a remote shared-memory access.
+/// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access...
 #[must_use]
 #[inline(never)]
 pub unsafe fn i0320(_arg0: *const u8, _arg1: u32) -> *const u8 {

--- a/crates/cuda-intrinsics/src/generated/abi_v1.rs
+++ b/crates/cuda-intrinsics/src/generated/abi_v1.rs
@@ -4563,7 +4563,7 @@ pub fn i0787(_arg0: f32) -> f32 {
 ///
 /// # Safety
 /// `_arg0` must point into CTA shared memory, and `_arg1` must name a rank in the same live cluster.
-/// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access...
+/// The result is a cluster-shared pointer in address space 7. Dereferencing it performs a remote DSMEM access; ordinary loads and stores compile to `ld.shared::cluster` and `st.shared::cluster`. The target CTA must remain live and synchronization must make the access race-free.
 #[must_use]
 #[inline(never)]
 pub unsafe fn i0320(_arg0: *const u8, _arg1: u32) -> *const u8 {

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -183,6 +183,8 @@ pub mod address_space {
     pub const LOCAL: u32 = 5;
     /// Tensor Memory - Blackwell+ (sm_100+) tcgen05 operands
     pub const TMEM: u32 = 6;
+    /// Cluster-shared memory (distributed shared memory, sm_90+)
+    pub const CLUSTER_SHARED: u32 = 7;
 }
 
 /// A pointer type with mutability and address space tracking.
@@ -197,6 +199,7 @@ pub mod address_space {
 /// - 4 (constant): Read-only constant memory
 /// - 5 (local): Per-thread local memory
 /// - 6 (tmem): Tensor Memory - Blackwell+ tcgen05 operands
+/// - 7 (cluster shared): Distributed shared memory across a thread-block cluster
 ///
 /// # Verification
 /// * Pointee type must be valid.
@@ -270,6 +273,15 @@ impl MirPtrType {
         Self::get(ctx, pointee, is_mutable, address_space::TMEM)
     }
 
+    /// Create a pointer in cluster-shared memory address space (7) - Hopper+.
+    pub fn get_cluster_shared(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+    ) -> TypedHandle<Self> {
+        Self::get(ctx, pointee, is_mutable, address_space::CLUSTER_SHARED)
+    }
+
     pub fn is_mutable(&self) -> bool {
         self.is_mutable
     }
@@ -286,6 +298,11 @@ impl MirPtrType {
     /// Check if this pointer is in tensor memory (addrspace 6) - Blackwell+ tcgen05.
     pub fn is_tmem(&self) -> bool {
         self.address_space == address_space::TMEM
+    }
+
+    /// Check if this pointer is in cluster-shared memory (addrspace 7).
+    pub fn is_cluster_shared(&self) -> bool {
+        self.address_space == address_space::CLUSTER_SHARED
     }
 }
 

--- a/crates/dialect-nvvm/src/ops/generated/cluster_memory.rs
+++ b/crates/dialect-nvvm/src/ops/generated/cluster_memory.rs
@@ -65,11 +65,19 @@ impl MapaSharedClusterOp {
     }
 
     pub fn build(ctx: &mut Context, source: Value, rank: Value) -> Ptr<Operation> {
-        let result_ty = source.get_type(ctx);
+        let source_ty = source.get_type(ctx);
+        let (pointee, is_mutable) = {
+            let source_ty_obj = source_ty.deref(ctx);
+            let source_ptr = source_ty_obj
+                .downcast_ref::<MirPtrType>()
+                .expect("nvvm.mapa_shared_cluster source must be a MIR pointer");
+            (source_ptr.pointee, source_ptr.is_mutable())
+        };
+        let result_ty = MirPtrType::get_cluster_shared(ctx, pointee, is_mutable);
         Operation::new(
             ctx,
             Self::get_concrete_op_info(),
-            vec![result_ty],
+            vec![result_ty.into()],
             vec![source, rank],
             vec![],
             0,
@@ -82,10 +90,24 @@ impl Verify for MapaSharedClusterOp {
         let operation = self.get_operation();
         verify_pointer_rank(ctx, operation, "nvvm.mapa_shared_cluster")?;
         let op = operation.deref(ctx);
-        if op.get_result(0).get_type(ctx) != op.get_operand(0).get_type(ctx) {
+        let source_ty = op.get_operand(0).get_type(ctx);
+        let result_ty = op.get_result(0).get_type(ctx);
+        let source_ty_obj = source_ty.deref(ctx);
+        let result_ty_obj = result_ty.deref(ctx);
+        let source_ptr = source_ty_obj.downcast_ref::<MirPtrType>().unwrap();
+        let Some(result_ptr) = result_ty_obj.downcast_ref::<MirPtrType>() else {
             return verify_err!(
                 op.loc(),
-                "nvvm.mapa_shared_cluster must preserve the pointer type"
+                "nvvm.mapa_shared_cluster result must be a MIR pointer"
+            );
+        };
+        if result_ptr.pointee != source_ptr.pointee
+            || result_ptr.is_mutable() != source_ptr.is_mutable()
+            || !result_ptr.is_cluster_shared()
+        {
+            return verify_err!(
+                op.loc(),
+                "nvvm.mapa_shared_cluster must preserve pointee and mutability and return addrspace(7)"
             );
         }
         Ok(())

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -608,6 +608,20 @@ fn classify_call(func: &mir::Operand) -> WriteClass {
         return WriteClass::Classified(address_space::SHARED);
     }
 
+    // --- addrspace 7 (cluster shared) producers ------------------------------
+    //
+    // `map_shared_rank` and `map_shared_rank_mut` return mapped DSMEM pointers.
+    // Their result slots must retain addrspace(7); otherwise `store_local` would
+    // insert a PtrToPtr cast back to generic and a later dereference would lose
+    // the `ld.shared::cluster` / `st.shared::cluster` selection contract.
+    if matches!(
+        path.as_str(),
+        "cuda_device::cluster::map_shared_rank"
+            | "cuda_device::cluster::map_shared_rank_mut"
+    ) {
+        return WriteClass::Classified(address_space::CLUSTER_SHARED);
+    }
+
     // --- explicit narrow to generic -----------------------------------------
     //
     // Public SharedArray pointer conversions deliberately `cvta.shared` the

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -616,8 +616,7 @@ fn classify_call(func: &mir::Operand) -> WriteClass {
     // the `ld.shared::cluster` / `st.shared::cluster` selection contract.
     if matches!(
         path.as_str(),
-        "cuda_device::cluster::map_shared_rank"
-            | "cuda_device::cluster::map_shared_rank_mut"
+        "cuda_device::cluster::map_shared_rank" | "cuda_device::cluster::map_shared_rank_mut"
     ) {
         return WriteClass::Classified(address_space::CLUSTER_SHARED);
     }

--- a/crates/mir-lower/src/convert/generated_intrinsics.rs
+++ b/crates/mir-lower/src/convert/generated_intrinsics.rs
@@ -9986,8 +9986,8 @@ impl MirToLlvmConversion for MapaSharedClusterOp {
             "=l,l,r",
         );
         let mapped = asm.deref(ctx).get_result(0);
-        let shared_pointer_ty = llvm_types::PointerType::get(ctx, 3);
-        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, shared_pointer_ty.into());
+        let cluster_shared_pointer_ty = llvm_types::PointerType::get(ctx, 7);
+        let int_to_ptr = llvm_ops::IntToPtrOp::new(ctx, mapped, cluster_shared_pointer_ty.into());
         rewriter.insert_operation(ctx, int_to_ptr.get_operation());
         rewriter.replace_operation(ctx, op, int_to_ptr.get_operation());
         Ok(())

--- a/crates/rustc-codegen-cuda/examples/cluster/README.md
+++ b/crates/rustc-codegen-cuda/examples/cluster/README.md
@@ -9,8 +9,9 @@ Demonstrates Thread Block Clusters, a Hopper feature that enables direct shared 
 1. **test_cluster_compile_time**: Compile-time cluster configuration with `#[cluster_launch]`
 2. **test_cluster_intrinsics**: Cluster special registers (ctaid, nctaid, rank, size)
 3. **test_cluster_sync**: Cluster-wide synchronization
-4. **test_dsmem_ring_exchange**: Distributed shared memory - read neighbor block's data
-5. **test_dsmem_reduction**: All-to-one reduction using DSMEM
+4. **test_dsmem_ring_exchange**: Distributed shared memory read through `map_shared_rank` + dereference
+5. **test_dsmem_reduction**: All-to-one reduction using `dsmem_read_u32`
+6. **test_dsmem_mapped_store**: Distributed shared memory write through `map_shared_rank_mut` + dereference
 
 ## Key Concepts Demonstrated
 
@@ -75,23 +76,39 @@ cluster::cluster_sync();
 
 ### Distributed Shared Memory (DSMEM)
 
+`map_shared_rank` maps a CTA-shared pointer to the same offset in another rank. The mapped result is represented as LLVM `addrspace(7)`, so an ordinary Rust dereference lowers through cluster shared memory.
+
 ```rust
 // Each block writes to its own shared memory
 SHMEM[0] = 1000 + my_rank;  // Block 0: 1000, Block 1: 1001, etc.
 thread::sync_threads();
 cluster::cluster_sync();
 
-// Read ANOTHER block's shared memory via dsmem_read_u32!
+// Read ANOTHER block's shared memory through a mapped cluster-shared pointer.
 let neighbor_rank = (my_rank + 1) % cluster_size;
-let neighbor_value = cluster::dsmem_read_u32(addr_of!(SHMEM) as *const u32, neighbor_rank);
+let neighbor_ptr =
+    cluster::map_shared_rank(addr_of!(SHMEM) as *const u32, neighbor_rank);
+let neighbor_value = *neighbor_ptr;
 
 // Block 0 reads 1001, Block 1 reads 1002, Block 2 reads 1003, Block 3 reads 1000
 ```
 
-**Why `dsmem_read_u32` instead of `map_shared_rank` + dereference?**
-`mapa.shared::cluster` returns a shared-space address that requires `ld.shared::cluster`
-to read. A generic load (`ld.b32`) cannot access it. `dsmem_read_u32` combines both
-into a single inline asm: `mapa.shared::cluster.u64` + `ld.shared::cluster.u32`.
+For a mutable mapping, the same address-space semantics apply:
+
+```rust
+let neighbor_ptr =
+    cluster::map_shared_rank_mut(addr_of_mut!(SHMEM) as *mut u32, neighbor_rank);
+*neighbor_ptr = 3000 + my_rank;
+```
+
+`dsmem_read_u32` remains available as a fixed-width convenience intrinsic. It combines the mapping and remote load in one inline-PTX block:
+
+```rust
+let neighbor_value =
+    cluster::dsmem_read_u32(addr_of!(SHMEM) as *const u32, neighbor_rank);
+```
+
+Both approaches require the target CTA to remain live and require cluster synchronization appropriate to the data dependency.
 
 ## Build and Run
 
@@ -132,6 +149,14 @@ Results (each block reads neighbor's value):
 Result: 100, expected: 100
 ✓ DSMEM reduction PASSED
 
+=== Test 5: DSMEM Mapped Remote Store (cluster launch) ===
+Results (each block observes the write from its previous rank):
+  Block 0: got 3003, expected 3003 ✓
+  Block 1: got 3000, expected 3000 ✓
+  Block 2: got 3001, expected 3001 ✓
+  Block 3: got 3002, expected 3002 ✓
+✓ DSMEM mapped remote store PASSED
+
 🎉 All cluster + DSMEM tests PASSED!
 ```
 
@@ -169,15 +194,15 @@ GPU Compute Capability: sm_86
 
 ## Cluster Intrinsic Reference
 
-| Intrinsic                    | PTX                             | Description                      |
-|------------------------------|---------------------------------|----------------------------------|
-| `cluster_ctaidX/Y/Z()`       | `mov.u32 %r, %clusterctaid.x`   | Block position in cluster        |
-| `cluster_nctaidX/Y/Z()`      | `mov.u32 %r, %clusternctaid.x`  | Cluster dimensions               |
-| `block_rank()`               | Computed                        | Linear block index               |
-| `cluster_size()`             | Computed                        | Total blocks in cluster          |
-| `cluster_sync()`             | `barrier.cluster.sync.aligned`  | Cluster-wide barrier             |
-| `map_shared_rank(ptr, rank)` | `mapa.shared::cluster`          | Pointer to other block's SMEM    |
-| `dsmem_read_u32(ptr, rank)`  | `mapa` + `ld.shared::cluster`   | Read u32 from other block's SMEM |
+| Intrinsic                    | PTX                             | Description                                      |
+|------------------------------|---------------------------------|--------------------------------------------------|
+| `cluster_ctaidX/Y/Z()`       | `mov.u32 %r, %clusterctaid.x`   | Block position in cluster                        |
+| `cluster_nctaidX/Y/Z()`      | `mov.u32 %r, %clusternctaid.x`  | Cluster dimensions                               |
+| `block_rank()`               | Computed                        | Linear block index                               |
+| `cluster_size()`             | Computed                        | Total blocks in cluster                          |
+| `cluster_sync()`             | `barrier.cluster.sync.aligned`  | Cluster-wide barrier                             |
+| `map_shared_rank(ptr, rank)` | `mapa.shared::cluster`          | `addrspace(7)` pointer to another block's SMEM   |
+| `dsmem_read_u32(ptr, rank)`  | `mapa` + `ld.shared::cluster`   | Read u32 from other block's SMEM                 |
 
 ## Generated PTX
 
@@ -203,15 +228,29 @@ GPU Compute Capability: sm_86
 }
 ```
 
+An ordinary dereference through `map_shared_rank` selects a cluster-shared load:
+
+```ptx
+mapa.shared::cluster.u64 %rd_mapped, %rd_local_shmem, %r_neighbor_rank;
+ld.shared::cluster.u32 %r_result, [%rd_mapped];
+```
+
+A mutable mapped pointer similarly selects a cluster-shared store:
+
+```ptx
+mapa.shared::cluster.u64 %rd_mapped, %rd_local_shmem, %r_neighbor_rank;
+st.shared::cluster.u32 [%rd_mapped], %r_value;
+```
+
 ## Potential Errors
 
-| Error                        | Cause                          | Solution                          |
-|------------------------------|--------------------------------|-----------------------------------|
-| `CUDA_ERROR_NOT_SUPPORTED`   | Pre-Hopper GPU                 | Use sm_90+ hardware               |
-| `CUDA_ERROR_INVALID_VALUE`   | Cluster dims > max             | Check device limits               |
-| `CUDA_ERROR_ILLEGAL_ADDRESS` | Used `map_shared_rank` + deref | Use `dsmem_read_u32` instead      |
-| `CUDA_ERROR_LAUNCH_FAILED`   | Blocks exited during DSMEM     | Add `cluster_sync()` before return|
-| DSMEM read wrong value       | Missing cluster_sync           | Add sync before DSMEM access      |
+| Error                        | Cause                                    | Solution                                  |
+|------------------------------|------------------------------------------|-------------------------------------------|
+| `CUDA_ERROR_NOT_SUPPORTED`   | Pre-Hopper GPU                           | Use sm_90+ hardware                       |
+| `CUDA_ERROR_INVALID_VALUE`   | Cluster dims > max                       | Check device limits                       |
+| `CUDA_ERROR_ILLEGAL_ADDRESS` | Invalid mapped pointer or dead target CTA | Keep target CTA live and validate pointer |
+| `CUDA_ERROR_LAUNCH_FAILED`   | Blocks exited during DSMEM               | Add `cluster_sync()` before return        |
+| DSMEM read/write wrong value | Missing or incorrect synchronization     | Add the required cluster synchronization  |
 
 ## Cluster Configuration Options
 

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -234,8 +234,9 @@ mod kernels {
 
         if tid == 0 {
             let neighbor_rank = (my_rank + 1) % cluster_size;
-            let neighbor_ptr =
-                unsafe { cluster::map_shared_rank_mut(addr_of_mut!(SHMEM) as *mut u32, neighbor_rank) };
+            let neighbor_ptr = unsafe {
+                cluster::map_shared_rank_mut(addr_of_mut!(SHMEM) as *mut u32, neighbor_rank)
+            };
             unsafe { *neighbor_ptr = 3000 + my_rank };
         }
 
@@ -549,8 +550,7 @@ fn main() {
         println!("⚠ Skipped - CUDA context corrupted by previous DSMEM error\n");
         false
     } else {
-        let mut store_output =
-            DeviceBuffer::<u32>::zeroed(&stream, cluster_size as usize).unwrap();
+        let mut store_output = DeviceBuffer::<u32>::zeroed(&stream, cluster_size as usize).unwrap();
 
         println!("Launching test_dsmem_mapped_store via cuLaunchKernelEx");
         println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1");

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -136,7 +136,7 @@ mod kernels {
     // Test 3: Distributed Shared Memory (Ring Exchange)
     // ============================================================================
 
-    /// Test kernel for distributed shared memory via dsmem_read_u32().
+    /// Test kernel for distributed shared memory via map_shared_rank() + dereference.
     #[kernel]
     #[cluster_launch(4, 1, 1)]
     pub fn test_dsmem_ring_exchange(mut output: DisjointSlice<u32>) {
@@ -158,8 +158,9 @@ mod kernels {
         // Step 3: Read neighbor's shared memory (ring pattern)
         if tid == 0 {
             let neighbor_rank = (my_rank + 1) % cluster_size;
-            let neighbor_value =
-                unsafe { cluster::dsmem_read_u32(addr_of!(SHMEM) as *const u32, neighbor_rank) };
+            let neighbor_ptr =
+                unsafe { cluster::map_shared_rank(addr_of!(SHMEM) as *const u32, neighbor_rank) };
+            let neighbor_value = unsafe { *neighbor_ptr };
 
             let idx = my_rank as usize;
             if idx < output.len() {
@@ -208,6 +209,46 @@ mod kernels {
         }
 
         // All blocks must stay alive while block 0 reads DSMEM
+        cluster::cluster_sync();
+    }
+
+    // ============================================================================
+    // Test 5: Distributed Shared Memory (Mapped Remote Store)
+    // ============================================================================
+
+    /// Test map_shared_rank_mut() followed by an ordinary Rust pointer store.
+    #[kernel]
+    #[cluster_launch(4, 1, 1)]
+    pub fn test_dsmem_mapped_store(mut output: DisjointSlice<u32>) {
+        static mut SHMEM: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let tid = thread::threadIdx_x();
+        let my_rank = cluster::block_rank();
+        let cluster_size = cluster::cluster_size();
+
+        if tid == 0 {
+            unsafe { (addr_of_mut!(SHMEM) as *mut u32).write(2000 + my_rank) };
+        }
+        thread::sync_threads();
+        cluster::cluster_sync();
+
+        if tid == 0 {
+            let neighbor_rank = (my_rank + 1) % cluster_size;
+            let neighbor_ptr =
+                unsafe { cluster::map_shared_rank_mut(addr_of_mut!(SHMEM) as *mut u32, neighbor_rank) };
+            unsafe { *neighbor_ptr = 3000 + my_rank };
+        }
+
+        cluster::cluster_sync();
+
+        if tid == 0 {
+            let idx = my_rank as usize;
+            if idx < output.len() {
+                let local_value = unsafe { *(addr_of!(SHMEM) as *const u32) };
+                unsafe { *output.get_unchecked_mut(idx) = local_value };
+            }
+        }
+
         cluster::cluster_sync();
     }
 }
@@ -499,6 +540,72 @@ fn main() {
     }
 
     // ====================================================================
+    // Test 5: DSMEM mapped remote store
+    // ====================================================================
+
+    println!("=== Test 5: DSMEM Mapped Remote Store (cluster launch) ===\n");
+
+    let store_pass = if dsmem_context_error {
+        println!("⚠ Skipped - CUDA context corrupted by previous DSMEM error\n");
+        false
+    } else {
+        let mut store_output =
+            DeviceBuffer::<u32>::zeroed(&stream, cluster_size as usize).unwrap();
+
+        println!("Launching test_dsmem_mapped_store via cuLaunchKernelEx");
+        println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1");
+        println!("  Each block writes through a mapped pointer into its next rank\n");
+
+        let store_result = unsafe {
+            module.test_dsmem_mapped_store(
+                (stream).as_ref(),
+                LaunchConfig {
+                    grid_dim: (cluster_size, 1, 1),
+                    block_dim: (32, 1, 1),
+                    shared_mem_bytes: 0,
+                },
+                &mut store_output,
+            )
+        };
+
+        match store_result {
+            Ok(_) => match stream.synchronize() {
+                Ok(()) => {
+                    let results: Vec<u32> = store_output.to_host_vec(&stream).unwrap();
+                    println!("Results (each block observes the write from its previous rank):");
+                    for (i, &val) in results.iter().enumerate() {
+                        let previous_rank = (i as u32 + cluster_size - 1) % cluster_size;
+                        let expected = 3000 + previous_rank;
+                        let status = if val == expected { "✓" } else { "?" };
+                        println!(
+                            "  Block {}: got {}, expected {} {}",
+                            i, val, expected, status
+                        );
+                    }
+                    results.iter().enumerate().all(|(i, &val)| {
+                        let previous_rank = (i as u32 + cluster_size - 1) % cluster_size;
+                        val == 3000 + previous_rank
+                    })
+                }
+                Err(e) => {
+                    println!("⚠ DSMEM mapped-store synchronize failed: {:?}", e);
+                    false
+                }
+            },
+            Err(e) => {
+                println!("⚠ Cluster launch failed: {:?}", e);
+                false
+            }
+        }
+    };
+
+    if store_pass {
+        println!("✓ DSMEM mapped remote store PASSED\n");
+    } else if !dsmem_context_error {
+        println!("⚠ DSMEM mapped remote store failed\n");
+    }
+
+    // ====================================================================
     // Summary
     // ====================================================================
 
@@ -508,7 +615,7 @@ fn main() {
     println!("  .explicitcluster");
     println!("  .reqnctapercluster 4, 1, 1\n");
 
-    let all_pass = ct_pass && sync_pass && ring_pass && reduce_pass;
+    let all_pass = ct_pass && sync_pass && ring_pass && reduce_pass && store_pass;
     if all_pass {
         println!("All cluster + DSMEM tests PASSED!");
     } else {
@@ -529,6 +636,10 @@ fn main() {
         println!(
             "  Test 4 (DSMEM reduction):        {}",
             if reduce_pass { "PASS" } else { "FAIL" }
+        );
+        println!(
+            "  Test 5 (DSMEM mapped store):     {}",
+            if store_pass { "PASS" } else { "FAIL" }
         );
         std::process::exit(1);
     }

--- a/crates/rustc-codegen-cuda/examples/cluster/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/cluster/verify-code-shape.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# map_shared_rank / map_shared_rank_mut must keep their results in the
+# cluster-shared address space end to end. If the mapped pointer decays to a
+# generic pointer, an ordinary Rust deref compiles to a CTA-local access and
+# the remote read/write silently targets the wrong shared memory. Assert the
+# LLVM IR loads and stores through `ptr addrspace(7)` and that the two
+# plain-deref kernels emit `ld.shared::cluster` / `st.shared::cluster`, so a
+# regression to generic accesses cannot pass compile-only CI.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ll="${root}/cluster.ll"
+ptx="${root}/cluster.ptx"
+
+test -s "${ll}"
+test -s "${ptx}"
+
+require_ll_shape() {
+    local description="$1"
+    local pattern="$2"
+    if ! grep -E "${pattern}" "${ll}" >/dev/null; then
+        echo "error: missing ${description} in ${ll}" >&2
+        exit 1
+    fi
+}
+
+# Print the body of one PTX entry. Waits for the header's `{` so a forward
+# declaration (which ends in `;`) is skipped.
+entry_body() {
+    local symbol="$1"
+    awk -v marker="${symbol}(" '
+        !emit && !candidate && index($0, marker) && index($0, ".entry") {
+            candidate = 1
+        }
+        candidate && $0 ~ /^[[:space:]]*;[[:space:]]*$/ {
+            candidate = 0
+            next
+        }
+        candidate && $0 ~ /^[[:space:]]*\{[[:space:]]*$/ {
+            emit = 1
+            candidate = 0
+        }
+        emit { print }
+        emit && index($0, "End function") != 0 { exit }
+    ' "${ptx}"
+}
+
+require_entry_shape() {
+    local symbol="$1"
+    local description="$2"
+    local pattern="$3"
+    if ! entry_body "${symbol}" | grep -E "${pattern}" >/dev/null; then
+        echo "error: missing ${description} in ${ptx}:${symbol}" >&2
+        exit 1
+    fi
+}
+
+# The mapped remote read and write must stay in addrspace(7) at the IR level.
+require_ll_shape "cluster-shared mapped load" \
+    'load i32, ptr addrspace\(7\)'
+require_ll_shape "cluster-shared mapped store" \
+    'store i32 [^,]+, ptr addrspace\(7\)'
+
+# The plain-deref kernels must select the cluster-shared PTX access forms.
+require_entry_shape test_dsmem_ring_exchange \
+    "cluster-shared remote load" 'ld\.shared::cluster\.'
+require_entry_shape test_dsmem_mapped_store \
+    "cluster-shared remote store" 'st\.shared::cluster\.'
+
+echo "cluster code shape: PASS"

--- a/cuda-oxide-book/advanced/cluster-programming.md
+++ b/cuda-oxide-book/advanced/cluster-programming.md
@@ -98,10 +98,11 @@ let cz = cluster::cluster_ctaidZ();     // block's Z position in the cluster
 The core feature of clusters is cross-block shared memory access. There are
 two ways to read a remote block's shared memory:
 
-### Method 1: map_shared_rank (pointer remapping)
+### Method 1: map_shared_rank + plain deref (any type)
 
-`map_shared_rank` takes a local shared memory pointer and returns a pointer
-to the same offset in another block's shared memory:
+`map_shared_rank` takes a local shared memory pointer and returns a real
+pointer to the same offset in another block's shared memory. It lives in
+the cluster-shared address space, so you can just dereference it:
 
 ```rust
 use cuda_device::{cluster, SharedArray, thread};
@@ -129,11 +130,16 @@ pub fn halo_exchange(/* ... */) {
 }
 ```
 
-### Method 2: dsmem_read_u32 (preferred)
+That last line is an ordinary Rust read. The compiler keeps the mapped
+pointer in the cluster-shared address space, so the deref compiles to
+`ld.shared::cluster`. Writes work the same way: map with
+`map_shared_rank_mut`, assign through the pointer, and the store compiles
+to `st.shared::cluster`. This works for any type and needs sm_90+.
 
-`dsmem_read_u32` is the preferred way to read remote shared memory. It
-compiles to the `ld.shared::cluster` PTX instruction, which the hardware
-handles more efficiently than a generic load through a remapped pointer:
+### Method 2: dsmem_read_u32 (fixed-width u32 reads)
+
+`dsmem_read_u32` maps and reads one `u32` in a single call. It takes the
+*local* pointer plus the target rank and does the rank mapping itself:
 
 ```rust
 let neighbor_val = unsafe {
@@ -144,11 +150,10 @@ let neighbor_val = unsafe {
 };
 ```
 
-The difference is subtle but matters for performance: `map_shared_rank`
-produces a pointer that goes through the generic load path, while
-`dsmem_read_u32` uses a dedicated instruction that the hardware can
-optimize. Use `dsmem_read_u32` for `u32`-sized reads; for larger types,
-`map_shared_rank` with the appropriate pointer type works.
+Both methods emit the same `ld.shared::cluster` PTX instruction. Plain
+deref through `map_shared_rank` is the primary method: it works for any
+type and supports writes. Reach for `dsmem_read_u32` when all you need is
+a single `u32` and you want the map and the load in one call.
 
 ---
 

--- a/cuda-oxide-book/appendix/api-quick-reference.md
+++ b/cuda-oxide-book/appendix/api-quick-reference.md
@@ -457,9 +457,18 @@ let rank = cluster::block_rank();        // This block's rank in the cluster
 let size = cluster::cluster_size();      // Number of blocks in cluster
 cluster::cluster_sync();                 // Barrier across all cluster blocks
 
-// Distributed Shared Memory
-let remote_ptr = cluster::map_shared_rank(local_ptr, target_rank);
-let val = cluster::dsmem_read_u32(remote_ptr);
+// Distributed Shared Memory. Both are `unsafe fn` and both take the *local*
+// pointer plus the target rank; they do the rank mapping themselves, so
+// never pass a pointer already returned by `map_shared_rank` back in.
+
+// `map_shared_rank` returns a real pointer into the target block's shared
+// memory (cluster-shared address space). Plain reads and writes through it
+// compile to ld.shared::cluster / st.shared::cluster and just work on sm_90+.
+let remote_ptr = unsafe { cluster::map_shared_rank(local_ptr, target_rank) };
+let val = unsafe { *remote_ptr };  // ld.shared::cluster
+
+// Fixed-width alternative: map and read one u32 in a single call.
+let val = unsafe { cluster::dsmem_read_u32(local_u32_ptr, target_rank) };
 ```
 
 ---

--- a/intrinsics/generated-reference.md
+++ b/intrinsics/generated-reference.md
@@ -5507,7 +5507,7 @@ This table is generated from the resolved catalog. Evidence stages below disting
 ## Cluster-memory contracts
 
 - `dsmem_read_u32` has no one-to-one LLVM intrinsic. Both backends use one convergent `mapa.shared::cluster.u64` plus `ld.shared::cluster.u32` block with a compiler memory clobber.
-- `map_shared_rank` keeps LLVM 22's address-space-7 result as source identity only. Both backends use exact convergent `mapa.shared::cluster.u64` inline PTX and preserve the established shared-address carrier; an ordinary pointer dereference is not a remote cluster load.
+- `map_shared_rank` preserves LLVM 22's address-space-7 result. Both backends use exact convergent `mapa.shared::cluster.u64` inline PTX, and ordinary Rust dereference of the mapped pointer lowers through cluster shared memory.
 
 ## movmatrix contracts
 

--- a/intrinsics/probes/map_shared_rank.ll
+++ b/intrinsics/probes/map_shared_rank.ll
@@ -6,11 +6,11 @@
 
 target triple = "nvptx64-nvidia-cuda"
 
-define ptr addrspace(3) @probe_map_shared_rank(ptr %source_generic, i32 %rank) #0 {
+define ptr addrspace(7) @probe_map_shared_rank(ptr %source_generic, i32 %rank) #0 {
   %source = addrspacecast ptr %source_generic to ptr addrspace(3)
   %mapped_integer = call i64 asm sideeffect "mapa.shared::cluster.u64 $0, $1, $2;", "=l,l,r"(ptr addrspace(3) %source, i32 %rank) #0
-  %mapped = inttoptr i64 %mapped_integer to ptr addrspace(3)
-  ret ptr addrspace(3) %mapped
+  %mapped = inttoptr i64 %mapped_integer to ptr addrspace(7)
+  ret ptr addrspace(7) %mapped
 }
 
 attributes #0 = { convergent }


### PR DESCRIPTION
Fixes #1034.

## Summary

Preserve the result of `map_shared_rank` and `map_shared_rank_mut` as a cluster-shared pointer (`addrspace(7)`) through MIR import and LLVM lowering.

This allows ordinary Rust pointer dereferences of mapped DSMEM addresses to select cluster-shared loads and stores instead of losing the mapped pointer semantics.

## Changes

- Add MIR address-space support for cluster-shared memory (`addrspace(7)`).
- Make `MapaSharedClusterOp` preserve pointee type and mutability while returning a cluster-shared pointer.
- Preserve `addrspace(7)` when `map_shared_rank` and `map_shared_rank_mut` results are stored into MIR locals.
- Lower `mapa.shared::cluster` results to LLVM `ptr addrspace(7)`.
- Update the generated probe and generated intrinsic documentation.
- Update the cluster example to validate:
  - mapped remote reads through ordinary Rust dereference;
  - mapped remote writes through ordinary Rust assignment.

## Result

The source pointer passed to `mapa.shared::cluster` remains CTA shared memory:

```llvm
ptr addrspace(3)
```

The mapped result is represented as:

```llvm
ptr addrspace(7)
```

An ordinary Rust read lowers to:

```llvm
%mapped = inttoptr i64 %mapped_integer to ptr addrspace(7)
%value = load i32, ptr addrspace(7) %mapped
```

and produces:

```ptx
mapa.shared::cluster.u64 ...
ld.shared::cluster.b32 ...
```

The mutable path similarly produces:

```llvm
store i32 %value, ptr addrspace(7) %mapped
```

and:

```ptx
mapa.shared::cluster.u64 ...
st.shared::cluster.b32 ...
```

## Validation

* Targeted crate/unit tests passed.
* `rustc-codegen-cuda` library tests: 23/23 passed.
* Workspace Clippy passed with warnings denied.
* Generated intrinsic outputs are current.
* Generated intrinsic probes: 1002/1002 passed.
* Intrinsic ABI history check passed.
* Cluster example build and pipeline passed.
* Mapped remote load passed on cluster-capable NVIDIA hardware.
* Mapped remote store passed on cluster-capable NVIDIA hardware.
* Compute Sanitizer memcheck: 0 errors.
* `git diff --check` passed.
