### PR TITLE
fix(mir-lower): support packed AS3 field projections through carrier locals

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -42,7 +42,7 @@ use crate::convert::types::{
     build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
     llvm_packed_struct_contains_pointer_in_address_space, llvm_type_contains_i1,
     llvm_type_size_align, make_slice_struct, mir_element_stride, mir_type_abi_align,
-    packed_shared_internal_abi_info,
+    packed_shared_internal_abi_info, packed_shared_local_storage_info,
 };
 use dialect_mir::ops::{
     MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
@@ -54,7 +54,7 @@ use dialect_mir::types::{
 };
 use llvm_export::attributes::{ICmpPredicateAttr, IntegerOverflowFlagsAttr};
 use llvm_export::op_interfaces::{
-    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag,
+    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag, PointerTypeResult,
 };
 use llvm_export::ops as llvm;
 use llvm_export::types as llvm_types;
@@ -1797,6 +1797,23 @@ pub(crate) fn convert_field_addr(
 
     let map = build_struct_slot_map(ctx, &layout).map_err(anyhow_to_pliron)?;
 
+    // A compiler-owned packed-AS3 local may have a target-stable carrier
+    // allocation even though the MIR pointer still names the semantic struct.
+    // Use the carrier as the typed GEP source so the pointer field addresses
+    // generic-pointer storage. Arbitrary pointers keep the semantic layout and
+    // remain subject to the existing fail-closed whole-value memory rules.
+    let local_storage_ty = if let Some(info) =
+        packed_shared_local_storage_info(ctx, mir_ptr_pointee).map_err(anyhow_to_pliron)?
+    {
+        ptr_operand
+            .defining_op()
+            .and_then(|def| Operation::get_op::<llvm::AllocaOp>(def, ctx))
+            .filter(|alloca| alloca.result_pointee_type(ctx) == info.storage_ty)
+            .map(|_| info.storage_ty)
+    } else {
+        None
+    };
+
     let slot = match map.decl_to_llvm.get(field_index) {
         Some(Some(slot)) => *slot,
         Some(None) => {
@@ -1830,13 +1847,19 @@ pub(crate) fn convert_field_addr(
 
     let rustc_offset = layout.field_offsets.get(field_index).copied();
 
-    // Preserve the #859 address-path contract independently of the value
-    // representation. `build_struct_slot_map` retains the offsets the same
-    // fields would have under natural LLVM layout; when those differ from
-    // rustc's recorded offsets, keep using the original aggregate pointer plus
-    // a byte GEP. The semantic value type may now be an LLVM packed struct, but
-    // changing this established field-address path is outside this change.
-    if let Some(expected_offset) = rustc_offset {
+    // Preserve the #859 byte-address path for ordinary semantic aggregates:
+    // `build_struct_slot_map` retains the offsets the same fields would have
+    // under natural LLVM layout, and divergent layouts must keep using rustc's
+    // recorded byte offset. Carrier locals are different: they are
+    // intentionally addressed by storage slot. Their
+    // target-stable packed LLVM struct is the physical representation, so a
+    // typed GEP through that carrier is byte-faithful and preserves the proof
+    // that the resulting address is still rooted in the compiler-owned local.
+    // The #859 byte-GEP fallback remains necessary for ordinary semantic
+    // aggregates whose natural LLVM slot offsets diverge from rustc's layout.
+    if local_storage_ty.is_none()
+        && let Some(expected_offset) = rustc_offset
+    {
         let actual_offset = map
             .natural_slot_offsets
             .as_ref()
@@ -1862,7 +1885,8 @@ pub(crate) fn convert_field_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Constant(slot)];
 
-    let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, map.llvm_struct_ty);
+    let gep_source_ty = local_storage_ty.unwrap_or(map.llvm_struct_ty);
+    let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, gep_source_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
     stamp_field_address_alignment(
         ctx,

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -49,15 +49,19 @@
 //! ```
 
 use crate::context::{DeviceGlobalsMap, DynamicSmemAlignmentMap, SharedGlobalsMap};
+use crate::convert::target_stable_storage::{
+    StorageRewriteOptions, coerce_target_stable_value, target_stable_storage_type,
+};
 use crate::convert::types::{
     StructLayoutInfo, build_struct_slot_map, convert_type, get_type_size,
     llvm_packed_struct_contains_pointer_in_address_space, mir_type_abi_align,
-    validate_initialized_global_layout, validate_relocated_initialized_global_layout,
+    packed_shared_local_storage_info, validate_initialized_global_layout,
+    validate_relocated_initialized_global_layout,
 };
 use crate::helpers;
 use dialect_mir::types::{MirPtrType, MirStructType};
 use llvm_export::attributes::IntegerOverflowFlagsAttr;
-use llvm_export::op_interfaces::IntBinArithOpWithOverflowFlag;
+use llvm_export::op_interfaces::{IntBinArithOpWithOverflowFlag, PointerTypeResult};
 use llvm_export::ops as llvm;
 use llvm_export::ops::GlobalOpExt;
 use llvm_export::types::{ArrayType, FuncType, StructLayout, StructType, VoidType};
@@ -107,16 +111,25 @@ pub(crate) fn convert_store(
         }
     };
 
-    // Packed whole-value stores are byte-faithful now that divergent rustc
-    // layouts lower to LLVM packed structs. Keep the target-dependent AS3 case
-    // fail-closed because its physical pointer width is selected only later.
-    fail_on_target_dependent_packed_aggregate(
-        ctx,
-        value_mir_type(ctx, operands_info, val),
-        "storing",
-    )?;
+    let local_carrier = packed_shared_local_storage_for_address(ctx, operands_info, ptr)?;
+    let stored_val = if local_carrier {
+        let storage_ty =
+            target_stable_local_value_type(ctx, val.get_type(ctx), "packed shared local store")?;
+        coerce_target_stable_value(ctx, rewriter, val, storage_ty, "packed shared local store")?
+    } else {
+        // Packed whole-value stores are byte-faithful now that divergent rustc
+        // layouts lower to LLVM packed structs. Keep the target-dependent AS3
+        // case fail-closed for arbitrary memory; only compiler-owned local
+        // carrier slots are exempt.
+        fail_on_target_dependent_packed_aggregate(
+            ctx,
+            value_mir_type(ctx, operands_info, val),
+            "storing",
+        )?;
+        val
+    };
 
-    let llvm_store = llvm::StoreOp::new(ctx, val, ptr);
+    let llvm_store = llvm::StoreOp::new(ctx, stored_val, ptr);
     if dialect_mir::ops::MirStoreOp::new(op).is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_store.get_operation(), true);
     }
@@ -178,6 +191,103 @@ fn value_mir_type(ctx: &Context, operands_info: &OperandsInfo, value: Value) -> 
         .copied()
         .find(|ty| ty.deref(ctx).is::<MirStructType>())
         .unwrap_or(current)
+}
+
+/// Return whether `ptr` addresses target-stable carrier storage for an
+/// eligible packed-AS3 local.
+///
+/// `OperandsInfo` records type history only for the current operation's direct
+/// operands. Do not walk from a projected pointer back to its alloca and then
+/// query that nested value's history: it is not present in a load/store's
+/// `OperandsInfo`.
+///
+/// Whole-local accesses are recognized from an `llvm.alloca` plus the MIR
+/// pointee recorded directly on that operand. Direct field projections are
+/// recognized from the converted `llvm.gep`: its direct operand history keeps
+/// the semantic field pointee (for #1036, p3), while the GEP's physical result
+/// pointee is the carrier field type (p0). Only packed, constant-index struct
+/// projections whose physical pointee is exactly the target-stable rewrite are
+/// admitted. Dynamic pointer arithmetic remains out of scope.
+fn packed_shared_local_storage_for_address(
+    ctx: &mut Context,
+    operands_info: &OperandsInfo,
+    ptr: Value,
+) -> Result<bool> {
+    let mir_pointee = {
+        let Some(mir_ptr) = operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, ptr) else {
+            return Ok(false);
+        };
+        let pointee = mir_ptr.pointee;
+        drop(mir_ptr);
+        pointee
+    };
+
+    let Some(defining_op) = ptr.defining_op() else {
+        return Ok(false);
+    };
+
+    if let Some(alloca) = Operation::get_op::<llvm::AllocaOp>(defining_op, ctx) {
+        let Some(info) =
+            packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)?
+        else {
+            return Ok(false);
+        };
+        return Ok(alloca.result_pointee_type(ctx) == info.storage_ty);
+    }
+
+    let Some(gep) = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx) else {
+        return Ok(false);
+    };
+
+    let indices = gep.indices(ctx);
+    let is_direct_field_projection = indices.len() == 2
+        && matches!(
+            indices.first(),
+            Some(&llvm_export::ops::GepIndex::Constant(0))
+        )
+        && indices
+            .iter()
+            .all(|index| matches!(index, &llvm_export::ops::GepIndex::Constant(_)));
+    if !is_direct_field_projection {
+        return Ok(false);
+    }
+
+    let source_is_packed_struct = {
+        let source_ty = gep.src_elem_type(ctx);
+        let source_ref = source_ty.deref(ctx);
+        source_ref
+            .downcast_ref::<StructType>()
+            .is_some_and(|ty| ty.layout() == StructLayout::Packed)
+    };
+    if !source_is_packed_struct {
+        return Ok(false);
+    }
+
+    let semantic_ty = convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
+    let storage_ty =
+        target_stable_local_value_type(ctx, semantic_ty, "packed shared local field projection")?;
+
+    // A scalar sibling has no representation rewrite and needs no special
+    // handling. The AS3 field is admitted only when the GEP physically points
+    // at the exact p0 carrier type computed from its semantic p3 type.
+    Ok(storage_ty != semantic_ty && gep.result_pointee_type(ctx) == storage_ty)
+}
+
+fn target_stable_local_value_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+    role: &str,
+) -> Result<TypeHandle> {
+    target_stable_storage_type(
+        ctx,
+        semantic_ty,
+        StorageRewriteOptions {
+            canonicalize_bool: false,
+        },
+        role,
+    )
+    .map(|rewrite| rewrite.ty)
+    .map_err(anyhow_to_pliron)
 }
 
 /// Refuse only packed by-value images whose physical bytes depend on the
@@ -475,14 +585,19 @@ pub(crate) fn convert_load(
     let ptr = op.deref(ctx).get_operand(0);
     let result_ty = op.deref(ctx).get_result(0).get_type(ctx);
 
-    // Packed whole-value loads are byte-faithful now that divergent rustc
-    // layouts lower to LLVM packed structs. Keep only the target-dependent AS3
-    // physical-image case fail-closed.
-    fail_on_target_dependent_packed_aggregate(ctx, result_ty, "loading")?;
+    let semantic_llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
+    let local_carrier = packed_shared_local_storage_for_address(ctx, _operands_info, ptr)?;
+    let load_ty = if local_carrier {
+        target_stable_local_value_type(ctx, semantic_llvm_ty, "packed shared local load")?
+    } else {
+        // Arbitrary packed-AS3 memory remains target-dependent. Only a
+        // compiler-owned carrier local may load its physical p0 representation
+        // and reconstruct the semantic p3 value afterwards.
+        fail_on_target_dependent_packed_aggregate(ctx, result_ty, "loading")?;
+        semantic_llvm_ty
+    };
 
-    let llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
-
-    let llvm_load = llvm::LoadOp::new(ctx, ptr, llvm_ty);
+    let llvm_load = llvm::LoadOp::new(ctx, ptr, load_ty);
     if dialect_mir::ops::MirLoadOp::new(op).is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_load.get_operation(), true);
     }
@@ -505,7 +620,19 @@ pub(crate) fn convert_load(
         llvm_export::ops::set_op_alignment(ctx, llvm_load.get_operation(), align as u32);
     }
     rewriter.insert_operation(ctx, llvm_load.get_operation());
-    rewriter.replace_operation(ctx, op, llvm_load.get_operation());
+    let loaded = llvm_load.get_operation().deref(ctx).get_result(0);
+    let semantic_value = if local_carrier {
+        coerce_target_stable_value(
+            ctx,
+            rewriter,
+            loaded,
+            semantic_llvm_ty,
+            "packed shared local load",
+        )?
+    } else {
+        loaded
+    };
+    rewriter.replace_operation_with_values(ctx, op, vec![semantic_value]);
 
     Ok(())
 }
@@ -556,7 +683,11 @@ pub(crate) fn convert_alloca(
         })?;
         mir_ptr.pointee
     };
-    let llvm_pointee = convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
+    let llvm_pointee =
+        match packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)? {
+            Some(info) => info.storage_ty,
+            None => convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?,
+        };
 
     let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
     let one_apint =
@@ -1418,6 +1549,187 @@ mod tests {
         // Element type should round-trip through convert_type as i32.
         let elem_ty = alloca.result_pointee_type(&ctx);
         assert!(elem_ty.deref(&ctx).is::<IntegerType>());
+    }
+
+    #[test]
+    fn packed_shared_local_slot_uses_carrier_for_field_projection() {
+        use dialect_mir::attributes::FieldIndexAttr;
+
+        let mut ctx = make_ctx();
+        let tag_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocal".into(),
+            vec!["tag".into(), "ptr".into()],
+            vec![tag_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed_ty, true);
+        let field_ptr_ty = MirPtrType::get_generic(&mut ctx, shared_ty, false);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, packed_ty);
+        undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_value = undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![slot, semantic_value],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+
+        let field_addr = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![field_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        field_addr.insert_at_back(block, &ctx);
+        let projected_ptr = field_addr.deref(&ctx).get_result(0);
+
+        let load = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![shared_ty],
+            vec![projected_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("eligible packed-AS3 locals must lower through carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let alloca = find_first::<llvm::AllocaOp>(&ctx, &body).expect("expected llvm.alloca");
+        let storage_ty = alloca.result_pointee_type(&ctx);
+        let storage_ref = storage_ty.deref(&ctx);
+        let storage_struct = storage_ref
+            .downcast_ref::<StructType>()
+            .expect("packed local carrier must remain a struct");
+        let pointer_ty = storage_struct.field_type(1);
+        let pointer_ref = pointer_ty.deref(&ctx);
+        let pointer = pointer_ref
+            .downcast_ref::<PointerType>()
+            .expect("carrier pointer field must lower to an LLVM pointer");
+        assert_eq!(pointer.address_space(), llvm_addr::GENERIC);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            2,
+            "the local store and projected load must convert p3 <-> p0 exactly once each"
+        );
+    }
+
+    #[test]
+    fn packed_shared_local_pointer_field_store_uses_carrier() {
+        use dialect_mir::attributes::FieldIndexAttr;
+
+        let mut ctx = make_ctx();
+        let tag_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedFieldStore".into(),
+            vec!["tag".into(), "ptr".into()],
+            vec![tag_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed_ty, true);
+        let field_ptr_ty = MirPtrType::get_generic(&mut ctx, shared_ty, true);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let field_addr = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![field_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        field_addr.insert_at_back(block, &ctx);
+        let projected_ptr = field_addr.deref(&ctx).get_result(0);
+
+        let shared_undef = mir::MirUndefOp::new(&mut ctx, shared_ty);
+        shared_undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_ptr = shared_undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![projected_ptr, semantic_ptr],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("projected packed-AS3 local stores must use carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            1,
+            "the projected store must convert the semantic p3 pointer to carrier p0 exactly once"
+        );
+
+        let store =
+            find_first::<llvm::StoreOp>(&ctx, &body).expect("expected projected llvm.store");
+        let stored_ty = store
+            .get_operation()
+            .deref(&ctx)
+            .get_operand(0)
+            .get_type(&ctx);
+        let stored_ref = stored_ty.deref(&ctx);
+        let stored_ptr = stored_ref
+            .downcast_ref::<PointerType>()
+            .expect("projected carrier store value must be an LLVM pointer");
+        assert_eq!(stored_ptr.address_space(), llvm_addr::GENERIC);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -459,6 +459,55 @@ pub(crate) fn packed_shared_internal_abi_info(
     }))
 }
 
+/// Recognize the deliberately narrow packed-AS3 shape that may use a
+/// target-stable local stack slot.
+///
+/// This gate is intentionally independent of future widening of the internal
+/// device ABI classifier. Local storage currently admits only one direct AS3
+/// pointer leaf with scalar non-ZST siblings, matching issue #1036. Recursive
+/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain a
+/// separate follow-up even when the internal call ABI supports them.
+pub(crate) fn packed_shared_local_storage_info(
+    ctx: &mut Context,
+    mir_ty: TypeHandle,
+) -> Result<Option<PackedSharedInternalAbiInfo>, anyhow::Error> {
+    let layout = {
+        let ty_ref = mir_ty.deref(ctx);
+        let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() else {
+            return Ok(None);
+        };
+        StructLayoutInfo::of_struct(struct_ty)
+    };
+
+    let map = build_struct_slot_map(ctx, &layout)?;
+    let mut direct_shared_pointers = 0_u64;
+    for field_ty in &map.field_llvm_types {
+        if is_zero_sized_type(ctx, *field_ty) {
+            continue;
+        }
+        let field_ref = field_ty.deref(ctx);
+        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
+            if pointer.address_space() == llvm_types::address_space::SHARED {
+                direct_shared_pointers += 1;
+            }
+            continue;
+        }
+        if field_ref.is::<IntegerType>()
+            || field_ref.is::<llvm_types::HalfType>()
+            || field_ref.is::<FP32Type>()
+            || field_ref.is::<FP64Type>()
+        {
+            continue;
+        }
+        return Ok(None);
+    }
+    if direct_shared_pointers != 1 {
+        return Ok(None);
+    }
+
+    packed_shared_internal_abi_info(ctx, mir_ty)
+}
+
 /// Convert a type that crosses a function boundary as one LLVM value.
 ///
 /// A struct with a natural-layout divergence is legal by value only when

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -77,13 +77,15 @@ mod kernels {
     #[inline(never)]
     #[device]
     unsafe fn consume_packed_shared(
-        _value: PackedShared,
+        value: PackedShared,
         shared: *mut SharedArray<u32, 1>,
         out: *mut u32,
     ) {
+        let tag = value.tag;
+        let round_tripped = value.ptr;
         unsafe {
-            (&mut *shared)[0] = (&*shared)[0].wrapping_add(0x0102_0304);
-            out.write(0x22);
+            (&mut *round_tripped)[0] = (&*round_tripped)[0].wrapping_add(0x0102_0304);
+            out.write(u32::from(tag.wrapping_add(1)));
             out.add(1).write((&*shared)[0]);
         }
     }
@@ -126,10 +128,10 @@ mod kernels {
             ptr: raw,
         });
 
-        // Keep the packed AS3 aggregate in SSA across both internal device ABI
-        // boundaries. The raw shared pointer is passed separately for the
-        // observable runtime check so this regression does not require a
-        // target-dependent whole-value packed store/load.
+        // Project both fields from the returned packed value. The compiler-owned
+        // local slot uses the target-stable carrier representation, so the AS3
+        // pointer field is loaded as p0 and reconstructed to p3 before use. The
+        // separate raw pointer makes the round-trip observable at runtime.
         unsafe { consume_packed_shared(value, raw, out) };
     }
 


### PR DESCRIPTION
Closes #1036

## Summary

Support local materialization and field projections for the deliberately narrow packed-AS3 shape introduced by the internal device ABI work.

Eligible packed locals now use a target-stable carrier representation:

```text
semantic <{ scalar, p3 }>
        |
        | store coercion
        v
carrier  <{ scalar, p0 }>
```

Loads reconstruct the semantic value in the opposite direction.

Field projections from those locals are addressed directly through the carrier slots. An AS3 pointer field therefore physically loads/stores as p0 and is explicitly converted between p0 and p3 at the semantic boundary.

Arbitrary packed-AS3 memory remains fail-closed.

## Implementation

### Local carrier admission

Add a dedicated `packed_shared_local_storage_info` gate for local storage.

The local-storage gate is intentionally independent of the internal ABI classifier:

* packed struct root;
* exactly one direct AS3/shared pointer field;
* all remaining non-ZST fields scalar;
* no recursive aggregates;
* no arrays or vectors;
* no multiple shared-pointer leaves.

Keeping this gate independent prevents future widening of the internal device ABI classifier from implicitly widening local-storage support.

### Local allocation

`mir.alloca` uses the target-stable carrier type for eligible packed-AS3 locals:

```text
<{ scalar, p3 }>  semantic type
<{ scalar, p0 }>  physical local storage
```

### Whole-value local stores and loads

Stores into compiler-owned carrier locals coerce the semantic packed value to the target-stable storage representation before emitting `llvm.store`.

Loads use the physical carrier type and reconstruct the semantic packed value after `llvm.load`.

The existing fail-closed path is preserved for arbitrary packed-AS3 memory.

### Field projections

`mir.field_addr` recognizes an eligible carrier-backed local and emits a typed GEP through the carrier struct.

This keeps field addressing by-slot while preserving the existing rustc byte-offset fallback for ordinary packed aggregates.

For the AS3 field:

```text
projected load:   p0 -> addrspacecast -> p3
projected store:  p3 -> addrspacecast -> p0
```

The projected load/store path uses operand type history to distinguish the semantic MIR pointee from the physical carrier pointee.

### End-to-end regression

Strengthen `packed_aggregate_abi` so `consume_packed_shared` actually projects both fields from the returned packed value.

The test now:

* reads `value.tag`;
* reads `value.ptr`;
* writes shared memory through the round-tripped `value.ptr`;
* observes the mutation through the independently passed raw shared pointer.

This makes broken carrier-to-semantic reconstruction observable at runtime, while the lowering tests independently cover the inverse projected-store conversion.

## Tests

Added lowering coverage for:

* carrier allocation for an eligible packed-AS3 local;
* whole-value semantic -> carrier store;
* projected pointer-field p0 -> p3 load;
* projected pointer-field p3 -> p0 store;
* carrier pointer storage remaining in generic address space.

Validation performed:

```text
cargo fmt --all -- --check
git diff --check

cargo test -p mir-lower --all-targets
cargo clippy -p mir-lower --all-targets -- -D warnings

cargo oxide run packed_aggregate_abi
```

Results:

```text
mir-lower unit tests: 254 passed
lowering tests:       117 passed
clippy -D warnings:   pass
packed_aggregate_abi: pass on sm_120a
```

## Out of scope

This PR intentionally does not add support for:

* kernel-entry ABI changes;
* device-global packed AS3 storage;
* arbitrary packed-AS3 memory;
* recursive or nested AS3 local projections;
* multiple AS3 pointer leaves;
* AS3 pointer arrays;
* AS3 pointer vectors;
* AS3-containing enums.

Those remain separate work.
