### PR TITLE
fix(cargo-oxide): `cargo oxide fmt` misses three scopes the fmt gate checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,16 +146,21 @@ hand even so.
 
 - Run `cargo oxide fmt` before submitting. All code must be formatted with
   `rustfmt`. Use `cargo oxide fmt` rather than a bare `cargo fmt`: the codegen
-  backend and every example are their own workspaces, so `cargo fmt` at the
-  repository root reaches none of them, while the `fmt` CI job checks all three
-  scopes and will fail on code you never had a chance to format.
-- Run clippy and address any warnings where reasonable. It has the same three
-  scopes, and there is no single command covering them:
+  backend, every example and the `cuda-macros` device-only test fixture are
+  each their own workspace, so `cargo fmt` at the repository root reaches none
+  of them, while the `fmt` CI job checks all four scopes and will fail on code
+  you never had a chance to format. `cargo oxide fmt` mirrors that job, nested
+  example workspaces included.
+- Run clippy and address any warnings where reasonable. There is no single
+  command covering its scopes, and it has more of them than `fmt`: the two
+  workspaces below, plus one run per example, plus the nested example
+  workspaces that their parent does not list as members, plus the device-only
+  fixture. `.github/workflows/clippy.yml` is the full list; the two worth
+  running by hand are:
 
   ```bash
   cargo clippy --workspace --all-targets -- -D warnings
   (cd crates/rustc-codegen-cuda && cargo clippy --all-targets -- -D warnings)
-  # and per example, as .github/workflows/clippy.yml does
   ```
 - Follow existing code patterns and conventions in the crate you are
   modifying.

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -4021,11 +4021,16 @@ pub fn codegen_debug(
 // Fmt command
 // =============================================================================
 
-/// Format (or check formatting of) all crates in the workspace.
+/// Format (or check formatting of) every scope the `fmt` CI gate checks.
 ///
-/// Runs `cargo fmt --all` in three scopes: root workspace, codegen backend
-/// crate, and every example that has a `Cargo.toml`. In `check` mode,
-/// reports which files need formatting without modifying them.
+/// `.github/workflows/fmt.yml` checks four: the root workspace, the codegen
+/// backend crate, the cuda-macros device-only fixture, and every `Cargo.toml`
+/// under `examples/`, nested ones included. This mirrors that set on purpose --
+/// the reason CONTRIBUTING tells contributors to prefer this command over a
+/// bare `cargo fmt` is so the gate cannot fail on code they had no way to
+/// format, which only holds while the two cover the same ground.
+///
+/// In `check` mode, reports which files need formatting without modifying them.
 pub fn format_all(ctx: &Context, check: bool) {
     let mode = if check { "Checking" } else { "Formatting" };
     let mut failed = false;
@@ -4040,22 +4045,44 @@ pub fn format_all(ctx: &Context, check: bool) {
         failed = true;
     }
 
-    if let Ok(entries) = std::fs::read_dir(&ctx.examples_dir) {
-        let mut examples: Vec<_> = entries.flatten().filter(|e| e.path().is_dir()).collect();
-        examples.sort_by_key(|e| e.file_name());
+    // Its own `[workspace]`, so neither run above reaches it and the examples
+    // walk below never sees it either. The gate carries a dedicated step for
+    // exactly this reason.
+    let fixture = ctx
+        .workspace_root
+        .join("crates")
+        .join("cuda-macros")
+        .join("tests")
+        .join("device-only");
+    if fixture.join("Cargo.toml").is_file() {
+        println!("📦 {} cuda-macros device-only fixture...", mode);
+        if !run_cargo_fmt(&fixture, check) {
+            failed = true;
+        }
+    }
 
-        for entry in examples {
-            let example_name = entry.file_name();
-            let example_path = entry.path();
+    // One `--manifest-path` run per manifest found, rather than `cargo fmt
+    // --all` once per top-level example directory. Both reasons match the gate:
+    //
+    //   * `--all` stops at a nested `[workspace]` boundary, and two examples
+    //     declare one (`cutile_inter_kernel/simt`,
+    //     `interop_cubin_identity/device`), so neither was ever formatted here.
+    //   * `--all` also formats an example's path dependencies, which means
+    //     re-formatting the large shared workspaces once per example.
+    let mut manifests = Vec::new();
+    collect_example_manifests(&ctx.examples_dir, &mut manifests);
+    manifests.sort();
 
-            if !example_path.join("Cargo.toml").exists() {
-                continue;
-            }
-
-            println!("📦 {} example: {}...", mode, example_name.to_string_lossy());
-            if !run_cargo_fmt(&example_path, check) {
-                failed = true;
-            }
+    for manifest in &manifests {
+        let label = manifest
+            .parent()
+            .and_then(|dir| dir.strip_prefix(&ctx.examples_dir).ok())
+            .unwrap_or(Path::new("."))
+            .display()
+            .to_string();
+        println!("📦 {} example: {}...", mode, label);
+        if !run_cargo_fmt_manifest(manifest, check) {
+            failed = true;
         }
     }
 
@@ -4087,12 +4114,61 @@ fn run_cargo_fmt(dir: &Path, check: bool) -> bool {
         cmd.arg("--check");
     }
 
+    run_fmt_command(cmd)
+}
+
+/// Run `cargo fmt` for one manifest. Returns `true` on success.
+///
+/// No `--all`: the caller walks every manifest, so a workspace member is
+/// visited through its own manifest rather than through its parent's.
+fn run_cargo_fmt_manifest(manifest: &Path, check: bool) -> bool {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("fmt").arg("--manifest-path").arg(manifest);
+
+    if check {
+        cmd.arg("--check");
+    }
+
+    run_fmt_command(cmd)
+}
+
+fn run_fmt_command(mut cmd: Command) -> bool {
     match cmd.status() {
         Ok(status) => status.success(),
         Err(e) => {
             eprintln!("  Failed to run cargo fmt: {}", e);
             false
         }
+    }
+}
+
+/// Collect every `Cargo.toml` under `dir`, recursively.
+///
+/// Mirrors the gate's `examples/**/Cargo.toml` glob, with one difference that
+/// only matters off CI: `target` directories are skipped. A fresh checkout has
+/// none, but a working tree does, and a packaged or vendored manifest under one
+/// is not a crate this repository formats.
+fn collect_example_manifests(dir: &Path, out: &mut Vec<PathBuf>) {
+    let manifest = dir.join("Cargo.toml");
+    if manifest.is_file() {
+        out.push(manifest);
+    }
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "target" || name.starts_with('.') {
+            continue;
+        }
+        collect_example_manifests(&path, out);
     }
 }
 
@@ -7055,6 +7131,65 @@ mod tests {
             .expect("system time before unix epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), unique))
+    }
+
+    /// The examples walk backing `cargo oxide fmt` must reach nested manifests
+    /// and skip build directories.
+    ///
+    /// The gate's glob is `examples/**/Cargo.toml`, so a nested manifest is a
+    /// scope of its own; the loop this replaced read only the first level, which
+    /// is how `cutile_inter_kernel/simt` and `interop_cubin_identity/device`
+    /// went unformatted. `target` is skipped because a working tree has one and
+    /// a packaged manifest under it is not a crate this repository formats.
+    #[test]
+    fn collect_example_manifests_reaches_nested_and_skips_target() {
+        let root = unique_temp_dir("cargo_oxide_fmt_walk");
+        let write = |rel: &str| {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "[package]\nname = \"x\"\n").unwrap();
+        };
+
+        write("plain/Cargo.toml");
+        write("with_member/Cargo.toml");
+        write("with_member/kernel-lib/Cargo.toml");
+        write("own_workspace/Cargo.toml");
+        write("own_workspace/simt/Cargo.toml");
+        write("built/Cargo.toml");
+        write("built/target/package/vendored/Cargo.toml");
+        write(".hidden/Cargo.toml");
+        std::fs::create_dir_all(root.join("no_manifest_here")).unwrap();
+
+        let mut found = Vec::new();
+        collect_example_manifests(&root, &mut found);
+        let mut got: Vec<String> = found
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/")
+            })
+            .collect();
+        got.sort();
+
+        assert_eq!(
+            got,
+            vec![
+                // `built` itself is a real example; only the manifest inside
+                // its `target/` is skipped.
+                "built/Cargo.toml",
+                "own_workspace/Cargo.toml",
+                "own_workspace/simt/Cargo.toml",
+                "plain/Cargo.toml",
+                "with_member/Cargo.toml",
+                "with_member/kernel-lib/Cargo.toml",
+            ],
+            "expected both nested manifests, and neither the one under target/ \
+             nor the one in a dot directory"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     fn test_materializer_handshake() -> cuda_artifact_finalizer::MaterializerHandshakeV1 {

--- a/cuda-oxide-book/getting-started/installation.md
+++ b/cuda-oxide-book/getting-started/installation.md
@@ -322,8 +322,10 @@ cannot:
 # Arguments after `--` go to cargo; with none it is a plain `cargo test`.
 cargo oxide test -- --lib
 
-# Format the root workspace, the codegen backend, and every example. Each has
-# its own [workspace], so a single `cargo fmt` at the root misses most of them.
+# Format every scope the fmt CI gate checks: the root workspace, the codegen
+# backend, the cuda-macros device-only fixture, and every manifest under
+# examples/ including nested ones. Each is its own [workspace], so a single
+# `cargo fmt` at the root misses most of them.
 cargo oxide fmt
 cargo oxide fmt --check
 


### PR DESCRIPTION
CONTRIBUTING tells contributors to run `cargo oxide fmt` rather than a bare `cargo fmt` for one stated reason: otherwise the gate *"will fail on code you never had a chance to format."* That only holds while the command covers what the gate covers, and **since #1027 it does not**.

`.github/workflows/fmt.yml` checks four scopes: the root workspace, the codegen backend, `crates/cuda-macros/tests/device-only`, and every `Cargo.toml` under `examples/` via a `**` glob — 225 manifests, nested ones included. `format_all` checked three: root, backend, and `cargo fmt --all` in each of the 215 top-level example directories. That misses exactly three manifests:

- **the device-only fixture** — not under `examples/` at all, and it had no scope of its own here (the gate gained one in #1027);
- **`examples/cutile_inter_kernel/simt`**;
- **`examples/interop_cubin_identity/device`**.

The last two are the only nested example manifests declaring their own `[workspace]`, so the parent's `cargo fmt --all` stops before reaching them. The other eight nested manifests are path-dependency members and were already covered.

## Measured, not inferred

With one unformatted function appended to a file in each of the three:

| what | result |
|---|---|
| `cargo fmt --all` in `cutile_inter_kernel` | **exit 0** — missed |
| `cargo fmt --all` in `interop_cubin_identity` | **exit 0** — missed |
| `cargo oxide fmt --check` (old) | walked 185 scopes including **both** parents, reported no failure, and never printed a fixture scope at all |
| the gate's fixture step | exit 1 — caught |
| the gate's `--manifest-path` on each nested manifest | exit 1 — caught |

## The fix

The examples loop becomes one `--manifest-path` run per manifest found, which is what the gate does, for the two reasons the gate's own comment gives: `--all` stops at a nested `[workspace]`, and `--all` also formats an example's path dependencies, so running it per example re-formats the large shared workspaces 215 times.

**That second point was expensive.** The old implementation had not finished 185 of 217 scopes after roughly 25 minutes. The new one covers all 228 in 19–41s depending on cache state.

The walk skips `target` and dot directories. The gate's glob does not need to — a fresh checkout has no build directories — but a working tree does, and a packaged or vendored manifest under one is not a crate this repository formats. A unit test covers the walk: nested manifests found, workspace members found, `target/` and dot directories skipped.

## Three stale documentation sites

All three stated the old three-scope shape and are corrected: the function's own doc comment, CONTRIBUTING's formatting section (whose clippy paragraph also said "the same three scopes" — clippy has more, since #1026), and the `cargo oxide fmt` comment in the book's CLI block. I grepped for other sites stating a scope count; these are the only ones.

## Verification

- **228 scopes visited**, matching the gate's four exactly (root + backend + fixture + 225 manifests).
- With the three probe files unformatted: reports exactly those three diffs, nothing else, exit 1.
- On the clean tree: exit 0.
- `cargo test -p cargo-oxide --all-targets` — 177 pass; `clippy --all-targets -- -D warnings` clean; `cargo fmt` clean.
- `check-cli-doc-coverage.sh` and `check-device-only-build.sh` pass; book builds under `sphinx-build -W`.