### PR TITLE
docs(cuda-macros): the README omits `#[constant]`, and its only derive

### DIFF
--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -235,6 +235,37 @@ pub fn grid_sync_kernel(mut out: DisjointSlice<u32>) {
 
 Semantic markers for the codegen backend (pass-through -- no code transformation).
 
+### `#[constant]` -- Constant-Memory Statics
+
+Marks a module-scope `static` as a CUDA constant-memory global. The static must
+be typed `ConstantMemory<T>`, whose `UnsafeCell<T>` semantics on the device stop
+the compiler constant-folding the initializer, so the host's `cuMemcpyHtoD`
+writes stay observable from kernels.
+
+```rust
+#[cuda_module]
+mod kernels {
+    #[constant]
+    static COEFFS: ConstantMemory<[f32; 4]> = ConstantMemory::UNINIT;
+}
+```
+
+The macro attaches a reserved `export_name` so the PTX symbol is resolvable via
+`cuModuleGetGlobal`, and the host-side `#[cuda_module]` expansion generates the
+setters:
+
+- `module.set_<name>(&stream, &value)` -- stream-ordered async write, which
+  orders correctly against surrounding launches. Prefer this one.
+- `module.set_<name>_blocking(&value)` -- synchronous `cuMemcpyHtoD`, for
+  one-shot initialization with no stream in scope.
+
+Three restrictions worth knowing before you reach for it: the initializer must
+be `ConstantMemory::UNINIT` (non-zero initializers are not honored yet, so
+populate from the host before any kernel reads), the attribute must appear
+inside a `#[cuda_module]` (elsewhere it silently produces an unreachable symbol
+with no setter), and the identifier must not start with the reserved cuda-oxide
+prefix.
+
 ## `#[cuda_module]` -- Typed Embedded Module Loading
 
 Wrap an inline module containing `#[kernel]` functions to generate a typed
@@ -484,13 +515,39 @@ supported. `"C"` operands count toward the 16-input limit.
 combined with clobbers. `options(may_diverge)` must be paired with
 `register_only`. More than 16 output operands are not implemented yet.
 
+## `#[derive(DeviceCopy)]` -- Device-Copyable Types
+
+The crate's one derive macro. It implements the `unsafe` trait
+`cuda_core::DeviceCopy` for a type whose fields are all themselves
+`DeviceCopy`. That trait is the promise that every byte pattern of the type is a
+valid value, which is what `DeviceBuffer` needs to turn raw device bytes back
+into initialized Rust values. `Copy` alone is not enough: `bool`, `char` and
+`NonZeroU32` are all `Copy`, and none of them accepts every bit pattern.
+
+Structs and unions only. Enums are rejected with a diagnostic, because a
+product type is `DeviceCopy` when every field is, and no such rule holds for a
+discriminated union.
+
+Unlike the macros above it is re-exported from `cuda_core`, next to the trait it
+implements, so one import brings both into scope in the serde `Serialize`
+trait-and-derive style:
+
+```rust
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+#[repr(C)]
+struct Params { scale: f32, count: u32 }
+```
+
 ## Source Layout
 
 ```text
 src/
-├── lib.rs       # All proc-macro definitions (kernel, device, launch, etc.)
-├── printf.rs    # gpu_printf! implementation
-└── ptx_asm.rs   # ptx_asm! implementation
+├── lib.rs         # All proc-macro definitions (kernel, device, launch, etc.)
+├── device_copy.rs # #[derive(DeviceCopy)] implementation
+├── printf.rs      # gpu_printf! implementation
+└── ptx_asm.rs     # ptx_asm! implementation
 ```
 
 ## Further Reading

--- a/crates/cuda-macros/README.md
+++ b/crates/cuda-macros/README.md
@@ -238,9 +238,9 @@ Semantic markers for the codegen backend (pass-through -- no code transformation
 ### `#[constant]` -- Constant-Memory Statics
 
 Marks a module-scope `static` as a CUDA constant-memory global. The static must
-be typed `ConstantMemory<T>`, whose `UnsafeCell<T>` semantics on the device stop
-the compiler constant-folding the initializer, so the host's `cuMemcpyHtoD`
-writes stay observable from kernels.
+be typed `ConstantMemory<T>`. Its `UnsafeCell<T>` interior stops the compiler
+from constant-folding the initializer, so the writes the host makes with
+`cuMemcpyHtoD` stay visible to kernels.
 
 ```rust
 #[cuda_module]
@@ -259,12 +259,14 @@ setters:
 - `module.set_<name>_blocking(&value)` -- synchronous `cuMemcpyHtoD`, for
   one-shot initialization with no stream in scope.
 
-Three restrictions worth knowing before you reach for it: the initializer must
-be `ConstantMemory::UNINIT` (non-zero initializers are not honored yet, so
-populate from the host before any kernel reads), the attribute must appear
-inside a `#[cuda_module]` (elsewhere it silently produces an unreachable symbol
-with no setter), and the identifier must not start with the reserved cuda-oxide
-prefix.
+Three restrictions worth knowing before you reach for it:
+
+- The initializer must be all-zeros, which in practice means
+  `ConstantMemory::UNINIT`. Non-zero initializers are not honored yet, so
+  populate from the host before any kernel reads.
+- The attribute must appear inside a `#[cuda_module]`. Anywhere else it
+  silently produces an unreachable symbol with no setter.
+- The identifier must not start with the reserved `cuda_oxide_` prefix.
 
 ## `#[cuda_module]` -- Typed Embedded Module Loading
 
@@ -519,18 +521,18 @@ combined with clobbers. `options(may_diverge)` must be paired with
 
 The crate's one derive macro. It implements the `unsafe` trait
 `cuda_core::DeviceCopy` for a type whose fields are all themselves
-`DeviceCopy`. That trait is the promise that every byte pattern of the type is a
+`DeviceCopy`. That trait is the promise that every bit pattern of the type is a
 valid value, which is what `DeviceBuffer` needs to turn raw device bytes back
 into initialized Rust values. `Copy` alone is not enough: `bool`, `char` and
 `NonZeroU32` are all `Copy`, and none of them accepts every bit pattern.
 
-Structs and unions only. Enums are rejected with a diagnostic, because a
-product type is `DeviceCopy` when every field is, and no such rule holds for a
-discriminated union.
+Structs and unions only. Enums are rejected with a diagnostic: a struct is
+`DeviceCopy` whenever all its fields are, but an enum's discriminant makes most
+bit patterns invalid, so no field-by-field rule can prove it safe.
 
-Unlike the macros above it is re-exported from `cuda_core`, next to the trait it
-implements, so one import brings both into scope in the serde `Serialize`
-trait-and-derive style:
+Unlike the macros above, this one is re-exported from `cuda_core`, next to the
+trait it implements. One import brings both into scope, the same way serde
+pairs `Serialize` with its derive:
 
 ```rust
 use cuda_core::DeviceCopy;


### PR DESCRIPTION
`cuda-macros` exports sixteen macros. Its 500-line README documents fourteen. The two it never mentions are `#[constant]` and `#[derive(DeviceCopy)]` — and the second is the crate's only derive macro.

## The omissions are connected

The "Source Layout" tree lists three files under `src/`:

```text
├── lib.rs       # All proc-macro definitions (kernel, device, launch, etc.)
├── printf.rs    # gpu_printf! implementation
└── ptx_asm.rs   # ptx_asm! implementation
```

There are four. **`device_copy.rs` — the derive's whole implementation — is not in the tree either**, so nothing in the README points at the macro or at the file that defines it.

## What each section says

`#[constant]` gets the three restrictions that decide whether it works, from its own rustdoc: the initializer must be `ConstantMemory::UNINIT` (non-zero initializers are not honored yet), it must appear inside a `#[cuda_module]` — elsewhere it silently produces an unreachable symbol with no setter, which is the failure mode worth warning about — and the identifier must not start with the reserved prefix. Both generated setters are named, with the stream-ordered one marked as the one to prefer.

`#[derive(DeviceCopy)]` gets what makes it more than `Copy`: the trait is `unsafe` and promises every bit pattern is valid, which `DeviceBuffer` relies on when it turns raw device bytes back into values. It also records that structs and unions are accepted and enums are rejected with a diagnostic, since that is the first thing someone tries.

## Verification

Against the tree:

- The sixteen exported macros — eleven `#[proc_macro_attribute]`, four `#[proc_macro]`, one `#[proc_macro_derive]` — are now all named in the README, and the four files under `src/` are all in the tree.
- The `#[constant]` snippet is the shape `examples/constant_memory_coeffs/src/main.rs` already uses, line for line.
- `DeviceCopy`'s `Copy` bound, its `bool`/`char`/`NonZeroU32` rationale and its enum rejection come from `cuda-core/src/device_buffer.rs` and `cuda-macros/src/device_copy.rs`; the derive example matches the `#[derive(Copy, Clone, DeviceCopy)]` form in `cuda-core`'s trybuild fixtures.

Documentation only — no source file changes, so `#[constant]`'s and the derive's behaviour is untouched.