### PR TITLE
docs(cuda-async): the README's key-methods table omits both non-blocking paths

### DIFF
--- a/crates/cuda-async/README.md
+++ b/crates/cuda-async/README.md
@@ -35,15 +35,21 @@ A lazy, composable unit of GPU work. Implements `Send + Sized + IntoFuture`. Key
 | `.sync_on(&stream)`   | The explicit stream you provide       | Yes            | No        |
 | `.async_on(&stream)`  | The explicit stream you provide       | No             | **Yes**   |
 
-`.async_on` is the only one of the five that is `unsafe`, and it is the only
-one that returns while GPU work may still be in flight: it executes and does
-not synchronize, so the caller owns keeping every buffer the operation touches
-alive and unread until the stream is synchronized by other means. Each of the
-other four ties its result to completion: `.sync` and `.sync_on` block,
+`.async_on` is the only `unsafe` method here, and the only one that returns
+while the GPU may still be working. It launches the work and never
+synchronizes. Until you synchronize the stream yourself, every buffer the
+operation touches must stay alive, and its outputs must not be read. Each of
+the other four ties its result to completion: `.sync` and `.sync_on` block,
 `.await` suspends until the `cuLaunchHostFunc` callback below fires, and
 `.schedule` hands back a `DeviceFuture` that does the same when awaited.
 (`DeviceOperation::execute` is `unsafe` too, but it is the primitive those four
 are built from rather than something to call directly.)
+
+```rust
+// SAFETY: `c_dev` stays alive and unread until the synchronize below.
+let out = unsafe { op.async_on(&stream)? };
+stream.synchronize()?; // now the outputs are safe to read
+```
 
 Combinators: `.and_then(f)`, `.and_then_with_context(f)`, `.arc()`, `zip!(a, b)`, `unzip!(op)`.
 

--- a/crates/cuda-async/README.md
+++ b/crates/cuda-async/README.md
@@ -27,11 +27,23 @@ The crate is organized around a single idea: GPU work is described lazily, sched
 
 A lazy, composable unit of GPU work. Implements `Send + Sized + IntoFuture`. Key methods:
 
-| Method              | Stream chosen by                      | Blocks thread? |
-|---------------------|---------------------------------------|----------------|
-| `.await`            | Default device's `SchedulingPolicy`   | No (suspends)  |
-| `.sync()`           | Default device's `SchedulingPolicy`   | Yes            |
-| `.sync_on(&stream)` | The explicit stream you provide       | Yes            |
+| Method                | Stream chosen by                      | Blocks thread? | `unsafe`? |
+|-----------------------|---------------------------------------|----------------|-----------|
+| `.schedule(&policy)`  | The policy you pass                   | No (returns a `DeviceFuture`) | No |
+| `.await`              | Default device's `SchedulingPolicy`   | No (suspends)  | No        |
+| `.sync()`             | Default device's `SchedulingPolicy`   | Yes            | No        |
+| `.sync_on(&stream)`   | The explicit stream you provide       | Yes            | No        |
+| `.async_on(&stream)`  | The explicit stream you provide       | No             | **Yes**   |
+
+`.async_on` is the only one of the five that is `unsafe`, and it is the only
+one that returns while GPU work may still be in flight: it executes and does
+not synchronize, so the caller owns keeping every buffer the operation touches
+alive and unread until the stream is synchronized by other means. Each of the
+other four ties its result to completion: `.sync` and `.sync_on` block,
+`.await` suspends until the `cuLaunchHostFunc` callback below fires, and
+`.schedule` hands back a `DeviceFuture` that does the same when awaited.
+(`DeviceOperation::execute` is `unsafe` too, but it is the primitive those four
+are built from rather than something to call directly.)
 
 Combinators: `.and_then(f)`, `.and_then_with_context(f)`, `.arc()`, `zip!(a, b)`, `unzip!(op)`.
 


### PR DESCRIPTION
`DeviceOperation` has five scheduling entry points. The README's table lists three: `.await`, `.sync()` and `.sync_on(&stream)`. The two it leaves out are `schedule` and `async_on` — which is to say, **both of the ones that do not block**, under a table whose own column is "Blocks thread?". Every row reads `Yes` or `No (suspends)` because the rows that would read otherwise are absent.

## `async_on` is the one that matters

It is the trait's only `unsafe` scheduling method, and it differs from `sync_on` by exactly one line:

```rust
fn sync_on(...)         { let res = unsafe { self.execute(&ctx) };
                          finish_sync(res, stream.synchronize()) }
unsafe fn async_on(...) { unsafe { self.execute(&ctx) } }
```

So it returns while GPU work may still be in flight, and the caller owns every buffer the operation touches until the stream is synchronized some other way. A reader of this README currently learns nothing about it.

#1028 made the two in-source tables say this, after they had listed `async_on` beside the four safe methods. This README is the **third** table and still did not mention it at all. This adds both missing rows, adds the `unsafe?` column the in-source table gained, and states the consequence in a sentence beneath, so the three tables agree.

`execute` is the trait's other `unsafe fn` and stays out of the table, noted parenthetically instead: it is the primitive the four safe methods are built from rather than an entry point to call.

## Verification

Cross-checked against the source rather than the docs:

- the trait declares exactly `execute`, `schedule`, `sync`, `sync_on` and `async_on` as scheduling methods (`and_then`, `and_then_with_context`, `apply` and `arc` are the combinators the next README line already lists);
- `execute` and `async_on` are the only two `unsafe`;
- `async_on`'s body contains no `synchronize` call and `sync_on`'s does — extracted by brace matching, not a fixed window;
- `schedule` returns a `DeviceFuture`.

All re-measured against `f1e62fe2`.