### PR TITLE
Add borrowed DeviceBuffer subviews for typed kernel launches

### DIFF
--- a/crates/cuda-core/src/device_buffer.rs
+++ b/crates/cuda-core/src/device_buffer.rs
@@ -31,6 +31,7 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::num::Wrapping;
+use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
 use cuda_bindings::CUdeviceptr;
@@ -152,6 +153,203 @@ pub struct DeviceBuffer<T> {
     _marker: PhantomData<T>,
 }
 
+/// Error returned when constructing or splitting a borrowed device-buffer view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeviceSliceError {
+    /// An excluded start bound could not be advanced by one element.
+    StartBoundOverflow,
+    /// An included end bound could not be advanced to its exclusive form.
+    EndBoundOverflow,
+    /// The normalized start index exceeds the parent view length.
+    StartOutOfBounds { start: usize, len: usize },
+    /// The normalized exclusive end index exceeds the parent view length.
+    EndOutOfBounds { end: usize, len: usize },
+    /// The normalized range has its start after its end.
+    StartAfterEnd { start: usize, end: usize },
+    /// Converting the element offset to a byte offset overflowed.
+    ByteOffsetOverflow { offset: usize, element_size: usize },
+    /// Adding the byte offset to the CUDA device pointer overflowed.
+    PointerOverflow { ptr: CUdeviceptr, byte_offset: u64 },
+}
+
+impl std::fmt::Display for DeviceSliceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::StartBoundOverflow => write!(f, "device slice start bound overflow"),
+            Self::EndBoundOverflow => write!(f, "device slice end bound overflow"),
+            Self::StartOutOfBounds { start, len } => {
+                write!(f, "device slice start {start} exceeds length {len}")
+            }
+            Self::EndOutOfBounds { end, len } => {
+                write!(f, "device slice end {end} exceeds length {len}")
+            }
+            Self::StartAfterEnd { start, end } => {
+                write!(f, "device slice start {start} exceeds end {end}")
+            }
+            Self::ByteOffsetOverflow {
+                offset,
+                element_size,
+            } => write!(
+                f,
+                "device slice byte offset overflow: {offset} * {element_size}"
+            ),
+            Self::PointerOverflow { ptr, byte_offset } => write!(
+                f,
+                "device slice pointer overflow: {ptr:#x} + {byte_offset:#x}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DeviceSliceError {}
+
+/// Immutable non-owning view over a contiguous range of a [`DeviceBuffer`].
+///
+/// The view carries only an adjusted CUDA device pointer and element count.
+/// Its lifetime borrows the parent allocation, so the allocation cannot be
+/// dropped while the view is live. Dropping the view never frees device memory.
+pub struct DeviceSlice<'a, T> {
+    ptr: CUdeviceptr,
+    len: usize,
+    _borrow: PhantomData<&'a T>,
+}
+
+impl<T> Copy for DeviceSlice<'_, T> {}
+
+impl<T> Clone for DeviceSlice<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> std::fmt::Debug for DeviceSlice<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceSlice")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+impl<'a, T> DeviceSlice<'a, T> {
+    /// Returns the adjusted CUDA device pointer for this view.
+    #[inline]
+    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+        self.ptr
+    }
+
+    /// Number of elements in this view.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` when this view contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Splits this immutable view into two contiguous views at `mid`.
+    ///
+    /// Consuming `self` preserves the original parent-buffer lifetime on both
+    /// returned views without introducing another owner.
+    pub fn split_at(self, mid: usize) -> Result<(Self, Self), DeviceSliceError> {
+        if mid > self.len {
+            return Err(DeviceSliceError::EndOutOfBounds {
+                end: mid,
+                len: self.len,
+            });
+        }
+        let right_ptr = checked_device_ptr_offset::<T>(self.ptr, mid)?;
+        Ok((
+            Self {
+                ptr: self.ptr,
+                len: mid,
+                _borrow: PhantomData,
+            },
+            Self {
+                ptr: right_ptr,
+                len: self.len - mid,
+                _borrow: PhantomData,
+            },
+        ))
+    }
+}
+
+/// Exclusive non-owning view over a contiguous range of a [`DeviceBuffer`].
+///
+/// The mutable borrow of the parent allocation is retained for `'a`. The type
+/// is intentionally neither `Copy` nor `Clone`; splitting consumes the view and
+/// returns two disjoint mutable views.
+pub struct DeviceSliceMut<'a, T> {
+    ptr: CUdeviceptr,
+    len: usize,
+    _borrow: PhantomData<&'a mut T>,
+}
+
+impl<T> std::fmt::Debug for DeviceSliceMut<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceSliceMut")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+impl<'a, T> DeviceSliceMut<'a, T> {
+    /// Returns the adjusted CUDA device pointer for this view.
+    #[inline]
+    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+        self.ptr
+    }
+
+    /// Number of elements in this view.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` when this view contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Splits this mutable view into two proven-disjoint mutable views.
+    pub fn split_at_mut(self, mid: usize) -> Result<(Self, Self), DeviceSliceError> {
+        if mid > self.len {
+            return Err(DeviceSliceError::EndOutOfBounds {
+                end: mid,
+                len: self.len,
+            });
+        }
+        let right_ptr = checked_device_ptr_offset::<T>(self.ptr, mid)?;
+        Ok((
+            Self {
+                ptr: self.ptr,
+                len: mid,
+                _borrow: PhantomData,
+            },
+            Self {
+                ptr: right_ptr,
+                len: self.len - mid,
+                _borrow: PhantomData,
+            },
+        ))
+    }
+
+    /// Consumes the exclusive view and downgrades it to an immutable view.
+    #[inline]
+    pub fn into_shared(self) -> DeviceSlice<'a, T> {
+        DeviceSlice {
+            ptr: self.ptr,
+            len: self.len,
+            _borrow: PhantomData,
+        }
+    }
+}
+
 // SAFETY: CUdeviceptr is a u64 handle valid across threads when the owning
 // context is bound. The PhantomData<T> is Send if T is Send.
 unsafe impl<T: Send> Send for DeviceBuffer<T> {}
@@ -207,6 +405,42 @@ impl<T> DeviceBuffer<T> {
     #[inline]
     pub fn context(&self) -> &Arc<CudaContext> {
         &self.ctx
+    }
+
+    /// Borrows a contiguous immutable subrange of this device allocation.
+    ///
+    /// The returned view does not allocate, copy, or own memory. Range
+    /// normalization, element-to-byte conversion, and pointer addition are all
+    /// checked before the adjusted pointer is exposed. Empty ranges are valid.
+    pub fn slice<R>(&self, range: R) -> Result<DeviceSlice<'_, T>, DeviceSliceError>
+    where
+        R: RangeBounds<usize>,
+    {
+        let (start, end) = normalize_device_range(self.len, range)?;
+        let ptr = checked_device_ptr_offset::<T>(self.ptr, start)?;
+        Ok(DeviceSlice {
+            ptr,
+            len: end - start,
+            _borrow: PhantomData,
+        })
+    }
+
+    /// Borrows a contiguous exclusive subrange of this device allocation.
+    ///
+    /// The exclusive parent borrow is retained by the returned view, preventing
+    /// safe creation of overlapping mutable views from the same buffer. Use
+    /// [`DeviceSliceMut::split_at_mut`] to derive multiple disjoint regions.
+    pub fn slice_mut<R>(&mut self, range: R) -> Result<DeviceSliceMut<'_, T>, DeviceSliceError>
+    where
+        R: RangeBounds<usize>,
+    {
+        let (start, end) = normalize_device_range(self.len, range)?;
+        let ptr = checked_device_ptr_offset::<T>(self.ptr, start)?;
+        Ok(DeviceSliceMut {
+            ptr,
+            len: end - start,
+            _borrow: PhantomData,
+        })
     }
 
     /// Constructs a `DeviceBuffer` from pre-existing raw parts.
@@ -885,6 +1119,58 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     }
 }
 
+fn normalize_device_range<R>(len: usize, range: R) -> Result<(usize, usize), DeviceSliceError>
+where
+    R: RangeBounds<usize>,
+{
+    let start = match range.start_bound() {
+        Bound::Included(&start) => start,
+        Bound::Excluded(&start) => start
+            .checked_add(1)
+            .ok_or(DeviceSliceError::StartBoundOverflow)?,
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(&end) => end
+            .checked_add(1)
+            .ok_or(DeviceSliceError::EndBoundOverflow)?,
+        Bound::Excluded(&end) => end,
+        Bound::Unbounded => len,
+    };
+
+    if start > len {
+        return Err(DeviceSliceError::StartOutOfBounds { start, len });
+    }
+    if end > len {
+        return Err(DeviceSliceError::EndOutOfBounds { end, len });
+    }
+    if start > end {
+        return Err(DeviceSliceError::StartAfterEnd { start, end });
+    }
+    Ok((start, end))
+}
+
+fn checked_device_ptr_offset<T>(
+    ptr: CUdeviceptr,
+    offset: usize,
+) -> Result<CUdeviceptr, DeviceSliceError> {
+    let element_size = std::mem::size_of::<T>();
+    let byte_offset =
+        offset
+            .checked_mul(element_size)
+            .ok_or(DeviceSliceError::ByteOffsetOverflow {
+                offset,
+                element_size,
+            })?;
+    let byte_offset =
+        u64::try_from(byte_offset).map_err(|_| DeviceSliceError::ByteOffsetOverflow {
+            offset,
+            element_size,
+        })?;
+    ptr.checked_add(byte_offset)
+        .ok_or(DeviceSliceError::PointerOverflow { ptr, byte_offset })
+}
+
 fn allocation_size<T>(len: usize) -> Result<usize, DriverError> {
     len.checked_mul(std::mem::size_of::<T>()).ok_or(DriverError(
         cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
@@ -912,7 +1198,10 @@ fn chunk_cast_len(bytes: usize, addr: usize, elem_size: usize, align: usize) -> 
 
 #[cfg(test)]
 mod chunk_cast_tests {
-    use super::chunk_cast_len;
+    use super::{
+        DeviceSliceError, checked_device_ptr_offset, chunk_cast_len, normalize_device_range,
+    };
+    use std::ops::Bound;
 
     /// A device allocation is at least 256-byte aligned, so the alignment check
     /// is expected to pass; these pin that it does, and that a hand-computed
@@ -971,5 +1260,45 @@ mod chunk_cast_tests {
         assert_eq!(chunk_cast_len(4096, 0x1000, 16, 0), None);
         // An empty buffer casts to an empty buffer.
         assert_eq!(chunk_cast_len(0, 0x1000, 16, 16), Some(0));
+    }
+
+    #[test]
+    fn normalizes_device_slice_ranges() {
+        assert_eq!(normalize_device_range(8, 2..6), Ok((2, 6)));
+        assert_eq!(normalize_device_range(8, ..=3), Ok((0, 4)));
+        assert_eq!(normalize_device_range(8, 8..8), Ok((8, 8)));
+        assert_eq!(
+            normalize_device_range(8, 9..),
+            Err(DeviceSliceError::StartOutOfBounds { start: 9, len: 8 })
+        );
+        assert_eq!(
+            normalize_device_range(8, (Bound::Included(6), Bound::Excluded(4)),),
+            Err(DeviceSliceError::StartAfterEnd { start: 6, end: 4 })
+        );
+    }
+
+    #[test]
+    fn rejects_range_bound_overflow() {
+        assert_eq!(
+            normalize_device_range(8, (Bound::Excluded(usize::MAX), Bound::Unbounded)),
+            Err(DeviceSliceError::StartBoundOverflow)
+        );
+        assert_eq!(
+            normalize_device_range(8, (Bound::Unbounded, Bound::Included(usize::MAX))),
+            Err(DeviceSliceError::EndBoundOverflow)
+        );
+    }
+
+    #[test]
+    fn checks_device_pointer_offset_arithmetic() {
+        assert_eq!(checked_device_ptr_offset::<u32>(0x1000, 3), Ok(0x100c));
+        assert_eq!(
+            checked_device_ptr_offset::<()>(0x1000, usize::MAX),
+            Ok(0x1000)
+        );
+        assert!(matches!(
+            checked_device_ptr_offset::<u64>(u64::MAX - 3, 1),
+            Err(DeviceSliceError::PointerOverflow { .. })
+        ));
     }
 }

--- a/crates/cuda-core/src/lib.rs
+++ b/crates/cuda-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use cuda_bindings as sys;
 /// `#[derive(DeviceCopy)]` macro, re-exported next to the `DeviceCopy` trait so
 /// `use cuda_core::DeviceCopy;` brings both into scope (serde trait+derive pattern).
 pub use cuda_macros::DeviceCopy;
-pub use device_buffer::{DeviceBuffer, DeviceCopy};
+pub use device_buffer::{DeviceBuffer, DeviceCopy, DeviceSlice, DeviceSliceError, DeviceSliceMut};
 pub use embedded::{EmbeddedModule, EmbeddedModuleError};
 pub use error::{DriverError, IntoResult};
 pub use event::CudaEvent;

--- a/crates/cuda-core/tests/device_buffer.rs
+++ b/crates/cuda-core/tests/device_buffer.rs
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cuda_core::{CudaContext, CudaStream, DeviceBuffer, DriverError, PinnedHostBuffer};
+use cuda_core::{
+    CudaContext, CudaStream, DeviceBuffer, DeviceSliceError, DriverError, PinnedHostBuffer,
+};
+use std::mem::size_of;
 use std::sync::{Mutex, MutexGuard, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -130,6 +133,75 @@ fn device_buffer_supports_empty_allocations() {
     assert_eq!(dev_buf_host.len(), 0);
     assert_eq!(dev_buf_host.num_bytes(), 0);
     assert!(dev_buf_host.is_empty());
+}
+
+#[test]
+fn device_buffer_borrowed_subviews_adjust_pointer_and_length() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+    let dev = DeviceBuffer::<u32>::zeroed(&stream, 8).expect("failed to allocate device buffer");
+    let base = dev.cu_deviceptr();
+
+    let view = dev.slice(2..6).expect("failed to create immutable subview");
+    assert_eq!(view.cu_deviceptr(), base + 2 * size_of::<u32>() as u64);
+    assert_eq!(view.len(), 4);
+    assert!(!view.is_empty());
+
+    let (left, right) = view.split_at(1).expect("failed to split immutable subview");
+    assert_eq!(left.cu_deviceptr(), base + 2 * size_of::<u32>() as u64);
+    assert_eq!(left.len(), 1);
+    assert_eq!(right.cu_deviceptr(), base + 3 * size_of::<u32>() as u64);
+    assert_eq!(right.len(), 3);
+
+    let empty = dev.slice(8..8).expect("failed to create empty subview");
+    assert_eq!(empty.cu_deviceptr(), base + 8 * size_of::<u32>() as u64);
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn device_buffer_mutable_subviews_split_into_disjoint_ranges() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+    let mut dev =
+        DeviceBuffer::<u32>::zeroed(&stream, 8).expect("failed to allocate device buffer");
+    let base = dev.cu_deviceptr();
+
+    let view = dev
+        .slice_mut(1..7)
+        .expect("failed to create mutable subview");
+    let (left, right) = view
+        .split_at_mut(2)
+        .expect("failed to split mutable subview");
+
+    assert_eq!(left.cu_deviceptr(), base + size_of::<u32>() as u64);
+    assert_eq!(left.len(), 2);
+    assert_eq!(right.cu_deviceptr(), base + 3 * size_of::<u32>() as u64);
+    assert_eq!(right.len(), 4);
+
+    let shared = right.into_shared();
+    assert_eq!(shared.cu_deviceptr(), base + 3 * size_of::<u32>() as u64);
+    assert_eq!(shared.len(), 4);
+}
+
+#[test]
+fn device_buffer_subviews_reject_invalid_ranges() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+    let dev = DeviceBuffer::<u32>::zeroed(&stream, 8).expect("failed to allocate device buffer");
+
+    assert_eq!(
+        dev.slice(9..).unwrap_err(),
+        DeviceSliceError::StartOutOfBounds { start: 9, len: 8 }
+    );
+    assert_eq!(
+        dev.slice(..9).unwrap_err(),
+        DeviceSliceError::EndOutOfBounds { end: 9, len: 8 }
+    );
+    assert_eq!(
+        dev.slice((std::ops::Bound::Included(6), std::ops::Bound::Excluded(4),))
+            .unwrap_err(),
+        DeviceSliceError::StartAfterEnd { start: 6, end: 4 }
+    );
 }
 
 #[test]

--- a/crates/cuda-host/src/launch.rs
+++ b/crates/cuda-host/src/launch.rs
@@ -150,9 +150,10 @@ pub fn push_kernel_scalar<T: KernelScalar>(args: &mut Vec<*mut c_void>, value: &
 /// parameters such as `&[T]`.
 #[inline]
 #[doc(hidden)]
-pub fn read_only_device_buffer_arg<T>(
-    buffer: &cuda_core::DeviceBuffer<T>,
-) -> (cuda_core::sys::CUdeviceptr, u64) {
+pub fn read_only_device_buffer_arg<B>(buffer: &B) -> (cuda_core::sys::CUdeviceptr, u64)
+where
+    B: KernelSliceArg + ?Sized,
+{
     (buffer.cu_deviceptr(), buffer.len() as u64)
 }
 
@@ -160,9 +161,10 @@ pub fn read_only_device_buffer_arg<T>(
 /// parameters such as `&mut [T]` and `DisjointSlice<T>`.
 #[inline]
 #[doc(hidden)]
-pub fn writable_device_buffer_arg<T>(
-    buffer: &mut cuda_core::DeviceBuffer<T>,
-) -> (cuda_core::sys::CUdeviceptr, u64) {
+pub fn writable_device_buffer_arg<B>(buffer: &mut B) -> (cuda_core::sys::CUdeviceptr, u64)
+where
+    B: KernelSliceArgMut + ?Sized,
+{
     (buffer.cu_deviceptr(), buffer.len() as u64)
 }
 
@@ -312,11 +314,11 @@ pub fn push_kernel_row_width_device_slice(
 }
 
 // =============================================================================
-// Typed Async Kernel Arguments
+// Typed Kernel Slice Arguments
 // =============================================================================
 
-/// A typed device allocation that can be passed to an async kernel launch as a
-/// read-only device slice.
+/// A typed device allocation or borrowed view that can be passed to a generated
+/// kernel launch as a read-only device slice.
 ///
 /// # Safety
 ///
@@ -343,7 +345,6 @@ pub fn push_kernel_row_width_device_slice(
 ///     fn len(&self) -> usize { 1_000_000 }
 /// }
 /// ```
-#[cfg(feature = "async")]
 pub unsafe trait KernelSliceArg {
     /// Element type stored in the allocation.
     type Elem;
@@ -360,8 +361,8 @@ pub unsafe trait KernelSliceArg {
     }
 }
 
-/// A typed device allocation that can be passed to an async kernel launch as a
-/// writable device slice.
+/// A typed device allocation or borrowed view that can be passed to a generated
+/// kernel launch as a writable device slice.
 ///
 /// # Safety
 ///
@@ -370,10 +371,8 @@ pub unsafe trait KernelSliceArg {
 /// this rule: the implementor must own exclusive device-write authority for
 /// the entire reported element range for the lifetime of the mutable borrow or
 /// owned operation.
-#[cfg(feature = "async")]
 pub unsafe trait KernelSliceArgMut: KernelSliceArg {}
 
-#[cfg(feature = "async")]
 // SAFETY: DeviceBuffer owns the reported allocation and keeps its CUDA context
 // alive; its pointer and length accessors describe that allocation exactly.
 unsafe impl<T> KernelSliceArg for cuda_core::DeviceBuffer<T> {
@@ -388,10 +387,41 @@ unsafe impl<T> KernelSliceArg for cuda_core::DeviceBuffer<T> {
     }
 }
 
-#[cfg(feature = "async")]
 // SAFETY: &mut DeviceBuffer provides exclusive host authority to launch device
 // writes through this adapter for the duration of the operation.
 unsafe impl<T> KernelSliceArgMut for cuda_core::DeviceBuffer<T> {}
+
+// SAFETY: DeviceSlice borrows its parent allocation for the view lifetime and
+// reports the checked adjusted pointer and element count for that subrange.
+unsafe impl<T> KernelSliceArg for cuda_core::DeviceSlice<'_, T> {
+    type Elem = T;
+
+    fn cu_deviceptr(&self) -> cuda_core::sys::CUdeviceptr {
+        self.cu_deviceptr()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+// SAFETY: DeviceSliceMut retains an exclusive borrow of its parent allocation
+// and reports only the checked subrange covered by that borrow.
+unsafe impl<T> KernelSliceArg for cuda_core::DeviceSliceMut<'_, T> {
+    type Elem = T;
+
+    fn cu_deviceptr(&self) -> cuda_core::sys::CUdeviceptr {
+        self.cu_deviceptr()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+// SAFETY: DeviceSliceMut's construction and consuming split operations preserve
+// exclusive authority over the reported subrange.
+unsafe impl<T> KernelSliceArgMut for cuda_core::DeviceSliceMut<'_, T> {}
 
 #[cfg(feature = "async")]
 // SAFETY: DeviceBox owns the reported allocation and its raw constructor
@@ -803,6 +833,18 @@ impl<T> HasLength for cuda_core::DeviceBuffer<T> {
     }
 }
 
+impl<T> HasLength for cuda_core::DeviceSlice<'_, T> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T> HasLength for cuda_core::DeviceSliceMut<'_, T> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -904,5 +946,17 @@ mod tests {
             ptr
         );
         assert_eq!(unsafe { *(args[1] as *const u64) }, len);
+    }
+
+    fn assert_slice_arg<T: KernelSliceArg>() {}
+    fn assert_slice_arg_mut<T: KernelSliceArgMut>() {}
+
+    #[test]
+    fn borrowed_device_views_implement_typed_slice_argument_traits() {
+        assert_slice_arg::<cuda_core::DeviceBuffer<u32>>();
+        assert_slice_arg::<cuda_core::DeviceSlice<'static, u32>>();
+        assert_slice_arg::<cuda_core::DeviceSliceMut<'static, u32>>();
+        assert_slice_arg_mut::<cuda_core::DeviceBuffer<u32>>();
+        assert_slice_arg_mut::<cuda_core::DeviceSliceMut<'static, u32>>();
     }
 }

--- a/crates/cuda-host/src/lib.rs
+++ b/crates/cuda-host/src/lib.rs
@@ -99,10 +99,10 @@ pub use kernel_family::{
     NoKernelSelectionCache, SelectedVariant, SelectionMode, SelectionSource,
 };
 pub use launch::{
-    CudaKernel, GenericCudaKernel, HasLength, KernelScalar, ReadOnly, RowWidth, RowWidthOwned,
-    Scalar, WriteOnly, push_kernel_device_slice, push_kernel_row_width_device_slice,
-    push_kernel_scalar, read_only_device_buffer_arg, row_width_device_buffer_arg,
-    writable_device_buffer_arg,
+    CudaKernel, GenericCudaKernel, HasLength, KernelScalar, KernelSliceArg, KernelSliceArgMut,
+    ReadOnly, RowWidth, RowWidthOwned, Scalar, WriteOnly, push_kernel_device_slice,
+    push_kernel_row_width_device_slice, push_kernel_scalar, read_only_device_buffer_arg,
+    row_width_device_buffer_arg, writable_device_buffer_arg,
 };
 #[doc(hidden)]
 pub use type_id::__intern_generic_kernel_name;
@@ -110,13 +110,12 @@ pub use type_id::{type_id_u128, type_id_u128_of_val};
 
 #[cfg(feature = "async")]
 pub use launch::{
-    KernelSliceArg, KernelSliceArgMut, PreparedAsyncKernelLaunch, PreparedOwnedAsyncKernelLaunch,
-    load_cuda_module_from_async_context, load_kernel_module_async, new_async_kernel_launch_builder,
-    new_owned_async_kernel_launch, new_prepared_async_kernel_launch,
-    new_prepared_owned_async_kernel_launch, push_async_kernel_scalar,
-    push_async_owned_row_width_device_slice, push_async_read_only_device_slice,
-    push_async_row_width_device_slice, push_async_writable_device_slice,
-    set_async_kernel_cluster_dim, set_async_kernel_cooperative,
+    PreparedAsyncKernelLaunch, PreparedOwnedAsyncKernelLaunch, load_cuda_module_from_async_context,
+    load_kernel_module_async, new_async_kernel_launch_builder, new_owned_async_kernel_launch,
+    new_prepared_async_kernel_launch, new_prepared_owned_async_kernel_launch,
+    push_async_kernel_scalar, push_async_owned_row_width_device_slice,
+    push_async_read_only_device_slice, push_async_row_width_device_slice,
+    push_async_writable_device_slice, set_async_kernel_cluster_dim, set_async_kernel_cooperative,
 };
 
 #[cfg(feature = "async")]

--- a/crates/cuda-host/tests/cuda_module_api.rs
+++ b/crates/cuda-host/tests/cuda_module_api.rs
@@ -5,7 +5,9 @@
 
 #![allow(dead_code, non_upper_case_globals, clippy::needless_lifetimes)]
 
-use cuda_core::{CudaStream, DeviceBuffer, LaunchConfig, LaunchConfig1D};
+use cuda_core::{
+    CudaStream, DeviceBuffer, DeviceSlice, DeviceSliceMut, LaunchConfig, LaunchConfig1D,
+};
 #[cfg(feature = "async")]
 use cuda_host::cuda_async::device_box::DeviceBox;
 #[cfg(feature = "async")]
@@ -227,6 +229,35 @@ unsafe fn generated_methods_accept_kernel_scalar_types(
     Ok(())
 }
 
+unsafe fn generated_sync_methods_accept_borrowed_device_views(
+    module: &kernels::LoadedModule,
+    stream: &CudaStream,
+    config: LaunchConfig,
+    input: &DeviceSlice<'_, f32>,
+    input_u32: &DeviceSlice<'_, u32>,
+    output: &mut DeviceSliceMut<'_, f32>,
+    output_u32: &mut DeviceSliceMut<'_, u32>,
+) -> Result<(), cuda_core::DriverError> {
+    let params = AffineParams {
+        scale: 2.0,
+        bias: 1.0,
+    };
+    let raw = core::ptr::null::<f32>();
+    let offset = 5u32;
+    let op = move |x: u32| x + offset;
+
+    unsafe {
+        module.scalar_args(stream, config, 2.0, params, raw, input, output)?;
+        module.copy_closure(stream, config, op, output_u32)?;
+        module.const_only::<4>(stream, config, output_u32)?;
+        module.mixed::<u32, 8>(stream, config, 7, output_u32)?;
+        module.lifetime_mixed::<u32, 4>(stream, config, input_u32, output_u32)?;
+        module.cooperative_grid_sync(stream, config, output_u32)?;
+    }
+
+    Ok(())
+}
+
 fn generated_prepared_methods_bind_the_exact_kernel_and_specialization(
     module: &kernels::LoadedModule,
     stream: &CudaStream,
@@ -271,6 +302,42 @@ fn generated_prepared_methods_bind_the_exact_kernel_and_specialization(
             input,
         )?;
     }
+    Ok(())
+}
+
+fn generated_prepared_methods_accept_borrowed_device_views(
+    module: &kernels::LoadedModule,
+    stream: &CudaStream,
+    input: &DeviceSlice<'_, u32>,
+) -> Result<(), cuda_core::LaunchContractError> {
+    let prepared = module.prepare_contracted_read(LaunchConfig1D::new(1, 64, 0))?;
+    module.contracted_read(stream, &prepared, input)?;
+
+    let sizes = module.prepare_contracted_sizes(LaunchConfig1D::new(1, 64, 0))?;
+    module.contracted_sizes(stream, &sizes, 4, input)?;
+
+    unsafe {
+        module.contracted_read_unchecked(
+            stream,
+            LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            input,
+        )?;
+        module.contracted_sizes_unchecked(
+            stream,
+            LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (64, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            4,
+            input,
+        )?;
+    }
+
     Ok(())
 }
 
@@ -436,7 +503,9 @@ fn generated_prepared_owned_async_methods_are_immutable_operations(
 #[test]
 fn generated_cuda_module_api_typechecks() {
     let _ = generated_methods_accept_kernel_scalar_types;
+    let _ = generated_sync_methods_accept_borrowed_device_views;
     let _ = generated_prepared_methods_bind_the_exact_kernel_and_specialization;
+    let _ = generated_prepared_methods_accept_borrowed_device_views;
     #[cfg(feature = "async")]
     let _ = generated_async_methods_accept_borrowed_buffers;
     #[cfg(feature = "async")]

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -433,9 +433,9 @@ fn scope_parameter_collision(input: &ItemFn, scope: &Ident) -> Option<Ident> {
 /// built with its `async` feature, the macro also emits borrowed async and owned
 /// async methods. Kernel parameter types are mapped to host-side launch types:
 ///
-/// - `&[T]` -> `&cuda_core::DeviceBuffer<T>`
-/// - `&mut [T]` -> `&mut cuda_core::DeviceBuffer<T>`
-/// - `DisjointSlice<T>` -> `&mut cuda_core::DeviceBuffer<T>`
+/// - `&[T]` -> `&impl cuda_host::KernelSliceArg<Elem = T>`
+/// - `&mut [T]` -> `&mut impl cuda_host::KernelSliceArgMut<Elem = T>`
+/// - `DisjointSlice<T>` -> `&mut impl cuda_host::KernelSliceArgMut<Elem = T>`
 /// - `Copy` scalar/struct/closure/raw-pointer arguments keep their original
 ///   type and pass through `cuda_host::KernelScalar`
 ///
@@ -2414,8 +2414,8 @@ fn validate_requires_operand(expr: &Expr, params: &[CudaModuleParam]) -> syn::Re
 /// different host type.
 #[derive(Clone, Copy)]
 enum RequiresLenAccess {
-    /// Sync prepared launcher: slice parameters are `&DeviceBuffer<T>` or
-    /// `&mut DeviceBuffer<T>`, so `.len()` resolves to the inherent method.
+    /// Sync prepared launcher: ordinary slices use `KernelSliceArg` traits,
+    /// while runtime-row-width slices use `RowWidth`; `.len()` works for both.
     SyncBuffer,
     /// Async prepared launcher: slice parameters are `&impl KernelSliceArg`
     /// or `&mut impl KernelSliceArgMut`.
@@ -2672,9 +2672,9 @@ fn cuda_module_host_type(
     let async_lifetime = cuda_module_async_lifetime();
     if let Some((elem_ty, mutable)) = cuda_module_slice_elem(ty) {
         let sync_host_ty = if mutable {
-            quote! { &mut ::cuda_core::DeviceBuffer<#elem_ty> }
+            quote! { &mut impl ::cuda_host::KernelSliceArgMut<Elem = #elem_ty> }
         } else {
-            quote! { &::cuda_core::DeviceBuffer<#elem_ty> }
+            quote! { &impl ::cuda_host::KernelSliceArg<Elem = #elem_ty> }
         };
         let (async_host_ty, marshal) = if mutable {
             (
@@ -2705,7 +2705,7 @@ fn cuda_module_host_type(
             ));
         }
         return Ok((
-            quote! { &mut ::cuda_core::DeviceBuffer<#elem_ty> },
+            quote! { &mut impl ::cuda_host::KernelSliceArgMut<Elem = #elem_ty> },
             quote! { &#async_lifetime mut impl ::cuda_host::KernelSliceArgMut<Elem = #elem_ty> },
             CudaModuleParamMarshal::WritableDeviceBuffer {
                 elem_ty: quote! { #elem_ty },
@@ -9028,6 +9028,43 @@ mod tests {
         assert!(expanded.contains("alias(launch_context)"));
         assert!(!expanded.contains("__internal::index_1d_u32"));
         assert_eq!(scope.ident, "launch_context");
+    }
+
+    #[test]
+    fn sync_slice_launchers_use_kernel_slice_arg_traits() {
+        let module: ItemMod = parse_quote! {
+            mod kernels {
+                #[kernel]
+                pub fn slices(
+                    input: &[u32],
+                    output: &mut [u32],
+                    mut disjoint: DisjointSlice<u32>,
+                ) {
+                }
+            }
+        };
+        let expanded = expand_to_compact_string(module);
+
+        assert!(
+            expanded.contains("input:&impl::cuda_host::KernelSliceArg<Elem=u32>"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("output:&mutimpl::cuda_host::KernelSliceArgMut<Elem=u32>"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("disjoint:&mutimpl::cuda_host::KernelSliceArgMut<Elem=u32>"),
+            "{expanded}"
+        );
+        assert!(
+            !expanded.contains("&::cuda_core::DeviceBuffer<u32>"),
+            "{expanded}"
+        );
+        assert!(
+            !expanded.contains("&mut::cuda_core::DeviceBuffer<u32>"),
+            "{expanded}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this adds

Borrowed `DeviceBuffer` subviews let a typed kernel operate on part of an allocation while the parent buffer retains ownership. Partially addresses #968.

## Shape of the change

- Add immutable and mutable views with checked ranges and consuming mutable splits.
- Pass each view through the existing pointer/length launch packet.
- Extend generated synchronous launchers to accept the new slice argument traits.

```text
parent allocation: [ a b | c d e | f ]
borrowed view:            c d e
kernel packet:           pointer + length 3
```

## Validation

- Focused runtime, host and macro checks passed on the submitted head.
- Borrowing controls cover parent lifetimes and disjoint mutable views.

## Remaining work

The runtime API must first land in its current owner, cutile-rs. Main now consumes `cuda-core` 0.3.1 from that project; the local runtime crates changed here were removed. Publish the view API there, update the shared dependency pins, then port the launcher integration to current main. GPU validation remains pending that integration.
