### PR TITLE
Add multi-value debug location infrastructure

### DIFF
--- a/crates/dialect-mir/src/ops/debug.rs
+++ b/crates/dialect-mir/src/ops/debug.rs
@@ -36,6 +36,7 @@ const DEBUG_LOCAL_DECL_FILE_KEY: &str = "cuda_oxide_debug_local_decl_file";
 const DEBUG_LOCAL_DECL_LINE_KEY: &str = "cuda_oxide_debug_local_decl_line";
 const DEBUG_LOCAL_DECL_COLUMN_KEY: &str = "cuda_oxide_debug_local_decl_column";
 const DEBUG_LOCAL_SCOPE_KEY: &str = "cuda_oxide_debug_local_scope";
+const DEBUG_VALUE_EXPRESSION_KEY: &str = "cuda_oxide_debug_value_expression";
 
 const DEBUG_LOCAL_ATTR_KEYS: &[&str] = &[
     DEBUG_LOCAL_NAME_KEY,
@@ -45,6 +46,7 @@ const DEBUG_LOCAL_ATTR_KEYS: &[&str] = &[
     DEBUG_LOCAL_DECL_LINE_KEY,
     DEBUG_LOCAL_DECL_COLUMN_KEY,
     DEBUG_LOCAL_SCOPE_KEY,
+    DEBUG_VALUE_EXPRESSION_KEY,
 ];
 
 /// Value-based source-local debug record.
@@ -85,6 +87,39 @@ impl MirDbgValueOp {
 }
 
 impl Verify for MirDbgValueOp {
+    fn verify(&self, _ctx: &Context) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Multi-value source-local debug record.
+///
+/// LLVM models a source value computed from multiple SSA values with a
+/// `DIArgList` plus a `DIExpression` containing `DW_OP_LLVM_arg` selectors.
+/// This MIR marker carries the ordered SSA operands; the expression itself is
+/// stored as generic debug metadata so `dialect-mir` stays independent of the
+/// LLVM exporter data structures.
+#[pliron_op(
+    name = "mir.dbg_value_list",
+    format,
+    interfaces = [NResultsInterface<0>]
+)]
+pub struct MirDbgValueListOp;
+
+impl MirDbgValueListOp {
+    /// Create a multi-value debug record from an ordered list of SSA values.
+    pub fn new(ctx: &mut Context, values: Vec<Value>) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], values, vec![], 0);
+        MirDbgValueListOp { op }
+    }
+
+    /// The ordered SSA values referenced by `DW_OP_LLVM_arg` operations.
+    pub fn values(&self, ctx: &Context) -> Vec<Value> {
+        self.get_operation().deref(ctx).operands().collect()
+    }
+}
+
+impl Verify for MirDbgValueListOp {
     fn verify(&self, _ctx: &Context) -> Result<(), Error> {
         Ok(())
     }
@@ -194,4 +229,5 @@ fn source_position_from_location(ctx: &Context, loc: &Location) -> Option<(Strin
 /// Register debug operations into the given context.
 pub fn register(ctx: &mut Context) {
     MirDbgValueOp::register(ctx);
+    MirDbgValueListOp::register(ctx);
 }

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -130,6 +130,7 @@ enum LlvmOp<'op> {
     Constant(&'op ops::ConstantOp),
     AddressOf(&'op ops::AddressOfOp),
     DebugValue(&'op ops::DebugValueOp),
+    DebugValueList(&'op ops::DebugValueListOp),
 }
 
 /// Try each `(Variant, OpType)` pair in order; return the first match.
@@ -218,6 +219,7 @@ impl<'op> TryFrom<&'op dyn Op> for LlvmOp<'op> {
             Constant     => ops::ConstantOp,
             AddressOf    => ops::AddressOfOp,
             DebugValue   => ops::DebugValueOp,
+            DebugValueList => ops::DebugValueListOp,
         })
     }
 }
@@ -226,7 +228,11 @@ impl LlvmOp<'_> {
     fn emits_real_instruction(&self) -> bool {
         !matches!(
             self,
-            Self::Undef(_) | Self::Constant(_) | Self::AddressOf(_) | Self::DebugValue(_)
+            Self::Undef(_)
+                | Self::Constant(_)
+                | Self::AddressOf(_)
+                | Self::DebugValue(_)
+                | Self::DebugValueList(_)
         )
     }
 
@@ -478,6 +484,9 @@ impl<'a> ModuleExportState<'a> {
             Some(LlvmOp::AddressOf(op)) => self.emit_address_of(op, value_names, output)?,
             Some(LlvmOp::DebugValue(op)) => {
                 self.emit_debug_value(op, value_names, debug_scope, &op_loc, output)?
+            }
+            Some(LlvmOp::DebugValueList(op)) => {
+                self.emit_debug_value_list(op, value_names, debug_scope, &op_loc, output)?
             }
             // Unknown
             None if self.legacy_typed_pointers() => {
@@ -838,6 +847,55 @@ impl<'a> ModuleExportState<'a> {
         }
     }
 
+    fn debug_expression_for_value_list(
+        expression: &ops::DebugValueExpression,
+        operand_count: usize,
+    ) -> Result<String, String> {
+        if expression.operations.is_empty() {
+            return Err("multi-value debug expression must not be empty".to_string());
+        }
+
+        let mut parts = Vec::with_capacity(expression.operations.len() * 2);
+        let mut saw_arg = false;
+        for operation in &expression.operations {
+            match operation {
+                ops::DebugValueExpressionOp::Arg(index) => {
+                    let index = *index as usize;
+                    if index >= operand_count {
+                        return Err(format!(
+                            "multi-value debug expression references argument {index}, but only {operand_count} operands exist"
+                        ));
+                    }
+                    saw_arg = true;
+                    parts.push("DW_OP_LLVM_arg".to_string());
+                    parts.push(index.to_string());
+                }
+                ops::DebugValueExpressionOp::ConstU(value) => {
+                    parts.push("DW_OP_constu".to_string());
+                    parts.push(value.to_string());
+                }
+                ops::DebugValueExpressionOp::Plus => parts.push("DW_OP_plus".to_string()),
+                ops::DebugValueExpressionOp::PlusUConst(value) => {
+                    parts.push("DW_OP_plus_uconst".to_string());
+                    parts.push(value.to_string());
+                }
+                ops::DebugValueExpressionOp::Mul => parts.push("DW_OP_mul".to_string()),
+                ops::DebugValueExpressionOp::Deref => parts.push("DW_OP_deref".to_string()),
+                ops::DebugValueExpressionOp::StackValue => {
+                    parts.push("DW_OP_stack_value".to_string())
+                }
+            }
+        }
+        if !saw_arg {
+            return Err(
+                "multi-value debug expression must reference at least one DIArgList operand"
+                    .to_string(),
+            );
+        }
+
+        Ok(format!("!DIExpression({})", parts.join(", ")))
+    }
+
     fn emit_debug_declare_for_alloca(
         &mut self,
         op: &ops::AllocaOp,
@@ -927,6 +985,57 @@ impl<'a> ModuleExportState<'a> {
         writeln!(
             output,
             ", metadata !{var_id}, metadata !DIExpression()), !dbg !{loc_id}"
+        )
+        .unwrap();
+        self.debug_value_used = true;
+
+        Ok(())
+    }
+
+    fn emit_debug_value_list(
+        &mut self,
+        op: &ops::DebugValueListOp,
+        value_names: &FxHashMap<Value, String>,
+        debug_scope: Option<usize>,
+        loc: &pliron::location::Location,
+        output: &mut String,
+    ) -> Result<(), String> {
+        if !self.debug_kind.variables_enabled() {
+            return Ok(());
+        }
+
+        let Some(scope) = debug_scope else {
+            return Ok(());
+        };
+        let Some(info) = crate::ops::debug_local_variable(self.ctx, op.get_operation()) else {
+            return Ok(());
+        };
+        let Some((var_id, loc_id)) =
+            self.debug_local_variable_for_scope(scope, loc, op.get_operation(), &info)
+        else {
+            return Ok(());
+        };
+
+        let values = op.values(self.ctx);
+        if values.len() < 2 {
+            return Err("llvm.dbg_value_list requires at least two operands".to_string());
+        }
+        let expression = crate::ops::debug_value_expression(self.ctx, op.get_operation())
+            .ok_or_else(|| "llvm.dbg_value_list is missing its debug expression".to_string())?;
+        let expression = Self::debug_expression_for_value_list(&expression, values.len())?;
+
+        write!(output, "  call void @llvm.dbg.value(metadata !DIArgList(").unwrap();
+        for (index, value) in values.into_iter().enumerate() {
+            if index != 0 {
+                write!(output, ", ").unwrap();
+            }
+            self.export_type(value.get_type(self.ctx), output)?;
+            write!(output, " ").unwrap();
+            self.export_value(value, value_names, output)?;
+        }
+        writeln!(
+            output,
+            "), metadata !{var_id}, metadata {expression}), !dbg !{loc_id}"
         )
         .unwrap();
         self.debug_value_used = true;

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -813,6 +813,34 @@ pub mod ops {
         pub ty: DebugLocalTypeKind,
     }
 
+    /// One operation in a multi-value LLVM debug expression.
+    ///
+    /// `Arg(N)` selects the Nth operand from the `DIArgList`. The remaining
+    /// operations are the small DWARF subset needed to combine addresses and
+    /// runtime scalar state without exposing raw expression strings to callers.
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    pub enum DebugValueExpressionOp {
+        Arg(u32),
+        ConstU(u64),
+        Plus,
+        PlusUConst(u64),
+        Mul,
+        Deref,
+        StackValue,
+    }
+
+    /// Ordered operations for a multi-value `llvm.dbg.value` location recipe.
+    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+    pub struct DebugValueExpression {
+        pub operations: Vec<DebugValueExpressionOp>,
+    }
+
+    impl DebugValueExpression {
+        pub fn new(operations: Vec<DebugValueExpressionOp>) -> Self {
+            Self { operations }
+        }
+    }
+
     /// A source variable whose storage is a supported projection of a MIR local.
     ///
     /// `offset_bytes` is measured from the current address after an optional
@@ -881,6 +909,7 @@ pub mod ops {
     const DEBUG_LOCAL_DECL_COLUMN_KEY: &str = "cuda_oxide_debug_local_decl_column";
     const DEBUG_LOCAL_SCOPE_KEY: &str = "cuda_oxide_debug_local_scope";
     const DEBUG_PROJECTED_COUNT_KEY: &str = "cuda_oxide_debug_projected_count";
+    const DEBUG_VALUE_EXPRESSION_KEY: &str = "cuda_oxide_debug_value_expression";
     const DEBUG_SOURCE_SCOPE_COUNT_KEY: &str = "cuda_oxide_debug_scope_count";
     const DEBUG_SOURCE_SCOPE_LOCATION_COUNT_KEY: &str = "cuda_oxide_debug_scope_location_count";
     /// Op-attribute key for ordinary volatile `load` / `store` operations.
@@ -1173,6 +1202,85 @@ pub mod ops {
     /// Read the MIR source-scope id that owns this source local.
     pub fn debug_local_source_scope(ctx: &Context, op: Ptr<Operation>) -> Option<u32> {
         get_string_attr(ctx, op, DEBUG_LOCAL_SCOPE_KEY).and_then(|scope| scope.parse().ok())
+    }
+
+    /// Attach a typed multi-value location expression to a debug marker.
+    pub fn set_debug_value_expression(
+        ctx: &mut Context,
+        op: Ptr<Operation>,
+        expression: &DebugValueExpression,
+    ) {
+        set_string_attr(
+            ctx,
+            op,
+            DEBUG_VALUE_EXPRESSION_KEY,
+            encode_debug_value_expression(expression),
+        );
+    }
+
+    /// Read a typed multi-value location expression from a debug marker.
+    pub fn debug_value_expression(
+        ctx: &Context,
+        op: Ptr<Operation>,
+    ) -> Option<DebugValueExpression> {
+        let encoded = get_string_attr(ctx, op, DEBUG_VALUE_EXPRESSION_KEY)?;
+        decode_debug_value_expression(&encoded)
+    }
+
+    fn encode_debug_value_expression(expression: &DebugValueExpression) -> String {
+        let mut encoded = String::from("v1");
+        for operation in &expression.operations {
+            encoded.push(' ');
+            match operation {
+                DebugValueExpressionOp::Arg(index) => {
+                    encoded.push_str("arg:");
+                    encoded.push_str(&index.to_string());
+                }
+                DebugValueExpressionOp::ConstU(value) => {
+                    encoded.push_str("constu:");
+                    encoded.push_str(&value.to_string());
+                }
+                DebugValueExpressionOp::Plus => encoded.push_str("plus"),
+                DebugValueExpressionOp::PlusUConst(value) => {
+                    encoded.push_str("plus_uconst:");
+                    encoded.push_str(&value.to_string());
+                }
+                DebugValueExpressionOp::Mul => encoded.push_str("mul"),
+                DebugValueExpressionOp::Deref => encoded.push_str("deref"),
+                DebugValueExpressionOp::StackValue => encoded.push_str("stack_value"),
+            }
+        }
+        encoded
+    }
+
+    fn decode_debug_value_expression(encoded: &str) -> Option<DebugValueExpression> {
+        let mut tokens = encoded.split_ascii_whitespace();
+        if tokens.next()? != "v1" {
+            return None;
+        }
+
+        let mut operations = Vec::new();
+        for token in tokens {
+            let operation = if let Some(index) = token.strip_prefix("arg:") {
+                DebugValueExpressionOp::Arg(index.parse::<u32>().ok()?)
+            } else if let Some(value) = token.strip_prefix("constu:") {
+                DebugValueExpressionOp::ConstU(value.parse::<u64>().ok()?)
+            } else if token == "plus" {
+                DebugValueExpressionOp::Plus
+            } else if let Some(value) = token.strip_prefix("plus_uconst:") {
+                DebugValueExpressionOp::PlusUConst(value.parse::<u64>().ok()?)
+            } else if token == "mul" {
+                DebugValueExpressionOp::Mul
+            } else if token == "deref" {
+                DebugValueExpressionOp::Deref
+            } else if token == "stack_value" {
+                DebugValueExpressionOp::StackValue
+            } else {
+                return None;
+            };
+            operations.push(operation);
+        }
+        Some(DebugValueExpression { operations })
     }
 
     /// Attach a function's MIR source-scope table.
@@ -1519,6 +1627,34 @@ pub mod ops {
     }
 
     impl Verify for DebugValueOp {
+        fn verify(&self, _ctx: &Context) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    /// LLVM multi-value debug marker used by the textual exporter.
+    ///
+    /// The operands form the ordered `DIArgList`; a `DebugValueExpression`
+    /// attached to the op selects and combines them with `DW_OP_LLVM_arg`.
+    #[pliron_op(
+        name = "llvm.dbg_value_list",
+        format,
+        interfaces = [NResultsInterface<0>]
+    )]
+    pub struct DebugValueListOp;
+
+    impl DebugValueListOp {
+        pub fn new(ctx: &mut Context, values: Vec<Value>) -> Self {
+            let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], values, vec![], 0);
+            DebugValueListOp { op }
+        }
+
+        pub fn values(&self, ctx: &Context) -> Vec<Value> {
+            self.get_operation().deref(ctx).operands().collect()
+        }
+    }
+
+    impl Verify for DebugValueListOp {
         fn verify(&self, _ctx: &Context) -> Result<(), Error> {
             Ok(())
         }

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -16,9 +16,10 @@ use llvm_export::{
         AddrSpaceCastOp, AddressOfOp, AllocaOp, BitcastOp, BrOp, CallOp, CondBrOp, ConstantOp,
         DebugEnumDiscriminant, DebugEnumVariant, DebugLocalTypeKind, DebugLocalVariableInfo,
         DebugProjectedVariableInfo, DebugSourcePosition, DebugSourceScope,
-        DebugSourceScopeLocation, DebugSourceScopeMap, DebugValueOp, FuncOp, GepIndex,
-        GetElementPtrOp, GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp, LoadOp,
-        ReturnOp, SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
+        DebugSourceScopeLocation, DebugSourceScopeMap, DebugValueExpression,
+        DebugValueExpressionOp, DebugValueListOp, DebugValueOp, FuncOp, GepIndex, GetElementPtrOp,
+        GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp, LoadOp, ReturnOp,
+        SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
     },
     types::{ArrayType, FuncType, HalfType, PointerType, StructLayout, StructType, VoidType},
 };
@@ -3107,6 +3108,122 @@ fn full_debug_metadata_emits_dbg_value_for_promoted_locals() {
     assert!(
         !ir.contains("llvm.dbg.declare"),
         "a value-only debug record should not force dbg.declare:\n{ir}"
+    );
+}
+
+#[test]
+fn full_debug_metadata_emits_diarglist_for_multi_value_locations() {
+    let mut ctx = Context::new();
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_region = module.get_operation().deref(&ctx).get_region(0);
+    let module_block = {
+        let region = module_region.deref(&ctx);
+        region.iter(&ctx).next().unwrap()
+    };
+
+    let ptr_ty = PointerType::get(&ctx, 0);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(
+        &ctx,
+        void_ty.to_handle(),
+        vec![ptr_ty.into(), i64_ty.into()],
+        false,
+    );
+    let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
+    let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 40, 1);
+    func.get_operation().deref_mut(&ctx).set_loc(func_loc);
+
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    let base = entry.deref(&ctx).get_argument(0);
+    let index = entry.deref(&ctx).get_argument(1);
+    let dbg_value = DebugValueListOp::new(&mut ctx, vec![base, index]);
+    let dbg_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 41, 17);
+    dbg_value.get_operation().deref_mut(&ctx).set_loc(dbg_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        dbg_value.get_operation(),
+        DebugLocalVariableInfo {
+            name: "item".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::Basic {
+                name: "u32".to_string(),
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            },
+        },
+    );
+    llvm_export::ops::set_debug_value_expression(
+        &mut ctx,
+        dbg_value.get_operation(),
+        &DebugValueExpression::new(vec![
+            DebugValueExpressionOp::Arg(0),
+            DebugValueExpressionOp::Arg(1),
+            DebugValueExpressionOp::ConstU(4),
+            DebugValueExpressionOp::Mul,
+            DebugValueExpressionOp::Plus,
+            DebugValueExpressionOp::Deref,
+        ]),
+    );
+    dbg_value.get_operation().insert_at_back(entry, &ctx);
+
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = DebugConfig {
+        inner: PtxExportConfig,
+        debug_kind: DebugKind::Full,
+    };
+    let ir =
+        export_module_to_string_with_config(&ctx, &module, &config).expect("debug export succeeds");
+
+    assert!(
+        ir.contains("call void @llvm.dbg.value(metadata !DIArgList(ptr %v0, i64 %v1), metadata !"),
+        "multi-value debug records should emit an inline DIArgList:\n{ir}"
+    );
+    assert!(
+        ir.contains(
+            "!DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_constu, 4, DW_OP_mul, DW_OP_plus, DW_OP_deref)"
+        ),
+        "multi-value debug records should emit the typed location recipe:\n{ir}"
+    );
+    assert!(
+        ir.contains("declare void @llvm.dbg.value(metadata, metadata, metadata)"),
+        "multi-value records should reuse the ordinary dbg.value intrinsic declaration:\n{ir}"
+    );
+
+    let Some(llvm_as) = ["llvm-as-22", "llvm-as-21", "llvm-as"]
+        .into_iter()
+        .find(|tool| {
+            std::process::Command::new(tool)
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success())
+        })
+    else {
+        eprintln!("skipping llvm-as parse gate: no llvm-as-22/llvm-as-21/llvm-as on PATH");
+        return;
+    };
+
+    let ll_path = std::env::temp_dir().join(format!(
+        "cuda_oxide_diarglist_parse_gate_{}.ll",
+        std::process::id()
+    ));
+    std::fs::write(&ll_path, &ir).expect("write temp .ll");
+    let output = std::process::Command::new(llvm_as)
+        .arg("-o")
+        .arg("/dev/null")
+        .arg(&ll_path)
+        .output()
+        .expect("run llvm-as");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = std::fs::remove_file(&ll_path);
+    assert!(
+        output.status.success(),
+        "{llvm_as} rejected the emitted multi-value debug module:\n{stderr}\n--- module ---\n{ir}"
     );
 }
 

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -29,12 +29,12 @@ use dialect_mir::ops::{
     MirBitXorOp, MirCallOp, MirCastOp, MirCheckedAddOp, MirCheckedMulOp, MirCheckedSubOp, MirCmpOp,
     MirCondBranchOp, MirConstantOp, MirConstructArrayOp, MirConstructDisjointSliceOp,
     MirConstructEnumOp, MirConstructSliceOp, MirConstructStructOp, MirConstructTupleOp,
-    MirDbgValueOp, MirDivOp, MirEnumPayloadOp, MirEqOp, MirExtractArrayElementOp,
-    MirExtractFieldOp, MirFieldAddrOp, MirFloatConstantOp, MirGeOp, MirGetDiscriminantOp,
-    MirGotoOp, MirGtOp, MirInsertFieldOp, MirLeOp, MirLoadOp, MirLtOp, MirMemcpyOp, MirMemmoveOp,
-    MirMulOp, MirNeOp, MirNegOp, MirNotOp, MirPtrOffsetOp, MirRefOp, MirRemOp, MirReturnOp,
-    MirSetDiscriminantOp, MirShlOp, MirShrOp, MirStorageDeadOp, MirStorageLiveOp, MirStoreOp,
-    MirSubOp, MirUndefOp, MirUnreachableOp, MirUnrollHintOp,
+    MirDbgValueListOp, MirDbgValueOp, MirDivOp, MirEnumPayloadOp, MirEqOp,
+    MirExtractArrayElementOp, MirExtractFieldOp, MirFieldAddrOp, MirFloatConstantOp, MirGeOp,
+    MirGetDiscriminantOp, MirGotoOp, MirGtOp, MirInsertFieldOp, MirLeOp, MirLoadOp, MirLtOp,
+    MirMemcpyOp, MirMemmoveOp, MirMulOp, MirNeOp, MirNegOp, MirNotOp, MirPtrOffsetOp, MirRefOp,
+    MirRemOp, MirReturnOp, MirSetDiscriminantOp, MirShlOp, MirShrOp, MirStorageDeadOp,
+    MirStorageLiveOp, MirStoreOp, MirSubOp, MirUndefOp, MirUnreachableOp, MirUnrollHintOp,
 };
 use dialect_nvvm::ops::{
     AssertFailOp, CvtaGenericToSharedOffsetOp, InlinePtxOp, NvvmAtomicCmpxchgOp, NvvmAtomicFenceOp,
@@ -451,6 +451,23 @@ impl MirToLlvmConversion for MirDbgValueOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::ops::memory::convert_dbg_value(ctx, rewriter, self.get_operation(), operands_info)
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for MirDbgValueListOp {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::ops::memory::convert_dbg_value_list(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
     }
 }
 

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -244,6 +244,9 @@ fn copy_debug_local_variable(ctx: &mut Context, mir_op: Ptr<Operation>, llvm_op:
             ctx, llvm_op, file, pos.line, pos.column,
         );
     }
+    if let Some(expression) = llvm_export::ops::debug_value_expression(ctx, mir_op) {
+        llvm_export::ops::set_debug_value_expression(ctx, llvm_op, &expression);
+    }
 }
 
 /// Carry Rust-local provenance from the MIR alloca to the LLVM alloca.
@@ -523,6 +526,33 @@ pub(crate) fn convert_dbg_value(
     let value = op.deref(ctx).get_operand(0);
     let loc = op.deref(ctx).loc().clone();
     let llvm_dbg_value = llvm::DebugValueOp::new(ctx, value);
+    llvm_dbg_value.get_operation().deref_mut(ctx).set_loc(loc);
+    copy_debug_local_variable(ctx, op, llvm_dbg_value.get_operation());
+    rewriter.insert_operation(ctx, llvm_dbg_value.get_operation());
+    rewriter.erase_operation(ctx, op);
+    Ok(())
+}
+
+/// Convert `mir.dbg_value_list` to the LLVM-export multi-value debug marker.
+///
+/// The ordered operands become a `DIArgList` during textual export. The typed
+/// location recipe is carried as generic metadata and copied unchanged here.
+pub(crate) fn convert_dbg_value_list(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    let values: Vec<_> = op.deref(ctx).operands().collect();
+    if values.len() < 2 {
+        return pliron::input_err_noloc!("mir.dbg_value_list requires at least two operands");
+    }
+    if llvm_export::ops::debug_value_expression(ctx, op).is_none() {
+        return pliron::input_err_noloc!("mir.dbg_value_list is missing its debug expression");
+    }
+
+    let loc = op.deref(ctx).loc().clone();
+    let llvm_dbg_value = llvm::DebugValueListOp::new(ctx, values);
     llvm_dbg_value.get_operation().deref_mut(ctx).set_loc(loc);
     copy_debug_local_variable(ctx, op, llvm_dbg_value.get_operation());
     rewriter.insert_operation(ctx, llvm_dbg_value.get_operation());
@@ -2518,6 +2548,56 @@ mod tests {
                 size_bits: 32,
                 encoding: "DW_ATE_signed",
             }
+        );
+    }
+
+    #[test]
+    fn convert_dbg_value_list_preserves_operands_and_expression() {
+        let mut ctx = make_ctx();
+        let i32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Signless).into();
+        let ptr_ty = MirPtrType::get_generic(&mut ctx, i32_ty, false);
+        let i64_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signless).into();
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![ptr_ty.into(), i64_ty], vec![]);
+        let base = block.deref(&ctx).get_argument(0);
+        let index = block.deref(&ctx).get_argument(1);
+
+        let dbg_op = mir::MirDbgValueListOp::new(&mut ctx, vec![base, index]);
+        llvm::set_debug_local_variable(
+            &mut ctx,
+            dbg_op.get_operation(),
+            llvm::DebugLocalVariableInfo {
+                name: "item".to_string(),
+                argument_index: None,
+                ty: llvm::DebugLocalTypeKind::Basic {
+                    name: "u32".to_string(),
+                    size_bits: 32,
+                    encoding: "DW_ATE_unsigned",
+                },
+            },
+        );
+        let expression = llvm::DebugValueExpression::new(vec![
+            llvm::DebugValueExpressionOp::Arg(0),
+            llvm::DebugValueExpressionOp::Arg(1),
+            llvm::DebugValueExpressionOp::ConstU(4),
+            llvm::DebugValueExpressionOp::Mul,
+            llvm::DebugValueExpressionOp::Plus,
+            llvm::DebugValueExpressionOp::Deref,
+        ]);
+        llvm::set_debug_value_expression(&mut ctx, dbg_op.get_operation(), &expression);
+        dbg_op.get_operation().insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        assert_eq!(count_ops::<mir::MirDbgValueListOp>(&ctx, &body), 0);
+        let dbg_value = find_first::<llvm::DebugValueListOp>(&ctx, &body)
+            .expect("expected lowered llvm.dbg_value_list marker");
+        assert_eq!(dbg_value.values(&ctx), vec![base, index]);
+        assert_eq!(
+            llvm::debug_value_expression(&ctx, dbg_value.get_operation()),
+            Some(expression)
         );
     }
 


### PR DESCRIPTION
Closes #1082 
Part of #226 

## Summary

Add generic multi-value debug-location support to the MIR-to-LLVM debug pipeline.

This provides the infrastructure needed for source-variable locations that depend on more than one runtime SSA value, such as a future runtime-indexed projection:

```text
*(base + index * stride)
```

## Changes

* add `mir.dbg_value_list` for ordered multi-value debug operands
* lower it to a new `llvm.dbg_value_list` marker
* add a typed `DebugValueExpression` representation
* preserve debug expressions through MIR-to-LLVM lowering
* export multi-value locations through `llvm.dbg.value` using `DIArgList`
* support:

  * `DW_OP_LLVM_arg`
  * `DW_OP_constu`
  * `DW_OP_plus`
  * `DW_OP_plus_uconst`
  * `DW_OP_mul`
  * `DW_OP_deref`
  * `DW_OP_stack_value`
* validate `DW_OP_LLVM_arg` operand indices during export
* add lowering coverage for operand ordering and expression preservation
* add LLVM-export coverage for `DIArgList`
* parse the emitted debug module with `llvm-as`

For example, the expression:

```text
*(base + index * 4)
```

is represented as:

```text
DW_OP_LLVM_arg, 0
DW_OP_LLVM_arg, 1
DW_OP_constu, 4
DW_OP_mul
DW_OP_plus
DW_OP_deref
```

with the base and index values carried in the corresponding `DIArgList`.

## Why

Existing projected debug locations use static byte offsets. That is sufficient for fields and constant indices, but not for runtime-dependent projections.

A dynamic array index requires both the base address and the runtime index to remain available to the debugger. LLVM's `DIArgList` plus `DW_OP_LLVM_arg` model provides the required representation without materializing a synthetic address computation in executable IR.

## Non-goals

This PR only introduces the generic multi-value location machinery.

It does not yet translate `ProjectionElem::Index` from rustc MIR. That will be implemented as a follow-up using this infrastructure.

It also does not change existing single-value `dbg.value` behavior or migrate the exporter to LLVM debug records.

## Validation

Validated locally with:

```text
cargo fmt --all -- --check
cargo test -p llvm-export full_debug_metadata_emits_diarglist_for_multi_value_locations -- --nocapture
cargo test -p llvm-export --all-targets
cargo test -p mir-lower --all-targets
cargo clippy --workspace --all-targets -- -D warnings
```

The new multi-value debug test also passes the generated LLVM module through an available `llvm-as-22`, `llvm-as-21`, or `llvm-as` parser.

All validation passed.
