### PR TITLE
feat(wgmma): add register-resident F16 counted K-loop lowering

### DIFF
--- a/crates/cuda-device/src/wgmma.rs
+++ b/crates/cuda-device/src/wgmma.rs
@@ -18,9 +18,9 @@
 //! - straight-line partial-wait pipelines with a static `wait_group<N>` and
 //!   `N + 1` independent accumulator slots.
 //!
-//! The `m64n64k16.f32.f16.f16` variant supports only the canonical linear
-//! full-drain shape. Every accepted asynchronous lifetime is fused into one
-//! convergent inline-PTX scope and ends in `wait_group<0>` before accumulator
+//! The `m64n64k16.f32.f16.f16` variant supports canonical linear full-drain
+//! regions and the canonical counted K-loop. Every accepted asynchronous
+//! lifetime is fused into one convergent inline-PTX scope and ends in `wait_group<0>` before accumulator
 //! values become visible to LLVM again. Unsupported BF16 full-drain pointer
 //! shapes retain the deferred pointer-form fallback. F16 has no pointer-form
 //! fallback, and TF32 MMA calls remain unsupported.
@@ -74,10 +74,10 @@
 //! - **BF16 linear full drain:** one canonical `[[f32; 8]; 4]` accumulator,
 //!   one commit, and a final `wgmma_wait_group::<0>()`.
 //! - **F16 linear full drain:** the same canonical accumulator and full-drain
-//!   lifetime are supported, but there is no pointer fallback, counted-loop
-//!   lowering, or partial-wait pipeline for F16.
-//! - **Canonical counted K-loop:** one BF16 MMA per iteration, compile-time trip
-//!   count, and `u64` descriptor recurrences of the form `desc + const`. The
+//!   lifetime are supported, but there is no pointer fallback or partial-wait
+//!   pipeline for F16.
+//! - **Canonical counted K-loop:** one BF16 or F16 MMA per iteration,
+//!   compile-time trip count, and `u64` descriptor recurrences of the form `desc + const`. The
 //!   fence-to-final-wait lifetime is fused so the accumulator is loaded and
 //!   stored once for the whole loop rather than once per iteration.
 //! - **Partial-wait pipeline:** a static `wgmma_wait_group::<N>()` with
@@ -88,7 +88,7 @@
 //!   lifetime is pending.
 //! - Unsupported BF16 full-drain accumulator pointer shapes retain the deferred
 //!   pointer-form lowering. Dynamic partial waits, unsupported control flow,
-//!   malformed pipeline schedules, F16 non-linear/pipelined shapes, and TF32
+//!   malformed pipeline schedules, F16 partial-wait/pipelined shapes, and TF32
 //!   MMA variants are rejected.
 //!
 //! # Hardware Support
@@ -242,10 +242,10 @@ pub unsafe fn wgmma_mma_m64n64k16_f32_bf16(acc: &mut [[f32; 8]; 4], desc_a: u64,
 
 /// WGMMA with f32 accumulator and f16 inputs.
 ///
-/// This variant supports a canonical linear full-drain region:
-/// `fence -> one or more MMA -> commit_group -> wait_group<0>`. The accumulator
-/// must have the public `[[f32; 8]; 4]` shape. Counted loops, partial waits, and
-/// non-canonical pointer fallback remain unsupported for F16.
+/// This variant supports canonical linear full-drain regions and canonical
+/// counted K-loops with a compile-time trip count and affine `u64` descriptor
+/// recurrences. The accumulator must have the public `[[f32; 8]; 4]` shape.
+/// Partial waits and non-canonical pointer fallback remain unsupported for F16.
 ///
 /// # PTX
 ///

--- a/crates/cuda-oxide-codegen/tests/wgmma_counted_loop_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_counted_loop_ptx.rs
@@ -11,8 +11,8 @@
 //! branches. This probe builds the canonical pointer-form K-loop (trip count
 //! 4, one MMA in the latch, affine descriptor recurrences), lets the deferred
 //! accumulator fusion rewrite it into the counted-loop asm scope, and then
-//! requires `llc` and `ptxas -arch=sm_90a` to accept the result with zero
-//! spill bytes while all 32 accumulator values stay live.
+//! requires `llc` and `ptxas -arch=sm_90a` to accept both BF16 and F16 forms
+//! with zero spill bytes while all 32 accumulator values stay live.
 
 #![cfg(unix)]
 
@@ -26,7 +26,7 @@ use dialect_mir::{
 };
 use dialect_nvvm::ops::{
     WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaWaitGroupSyncAlignedOp,
+    WgmmaMmaM64N64K16F32F16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 use pliron::builtin::attributes::IntegerAttr;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -50,6 +50,21 @@ const ACCUMULATOR_LEN: u32 = 32;
 const TRIP_COUNT: u64 = 4;
 const DESC_A_STEP: u64 = 16;
 const DESC_B_STEP: u64 = 32;
+
+#[derive(Clone, Copy, Debug)]
+enum WgmmaInputKind {
+    Bf16,
+    F16,
+}
+
+impl WgmmaInputKind {
+    fn ptx_suffix(self) -> &'static str {
+        match self {
+            Self::Bf16 => "bf16.bf16",
+            Self::F16 => "f16.f16",
+        }
+    }
+}
 
 fn append_unsigned_constant(
     ctx: &mut Context,
@@ -89,7 +104,7 @@ fn append_unsigned_constant(
 /// latch: mma(acc, desc_a, desc_b); goto header(i + 1, desc_a + 16, desc_b + 32)
 /// exit: commit_group; wait_group<0>; return
 /// ```
-fn build_wgmma_counted_loop_kernel(module: &mut CodegenModule) {
+fn build_wgmma_counted_loop_kernel(module: &mut CodegenModule, input_kind: WgmmaInputKind) {
     module.edit(|ctx, module| {
         let module_region = module.get_operation().deref(ctx).get_region(0);
         let module_block = module_region
@@ -196,9 +211,13 @@ fn build_wgmma_counted_loop_kernel(module: &mut CodegenModule) {
         branch.insert_at_back(header, ctx);
 
         // latch: one MMA per K iteration and affine descriptor recurrences.
+        let mma_op_info = match input_kind {
+            WgmmaInputKind::Bf16 => WgmmaMmaM64N64K16F32Bf16Op::get_concrete_op_info(),
+            WgmmaInputKind::F16 => WgmmaMmaM64N64K16F32F16Op::get_concrete_op_info(),
+        };
         Operation::new(
             ctx,
-            WgmmaMmaM64N64K16F32Bf16Op::get_concrete_op_info(),
+            mma_op_info,
             vec![],
             vec![accumulator, desc_a, desc_b],
             vec![],
@@ -296,10 +315,9 @@ fn used_register_count(ptxas_stderr: &str) -> Option<u32> {
     })
 }
 
-#[test]
-fn counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
+fn assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(input_kind: WgmmaInputKind) {
     let mut module = CodegenModule::new("wgmma_counted_loop").unwrap();
-    build_wgmma_counted_loop_kernel(&mut module);
+    build_wgmma_counted_loop_kernel(&mut module, input_kind);
 
     let compiler = Compiler::discover().expect("LLVM 21+ llc/opt must be installed");
     let options = CompileOptions::new(Target::parse("sm_90a").unwrap());
@@ -346,11 +364,14 @@ fn counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
         1,
         "the counted loop must contain exactly one fence:\n{text}",
     );
+    let expected_mma = format!(
+        "wgmma.mma_async.sync.aligned.m64n64k16.f32.{}",
+        input_kind.ptx_suffix()
+    );
     assert_eq!(
-        text.matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16")
-            .count(),
+        text.matches(&expected_mma).count(),
         1,
-        "the loop body must contain exactly one BF16 MMA:\n{text}",
+        "the loop body must contain exactly one {input_kind:?} MMA:\n{text}",
     );
     assert_eq!(
         text.matches("wgmma.commit_group.sync.aligned").count(),
@@ -373,7 +394,7 @@ fn counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
         .unwrap_or(0);
 
     let directory = std::env::temp_dir().join(format!(
-        "wgmma_counted_loop_ptx_{}_{}",
+        "wgmma_counted_loop_ptx_{input_kind:?}_{}_{}",
         std::process::id(),
         unique,
     ));
@@ -429,4 +450,14 @@ fn counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
     );
 
     eprintln!("{stderr}");
+}
+
+#[test]
+fn bf16_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
+    assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(WgmmaInputKind::Bf16);
+}
+
+#[test]
+fn f16_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
+    assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(WgmmaInputKind::F16);
 }

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -21,9 +21,9 @@
 //! depths can keep committed groups in flight without exposing an in-flight
 //! accumulator to LLVM. The pointer-form group remains the deferred fallback.
 //!
-//! F16 uses the same 32-value accumulator carrier only for canonical linear
-//! full-drain regions. It intentionally has no deferred pointer-form group,
-//! counted-loop carrier, or partial-wait pipeline carrier.
+//! F16 uses the same 32-value accumulator model for canonical linear
+//! full-drain regions and the canonical counted K-loop. It intentionally has
+//! no deferred pointer-form group or partial-wait pipeline carrier.
 
 use dialect_mir::types::{MirPtrType, address_space};
 use pliron::{
@@ -608,6 +608,120 @@ impl Verify for WgmmaMmaLoopValuesM64N64K16F32Bf16Op {
     }
 }
 
+/// Value-form F16 WGMMA counted loop with 32 SSA accumulator values.
+///
+/// Operand layout:
+///
+/// ```text
+/// [
+///   acc_0, ..., acc_31,
+///   desc_a_base, desc_b_base,
+///   desc_a_step, desc_b_step,
+///   trip_count,
+/// ]
+/// ```
+///
+/// Result layout:
+///
+/// ```text
+/// [acc_0', ..., acc_31']
+/// ```
+///
+/// The operation owns one complete asynchronous WGMMA lifetime. It fences the
+/// accumulator registers, executes one MMA per counted-loop iteration while
+/// advancing both descriptors by their supplied descriptor deltas,
+/// commits the resulting group, and performs a final `wait_group<0>` before the
+/// 32 accumulator values become visible to LLVM again.
+#[pliron_op(name = "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16", format)]
+pub struct WgmmaMmaLoopValuesM64N64K16F32F16Op;
+
+impl WgmmaMmaLoopValuesM64N64K16F32F16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+
+    /// Build a counted-loop group from 32 accumulators and loop-control values.
+    pub fn build(
+        ctx: &mut Context,
+        accumulators: Vec<Value>,
+        desc_a_base: Value,
+        desc_b_base: Value,
+        desc_a_step: Value,
+        desc_b_step: Value,
+        trip_count: Value,
+    ) -> Ptr<Operation> {
+        let f32_ty = FP32Type::get(ctx);
+        let mut operands =
+            Vec::with_capacity(accumulators.len() + WGMMA_COUNTED_LOOP_CONTROL_COUNT);
+        operands.extend(accumulators);
+        operands.extend([
+            desc_a_base,
+            desc_b_base,
+            desc_a_step,
+            desc_b_step,
+            trip_count,
+        ]);
+
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![f32_ty.into(); WGMMA_M64N64_F32_ACCUMULATOR_COUNT],
+            operands,
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for WgmmaMmaLoopValuesM64N64K16F32F16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let expected_operands =
+            WGMMA_M64N64_F32_ACCUMULATOR_COUNT + WGMMA_COUNTED_LOOP_CONTROL_COUNT;
+
+        if op.get_num_operands() != expected_operands {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16 requires 32 f32 accumulators and exactly five u64 loop-control operands"
+            );
+        }
+
+        if op.get_num_results() != WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16 requires exactly 32 f32 results"
+            );
+        }
+
+        for accumulator_index in 0..WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16 accumulator operands must be f32"
+                );
+            }
+            if !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16 results must be f32"
+                );
+            }
+        }
+
+        for control_index in WGMMA_M64N64_F32_ACCUMULATOR_COUNT..expected_operands {
+            if !is_u64(ctx, op.get_operand(control_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k16_f32_f16 descriptor bases, descriptor steps, and trip count must be u64"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Value-form BF16 WGMMA counted loop with independent accumulator slots.
 ///
 /// This deliberately narrow carrier supports the production counted-loop
@@ -927,6 +1041,7 @@ pub(super) fn register(ctx: &mut Context) {
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaGroupValuesM64N64K16F32F16Op::register(ctx);
     WgmmaMmaLoopValuesM64N64K16F32Bf16Op::register(ctx);
+    WgmmaMmaLoopValuesM64N64K16F32F16Op::register(ctx);
     WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -41,7 +41,7 @@ use dialect_nvvm::ops::{
     WgmmaMakeSmemDescOp, WgmmaMaxPendingAttr, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaGroupValuesM64N64K16F32F16Op,
     WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
@@ -97,6 +97,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32Bf16Op"),
+        ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaPipelineValuesM64N64K16F32Bf16Op"),
     ];
@@ -4792,6 +4793,42 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
         WgmmaMmaLoopValuesM64N64K16F32Bf16Op::new(loop_group)
             .verify(&ctx)
             .is_ok()
+    );
+
+    let f16_loop_group = WgmmaMmaLoopValuesM64N64K16F32F16Op::build(
+        &mut ctx,
+        vec![f32_value; 32],
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+    );
+    {
+        let loop_group_ref = f16_loop_group.deref(&ctx);
+        assert_eq!(loop_group_ref.get_num_operands(), 37);
+        assert_eq!(loop_group_ref.get_num_results(), 32);
+    }
+    assert!(
+        WgmmaMmaLoopValuesM64N64K16F32F16Op::new(f16_loop_group)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let mut f16_wrong_loop_control_operands = vec![f32_value; 32];
+    f16_wrong_loop_control_operands.extend([u64_value, u64_value, u32_value, u64_value, u64_value]);
+    let f16_wrong_loop_control = Operation::new(
+        &mut ctx,
+        WgmmaMmaLoopValuesM64N64K16F32F16Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 32],
+        f16_wrong_loop_control_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaLoopValuesM64N64K16F32F16Op::new(f16_wrong_loop_control)
+            .verify(&ctx)
+            .is_err()
     );
 
     let too_few_loop_accumulators = WgmmaMmaLoopValuesM64N64K16F32Bf16Op::build(

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -42,7 +42,7 @@ use dialect_nvvm::ops::{
     ReadPtxSregNclusterIdOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaGroupValuesM64N64K16F32F16Op,
     WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
@@ -1127,6 +1127,23 @@ impl MirToLlvmConversion for WgmmaMmaLoopValuesM64N64K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma_loop_values(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaLoopValuesM64N64K16F32F16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma_loop_values_f16(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -32,6 +32,15 @@ enum WgmmaInputKind {
     F16,
 }
 
+impl WgmmaInputKind {
+    fn ptx_suffix(self) -> &'static str {
+        match self {
+            Self::Bf16 => "bf16.bf16",
+            Self::F16 => "f16.f16",
+        }
+    }
+}
+
 /// Convert WGMMA make_smem_desc to inline PTX.
 pub(crate) fn convert_make_smem_desc(
     ctx: &mut Context,
@@ -116,10 +125,7 @@ fn value_group_template(mma_count: usize, input_kind: WgmmaInputKind) -> String 
     let mut template = String::from("{\n    wgmma.fence.sync.aligned;\n");
     let accumulators = value_accumulator_operand_list();
     let descriptor_base = VALUE_ACCUMULATOR_COUNT * 2;
-    let input_types = match input_kind {
-        WgmmaInputKind::Bf16 => "bf16.bf16",
-        WgmmaInputKind::F16 => "f16.f16",
-    };
+    let input_types = input_kind.ptx_suffix();
 
     for mma_index in 0..mma_count {
         let desc_a = descriptor_base + mma_index * 2;
@@ -144,7 +150,7 @@ fn value_group_constraints(descriptor_count: usize) -> String {
     constraints.join(",")
 }
 
-fn counted_loop_template() -> String {
+fn counted_loop_template(input_kind: WgmmaInputKind) -> String {
     let accumulators = value_accumulator_operand_list();
     let descriptor_base = VALUE_ACCUMULATOR_COUNT * 2;
     let desc_a_base = descriptor_base;
@@ -163,8 +169,9 @@ fn counted_loop_template() -> String {
     template.push_str("    setp.eq.u64 %loop_more, %remaining, 0;\n");
     template.push_str("    @%loop_more bra.uni L__wgmma_done_${:uid};\n");
     template.push_str("L__wgmma_loop_${:uid}:\n");
+    let input_types = input_kind.ptx_suffix();
     template.push_str(&format!(
-        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16 \
+        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.{input_types} \
          {{{accumulators}}}, %desc_a, %desc_b, 1, 1, 1, 0, 0;\n"
     ));
     template.push_str(&format!("    add.u64 %desc_a, %desc_a, ${desc_a_step};\n"));
@@ -427,17 +434,37 @@ fn convert_mma_group_values_for_kind(
 }
 
 /// Lower a counted BF16 WGMMA K-loop to one multi-result inline-PTX scope.
+pub(crate) fn convert_mma_loop_values(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    convert_mma_loop_values_for_kind(ctx, rewriter, op, WgmmaInputKind::Bf16)
+}
+
+/// Lower a counted F16 WGMMA K-loop to one multi-result inline-PTX scope.
+pub(crate) fn convert_mma_loop_values_f16(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    convert_mma_loop_values_for_kind(ctx, rewriter, op, WgmmaInputKind::F16)
+}
+
+/// Lower one counted WGMMA K-loop to a tied-register inline-PTX scope.
 ///
 /// The first 32 operands/results are tied accumulator registers. The remaining
 /// operands are the descriptor bases, descriptor deltas, and trip count. Loop
 /// control and descriptor updates stay inside the same convergent asm statement
 /// as the asynchronous WGMMA instructions, so LLVM never observes an in-flight
 /// accumulator lifetime.
-pub(crate) fn convert_mma_loop_values(
+fn convert_mma_loop_values_for_kind(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
-    _operands_info: &OperandsInfo,
+    input_kind: WgmmaInputKind,
 ) -> Result<()> {
     let loc = op.deref(ctx).loc();
     let result_count = op.deref(ctx).get_num_results();
@@ -454,7 +481,7 @@ pub(crate) fn convert_mma_loop_values(
         );
     }
 
-    let template = counted_loop_template();
+    let template = counted_loop_template(input_kind);
     let constraints = counted_loop_constraints();
 
     let f32_ty = FP32Type::get(ctx);
@@ -755,7 +782,8 @@ mod tests {
 
     #[test]
     fn counted_loop_template_keeps_descriptor_recurrence_inside_one_scope() {
-        let template = counted_loop_template();
+        let template = counted_loop_template(WgmmaInputKind::Bf16);
+        assert!(template.contains("m64n64k16.f32.bf16.bf16"));
         assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
         assert_eq!(template.matches("wgmma.mma_async").count(), 1);
         assert_eq!(
@@ -800,6 +828,33 @@ mod tests {
             5
         );
         assert!(constraints.ends_with("~{memory}"));
+    }
+
+    #[test]
+    fn f16_counted_loop_template_changes_only_the_input_element_types() {
+        let template = counted_loop_template(WgmmaInputKind::F16);
+        assert_eq!(template.matches("wgmma.mma_async").count(), 1);
+        assert!(template.contains("m64n64k16.f32.f16.f16"));
+        assert!(!template.contains(".bf16.bf16"));
+        assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(
+            template.matches("wgmma.commit_group.sync.aligned").count(),
+            1
+        );
+        assert_eq!(
+            template.matches("wgmma.wait_group.sync.aligned 0").count(),
+            1
+        );
+        assert!(template.contains("L__wgmma_loop_${:uid}:"));
+        assert!(template.contains("L__wgmma_done_${:uid}:"));
+        assert!(template.contains("mov.u64 %desc_a, $64;"));
+        assert!(template.contains("mov.u64 %desc_b, $65;"));
+        assert!(template.contains("add.u64 %desc_a, %desc_a, $66;"));
+        assert!(template.contains("add.u64 %desc_b, %desc_b, $67;"));
+        assert!(template.contains("mov.u64 %remaining, $68;"));
+        assert!(!template.contains("ld.f32"));
+        assert!(!template.contains("st.f32"));
+        assert!(!template.contains(".reg .f32"));
     }
 
     #[test]

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Fuse sound BF16 WGMMA sequences and canonical F16 full-drain regions before
-//! MIR-to-LLVM conversion.
+//! Fuse sound BF16 WGMMA sequences plus canonical F16 full-drain and counted
+//! K-loop regions before MIR-to-LLVM conversion.
 //!
 //! The public MMA operation exposes its accumulator through a pointer, but PTX
 //! requires all 32 accumulator registers to remain inaccessible until the
@@ -13,8 +13,9 @@
 //! canonical `[[f32; 8]; 4]` accumulator is adapted through 32 scalar SSA values;
 //! unsupported BF16 accumulator shapes retain the existing deferred pointer
 //! fallback.
-//! F16 is accepted only for the canonical accumulator in a linear full-drain
-//! region; counted loops, partial waits, and pointer fallback remain BF16-only.
+//! F16 is accepted for the canonical accumulator in linear full-drain regions
+//! and the canonical single-slot counted K-loop. Partial waits, counted
+//! pipelines, and pointer fallback remain BF16-only.
 //!
 //! Straight-line regions keep the existing shape:
 //!
@@ -26,11 +27,10 @@
 //! wgmma.wait_group<0>
 //! ```
 //!
-//! A BF16 counted K-loop may place the fence in the loop preheader, one
-//! pointer-form
-//! MMA in the unique latch, and the commit/final `wait_group<0>` in the unique
-//! exit. The loop must have a compile-time trip count and two `u64` descriptor
-//! block arguments whose back-edge values are either unchanged or `arg + const`.
+//! A BF16 or F16 counted K-loop may place the fence in the loop preheader, one
+//! pointer-form MMA in the unique latch, and the commit/final `wait_group<0>` in
+//! the unique exit. The loop must have a compile-time trip count and two `u64`
+//! descriptor block arguments whose back-edge values are either unchanged or `arg + const`.
 //! The complete asynchronous lifetime is then represented by one value-form loop
 //! operation so LLVM never sees an in-flight accumulator between iterations.
 //!
@@ -61,7 +61,7 @@ use dialect_nvvm::ops::{
     WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op, WgmmaMmaGroupValuesM64N64K16F32F16Op,
     WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 use mir_transforms::analyses::{induction, loop_info::LoopInfo};
@@ -98,7 +98,7 @@ const ACCUMULATOR_COLUMNS: usize = 8;
 const ACCUMULATOR_LEN: usize = ACCUMULATOR_ROWS * ACCUMULATOR_COLUMNS;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum LinearMmaKind {
+enum WgmmaMmaKind {
     Bf16,
     F16,
 }
@@ -110,7 +110,7 @@ struct FusionPlan {
     wait: Ptr<Operation>,
     accumulator: Value,
     descriptors: Vec<Value>,
-    kind: LinearMmaKind,
+    kind: WgmmaMmaKind,
 }
 
 struct PipelinePlan {
@@ -146,6 +146,7 @@ struct CountedLoopPlan {
     commit: Ptr<Operation>,
     wait: Ptr<Operation>,
     accumulator: Value,
+    kind: WgmmaMmaKind,
     desc_a_base: Value,
     desc_b_base: Value,
     desc_a_step: u64,
@@ -283,11 +284,12 @@ fn counted_loop_operation_is_supported(ctx: &Context, operation: Ptr<Operation>)
         || Operation::get_op::<MirGeOp>(operation, ctx).is_some()
         || Operation::get_op::<MirCondBranchOp>(operation, ctx).is_some()
         || Operation::get_op::<MirGotoOp>(operation, ctx).is_some()
-        || Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some()
+        || wgmma_mma_kind(ctx, operation).is_some()
 }
 
 fn pipelined_counted_loop_operation_is_supported(ctx: &Context, operation: Ptr<Operation>) -> bool {
-    counted_loop_operation_is_supported(ctx, operation)
+    (counted_loop_operation_is_supported(ctx, operation)
+        && wgmma_mma_kind(ctx, operation) != Some(WgmmaMmaKind::F16))
         || Operation::get_op::<WgmmaCommitGroupSyncAlignedOp>(operation, ctx).is_some()
         || Operation::get_op::<WgmmaWaitGroupSyncAlignedOp>(operation, ctx).is_some()
 }
@@ -739,12 +741,12 @@ fn match_counted_loop(
             if !counted_loop_operation_is_supported(ctx, operation) {
                 return Ok(None);
             }
-            if Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some() {
-                mmas.push(operation);
+            if let Some(kind) = wgmma_mma_kind(ctx, operation) {
+                mmas.push((operation, kind));
             }
         }
     }
-    let [mma] = mmas.as_slice() else {
+    let [(mma, kind)] = mmas.as_slice() else {
         return Ok(None);
     };
     if mma.deref(ctx).get_parent_block() != Some(latch) {
@@ -818,6 +820,7 @@ fn match_counted_loop(
         commit,
         wait,
         accumulator,
+        kind: *kind,
         desc_a_base,
         desc_b_base,
         desc_a_step,
@@ -886,11 +889,11 @@ fn require_pointer_mma_shape(ctx: &Context, operation: Ptr<Operation>) -> Result
     Ok(())
 }
 
-fn linear_mma_kind(ctx: &Context, operation: Ptr<Operation>) -> Option<LinearMmaKind> {
+fn wgmma_mma_kind(ctx: &Context, operation: Ptr<Operation>) -> Option<WgmmaMmaKind> {
     if Operation::get_op::<WgmmaMmaM64N64K16F32Bf16Op>(operation, ctx).is_some() {
-        Some(LinearMmaKind::Bf16)
+        Some(WgmmaMmaKind::Bf16)
     } else if Operation::get_op::<WgmmaMmaM64N64K16F32F16Op>(operation, ctx).is_some() {
-        Some(LinearMmaKind::F16)
+        Some(WgmmaMmaKind::F16)
     } else {
         None
     }
@@ -1144,7 +1147,7 @@ fn apply_value_plan(
     wait: Ptr<Operation>,
     accumulator: Value,
     descriptors: Vec<Value>,
-    kind: LinearMmaKind,
+    kind: WgmmaMmaKind,
     row_type: TypeHandle,
     element_type: TypeHandle,
 ) {
@@ -1153,10 +1156,10 @@ fn apply_value_plan(
         load_accumulator_values_before(ctx, wait, accumulator, row_type, element_type, loc.clone());
 
     let group = match kind {
-        LinearMmaKind::Bf16 => {
+        WgmmaMmaKind::Bf16 => {
             WgmmaMmaGroupValuesM64N64K16F32Bf16Op::build(ctx, accumulator_values, descriptors)
         }
-        LinearMmaKind::F16 => {
+        WgmmaMmaKind::F16 => {
             WgmmaMmaGroupValuesM64N64K16F32F16Op::build(ctx, accumulator_values, descriptors)
         }
     };
@@ -1294,6 +1297,7 @@ fn apply_counted_loop_plan(ctx: &mut Context, plan: CountedLoopPlan) {
         commit,
         wait,
         accumulator,
+        kind,
         desc_a_base,
         desc_b_base,
         desc_a_step,
@@ -1323,15 +1327,26 @@ fn apply_counted_loop_plan(ctx: &mut Context, plan: CountedLoopPlan) {
     let desc_b_step = insert_u64_constant_before(ctx, desc_b_step, preheader_terminator);
     let trip_count = insert_u64_constant_before(ctx, trip_count, preheader_terminator);
 
-    let group = WgmmaMmaLoopValuesM64N64K16F32Bf16Op::build(
-        ctx,
-        accumulator_values,
-        desc_a_base,
-        desc_b_base,
-        desc_a_step,
-        desc_b_step,
-        trip_count,
-    );
+    let group = match kind {
+        WgmmaMmaKind::Bf16 => WgmmaMmaLoopValuesM64N64K16F32Bf16Op::build(
+            ctx,
+            accumulator_values,
+            desc_a_base,
+            desc_b_base,
+            desc_a_step,
+            desc_b_step,
+            trip_count,
+        ),
+        WgmmaMmaKind::F16 => WgmmaMmaLoopValuesM64N64K16F32F16Op::build(
+            ctx,
+            accumulator_values,
+            desc_a_base,
+            desc_b_base,
+            desc_a_step,
+            desc_b_step,
+            trip_count,
+        ),
+    };
     group.deref_mut(ctx).set_loc(loc.clone());
     let accumulator_results = (0..ACCUMULATOR_LEN)
         .map(|index| group.deref(ctx).get_result(index))
@@ -1723,7 +1738,7 @@ fn match_sequence(ctx: &Context, fence: Ptr<Operation>) -> Result<Option<FusionP
                 );
             }
 
-            if let Some(current_kind) = linear_mma_kind(ctx, operation) {
+            if let Some(current_kind) = wgmma_mma_kind(ctx, operation) {
                 require_pointer_mma_shape(ctx, operation)?;
                 if commit.is_some() {
                     return pliron::input_err_noloc!(
@@ -1743,7 +1758,7 @@ fn match_sequence(ctx: &Context, fence: Ptr<Operation>) -> Result<Option<FusionP
                 let operation_ref = operation.deref(ctx);
                 let current_accumulator = operation_ref.get_operand(0);
                 require_supported_accumulator(ctx, current_accumulator)?;
-                if current_kind == LinearMmaKind::F16
+                if current_kind == WgmmaMmaKind::F16
                     && value_accumulator_shape(ctx, current_accumulator).is_none()
                 {
                     return pliron::input_err_noloc!(
@@ -1925,7 +1940,7 @@ fn apply_plan(ctx: &mut Context, plan: FusionPlan) -> Result<()> {
             row_type,
             element_type,
         );
-    } else if kind == LinearMmaKind::Bf16 {
+    } else if kind == WgmmaMmaKind::Bf16 {
         apply_pointer_fallback(ctx, fence, mmas, commit, wait, accumulator, descriptors);
     } else {
         return pliron::input_err_noloc!(
@@ -1972,7 +1987,7 @@ fn region_is_fully_reachable(ctx: &Context, region: Ptr<Region>) -> bool {
     reachable.len() == all_blocks.len()
 }
 
-/// Adapt every supported pointer-form BF16 WGMMA sequence in `module_op`.
+/// Adapt every supported pointer-form BF16/F16 WGMMA sequence in `module_op`.
 ///
 /// Canonical counted loops are handled first because their fence and final wait
 /// live in different CFG blocks. Each successful loop rewrite bypasses the old

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -10690,12 +10690,14 @@ fn test_pointer_form_wgmma_counted_k_loop_stays_register_resident() -> Result<()
 }
 
 #[test]
-fn test_f16_wgmma_counted_k_loop_remains_unsupported() -> Result<(), anyhow::Error> {
+fn test_f16_wgmma_counted_k_loop_stays_register_resident() -> Result<(), anyhow::Error> {
     use dialect_mir::types::{MirArrayType, MirPtrType};
     use pliron::basic_block::BasicBlock;
     use pliron::builtin::op_interfaces::OperandSegmentInterface;
     use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
 
+    const ACCUMULATOR_LEN: usize = 32;
+    const LOOP_CONTROL_COUNT: usize = 5;
     const TRIP_COUNT: u64 = 4;
     const DESC_A_STEP: u64 = 16;
     const DESC_B_STEP: u64 = 32;
@@ -10840,11 +10842,130 @@ fn test_f16_wgmma_counted_k_loop_remains_unsupported() -> Result<(), anyhow::Err
     append_wgmma_wait_group_constant(&mut ctx, exit, 0);
     append_return(&mut ctx, exit);
 
-    assert_wgmma_lowering_rejected(
-        &mut ctx,
-        module_ptr,
-        "WGMMA MMA reached lowering without deferred accumulator fusion",
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let body = lowered_kernel_body(&ctx, module_ptr);
+    let matching = body
+        .iter()
+        .copied()
+        .filter_map(|operation| {
+            Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx)
+                .map(|inline_asm| (operation, inline_asm))
+        })
+        .filter(|(_, asm)| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("L__wgmma_loop_${:uid}:"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one fused F16 counted-loop WGMMA asm"
     );
+
+    let (asm_operation, asm) = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("F16 counted-loop WGMMA template");
+
+    assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(
+        template
+            .matches("wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16")
+            .count(),
+        1,
+        "the F16 counted-loop template must contain exactly one F16 MMA"
+    );
+    assert!(!template.contains(".bf16.bf16"));
+    assert_eq!(
+        template.matches("wgmma.commit_group.sync.aligned").count(),
+        1
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1
+    );
+    assert!(template.contains("mov.u64 %desc_a, $64;"));
+    assert!(template.contains("mov.u64 %desc_b, $65;"));
+    assert!(template.contains("add.u64 %desc_a, %desc_a, $66;"));
+    assert!(template.contains("add.u64 %desc_b, %desc_b, $67;"));
+    assert!(template.contains("mov.u64 %remaining, $68;"));
+    assert!(template.contains("@%loop_more bra.uni L__wgmma_done_${:uid};"));
+    assert!(template.contains("@%loop_more bra.uni L__wgmma_loop_${:uid};"));
+    assert!(template.contains("L__wgmma_done_${:uid}:"));
+    assert!(
+        !template.contains(".reg .f32")
+            && !template.contains("ld.f32")
+            && !template.contains("st.f32"),
+        "F16 counted-loop WGMMA must keep accumulator memory outside asm: {template}"
+    );
+
+    let mut expected_constraints = vec!["=f".to_owned(); ACCUMULATOR_LEN];
+    expected_constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
+    expected_constraints.extend((0..LOOP_CONTROL_COUNT).map(|_| "l".to_owned()));
+    expected_constraints.push("~{memory}".to_owned());
+    let expected_constraints = expected_constraints.join(",");
+    assert_eq!(
+        asm.get_attr_inline_asm_constraints(&ctx)
+            .map(|value| String::from((*value).clone()))
+            .as_deref(),
+        Some(expected_constraints.as_str())
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+    assert_eq!(
+        asm_operation.deref(&ctx).get_num_operands(),
+        ACCUMULATOR_LEN + LOOP_CONTROL_COUNT
+    );
+
+    let asm_position = body
+        .iter()
+        .position(|operation| operation == asm_operation)
+        .expect("F16 counted-loop WGMMA asm must be in the lowered kernel body");
+
+    let load_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::LoadOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        load_positions.len(),
+        ACCUMULATOR_LEN,
+        "F16 K-loop accumulator must be loaded exactly once"
+    );
+    assert!(load_positions.iter().all(|index| *index < asm_position));
+
+    let store_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::StoreOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        store_positions.len(),
+        ACCUMULATOR_LEN,
+        "F16 K-loop accumulator must be stored exactly once after the final wait"
+    );
+    assert!(store_positions.iter().all(|index| *index > asm_position));
+
+    assert_eq!(
+        body.iter()
+            .filter(
+                |operation| Operation::get_op::<llvm::ExtractValueOp>(**operation, &ctx).is_some()
+            )
+            .count(),
+        ACCUMULATOR_LEN
+    );
+
     Ok(())
 }
 

--- a/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
+++ b/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
@@ -107,8 +107,9 @@ unsafe {
 
 The compiler supports `m64n64k16.f32.bf16.bf16` across three conservative
 lowering shapes, and `m64n64k16.f32.f16.f16` for canonical linear full-drain
-regions only. In every accepted case, the entire asynchronous accumulator
-lifetime stays inside one convergent inline-PTX statement so LLVM cannot insert
+and counted K-loop regions. In every accepted case, the entire asynchronous
+accumulator lifetime stays inside one convergent inline-PTX statement so LLVM
+cannot insert
 a spill boundary while a WGMMA group is pending.
 
 **Linear full drain.** A canonical `[[f32; 8]; 4]` accumulator is loaded into
@@ -117,9 +118,9 @@ a spill boundary while a WGMMA group is pending.
 BF16 full-drain pointer shapes retain the original deferred pointer-form
 lowering; F16 does not have a pointer-form fallback.
 
-**Canonical counted K-loop.** For a compile-time counted BF16 loop with one MMA per
-iteration and affine `u64` descriptor recurrences, cuda-oxide moves the loop
-control and descriptor arithmetic into the same convergent PTX region as the
+**Canonical counted K-loop.** For a compile-time counted BF16 or F16 loop with
+one MMA per iteration and affine `u64` descriptor recurrences, cuda-oxide moves
+the loop control and descriptor arithmetic into the same convergent PTX region as the
 WGMMA instruction. The accumulator is therefore loaded once before the K-loop
 and stored once after its final wait rather than round-tripped every iteration.
 
@@ -143,9 +144,9 @@ accumulator. A final `wait_group<0>` is mandatory before any accumulator value
 escapes the fused region.
 
 Selection is intentionally fail-closed. Dynamic partial waits, unsupported
-control flow, malformed accumulator schedules, F16 counted-loop or partial-wait
-shapes, F16 non-canonical accumulators, and the TF32 public compatibility entry
-point are rejected instead of exposing an in-flight accumulator to LLVM.
+control flow, malformed accumulator schedules, F16 partial-wait shapes, F16
+non-canonical accumulators, and the TF32 public compatibility entry point are
+rejected instead of exposing an in-flight accumulator to LLVM.
 
 :::{tip}
 WGMMA is often paired with a **multi-stage pipeline**: while the tensor


### PR DESCRIPTION
Closes #1074 

## Summary

Extend the existing register-resident WGMMA counted K-loop lowering to `m64n64k16.f32.f16.f16`.

The new path reuses the same counted-loop control and accumulator model already used by BF16:

```text
fence
counted K-loop:
    mma
    descriptor recurrence
commit_group
wait_group<0>
```

All 32 per-thread `f32` accumulator values remain tied across one convergent
inline-PTX statement, so LLVM never observes an in-flight asynchronous WGMMA accumulator between loop iterations.

## What changed

* Add an F16 counted-loop value carrier:
  `WgmmaMmaLoopValuesM64N64K16F32F16Op`.
* Extend the single-slot counted-loop recognizer to accept canonical F16 loops.
* Generalize the counted-loop PTX template over the existing WGMMA input kind.
* Add MIR-to-LLVM conversion for the F16 counted-loop carrier.
* Add verifier and lowering coverage for the new carrier.
* Extend the real `llc` / `ptxas` counted-loop probe to cover both BF16 and F16.
* Update the public WGMMA documentation to describe F16 counted-loop support.

The existing counted-pipeline path remains BF16-only.

## Scope

Supported F16 shape:

* canonical `[[f32; 8]; 4]` accumulator;
* one MMA per counted-loop iteration;
* compile-time positive trip count;
* affine `u64` descriptor recurrences;
* `fence -> counted loop -> commit_group -> wait_group<0>`.

Still unsupported:

* F16 `wait_group<N>` for `N > 0`;
* F16 multi-slot pipelines;
* F16 counted pipelines;
* non-canonical F16 accumulator fallback;
* dynamic trip counts;
* arbitrary loop CFGs;
* TF32 WGMMA.

## Validation

```text
cargo fmt --all -- --check
cargo check -p dialect-nvvm -p mir-lower -p cuda-device -p cuda-oxide-codegen
cargo test -p dialect-nvvm --test ops_test
cargo test -p mir-lower --test lowering_test
cargo test -p cuda-oxide-codegen --test wgmma_counted_loop_ptx -- --nocapture
cargo clippy -p dialect-nvvm -p mir-lower -p cuda-device -p cuda-oxide-codegen --all-targets -- -D warnings
```

Results:

* `dialect-nvvm`: 51 passed
* `mir-lower lowering_test`: 117 passed
* BF16 counted-loop `ptxas`: 58 registers, 0-byte stack, 0 spill stores, 0 spill loads
* F16 counted-loop `ptxas`: 58 registers, 0-byte stack, 0 spill stores, 0 spill loads
* `clippy -D warnings`: clean

The F16 lowering therefore matches the existing BF16 counted-loop register
footprint in the current probe while remaining spill-free on `sm_90a`.
