### PR TITLE
docs(book): the fuzzing chapter says the adapter rejects five types it accepts

### DIFF
--- a/cuda-oxide-book/compiler/fuzzing-and-differential-testing.md
+++ b/cuda-oxide-book/compiler/fuzzing-and-differential-testing.md
@@ -158,7 +158,7 @@ The runner prints one line per seed and then a full summary:
 
 ```text
 results:
-  seed 0: UNSUPPORTED [adapter] unsupported dumped type for Stage 2 adapter: u128 (...)
+  seed 0: UNSUPPORTED [adapter] unsupported dumped type for Stage 2 adapter: *const i8 (...)
   seed 1: COMPILE_FAIL [backend] Unsupported construct: Type translation not yet implemented for: RigidTy(Char) (...)
 summary: COMPILE_FAIL=1, UNSUPPORTED=1
 ```
@@ -183,20 +183,27 @@ unsupported MIR type -- but the backend is the component that rejected it.
 refused to turn it into a smoke case. For example:
 
 ```text
-unsupported dumped type for Stage 2 adapter: u128
+unsupported dumped type for Stage 2 adapter: *const i8
 ```
 
 That usually means the generated MIR had a `dump_var(...)` containing a type
-our trace API does not yet know how to hash. Today the trace supports:
+our trace API does not yet know how to hash. The trace hashes these scalars:
 
 ```text
-bool, i8, i16, i32, i64, u8, u16, u32, u64
+bool, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, char,
+f32, f64
 ```
 
-It does not yet support `u128`, `i128`, `usize`, `isize`, or `char`. Many
-adapter-level unsupported cases are therefore not "bad MIR" and not cuda-oxide
-bugs. They are simply places where the fuzzer harness has not grown up yet.
-Compilers, like people, need snacks before they can handle `u128`.
+It also hashes an array or a tuple of anything in that list, to any nesting
+depth, by folding the leaves -- so support is a recursive question rather than
+set membership. A tuple is hashed up to arity 5, matching the `TraceDump`
+implementations.
+
+What is left out is anything with no byte-wise value to fold: raw pointers and
+references, and tuples wider than arity 5. Many adapter-level unsupported cases
+are therefore not "bad MIR" and not cuda-oxide bugs. They are simply places
+where the fuzzer harness has not grown up yet. Compilers, like people, need
+snacks before they can hash a raw pointer.
 
 ---
 
@@ -230,13 +237,15 @@ The current config is intentionally small. It keeps the first stage focused on
 scalar custom MIR and backend plumbing rather than every Rust construct at once.
 That is why many early seeds classify as `UNSUPPORTED [adapter]`.
 
-The widening plan is incremental:
+The widening plan is incremental. Two steps have landed: every Rust scalar the
+trace API can hash is now in the adapter's set, and arrays and tuples fold by
+their leaves ([#792](https://github.com/NVlabs/cuda-oxide/pull/792)). What
+remains:
 
-1. Add trace support for more scalar types (`u128`, `i128`, `usize`, `isize`).
-2. Decide whether and how to support `char` in cuda-oxide's type translation.
-3. Expand control-flow and cast coverage.
-4. Add arrays, tuples, and eventually structs/enums.
-5. Add minimization for failing seeds.
+1. Decide whether and how to support `char` in cuda-oxide's type translation.
+2. Expand control-flow and cast coverage.
+3. Add structs and enums, the aggregates that folding does not yet reach.
+4. Add minimization for failing seeds.
 
 That order is deliberate. A fuzzer that generates everything on day one mostly
 generates noise. A fuzzer that grows one axis at a time tells you what broke,

--- a/cuda-oxide-book/compiler/fuzzing-and-differential-testing.md
+++ b/cuda-oxide-book/compiler/fuzzing-and-differential-testing.md
@@ -158,7 +158,7 @@ The runner prints one line per seed and then a full summary:
 
 ```text
 results:
-  seed 0: UNSUPPORTED [adapter] unsupported dumped type for Stage 2 adapter: *const i8 (...)
+  seed 0: UNSUPPORTED [adapter] unsupported return type for return-value tracing: *const i8 (...)
   seed 1: COMPILE_FAIL [backend] Unsupported construct: Type translation not yet implemented for: RigidTy(Char) (...)
 summary: COMPILE_FAIL=1, UNSUPPORTED=1
 ```
@@ -183,27 +183,38 @@ unsupported MIR type -- but the backend is the component that rejected it.
 refused to turn it into a smoke case. For example:
 
 ```text
-unsupported dumped type for Stage 2 adapter: *const i8
+unsupported return type for return-value tracing: *const i8
 ```
 
-That usually means the generated MIR had a `dump_var(...)` containing a type
-our trace API does not yet know how to hash. The trace hashes these scalars:
+That refusal comes from the function boundary, not from a dump site. rustlantis
+only dumps values it can hash, and the adapter accepts all of those. What the
+adapter can still refuse is the function itself: a return type the trace API
+cannot hash, or an argument type it has no literal for. The trace hashes these
+scalars:
 
 ```text
 bool, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, char,
 f32, f64
 ```
 
-It also hashes an array or a tuple of anything in that list, to any nesting
-depth, by folding the leaves -- so support is a recursive question rather than
-set membership. A tuple is hashed up to arity 5, matching the `TraceDump`
-implementations.
+It also hashes arrays and tuples of anything in that list, nested as deep as
+you like: the trace just hashes every scalar inside. Tuples work up to 5
+elements, matching the `TraceDump` implementations.
 
-What is left out is anything with no byte-wise value to fold: raw pointers and
-references, and tuples wider than arity 5. Many adapter-level unsupported cases
-are therefore not "bad MIR" and not cuda-oxide bugs. They are simply places
-where the fuzzer harness has not grown up yet. Compilers, like people, need
-snacks before they can hash a raw pointer.
+```text
+[u128; 4]                  hashes fine
+(u32, char)                hashes fine
+(i8, i8, i8, i8, i8, i8)   rejected: six elements
+*const i8                  rejected: pointer
+```
+
+What's left out: raw pointers and references, because the CPU and the GPU hold
+different addresses for the same object, so a pointer's hash could never match;
+and tuples with more than 5 elements. Many adapter-level unsupported cases are
+therefore not "bad MIR" and not cuda-oxide bugs. The pointer refusal is
+permanent by design; no amount of widening makes those hashes agree. The tuple
+limit is just a gap. The harness needs one more `TraceDump` impl, and maybe a
+snack, before it can hash a six-element tuple.
 
 ---
 
@@ -237,14 +248,15 @@ The current config is intentionally small. It keeps the first stage focused on
 scalar custom MIR and backend plumbing rather than every Rust construct at once.
 That is why many early seeds classify as `UNSUPPORTED [adapter]`.
 
-The widening plan is incremental. Two steps have landed: every Rust scalar the
-trace API can hash is now in the adapter's set, and arrays and tuples fold by
-their leaves ([#792](https://github.com/NVlabs/cuda-oxide/pull/792)). What
-remains:
+The widening plan is incremental, and two steps have already landed: the
+adapter now accepts every scalar the trace API can hash (f32 and f64 arrived
+last, in [#484](https://github.com/NVlabs/cuda-oxide/pull/484)), plus arrays
+and tuples built from them
+([#792](https://github.com/NVlabs/cuda-oxide/pull/792)). What remains:
 
 1. Decide whether and how to support `char` in cuda-oxide's type translation.
 2. Expand control-flow and cast coverage.
-3. Add structs and enums, the aggregates that folding does not yet reach.
+3. Add structs and enums; the trace can't look inside those yet.
 4. Add minimization for failing seeds.
 
 That order is deliberate. A fuzzer that generates everything on day one mostly


### PR DESCRIPTION
`fuzzing-and-differential-testing.md` documents the trace API's type support as nine scalars and then rules out five more:

> Today the trace supports:
> ```
> bool, i8, i16, i32, i64, u8, u16, u32, u64
> ```
> It does not yet support `u128`, `i128`, `usize`, `isize`, or `char`.

`SCALAR_TRACE_TYPES` in `crates/fuzzer/tools/mir_generator.py` holds **sixteen**, including all five of those plus `f32` and `f64`, and `supported_trace_type` gates the adapter on exactly that set. Importing the module and calling the real predicate:

```
u128 True   i128 True   usize True   isize True   char True   f32 True   f64 True
[u128; 4] True     (u32, char) True
*const i8 False    &i32 False    (i8,i8,i8,i8,i8,i8) False
```

So the paragraph is wrong about every type it names, and understates the rest: support is not set membership but a recursive question, because an array or tuple folds by its leaves up to arity 5 (#792) — and `f32`/`f64` have been in since #484.

`crates/fuzzer/README.md` **already states all of this correctly**, listing the same sixteen scalars and the folding rule. The book page is the one outlier, so this brings it in line with the README and the code rather than inventing a third description.

## Two consequences

- The sample `UNSUPPORTED [adapter]` line used `u128` as its rejected type, which the adapter now accepts, so that example cannot be produced. It becomes `*const i8`, which the predicate does reject (measured above) and which the fuzzer README already uses as its own example of an adapter refusal.

- The widening plan listed "Add trace support for more scalar types (`u128`, `i128`, `usize`, `isize`)" and "Add arrays, tuples, and eventually structs/enums" as future work. The first is done and the second is half done, so the plan now records what landed and keeps structs and enums as what remains.

## Left alone deliberately

The `RigidTy(Char)` backend classification in the same sample output. `char` behaviour is nuanced — translation maps it to `u32` (`mir-importer/src/translator/types.rs:543`), while whether `#[device]` extern signatures accept it is open (#875) — and I did not reproduce that line end to end, so it is not mine to rewrite here.

**Verified:** the predicate results above come from importing `mir_generator.py` and calling `supported_trace_type`, not from reading it. Book builds clean under `sphinx-build -W`; `check-book-api-names.sh` passes.