### PR TITLE
docs(book): the dialect-nvvm counts predate the catalog, by the page's own test

### DIFF
--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -296,16 +296,16 @@ they become `call` instructions to `@llvm.nvvm.*` intrinsics.
 
 ### Architecture Coverage
 
-At catalog SHA-256 `20440c06` (the stamp in every `ops/generated/` file
-header), the dialect holds 560 operations across 42 modules, and they come
+At catalog SHA-256 `26a9cc13` (the stamp in every `ops/generated/` file
+header), the dialect holds 570 operations across 42 modules, and they come
 from two different places. The split is the first thing to know about it,
 because it decides where -- and whether -- you would add one. If the header
-stamp no longer starts with `20440c06`, the counts on this page predate the
+stamp no longer starts with `26a9cc13`, the counts on this page predate the
 catalog you are reading.
 
 **Hand-written**, directly under `crates/dialect-nvvm/src/ops/`. These are the
 ops with bespoke verification or lowering that the intrinsic catalog does not
-describe. There are seven modules and 19 operations:
+describe. There are seven modules and 21 operations:
 
 | Module    | Description                                                 | Ops |
 | :-------- | :---------------------------------------------------------- | --: |
@@ -315,12 +315,12 @@ describe. There are seven modules and 19 operations:
 | `debug`   | `assertfail`, `vprintf`                                     |   2 |
 | `grid`    | Cooperative `grid_sync`                                     |   1 |
 | `memory`  | Generic-to-shared address conversion with a byte offset     |   1 |
-| `wgmma`   | Warpgroup MMA descriptors and the m64n64k16 bf16 shapes     |   7 |
+| `wgmma`   | Warpgroup MMA descriptors and the m64n64k16 bf16/f16 shapes |   9 |
 
 **Generated**, under `ops/generated/`, from `intrinsics/catalog.json` by
 `cuda-intrinsics-gen`. Every file there opens with `// @generated ... DO NOT
 EDIT.`, and editing one by hand is undone by the next generator run. This is
-the large majority -- 35 modules and 541 operations, resolved from 1002 catalog
+the large majority -- 35 modules and 549 operations, resolved from 1010 catalog
 entries, since several intrinsics can share one structural op:
 
 | Area                        | Modules                                                                       | Ops |
@@ -330,7 +330,7 @@ entries, since several intrinsics can share one structural op:
 | Special registers           | `sreg`                                                                        |  44 |
 | Packed (SIMD-in-register)   | `packed_alu`, `packed_conversion`, `packed_atomic`                            |  51 |
 | Async copy and barriers     | `cp_async`, `mbarrier_extended`, `mbarrier_basic`, `sync`                     |  34 |
-| Warp-level                  | `warp_shuffle`, `redux`, `vote`, `warp_match`, `warp_barrier`, `active_mask`, `elect` |  31 |
+| Warp-level                  | `warp_shuffle`, `redux`, `vote`, `warp_match`, `warp_barrier`, `active_mask`, `elect` |  39 |
 | Matrix fragment movement    | `ldmatrix`, `register_mma`, `stmatrix`, `wgmma_control`, `movmatrix`, `sparse_mma` |  22 |
 | Execution and debug control | `execution_control`, `debug_control`                                          |  11 |
 | Cluster                     | `clc`, `cluster_barrier`, `cluster_memory`                                    |  10 |


### PR DESCRIPTION
`mlir-dialects.md` anchors its op counts to a catalog stamp and says how to tell when they have rotted:

> At catalog SHA-256 `20440c06` (the stamp in every `ops/generated/` file header), the dialect holds 560 operations across 42 modules … **If the header stamp no longer starts with `20440c06`, the counts on this page predate the catalog you are reading.**

Every generated file now stamps `26a9cc13`, so that condition is true.

| claim | page | tree |
|---|--:|--:|
| dialect total | 560 | **570** |
| hand-written ops | 19 | **21** |
| hand-written `wgmma` row | 7 | **9** |
| generated ops | 541 | **549** |
| catalog entries | 1002 | **1010** |
| generated "Warp-level" row | 31 | **39** |

Both deltas are traceable. #1021 and #1025 added two hand-written `wgmma` ops (19 → 21). #1032 added the eight `redux.sync` f32 variants, which moves the generated total, the catalog count, and the one area row that owns `redux` (541 → 549, 1002 → 1010, 31 → 39).

## The description moved with the count, not just the number

The `wgmma` row read "the m64n64k16 **bf16** shapes". #1025 added `WgmmaMmaM64N64K16F32F16Op` and `WgmmaMmaGroupValuesM64N64K16F32F16Op`, so the module holds f16 shapes too — the row now says `bf16/f16`. A count fix that left that alone would have replaced one wrong statement with another.

Module counts did not change: 7 hand-written plus 35 generated is still 42.

## Verification

Measured against the tree, not against the merge descriptions:

- `^pub struct \w+Op;` counts **21** under `src/ops/` and **549** under `src/ops/generated/` — **570** together.
- `intrinsics/catalog.json` holds **1010** entries.
- All 35 generated files carry exactly one distinct stamp, `26a9cc13`.
- Both tables sum to their new totals (7 rows → 21, 11 rows → 549), and each still lists every module on disk with nothing in it that is not a module.
- Book builds clean under `sphinx-build -W`.