### PR TITLE
cargo-oxide: hold the fmt gate and `cargo oxide fmt` to one scope list

### DIFF
--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -438,7 +438,7 @@ pub fn resolve_context() -> Context {
 pub fn resolve_passive_context() -> Context {
     if let Some(workspace_root) = backend::find_workspace_root() {
         let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
-        let examples_dir = codegen_crate.join("examples");
+        let examples_dir = workspace_root.join(FMT_EXAMPLES_DIR);
         let config = load_oxide_config_lenient(&workspace_root);
         let backend_so = backend::backend_so_candidate(&workspace_root, config.backend.as_deref());
         return Context {
@@ -4021,16 +4021,6 @@ pub fn codegen_debug(
 // Fmt command
 // =============================================================================
 
-/// Format (or check formatting of) every scope the `fmt` CI gate checks.
-///
-/// `.github/workflows/fmt.yml` checks four: the root workspace, the codegen
-/// backend crate, the cuda-macros device-only fixture, and every `Cargo.toml`
-/// under `examples/`, nested ones included. This mirrors that set on purpose --
-/// the reason CONTRIBUTING tells contributors to prefer this command over a
-/// bare `cargo fmt` is so the gate cannot fail on code they had no way to
-/// format, which only holds while the two cover the same ground.
-///
-/// In `check` mode, reports which files need formatting without modifying them.
 /// Directories `cargo oxide fmt` formats in their own right, relative to the
 /// workspace root, with the label each is announced under.
 ///
@@ -4060,6 +4050,16 @@ pub(crate) const FIXED_FMT_SCOPES: &[(&str, &str)] = &[
 /// with it.
 pub(crate) const FMT_EXAMPLES_DIR: &str = "crates/rustc-codegen-cuda/examples";
 
+/// Format (or check formatting of) every scope the `fmt` CI gate checks.
+///
+/// `.github/workflows/fmt.yml` checks four: the root workspace, the codegen
+/// backend crate, the cuda-macros device-only fixture, and every `Cargo.toml`
+/// under `examples/`, nested ones included. This mirrors that set on purpose --
+/// the reason CONTRIBUTING tells contributors to prefer this command over a
+/// bare `cargo fmt` is so the gate cannot fail on code they had no way to
+/// format, which only holds while the two cover the same ground.
+///
+/// In `check` mode, reports which files need formatting without modifying them.
 pub fn format_all(ctx: &Context, check: bool) {
     let mode = if check { "Checking" } else { "Formatting" };
     let mut failed = false;

--- a/crates/cargo-oxide/src/commands.rs
+++ b/crates/cargo-oxide/src/commands.rs
@@ -388,7 +388,7 @@ pub struct Context {
 pub fn resolve_context() -> Context {
     if let Some(workspace_root) = backend::find_workspace_root() {
         let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
-        let examples_dir = codegen_crate.join("examples");
+        let examples_dir = workspace_root.join(FMT_EXAMPLES_DIR);
         let config = load_oxide_config(&workspace_root);
         let backend_so = backend::find_or_build_backend(&workspace_root, config.backend.as_deref());
         return Context {
@@ -4031,32 +4031,46 @@ pub fn codegen_debug(
 /// format, which only holds while the two cover the same ground.
 ///
 /// In `check` mode, reports which files need formatting without modifying them.
+/// Directories `cargo oxide fmt` formats in their own right, relative to the
+/// workspace root, with the label each is announced under.
+///
+/// These mirror the fixed steps in `.github/workflows/fmt.yml`. The mirroring
+/// used to be convention only, and the gate grew a fourth scope while this
+/// command kept three (#1047), so contributors could format everything locally
+/// and still fail CI. `fmt_gate_and_cargo_oxide_fmt_cover_the_same_scopes`
+/// reads the workflow and fails when the two sets diverge.
+///
+/// The example crates are not listed: both sides walk
+/// `crates/rustc-codegen-cuda/examples` for manifests instead, which the same
+/// test checks separately.
+pub(crate) const FIXED_FMT_SCOPES: &[(&str, &str)] = &[
+    (".", "root workspace"),
+    ("crates/rustc-codegen-cuda", "rustc-codegen-cuda"),
+    // Its own `[workspace]`, so the root run does not reach it and the examples
+    // walk never sees it either. The gate carries a dedicated step for exactly
+    // this reason.
+    (
+        "crates/cuda-macros/tests/device-only",
+        "cuda-macros device-only fixture",
+    ),
+];
+
+/// Directory both sides walk for example manifests, relative to the workspace
+/// root. Kept beside [`FIXED_FMT_SCOPES`] because the gate's glob has to agree
+/// with it.
+pub(crate) const FMT_EXAMPLES_DIR: &str = "crates/rustc-codegen-cuda/examples";
+
 pub fn format_all(ctx: &Context, check: bool) {
     let mode = if check { "Checking" } else { "Formatting" };
     let mut failed = false;
 
-    println!("📦 {} root workspace...", mode);
-    if !run_cargo_fmt(&ctx.workspace_root, check) {
-        failed = true;
-    }
-
-    println!("📦 {} rustc-codegen-cuda...", mode);
-    if !run_cargo_fmt(&ctx.codegen_crate, check) {
-        failed = true;
-    }
-
-    // Its own `[workspace]`, so neither run above reaches it and the examples
-    // walk below never sees it either. The gate carries a dedicated step for
-    // exactly this reason.
-    let fixture = ctx
-        .workspace_root
-        .join("crates")
-        .join("cuda-macros")
-        .join("tests")
-        .join("device-only");
-    if fixture.join("Cargo.toml").is_file() {
-        println!("📦 {} cuda-macros device-only fixture...", mode);
-        if !run_cargo_fmt(&fixture, check) {
+    for (scope, label) in FIXED_FMT_SCOPES {
+        let dir = ctx.workspace_root.join(scope);
+        if !dir.join("Cargo.toml").is_file() {
+            continue;
+        }
+        println!("📦 {} {}...", mode, label);
+        if !run_cargo_fmt(&dir, check) {
             failed = true;
         }
     }
@@ -7131,6 +7145,71 @@ mod tests {
             .expect("system time before unix epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), unique))
+    }
+
+    /// The fmt gate and `cargo oxide fmt` are two implementations of one scope
+    /// list. #1047 was that list drifting: the gate grew a fourth scope and the
+    /// command kept three, so a contributor could format everything locally and
+    /// still fail CI. Read the workflow and hold the two sets together.
+    #[test]
+    fn fmt_gate_and_cargo_oxide_fmt_cover_the_same_scopes() {
+        let workflow = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join(".github/workflows/fmt.yml");
+        let yaml = std::fs::read_to_string(&workflow)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", workflow.display()));
+
+        // Every step that runs a whole-directory `cargo fmt` contributes one
+        // scope: the directory named by a following `working-directory:`, or
+        // the workspace root when the step has none.
+        let mut gate_scopes: Vec<String> = Vec::new();
+        let mut lines = yaml.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim() != "run: cargo fmt --all -- --check" {
+                continue;
+            }
+            let scope = match lines.peek().map(|next| next.trim()) {
+                Some(next) if next.starts_with("working-directory:") => next
+                    .trim_start_matches("working-directory:")
+                    .trim()
+                    .to_string(),
+                _ => ".".to_string(),
+            };
+            gate_scopes.push(scope);
+        }
+        gate_scopes.sort();
+
+        let mut command_scopes: Vec<String> = FIXED_FMT_SCOPES
+            .iter()
+            .map(|(scope, _)| (*scope).to_string())
+            .collect();
+        command_scopes.sort();
+
+        assert_eq!(
+            gate_scopes, command_scopes,
+            "fmt.yml and FIXED_FMT_SCOPES disagree; a scope added to one needs the other"
+        );
+
+        // Both sides then walk the same directory for example manifests. The
+        // gate spells it as a glob, so compare against that.
+        let glob = format!("{FMT_EXAMPLES_DIR}/**/Cargo.toml");
+        assert!(
+            yaml.contains(&glob),
+            "fmt.yml does not glob {glob}; FMT_EXAMPLES_DIR and the gate disagree"
+        );
+
+        // A scope the command lists has to be a real directory, or it silently
+        // formats nothing while the gate still checks it.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for (scope, _) in FIXED_FMT_SCOPES {
+            let manifest = root.join(scope).join("Cargo.toml");
+            assert!(
+                manifest.is_file(),
+                "FIXED_FMT_SCOPES names {scope}, which has no Cargo.toml"
+            );
+        }
+        assert!(root.join(FMT_EXAMPLES_DIR).is_dir());
     }
 
     /// The examples walk backing `cargo oxide fmt` must reach nested manifests


### PR DESCRIPTION
Closes #1048, taking the first of the two options there — the check that compares the gate's scopes against the command's — since the second needs a cached backend binary the fmt job does not have.

## What changed

`format_all` hand-unrolled its three fixed scopes as three blocks. They are now one list:

```rust
pub(crate) const FIXED_FMT_SCOPES: &[(&str, &str)] = &[
    (".", "root workspace"),
    ("crates/rustc-codegen-cuda", "rustc-codegen-cuda"),
    ("crates/cuda-macros/tests/device-only", "cuda-macros device-only fixture"),
];
```

and `format_all` iterates it. The `Cargo.toml` existence check that guarded only the device-only fixture now guards every scope, which is what the fixture's block was doing anyway.

`fmt_gate_and_cargo_oxide_fmt_cover_the_same_scopes` reads `.github/workflows/fmt.yml` and takes the directory from each whole-directory `cargo fmt` step — the `working-directory:` that follows it, or the workspace root when there is none — then compares that set against `FIXED_FMT_SCOPES`.

The examples walk is held the same way: `FMT_EXAMPLES_DIR` now names the directory `resolve_context` builds `examples_dir` from, and the test asserts the gate globs `{FMT_EXAMPLES_DIR}/**/Cargo.toml`. So the constant is load-bearing rather than a second copy of the path.

The test also asserts every listed scope really has a `Cargo.toml`, so a rename cannot leave the command silently formatting nothing while the gate still checks it.

## Test plan

- Ran: `cargo test -p cargo-oxide` — 178 passed, 0 failed (177 pre-existing + 1 new).
- Ran: `cargo clippy -p cargo-oxide --all-targets` — 0 warnings.
- Ran: `cargo fmt --all -- --check` — clean.
- Checked: reproduced the #1047 drift by adding a fourth `working-directory:` step to `fmt.yml` and leaving the command alone. The check fails with the diff spelled out:

```
assertion `left == right` failed: fmt.yml and FIXED_FMT_SCOPES disagree;
a scope added to one needs the other
  left:  [".", "crates/cuda-host", "crates/cuda-macros/tests/device-only", "crates/rustc-codegen-cuda"]
  right: [".", "crates/cuda-macros/tests/device-only", "crates/rustc-codegen-cuda"]
```

## Scope

Deliberately text-level rather than a YAML dependency: the shape it has to recognise is "a step running `cargo fmt --all -- --check`, optionally with a `working-directory:`", which is what the gate writes today and what a new scope would be written as. If the gate ever moves to a matrix or a composite action this needs revisiting, and the assertion message says which two places disagree so that is a visible failure rather than a silent pass.