### PR TITLE
docs(cuda-device): the re-export table lists 10 of the 13 macros re-exported

### DIFF
--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -210,21 +210,21 @@ These are defined in `cuda-macros` and re-exported from `cuda-device` for
 convenience. The table is the whole `pub use cuda_macros::{...}` list in
 `src/lib.rs`:
 
-| Attribute                | Purpose                                       |
-|--------------------------|-----------------------------------------------|
-| `#[kernel]`              | Mark a function as a GPU kernel entry point   |
-| `#[device]`              | Mark a helper function or extern block        |
-| `#[cuda_module]`         | Collect a module's kernels into a typed host module with `load` and launchers |
-| `#[launch_bounds]`       | Set max threads / min blocks per SM           |
-| `#[launch_contract]`     | Declare the launch shape a kernel requires, unlocking a safe launch |
-| `#[cluster_launch]`      | Set compile-time cluster dimensions           |
-| `#[cooperative_launch]`  | Launch as cooperative (for `grid::sync()`)    |
-| `#[convergent]`          | Mark as convergent (barrier semantics)        |
-| `#[pure]`                | Mark as pure (no side effects)                |
-| `#[readonly]`            | Mark as read-only                             |
-| `#[constant]`            | Place a `ConstantMemory<T>` static in constant memory, with a host `set_<name>` |
-| `gpu_printf!`            | Device-side printf                            |
-| `ptx_asm!`               | Unsafe CUDA inline PTX                        |
+| Attribute                | Purpose                                                                                |
+|--------------------------|----------------------------------------------------------------------------------------|
+| `#[kernel]`              | Mark a function as a GPU kernel entry point                                            |
+| `#[device]`              | Mark a helper function or extern block                                                 |
+| `#[cuda_module]`         | Collect a module's kernels into a typed host module with `load` and launchers          |
+| `#[launch_bounds]`       | Set max threads / min blocks per SM                                                    |
+| `#[launch_contract]`     | Declare a kernel's launch requirements, unlocking a safe launch                        |
+| `#[cluster_launch]`      | Set compile-time cluster dimensions                                                    |
+| `#[cooperative_launch]`  | Launch as cooperative (for `grid::sync()`)                                             |
+| `#[convergent]`          | Mark as convergent (barrier semantics)                                                 |
+| `#[pure]`                | Mark as pure (no side effects)                                                         |
+| `#[readonly]`            | Mark as read-only                                                                      |
+| `#[constant]`            | Place a `ConstantMemory<T>` static in constant memory, plus a host `set_<name>` setter |
+| `gpu_printf!`            | Device-side printf                                                                     |
+| `ptx_asm!`               | Unsafe CUDA inline PTX                                                                 |
 
 ## Safety Model
 

--- a/crates/cuda-device/README.md
+++ b/crates/cuda-device/README.md
@@ -206,18 +206,23 @@ and `globaltimer()`.
 
 ## Proc-Macro Re-exports
 
-These are defined in `cuda-macros` and re-exported from `cuda-device` for convenience:
+These are defined in `cuda-macros` and re-exported from `cuda-device` for
+convenience. The table is the whole `pub use cuda_macros::{...}` list in
+`src/lib.rs`:
 
 | Attribute                | Purpose                                       |
 |--------------------------|-----------------------------------------------|
 | `#[kernel]`              | Mark a function as a GPU kernel entry point   |
 | `#[device]`              | Mark a helper function or extern block        |
+| `#[cuda_module]`         | Collect a module's kernels into a typed host module with `load` and launchers |
 | `#[launch_bounds]`       | Set max threads / min blocks per SM           |
+| `#[launch_contract]`     | Declare the launch shape a kernel requires, unlocking a safe launch |
 | `#[cluster_launch]`      | Set compile-time cluster dimensions           |
 | `#[cooperative_launch]`  | Launch as cooperative (for `grid::sync()`)    |
 | `#[convergent]`          | Mark as convergent (barrier semantics)        |
 | `#[pure]`                | Mark as pure (no side effects)                |
 | `#[readonly]`            | Mark as read-only                             |
+| `#[constant]`            | Place a `ConstantMemory<T>` static in constant memory, with a host `set_<name>` |
 | `gpu_printf!`            | Device-side printf                            |
 | `ptx_asm!`               | Unsafe CUDA inline PTX                        |
 


### PR DESCRIPTION
`src/lib.rs` re-exports thirteen macros from `cuda-macros`:

```rust
pub use cuda_macros::{
    cluster_launch, constant, convergent, cooperative_launch, cuda_module,
    device, gpu_printf, kernel, launch_bounds, launch_contract, ptx_asm,
    pure, readonly,
};
```

The README's "Proc-Macro Re-exports" table lists ten. Missing are `#[cuda_module]`, `#[launch_contract]` and `#[constant]` — the entry point for typed module loading, the attribute that unlocks a safe launch, and the one that puts a static in constant memory.

Not obscure corners: **this same README already relies on two of the three.** Its `DisjointSlice` section uses `#[launch_contract(domain = 1, ...)]` in prose, and its module table documents the `constant` module. So the crate's own README uses macros it does not list.

Add the three rows, and tie the table's lead-in to the `pub use` list it mirrors so the next macro added there has an obvious place to land.

Descriptions are taken verbatim from the book's API quick reference, which already carries all three — so the two documents now say the same thing rather than two things.

**Verified:** the thirteen names in the `pub use` and the thirteen backticked rows in the table are the same set, with nothing in the table that is not re-exported.