### PR TITLE
fix(mir-importer): materialize relocation-free pointer/integer unions

### DIFF
--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -8417,6 +8417,74 @@ fn classify_union_constant_storage(
     })
 }
 
+/// Whether a mixed thin-pointer/integer union can use its evaluated byte image
+/// when the allocation carries no relocation provenance.
+///
+/// Keep this deliberately narrower than [`classify_union_constant_storage`]:
+/// the ordinary classifier remains the provenance-preserving authority used by
+/// pointer-bearing constants and device-static union initializers. This helper
+/// only admits one naturally aligned pointer word whose non-ZST alternatives
+/// are compatible thin pointers or full-width integers.
+fn relocation_free_pointer_integer_union_uses_byte_image(
+    ctx: &Context,
+    union_ty: TypeHandle,
+    pointer_width: usize,
+) -> bool {
+    let (union_size, union_align, field_types) = {
+        let ty_ref = union_ty.deref(ctx);
+        let Some(union_ty) = ty_ref.downcast_ref::<dialect_mir::types::MirUnionType>() else {
+            return false;
+        };
+        (
+            union_ty.total_size(),
+            union_ty.abi_align(),
+            union_ty.field_types().to_vec(),
+        )
+    };
+
+    let pointer_width_u64 = pointer_width as u64;
+    if union_size != pointer_width_u64 || union_align != pointer_width_u64 {
+        return false;
+    }
+
+    let integer_width = (pointer_width * 8) as u32;
+    let mut pointer_address_space = None;
+    let mut saw_pointer = false;
+    let mut saw_integer = false;
+
+    for field_ty in field_types {
+        if types::is_zst_type(ctx, field_ty) {
+            continue;
+        }
+
+        let field_ref = field_ty.deref(ctx);
+        if let Some(pointer) = field_ref.downcast_ref::<dialect_mir::types::MirPtrType>() {
+            match pointer_address_space {
+                None => pointer_address_space = Some(pointer.address_space),
+                Some(address_space) if address_space == pointer.address_space => {}
+                Some(_) => return false,
+            }
+            saw_pointer = true;
+            continue;
+        }
+
+        if field_ref
+            .downcast_ref::<IntegerType>()
+            .is_some_and(|integer| integer.width() == integer_width)
+        {
+            saw_integer = true;
+            continue;
+        }
+
+        // Fat pointers, nested pointer aggregates, partial-width integers, and
+        // unrelated scalar/aggregate alternatives keep the existing fail-closed
+        // path. The byte-image exception is intentionally pointer-word exact.
+        return false;
+    }
+
+    saw_pointer && saw_integer
+}
+
 /// Admit only the device-static union shape whose complete storage can be
 /// represented by one provenance-preserving thin-pointer relocation.
 ///
@@ -8612,8 +8680,11 @@ fn translate_union_constant(
 /// Pointer-free unions retain the existing byte-image path and exact initialization
 /// mask. A union whose every non-ZST alternative is a compatible thin pointer
 /// instead uses one typed pointer carrier so rustc relocation provenance never
-/// becomes integer bytes. Pointer/integer overlap, fat pointers, nested pointer
-/// aggregates, and ambiguous relocation layouts remain fail-closed.
+/// becomes integer bytes. A naturally aligned pointer-word union that overlaps
+/// compatible thin pointers with full-width integers may also use the byte image,
+/// but only when no relocation overlaps its storage. Relocation-bearing mixed
+/// unions, fat pointers, nested pointer aggregates, and ambiguous layouts remain
+/// fail-closed.
 #[allow(clippy::too_many_arguments)]
 fn translate_union_constant_from_alloc(
     ctx: &mut Context,
@@ -8655,6 +8726,25 @@ fn translate_union_constant_from_alloc(
         end,
         pointer_width,
     );
+
+    // A mixed pointer/integer union initialized through the integer view carries
+    // no relocation provenance. In that one case the evaluated bytes and init
+    // mask are the complete storage truth, so reuse the existing byte-image
+    // materializer before the provenance-aware classifier rejects the overlap.
+    // Keep classify_union_constant_storage unchanged: #984's device-static gate
+    // and relocation-bearing union constants still depend on its strict policy.
+    if relocations.is_empty()
+        && relocation_free_pointer_integer_union_uses_byte_image(ctx, union_ty, pointer_width)
+    {
+        return translate_union_constant_from_storage(
+            ctx,
+            union_ty,
+            &alloc.bytes[base_offset..end],
+            block_ptr,
+            prev_op,
+            loc,
+        );
+    }
 
     let storage_kind = classify_union_constant_storage(ctx, union_ty)
         .map_err(|message| input_error!(loc.clone(), TranslationErr::unsupported(message)))?;
@@ -13797,9 +13887,9 @@ mod aggregate_relocation_tests {
     use super::{
         UnionConstantStorageKind, classify_union_constant_storage, constant_type_contains_pointer,
         decode_relocation_addend, find_unconsumed_relocation, match_thin_pointer_relocation,
-        provenance_starts_in_range, relocation_offsets_overlapping_range,
-        validate_array_value_element_type, validate_device_static_union_storage,
-        validate_slice_relocation_shape,
+        provenance_starts_in_range, relocation_free_pointer_integer_union_uses_byte_image,
+        relocation_offsets_overlapping_range, validate_array_value_element_type,
+        validate_device_static_union_storage, validate_slice_relocation_shape,
     };
     use dialect_mir::types::{
         EnumVariant, MirArrayType, MirEnumType, MirPtrType, MirStructType, MirTupleType,
@@ -14112,10 +14202,44 @@ mod aggregate_relocation_tests {
         )
         .into();
         let pointer_integer_error = classify_union_constant_storage(&ctx, pointer_integer_union_ty)
-            .expect_err("pointer/integer overlap must remain fail-closed");
+            .expect_err("the provenance-aware classifier must keep pointer/integer overlap closed");
         assert!(
             pointer_integer_error.contains("pointer/integer union constants"),
             "diagnostic must explain the provenance-vs-bits conflict: {pointer_integer_error}"
+        );
+        assert!(
+            relocation_free_pointer_integer_union_uses_byte_image(
+                &ctx,
+                pointer_integer_union_ty,
+                8,
+            ),
+            "a pointer-word ptr/u64 union is byte-image eligible when the allocation has no relocation"
+        );
+        assert!(
+            !relocation_free_pointer_integer_union_uses_byte_image(
+                &ctx,
+                pointer_integer_union_ty,
+                4,
+            ),
+            "the exception must not cross a target pointer-width mismatch"
+        );
+
+        let u32_pointer_integer_union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "PointerNarrowBits".into(),
+            vec!["ptr".into(), "bits".into()],
+            vec![pointer_field_ty, u32_ty],
+            8,
+            8,
+        )
+        .into();
+        assert!(
+            !relocation_free_pointer_integer_union_uses_byte_image(
+                &ctx,
+                u32_pointer_integer_union_ty,
+                8,
+            ),
+            "partial-width integer alternatives stay outside the initial pointer-word exception"
         );
 
         let slice_ty: TypeHandle = dialect_mir::types::MirSliceType::get(&mut ctx, u32_ty).into();

--- a/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/array_constants/src/main.rs
@@ -23,6 +23,7 @@
 //! - tuple-array pointer relocations with non-zero static addends,
 //! - initialized union constants, including `[U; N]` runtime indexing,
 //! - thin-pointer-only union constants that preserve device-static provenance,
+//! - relocation-free pointer/integer union constants materialized as byte images,
 //! - unions nested inside tuple and struct constants,
 //! - `MaybeUninit<T>` array constants.
 //!
@@ -167,6 +168,26 @@ const POINTER_UNION_TABLE: [PointerBits; 2] = [
         // Initialize through the other union view and keep a non-zero addend.
         // Import must preserve the relocation rather than the placeholder bytes.
         bytes: &POINTER_VALUES[2] as *const u32 as *const u8,
+    },
+];
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+#[repr(C)]
+union PointerOrBits {
+    pointer: *const u32,
+    bits: u64,
+}
+
+const DIRECT_POINTER_INTEGER_UNION: PointerOrBits = PointerOrBits {
+    bits: 0x1122_3344_5566_7788,
+};
+const POINTER_INTEGER_UNION_TABLE: [PointerOrBits; 2] = [
+    PointerOrBits {
+        bits: 0x0123_4567_89ab_cdef,
+    },
+    PointerOrBits {
+        bits: 0xfedc_ba98_7654_3210,
     },
 ];
 
@@ -377,6 +398,24 @@ mod kernels {
     }
 
     #[inline(never)]
+    fn fold_pointer_integer_union(value: PointerOrBits) -> u32 {
+        let bits = unsafe { value.bits };
+        (bits as u32)
+            .wrapping_mul(257)
+            .wrapping_add((bits >> 32) as u32)
+    }
+
+    #[inline(never)]
+    fn direct_pointer_integer_union_value() -> u32 {
+        fold_pointer_integer_union(DIRECT_POINTER_INTEGER_UNION)
+    }
+
+    #[inline(never)]
+    fn pointer_integer_union_array_value(i: usize) -> u32 {
+        fold_pointer_integer_union(POINTER_INTEGER_UNION_TABLE[i & 1])
+    }
+
+    #[inline(never)]
     fn read_bits_word(bits: Bits) -> u32 {
         unsafe { bits.word }
     }
@@ -433,6 +472,10 @@ mod kernels {
         direct_pointer_union_value()
             .wrapping_mul(257)
             .wrapping_add(pointer_union_array_value(i))
+            .wrapping_mul(257)
+            .wrapping_add(direct_pointer_integer_union_value())
+            .wrapping_mul(257)
+            .wrapping_add(pointer_integer_union_array_value(i))
             .wrapping_mul(257)
             .wrapping_add(direct_union_value())
             .wrapping_mul(257)
@@ -526,14 +569,25 @@ mod kernels {
     }
 }
 
+fn fold_u64_for_union_test(bits: u64) -> u32 {
+    (bits as u32)
+        .wrapping_mul(257)
+        .wrapping_add((bits >> 32) as u32)
+}
+
 fn expected_union(i: usize) -> u32 {
     let pointer = [11u32, 23][i & 1];
+    let pointer_integer = [0x0123_4567_89ab_cdefu64, 0xfedc_ba98_7654_3210][i & 1];
     let table = [0x1122_3344u32, 0x5566_7788, 0x99aa_bbcc, 0xdead_beef][i & 3];
     let maybe = [0x1357_9bdfu32, 0x2468_ace0][i & 1];
 
     11u32
         .wrapping_mul(257)
         .wrapping_add(pointer)
+        .wrapping_mul(257)
+        .wrapping_add(fold_u64_for_union_test(0x1122_3344_5566_7788))
+        .wrapping_mul(257)
+        .wrapping_add(fold_u64_for_union_test(pointer_integer))
         .wrapping_mul(257)
         .wrapping_add(0x1122_3344)
         .wrapping_mul(257)
@@ -714,7 +768,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if failures == 0 {
         println!(
-            "array_constants: PASS ({N} threads; primitive, enum, initialized union/MaybeUninit, pointer-union provenance, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, padded/nested/packed/ZST struct, pointer-to-array including packed struct references, and tuple-array static-pointer constants)"
+            "array_constants: PASS ({N} threads; primitive, enum, initialized union/MaybeUninit, pointer-union provenance, relocation-free pointer/integer unions, padded/reordered/over-aligned tuple, nested/equal-offset ZST tuple, padded/nested/packed/ZST struct, pointer-to-array including packed struct references, and tuple-array static-pointer constants)"
         );
         Ok(())
     } else {

--- a/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
@@ -237,6 +237,8 @@ require_symbol_shape "${llvm_ir}" llvm "${bare_enum_symbol}" \
 
 pointer_union_array_symbol='array_constants__kernels__pointer_union_array_value'
 direct_pointer_union_symbol='array_constants__kernels__direct_pointer_union_value'
+pointer_integer_union_array_symbol='array_constants__kernels__pointer_integer_union_array_value'
+direct_pointer_integer_union_symbol='array_constants__kernels__direct_pointer_integer_union_value'
 union_array_symbol='array_constants__kernels__union_array_value'
 direct_union_symbol='array_constants__kernels__direct_union_value'
 union_tuple_symbol='array_constants__kernels__union_tuple_value'
@@ -267,6 +269,21 @@ reject_symbol_shape "${llvm_ir}" llvm "${direct_pointer_union_symbol}" \
 reject_symbol_shape "${llvm_ir}" llvm "${direct_pointer_union_symbol}" \
     "raw eight-byte image materialization for direct pointer unions" \
     'alloca \[8 x i8\]'
+
+# A pointer/integer union initialized through its integer view has no relocation
+# provenance to preserve. The importer must therefore use the exact evaluated
+# byte image instead of inventing a pointer carrier. Both direct and array forms
+# pin the new path; neither may reconstruct a pointer with inttoptr.
+for symbol in \
+    "${direct_pointer_integer_union_symbol}" \
+    "${pointer_integer_union_array_symbol}"; do
+    require_symbol_shape "${llvm_ir}" llvm "${symbol}" \
+        "relocation-free pointer/integer union byte-image materialization" \
+        'alloca \[8 x i8\]'
+    reject_symbol_shape "${llvm_ir}" llvm "${symbol}" \
+        "inttoptr reconstruction for relocation-free pointer/integer unions" \
+        'inttoptr'
+done
 
 # Initialized union constants are deliberately materialized element-wise instead
 # of taking the promoted-global fast path. rustc gives the importer a byte image

--- a/cuda-oxide-book/appendix/supported-features.md
+++ b/cuda-oxide-book/appendix/supported-features.md
@@ -88,10 +88,15 @@ array-to-slice view. Their literal `usize` length metadata is decoded
 independently, including non-zero static byte addends and nested aggregate field
 offsets. Thin-pointer-only union constants preserve the same relocation
 provenance, including non-zero addends, by reconstructing one typed pointer
-carrier instead of transmuting placeholder bytes. Pointer/integer overlapping
-unions, fat or nested pointer storage in unions, over-aligned/padded pointer
-unions, unsupported fat-pointer metadata, pointer-to-array union constants
-(`&[U; N]`), and pointer relocations in device-global union initializers remain
+carrier instead of transmuting placeholder bytes. Relocation-free
+pointer/integer unions whose storage is exactly one naturally aligned pointer
+word and whose integer alternatives are full-width may instead use rustc's
+evaluated byte image when no relocation overlaps the union storage.
+Relocation-bearing pointer/integer unions, fat or nested pointer storage in
+unions, over-aligned/padded pointer unions, unsupported fat-pointer metadata,
+and pointer-to-array union constants (`&[U; N]`) remain rejected. Top-level
+thin-pointer-only device-global union initializers may preserve one full-width
+relocation at byte zero; mixed pointer/integer device-global initializers remain
 rejected.
 
 Enum constants preserve payload relocations to device statics, including


### PR DESCRIPTION
Closes #1058 

## Summary

Allow a narrow class of pointer/integer union constants to use the existing byte-image materialization path when their evaluated allocation contains no relocation provenance.

Previously, `classify_union_constant_storage` rejected all pointer/integer overlap because a byte image cannot represent both arbitrary integer bits and pointer provenance.

That remains correct for relocation-bearing constants. However, when the evaluated union storage contains no relocations—for example, when initialized through a full-width integer alternative—rustc's evaluated byte image is already the complete storage truth.

## What changed

`translate_union_constant_from_alloc` now recognizes relocation-free mixed pointer/integer unions before invoking the provenance-aware classifier.

The byte-image exception is intentionally limited to unions where:

- storage size is exactly one target pointer word,
- ABI alignment is exactly one target pointer word,
- non-ZST pointer alternatives are thin pointers,
- pointer alternatives use the same address space,
- integer alternatives are exactly pointer-width, and
- no relocation overlaps the union storage.

The existing `classify_union_constant_storage` behavior is unchanged.

This is intentional: relocation-bearing pointer/integer unions and the device-static union validation path continue to use the existing strict provenance rules.

## Still rejected

This change does not admit:

- relocation-bearing pointer/integer unions,
- fat pointers,
- nested pointer aggregates,
- partial-width integer alternatives,
- mixed pointer address spaces,
- padded or over-aligned pointer unions, or
- mixed pointer/integer device-global union initializers.

Thin-pointer-only unions carrying relocations continue to use the existing typed pointer carrier.

## Tests

Extended `array_constants` with direct and runtime-indexed `[U; N]` pointer/integer union constants initialized through their integer alternatives.

The LLVM code-shape regression verifies that these constants:

- materialize through an `[8 x i8]` byte image on the current 64-bit target, and
- do not reconstruct a pointer using `inttoptr`.

Existing pointer-only union checks continue to verify the provenance-preserving representation.

Validated locally with:

```text
cargo fmt --all -- --check
cargo test -p mir-importer --lib
cargo clippy -p mir-importer --all-targets -- -D warnings
cargo oxide run array_constants
CUDA_OXIDE_NO_OPT=1 cargo oxide run array_constants
scripts/smoketest.sh --only '^array_constants$' --no-color --keep-logs
bash crates/rustc-codegen-cuda/examples/array_constants/verify-code-shape.sh
git diff --check
```

`mir-importer` result:

```text
1101 passed; 0 failed
```

The optimized and non-optimized `array_constants` runs, focused smoketest, and LLVM code-shape verification all pass.

## Documentation

Update `supported-features.md` to distinguish:

* relocation-free pointer/integer unions, which may use a byte image,
* relocation-bearing pointer/integer unions, which remain unsupported, and
* thin-pointer-only device-global unions, which may preserve the supported single relocation at byte zero.

Follow-up to #927.
