### PR TITLE
cuda-macros: reject a variadic `#[device]` extern at expansion

### DIFF
--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -6928,6 +6928,22 @@ fn generate_device_extern_block(mut input: ItemForeignMod) -> TokenStream {
                 return err;
             }
 
+            // `...` is purely syntactic, so it can be refused here rather than
+            // in device codegen. That gives the user a span on the offending
+            // tokens instead of a signature-less error at final-binary codegen,
+            // and it also catches a variadic extern that is declared but never
+            // called -- the collector only registers externs reached from
+            // kernel MIR, so that one used to compile clean.
+            //
+            // The codegen rejection stays: the collector recognises device
+            // externs by their reserved name prefix, so a hand-written extern
+            // block never passes through this macro at all.
+            if let Some(variadic) = &foreign_fn.sig.variadic {
+                return syn::Error::new_spanned(variadic, "#[device] externs cannot be variadic")
+                    .to_compile_error()
+                    .into();
+            }
+
             // Save original info for wrapper generation
             let original_name = foreign_fn.sig.ident.clone();
             let original_attrs = foreign_fn.attrs.clone();

--- a/crates/cuda-macros/tests/compile_fail/device_extern_variadic.rs
+++ b/crates/cuda-macros/tests/compile_fail/device_extern_variadic.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_macros::device;
+
+#[device]
+unsafe extern "C" {
+    fn variadic_helper(x: f32, ...) -> f32;
+}
+
+fn main() {}

--- a/crates/cuda-macros/tests/compile_fail/device_extern_variadic.stderr
+++ b/crates/cuda-macros/tests/compile_fail/device_extern_variadic.stderr
@@ -1,0 +1,5 @@
+error: #[device] externs cannot be variadic
+ --> tests/compile_fail/device_extern_variadic.rs:8:32
+  |
+8 |     fn variadic_helper(x: f32, ...) -> f32;
+  |                                ^^^

--- a/crates/cuda-macros/tests/macro_guard.rs
+++ b/crates/cuda-macros/tests/macro_guard.rs
@@ -14,6 +14,7 @@ fn macro_guards() {
     t.compile_fail("tests/compile_fail/device_reserved_name.rs");
     t.compile_fail("tests/compile_fail/device_extern_reserved_name.rs");
     t.compile_fail("tests/compile_fail/device_extern_wrong_abi.rs");
+    t.compile_fail("tests/compile_fail/device_extern_variadic.rs");
     t.compile_fail("tests/compile_fail/kernel_legacy_const_instantiation.rs");
     t.compile_fail("tests/compile_fail/kernel_legacy_lifetime_instantiation.rs");
     t.compile_fail("tests/compile_fail/kernel_impl_trait_parameter.rs");


### PR DESCRIPTION
Fixes #876, following @nihalpasham's spec in [this comment](https://github.com/NVlabs/cuda-oxide/issues/876#issuecomment-5291377911) — including both corrections.

## The change

`generate_device_extern_block` now refuses `...` where it is written, six lines modelled on the spanned ABI check just above it:

```rust
if let Some(variadic) = &foreign_fn.sig.variadic {
    return syn::Error::new_spanned(variadic, "#[device] externs cannot be variadic")
        .to_compile_error()
        .into();
}
```

Both holes close together:

| | before | after |
|---|---|---|
| declared **and** called | late error, no file, no line, no span | spanned error at expansion |
| declared, never called | compiles clean | spanned error at expansion |

The second was the quieter one: the collector only registers externs reached from kernel MIR, so a variadic device extern nobody called went through untouched.

What the user sees now:

```
error: #[device] externs cannot be variadic
 --> tests/compile_fail/device_extern_variadic.rs:8:32
  |
8 |     fn variadic_helper(x: f32, ...) -> f32;
  |                                ^^^
```

## What deliberately did not change

- The `c_variadic` rejection in `device_codegen.rs` stays a real error, not an assertion. The collector detects device externs by their reserved name prefix, so a hand-written extern block never passes through this macro and the backend check is the only gate on that path.
- Nothing was lifted for `char` / `f128` / arrays-by-value. Those need resolved types — `type MyF = f128;` or a generic hides the type from a syntactic macro. `...` is the one purely syntactic check, which is why it belongs here.

## Test plan

- Added the trybuild fixture pair `tests/compile_fail/device_extern_variadic.{rs,stderr}`, modelled on `device_extern_wrong_abi`, and registered it in `tests/macro_guard.rs` beside it.
- Ran: `trybuild` against the fixture on the pinned `nightly-2026-04-03` — passes, and the checked-in `.stderr` is the exact output trybuild generated rather than a hand-written guess.
- Ran: `cargo fmt --all -- --check` — clean.
- Not run: `cargo test -p cuda-macros` in full. Its dev-dependency chain reaches `cuda-bindings`, which needs `cuda.h`, and this machine has no CUDA toolkit. The fixture was therefore exercised through a scratch harness depending only on `cuda-macros` (which is all the fixture uses — `use cuda_macros::device;`), so the fixture path and hence the `-->` line in the `.stderr` match what `macro_guard.rs` will produce.