### PR TITLE
docs(backend): five rustdoc errors in the collector the docs gate cannot see

### DIFF
--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -723,9 +723,9 @@ fn const_str_text<'tcx>(tcx: TyCtxt<'tcx>, constant: &ConstOperand<'tcx>) -> Opt
 
 /// Extracts the stub function name out of a stub panic message.
 ///
-/// The message reads "internal error: entered unreachable code:
-/// thread::index_1d called outside #[kernel] / #[device] ...", so the
-/// stub name is the last word before " called outside".
+/// The message reads `internal error: entered unreachable code:
+/// thread::index_1d called outside #[kernel] / #[device] ...`, so the
+/// stub name is the last word before `" called outside"`.
 fn stub_name_from_marker_message(text: &str) -> &str {
     text.split(" called outside")
         .next()
@@ -1939,7 +1939,7 @@ impl<'tcx> DeviceCollector<'tcx> {
 
     /// Computes the export name for a function.
     ///
-    /// `name` must be the FQDN (from [`fqdn()`]) so that non-generic export names
+    /// `name` must be the FQDN (from [`Self::fqdn`]) so that non-generic export names
     /// match what `CrateDef::name()` returns on the call side. Both sides feed
     /// the FQDN through pliron's `Legaliser`, which replaces every
     /// non-`[A-Za-z0-9]` character with `_`. We return the *raw* FQDN here so
@@ -2127,7 +2127,7 @@ impl<'tcx> DeviceCollector<'tcx> {
     /// Diagnoses a callee whose entire body is panic machinery (issue #76).
     ///
     /// Reached from the `is_unreachable_body` skip in
-    /// [`process_call_operand`]. Genuine intrinsic placeholders (the
+    /// [`Self::process_call_operand`]. Genuine intrinsic placeholders (the
     /// `cuda_device` stubs the translator rewrites by name) must keep
     /// being skipped silently, so this only reports two specific cases:
     ///
@@ -2266,7 +2266,7 @@ impl<'tcx> DeviceCollector<'tcx> {
     /// Diagnoses a missing `#[device]` annotation found through the panic
     /// machinery of a collected body (issue #76).
     ///
-    /// Called from [`collect`] for every function that is about to be
+    /// Called from [`Self::collect`] for every function that is about to be
     /// translated. A basic block ending in a call into `core::panicking`
     /// is a panic path; the string constants it materializes are the panic
     /// message (or the pieces of a `format_args!` template).


### PR DESCRIPTION
`cargo doc` without `--document-private-items` never renders a private item, so it never checks the intra-doc links in a private item's documentation. All five of these sites are on a private fn or method of `DeviceCollector`, and every one is an error the moment that flag is on:

```
error: unresolved link to `kernel`                collector.rs:727
error: unresolved link to `device`                collector.rs:727
error: unresolved link to `fqdn`                  collector.rs:1942
error: unresolved link to `process_call_operand`  collector.rs:2130
error: unresolved link to `collect`               collector.rs:2269
```

**The first two are not links at all.** Line 727 quotes a runtime panic message containing `#[kernel]` / `#[device]`, and rustdoc reads the brackets as reference syntax. The message is a literal string, so it becomes one code span and stops being parsed.

**The other three name methods on the same `impl<'tcx> DeviceCollector<'tcx>`** block the documented items live in, so they only need the `Self::` prefix to resolve. `fqdn` also loses its `()` suffix, which rustdoc does not accept on a method path. All three now resolve to the intended methods — `fqdn` at `:994`, `collect` at `:1031`, `process_call_operand` at `:1336` — rather than silently pointing nowhere.

## Scope

This is part of the cleanup named in #1014's merge note ("Leaving the CI flag off until the other crates' private-doc errors are cleaned is deliberate; that cleanup is a follow-up").

Four more of these errors remain, re-measured against `f1e62fe2`:

| File | Broken link |
|---|---|
| `crates/llvm-export/src/export/ops.rs:55` | `classify_op!` |
| `crates/mir-importer/src/translator/rvalue.rs:4552` | `MirFieldAddrOp` |
| `crates/mir-importer/src/translator/rvalue.rs:4556` | `MirArrayElementAddrOp` |
| `crates/mir-lower/src/convert/ops/aggregate.rs:618` | `make_disjoint_slice_struct` |

All three of those files are under open pull requests right now, so they are left for a follow-up rather than raced. `--document-private-items` can join the docs gate once they land; with this change the backend workspace is clean under it.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` in `crates/rustc-codegen-cuda` reports exactly the five errors above on `main`, and exits 0 with this change.
- The gate's own invocation (without the flag) exits 0 both before and after, so nothing about today's CI changes.
- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean in that workspace.

Comment-only change; no code paths touched.