### PR TITLE
ci: cargo-deny reaches two of the three non-example workspace roots

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -6,9 +6,11 @@ name: cargo-deny
 # Concurrency for the CI path is governed by CI's own group.
 #
 # Four parts of the same concern. `check` enforces the license *policy* over
-# the whole resolved graph from deny.toml -- once for the root workspace and
-# once for crates/rustc-codegen-cuda, which has its own `[workspace]` and so is
-# a separate resolution the root run cannot reach. `license-manifest` enforces that
+# the whole resolved graph from deny.toml, once per `[workspace]` root that
+# resolves third-party crates and is not an example: the root workspace,
+# crates/rustc-codegen-cuda, and the cuda-macros device-only fixture. Each
+# declares its own `[workspace]`, so each is a separate resolution the others
+# cannot reach. `license-manifest` enforces that
 # the human-readable inventory in dependency-licenses.csv still lists what the
 # workspace declares, which nothing checked before: CONTRIBUTING asks
 # contributors to update that file by hand, and it had fallen behind by eight
@@ -49,12 +51,29 @@ jobs:
 
       # crates/rustc-codegen-cuda carries its own `[workspace]` for the
       # rustc-private dylibs, so the run above stops at that boundary and never
-      # sees the 82 third-party crates it resolves. Same policy, second
+      # sees the 88 third-party crates it resolves. Same policy, second
       # workspace -- the pass asked for in the #662 review. No --config:
       # cargo-deny walks up from the manifest directory and finds the
       # repository-root deny.toml, as the example-policy script relies on too.
       - name: Run cargo-deny over the codegen backend workspace
         run: cargo deny --manifest-path crates/rustc-codegen-cuda/Cargo.toml --locked check
+
+      # The fourth and last `[workspace]` root under version control that
+      # resolves third-party crates. `crates/cuda-macros/tests/device-only`
+      # declares its own `[workspace]` so that its graph provably excludes
+      # cuda-host, which is the whole point of the fixture -- and that same
+      # boundary puts it outside the root run above, outside the backend run,
+      # and outside the example-policy script (which walks
+      # crates/rustc-codegen-cuda/examples only). Its lock resolves
+      # proc-macro2, quote and syn at versions that appear nowhere in the root
+      # lock, so those three (name, version) pairs were governed by no policy
+      # at all. It passes today: advisories ok, bans ok, licenses ok, sources
+      # ok. (crates/fuzzer/rustlantis is the fifth `[workspace]` root and is
+      # deliberately not here: it is a vendored upstream project, not
+      # first-party code, and bringing its graph under deny.toml is a policy
+      # call rather than a gap.)
+      - name: Run cargo-deny over the cuda-macros device-only fixture
+        run: cargo deny --manifest-path crates/cuda-macros/tests/device-only/Cargo.toml --locked check
 
   license-manifest:
     name: dependency-licenses.csv covers every declared crate
@@ -82,7 +101,7 @@ jobs:
 
       # Resolves each example workspace's own graph, so it needs the network but
       # no CUDA toolkit and no LLVM. One run per distinct dependency set rather
-      # than per workspace: 26 runs instead of 187, covering the same crates.
+      # than per workspace: 31 runs instead of 217, covering the same crates.
       - name: Run cargo-deny over the example workspaces
         run: bash scripts/check-example-license-policy.sh
 

--- a/Justfile
+++ b/Justfile
@@ -210,10 +210,11 @@ check-errors:
 # command reference, the book's device-API names, the device-only build, and
 # test-matrix coverage),
 # the naming-guard's reserved-prefix search, and all four cargo-deny jobs:
-# `cargo deny check` enforces deny.toml over the root workspace's resolved
-# graph and again over crates/rustc-codegen-cuda, which resolves its own
-# because it has its own `[workspace]`; the license inventory covers what both
-# declare; deny.toml holds over the example workspaces; and every first-party
+# `cargo deny check` enforces deny.toml over each non-example `[workspace]`
+# root that resolves third-party crates -- the root workspace,
+# crates/rustc-codegen-cuda, and the cuda-macros device-only fixture, each of
+# which resolves its own graph because each declares its own `[workspace]`;
+# the license inventory covers what the first two declare; deny.toml holds over the example workspaces; and every first-party
 # source file carries an SPDX header. These were only reachable by reading the
 # workflows, so `just check` could pass while status-guard or cargo-deny
 # failed. Keep this list in step when a guard is added to any of the three
@@ -235,6 +236,7 @@ check-guards:
     bash scripts/check-test-matrix-coverage.sh
     cargo deny --locked check
     cargo deny --manifest-path crates/rustc-codegen-cuda/Cargo.toml --locked check
+    cargo deny --manifest-path crates/cuda-macros/tests/device-only/Cargo.toml --locked check
     bash scripts/check-dependency-licenses.sh
     bash scripts/check-example-license-policy.sh
     bash scripts/check-spdx-headers.sh


### PR DESCRIPTION
`cargo deny check` stops at a `[workspace]` boundary, which is why this workflow already runs it twice: once at the root and once for `crates/rustc-codegen-cuda`. There is a **third** such root under version control that resolves third-party crates, and nothing judges it.

`crates/cuda-macros/tests/device-only` declares its own `[workspace]` on purpose — the fixture exists to prove a graph that does *not* contain `cuda-host` (#701/#702), so it must resolve independently rather than share the root lock. That same boundary puts it outside all three existing runs:

- the root `cargo deny check` stops at it,
- the backend run names a different manifest,
- `check-example-license-policy.sh` walks `crates/rustc-codegen-cuda/examples` only.

## The gap is not theoretical

Its lock against both governed locks:

| crate | fixture | root | backend | governed? |
|---|---|---|---|---|
| `proc-macro2` | 1.0.107 | 1.0.106 | 1.0.106 | **no** |
| `quote` | 1.0.47 | 1.0.45 | 1.0.44 | **no** |
| `syn` | 2.0.119 | 2.0.117, 3.0.3 | 2.0.114, 3.0.3 | **no** |
| `unicode-ident` | 1.0.24 | 1.0.24 | 1.0.22 | yes |

Three of its four third-party `(name, version)` pairs appear in neither governed lock, so no advisory, license, ban or source policy has ever been applied to them. `(name, version, source)` is this repo's own unit of policy — it is the grouping key `check-example-license-policy.sh` uses to argue its runs-for-workspaces equivalence — so a version present nowhere else is a distinct policy question, not a duplicate.

## What this does

Adds the third run with `--locked`, like the other two. A check that can rewrite its own input is not a check, and verified here: deleting a package block from that lock makes the run stop with `cannot update the lock file` rather than silently re-resolving.

`crates/fuzzer/rustlantis` is the one remaining `[workspace]` root and is **deliberately left out**: it is a vendored upstream project rather than first-party code, so bringing its graph under `deny.toml` is a policy call for a maintainer, not a gap to close silently. The header comment now records which roots are in scope and why.

Two present-tense counts in this file had also drifted and are corrected against the current tree:

- the backend workspace resolves **88** third-party crates, not 82 (`cargo metadata --manifest-path crates/rustc-codegen-cuda/Cargo.toml`, packages with a non-null `source`);
- the example-policy script is **31 runs over 217 lock files**, not 26 over 187 — 31 is the number the script itself announces.

## Verification

- The new invocation reports `advisories ok, bans ok, licenses ok, sources ok` and exits 0 on today's tree, so `main` stays green.
- Every workflow still parses.
- `just check-guards` carries the same third run, so the local mirror keeps predicting CI.
- All four counts re-measured against `f1e62fe2`.