### PR TITLE
docs(llvm-export): a rustdoc error the docs gate cannot see

### DIFF
--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -52,7 +52,7 @@ use super::{
 /// textual export touches four places in this file:
 ///
 /// 1. Add a variant to `LlvmOp` below.
-/// 2. Add a matching entry in the [`classify_op!`] invocation.
+/// 2. Add a matching entry in the `classify_op!` invocation below.
 /// 3. Add an `emit_*` helper method on [`ModuleExportState`].
 /// 4. Add a `Some(LlvmOp::X(op)) => self.emit_x(...)` arm in `export_op`.
 ///


### PR DESCRIPTION
The docs gate runs `cargo doc` without `--document-private-items`, so it never renders a private item and never checks the intra-doc links in one. #1014 and #1042 cleaned `cuda-macros`, `mir-importer/statement.rs` and the codegen backend's collector; this is one of the four that were left:

```
error: unresolved link to `classify_op`
  --> crates/llvm-export/src/export/ops.rs:55
```

`classify_op` is a `macro_rules!` defined further down the same file, at `:138`. A `macro_rules!` macro is in scope only textually after its definition unless it is exported, so no path resolves from a doc comment above it — rustdoc says as much: *"`macro_rules` named `classify_op` exists in this crate, but it is not in scope at this link's location"*. It becomes a plain code span, and since the sentence is one step of a four-step contract about this file, it gains "below" so the reference still points somewhere.

## Scope

Three of the four remain, and all three are in files under open pull requests, so they are left rather than raced:

| error | file | open PRs |
|---|---|---|
| `make_disjoint_slice_struct` | `mir-lower/src/convert/ops/aggregate.rs` | #1062, #1064 |
| `MirFieldAddrOp` | `mir-importer/src/translator/rvalue.rs` | #1059, #1062 |
| `MirArrayElementAddrOp` | same | same |

The first needs only a `crate::convert::types::` prefix; I had it ready and dropped it when #1062 and #1064 appeared on that file mid-change. `--document-private-items` can join the docs gate once they land.

**Verified:** `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items -p llvm-export` reports one unresolved link on `main` and none with this change. The gate's own invocation passes before and after. fmt clean.

Comment-only change.