### PR TITLE
docs(book): the warp chapter says the f32 redux.sync form does not exist

### DIFF
--- a/cuda-oxide-book/advanced/warp-level-programming.md
+++ b/cuda-oxide-book/advanced/warp-level-programming.md
@@ -183,18 +183,22 @@ own entry point.
 
 The `.NaN` forms matter for reductions that must not lose a NaN. The plain and
 `.abs` forms *ignore* NaN inputs; the `.NaN` forms propagate NaN when any lane
-contributes one. Pick deliberately -- the two differ only when a lane holds a
-NaN, which is exactly when it matters.
+contributes one. Pick deliberately. The two differ only when a lane holds a
+NaN, and that is when the choice matters.
 
-**This is Blackwell-only, and narrower than "sm_100+".** The catalog records
-the family at PTX 8.6 with a target union of
-`sm_100a|sm_100f|sm_103a|sm_103f`, so it is not selected on `sm_110a` or
-`sm_120a` -- consumer Blackwell included. Build for one of those four targets
-or the intrinsic will not lower.
+Say one lane holds `NaN` and the smallest ordinary value in the warp is `-1.0`:
 
-The `redux_f32` example is the working reference. It pins `sm_100a`, so CI
-compiles it and checks the emitted PTX rather than running it, and its `main`
-skips unless the device reports exactly `sm_100`.
+- `redux_sync_min_f32(mask, v)` returns `-1.0` (the NaN is ignored)
+- `redux_sync_min_nan_f32(mask, v)` returns `NaN` (the NaN propagates)
+
+**This is Blackwell-only, and narrower than "sm_100+".** The f32 forms need
+PTX 8.6 and exist only on `sm_100a`, `sm_100f`, `sm_103a`, and `sm_103f`. They
+are not available on `sm_110a` or `sm_120a`, so consumer Blackwell is out.
+Build for one of those four targets or compilation fails.
+
+The `redux_f32` example is the working reference. It builds for `sm_100a`, so
+CI compiles it and checks the emitted PTX rather than running it. Its `main`
+skips unless the device reports `sm_100` and nothing else.
 
 ---
 

--- a/cuda-oxide-book/advanced/warp-level-programming.md
+++ b/cuda-oxide-book/advanced/warp-level-programming.md
@@ -149,8 +149,9 @@ an inner loop.
 
 Three constraints:
 
-- **Integers only.** There is no `f32`/`f64` form before `sm_100`, so float
-  reductions keep the butterfly.
+- **Integers only on Ampere.** There is an `f32` form, but it needs Blackwell;
+  see the next subsection. `f64` has no `redux.sync` form at all, so `f64`
+  reductions keep the butterfly everywhere.
 - **A full, converged warp.** All 32 lanes must be live and must reach the same
   call with the same mask -- the same contract the shuffle reductions already
   require. Sub-warp tiles and short tail warps keep the shuffle path (see
@@ -163,6 +164,37 @@ Three constraints:
 automatically needs a way for device code to know its target architecture,
 which is the open question in
 [#811](https://github.com/NVlabs/cuda-oxide/issues/811).
+
+### Floats on Blackwell: `redux.sync` for `f32`
+
+`redux.sync` gained an `f32` min/max form, exposed as eight functions. Each
+takes `(mask: u32, value: f32)` and returns `f32`, like the integer ones:
+
+| function | reduces |
+|:---------|:--------|
+| `warp::redux_sync_min_f32` / `warp::redux_sync_max_f32` | minimum / maximum, NaN inputs ignored |
+| `warp::redux_sync_min_abs_f32` / `warp::redux_sync_max_abs_f32` | same, over the absolute values (`.abs`) |
+| `warp::redux_sync_min_nan_f32` / `warp::redux_sync_max_nan_f32` | NaN-propagating (`.NaN`) |
+| `warp::redux_sync_min_abs_nan_f32` / `warp::redux_sync_max_abs_nan_f32` | both modifiers |
+
+So unlike the integer family this is not one function per operation: `.abs`
+and `.NaN` are independent instruction modifiers, and each combination is its
+own entry point.
+
+The `.NaN` forms matter for reductions that must not lose a NaN. The plain and
+`.abs` forms *ignore* NaN inputs; the `.NaN` forms propagate NaN when any lane
+contributes one. Pick deliberately -- the two differ only when a lane holds a
+NaN, which is exactly when it matters.
+
+**This is Blackwell-only, and narrower than "sm_100+".** The catalog records
+the family at PTX 8.6 with a target union of
+`sm_100a|sm_100f|sm_103a|sm_103f`, so it is not selected on `sm_110a` or
+`sm_120a` -- consumer Blackwell included. Build for one of those four targets
+or the intrinsic will not lower.
+
+The `redux_f32` example is the working reference. It pins `sm_100a`, so CI
+compiles it and checks the emitted PTX rather than running it, and its `main`
+skips unless the device reports exactly `sm_100`.
 
 ---
 


### PR DESCRIPTION
`warp-level-programming.md` closes its `redux.sync` section with:

> - **Integers only.** There is no `f32`/`f64` form before `sm_100`, so float reductions keep the butterfly.

#1032 shipped that form. `cuda-device` now exports eight `f32` entry points the chapter mentions nowhere:

```
redux_sync_min_f32          redux_sync_max_f32
redux_sync_min_abs_f32      redux_sync_max_abs_f32
redux_sync_min_nan_f32      redux_sync_max_nan_f32
redux_sync_min_abs_nan_f32  redux_sync_max_abs_nan_f32
```

A reader following this page today writes the shuffle butterfly for an `f32` min/max reduction the hardware does in one instruction, because the book told them the instruction does not exist. `f64` still has no form, so that half of the claim stands and is kept.

## Three things the new subsection is careful about

**It is not one function per operation.** The integer family is, and the page says so. For `f32`, `.abs` and `.NaN` are independent instruction modifiers, so each of the four combinations is its own entry point.

**The `.NaN` distinction is stated in the catalog's own terms.** The plain and `.abs` forms ignore NaN inputs; the `.NaN` forms propagate NaN when any lane contributes one. That is the difference that decides which to call, and it comes from the catalog summaries rather than from my own gloss on IEEE semantics.

**The floor is narrower than "sm_100+".** The catalog records PTX 8.6 with a target union of `sm_100a|sm_100f|sm_103a|sm_103f`, so the intrinsic is not selected on `sm_110a` or `sm_120a` — consumer Blackwell included. Saying just "Blackwell" would send RTX-50 users down a path that cannot lower.

## No performance claim

The integer section's 4.74x is a measurement on an A10G. The f32 family needs a B200/GB200, `redux_f32` sits in `SM100_COMPILE_EXAMPLES` so CI checks its emitted PTX rather than running it, and its `main` skips unless the device reports exactly `sm_100`. The subsection says that instead of implying a number.

## Verification

- All eight names exist as `pub fn` in `crates/cuda-device/src/warp.rs`.
- Arch union, PTX version and NaN/abs semantics all come from `intrinsics/catalog.json`.
- Every one of the eight is written module-qualified, so `check-book-api-names.sh` now covers all of them: it checks **39** qualified names where it checked 35, and renaming one to `redux_sync_max_abs_nan_f64` makes it fail.
- Book builds clean under `sphinx-build -W`.