### PR TITLE
fix(docs): an example README names `warp::shfl`, which has never existed

### DIFF
--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -93,10 +93,12 @@ jobs:
       - name: Verify the book documents every cargo oxide subcommand
         run: bash scripts/check-cli-doc-coverage.sh
 
-  # A Rust code block in the book is something a reader pastes. When a device
-  # function is renamed the book keeps compiling and rendering, so the stale name
+  # A Rust code block in the book or a README is something a reader pastes. When
+  # a device function is renamed the docs still render, so the stale name
   # survives until someone tries it -- #797 and the `warp::shuffle_xor_i32` entry
-  # in the API quick reference were both found by hand, months apart.
+  # in the API quick reference were both found by hand, months apart. An example
+  # README naming `warp::shfl`, which has never existed, widened the scope to
+  # the crate and example READMEs.
   book-api-names:
     name: book device-API names
     runs-on: ubuntu-latest
@@ -105,7 +107,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      # Reads the book and cuda-device's sources: no cargo, no build, no network.
+      # Reads the book, the crate and example READMEs, and cuda-device's
+      # sources: no cargo, no build, no network.
       - name: Verify every device call the book shows resolves
         run: bash scripts/check-book-api-names.sh
 

--- a/crates/rustc-codegen-cuda/examples/hashmap_v3/README.md
+++ b/crates/rustc-codegen-cuda/examples/hashmap_v3/README.md
@@ -28,7 +28,7 @@ What v2 had that v3 dropped (with the empirical reason):
   v2's perf table showed Protocol B (payload-first) beat it by ~20 %
   at every load. The `RESERVED` tag is reused in v3 for a different
   purpose — the `DELETED -> RESERVED -> FULL(h2)` reclaim handshake.
-- **Raw `warp::ballot` / `warp::shfl` find kernel.** v3 uses only the
+- **Raw `warp::ballot` / `warp::shuffle` find kernel.** v3 uses only the
   typed cooperative-groups API; the `~12 %` non-inlining penalty
   (documented in the v2 perf section) is real, but `WarpTile<16>` more
   than makes it back at moderate load.

--- a/scripts/check-book-api-names.sh
+++ b/scripts/check-book-api-names.sh
@@ -6,9 +6,9 @@
 #
 # Scope is the book plus every crate and example README. The book half is the
 # original; the READMEs were added after one of them was found naming
-# `warp::shfl`, which has never existed -- `cuda-device` exports 32
-# `shuffle*` functions and no `shfl`, which is the cooperative-groups *method*
-# name. Example READMEs carry over a hundred qualified device names and are
+# `warp::shfl`, which has never existed. `cuda-device` exports 32 `shuffle*`
+# functions and no `shfl`; `shfl` is the cooperative-groups *method* name.
+# Example READMEs carry over a hundred qualified device names and are
 # the first thing a reader of an example opens, so they rot the same way the
 # book does and were checked by nothing.
 #
@@ -17,10 +17,10 @@
 # same sweep later found `warp::shuffle_xor_i32` in the API quick reference,
 # advertised as an "i32 variant" that has never existed, and a dispatch helper
 # in the compiler pages that had been replaced by generated code. Nothing fails
-# when the book names a function the tree does not have: it renders, it builds,
+# when a page names a function the tree does not have: it renders, it builds,
 # and a reader finds out by pasting it.
 #
-# Two passes, because the book names APIs two ways:
+# Two passes, because the docs name APIs two ways:
 #
 #   * A call in a ```rust fenced block -- `warp::foo(...)` -- which a reader
 #     pastes, so the name has to exist.
@@ -40,7 +40,7 @@
 # Scope otherwise unchanged, so the guard stays precise rather than merely broad:
 #
 #   * Only the device modules -- `warp`, `thread`, `grid`, `cluster`. Those are
-#     the paths the book uses in kernel examples and the ones that rot. Host
+#     the paths the docs use in kernel examples and the ones that rot. Host
 #     APIs are checked by rustdoc, which builds under `-D warnings`.
 #   * Existence only, never arity or types. Those change for good reasons and
 #     the compiler catches them; a name that is simply absent is the silent case.
@@ -155,14 +155,17 @@ for page in pages:
             mentions.setdefault((match.group(1), name), set()).add(page)
 
 if blocks < 20:
-    sys.exit(f"parse self-test failed: read {blocks} rust code blocks from the book")
+    sys.exit(
+        f"parse self-test failed: read {blocks} rust code blocks from the book "
+        "and READMEs"
+    )
 
 # Both passes have to find something, or a rot in either regex reads as a clean
-# book rather than a broken check.
+# tree rather than a broken check.
 if len(mentions) < 5:
     sys.exit(
         f"parse self-test failed: found {len(mentions)} qualified device names in "
-        "the book's prose and tables"
+        "the docs' prose and tables"
     )
 
 exported = set()
@@ -203,9 +206,9 @@ def report(found, heading, closing):
 
 failed = report(
     unresolved(calls),
-    "error: the book calls device functions that cuda-device does not export:",
+    "error: the docs call device functions that cuda-device does not export:",
     "A Rust code block is something a reader pastes. Either the function was\n"
-    "renamed and the book missed it, or the example was written from memory.",
+    "renamed and the docs missed it, or the example was written from memory.",
 )
 failed = (
     report(

--- a/scripts/check-book-api-names.sh
+++ b/scripts/check-book-api-names.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# Verify every device-API name the book shows resolves to a function
+# Verify every device-API name the docs show resolves to a function
 # `cuda-device` actually exports.
+#
+# Scope is the book plus every crate and example README. The book half is the
+# original; the READMEs were added after one of them was found naming
+# `warp::shfl`, which has never existed -- `cuda-device` exports 32
+# `shuffle*` functions and no `shfl`, which is the cooperative-groups *method*
+# name. Example READMEs carry over a hundred qualified device names and are
+# the first thing a reader of an example opens, so they rot the same way the
+# book does and were checked by nothing.
 #
 # The failure this catches is silent and has now happened three times. #797
 # found the intrinsics guide pointing at op files that no longer existed; the
@@ -46,23 +54,25 @@ cd "$(dirname "$0")/.."
 
 BOOK=cuda-oxide-book
 DEVICE=crates/cuda-device/src
+CRATES=crates
 
 if ! command -v python3 >/dev/null 2>&1; then
-    echo "error: python3 is required to verify the book's API names" >&2
+    echo "error: python3 is required to verify the docs' API names" >&2
     echo "       refusing to report success from a check that cannot run" >&2
     exit 1
 fi
 
 test -d "${BOOK}"
 test -d "${DEVICE}"
+test -d "${CRATES}"
 
-python3 - "${BOOK}" "${DEVICE}" <<'PY'
+python3 - "${BOOK}" "${DEVICE}" "${CRATES}" <<'PY'
 import glob
 import os
 import re
 import sys
 
-book_root, device_root = sys.argv[1], sys.argv[2]
+book_root, device_root, crates_root = sys.argv[1], sys.argv[2], sys.argv[3]
 
 RUST_BLOCK = re.compile(r"```rust[^\n]*\n(.*?)```", re.S)
 # `mod::name(` inside a code block: a call, so the name must exist.
@@ -84,27 +94,47 @@ EXPORTED = re.compile(r"pub (?:unsafe )?fn ([A-Za-z_][A-Za-z0-9_]*)")
 # and the truncated `threadIdx_` reported as missing.
 PROSE_NAME = re.compile(
     r"`(?:cuda_device::)?(warp|thread|grid|cluster)::"
-    r"([A-Za-z_][A-Za-z0-9_]*(?:\{[A-Za-z0-9_,]+\})?)"
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\{[A-Za-z0-9_,]+\}[A-Za-z0-9_]*)?)"
 )
-# `name_{a,b,c}` is the book's shorthand for a family, live today in
+# `name_{a,b,c}` is the shorthand for a family, live today in
 # `thread::threadIdx_{x,y,z}()` and the notation that carried #815's fictional
 # rows. Expanded, so a family with one bad member fails on that member instead of
 # passing as an unrecognised literal.
-BRACES = re.compile(r"^(.*)_\{([A-Za-z0-9_,]+)\}$")
+#
+# The group can sit anywhere in the name, not only at the end:
+# `warp::reduce_{sum,max,min}_f32` is real notation in an example README, and an
+# end-anchored pattern read it as the family `reduce_{sum,max,min}` and dropped
+# the `_f32`, reporting three functions missing that were never named.
+BRACES = re.compile(r"^([A-Za-z0-9_]*)\{([A-Za-z0-9_,]+)\}([A-Za-z0-9_]*)$")
 
 
 def expand(name):
-    """`foo_{a,b}` -> [`foo_a`, `foo_b`]; anything else -> [itself]."""
+    """`foo_{a,b}_bar` -> [`foo_a_bar`, `foo_b_bar`]; anything else -> [itself]."""
     match = BRACES.match(name)
     if not match:
         return [name]
-    stem, options = match.group(1), match.group(2)
-    return [f"{stem}_{option.strip()}" for option in options.split(",") if option.strip()]
+    prefix, options, suffix = match.group(1), match.group(2), match.group(3)
+    return [
+        f"{prefix}{option.strip()}{suffix}"
+        for option in options.split(",")
+        if option.strip()
+    ]
 
 
 pages = sorted(glob.glob(os.path.join(book_root, "**", "*.md"), recursive=True))
 if len(pages) < 20:
     sys.exit(f"parse self-test failed: found {len(pages)} book pages under {book_root}")
+
+# Crate and example READMEs, minus the vendored rustlantis subtree, whose files
+# keep their upstream form and document another project's API.
+readmes = sorted(
+    path
+    for path in glob.glob(os.path.join(crates_root, "**", "README.md"), recursive=True)
+    if "rustlantis" not in path.split(os.sep)
+)
+if len(readmes) < 50:
+    sys.exit(f"parse self-test failed: found {len(readmes)} READMEs under {crates_root}")
+pages += readmes
 
 calls = {}
 mentions = {}
@@ -164,7 +194,7 @@ def report(found, heading, closing):
         return False
     print(heading, file=sys.stderr)
     for module, name, where in found:
-        pages_text = ", ".join(os.path.relpath(p, book_root) for p in where)
+        pages_text = ", ".join(os.path.relpath(p) for p in where)
         print(f"  {module}::{name}   in {pages_text}", file=sys.stderr)
     print(file=sys.stderr)
     print(closing, file=sys.stderr)
@@ -180,7 +210,7 @@ failed = report(
 failed = (
     report(
         unresolved(mentions),
-        "error: the book names device functions that cuda-device does not export:",
+        "error: the docs name device functions that cuda-device does not export:",
         "These are in prose or a table rather than a code block, which is where the\n"
         "fictional `shuffle_xor_{f32,i32}` rows survived until #815. A `_{a,b}`\n"
         "family is expanded, so the member named above is the one that is missing.",
@@ -192,8 +222,9 @@ if failed:
     sys.exit(1)
 
 print(
-    f"OK: all {len(calls)} device-API calls in the book's {blocks} Rust blocks, and "
-    f"{len(mentions)} qualified names in its prose and tables, resolve against "
+    f"OK: all {len(calls)} device-API calls in {blocks} Rust blocks across the "
+    f"book and {len(readmes)} READMEs, and "
+    f"{len(mentions)} qualified names in their prose and tables, resolve against "
     f"cuda-device's {len(exported)} exported functions."
 )
 PY


### PR DESCRIPTION
`hashmap_v3/README.md` contrasts v3's typed cooperative-groups API against what v2 did:

> - **Raw `warp::ballot` / `warp::shfl` find kernel.** v3 uses only the typed cooperative-groups API; …

`cuda-device` exports **32** `shuffle*` functions from `warp` and **no** `shfl` at all. `shfl` is the cooperative-groups *method* name, which is what v3 itself calls (`.shfl(`, twice) — so the sentence describes the raw path using the typed path's vocabulary. v2's source settles the right name: it calls `warp::shuffle` five times, alongside `warp::ballot` six times and `warp::lane_id` twice.

## Nothing would have caught it

`check-book-api-names.sh` exists precisely because a name the tree does not have *"renders, it builds, and a reader finds out by pasting it"* — but it looked only at `cuda-oxide-book`. Crate and example READMEs carry 122 qualified device names, are the first thing a reader of an example opens, and rot the same way. This extends the guard's file scope to them, minus the vendored `rustlantis` subtree, whose files keep their upstream form and document another project's API.

## Extending it exposed a second limitation

The family-shorthand expander was end-anchored (`^(.*)_\{...\}$`), so `warp::reduce_{sum,max,min}_f32` — real notation in `warp_reduce/README.md` — parsed as the family `reduce_{sum,max,min}` with the `_f32` dropped, and the guard reported three functions missing that were never named. The pattern now allows the group anywhere in the name, so `foo_{a,b}_bar` expands to `foo_a_bar` and `foo_b_bar` while `threadIdx_{x,y,z}` keeps working.

## Verification

- The guard passes on this tree: **42** device-API calls in **465** Rust blocks across the book and **159** READMEs, and **38** qualified prose names, all resolving against cuda-device's 1190 exported functions — up from 34 calls in 277 blocks and 31 names.
- Putting `warp::shfl` back fails it, naming the file.
- Planting `warp::ballot_nonexistent` in a README fails it, naming the file.
- Before the expander change the guard reported `warp::reduce_sum`, `warp::reduce_max` and `warp::reduce_min` missing; after it, none.
- Both new self-tests fire on an empty result: fewer than 20 book pages, or fewer than 50 READMEs, stops the run rather than reporting a clean tree.

The script keeps its name and its `status-guard.yml` wiring; only its scope and its two messages change.