### PR TITLE
docs(book): the feature appendix has no row for tensor cores, and calls FP8 Planned

### DIFF
--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -217,6 +217,7 @@ Anonymous promoted allocations remain unsupported.
 | Warp Shuffle Operations | **Full** | `shuffle`, `shuffle_xor`, `shuffle_down`, `shuffle_up`. Unsuffixed forms take `u32`; `_f32`, `_u64`, `_f64` variants and a `_sync` form of each. |
 | Warp Vote Operations | **Full** | `all(pred)`, `any(pred)`, `ballot(pred)` → bitmask. |
 | Lane/Warp ID | **Full** | `lane_id()` (0–31), `warp_id()`. Direct register reads. |
+| Warp Reduction (`redux.sync`) | **Full** | One-instruction full-warp reduction. Integers on sm_80+: `redux_sync_add`, `_min_{u32,i32}`, `_max_{u32,i32}`, `_and`, `_or`, `_xor`. `f32` min/max with optional `.abs` and `.NaN` on `sm_100a`/`sm_100f`/`sm_103a`/`sm_103f`. No `f64` form. |
 
 ## Runtime Library: Cooperative Groups
 
@@ -259,12 +260,24 @@ Anonymous promoted allocations remain unsupported.
 
 ---
 
+## Runtime Library: Matrix and Tensor Cores
+
+| Feature | Status | Description |
+|:--------|:-------|:------------|
+| Warp-Level MMA (`wmma`) | **Full** | Register-only `mma.sync` shapes, `movmatrix`, and warp-cooperative `ldmatrix` loads. |
+| Sparse MMA | **Full** | Structured-sparsity `mma.sp` shapes alongside the dense ones, same module. |
+| Warpgroup MMA (`wgmma`) | **Full** | Hopper `sm_90a`: fence/commit/wait pipeline, shared-memory descriptors, bf16/f16/tf32 accumulate. |
+| Tensor Core Gen 5 (`tcgen05`) | **Full** | Blackwell sm_100+: TMEM alloc/dealloc, MMA, `stmatrix`, CTA-pair (cg2) variants. |
+| Accumulator Fragment Algebra (`mma_frag`) | **Full** | Index algebra for the `m16n8k16` accumulator, so a lane can address its own slots of the `[f32; 4]` fragment. |
+| FP8 / FP6 / FP4 Formats | **Partial** | Conversions (`convert::cvt_*` for `e4m3`/`e5m2`) and the matrix path (FP8 `mma.sync` shapes, the `mxf8f6f4` shapes, tcgen05 descriptors) ship; the `mma_mxf8f6f4` example compiles them. Gap: no *arithmetic* on these formats -- no add/mul/min/max the way `f16` and `bf16` have -- so values are carried as packed bit patterns and converted before use. |
+
+---
+
 ## Not Yet Implemented
 
 | Feature | Status | Notes |
 |:--------|:-------|:------|
 | Rust `asm!` macro | **Planned** | Use `ptx_asm!` for CUDA inline PTX. Direct lowering of Rust MIR `InlineAsm` is not implemented. |
-| FP8 / MX Data Types | **Planned** | Roadmap item for Blackwell. No architectural limitation. |
 | Dynamic Dispatch (`dyn Trait`) | **N/A** | Use generics with static dispatch. Haven't found a real need for this. |
 | Heap Allocation (`Box`, `Vec`) | **N/A** | CUDA has a device-side heap (`malloc`/`free` in kernels), and the compiler allows the `alloc` crate through -- but no device-side `#[global_allocator]` is wired up today. Even if it were, device `malloc` is extremely slow (serialized, fragmented, uncoalesced). Use slices and `SharedArray`. |
 | `String` / `format_args!` | **N/A** | Use `gpu_printf!` for formatted output. |

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -265,11 +265,11 @@ Anonymous promoted allocations remain unsupported.
 | Feature | Status | Description |
 |:--------|:-------|:------------|
 | Warp-Level MMA (`wmma`) | **Full** | Register-only `mma.sync` shapes, `movmatrix`, and warp-cooperative `ldmatrix` loads. |
-| Sparse MMA | **Full** | Structured-sparsity `mma.sp` shapes alongside the dense ones, same module. |
-| Warpgroup MMA (`wgmma`) | **Full** | Hopper `sm_90a`: fence/commit/wait pipeline, shared-memory descriptors, bf16/f16/tf32 accumulate. |
+| Sparse MMA | **Full** | Structured-sparsity `mma.sp` shapes alongside the dense ones, in the same `wmma` module. |
+| Warpgroup MMA (`wgmma`) | **Partial** | Hopper `sm_90a`: fence/commit/wait pipeline, shared-memory descriptors, and `m64n64k16` MMA with `bf16`/`f16` inputs and `f32` accumulate. Gap: the lowering covers specific proven loop patterns (`bf16` works in straight-line code, counted K-loops, and partial-wait pipelines; `f16` in straight-line code only), and `tf32` calls are rejected pending [#1076](https://github.com/NVlabs/cuda-oxide/issues/1076). |
 | Tensor Core Gen 5 (`tcgen05`) | **Full** | Blackwell sm_100+: TMEM alloc/dealloc, MMA, `stmatrix`, CTA-pair (cg2) variants. |
 | Accumulator Fragment Algebra (`mma_frag`) | **Full** | Index algebra for the `m16n8k16` accumulator, so a lane can address its own slots of the `[f32; 4]` fragment. |
-| FP8 / FP6 / FP4 Formats | **Partial** | Conversions (`convert::cvt_*` for `e4m3`/`e5m2`) and the matrix path (FP8 `mma.sync` shapes, the `mxf8f6f4` shapes, tcgen05 descriptors) ship; the `mma_mxf8f6f4` example compiles them. Gap: no *arithmetic* on these formats -- no add/mul/min/max the way `f16` and `bf16` have -- so values are carried as packed bit patterns and converted before use. |
+| FP8 / FP6 / FP4 Formats | **Partial** | Conversions (`convert::cvt_*` for `e4m3`/`e5m2`) and the matrix path (FP8 `mma.sync` shapes, the `mxf8f6f4` shapes, tcgen05 descriptors) ship; the `mma_mxf8f6f4` example compiles them. Gap: no *arithmetic* on these formats. There's no add/mul/min/max the way `f16` and `bf16` have, so values are carried as packed bit patterns and converted before use. |
 
 ---
 


### PR DESCRIPTION
The page opens by promising "every compiler capability, runtime API, and hardware feature along with its current support status." Three gaps against that, in increasing size.

## 1. FP8 is listed as not implemented

Under **Not Yet Implemented**:

```
| FP8 / MX Data Types | **Planned** | Roadmap item for Blackwell.
                                      No architectural limitation. |
```

The catalog holds **158** entries for these formats — 12 conversions and 146 matrix ops — surfacing as `pub unsafe fn` in `cuda_device::convert`, `cuda_device::wmma` and `cuda_device::tcgen05`, and the `mma_mxf8f6f4` example compiles them. By the page's own legend that is **Partial**, not Planned.

The gap is real and worth naming rather than deleting the row: there is **no arithmetic** on these formats. Grouping the 158 by kind gives 12 `cvt` and 146 `mma`, and nothing matching add/mul/sub/fma/min/max/abs. So a value is carried as a packed bit pattern and converted before use, unlike `f16`/`bf16`, which have their own arithmetic modules. That is what the new row says.

## 2. The Warp section has no `redux.sync` row

`cuda_device::warp` exports sixteen of them; the section lists shuffle, vote and lane/warp ID. The new row carries both halves and their different floors: integers on sm_80+, and `f32` min/max with optional `.abs`/`.NaN` on `sm_100a`/`sm_100f`/`sm_103a`/`sm_103f` (#1032). `f64` has no form, which the row also says.

## 3. There is no matrix or tensor-core section at all

`grep -i` for "tensor core", "wgmma", "tcgen05", "wmma", "mma" or "TMEM" across the whole appendix returns **nothing**. No row for warp-level `mma.sync`, sparse MMA, Hopper warpgroup MMA, Blackwell tcgen05/TMEM, or the accumulator fragment algebra — in the feature matrix of a compiler whose headline example is a Blackwell GEMM. This adds a section for it, and moves the FP8 row there, since the matrix path is where those formats are used.

## Calibration and sourcing

Statuses follow the existing TMA section, the other Hopper+ hardware feature, which marks compile-only-in-CI capabilities **Full** with the architecture stated in the description.

Every row is sourced from the tree: module summaries from each module's own `//!` header (`wgmma` states Hopper `sm_90a`, `tcgen05` Blackwell sm_100+), sparse MMA from the `mma.sp.sync.aligned.*` strings in `generated/sparse_mma.rs`, and the redux names from `pub fn` declarations in `warp.rs`. Book builds clean under `sphinx-build -W`; `check-book-api-names.sh` passes.