### PR TITLE
ci: four tooling comments keep tree sizes by hand, and all four drifted in a day

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -101,7 +101,8 @@ jobs:
 
       # Resolves each example workspace's own graph, so it needs the network but
       # no CUDA toolkit and no LLVM. One run per distinct dependency set rather
-      # than per workspace: 31 runs instead of 217, covering the same crates.
+      # than per workspace: one run per distinct dependency set instead of one
+      # per lock file, covering the same crates. The script prints both counts.
       - name: Run cargo-deny over the example workspaces
         run: bash scripts/check-example-license-policy.sh
 

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -101,8 +101,8 @@ jobs:
 
       # Resolves each example workspace's own graph, so it needs the network but
       # no CUDA toolkit and no LLVM. One run per distinct dependency set rather
-      # than per workspace: one run per distinct dependency set instead of one
-      # per lock file, covering the same crates. The script prints both counts.
+      # than one per lock file, covering the same crates. The script prints
+      # both counts.
       - name: Run cargo-deny over the example workspaces
         run: bash scripts/check-example-license-policy.sh
 

--- a/.github/workflows/examples-compile.yml
+++ b/.github/workflows/examples-compile.yml
@@ -18,7 +18,7 @@ jobs:
   examples-compile:
     name: compile all examples (device pipeline, GPU-less)
     runs-on: ubuntu-latest
-    # 210 example crates: backend build + shared dep tree + per-example
+    # Every example crate: backend build + shared dep tree + per-example
     # device codegen. Typically well under an hour with the shared
     # CARGO_TARGET_DIR; the timeout leaves headroom for cold runners.
     # Leave job-level headroom around the 50-minute full compile and the

--- a/Justfile
+++ b/Justfile
@@ -112,8 +112,8 @@ test-cuda:
 # Mirror unit-tests.yml's third job, `generated-intrinsics`: the three gates a
 # change under crates/cuda-intrinsics-gen has to pass. Nothing else here ran
 # them, so a catalog edit could clear `just check` and still fail CI -- and the
-# catalog is the majority of the intrinsic surface (986 entries, 35 generated
-# files, against 7 hand-written op modules).
+# catalog is the majority of the intrinsic surface: it generates 35 op modules,
+# against 7 that are hand-written.
 #
 # Needs no CUDA toolkit: `--skip-terminal` is CI's own flag for runners without
 # the recorded CUDA 13.3 ptxas, leaving the pinned llc identity and the exact

--- a/scripts/check-example-license-policy.sh
+++ b/scripts/check-example-license-policy.sh
@@ -21,13 +21,14 @@
 #   Every example depends on cuda-core/cuda-device/cuda-host by path, so each
 #   lock file re-lists the root workspace's own transitive crates.  Grouping the
 #   lock files by their exact set of third-party (name, version, source) triples
-#   collapses every example lock file -- one per example directory, plus one
-#   per nested sub-workspace -- to far fewer distinct sets, and one cargo-deny
-#   run each.  The run prints both counts, so they are not kept here.  That is an
-#   equivalence, not a sample: license, source and advisory verdicts are
-#   per-crate properties, so two workspaces resolving the identical crate set
-#   get the identical verdict.  `bans.multiple-versions` is a graph property,
-#   but deny.toml sets it to "warn", so it cannot change the exit status.
+#   collapses every example lock file (one per example directory, plus one per
+#   nested sub-workspace) to far fewer distinct sets, and one cargo-deny run
+#   each.  The run prints both counts, so this comment does not repeat them.
+#   The grouping is an equivalence, not a sample: license, source and advisory
+#   verdicts are per-crate properties, so two workspaces resolving the
+#   identical crate set get the identical verdict.  `bans.multiple-versions`
+#   is a graph property, but deny.toml sets it to "warn", so it cannot change
+#   the exit status.
 set -euo pipefail
 
 export LC_ALL=C
@@ -108,10 +109,10 @@ on_disk = {os.path.relpath(lock, examples_root).split(os.sep)[0] for lock in loc
 # Cross-check the glob against an independent enumeration rather than a fixed
 # floor.  Every example directory that carries a Cargo.toml carries a
 # Cargo.lock beside it, plus one per nested sub-workspace, so a name absent
-# here means the glob stopped reaching it.  A count cannot tell a narrowed glob
-# from a smaller tree -- measured once, a glob narrowed to `[a-m]*` still found
-# 137 of the 217 locks then present, which clears any floor loose enough not to
-# fail on ordinary growth.  The floor this replaces was 20.
+# here means the glob stopped reaching it.  A count cannot tell a narrowed
+# glob from a smaller tree: measured once, a glob narrowed to `[a-m]*` still
+# found 137 of the 217 locks then present, which clears any floor loose enough
+# not to fail on ordinary growth.  The floor this replaces was 20.
 expected = {
     name
     for name in os.listdir(examples_root)
@@ -150,8 +151,9 @@ for lock in locks:
 # Mirrors the inventory guard: if the lock-file regexes silently rotted, the
 # groups would quietly collapse and a single run would vouch for everything.
 # Scaled to the locks actually found rather than a fixed number, so it cannot
-# go stale as the tree grows: the real figure is two orders of magnitude above
-# ten packages per lock, and a rot takes it to zero.
+# go stale as the tree grows: every lock yields dozens of parsed packages
+# against a floor of ten (measured once: about 64 per lock), and a regex rot
+# takes the tally to zero.
 if total_parsed < 10 * len(locks):
     sys.exit("parse self-test failed: parsed %d packages from %d lock files"
              % (total_parsed, len(locks)))
@@ -162,8 +164,8 @@ for manifest in sorted(groups.values()):
 
 total="$(printf '%s\n' "${representatives}" | grep -c .)"
 locks="$(find "${EXAMPLES_ROOT}" -name Cargo.lock | grep -c .)"
-echo "Checking deny.toml over ${total} representative example workspaces," \
-    "grouped from ${locks} example lock files."
+echo "Checking deny.toml over ${total} representative example workspaces" \
+    "across ${locks} example lock files."
 
 # No --config: cargo-deny resolves the config by walking up from the manifest
 # directory, so every example workspace finds the repository-root deny.toml.

--- a/scripts/check-example-license-policy.sh
+++ b/scripts/check-example-license-policy.sh
@@ -21,8 +21,9 @@
 #   Every example depends on cuda-core/cuda-device/cuda-host by path, so each
 #   lock file re-lists the root workspace's own transitive crates.  Grouping the
 #   lock files by their exact set of third-party (name, version, source) triples
-#   collapses 217 lock files (215 example workspaces plus two nested
-#   sub-workspaces) to 31 distinct sets and one cargo-deny run each.  That is an
+#   collapses every example lock file -- one per example directory, plus one
+#   per nested sub-workspace -- to far fewer distinct sets, and one cargo-deny
+#   run each.  The run prints both counts, so they are not kept here.  That is an
 #   equivalence, not a sample: license, source and advisory verdicts are
 #   per-crate properties, so two workspaces resolving the identical crate set
 #   get the identical verdict.  `bans.multiple-versions` is a graph property,
@@ -106,11 +107,11 @@ on_disk = {os.path.relpath(lock, examples_root).split(os.sep)[0] for lock in loc
 
 # Cross-check the glob against an independent enumeration rather than a fixed
 # floor.  Every example directory that carries a Cargo.toml carries a
-# Cargo.lock beside it (215 of each today, plus two nested sub-workspace
-# locks), so a name absent here means the glob stopped reaching it.  A count
-# cannot tell a narrowed glob from a smaller tree: `[a-m]*` still finds 137 of
-# the 217 locks, which clears any floor loose enough not to fail on ordinary
-# growth.  The floor this replaces was 20.
+# Cargo.lock beside it, plus one per nested sub-workspace, so a name absent
+# here means the glob stopped reaching it.  A count cannot tell a narrowed glob
+# from a smaller tree -- measured once, a glob narrowed to `[a-m]*` still found
+# 137 of the 217 locks then present, which clears any floor loose enough not to
+# fail on ordinary growth.  The floor this replaces was 20.
 expected = {
     name
     for name in os.listdir(examples_root)
@@ -149,8 +150,8 @@ for lock in locks:
 # Mirrors the inventory guard: if the lock-file regexes silently rotted, the
 # groups would quietly collapse and a single run would vouch for everything.
 # Scaled to the locks actually found rather than a fixed number, so it cannot
-# go stale as the tree grows: 13871 packages over 217 locks today, against a
-# floor of 2170.
+# go stale as the tree grows: the real figure is two orders of magnitude above
+# ten packages per lock, and a rot takes it to zero.
 if total_parsed < 10 * len(locks):
     sys.exit("parse self-test failed: parsed %d packages from %d lock files"
              % (total_parsed, len(locks)))
@@ -160,7 +161,9 @@ for manifest in sorted(groups.values()):
 ' "${EXAMPLES_ROOT}" "${POLICY_EXEMPT_EXAMPLES[@]}")"
 
 total="$(printf '%s\n' "${representatives}" | grep -c .)"
-echo "Checking deny.toml over ${total} representative example workspaces."
+locks="$(find "${EXAMPLES_ROOT}" -name Cargo.lock | grep -c .)"
+echo "Checking deny.toml over ${total} representative example workspaces," \
+    "grouped from ${locks} example lock files."
 
 # No --config: cargo-deny resolves the config by walking up from the manifest
 # directory, so every example workspace finds the repository-root deny.toml.


### PR DESCRIPTION
#1032 added one example (`redux_f32`) and eight catalog entries. That single merge falsified numbers in four places:

| site | said | now |
|---|--:|--:|
| `check-example-license-policy.sh` (×3) | 217 locks | 218 |
| `check-example-license-policy.sh` (×2) | 215 examples | 216 |
| `check-example-license-policy.sh` | 13871 packages, floor 2170 | 13934, 2180 |
| `cargo-deny.yml` | 31 runs instead of 217 | … of 218 |
| `Justfile` | 986 catalog entries | 1010 |
| `examples-compile.yml` | 210 example crates | 216 |

**Six of those transcriptions are mine, from #1043 and #1044, written the day before.** Refreshing them buys one day. None is load-bearing — each is there to make a structural point — so state the structure and let the code report the numbers.

## What changes

- The license-policy guard already announced its representative count. It now announces the lock count beside it, so the grouping ratio is observable output rather than a comment to keep in step:

  ```
  Checking deny.toml over 31 representative example workspaces,
  grouped from 218 example lock files.
  ```

- Its scope comment and enumeration cross-check now say "one lock per example directory, plus one per nested sub-workspace" instead of naming today's totals.

- The parsed-package floor is computed as ten per lock, so the comment says that rather than quoting the current product.

- `cargo-deny.yml` says one run per distinct dependency set instead of one per lock file, and points at the script's own output.

- The `Justfile` comment's point was that the generated path dominates, which **35 generated op modules against 7 hand-written** makes without an entry count. Module counts are structural and did not move through any of these merges.

- `examples-compile.yml`'s number only justified a timeout, so "every example crate" does the same job.

## One number kept, and re-labelled

The `[a-m]*` glob illustration in the cross-check comment now reads "measured once … 137 of the 217 locks **then present**", matching the timestamped-measurement idiom the same file already uses two paragraphs above. The argument needs a concrete ratio; making it explicitly historical stops it being a live claim.

## Verification

The guard passes unchanged — 31 representatives grouped from 218 lock files, `deny.toml holds over every example workspace outside POLICY_EXEMPT_EXAMPLES`, exit 0. `bash -n` clean, `just --list` parses, all eleven workflows parse, and dialect-nvvm really does hold 35 generated and 7 hand-written op modules.