### PR TITLE
fix(mir-lower): support recursive packed address-space 3 internal ABI

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -464,9 +464,10 @@ pub(crate) fn convert_construct_struct(
     }
 
     // A packed struct containing AS3 remains target-dependent as a physical
-    // memory image. The narrow internal-call ABI exception is safe to construct
-    // in SSA because its return boundary rebuilds the value into a target-stable
-    // generic-pointer carrier before the aggregate crosses the function ABI.
+    // memory image. The internal-call ABI exception is safe to construct in SSA
+    // because its return boundary recursively rebuilds every supported AS3 leaf
+    // into a target-stable generic-pointer carrier before the aggregate crosses
+    // the function ABI.
     if llvm_packed_struct_contains_pointer_in_address_space(
         ctx,
         map.llvm_struct_ty,
@@ -2971,6 +2972,177 @@ mod tests {
             count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
             0,
             "construction itself must not genericize the shared pointer"
+        );
+    }
+
+    #[test]
+    fn packed_struct_construction_with_multiple_direct_shared_pointers_stays_semantic_in_ssa() {
+        use dialect_mir::ops::MirConstructStructOp;
+
+        let mut ctx = make_ctx();
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedPair".into(),
+            vec!["tag".into(), "left".into(), "right".into()],
+            vec![u8_ty, shared_ty, shared_ty],
+            vec![0, 1, 2],
+            vec![0, 1, 9],
+            17,
+            1,
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![u8_ty, shared_ty, shared_ty], vec![]);
+        let tag = block.deref(&ctx).get_argument(0);
+        let left = block.deref(&ctx).get_argument(1);
+        let right = block.deref(&ctx).get_argument(2);
+        let construct = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![packed_ty],
+            vec![tag, left, right],
+            vec![],
+            0,
+        );
+        construct.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("multiple direct AS3 leaves in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        assert_eq!(
+            insert_indices(&ctx, &inserts),
+            vec![vec![0], vec![1], vec![2]],
+            "all direct shared leaves must remain in their semantic packed slots"
+        );
+
+        let result_ty = inserts
+            .last()
+            .expect("packed AS3 construction must emit insertvalue")
+            .get_operation()
+            .deref(&ctx)
+            .get_result(0)
+            .get_type(&ctx);
+        let result_ty_ref = result_ty.deref(&ctx);
+        let struct_ty = result_ty_ref
+            .downcast_ref::<llvm_types::StructType>()
+            .expect("packed AS3 construction result must be an LLVM struct");
+        assert_eq!(struct_ty.layout(), llvm_types::StructLayout::Packed);
+        assert_eq!(llvm_type_size_align(&ctx, result_ty), Some((17, 1)));
+        for slot in [1usize, 2] {
+            let pointer_ty = struct_ty.field_type(slot);
+            let pointer_ty_ref = pointer_ty.deref(&ctx);
+            let pointer = pointer_ty_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("direct shared leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::SHARED);
+        }
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "semantic construction must not genericize any direct shared leaf"
+        );
+    }
+
+    #[test]
+    fn packed_struct_construction_with_nested_shared_pointers_stays_semantic_in_ssa() {
+        use dialect_mir::ops::MirConstructStructOp;
+
+        let mut ctx = make_ctx();
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let inner_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "SharedPair".into(),
+            vec!["left".into(), "right".into()],
+            vec![shared_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedNestedShared".into(),
+            vec!["tag".into(), "pair".into()],
+            vec![u8_ty, inner_ty],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![u8_ty, shared_ty, shared_ty], vec![]);
+        let tag = block.deref(&ctx).get_argument(0);
+        let left = block.deref(&ctx).get_argument(1);
+        let right = block.deref(&ctx).get_argument(2);
+
+        let inner = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![inner_ty],
+            vec![left, right],
+            vec![],
+            0,
+        );
+        inner.insert_at_back(block, &ctx);
+        let inner_value = inner.deref(&ctx).get_result(0);
+
+        let outer = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![packed_ty],
+            vec![tag, inner_value],
+            vec![],
+            0,
+        );
+        outer.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("nested AS3 leaves in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "semantic construction must keep nested shared leaves in AS3"
+        );
+
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        let packed_result = inserts
+            .iter()
+            .filter_map(|insert| {
+                let result_ty = insert
+                    .get_operation()
+                    .deref(&ctx)
+                    .get_result(0)
+                    .get_type(&ctx);
+                let is_packed = result_ty
+                    .deref(&ctx)
+                    .downcast_ref::<llvm_types::StructType>()
+                    .is_some_and(|ty| ty.layout() == llvm_types::StructLayout::Packed);
+                is_packed.then_some(result_ty)
+            })
+            .last()
+            .expect("outer packed construction must produce a packed LLVM struct");
+
+        assert_eq!(llvm_type_size_align(&ctx, packed_result), Some((17, 1)));
+        assert!(
+            llvm_packed_struct_contains_pointer_in_address_space(
+                &ctx,
+                packed_result,
+                llvm_types::address_space::SHARED,
+            ),
+            "the semantic packed value must retain its recursively nested AS3 leaves"
         );
     }
 

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -365,12 +365,12 @@ pub(crate) fn transparent_scalar_llvm_type(
     Ok(transparent_scalar_abi_info(ctx, struct_ty)?.scalar_ty)
 }
 
-/// Target-stable ABI projection for the deliberately narrow packed-AS3
-/// internal device return case.
+/// Target-stable ABI projection for packed aggregates containing AS3 leaves
+/// across the internal device return boundary.
 ///
-/// The function body continues to use the semantic packed LLVM struct with a
-/// shared pointer. Only the physical return value replaces that direct AS3
-/// pointer with a generic pointer, whose width is stable across the legacy/PTX
+/// The function body continues to use the semantic packed LLVM struct with
+/// shared pointers. Only the physical return value recursively replaces AS3
+/// leaves with generic pointers, whose width is stable across the legacy/PTX
 /// and modern NVVM data layouts.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PackedSharedInternalAbiInfo {
@@ -378,13 +378,49 @@ pub(crate) struct PackedSharedInternalAbiInfo {
     pub storage_ty: TypeHandle,
 }
 
-/// Recognize the first supported packed-AS3 internal ABI shape.
+/// Whether a MIR value shape belongs to the recursive packed-AS3 ABI lane.
 ///
-/// Scope is intentionally fail-closed: one direct shared-pointer field in a
-/// byte-faithful packed struct, with every other non-ZST field scalar. Nested
-/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain out
-/// of scope even though the generic storage utility can represent broader
-/// shapes for enum payloads.
+/// Structs and tuples may nest arbitrarily and may contain any number of scalar
+/// pointer leaves. Arrays and vectors remain deliberately excluded here: an
+/// AS3 array would expand into one conversion per element and belongs to the
+/// separately bounded array follow-up. Other aggregate kinds keep their
+/// existing fail-closed behavior.
+fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: TypeHandle) -> bool {
+    let children = {
+        let ty_ref = mir_ty.deref(ctx);
+        if ty_ref.is::<IntegerType>()
+            || ty_ref.is::<MirFP16Type>()
+            || ty_ref.is::<llvm_types::HalfType>()
+            || ty_ref.is::<FP32Type>()
+            || ty_ref.is::<FP64Type>()
+            || ty_ref.is::<MirPtrType>()
+            || ty_ref.is::<llvm_types::PointerType>()
+        {
+            return true;
+        }
+        if let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() {
+            Some(struct_ty.field_types.clone())
+        } else {
+            ty_ref
+                .downcast_ref::<MirTupleType>()
+                .map(|tuple_ty| tuple_ty.get_types().to_vec())
+        }
+    };
+
+    children.is_some_and(|children| {
+        children
+            .into_iter()
+            .all(|child| packed_shared_internal_abi_mir_shape_is_supported(ctx, child))
+    })
+}
+
+/// Recognize a recursive packed-AS3 internal ABI shape.
+///
+/// The root must remain a byte-faithful packed struct. Nested structs/tuples
+/// and multiple AS3 leaves are admitted, while arrays, vectors, and unrelated
+/// aggregate kinds remain out of scope. The target-stable storage utility owns
+/// the recursive AS3 -> generic rewrite and this classifier only decides which
+/// semantic shapes may use it.
 pub(crate) fn packed_shared_internal_abi_info(
     ctx: &mut Context,
     mir_ty: TypeHandle,
@@ -396,6 +432,10 @@ pub(crate) fn packed_shared_internal_abi_info(
         };
         StructLayoutInfo::of_struct(struct_ty)
     };
+
+    if !packed_shared_internal_abi_mir_shape_is_supported(ctx, mir_ty) {
+        return Ok(None);
+    }
 
     let map = build_struct_slot_map(ctx, &layout)?;
     if !map.by_value_layout_faithful {
@@ -410,31 +450,6 @@ pub(crate) fn packed_shared_internal_abi_info(
         return Ok(None);
     }
 
-    let mut direct_shared_pointers = 0_u64;
-    for field_ty in &map.field_llvm_types {
-        if is_zero_sized_type(ctx, *field_ty) {
-            continue;
-        }
-        let field_ref = field_ty.deref(ctx);
-        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
-            if pointer.address_space() == llvm_types::address_space::SHARED {
-                direct_shared_pointers += 1;
-            }
-            continue;
-        }
-        if field_ref.is::<IntegerType>()
-            || field_ref.is::<llvm_types::HalfType>()
-            || field_ref.is::<FP32Type>()
-            || field_ref.is::<FP64Type>()
-        {
-            continue;
-        }
-        return Ok(None);
-    }
-    if direct_shared_pointers != 1 {
-        return Ok(None);
-    }
-
     let rewrite = target_stable_storage_type(
         ctx,
         map.llvm_struct_ty,
@@ -443,7 +458,7 @@ pub(crate) fn packed_shared_internal_abi_info(
         },
         "packed shared internal ABI",
     )?;
-    if rewrite.shared_pointer_leaves != 1 || rewrite.array_shared_pointer_leaves != 0 {
+    if rewrite.shared_pointer_leaves == 0 || rewrite.array_shared_pointer_leaves != 0 {
         return Ok(None);
     }
     let Some((storage_size, _)) = llvm_type_size_align(ctx, rewrite.ty) else {
@@ -5150,18 +5165,63 @@ mod tests {
     }
 
     #[test]
-    fn packed_shared_internal_abi_rejects_nested_shared_pointer() {
+    fn packed_shared_internal_abi_genericizes_multiple_direct_shared_pointers() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedPair".into(),
+            vec!["tag".into(), "left".into(), "right".into()],
+            vec![tag, shared, shared],
+            vec![0, 1, 2],
+            vec![0, 1, 9],
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, packed)
+            .expect("ABI classification must succeed")
+            .expect("multiple direct AS3 leaves must use the recursive internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((17, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+        assert!(llvm_packed_struct_contains_pointer_in_address_space(
+            &ctx,
+            abi.semantic_ty,
+            llvm_types::address_space::SHARED,
+        ));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+
+        let fields = struct_fields(&ctx, abi.storage_ty);
+        assert_eq!(fields.len(), 3);
+        for field in &fields[1..] {
+            let field_ref = field.deref(&ctx);
+            let pointer = field_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("both pointer leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        }
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_genericizes_nested_struct_shared_pointers() {
         let mut ctx = make_ctx();
         let pointee = mir_uint(&mut ctx, 32);
         let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
         let inner: TypeHandle = MirStructType::get_with_full_layout(
             &mut ctx,
-            "InnerShared".into(),
-            vec!["ptr".into()],
-            vec![shared],
-            vec![0],
-            vec![0],
-            8,
+            "InnerSharedPair".into(),
+            vec!["left".into(), "right".into()],
+            vec![shared, shared],
+            vec![0, 1],
+            vec![0, 8],
+            16,
             8,
         )
         .into();
@@ -5173,7 +5233,90 @@ mod tests {
             vec![tag, inner],
             vec![0, 1],
             vec![0, 1],
-            9,
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, outer)
+            .expect("classification must not error")
+            .expect("nested AS3 leaves must use the recursive internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((17, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+
+        let outer_fields = struct_fields(&ctx, abi.storage_ty);
+        let inner_fields = struct_fields(&ctx, outer_fields[1]);
+        assert_eq!(inner_fields.len(), 2);
+        for field in inner_fields {
+            let field_ref = field.deref(&ctx);
+            let pointer = field_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("nested shared leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        }
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_genericizes_nested_tuple_shared_pointer() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let word = mir_uint(&mut ctx, 32);
+        let inner: TypeHandle = MirTupleType::get_with_layout(
+            &mut ctx,
+            vec![shared, word],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedNestedTupleShared".into(),
+            vec!["tag".into(), "inner".into()],
+            vec![tag, inner],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, outer)
+            .expect("classification must not error")
+            .expect("an AS3 leaf nested in a tuple must use the recursive carrier");
+        let outer_fields = struct_fields(&ctx, abi.storage_ty);
+        let inner_fields = struct_fields(&ctx, outer_fields[1]);
+        let inner_field_ref = inner_fields[0].deref(&ctx);
+        let pointer = inner_field_ref
+            .downcast_ref::<llvm_types::PointerType>()
+            .expect("nested tuple leaf must remain pointer-typed");
+        assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_keeps_shared_pointer_arrays_out_of_scope() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let shared_array: TypeHandle = MirArrayType::get(&mut ctx, shared, 2).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArray".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, shared_array],
+            vec![0, 1],
+            vec![0, 1],
+            17,
             1,
         )
         .into();
@@ -5182,7 +5325,7 @@ mod tests {
             packed_shared_internal_abi_info(&mut ctx, outer)
                 .expect("classification must not error")
                 .is_none(),
-            "the first internal ABI lane intentionally accepts only a direct AS3 field"
+            "AS3 arrays remain reserved for the bounded-array follow-up"
         );
     }
 

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -378,13 +378,40 @@ pub(crate) struct PackedSharedInternalAbiInfo {
     pub storage_ty: TypeHandle,
 }
 
+/// Whether a MIR type converts to a zero-sized LLVM type.
+///
+/// MIR-side mirror of [`is_zero_sized_type`]: zero-length arrays, arrays of
+/// zero-sized elements, and structs/tuples whose fields are all zero-sized
+/// (including empty ones such as `PhantomData`) vanish at the LLVM level and
+/// must not affect ABI-lane classification.
+fn mir_type_is_zero_sized(ctx: &Context, ty: TypeHandle) -> bool {
+    let ty_ref = ty.deref(ctx);
+    if let Some(array_ty) = ty_ref.downcast_ref::<MirArrayType>() {
+        return array_ty.size() == 0 || mir_type_is_zero_sized(ctx, array_ty.element_type());
+    }
+    if let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() {
+        return struct_ty
+            .field_types
+            .iter()
+            .all(|field| mir_type_is_zero_sized(ctx, *field));
+    }
+    if let Some(tuple_ty) = ty_ref.downcast_ref::<MirTupleType>() {
+        return tuple_ty
+            .get_types()
+            .iter()
+            .all(|field| mir_type_is_zero_sized(ctx, *field));
+    }
+    false
+}
+
 /// Whether a MIR value shape belongs to the recursive packed-AS3 ABI lane.
 ///
 /// Structs and tuples may nest arbitrarily and may contain any number of scalar
-/// pointer leaves. Arrays and vectors remain deliberately excluded here: an
-/// AS3 array would expand into one conversion per element and belongs to the
-/// separately bounded array follow-up. Other aggregate kinds keep their
-/// existing fail-closed behavior.
+/// pointer leaves. Zero-sized fields are skipped, matching the post-conversion
+/// field scan this predicate replaced. Arrays and vectors remain deliberately
+/// excluded here: an AS3 array would expand into one conversion per element and
+/// belongs to the separately bounded array follow-up. Other aggregate kinds
+/// keep their existing fail-closed behavior.
 fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: TypeHandle) -> bool {
     let children = {
         let ty_ref = mir_ty.deref(ctx);
@@ -408,9 +435,10 @@ fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: Type
     };
 
     children.is_some_and(|children| {
-        children
-            .into_iter()
-            .all(|child| packed_shared_internal_abi_mir_shape_is_supported(ctx, child))
+        children.into_iter().all(|child| {
+            mir_type_is_zero_sized(ctx, child)
+                || packed_shared_internal_abi_mir_shape_is_supported(ctx, child)
+        })
     })
 }
 
@@ -5300,6 +5328,38 @@ mod tests {
             .expect("nested tuple leaf must remain pointer-typed");
         assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
         assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_skips_zero_sized_fields() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let byte = mir_uint(&mut ctx, 8);
+        let marker: TypeHandle = MirArrayType::get(&mut ctx, byte, 0).into();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedZstMarker".into(),
+            vec!["tag".into(), "marker".into(), "ptr".into()],
+            vec![tag, marker, shared],
+            vec![0, 1, 2],
+            vec![0, 1, 1],
+            9,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, packed)
+            .expect("ABI classification must succeed")
+            .expect("a zero-sized field must not knock the struct out of the ABI lane");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((9, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((9, 1)));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -5,13 +5,17 @@
 
 //! End-to-end ABI regression coverage for packed aggregates.
 //!
-//! This example exercises five paths that must agree on the same rustc byte
+//! This example exercises seven paths that must agree on the same rustc byte
 //! layout:
 //!
 //! - packed structs passed by value across the host -> kernel boundary;
 //! - packed structs passed to and returned from an internal device helper;
-//! - packed structs containing a shared pointer returned from an internal
+//! - packed structs containing one shared pointer returned from an internal
 //!   device helper through a target-stable generic-pointer carrier;
+//! - packed structs containing multiple direct shared-pointer leaves crossing
+//!   the same internal device ABI;
+//! - packed structs containing recursively nested shared-pointer leaves crossing
+//!   the same internal device ABI;
 //! - whole-value stores of packed structs to device memory;
 //! - whole-value loads of packed structs from device memory.
 //!
@@ -42,6 +46,28 @@ pub struct Packed2 {
 pub struct PackedShared {
     pub tag: u8,
     pub ptr: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedSharedPair {
+    pub tag: u8,
+    pub left: *mut SharedArray<u32, 1>,
+    pub right: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SharedPair {
+    pub left: *mut SharedArray<u32, 1>,
+    pub right: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedNestedShared {
+    pub tag: u8,
+    pub pair: SharedPair,
 }
 
 #[cuda_module]
@@ -76,6 +102,18 @@ mod kernels {
 
     #[inline(never)]
     #[device]
+    fn bounce_packed_shared_pair(value: PackedSharedPair) -> PackedSharedPair {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
+    fn bounce_packed_nested_shared(value: PackedNestedShared) -> PackedNestedShared {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
     unsafe fn consume_packed_shared(
         _value: PackedShared,
         shared: *mut SharedArray<u32, 1>,
@@ -85,6 +123,40 @@ mod kernels {
             (&mut *shared)[0] = (&*shared)[0].wrapping_add(0x0102_0304);
             out.write(0x22);
             out.add(1).write((&*shared)[0]);
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_shared_pair(
+        _value: PackedSharedPair,
+        left: *mut SharedArray<u32, 1>,
+        right: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *left)[0] = (&*left)[0].wrapping_add(0x0102_0304);
+            (&mut *right)[0] = (&*right)[0].wrapping_add(0x0203_0405);
+            out.write(0x32);
+            out.add(1).write((&*left)[0]);
+            out.add(2).write((&*right)[0]);
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_nested_shared(
+        _value: PackedNestedShared,
+        left: *mut SharedArray<u32, 1>,
+        right: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *left)[0] = (&*left)[0].wrapping_add(0x0304_0506);
+            (&mut *right)[0] = (&*right)[0].wrapping_add(0x0405_0607);
+            out.write(0x42);
+            out.add(1).write((&*left)[0]);
+            out.add(2).write((&*right)[0]);
         }
     }
 
@@ -131,6 +203,54 @@ mod kernels {
         // observable runtime check so this regression does not require a
         // target-dependent whole-value packed store/load.
         unsafe { consume_packed_shared(value, raw, out) };
+    }
+
+    #[kernel]
+    pub unsafe fn packed_shared_pair(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+        unsafe {
+            (&mut *left)[0] = 0x1020_3040;
+            (&mut *right)[0] = 0x2030_4050;
+        }
+
+        let value = bounce_packed_shared_pair(PackedSharedPair {
+            tag: 0x31,
+            left,
+            right,
+        });
+
+        // The returned packed value contains two direct AS3 leaves. Keep it in
+        // SSA and pass it whole into another device helper; the raw pointers
+        // remain separate only to make the runtime effect observable before
+        // packed field projections gain carrier-backed local storage.
+        unsafe { consume_packed_shared_pair(value, left, right, out) };
+    }
+
+    #[kernel]
+    pub unsafe fn packed_nested_shared(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+        unsafe {
+            (&mut *left)[0] = 0x3040_5060;
+            (&mut *right)[0] = 0x4050_6070;
+        }
+
+        let value = bounce_packed_nested_shared(PackedNestedShared {
+            tag: 0x41,
+            pair: SharedPair { left, right },
+        });
+
+        // The AS3 leaves live under a nested aggregate. As above, keep the
+        // packed outer value in SSA so this exercises only the internal ABI
+        // carrier generalization and does not depend on packed local storage.
+        unsafe { consume_packed_nested_shared(value, left, right, out) };
     }
 
     #[kernel]
@@ -253,6 +373,34 @@ fn assert_host_layout() {
     assert_eq!(core::mem::align_of::<PackedShared>(), 1);
     assert_eq!(core::mem::offset_of!(PackedShared, tag), 0);
     assert_eq!(core::mem::offset_of!(PackedShared, ptr), 1);
+
+    assert_eq!(
+        core::mem::size_of::<PackedSharedPair>(),
+        1 + 2 * core::mem::size_of::<usize>()
+    );
+    assert_eq!(core::mem::align_of::<PackedSharedPair>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedSharedPair, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedSharedPair, left), 1);
+    assert_eq!(
+        core::mem::offset_of!(PackedSharedPair, right),
+        1 + core::mem::size_of::<usize>()
+    );
+
+    assert_eq!(core::mem::size_of::<SharedPair>(), 2 * core::mem::size_of::<usize>());
+    assert_eq!(core::mem::align_of::<SharedPair>(), core::mem::align_of::<usize>());
+    assert_eq!(core::mem::offset_of!(SharedPair, left), 0);
+    assert_eq!(
+        core::mem::offset_of!(SharedPair, right),
+        core::mem::size_of::<usize>()
+    );
+
+    assert_eq!(
+        core::mem::size_of::<PackedNestedShared>(),
+        1 + core::mem::size_of::<SharedPair>()
+    );
+    assert_eq!(core::mem::align_of::<PackedNestedShared>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedNestedShared, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedNestedShared, pair), 1);
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -278,6 +426,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let by_value1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let by_value2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let packed_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
+    let packed_shared_pair_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
+    let packed_nested_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let load1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let storage1 = DeviceBuffer::<u8>::zeroed(&stream, core::mem::size_of::<Packed1>())?;
@@ -302,10 +452,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // SAFETY: every kernel launches one thread. The u32 output buffers contain
-    // two writable elements. The byte buffers are CUDA allocations, so their
-    // base addresses satisfy Packed1/Packed2 alignment and have exact storage
-    // for one value of the corresponding type. The packed-shared kernel creates
-    // its AS3 pointer on device and never exposes it through the host ABI.
+    // enough writable elements for their respective checks. The byte buffers
+    // are CUDA allocations, so their base addresses satisfy Packed1/Packed2
+    // alignment and have exact storage for one value of the corresponding
+    // type. The packed-shared kernels create their AS3 pointers on device and
+    // never expose them through the host ABI.
     unsafe {
         module.packed1(
             &stream,
@@ -323,6 +474,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &stream,
             config,
             packed_shared_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.packed_shared_pair(
+            &stream,
+            config,
+            packed_shared_pair_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.packed_nested_shared(
+            &stream,
+            config,
+            packed_nested_shared_out.cu_deviceptr() as *mut u32,
         )?;
 
         module.store_packed1(
@@ -355,6 +516,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(by_value1_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
     assert_eq!(by_value2_out.to_host_vec(&stream)?, [0x33, 0x6172_8394]);
     assert_eq!(packed_shared_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
+    assert_eq!(
+        packed_shared_pair_out.to_host_vec(&stream)?,
+        [0x32, 0x1122_3344, 0x2233_4455]
+    );
+    assert_eq!(
+        packed_nested_shared_out.to_host_vec(&stream)?,
+        [0x42, 0x3344_5566, 0x4455_6677]
+    );
     assert_eq!(load1_out.to_host_vec(&stream)?, [0x41, 0x90a0_b0c0]);
     assert_eq!(load2_out.to_host_vec(&stream)?, [0x51, 0xd0e0_f001]);
 
@@ -368,7 +537,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&bytes2[2..6], &0xd0e0_f001u32.to_le_bytes());
 
     println!(
-        "packed_aggregate_abi: PASS (runtime values, packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
+        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
     );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -386,8 +386,14 @@ fn assert_host_layout() {
         1 + core::mem::size_of::<usize>()
     );
 
-    assert_eq!(core::mem::size_of::<SharedPair>(), 2 * core::mem::size_of::<usize>());
-    assert_eq!(core::mem::align_of::<SharedPair>(), core::mem::align_of::<usize>());
+    assert_eq!(
+        core::mem::size_of::<SharedPair>(),
+        2 * core::mem::size_of::<usize>()
+    );
+    assert_eq!(
+        core::mem::align_of::<SharedPair>(),
+        core::mem::align_of::<usize>()
+    );
     assert_eq!(core::mem::offset_of!(SharedPair, left), 0);
     assert_eq!(
         core::mem::offset_of!(SharedPair, right),


### PR DESCRIPTION
Closes #1063 

## Summary

Generalize the packed-AS3 internal device ABI support introduced by #1001 from a single direct shared-pointer leaf to recursive and multi-leaf aggregate shapes.

The internal ABI can now carry packed structs containing:

- multiple direct AS3 pointer leaves;
- AS3 pointer leaves nested inside structs;
- AS3 pointer leaves nested inside tuples.

The function body still operates on the semantic packed aggregate containing AS3 pointers. Internal device arguments continue to use the existing flattened argument ABI. At the return boundary, the existing target-stable storage machinery recursively replaces every admitted AS3 leaf with a generic pointer.

## Implementation

This change widens `packed_shared_internal_abi_info` without duplicating the existing recursive storage/coercion machinery.

The classifier now:

- admits scalar and pointer leaves;
- recursively traverses MIR structs and tuples;
- accepts one or more AS3 leaves;
- continues to require a byte-faithful packed root struct;
- rejects arrays and vectors for this lane.

`target_stable_storage_type` remains responsible for the actual recursive AS3 -> generic storage rewrite.

The packed aggregate construction path continues to keep semantic AS3 pointers in SSA and uses the widened classifier only as the admission gate.

## Tests

Added coverage for:

- multiple direct AS3 leaves;
- nested struct AS3 leaves;
- nested tuple AS3 leaves;
- arrays remaining out of scope;
- semantic packed SSA construction with multiple direct leaves;
- semantic packed SSA construction with nested leaves;
- end-to-end device call/return coverage for multi-leaf and nested packed aggregates.

Validation performed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p mir-lower packed_shared_internal_abi -- --nocapture`
- `cargo test -p mir-lower packed_struct_construction_with -- --nocapture`
- `cargo test -p mir-lower --all-targets`
- `cargo clippy -p mir-lower --all-targets -- -D warnings`
- `cargo oxide build packed_aggregate_abi`
- `cargo oxide run packed_aggregate_abi`
- `cargo oxide run addressof_sharedarray`

`mir-lower` passes 257 unit tests and 117 lowering tests.

The end-to-end `packed_aggregate_abi` regression passes on `sm_120a`, including recursive and multi-leaf packed shared internal ABI coverage.

## Out of scope

This PR intentionally does not add support for:

- AS3 pointer arrays;
- AS3 pointer vectors;
- whole-value packed AS3 memory loads/stores;
- packed-AS3 field projections requiring local materialization;
- kernel-entry ABI changes.

Those remain separate follow-up work.