### PR TITLE
codegen: accept `char` in device-extern signatures

### DIFF
--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
@@ -177,6 +177,28 @@ extern "C" __device__ float warp_reduce_sum(float val) {
 | `warp_ballot`        | Warp ballot             |
 | `simple_add`         | Simple a + b            |
 | `clamp_value`        | Clamp to range          |
+| `char_to_upper`      | ASCII uppercase, `char` |
+
+### `char` in a `#[device]` extern
+
+Rust `char` is a 32-bit Unicode scalar value, so it already fills a parameter
+slot: it lowers to a plain `i32` with no extension attribute, in the parameter,
+result and pointee positions alike. That is the same lowering `u32` gets, which
+is why the C side declares `char_to_upper` as `unsigned int`:
+
+```text
+.ll:   declare i32 @char_to_upper(i32)      call i32 @char_to_upper(i32 113)
+.ptx:  .extern .func (.param .b32 func_retval0) char_to_upper (.param .b32 ...)
+```
+
+Two caveats:
+
+- A value that is not a Unicode scalar — above `0x10FFFF`, or a surrogate in
+  `0xD800..=0xDFFF` — is undefined behaviour once it reaches the Rust side, the
+  same shape of contract as `bool` and its 0/1 rule. Keep the C function's
+  return value in range.
+- rustc's `improper_ctypes` lint still fires on a `char` in an extern
+  signature; callers may `#[allow(improper_ctypes)]` it.
 
 ### From `extern-libs/cccl_wrappers.cu` (CUB)
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
@@ -45,6 +45,21 @@ extern "C" __device__ float fast_rsqrt(float x) {
 }
 
 /**
+ * Uppercase one Unicode scalar value, ASCII range only.
+ *
+ * Declared `unsigned int` on this side: Rust `char` is a 32-bit Unicode
+ * scalar and lowers to a plain i32 parameter slot with no extension
+ * attribute, so the two signatures line up exactly.
+ *
+ * Returning a value outside the Unicode scalar range (above 0x10FFFF, or a
+ * surrogate in 0xD800..0xDFFF) would be undefined behaviour on the Rust side,
+ * so this only shifts ASCII letters.
+ */
+extern "C" __device__ unsigned int char_to_upper(unsigned int c) {
+    return (c >= 'a' && c <= 'z') ? c - 32u : c;
+}
+
+/**
  * Simple addition - basic device function.
  * Pure function - no memory access.
  */

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -42,7 +42,9 @@ unsafe extern "C" {
     fn simple_add(a: f32, b: f32) -> f32;
     // Rust `char` is a 32-bit Unicode scalar, so it lowers to a plain i32
     // parameter slot with no extension attribute -- the C side declares it
-    // `unsigned int`.
+    // `unsigned int`. `improper_ctypes` still flags `char` (no C equivalent);
+    // the u32 mapping above is the supported ABI, so allow it here.
+    #[allow(improper_ctypes)]
     fn char_to_upper(c: char) -> char;
     fn clamp_value(val: f32, min_val: f32, max_val: f32) -> f32;
     fn smem_write_aligned_128(offset: i32, value: f32);
@@ -708,7 +710,7 @@ fn test_char_ffi_runner(
     println!("--- Test: test_char_ffi ---");
 
     let stream = ctx.default_stream();
-    let mut d_output = stream.alloc_zeros::<u32>(2).unwrap();
+    let d_output = DeviceBuffer::<u32>::zeroed(&stream, 2).unwrap();
 
     let config = LaunchConfig {
         grid_dim: (1, 1, 1),

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -40,6 +40,10 @@ unsafe extern "C" {
     fn warp_reduce_sum(val: f32) -> f32;
     fn warp_ballot(predicate: i32) -> u32;
     fn simple_add(a: f32, b: f32) -> f32;
+    // Rust `char` is a 32-bit Unicode scalar, so it lowers to a plain i32
+    // parameter slot with no extension attribute -- the C side declares it
+    // `unsigned int`.
+    fn char_to_upper(c: char) -> char;
     fn clamp_value(val: f32, min_val: f32, max_val: f32) -> f32;
     fn smem_write_aligned_128(offset: i32, value: f32);
     fn smem_read_aligned_128(offset: i32) -> f32;
@@ -88,6 +92,23 @@ mod kernels {
         if tid.is_multiple_of(32) {
             unsafe {
                 *output.add((tid / 32) as usize) = sum;
+            }
+        }
+    }
+
+    /// Round-trip a `char` through an external `unsigned int` device function.
+    ///
+    /// Exercises `char` in both the parameter and the result position of a
+    /// `#[device]` extern.
+    #[kernel]
+    pub fn test_char_ffi(output: *mut u32) {
+        let tid = cuda_device::thread::threadIdx_x();
+        if tid == 0 {
+            let upper = unsafe { char_to_upper('q') };
+            let unchanged = unsafe { char_to_upper('Z') };
+            unsafe {
+                *output = upper as u32;
+                *output.add(1) = unchanged as u32;
             }
         }
     }
@@ -526,6 +547,7 @@ fn main() {
     let mut tests_failed = 0;
 
     test_simple_device_funcs_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
+    test_char_ffi_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_cub_warp_reduce_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_mixed_attrs_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_smem_alignment_cross_module_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
@@ -669,6 +691,53 @@ fn test_cub_warp_reduce_runner(
         *passed += 1;
     } else {
         println!("    ✗ FAILED ({} errors)", errors);
+        *failed += 1;
+    }
+}
+
+/// Test: `char` across a `#[device]` extern boundary.
+///
+/// `char_to_upper` is declared `unsigned int` in the .cu and `char` in Rust.
+/// Both lower to a plain i32 slot, so the two agree without a wrapper.
+fn test_char_ffi_runner(
+    ctx: &Arc<CudaContext>,
+    module: &kernels::LoadedModule,
+    passed: &mut i32,
+    failed: &mut i32,
+) {
+    println!("--- Test: test_char_ffi ---");
+
+    let stream = ctx.default_stream();
+    let mut d_output = stream.alloc_zeros::<u32>(2).unwrap();
+
+    let config = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (1, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    // SAFETY: launch shape/resources match the kernel; the buffer covers both writes.
+    unsafe {
+        module.test_char_ffi(
+            (stream).as_ref(),
+            config,
+            d_output.cu_deviceptr() as *mut u32,
+        )
+    }
+    .expect("Kernel launch failed");
+
+    let h_output = d_output.to_host_vec(&stream).unwrap();
+    let expected = [u32::from('Q'), u32::from('Z')];
+
+    if h_output[..2] == expected {
+        println!("    ✓ PASSED ('q' -> 'Q', 'Z' unchanged)");
+        *passed += 1;
+    } else {
+        println!(
+            "    ✗ FAILED (got {:?}, expected {:?})",
+            &h_output[..2],
+            expected
+        );
         *failed += 1;
     }
 }

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -228,11 +228,7 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 // Rust's `*mut ()` is its common spelling for a void pointer.
                 E::Integer(8)
             } else {
-                rustc_ty_to_device_extern_type(
-                    tcx,
-                    *pointee,
-                    DeviceExternTypePosition::Pointee,
-                )?
+                rustc_ty_to_device_extern_type(tcx, *pointee, DeviceExternTypePosition::Pointee)?
             };
             Ok(E::pointer_to(pointee, 0))
         }
@@ -240,11 +236,8 @@ fn rustc_ty_to_device_extern_type<'tcx>(
             let len = len.try_to_target_usize(tcx).ok_or_else(|| {
                 format!("device-extern array length for `{ty}` is not a concrete constant")
             })?;
-            let element = rustc_ty_to_device_extern_type(
-                tcx,
-                *element,
-                DeviceExternTypePosition::Pointee,
-            )?;
+            let element =
+                rustc_ty_to_device_extern_type(tcx, *element, DeviceExternTypePosition::Pointee)?;
             Ok(E::Array {
                 element: Box::new(element),
                 len,
@@ -265,9 +258,16 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 Ok(E::ZeroExtInteger(1))
             }
         }
-        TyKind::Char => Err(
-            "Rust `char` is not supported in device extern signatures; use `u32` in a C-compatible wrapper".to_string(),
-        ),
+        // `char` is a 32-bit Unicode scalar value, so it already fills a
+        // parameter slot and needs no extension attribute in any position --
+        // plain i32 by value, behind a pointer, and as a result, exactly as
+        // `u32` lowers. The C side declares it `unsigned int`.
+        //
+        // Rust requires the value to be a Unicode scalar: a device function
+        // handing back anything above 0x10FFFF, or a surrogate in
+        // 0xD800..=0xDFFF, is UB on the Rust side -- the same shape of
+        // contract as `bool` and its 0/1 rule above.
+        TyKind::Char => unsigned_integer(32),
         TyKind::Never => Err("never-returning device externs are not yet supported".to_string()),
         _ => Err(format!(
             "unsupported device-extern ABI type `{ty}`; use scalar C types or raw pointers to supported scalar/array pointees"


### PR DESCRIPTION
Fixes #875, following @nihalpasham's spec in [this comment](https://github.com/NVlabs/cuda-oxide/issues/875#issuecomment-5291377721).

## The change

`TyKind::Char` in `rustc_ty_to_device_extern_type` now routes through the same `unsigned_integer` helper `u32` uses:

```rust
TyKind::Char => unsigned_integer(32),
```

Not the `bool` shape and not `ZeroExtInteger(32)`. Extension attributes widen sub-32-bit values into a 32-bit slot; `char` is already 32 bits and fills the slot as it stands, so it lowers to a plain `i32` in the parameter, result and pointee positions alike.

## Test surface

Per the updated acceptance criteria, `device_ffi_test` is the surface rather than a `TyCtxt` unit test:

- `extern-libs/external_device_funcs.cu` gains `unsigned int char_to_upper(unsigned int)` — ASCII uppercase only, so its return value can never leave the Unicode scalar range.
- `src/main.rs` declares it as `fn char_to_upper(c: char) -> char;` in the existing `#[device]` extern block, exercising `char` in both the parameter and the result position, and adds a `test_char_ffi` kernel that round-trips `'q'` (expects `'Q'`) and `'Z'` (expects `'Z'`), with a host runner asserting both exactly.
- The example README documents the mapping, the expected `.ll` / `.ptx` shape, and both caveats: a value outside the Unicode scalar range (above `0x10FFFF`, or a surrogate in `0xD800..=0xDFFF`) is UB once it reaches Rust, and rustc's `improper_ctypes` lint still fires on `char` externs.

## Test plan

- Ran: `cargo check` in `crates/rustc-codegen-cuda` — clean.
- Ran: `cargo clippy` in `crates/rustc-codegen-cuda` — no new errors or warnings.
- Ran: `cargo fmt --check` — clean (see the note below).
- Ran: `rustfmt --edition 2024 --check` on the example's `main.rs` — clean.
- Not run: `scripts/smoketest.sh device_ffi_test` — no NVIDIA device on this machine. The expected values in the new runner are the exact `'q' -> 'Q'`, `'Z' -> 'Z'` round trip, so a mismatch fails loudly rather than silently.

## One incidental hunk

`cargo fmt` reflows two calls in the same `match` (`rustc_ty_to_device_extern_type` in the `RawPtr` and `Array` arms) that it had previously left alone. The old `TyKind::Char` arm held an over-long string literal, which made rustfmt give up on formatting the enclosing expression; with that line gone it formats the arm bodies it could not reach before. The tree is `cargo fmt --check` clean before and after, so I took rustfmt's output rather than fighting it — happy to drop those two hunks if you would rather keep the diff to the one arm.