### PR TITLE
docs(cuda-device): the Modules table names 17 of the crate's 39 public modules

### DIFF
--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -46,6 +46,40 @@
 
 - *cooperative_groups* also features support for warp/block reductions and scans
 
+### The remaining public modules
+
+The table above is the crate's headline surface, but it is 17 of the 39 modules
+`src/lib.rs` declares `pub` (`grep -c '^pub mod ' src/lib.rs`). The other 22 are
+below. They carry no GPU column because their architecture floor is per function
+rather than per module -- `int`, for instance, holds both an intrinsic-free
+scalar min/max and the `sm_90+` `min.relu.s32` -- so each item's requirement is
+stated in its own rustdoc.
+
+| Module       | Description                                                                     |
+|--------------|---------------------------------------------------------------------------------|
+| `access`     | Inverted tile-shape query: given a target transaction width, what shape is needed|
+| `async_copy` | Classic global-to-shared asynchronous copy intrinsics                           |
+| `bf16`       | Scalar `bf16` min/max; each value is the `u16` bit pattern of one bfloat16       |
+| `bf16x2`     | Packed `bf16x2` arithmetic; two values per `u32`, the first in the low 16 bits   |
+| `constant`   | `ConstantMemory<T>` -- module-scope statics in PTX `.const` (address space 4)    |
+| `convert`    | PTX type-conversion instructions                                                |
+| `dotprod`    | Integer dot products: `dp4a` (packed bytes) and `dp2a` (packed halves)           |
+| `f16`        | Scalar `f16` min/max; each value is the `u16` bit pattern of one IEEE half       |
+| `f16x2`      | Packed `f16x2` arithmetic; two values per `u32`, the first in the low 16 bits    |
+| `f32x2`      | Native SM100 two-lane `f32` arithmetic, each pair carried in a `u64`            |
+| `float`      | Scalar floating-point intrinsics                                                |
+| `i16x2`      | Packed 16-bit integer min/max; two values per `u32`, the first in the low bits   |
+| `iket`       | Semantic annotations for In-Kernel Event Tracing; compiler markers behind macros |
+| `int`        | Scalar integer intrinsics, including the `sm_90+` `min.relu.s32`/`max.relu.s32`  |
+| `mma_frag`   | Fragment index algebra for the `m16n8k16` tensor-core accumulator                |
+| `prmt`       | Byte permutation intrinsics                                                     |
+| `ptx`        | Inline PTX support; user code goes through `ptx_asm!`, not this module directly  |
+| `swizzle`    | XOR swizzles for shared memory, and the bank-conflict arithmetic to pick one     |
+| `uniform`    | Launch-uniform scalar witnesses for APIs needing a value identical in every thread|
+| `vector`     | Over-aligned element types, and a checked way to view a flat slice as them       |
+| `view`       | Checked-once views for 32-bit kernel indexing, backed by a launch contract       |
+| `wmma`       | Warp-level matrix ops: `movmatrix`, `mma.sync`, and cooperative `ldmatrix` loads |
+
 ## Key Types
 
 ### `ThreadIndex<'kernel, IndexSpace>` and `DisjointSlice<T, IndexSpace>`

--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -48,16 +48,15 @@
 
 ### The remaining public modules
 
-The table above is the crate's headline surface, but it is 17 of the 39 modules
-`src/lib.rs` declares `pub` (`grep -c '^pub mod ' src/lib.rs`). The other 22 are
-below. They carry no GPU column because their architecture floor is per function
-rather than per module -- `int`, for instance, holds both an intrinsic-free
-scalar min/max and the `sm_90+` `min.relu.s32` -- so each item's requirement is
-stated in its own rustdoc.
+The table above covers the most-used modules, but it is not the whole crate.
+The remaining public modules are below. There is no GPU column here because
+the minimum architecture varies per function, not per module. `int`, for
+example, has plain scalar min/max that runs anywhere, plus `min.relu.s32`
+which needs `sm_90+`. Each function's rustdoc states its own requirement.
 
 | Module       | Description                                                                     |
 |--------------|---------------------------------------------------------------------------------|
-| `access`     | Inverted tile-shape query: given a target transaction width, what shape is needed|
+| `access`     | Choosing a tile shape from a target memory transaction width.                   |
 | `async_copy` | Classic global-to-shared asynchronous copy intrinsics                           |
 | `bf16`       | Scalar `bf16` min/max; each value is the `u16` bit pattern of one bfloat16       |
 | `bf16x2`     | Packed `bf16x2` arithmetic; two values per `u32`, the first in the low 16 bits   |


### PR DESCRIPTION
`src/lib.rs` declares 39 `pub mod`. The README's `## Modules` table lists 17 of them, and the other 22 appear **nowhere in the file** — not in the table, not in the ASCII diagram, not in prose:

```
access  async_copy  bf16  bf16x2  constant  convert  dotprod  f16
f16x2   f32x2       float i16x2   iket      int      mma_frag  prmt
ptx     swizzle     uniform vector view     wmma
```

None is `#[doc(hidden)]` and none is `#[cfg]`-gated, so all 22 are ordinary public API of a published crate. Between them they hold the packed-type families (`f16x2`, `bf16x2`, `i16x2`, `f32x2`), the register matrix ops (`wmma`, `mma_frag`), constant memory, inline PTX, the swizzle and transaction-width helpers, and the checked view/witness types — so a reader using this table as the crate's index misses most of it.

## Why this is an inventory and not a sample

Every name in the existing table is a real module and every description matches its module, so the table reads as the inventory; it is simply 22 rows short. The additions go in a second table, with each description taken from that module's own `//!` summary line.

## No GPU column on the additions

The floor for these is **per function, not per module** — `int` holds both an intrinsic-free scalar min/max *and* the `sm_90+` `min.relu.s32` — so inventing a per-module floor would be less accurate than pointing at the rustdoc, which states it per item. Where a module's own documentation names an architecture the row keeps it (`f32x2` is native SM100, `int`'s relu clamps are `sm_90+`).

I checked whether the floors could be derived mechanically and they cannot: grepping `sm_` across these files returns measurement notes ("measured on sm_86") as often as requirements, so filling that column would have meant guessing.

## Deliberately untouched

This commit is **insertions only** — the first table, its GPU column and the diagram are unchanged. The diagram's `stmatrix` is not a module (it is part of `tcgen05`, as that table row already says) and `coop_grps` is an abbreviation, but both read as feature labels in a picture rather than inventory claims, so they are left alone.

## Verification

The README's 39 backticked module rows and `src/lib.rs`'s 39 `pub mod` declarations are now the same set, with nothing in the tables that is not a module. Both counts re-measured against `f1e62fe2`. Book builds clean under `sphinx-build -W`; `check-book-api-names.sh` passes.