### PR TITLE
fix(mir-lower): support recursive packed AS3 carrier locals

### DIFF
--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -464,9 +464,10 @@ pub(crate) fn convert_construct_struct(
     }
 
     // A packed struct containing AS3 remains target-dependent as a physical
-    // memory image. The narrow internal-call ABI exception is safe to construct
-    // in SSA because its return boundary rebuilds the value into a target-stable
-    // generic-pointer carrier before the aggregate crosses the function ABI.
+    // memory image. The internal-call ABI exception is safe to construct in SSA
+    // because its return boundary recursively rebuilds every supported AS3 leaf
+    // into a target-stable generic-pointer carrier before the aggregate crosses
+    // the function ABI.
     if llvm_packed_struct_contains_pointer_in_address_space(
         ctx,
         map.llvm_struct_ty,
@@ -2971,6 +2972,177 @@ mod tests {
             count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
             0,
             "construction itself must not genericize the shared pointer"
+        );
+    }
+
+    #[test]
+    fn packed_struct_construction_with_multiple_direct_shared_pointers_stays_semantic_in_ssa() {
+        use dialect_mir::ops::MirConstructStructOp;
+
+        let mut ctx = make_ctx();
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedPair".into(),
+            vec!["tag".into(), "left".into(), "right".into()],
+            vec![u8_ty, shared_ty, shared_ty],
+            vec![0, 1, 2],
+            vec![0, 1, 9],
+            17,
+            1,
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![u8_ty, shared_ty, shared_ty], vec![]);
+        let tag = block.deref(&ctx).get_argument(0);
+        let left = block.deref(&ctx).get_argument(1);
+        let right = block.deref(&ctx).get_argument(2);
+        let construct = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![packed_ty],
+            vec![tag, left, right],
+            vec![],
+            0,
+        );
+        construct.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("multiple direct AS3 leaves in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        assert_eq!(
+            insert_indices(&ctx, &inserts),
+            vec![vec![0], vec![1], vec![2]],
+            "all direct shared leaves must remain in their semantic packed slots"
+        );
+
+        let result_ty = inserts
+            .last()
+            .expect("packed AS3 construction must emit insertvalue")
+            .get_operation()
+            .deref(&ctx)
+            .get_result(0)
+            .get_type(&ctx);
+        let result_ty_ref = result_ty.deref(&ctx);
+        let struct_ty = result_ty_ref
+            .downcast_ref::<llvm_types::StructType>()
+            .expect("packed AS3 construction result must be an LLVM struct");
+        assert_eq!(struct_ty.layout(), llvm_types::StructLayout::Packed);
+        assert_eq!(llvm_type_size_align(&ctx, result_ty), Some((17, 1)));
+        for slot in [1usize, 2] {
+            let pointer_ty = struct_ty.field_type(slot);
+            let pointer_ty_ref = pointer_ty.deref(&ctx);
+            let pointer = pointer_ty_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("direct shared leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::SHARED);
+        }
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "semantic construction must not genericize any direct shared leaf"
+        );
+    }
+
+    #[test]
+    fn packed_struct_construction_with_nested_shared_pointers_stays_semantic_in_ssa() {
+        use dialect_mir::ops::MirConstructStructOp;
+
+        let mut ctx = make_ctx();
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let inner_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "SharedPair".into(),
+            vec!["left".into(), "right".into()],
+            vec![shared_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedNestedShared".into(),
+            vec!["tag".into(), "pair".into()],
+            vec![u8_ty, inner_ty],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![u8_ty, shared_ty, shared_ty], vec![]);
+        let tag = block.deref(&ctx).get_argument(0);
+        let left = block.deref(&ctx).get_argument(1);
+        let right = block.deref(&ctx).get_argument(2);
+
+        let inner = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![inner_ty],
+            vec![left, right],
+            vec![],
+            0,
+        );
+        inner.insert_at_back(block, &ctx);
+        let inner_value = inner.deref(&ctx).get_result(0);
+
+        let outer = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![packed_ty],
+            vec![tag, inner_value],
+            vec![],
+            0,
+        );
+        outer.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("nested AS3 leaves in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "semantic construction must keep nested shared leaves in AS3"
+        );
+
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        let packed_result = inserts
+            .iter()
+            .filter_map(|insert| {
+                let result_ty = insert
+                    .get_operation()
+                    .deref(&ctx)
+                    .get_result(0)
+                    .get_type(&ctx);
+                let is_packed = result_ty
+                    .deref(&ctx)
+                    .downcast_ref::<llvm_types::StructType>()
+                    .is_some_and(|ty| ty.layout() == llvm_types::StructLayout::Packed);
+                is_packed.then_some(result_ty)
+            })
+            .last()
+            .expect("outer packed construction must produce a packed LLVM struct");
+
+        assert_eq!(llvm_type_size_align(&ctx, packed_result), Some((17, 1)));
+        assert!(
+            llvm_packed_struct_contains_pointer_in_address_space(
+                &ctx,
+                packed_result,
+                llvm_types::address_space::SHARED,
+            ),
+            "the semantic packed value must retain its recursively nested AS3 leaves"
         );
     }
 

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -42,7 +42,7 @@ use crate::convert::types::{
     build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
     llvm_packed_struct_contains_pointer_in_address_space, llvm_type_contains_i1,
     llvm_type_size_align, make_slice_struct, mir_element_stride, mir_type_abi_align,
-    packed_shared_internal_abi_info,
+    packed_shared_internal_abi_info, packed_shared_local_storage_info,
 };
 use dialect_mir::ops::{
     MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
@@ -54,7 +54,7 @@ use dialect_mir::types::{
 };
 use llvm_export::attributes::{ICmpPredicateAttr, IntegerOverflowFlagsAttr};
 use llvm_export::op_interfaces::{
-    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag,
+    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag, PointerTypeResult,
 };
 use llvm_export::ops as llvm;
 use llvm_export::types as llvm_types;
@@ -1797,6 +1797,23 @@ pub(crate) fn convert_field_addr(
 
     let map = build_struct_slot_map(ctx, &layout).map_err(anyhow_to_pliron)?;
 
+    // A compiler-owned packed-AS3 local may have a target-stable carrier
+    // allocation even though the MIR pointer still names the semantic struct.
+    // Use the carrier as the typed GEP source so the pointer field addresses
+    // generic-pointer storage. Arbitrary pointers keep the semantic layout and
+    // remain subject to the existing fail-closed whole-value memory rules.
+    let local_storage_ty = if let Some(info) =
+        packed_shared_local_storage_info(ctx, mir_ptr_pointee).map_err(anyhow_to_pliron)?
+    {
+        ptr_operand
+            .defining_op()
+            .and_then(|def| Operation::get_op::<llvm::AllocaOp>(def, ctx))
+            .filter(|alloca| alloca.result_pointee_type(ctx) == info.storage_ty)
+            .map(|_| info.storage_ty)
+    } else {
+        None
+    };
+
     let slot = match map.decl_to_llvm.get(field_index) {
         Some(Some(slot)) => *slot,
         Some(None) => {
@@ -1830,13 +1847,19 @@ pub(crate) fn convert_field_addr(
 
     let rustc_offset = layout.field_offsets.get(field_index).copied();
 
-    // Preserve the #859 address-path contract independently of the value
-    // representation. `build_struct_slot_map` retains the offsets the same
-    // fields would have under natural LLVM layout; when those differ from
-    // rustc's recorded offsets, keep using the original aggregate pointer plus
-    // a byte GEP. The semantic value type may now be an LLVM packed struct, but
-    // changing this established field-address path is outside this change.
-    if let Some(expected_offset) = rustc_offset {
+    // Preserve the #859 byte-address path for ordinary semantic aggregates:
+    // `build_struct_slot_map` retains the offsets the same fields would have
+    // under natural LLVM layout, and divergent layouts must keep using rustc's
+    // recorded byte offset. Carrier locals are different: they are
+    // intentionally addressed by storage slot. Their
+    // target-stable packed LLVM struct is the physical representation, so a
+    // typed GEP through that carrier is byte-faithful and preserves the proof
+    // that the resulting address is still rooted in the compiler-owned local.
+    // The #859 byte-GEP fallback remains necessary for ordinary semantic
+    // aggregates whose natural LLVM slot offsets diverge from rustc's layout.
+    if local_storage_ty.is_none()
+        && let Some(expected_offset) = rustc_offset
+    {
         let actual_offset = map
             .natural_slot_offsets
             .as_ref()
@@ -1862,7 +1885,8 @@ pub(crate) fn convert_field_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Constant(slot)];
 
-    let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, map.llvm_struct_ty);
+    let gep_source_ty = local_storage_ty.unwrap_or(map.llvm_struct_ty);
+    let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, gep_source_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
     stamp_field_address_alignment(
         ctx,

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -37,12 +37,15 @@
 //! introduces no extra tag.
 
 use crate::convert::enum_payload_storage::{coerce_enum_payload_value, enum_payload_storage_type};
+use crate::convert::ops::memory::{
+    set_target_stable_storage_pointee, target_stable_storage_pointee,
+};
 use crate::convert::types::{
     EnumSlotMap, StructLayoutInfo, StructSlotMap, build_enum_slot_map, build_struct_slot_map,
     build_union_storage_type, convert_type, is_zero_sized_type, llvm_byte_faithful_twin,
     llvm_packed_struct_contains_pointer_in_address_space, llvm_type_contains_i1,
     llvm_type_size_align, make_slice_struct, mir_element_stride, mir_type_abi_align,
-    packed_shared_internal_abi_info, packed_shared_local_storage_info,
+    packed_shared_internal_abi_info,
 };
 use dialect_mir::ops::{
     MirConstantOp, MirConstructEnumOp, MirEnumPayloadOp, MirExtractFieldOp, MirFieldAddrOp,
@@ -54,7 +57,7 @@ use dialect_mir::types::{
 };
 use llvm_export::attributes::{ICmpPredicateAttr, IntegerOverflowFlagsAttr};
 use llvm_export::op_interfaces::{
-    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag, PointerTypeResult,
+    CastOpInterface, CastOpWithNNegInterface, IntBinArithOpWithOverflowFlag,
 };
 use llvm_export::ops as llvm;
 use llvm_export::types as llvm_types;
@@ -1625,6 +1628,34 @@ pub(crate) fn convert_enum_payload(
 // MirFieldAddrOp Conversion
 // ============================================================================
 
+/// Resolve one field's physical pointee inside a target-stable carrier.
+///
+/// Carrier structs preserve the semantic aggregate's slot topology while
+/// recursively replacing AS3 pointer leaves with generic pointers. `slot` is
+/// therefore the same slot selected from the semantic `StructSlotMap`.
+fn carrier_struct_field_type(
+    ctx: &Context,
+    storage_parent: TypeHandle,
+    slot: u32,
+) -> Result<TypeHandle> {
+    let storage_ref = storage_parent.deref(ctx);
+    let storage_struct = storage_ref
+        .downcast_ref::<llvm_types::StructType>()
+        .ok_or_else(|| {
+            pliron::input_error_noloc!(
+                "target-stable field projection expected struct storage, got {}",
+                storage_parent.deref(ctx).disp(ctx)
+            )
+        })?;
+    storage_struct.fields().nth(slot as usize).ok_or_else(|| {
+        pliron::input_error_noloc!(
+            "target-stable field projection slot {} out of bounds for storage type {}",
+            slot,
+            storage_parent.deref(ctx).disp(ctx)
+        )
+    })
+}
+
 /// Convert `mir.field_addr` to `llvm.getelementptr`.
 ///
 /// Computes the address of a struct field using GEP. This is needed when
@@ -1798,22 +1829,7 @@ pub(crate) fn convert_field_addr(
 
     let map = build_struct_slot_map(ctx, &layout).map_err(anyhow_to_pliron)?;
 
-    // A compiler-owned packed-AS3 local may have a target-stable carrier
-    // allocation even though the MIR pointer still names the semantic struct.
-    // Use the carrier as the typed GEP source so the pointer field addresses
-    // generic-pointer storage. Arbitrary pointers keep the semantic layout and
-    // remain subject to the existing fail-closed whole-value memory rules.
-    let local_storage_ty = if let Some(info) =
-        packed_shared_local_storage_info(ctx, mir_ptr_pointee).map_err(anyhow_to_pliron)?
-    {
-        ptr_operand
-            .defining_op()
-            .and_then(|def| Operation::get_op::<llvm::AllocaOp>(def, ctx))
-            .filter(|alloca| alloca.result_pointee_type(ctx) == info.storage_ty)
-            .map(|_| info.storage_ty)
-    } else {
-        None
-    };
+    let carrier_storage_parent = target_stable_storage_pointee(ctx, ptr_operand);
 
     let slot = match map.decl_to_llvm.get(field_index) {
         Some(Some(slot)) => *slot,
@@ -1846,6 +1862,11 @@ pub(crate) fn convert_field_addr(
         }
     };
 
+    let carrier_storage_field = match carrier_storage_parent {
+        Some(storage_parent) => Some(carrier_struct_field_type(ctx, storage_parent, slot)?),
+        None => None,
+    };
+
     let rustc_offset = layout.field_offsets.get(field_index).copied();
 
     // Preserve the #859 byte-address path for ordinary semantic aggregates:
@@ -1858,7 +1879,7 @@ pub(crate) fn convert_field_addr(
     // that the resulting address is still rooted in the compiler-owned local.
     // The #859 byte-GEP fallback remains necessary for ordinary semantic
     // aggregates whose natural LLVM slot offsets diverge from rustc's layout.
-    if local_storage_ty.is_none()
+    if carrier_storage_parent.is_none()
         && let Some(expected_offset) = rustc_offset
     {
         let actual_offset = map
@@ -1886,9 +1907,12 @@ pub(crate) fn convert_field_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Constant(slot)];
 
-    let gep_source_ty = local_storage_ty.unwrap_or(map.llvm_struct_ty);
+    let gep_source_ty = carrier_storage_parent.unwrap_or(map.llvm_struct_ty);
     let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, gep_source_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
+    if let Some(storage_field) = carrier_storage_field {
+        set_target_stable_storage_pointee(ctx, gep_op.get_operation(), storage_field);
+    }
     stamp_field_address_alignment(
         ctx,
         gep_op.get_operation(),
@@ -1988,7 +2012,24 @@ pub(crate) fn convert_array_element_addr(
         mir_ptr_pointee
     };
 
-    let llvm_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
+    let carrier_storage_array = target_stable_storage_pointee(ctx, arr_ptr);
+    let semantic_array_ty = convert_type(ctx, pointee_ty).map_err(anyhow_to_pliron)?;
+    let llvm_array_ty = carrier_storage_array.unwrap_or(semantic_array_ty);
+    let carrier_storage_element = match carrier_storage_array {
+        Some(storage_array) => {
+            let storage_ref = storage_array.deref(ctx);
+            let storage_array = storage_ref
+                .downcast_ref::<llvm_types::ArrayType>()
+                .ok_or_else(|| {
+                    pliron::input_error_noloc!(
+                        "target-stable array projection expected array storage, got {}",
+                        storage_array.deref(ctx).disp(ctx)
+                    )
+                })?;
+            Some(storage_array.elem_type())
+        }
+        None => None,
+    };
 
     // The typed GEP below strides by the allocation size of the converted
     // element type. For packed Rust elements this is now the LLVM packed-struct
@@ -2004,7 +2045,8 @@ pub(crate) fn convert_array_element_addr(
                 .element_type()
         };
         let rustc_stride = mir_element_stride(ctx, element_ty);
-        let llvm_element_ty = convert_type(ctx, element_ty).map_err(anyhow_to_pliron)?;
+        let semantic_element_ty = convert_type(ctx, element_ty).map_err(anyhow_to_pliron)?;
+        let llvm_element_ty = carrier_storage_element.unwrap_or(semantic_element_ty);
         let llvm_size = llvm_type_size_align(ctx, llvm_element_ty).map(|(size, _)| size);
         if let (Some(stride), Some(llvm_size)) = (rustc_stride, llvm_size)
             && stride != llvm_size
@@ -2026,6 +2068,9 @@ pub(crate) fn convert_array_element_addr(
 
     let gep_op = llvm::GetElementPtrOp::new(ctx, arr_ptr, gep_indices, llvm_array_ty);
     rewriter.insert_operation(ctx, gep_op.get_operation());
+    if let Some(storage_element) = carrier_storage_element {
+        set_target_stable_storage_pointee(ctx, gep_op.get_operation(), storage_element);
+    }
     if let Some(align) = element_align {
         llvm_export::ops::set_address_alignment(ctx, gep_op.get_operation(), align);
     }

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -3146,6 +3146,92 @@ mod tests {
         );
     }
 
+    #[test]
+    fn packed_struct_construction_with_bounded_shared_pointer_array_stays_semantic_in_ssa() {
+        use dialect_mir::ops::{MirConstructArrayOp, MirConstructStructOp};
+
+        let mut ctx = make_ctx();
+        let u8_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let array_ty: TypeHandle = MirArrayType::get(&mut ctx, shared_ty, 2).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArray".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![u8_ty, array_ty],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let (module, block) = build_kernel(&mut ctx, vec![u8_ty, shared_ty, shared_ty], vec![]);
+        let tag = block.deref(&ctx).get_argument(0);
+        let left = block.deref(&ctx).get_argument(1);
+        let right = block.deref(&ctx).get_argument(2);
+
+        let array = Operation::new(
+            &mut ctx,
+            MirConstructArrayOp::get_concrete_op_info(),
+            vec![array_ty],
+            vec![left, right],
+            vec![],
+            0,
+        );
+        array.insert_at_back(block, &ctx);
+        let array_value = array.deref(&ctx).get_result(0);
+
+        let outer = Operation::new(
+            &mut ctx,
+            MirConstructStructOp::get_concrete_op_info(),
+            vec![packed_ty],
+            vec![tag, array_value],
+            vec![],
+            0,
+        );
+        outer.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module)
+            .expect("a bounded AS3 array in a packed SSA aggregate must lower");
+
+        let body = kernel_blocks(&ctx, module);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            0,
+            "semantic construction must keep array elements in AS3"
+        );
+
+        let inserts = find_all::<llvm::InsertValueOp>(&ctx, &body);
+        let packed_result = inserts
+            .iter()
+            .filter_map(|insert| {
+                let result_ty = insert
+                    .get_operation()
+                    .deref(&ctx)
+                    .get_result(0)
+                    .get_type(&ctx);
+                let is_packed = result_ty
+                    .deref(&ctx)
+                    .downcast_ref::<llvm_types::StructType>()
+                    .is_some_and(|ty| ty.layout() == llvm_types::StructLayout::Packed);
+                is_packed.then_some(result_ty)
+            })
+            .last()
+            .expect("outer packed array construction must produce a packed LLVM struct");
+        assert_eq!(llvm_type_size_align(&ctx, packed_result), Some((17, 1)));
+        assert!(
+            llvm_packed_struct_contains_pointer_in_address_space(
+                &ctx,
+                packed_result,
+                llvm_types::address_space::SHARED,
+            ),
+            "the semantic packed value must retain AS3 array elements"
+        );
+    }
+
     /// Packed LLVM element types carry the same allocation size as rustc, so
     /// typed array GEPs now stride by the correct packed byte count.
     #[test]

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -49,9 +49,7 @@
 //! ```
 
 use crate::context::{DeviceGlobalsMap, DynamicSmemAlignmentMap, SharedGlobalsMap};
-use crate::convert::target_stable_storage::{
-    StorageRewriteOptions, coerce_target_stable_value, target_stable_storage_type,
-};
+use crate::convert::target_stable_storage::coerce_target_stable_value;
 use crate::convert::types::{
     StructLayoutInfo, build_struct_slot_map, convert_type, get_type_size,
     llvm_packed_struct_contains_pointer_in_address_space, mir_type_abi_align,
@@ -61,12 +59,12 @@ use crate::convert::types::{
 use crate::helpers;
 use dialect_mir::types::{MirPtrType, MirStructType};
 use llvm_export::attributes::IntegerOverflowFlagsAttr;
-use llvm_export::op_interfaces::{IntBinArithOpWithOverflowFlag, PointerTypeResult};
+use llvm_export::op_interfaces::IntBinArithOpWithOverflowFlag;
 use llvm_export::ops as llvm;
 use llvm_export::ops::GlobalOpExt;
 use llvm_export::types::{ArrayType, FuncType, StructLayout, StructType, VoidType};
 use pliron::attribute::AttrObj;
-use pliron::builtin::attributes::IntegerAttr;
+use pliron::builtin::attributes::{IntegerAttr, TypeAttr};
 use pliron::builtin::op_interfaces::CallOpCallable;
 use pliron::builtin::op_interfaces::SymbolOpInterface;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -92,6 +90,35 @@ fn anyhow_to_pliron(e: anyhow::Error) -> pliron::result::Error {
     )
 }
 
+const TARGET_STABLE_STORAGE_POINTEE_KEY: &str = "cuda_oxide_target_stable_storage_pointee";
+
+/// Record the physical pointee type carried by a target-stable local address.
+///
+/// LLVM pointers are opaque, while recursive MIR projections still need to
+/// distinguish the semantic pointee from the physical carrier pointee. Only
+/// compiler-owned local addresses admitted by `packed_shared_local_storage_info`
+/// receive this marker, and projections propagate it to their results.
+pub(crate) fn set_target_stable_storage_pointee(
+    ctx: &mut Context,
+    op: Ptr<Operation>,
+    pointee: TypeHandle,
+) {
+    op.deref_mut(ctx).attributes.set(
+        TARGET_STABLE_STORAGE_POINTEE_KEY.try_into().unwrap(),
+        TypeAttr::new(pointee),
+    );
+}
+
+/// Physical pointee type for an address inside a target-stable carrier local.
+pub(crate) fn target_stable_storage_pointee(ctx: &Context, ptr: Value) -> Option<TypeHandle> {
+    let defining_op = ptr.defining_op()?;
+    defining_op
+        .deref(ctx)
+        .attributes
+        .get::<TypeAttr>(&TARGET_STABLE_STORAGE_POINTEE_KEY.try_into().unwrap())
+        .map(|attr| attr.get_type(ctx))
+}
+
 /// Convert `mir.store` to `llvm.store`.
 ///
 /// Operand order: `[ptr, value]` - stores `value` to address `ptr`.
@@ -111,21 +138,23 @@ pub(crate) fn convert_store(
         }
     };
 
-    let local_carrier = packed_shared_local_storage_for_address(ctx, operands_info, ptr)?;
-    let stored_val = if local_carrier {
-        let storage_ty =
-            target_stable_local_value_type(ctx, val.get_type(ctx), "packed shared local store")?;
-        coerce_target_stable_value(ctx, rewriter, val, storage_ty, "packed shared local store")?
-    } else {
-        // Packed whole-value stores are byte-faithful now that divergent rustc
-        // layouts lower to LLVM packed structs. Keep the target-dependent AS3
-        // case fail-closed for arbitrary memory; only compiler-owned local
-        // carrier slots are exempt.
+    let storage_pointee = target_stable_storage_pointee(ctx, ptr);
+
+    // Arbitrary packed-AS3 memory remains fail-closed. A compiler-owned local
+    // admitted by `packed_shared_local_storage_info` is different: its address
+    // path carries the exact target-stable physical pointee, so the semantic
+    // value can be converted explicitly at this boundary.
+    if storage_pointee.is_none() {
         fail_on_target_dependent_packed_aggregate(
             ctx,
             value_mir_type(ctx, operands_info, val),
             "storing",
         )?;
+    }
+
+    let stored_val = if let Some(storage_ty) = storage_pointee {
+        coerce_target_stable_value(ctx, rewriter, val, storage_ty, "packed shared local store")?
+    } else {
         val
     };
 
@@ -191,103 +220,6 @@ fn value_mir_type(ctx: &Context, operands_info: &OperandsInfo, value: Value) -> 
         .copied()
         .find(|ty| ty.deref(ctx).is::<MirStructType>())
         .unwrap_or(current)
-}
-
-/// Return whether `ptr` addresses target-stable carrier storage for an
-/// eligible packed-AS3 local.
-///
-/// `OperandsInfo` records type history only for the current operation's direct
-/// operands. Do not walk from a projected pointer back to its alloca and then
-/// query that nested value's history: it is not present in a load/store's
-/// `OperandsInfo`.
-///
-/// Whole-local accesses are recognized from an `llvm.alloca` plus the MIR
-/// pointee recorded directly on that operand. Direct field projections are
-/// recognized from the converted `llvm.gep`: its direct operand history keeps
-/// the semantic field pointee (for #1036, p3), while the GEP's physical result
-/// pointee is the carrier field type (p0). Only packed, constant-index struct
-/// projections whose physical pointee is exactly the target-stable rewrite are
-/// admitted. Dynamic pointer arithmetic remains out of scope.
-fn packed_shared_local_storage_for_address(
-    ctx: &mut Context,
-    operands_info: &OperandsInfo,
-    ptr: Value,
-) -> Result<bool> {
-    let mir_pointee = {
-        let Some(mir_ptr) = operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, ptr) else {
-            return Ok(false);
-        };
-        let pointee = mir_ptr.pointee;
-        drop(mir_ptr);
-        pointee
-    };
-
-    let Some(defining_op) = ptr.defining_op() else {
-        return Ok(false);
-    };
-
-    if let Some(alloca) = Operation::get_op::<llvm::AllocaOp>(defining_op, ctx) {
-        let Some(info) =
-            packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)?
-        else {
-            return Ok(false);
-        };
-        return Ok(alloca.result_pointee_type(ctx) == info.storage_ty);
-    }
-
-    let Some(gep) = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx) else {
-        return Ok(false);
-    };
-
-    let indices = gep.indices(ctx);
-    let is_direct_field_projection = indices.len() == 2
-        && matches!(
-            indices.first(),
-            Some(&llvm_export::ops::GepIndex::Constant(0))
-        )
-        && indices
-            .iter()
-            .all(|index| matches!(index, &llvm_export::ops::GepIndex::Constant(_)));
-    if !is_direct_field_projection {
-        return Ok(false);
-    }
-
-    let source_is_packed_struct = {
-        let source_ty = gep.src_elem_type(ctx);
-        let source_ref = source_ty.deref(ctx);
-        source_ref
-            .downcast_ref::<StructType>()
-            .is_some_and(|ty| ty.layout() == StructLayout::Packed)
-    };
-    if !source_is_packed_struct {
-        return Ok(false);
-    }
-
-    let semantic_ty = convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
-    let storage_ty =
-        target_stable_local_value_type(ctx, semantic_ty, "packed shared local field projection")?;
-
-    // A scalar sibling has no representation rewrite and needs no special
-    // handling. The AS3 field is admitted only when the GEP physically points
-    // at the exact p0 carrier type computed from its semantic p3 type.
-    Ok(storage_ty != semantic_ty && gep.result_pointee_type(ctx) == storage_ty)
-}
-
-fn target_stable_local_value_type(
-    ctx: &mut Context,
-    semantic_ty: TypeHandle,
-    role: &str,
-) -> Result<TypeHandle> {
-    target_stable_storage_type(
-        ctx,
-        semantic_ty,
-        StorageRewriteOptions {
-            canonicalize_bool: false,
-        },
-        role,
-    )
-    .map(|rewrite| rewrite.ty)
-    .map_err(anyhow_to_pliron)
 }
 
 /// Refuse only packed by-value images whose physical bytes depend on the
@@ -585,17 +517,17 @@ pub(crate) fn convert_load(
     let ptr = op.deref(ctx).get_operand(0);
     let result_ty = op.deref(ctx).get_result(0).get_type(ctx);
 
-    let semantic_llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
-    let local_carrier = packed_shared_local_storage_for_address(ctx, _operands_info, ptr)?;
-    let load_ty = if local_carrier {
-        target_stable_local_value_type(ctx, semantic_llvm_ty, "packed shared local load")?
-    } else {
-        // Arbitrary packed-AS3 memory remains target-dependent. Only a
-        // compiler-owned carrier local may load its physical p0 representation
-        // and reconstruct the semantic p3 value afterwards.
+    let storage_pointee = target_stable_storage_pointee(ctx, ptr);
+
+    // Arbitrary packed-AS3 memory remains target-dependent. Only a
+    // compiler-owned carrier address may load its physical representation and
+    // reconstruct the semantic value afterwards.
+    if storage_pointee.is_none() {
         fail_on_target_dependent_packed_aggregate(ctx, result_ty, "loading")?;
-        semantic_llvm_ty
-    };
+    }
+
+    let semantic_llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
+    let load_ty = storage_pointee.unwrap_or(semantic_llvm_ty);
 
     let llvm_load = llvm::LoadOp::new(ctx, ptr, load_ty);
     if dialect_mir::ops::MirLoadOp::new(op).is_volatile(ctx) {
@@ -621,7 +553,7 @@ pub(crate) fn convert_load(
     }
     rewriter.insert_operation(ctx, llvm_load.get_operation());
     let loaded = llvm_load.get_operation().deref(ctx).get_result(0);
-    let semantic_value = if local_carrier {
+    let semantic_value = if storage_pointee.is_some() {
         coerce_target_stable_value(
             ctx,
             rewriter,
@@ -659,9 +591,11 @@ pub(crate) fn convert_dbg_value(
 
 /// Convert `mir.alloca` to `llvm.alloca`.
 ///
-/// `mir.alloca` carries its element type on the result pointer's pointee, and
-/// emits a single-element stack slot of that type. We therefore convert the
-/// pointee to an LLVM type and emit `llvm.alloca <pointee_ty>, i32 1`.
+/// `mir.alloca` carries its element type on the result pointer's pointee.
+/// Ordinary locals use the converted semantic LLVM pointee. Eligible
+/// packed-AS3 locals instead allocate the target-stable carrier and record its
+/// physical pointee so loads, stores, and recursive projections stay on that
+/// representation.
 ///
 /// No value is stored into the slot; that is the caller's job via subsequent
 /// `mir.store` / `llvm.store` ops. This matches the mem2reg-ready translator
@@ -683,11 +617,12 @@ pub(crate) fn convert_alloca(
         })?;
         mir_ptr.pointee
     };
-    let llvm_pointee =
-        match packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)? {
-            Some(info) => info.storage_ty,
-            None => convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?,
-        };
+    let local_storage =
+        packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
+    let llvm_pointee = match local_storage {
+        Some(info) => info.storage_ty,
+        None => convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?,
+    };
 
     let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
     let one_apint =
@@ -705,6 +640,9 @@ pub(crate) fn convert_alloca(
     }
     copy_debug_local_variable(ctx, op, alloca.get_operation());
     copy_local_memory_provenance(ctx, op, alloca.get_operation());
+    if local_storage.is_some() {
+        set_target_stable_storage_pointee(ctx, alloca.get_operation(), llvm_pointee);
+    }
     rewriter.insert_operation(ctx, alloca.get_operation());
     rewriter.replace_operation(ctx, op, alloca.get_operation());
 
@@ -1730,6 +1668,237 @@ mod tests {
             .downcast_ref::<PointerType>()
             .expect("projected carrier store value must be an LLVM pointer");
         assert_eq!(stored_ptr.address_space(), llvm_addr::GENERIC);
+    }
+
+    #[test]
+    fn packed_shared_nested_tuple_projection_preserves_carrier_pointee() {
+        use dialect_mir::attributes::FieldIndexAttr;
+
+        let mut ctx = make_ctx();
+        let tag: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let pair: TypeHandle = MirTupleType::get_with_layout(
+            &mut ctx,
+            vec![shared, shared],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedNestedTupleLocal".into(),
+            vec!["tag".into(), "pair".into()],
+            vec![tag, pair],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed, true);
+        let pair_ptr_ty = MirPtrType::get_generic(&mut ctx, pair, false);
+        let shared_ptr_ty = MirPtrType::get_generic(&mut ctx, shared, false);
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, packed);
+        undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_value = undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![slot, semantic_value],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+
+        let outer_field = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![pair_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(outer_field).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        outer_field.insert_at_back(block, &ctx);
+        let pair_addr = outer_field.deref(&ctx).get_result(0);
+
+        let inner_field = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![shared_ptr_ty.into()],
+            vec![pair_addr],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(inner_field).set_attr_field_index(&ctx, FieldIndexAttr(0));
+        inner_field.insert_at_back(block, &ctx);
+        let projected_ptr = inner_field.deref(&ctx).get_result(0);
+
+        let load = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![shared],
+            vec![projected_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("nested packed-AS3 local projection must preserve carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let alloca = find_first::<llvm::AllocaOp>(&ctx, &body).expect("expected llvm.alloca");
+        assert!(
+            !llvm_packed_struct_contains_pointer_in_address_space(
+                &ctx,
+                alloca.result_pointee_type(&ctx),
+                llvm_addr::SHARED,
+            ),
+            "recursive local carrier must not contain AS3 leaves"
+        );
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            3,
+            "two store leaves and one projected load must cross p3 <-> p0 boundaries"
+        );
+    }
+
+    #[test]
+    fn packed_shared_array_element_projection_preserves_carrier_pointee() {
+        use dialect_mir::attributes::FieldIndexAttr;
+        use pliron::builtin::attributes::IntegerAttr;
+        use std::num::NonZeroUsize;
+
+        let mut ctx = make_ctx();
+        let tag: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let array: TypeHandle = MirArrayType::get(&mut ctx, shared, 2).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArrayLocal".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, array],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed, true);
+        let array_ptr_ty = MirPtrType::get_generic(&mut ctx, array, false);
+        let shared_ptr_ty = MirPtrType::get_generic(&mut ctx, shared, false);
+        let index_ty: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, packed);
+        undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_value = undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![slot, semantic_value],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+
+        let array_field = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![array_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(array_field).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        array_field.insert_at_back(block, &ctx);
+        let array_addr = array_field.deref(&ctx).get_result(0);
+
+        let index = Operation::new(
+            &mut ctx,
+            mir::MirConstantOp::get_concrete_op_info(),
+            vec![index_ty],
+            vec![],
+            vec![],
+            0,
+        );
+        mir::MirConstantOp::new(index).set_attr_value(
+            &ctx,
+            IntegerAttr::new(
+                IntegerType::get(&ctx, 64, Signedness::Signed),
+                APInt::from_u64(1, NonZeroUsize::new(64).unwrap()),
+            ),
+        );
+        index.insert_at_back(block, &ctx);
+        let index_value = index.deref(&ctx).get_result(0);
+
+        let element_addr = Operation::new(
+            &mut ctx,
+            mir::MirArrayElementAddrOp::get_concrete_op_info(),
+            vec![shared_ptr_ty.into()],
+            vec![array_addr, index_value],
+            vec![],
+            0,
+        );
+        element_addr.insert_at_back(block, &ctx);
+        let projected_ptr = element_addr.deref(&ctx).get_result(0);
+
+        let load = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![shared],
+            vec![projected_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("packed-AS3 local array projection must preserve carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            3,
+            "two store leaves and one array-element load must cross p3 <-> p0 boundaries"
+        );
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -49,15 +49,19 @@
 //! ```
 
 use crate::context::{DeviceGlobalsMap, DynamicSmemAlignmentMap, SharedGlobalsMap};
+use crate::convert::target_stable_storage::{
+    StorageRewriteOptions, coerce_target_stable_value, target_stable_storage_type,
+};
 use crate::convert::types::{
     StructLayoutInfo, build_struct_slot_map, convert_type, get_type_size,
     llvm_packed_struct_contains_pointer_in_address_space, mir_type_abi_align,
-    validate_initialized_global_layout, validate_relocated_initialized_global_layout,
+    packed_shared_local_storage_info, validate_initialized_global_layout,
+    validate_relocated_initialized_global_layout,
 };
 use crate::helpers;
 use dialect_mir::types::{MirPtrType, MirStructType};
 use llvm_export::attributes::IntegerOverflowFlagsAttr;
-use llvm_export::op_interfaces::IntBinArithOpWithOverflowFlag;
+use llvm_export::op_interfaces::{IntBinArithOpWithOverflowFlag, PointerTypeResult};
 use llvm_export::ops as llvm;
 use llvm_export::ops::GlobalOpExt;
 use llvm_export::types::{ArrayType, FuncType, StructLayout, StructType, VoidType};
@@ -107,16 +111,25 @@ pub(crate) fn convert_store(
         }
     };
 
-    // Packed whole-value stores are byte-faithful now that divergent rustc
-    // layouts lower to LLVM packed structs. Keep the target-dependent AS3 case
-    // fail-closed because its physical pointer width is selected only later.
-    fail_on_target_dependent_packed_aggregate(
-        ctx,
-        value_mir_type(ctx, operands_info, val),
-        "storing",
-    )?;
+    let local_carrier = packed_shared_local_storage_for_address(ctx, operands_info, ptr)?;
+    let stored_val = if local_carrier {
+        let storage_ty =
+            target_stable_local_value_type(ctx, val.get_type(ctx), "packed shared local store")?;
+        coerce_target_stable_value(ctx, rewriter, val, storage_ty, "packed shared local store")?
+    } else {
+        // Packed whole-value stores are byte-faithful now that divergent rustc
+        // layouts lower to LLVM packed structs. Keep the target-dependent AS3
+        // case fail-closed for arbitrary memory; only compiler-owned local
+        // carrier slots are exempt.
+        fail_on_target_dependent_packed_aggregate(
+            ctx,
+            value_mir_type(ctx, operands_info, val),
+            "storing",
+        )?;
+        val
+    };
 
-    let llvm_store = llvm::StoreOp::new(ctx, val, ptr);
+    let llvm_store = llvm::StoreOp::new(ctx, stored_val, ptr);
     if dialect_mir::ops::MirStoreOp::new(op).is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_store.get_operation(), true);
     }
@@ -178,6 +191,103 @@ fn value_mir_type(ctx: &Context, operands_info: &OperandsInfo, value: Value) -> 
         .copied()
         .find(|ty| ty.deref(ctx).is::<MirStructType>())
         .unwrap_or(current)
+}
+
+/// Return whether `ptr` addresses target-stable carrier storage for an
+/// eligible packed-AS3 local.
+///
+/// `OperandsInfo` records type history only for the current operation's direct
+/// operands. Do not walk from a projected pointer back to its alloca and then
+/// query that nested value's history: it is not present in a load/store's
+/// `OperandsInfo`.
+///
+/// Whole-local accesses are recognized from an `llvm.alloca` plus the MIR
+/// pointee recorded directly on that operand. Direct field projections are
+/// recognized from the converted `llvm.gep`: its direct operand history keeps
+/// the semantic field pointee (for #1036, p3), while the GEP's physical result
+/// pointee is the carrier field type (p0). Only packed, constant-index struct
+/// projections whose physical pointee is exactly the target-stable rewrite are
+/// admitted. Dynamic pointer arithmetic remains out of scope.
+fn packed_shared_local_storage_for_address(
+    ctx: &mut Context,
+    operands_info: &OperandsInfo,
+    ptr: Value,
+) -> Result<bool> {
+    let mir_pointee = {
+        let Some(mir_ptr) = operands_info.lookup_most_recent_of_type::<MirPtrType>(ctx, ptr) else {
+            return Ok(false);
+        };
+        let pointee = mir_ptr.pointee;
+        drop(mir_ptr);
+        pointee
+    };
+
+    let Some(defining_op) = ptr.defining_op() else {
+        return Ok(false);
+    };
+
+    if let Some(alloca) = Operation::get_op::<llvm::AllocaOp>(defining_op, ctx) {
+        let Some(info) =
+            packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)?
+        else {
+            return Ok(false);
+        };
+        return Ok(alloca.result_pointee_type(ctx) == info.storage_ty);
+    }
+
+    let Some(gep) = Operation::get_op::<llvm::GetElementPtrOp>(defining_op, ctx) else {
+        return Ok(false);
+    };
+
+    let indices = gep.indices(ctx);
+    let is_direct_field_projection = indices.len() == 2
+        && matches!(
+            indices.first(),
+            Some(&llvm_export::ops::GepIndex::Constant(0))
+        )
+        && indices
+            .iter()
+            .all(|index| matches!(index, &llvm_export::ops::GepIndex::Constant(_)));
+    if !is_direct_field_projection {
+        return Ok(false);
+    }
+
+    let source_is_packed_struct = {
+        let source_ty = gep.src_elem_type(ctx);
+        let source_ref = source_ty.deref(ctx);
+        source_ref
+            .downcast_ref::<StructType>()
+            .is_some_and(|ty| ty.layout() == StructLayout::Packed)
+    };
+    if !source_is_packed_struct {
+        return Ok(false);
+    }
+
+    let semantic_ty = convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
+    let storage_ty =
+        target_stable_local_value_type(ctx, semantic_ty, "packed shared local field projection")?;
+
+    // A scalar sibling has no representation rewrite and needs no special
+    // handling. The AS3 field is admitted only when the GEP physically points
+    // at the exact p0 carrier type computed from its semantic p3 type.
+    Ok(storage_ty != semantic_ty && gep.result_pointee_type(ctx) == storage_ty)
+}
+
+fn target_stable_local_value_type(
+    ctx: &mut Context,
+    semantic_ty: TypeHandle,
+    role: &str,
+) -> Result<TypeHandle> {
+    target_stable_storage_type(
+        ctx,
+        semantic_ty,
+        StorageRewriteOptions {
+            canonicalize_bool: false,
+        },
+        role,
+    )
+    .map(|rewrite| rewrite.ty)
+    .map_err(anyhow_to_pliron)
 }
 
 /// Refuse only packed by-value images whose physical bytes depend on the
@@ -475,14 +585,19 @@ pub(crate) fn convert_load(
     let ptr = op.deref(ctx).get_operand(0);
     let result_ty = op.deref(ctx).get_result(0).get_type(ctx);
 
-    // Packed whole-value loads are byte-faithful now that divergent rustc
-    // layouts lower to LLVM packed structs. Keep only the target-dependent AS3
-    // physical-image case fail-closed.
-    fail_on_target_dependent_packed_aggregate(ctx, result_ty, "loading")?;
+    let semantic_llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
+    let local_carrier = packed_shared_local_storage_for_address(ctx, _operands_info, ptr)?;
+    let load_ty = if local_carrier {
+        target_stable_local_value_type(ctx, semantic_llvm_ty, "packed shared local load")?
+    } else {
+        // Arbitrary packed-AS3 memory remains target-dependent. Only a
+        // compiler-owned carrier local may load its physical p0 representation
+        // and reconstruct the semantic p3 value afterwards.
+        fail_on_target_dependent_packed_aggregate(ctx, result_ty, "loading")?;
+        semantic_llvm_ty
+    };
 
-    let llvm_ty = convert_type(ctx, result_ty).map_err(anyhow_to_pliron)?;
-
-    let llvm_load = llvm::LoadOp::new(ctx, ptr, llvm_ty);
+    let llvm_load = llvm::LoadOp::new(ctx, ptr, load_ty);
     if dialect_mir::ops::MirLoadOp::new(op).is_volatile(ctx) {
         llvm_export::ops::set_op_volatile(ctx, llvm_load.get_operation(), true);
     }
@@ -505,7 +620,19 @@ pub(crate) fn convert_load(
         llvm_export::ops::set_op_alignment(ctx, llvm_load.get_operation(), align as u32);
     }
     rewriter.insert_operation(ctx, llvm_load.get_operation());
-    rewriter.replace_operation(ctx, op, llvm_load.get_operation());
+    let loaded = llvm_load.get_operation().deref(ctx).get_result(0);
+    let semantic_value = if local_carrier {
+        coerce_target_stable_value(
+            ctx,
+            rewriter,
+            loaded,
+            semantic_llvm_ty,
+            "packed shared local load",
+        )?
+    } else {
+        loaded
+    };
+    rewriter.replace_operation_with_values(ctx, op, vec![semantic_value]);
 
     Ok(())
 }
@@ -556,7 +683,11 @@ pub(crate) fn convert_alloca(
         })?;
         mir_ptr.pointee
     };
-    let llvm_pointee = convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?;
+    let llvm_pointee =
+        match packed_shared_local_storage_info(ctx, mir_pointee).map_err(anyhow_to_pliron)? {
+            Some(info) => info.storage_ty,
+            None => convert_type(ctx, mir_pointee).map_err(anyhow_to_pliron)?,
+        };
 
     let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
     let one_apint =
@@ -1418,6 +1549,187 @@ mod tests {
         // Element type should round-trip through convert_type as i32.
         let elem_ty = alloca.result_pointee_type(&ctx);
         assert!(elem_ty.deref(&ctx).is::<IntegerType>());
+    }
+
+    #[test]
+    fn packed_shared_local_slot_uses_carrier_for_field_projection() {
+        use dialect_mir::attributes::FieldIndexAttr;
+
+        let mut ctx = make_ctx();
+        let tag_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocal".into(),
+            vec!["tag".into(), "ptr".into()],
+            vec![tag_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed_ty, true);
+        let field_ptr_ty = MirPtrType::get_generic(&mut ctx, shared_ty, false);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let undef = mir::MirUndefOp::new(&mut ctx, packed_ty);
+        undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_value = undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![slot, semantic_value],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+
+        let field_addr = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![field_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        field_addr.insert_at_back(block, &ctx);
+        let projected_ptr = field_addr.deref(&ctx).get_result(0);
+
+        let load = Operation::new(
+            &mut ctx,
+            mir::MirLoadOp::get_concrete_op_info(),
+            vec![shared_ty],
+            vec![projected_ptr],
+            vec![],
+            0,
+        );
+        load.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("eligible packed-AS3 locals must lower through carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        let alloca = find_first::<llvm::AllocaOp>(&ctx, &body).expect("expected llvm.alloca");
+        let storage_ty = alloca.result_pointee_type(&ctx);
+        let storage_ref = storage_ty.deref(&ctx);
+        let storage_struct = storage_ref
+            .downcast_ref::<StructType>()
+            .expect("packed local carrier must remain a struct");
+        let pointer_ty = storage_struct.field_type(1);
+        let pointer_ref = pointer_ty.deref(&ctx);
+        let pointer = pointer_ref
+            .downcast_ref::<PointerType>()
+            .expect("carrier pointer field must lower to an LLVM pointer");
+        assert_eq!(pointer.address_space(), llvm_addr::GENERIC);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            2,
+            "the local store and projected load must convert p3 <-> p0 exactly once each"
+        );
+    }
+
+    #[test]
+    fn packed_shared_local_pointer_field_store_uses_carrier() {
+        use dialect_mir::attributes::FieldIndexAttr;
+
+        let mut ctx = make_ctx();
+        let tag_ty: TypeHandle = IntegerType::get(&ctx, 8, Signedness::Unsigned).into();
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared_ty: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed_ty: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedFieldStore".into(),
+            vec!["tag".into(), "ptr".into()],
+            vec![tag_ty, shared_ty],
+            vec![0, 1],
+            vec![0, 1],
+            9,
+            1,
+        )
+        .into();
+        let local_ptr_ty = MirPtrType::get_generic(&mut ctx, packed_ty, true);
+        let field_ptr_ty = MirPtrType::get_generic(&mut ctx, shared_ty, true);
+
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+
+        let alloca_op = Operation::new(
+            &mut ctx,
+            mir::MirAllocaOp::get_concrete_op_info(),
+            vec![local_ptr_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+        alloca_op.insert_at_back(block, &ctx);
+        let slot = alloca_op.deref(&ctx).get_result(0);
+
+        let field_addr = Operation::new(
+            &mut ctx,
+            mir::MirFieldAddrOp::get_concrete_op_info(),
+            vec![field_ptr_ty.into()],
+            vec![slot],
+            vec![],
+            0,
+        );
+        mir::MirFieldAddrOp::new(field_addr).set_attr_field_index(&ctx, FieldIndexAttr(1));
+        field_addr.insert_at_back(block, &ctx);
+        let projected_ptr = field_addr.deref(&ctx).get_result(0);
+
+        let shared_undef = mir::MirUndefOp::new(&mut ctx, shared_ty);
+        shared_undef.get_operation().insert_at_back(block, &ctx);
+        let semantic_ptr = shared_undef.get_operation().deref(&ctx).get_result(0);
+
+        let store = Operation::new(
+            &mut ctx,
+            mir::MirStoreOp::get_concrete_op_info(),
+            vec![],
+            vec![projected_ptr, semantic_ptr],
+            vec![],
+            0,
+        );
+        store.insert_at_back(block, &ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect("projected packed-AS3 local stores must use carrier storage");
+
+        let body = kernel_blocks(&ctx, module_ptr);
+        assert_eq!(
+            count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body),
+            1,
+            "the projected store must convert the semantic p3 pointer to carrier p0 exactly once"
+        );
+
+        let store =
+            find_first::<llvm::StoreOp>(&ctx, &body).expect("expected projected llvm.store");
+        let stored_ty = store
+            .get_operation()
+            .deref(&ctx)
+            .get_operand(0)
+            .get_type(&ctx);
+        let stored_ref = stored_ty.deref(&ctx);
+        let stored_ptr = stored_ref
+            .downcast_ref::<PointerType>()
+            .expect("projected carrier store value must be an LLVM pointer");
+        assert_eq!(stored_ptr.address_space(), llvm_addr::GENERIC);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -365,12 +365,12 @@ pub(crate) fn transparent_scalar_llvm_type(
     Ok(transparent_scalar_abi_info(ctx, struct_ty)?.scalar_ty)
 }
 
-/// Target-stable ABI projection for the deliberately narrow packed-AS3
-/// internal device return case.
+/// Target-stable ABI projection for packed aggregates containing AS3 leaves
+/// across the internal device return boundary.
 ///
-/// The function body continues to use the semantic packed LLVM struct with a
-/// shared pointer. Only the physical return value replaces that direct AS3
-/// pointer with a generic pointer, whose width is stable across the legacy/PTX
+/// The function body continues to use the semantic packed LLVM struct with
+/// shared pointers. Only the physical return value recursively replaces AS3
+/// leaves with generic pointers, whose width is stable across the legacy/PTX
 /// and modern NVVM data layouts.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PackedSharedInternalAbiInfo {
@@ -378,13 +378,49 @@ pub(crate) struct PackedSharedInternalAbiInfo {
     pub storage_ty: TypeHandle,
 }
 
-/// Recognize the first supported packed-AS3 internal ABI shape.
+/// Whether a MIR value shape belongs to the recursive packed-AS3 ABI lane.
 ///
-/// Scope is intentionally fail-closed: one direct shared-pointer field in a
-/// byte-faithful packed struct, with every other non-ZST field scalar. Nested
-/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain out
-/// of scope even though the generic storage utility can represent broader
-/// shapes for enum payloads.
+/// Structs and tuples may nest arbitrarily and may contain any number of scalar
+/// pointer leaves. Arrays and vectors remain deliberately excluded here: an
+/// AS3 array would expand into one conversion per element and belongs to the
+/// separately bounded array follow-up. Other aggregate kinds keep their
+/// existing fail-closed behavior.
+fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: TypeHandle) -> bool {
+    let children = {
+        let ty_ref = mir_ty.deref(ctx);
+        if ty_ref.is::<IntegerType>()
+            || ty_ref.is::<MirFP16Type>()
+            || ty_ref.is::<llvm_types::HalfType>()
+            || ty_ref.is::<FP32Type>()
+            || ty_ref.is::<FP64Type>()
+            || ty_ref.is::<MirPtrType>()
+            || ty_ref.is::<llvm_types::PointerType>()
+        {
+            return true;
+        }
+        if let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() {
+            Some(struct_ty.field_types.clone())
+        } else {
+            ty_ref
+                .downcast_ref::<MirTupleType>()
+                .map(|tuple_ty| tuple_ty.get_types().to_vec())
+        }
+    };
+
+    children.is_some_and(|children| {
+        children
+            .into_iter()
+            .all(|child| packed_shared_internal_abi_mir_shape_is_supported(ctx, child))
+    })
+}
+
+/// Recognize a recursive packed-AS3 internal ABI shape.
+///
+/// The root must remain a byte-faithful packed struct. Nested structs/tuples
+/// and multiple AS3 leaves are admitted, while arrays, vectors, and unrelated
+/// aggregate kinds remain out of scope. The target-stable storage utility owns
+/// the recursive AS3 -> generic rewrite and this classifier only decides which
+/// semantic shapes may use it.
 pub(crate) fn packed_shared_internal_abi_info(
     ctx: &mut Context,
     mir_ty: TypeHandle,
@@ -396,6 +432,10 @@ pub(crate) fn packed_shared_internal_abi_info(
         };
         StructLayoutInfo::of_struct(struct_ty)
     };
+
+    if !packed_shared_internal_abi_mir_shape_is_supported(ctx, mir_ty) {
+        return Ok(None);
+    }
 
     let map = build_struct_slot_map(ctx, &layout)?;
     if !map.by_value_layout_faithful {
@@ -410,31 +450,6 @@ pub(crate) fn packed_shared_internal_abi_info(
         return Ok(None);
     }
 
-    let mut direct_shared_pointers = 0_u64;
-    for field_ty in &map.field_llvm_types {
-        if is_zero_sized_type(ctx, *field_ty) {
-            continue;
-        }
-        let field_ref = field_ty.deref(ctx);
-        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
-            if pointer.address_space() == llvm_types::address_space::SHARED {
-                direct_shared_pointers += 1;
-            }
-            continue;
-        }
-        if field_ref.is::<IntegerType>()
-            || field_ref.is::<llvm_types::HalfType>()
-            || field_ref.is::<FP32Type>()
-            || field_ref.is::<FP64Type>()
-        {
-            continue;
-        }
-        return Ok(None);
-    }
-    if direct_shared_pointers != 1 {
-        return Ok(None);
-    }
-
     let rewrite = target_stable_storage_type(
         ctx,
         map.llvm_struct_ty,
@@ -443,7 +458,7 @@ pub(crate) fn packed_shared_internal_abi_info(
         },
         "packed shared internal ABI",
     )?;
-    if rewrite.shared_pointer_leaves != 1 || rewrite.array_shared_pointer_leaves != 0 {
+    if rewrite.shared_pointer_leaves == 0 || rewrite.array_shared_pointer_leaves != 0 {
         return Ok(None);
     }
     let Some((storage_size, _)) = llvm_type_size_align(ctx, rewrite.ty) else {
@@ -5150,18 +5165,63 @@ mod tests {
     }
 
     #[test]
-    fn packed_shared_internal_abi_rejects_nested_shared_pointer() {
+    fn packed_shared_internal_abi_genericizes_multiple_direct_shared_pointers() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedPair".into(),
+            vec!["tag".into(), "left".into(), "right".into()],
+            vec![tag, shared, shared],
+            vec![0, 1, 2],
+            vec![0, 1, 9],
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, packed)
+            .expect("ABI classification must succeed")
+            .expect("multiple direct AS3 leaves must use the recursive internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((17, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+        assert!(llvm_packed_struct_contains_pointer_in_address_space(
+            &ctx,
+            abi.semantic_ty,
+            llvm_types::address_space::SHARED,
+        ));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+
+        let fields = struct_fields(&ctx, abi.storage_ty);
+        assert_eq!(fields.len(), 3);
+        for field in &fields[1..] {
+            let field_ref = field.deref(&ctx);
+            let pointer = field_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("both pointer leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        }
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_genericizes_nested_struct_shared_pointers() {
         let mut ctx = make_ctx();
         let pointee = mir_uint(&mut ctx, 32);
         let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
         let inner: TypeHandle = MirStructType::get_with_full_layout(
             &mut ctx,
-            "InnerShared".into(),
-            vec!["ptr".into()],
-            vec![shared],
-            vec![0],
-            vec![0],
-            8,
+            "InnerSharedPair".into(),
+            vec!["left".into(), "right".into()],
+            vec![shared, shared],
+            vec![0, 1],
+            vec![0, 8],
+            16,
             8,
         )
         .into();
@@ -5173,7 +5233,90 @@ mod tests {
             vec![tag, inner],
             vec![0, 1],
             vec![0, 1],
-            9,
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, outer)
+            .expect("classification must not error")
+            .expect("nested AS3 leaves must use the recursive internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((17, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+
+        let outer_fields = struct_fields(&ctx, abi.storage_ty);
+        let inner_fields = struct_fields(&ctx, outer_fields[1]);
+        assert_eq!(inner_fields.len(), 2);
+        for field in inner_fields {
+            let field_ref = field.deref(&ctx);
+            let pointer = field_ref
+                .downcast_ref::<llvm_types::PointerType>()
+                .expect("nested shared leaves must remain pointer-typed");
+            assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        }
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_genericizes_nested_tuple_shared_pointer() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let word = mir_uint(&mut ctx, 32);
+        let inner: TypeHandle = MirTupleType::get_with_layout(
+            &mut ctx,
+            vec![shared, word],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedNestedTupleShared".into(),
+            vec!["tag".into(), "inner".into()],
+            vec![tag, inner],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let abi = packed_shared_internal_abi_info(&mut ctx, outer)
+            .expect("classification must not error")
+            .expect("an AS3 leaf nested in a tuple must use the recursive carrier");
+        let outer_fields = struct_fields(&ctx, abi.storage_ty);
+        let inner_fields = struct_fields(&ctx, outer_fields[1]);
+        let inner_field_ref = inner_fields[0].deref(&ctx);
+        let pointer = inner_field_ref
+            .downcast_ref::<llvm_types::PointerType>()
+            .expect("nested tuple leaf must remain pointer-typed");
+        assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_keeps_shared_pointer_arrays_out_of_scope() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let shared_array: TypeHandle = MirArrayType::get(&mut ctx, shared, 2).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArray".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, shared_array],
+            vec![0, 1],
+            vec![0, 1],
+            17,
             1,
         )
         .into();
@@ -5182,7 +5325,7 @@ mod tests {
             packed_shared_internal_abi_info(&mut ctx, outer)
                 .expect("classification must not error")
                 .is_none(),
-            "the first internal ABI lane intentionally accepts only a direct AS3 field"
+            "AS3 arrays remain reserved for the bounded-array follow-up"
         );
     }
 

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -486,14 +486,62 @@ pub(crate) fn packed_shared_internal_abi_info(
     }))
 }
 
-/// Recognize the deliberately narrow packed-AS3 shape that may use a
-/// target-stable local stack slot.
+/// Maximum number of shared-pointer leaves introduced by fixed-array expansion
+/// in one packed-AS3 local carrier.
 ///
-/// This gate is intentionally independent of future widening of the internal
-/// device ABI classifier. Local storage currently admits only one direct AS3
-/// pointer leaf with scalar non-ZST siblings, matching issue #1036. Recursive
-/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain a
-/// separate follow-up even when the internal call ABI supports them.
+/// This is intentionally a local-storage policy constant rather than an alias
+/// of the internal-ABI limit. The two lanes happen to use the same bound today,
+/// but widening one must not implicitly widen the other.
+pub(crate) const MAX_PACKED_SHARED_LOCAL_ARRAY_REWRITE_LEAVES: u64 = 16;
+
+/// Whether a MIR value shape belongs to the recursive packed-AS3 local-storage
+/// lane.
+///
+/// Keep this policy independent of the internal device ABI classifier. Local
+/// storage may recurse through structs, tuples, and fixed arrays, but vectors
+/// and unrelated aggregate kinds remain fail-closed.
+fn packed_shared_local_storage_mir_shape_is_supported(ctx: &Context, mir_ty: TypeHandle) -> bool {
+    let children = {
+        let ty_ref = mir_ty.deref(ctx);
+        if ty_ref.is::<IntegerType>()
+            || ty_ref.is::<MirFP16Type>()
+            || ty_ref.is::<llvm_types::HalfType>()
+            || ty_ref.is::<FP32Type>()
+            || ty_ref.is::<FP64Type>()
+            || ty_ref.is::<MirPtrType>()
+            || ty_ref.is::<llvm_types::PointerType>()
+        {
+            return true;
+        }
+        if let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() {
+            Some(struct_ty.field_types.clone())
+        } else if let Some(tuple_ty) = ty_ref.downcast_ref::<MirTupleType>() {
+            Some(tuple_ty.get_types().to_vec())
+        } else {
+            ty_ref
+                .downcast_ref::<MirArrayType>()
+                .map(|array_ty| vec![array_ty.element_type()])
+        }
+    };
+
+    children.is_some_and(|children| {
+        children
+            .into_iter()
+            .all(|child| packed_shared_local_storage_mir_shape_is_supported(ctx, child))
+    })
+}
+
+/// Recognize a packed-AS3 shape that may use a target-stable local stack slot.
+///
+/// The root must be a byte-faithful packed struct. Multiple direct AS3 leaves,
+/// recursively nested struct/tuple leaves, and bounded fixed arrays are
+/// admitted. The target-stable storage utility performs the recursive AS3 ->
+/// generic rewrite; this gate decides only which compiler-owned locals may use
+/// that representation.
+///
+/// This classifier intentionally does not delegate to
+/// [`packed_shared_internal_abi_info`]. Future widening of either policy must
+/// remain explicit in the other.
 pub(crate) fn packed_shared_local_storage_info(
     ctx: &mut Context,
     mir_ty: TypeHandle,
@@ -506,33 +554,47 @@ pub(crate) fn packed_shared_local_storage_info(
         StructLayoutInfo::of_struct(struct_ty)
     };
 
-    let map = build_struct_slot_map(ctx, &layout)?;
-    let mut direct_shared_pointers = 0_u64;
-    for field_ty in &map.field_llvm_types {
-        if is_zero_sized_type(ctx, *field_ty) {
-            continue;
-        }
-        let field_ref = field_ty.deref(ctx);
-        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
-            if pointer.address_space() == llvm_types::address_space::SHARED {
-                direct_shared_pointers += 1;
-            }
-            continue;
-        }
-        if field_ref.is::<IntegerType>()
-            || field_ref.is::<llvm_types::HalfType>()
-            || field_ref.is::<FP32Type>()
-            || field_ref.is::<FP64Type>()
-        {
-            continue;
-        }
-        return Ok(None);
-    }
-    if direct_shared_pointers != 1 {
+    if !packed_shared_local_storage_mir_shape_is_supported(ctx, mir_ty) {
         return Ok(None);
     }
 
-    packed_shared_internal_abi_info(ctx, mir_ty)
+    let map = build_struct_slot_map(ctx, &layout)?;
+    if !map.by_value_layout_faithful {
+        return Ok(None);
+    }
+    let is_packed = map
+        .llvm_struct_ty
+        .deref(ctx)
+        .downcast_ref::<llvm_types::StructType>()
+        .is_some_and(|struct_ty| struct_ty.layout() == llvm_types::StructLayout::Packed);
+    if !is_packed {
+        return Ok(None);
+    }
+
+    let rewrite = target_stable_storage_type(
+        ctx,
+        map.llvm_struct_ty,
+        StorageRewriteOptions {
+            canonicalize_bool: false,
+        },
+        "packed shared local storage",
+    )?;
+    if rewrite.shared_pointer_leaves == 0
+        || rewrite.array_shared_pointer_leaves > MAX_PACKED_SHARED_LOCAL_ARRAY_REWRITE_LEAVES
+    {
+        return Ok(None);
+    }
+    let Some((storage_size, _)) = llvm_type_size_align(ctx, rewrite.ty) else {
+        return Ok(None);
+    };
+    if layout.total_size > 0 && storage_size != layout.total_size {
+        return Ok(None);
+    }
+
+    Ok(Some(PackedSharedInternalAbiInfo {
+        semantic_ty: map.llvm_struct_ty,
+        storage_ty: rewrite.ty,
+    }))
 }
 
 /// Convert a type that crosses a function boundary as one LLVM value.
@@ -5489,6 +5551,202 @@ mod tests {
                 .expect("classification must not error")
                 .is_none(),
             "shared-pointer vectors must remain outside the packed-AS3 internal ABI lane"
+        );
+    }
+
+    #[test]
+    fn packed_shared_local_storage_accepts_multiple_direct_shared_pointers() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocalPair".into(),
+            vec!["tag".into(), "left".into(), "right".into()],
+            vec![tag, shared, shared],
+            vec![0, 1, 2],
+            vec![0, 1, 9],
+            17,
+            1,
+        )
+        .into();
+
+        let info = packed_shared_local_storage_info(&mut ctx, packed)
+            .expect("local-storage classification must succeed")
+            .expect("multiple direct AS3 leaves must use a local carrier");
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            info.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+    }
+
+    #[test]
+    fn packed_shared_local_storage_accepts_nested_struct_and_tuple() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let nested_struct: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "LocalSharedPair".into(),
+            vec!["left".into(), "right".into()],
+            vec![shared, shared],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let nested_tuple: TypeHandle = MirTupleType::get_with_layout(
+            &mut ctx,
+            vec![shared, shared],
+            vec![0, 1],
+            vec![0, 8],
+            16,
+            8,
+        )
+        .into();
+        let tag = mir_uint(&mut ctx, 8);
+
+        for (name, nested) in [
+            ("PackedLocalNestedStruct", nested_struct),
+            ("PackedLocalNestedTuple", nested_tuple),
+        ] {
+            let outer: TypeHandle = MirStructType::get_with_full_layout(
+                &mut ctx,
+                name.into(),
+                vec!["tag".into(), "nested".into()],
+                vec![tag, nested],
+                vec![0, 1],
+                vec![0, 1],
+                17,
+                1,
+            )
+            .into();
+
+            let info = packed_shared_local_storage_info(&mut ctx, outer)
+                .expect("local-storage classification must succeed")
+                .expect("nested AS3 leaves must use a local carrier");
+            assert!(!llvm_type_contains_pointer_in_address_space(
+                &ctx,
+                info.storage_ty,
+                llvm_types::address_space::SHARED,
+            ));
+        }
+    }
+
+    #[test]
+    fn packed_shared_local_storage_accepts_bounded_shared_pointer_array() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let array: TypeHandle = MirArrayType::get(&mut ctx, shared, 2).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocalArray".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, array],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        let info = packed_shared_local_storage_info(&mut ctx, packed)
+            .expect("local-storage classification must succeed")
+            .expect("bounded AS3 arrays must use a local carrier");
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            info.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+    }
+
+    #[test]
+    fn packed_shared_local_storage_accepts_array_rewrite_at_exact_bound() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let count = MAX_PACKED_SHARED_LOCAL_ARRAY_REWRITE_LEAVES;
+        let array: TypeHandle = MirArrayType::get(&mut ctx, shared, count).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocalArrayAtBound".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, array],
+            vec![0, 1],
+            vec![0, 1],
+            1 + 8 * count,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_local_storage_info(&mut ctx, packed)
+                .expect("local-storage classification must succeed")
+                .is_some(),
+            "the exact local array rewrite bound must remain supported"
+        );
+    }
+
+    #[test]
+    fn packed_shared_local_storage_rejects_array_rewrite_above_bound() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let count = MAX_PACKED_SHARED_LOCAL_ARRAY_REWRITE_LEAVES + 1;
+        let array: TypeHandle = MirArrayType::get(&mut ctx, shared, count).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocalArrayAboveBound".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, array],
+            vec![0, 1],
+            vec![0, 1],
+            1 + 8 * count,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_local_storage_info(&mut ctx, packed)
+                .expect("local-storage classification must succeed")
+                .is_none(),
+            "array-expanded AS3 leaves above the local budget must fail closed"
+        );
+    }
+
+    #[test]
+    fn packed_shared_local_storage_rejects_shared_pointer_vector() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let shared_pointer: TypeHandle =
+            llvm_types::PointerType::get(&ctx, llvm_types::address_space::SHARED).into();
+        let vector: TypeHandle =
+            llvm_types::VectorType::get(&ctx, shared_pointer, 2, llvm_types::VectorTypeKind::Fixed)
+                .into();
+        let packed: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedLocalVector".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, vector],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_local_storage_info(&mut ctx, packed)
+                .expect("local-storage classification must succeed")
+                .is_none(),
+            "shared-pointer vectors must remain outside the local carrier lane"
         );
     }
 

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -459,6 +459,55 @@ pub(crate) fn packed_shared_internal_abi_info(
     }))
 }
 
+/// Recognize the deliberately narrow packed-AS3 shape that may use a
+/// target-stable local stack slot.
+///
+/// This gate is intentionally independent of future widening of the internal
+/// device ABI classifier. Local storage currently admits only one direct AS3
+/// pointer leaf with scalar non-ZST siblings, matching issue #1036. Recursive
+/// aggregates, arrays, vectors, and multiple shared-pointer leaves remain a
+/// separate follow-up even when the internal call ABI supports them.
+pub(crate) fn packed_shared_local_storage_info(
+    ctx: &mut Context,
+    mir_ty: TypeHandle,
+) -> Result<Option<PackedSharedInternalAbiInfo>, anyhow::Error> {
+    let layout = {
+        let ty_ref = mir_ty.deref(ctx);
+        let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() else {
+            return Ok(None);
+        };
+        StructLayoutInfo::of_struct(struct_ty)
+    };
+
+    let map = build_struct_slot_map(ctx, &layout)?;
+    let mut direct_shared_pointers = 0_u64;
+    for field_ty in &map.field_llvm_types {
+        if is_zero_sized_type(ctx, *field_ty) {
+            continue;
+        }
+        let field_ref = field_ty.deref(ctx);
+        if let Some(pointer) = field_ref.downcast_ref::<llvm_types::PointerType>() {
+            if pointer.address_space() == llvm_types::address_space::SHARED {
+                direct_shared_pointers += 1;
+            }
+            continue;
+        }
+        if field_ref.is::<IntegerType>()
+            || field_ref.is::<llvm_types::HalfType>()
+            || field_ref.is::<FP32Type>()
+            || field_ref.is::<FP64Type>()
+        {
+            continue;
+        }
+        return Ok(None);
+    }
+    if direct_shared_pointers != 1 {
+        return Ok(None);
+    }
+
+    packed_shared_internal_abi_info(ctx, mir_ty)
+}
+
 /// Convert a type that crosses a function boundary as one LLVM value.
 ///
 /// A struct with a natural-layout divergence is legal by value only when

--- a/crates/mir-lower/src/convert/types.rs
+++ b/crates/mir-lower/src/convert/types.rs
@@ -378,13 +378,21 @@ pub(crate) struct PackedSharedInternalAbiInfo {
     pub storage_ty: TypeHandle,
 }
 
+/// Maximum number of shared-pointer leaves introduced by fixed-array expansion
+/// in one packed-AS3 internal return carrier.
+///
+/// Struct/tuple nesting and direct pointer leaves remain proportional to source
+/// structure. Arrays can encode an arbitrarily large number of per-element
+/// extract/cast/insert sequences compactly, so only array-expanded AS3 leaves
+/// count against this code-shape budget.
+pub(crate) const MAX_PACKED_SHARED_INTERNAL_ABI_ARRAY_REWRITE_LEAVES: u64 = 16;
+
 /// Whether a MIR value shape belongs to the recursive packed-AS3 ABI lane.
 ///
-/// Structs and tuples may nest arbitrarily and may contain any number of scalar
-/// pointer leaves. Arrays and vectors remain deliberately excluded here: an
-/// AS3 array would expand into one conversion per element and belongs to the
-/// separately bounded array follow-up. Other aggregate kinds keep their
-/// existing fail-closed behavior.
+/// Structs, tuples, and fixed arrays may nest recursively and may contain any
+/// number of scalar pointer leaves. The array-specific expansion budget is
+/// enforced after conversion from the storage rewrite's exact AS3 leaf count.
+/// Vectors and unrelated aggregate kinds remain deliberately fail-closed.
 fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: TypeHandle) -> bool {
     let children = {
         let ty_ref = mir_ty.deref(ctx);
@@ -400,10 +408,12 @@ fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: Type
         }
         if let Some(struct_ty) = ty_ref.downcast_ref::<MirStructType>() {
             Some(struct_ty.field_types.clone())
+        } else if let Some(tuple_ty) = ty_ref.downcast_ref::<MirTupleType>() {
+            Some(tuple_ty.get_types().to_vec())
         } else {
             ty_ref
-                .downcast_ref::<MirTupleType>()
-                .map(|tuple_ty| tuple_ty.get_types().to_vec())
+                .downcast_ref::<MirArrayType>()
+                .map(|array_ty| vec![array_ty.element_type()])
         }
     };
 
@@ -416,11 +426,11 @@ fn packed_shared_internal_abi_mir_shape_is_supported(ctx: &Context, mir_ty: Type
 
 /// Recognize a recursive packed-AS3 internal ABI shape.
 ///
-/// The root must remain a byte-faithful packed struct. Nested structs/tuples
-/// and multiple AS3 leaves are admitted, while arrays, vectors, and unrelated
-/// aggregate kinds remain out of scope. The target-stable storage utility owns
-/// the recursive AS3 -> generic rewrite and this classifier only decides which
-/// semantic shapes may use it.
+/// The root must remain a byte-faithful packed struct. Nested structs/tuples,
+/// multiple AS3 leaves, and bounded fixed arrays are admitted. Vectors and
+/// unrelated aggregate kinds remain out of scope. The target-stable storage
+/// utility owns the recursive AS3 -> generic rewrite and this classifier only
+/// decides which semantic shapes may use it.
 pub(crate) fn packed_shared_internal_abi_info(
     ctx: &mut Context,
     mir_ty: TypeHandle,
@@ -458,7 +468,9 @@ pub(crate) fn packed_shared_internal_abi_info(
         },
         "packed shared internal ABI",
     )?;
-    if rewrite.shared_pointer_leaves == 0 || rewrite.array_shared_pointer_leaves != 0 {
+    if rewrite.shared_pointer_leaves == 0
+        || rewrite.array_shared_pointer_leaves > MAX_PACKED_SHARED_INTERNAL_ABI_ARRAY_REWRITE_LEAVES
+    {
         return Ok(None);
     }
     let Some((storage_size, _)) = llvm_type_size_align(ctx, rewrite.ty) else {
@@ -5303,7 +5315,7 @@ mod tests {
     }
 
     #[test]
-    fn packed_shared_internal_abi_keeps_shared_pointer_arrays_out_of_scope() {
+    fn packed_shared_internal_abi_genericizes_bounded_shared_pointer_array() {
         let mut ctx = make_ctx();
         let pointee = mir_uint(&mut ctx, 32);
         let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
@@ -5321,11 +5333,113 @@ mod tests {
         )
         .into();
 
+        let abi = packed_shared_internal_abi_info(&mut ctx, outer)
+            .expect("classification must not error")
+            .expect("a bounded AS3 array must use the target-stable internal carrier");
+        assert_eq!(llvm_type_size_align(&ctx, abi.semantic_ty), Some((17, 1)));
+        assert_eq!(llvm_type_size_align(&ctx, abi.storage_ty), Some((17, 1)));
+        assert!(!llvm_type_contains_pointer_in_address_space(
+            &ctx,
+            abi.storage_ty,
+            llvm_types::address_space::SHARED,
+        ));
+
+        let outer_fields = struct_fields(&ctx, abi.storage_ty);
+        let array_ref = outer_fields[1].deref(&ctx);
+        let array = array_ref
+            .downcast_ref::<llvm_types::ArrayType>()
+            .expect("bounded array field must remain an LLVM array");
+        assert_eq!(array.size(), 2);
+        let element = array.elem_type();
+        let element_ref = element.deref(&ctx);
+        let pointer = element_ref
+            .downcast_ref::<llvm_types::PointerType>()
+            .expect("array elements must remain pointer-typed");
+        assert_eq!(pointer.address_space(), llvm_types::address_space::GENERIC);
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_accepts_array_rewrite_at_exact_bound() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let count = MAX_PACKED_SHARED_INTERNAL_ABI_ARRAY_REWRITE_LEAVES;
+        let shared_array: TypeHandle = MirArrayType::get(&mut ctx, shared, count).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArrayAtBound".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, shared_array],
+            vec![0, 1],
+            vec![0, 1],
+            1 + 8 * count,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_internal_abi_info(&mut ctx, outer)
+                .expect("classification must not error")
+                .is_some(),
+            "the exact bounded-array rewrite limit must remain supported"
+        );
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_rejects_array_rewrite_above_bound() {
+        let mut ctx = make_ctx();
+        let pointee = mir_uint(&mut ctx, 32);
+        let shared: TypeHandle = MirPtrType::get_shared(&mut ctx, pointee, false).into();
+        let count = MAX_PACKED_SHARED_INTERNAL_ABI_ARRAY_REWRITE_LEAVES + 1;
+        let shared_array: TypeHandle = MirArrayType::get(&mut ctx, shared, count).into();
+        let tag = mir_uint(&mut ctx, 8);
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedArrayAboveBound".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, shared_array],
+            vec![0, 1],
+            vec![0, 1],
+            1 + 8 * count,
+            1,
+        )
+        .into();
+
         assert!(
             packed_shared_internal_abi_info(&mut ctx, outer)
                 .expect("classification must not error")
                 .is_none(),
-            "AS3 arrays remain reserved for the bounded-array follow-up"
+            "array-expanded AS3 leaves above the explicit budget must fail closed"
+        );
+    }
+
+    #[test]
+    fn packed_shared_internal_abi_rejects_shared_pointer_vector() {
+        let mut ctx = make_ctx();
+        let tag = mir_uint(&mut ctx, 8);
+        let shared_pointer: TypeHandle =
+            llvm_types::PointerType::get(&ctx, llvm_types::address_space::SHARED).into();
+        let shared_vector: TypeHandle =
+            llvm_types::VectorType::get(&ctx, shared_pointer, 2, llvm_types::VectorTypeKind::Fixed)
+                .into();
+        let outer: TypeHandle = MirStructType::get_with_full_layout(
+            &mut ctx,
+            "PackedSharedVector".into(),
+            vec!["tag".into(), "ptrs".into()],
+            vec![tag, shared_vector],
+            vec![0, 1],
+            vec![0, 1],
+            17,
+            1,
+        )
+        .into();
+
+        assert!(
+            packed_shared_internal_abi_info(&mut ctx, outer)
+                .expect("classification must not error")
+                .is_none(),
+            "shared-pointer vectors must remain outside the packed-AS3 internal ABI lane"
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -5,7 +5,7 @@
 
 //! End-to-end ABI regression coverage for packed aggregates.
 //!
-//! This example exercises seven paths that must agree on the same rustc byte
+//! This example exercises eight paths that must agree on the same rustc byte
 //! layout:
 //!
 //! - packed structs passed by value across the host -> kernel boundary;
@@ -15,6 +15,8 @@
 //! - packed structs containing multiple direct shared-pointer leaves crossing
 //!   the same internal device ABI;
 //! - packed structs containing recursively nested shared-pointer leaves crossing
+//!   the same internal device ABI;
+//! - packed structs containing bounded arrays of shared-pointer leaves crossing
 //!   the same internal device ABI;
 //! - whole-value stores of packed structs to device memory;
 //! - whole-value loads of packed structs from device memory.
@@ -70,6 +72,13 @@ pub struct PackedNestedShared {
     pub pair: SharedPair,
 }
 
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedSharedArray {
+    pub tag: u8,
+    pub ptrs: [*mut SharedArray<u32, 1>; 2],
+}
+
 #[cuda_module]
 mod kernels {
     use super::*;
@@ -109,6 +118,12 @@ mod kernels {
     #[inline(never)]
     #[device]
     fn bounce_packed_nested_shared(value: PackedNestedShared) -> PackedNestedShared {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
+    fn bounce_packed_shared_array(value: PackedSharedArray) -> PackedSharedArray {
         value
     }
 
@@ -155,6 +170,23 @@ mod kernels {
             (&mut *left)[0] = (&*left)[0].wrapping_add(0x0304_0506);
             (&mut *right)[0] = (&*right)[0].wrapping_add(0x0405_0607);
             out.write(0x42);
+            out.add(1).write((&*left)[0]);
+            out.add(2).write((&*right)[0]);
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_shared_array(
+        _value: PackedSharedArray,
+        left: *mut SharedArray<u32, 1>,
+        right: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *left)[0] = (&*left)[0].wrapping_add(0x0506_0708);
+            (&mut *right)[0] = (&*right)[0].wrapping_add(0x0607_0809);
+            out.write(0x52);
             out.add(1).write((&*left)[0]);
             out.add(2).write((&*right)[0]);
         }
@@ -251,6 +283,30 @@ mod kernels {
         // packed outer value in SSA so this exercises only the internal ABI
         // carrier generalization and does not depend on packed local storage.
         unsafe { consume_packed_nested_shared(value, left, right, out) };
+    }
+
+    #[kernel]
+    pub unsafe fn packed_shared_array(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+        unsafe {
+            (&mut *left)[0] = 0x5060_7080;
+            (&mut *right)[0] = 0x6070_8090;
+        }
+
+        let value = bounce_packed_shared_array(PackedSharedArray {
+            tag: 0x51,
+            ptrs: [left, right],
+        });
+
+        // The two AS3 leaves live inside one fixed array. Keep the packed
+        // value in SSA so the return boundary must rebuild the array through
+        // the bounded target-stable carrier without relying on packed local
+        // storage or field projection support.
+        unsafe { consume_packed_shared_array(value, left, right, out) };
     }
 
     #[kernel]
@@ -401,6 +457,14 @@ fn assert_host_layout() {
     assert_eq!(core::mem::align_of::<PackedNestedShared>(), 1);
     assert_eq!(core::mem::offset_of!(PackedNestedShared, tag), 0);
     assert_eq!(core::mem::offset_of!(PackedNestedShared, pair), 1);
+
+    assert_eq!(
+        core::mem::size_of::<PackedSharedArray>(),
+        1 + 2 * core::mem::size_of::<usize>()
+    );
+    assert_eq!(core::mem::align_of::<PackedSharedArray>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedSharedArray, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedSharedArray, ptrs), 1);
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -428,6 +492,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let packed_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let packed_shared_pair_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let packed_nested_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
+    let packed_shared_array_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let load1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let storage1 = DeviceBuffer::<u8>::zeroed(&stream, core::mem::size_of::<Packed1>())?;
@@ -485,6 +550,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             config,
             packed_nested_shared_out.cu_deviceptr() as *mut u32,
         )?;
+        module.packed_shared_array(
+            &stream,
+            config,
+            packed_shared_array_out.cu_deviceptr() as *mut u32,
+        )?;
 
         module.store_packed1(
             &stream,
@@ -524,6 +594,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         packed_nested_shared_out.to_host_vec(&stream)?,
         [0x42, 0x3344_5566, 0x4455_6677]
     );
+    assert_eq!(
+        packed_shared_array_out.to_host_vec(&stream)?,
+        [0x52, 0x5566_7788, 0x6677_8899]
+    );
     assert_eq!(load1_out.to_host_vec(&stream)?, [0x41, 0x90a0_b0c0]);
     assert_eq!(load2_out.to_host_vec(&stream)?, [0x51, 0xd0e0_f001]);
 
@@ -537,7 +611,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&bytes2[2..6], &0xd0e0_f001u32.to_le_bytes());
 
     println!(
-        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
+        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf/bounded-array packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
     );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -5,13 +5,17 @@
 
 //! End-to-end ABI regression coverage for packed aggregates.
 //!
-//! This example exercises five paths that must agree on the same rustc byte
+//! This example exercises seven paths that must agree on the same rustc byte
 //! layout:
 //!
 //! - packed structs passed by value across the host -> kernel boundary;
 //! - packed structs passed to and returned from an internal device helper;
-//! - packed structs containing a shared pointer returned from an internal
+//! - packed structs containing one shared pointer returned from an internal
 //!   device helper through a target-stable generic-pointer carrier;
+//! - packed structs containing multiple direct shared-pointer leaves crossing
+//!   the same internal device ABI;
+//! - packed structs containing recursively nested shared-pointer leaves crossing
+//!   the same internal device ABI;
 //! - whole-value stores of packed structs to device memory;
 //! - whole-value loads of packed structs from device memory.
 //!
@@ -42,6 +46,28 @@ pub struct Packed2 {
 pub struct PackedShared {
     pub tag: u8,
     pub ptr: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedSharedPair {
+    pub tag: u8,
+    pub left: *mut SharedArray<u32, 1>,
+    pub right: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SharedPair {
+    pub left: *mut SharedArray<u32, 1>,
+    pub right: *mut SharedArray<u32, 1>,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct PackedNestedShared {
+    pub tag: u8,
+    pub pair: SharedPair,
 }
 
 #[cuda_module]
@@ -76,6 +102,18 @@ mod kernels {
 
     #[inline(never)]
     #[device]
+    fn bounce_packed_shared_pair(value: PackedSharedPair) -> PackedSharedPair {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
+    fn bounce_packed_nested_shared(value: PackedNestedShared) -> PackedNestedShared {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
     unsafe fn consume_packed_shared(
         _value: PackedShared,
         shared: *mut SharedArray<u32, 1>,
@@ -85,6 +123,40 @@ mod kernels {
             (&mut *shared)[0] = (&*shared)[0].wrapping_add(0x0102_0304);
             out.write(0x22);
             out.add(1).write((&*shared)[0]);
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_shared_pair(
+        _value: PackedSharedPair,
+        left: *mut SharedArray<u32, 1>,
+        right: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *left)[0] = (&*left)[0].wrapping_add(0x0102_0304);
+            (&mut *right)[0] = (&*right)[0].wrapping_add(0x0203_0405);
+            out.write(0x32);
+            out.add(1).write((&*left)[0]);
+            out.add(2).write((&*right)[0]);
+        }
+    }
+
+    #[inline(never)]
+    #[device]
+    unsafe fn consume_packed_nested_shared(
+        _value: PackedNestedShared,
+        left: *mut SharedArray<u32, 1>,
+        right: *mut SharedArray<u32, 1>,
+        out: *mut u32,
+    ) {
+        unsafe {
+            (&mut *left)[0] = (&*left)[0].wrapping_add(0x0304_0506);
+            (&mut *right)[0] = (&*right)[0].wrapping_add(0x0405_0607);
+            out.write(0x42);
+            out.add(1).write((&*left)[0]);
+            out.add(2).write((&*right)[0]);
         }
     }
 
@@ -131,6 +203,54 @@ mod kernels {
         // observable runtime check so this regression does not require a
         // target-dependent whole-value packed store/load.
         unsafe { consume_packed_shared(value, raw, out) };
+    }
+
+    #[kernel]
+    pub unsafe fn packed_shared_pair(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+        unsafe {
+            (&mut *left)[0] = 0x1020_3040;
+            (&mut *right)[0] = 0x2030_4050;
+        }
+
+        let value = bounce_packed_shared_pair(PackedSharedPair {
+            tag: 0x31,
+            left,
+            right,
+        });
+
+        // The returned packed value contains two direct AS3 leaves. Keep it in
+        // SSA and pass it whole into another device helper; the raw pointers
+        // remain separate only to make the runtime effect observable before
+        // packed field projections gain carrier-backed local storage.
+        unsafe { consume_packed_shared_pair(value, left, right, out) };
+    }
+
+    #[kernel]
+    pub unsafe fn packed_nested_shared(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+        unsafe {
+            (&mut *left)[0] = 0x3040_5060;
+            (&mut *right)[0] = 0x4050_6070;
+        }
+
+        let value = bounce_packed_nested_shared(PackedNestedShared {
+            tag: 0x41,
+            pair: SharedPair { left, right },
+        });
+
+        // The AS3 leaves live under a nested aggregate. As above, keep the
+        // packed outer value in SSA so this exercises only the internal ABI
+        // carrier generalization and does not depend on packed local storage.
+        unsafe { consume_packed_nested_shared(value, left, right, out) };
     }
 
     #[kernel]
@@ -253,6 +373,34 @@ fn assert_host_layout() {
     assert_eq!(core::mem::align_of::<PackedShared>(), 1);
     assert_eq!(core::mem::offset_of!(PackedShared, tag), 0);
     assert_eq!(core::mem::offset_of!(PackedShared, ptr), 1);
+
+    assert_eq!(
+        core::mem::size_of::<PackedSharedPair>(),
+        1 + 2 * core::mem::size_of::<usize>()
+    );
+    assert_eq!(core::mem::align_of::<PackedSharedPair>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedSharedPair, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedSharedPair, left), 1);
+    assert_eq!(
+        core::mem::offset_of!(PackedSharedPair, right),
+        1 + core::mem::size_of::<usize>()
+    );
+
+    assert_eq!(core::mem::size_of::<SharedPair>(), 2 * core::mem::size_of::<usize>());
+    assert_eq!(core::mem::align_of::<SharedPair>(), core::mem::align_of::<usize>());
+    assert_eq!(core::mem::offset_of!(SharedPair, left), 0);
+    assert_eq!(
+        core::mem::offset_of!(SharedPair, right),
+        core::mem::size_of::<usize>()
+    );
+
+    assert_eq!(
+        core::mem::size_of::<PackedNestedShared>(),
+        1 + core::mem::size_of::<SharedPair>()
+    );
+    assert_eq!(core::mem::align_of::<PackedNestedShared>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedNestedShared, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedNestedShared, pair), 1);
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -278,6 +426,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let by_value1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let by_value2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let packed_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
+    let packed_shared_pair_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
+    let packed_nested_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let load1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let storage1 = DeviceBuffer::<u8>::zeroed(&stream, core::mem::size_of::<Packed1>())?;
@@ -302,10 +452,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // SAFETY: every kernel launches one thread. The u32 output buffers contain
-    // two writable elements. The byte buffers are CUDA allocations, so their
-    // base addresses satisfy Packed1/Packed2 alignment and have exact storage
-    // for one value of the corresponding type. The packed-shared kernel creates
-    // its AS3 pointer on device and never exposes it through the host ABI.
+    // enough writable elements for their respective checks. The byte buffers
+    // are CUDA allocations, so their base addresses satisfy Packed1/Packed2
+    // alignment and have exact storage for one value of the corresponding
+    // type. The packed-shared kernels create their AS3 pointers on device and
+    // never expose them through the host ABI.
     unsafe {
         module.packed1(
             &stream,
@@ -323,6 +474,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &stream,
             config,
             packed_shared_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.packed_shared_pair(
+            &stream,
+            config,
+            packed_shared_pair_out.cu_deviceptr() as *mut u32,
+        )?;
+        module.packed_nested_shared(
+            &stream,
+            config,
+            packed_nested_shared_out.cu_deviceptr() as *mut u32,
         )?;
 
         module.store_packed1(
@@ -355,6 +516,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(by_value1_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
     assert_eq!(by_value2_out.to_host_vec(&stream)?, [0x33, 0x6172_8394]);
     assert_eq!(packed_shared_out.to_host_vec(&stream)?, [0x22, 0x1122_3344]);
+    assert_eq!(
+        packed_shared_pair_out.to_host_vec(&stream)?,
+        [0x32, 0x1122_3344, 0x2233_4455]
+    );
+    assert_eq!(
+        packed_nested_shared_out.to_host_vec(&stream)?,
+        [0x42, 0x3344_5566, 0x4455_6677]
+    );
     assert_eq!(load1_out.to_host_vec(&stream)?, [0x41, 0x90a0_b0c0]);
     assert_eq!(load2_out.to_host_vec(&stream)?, [0x51, 0xd0e0_f001]);
 
@@ -368,7 +537,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&bytes2[2..6], &0xd0e0_f001u32.to_le_bytes());
 
     println!(
-        "packed_aggregate_abi: PASS (runtime values, packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
+        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
     );
     Ok(())
 }

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -77,13 +77,15 @@ mod kernels {
     #[inline(never)]
     #[device]
     unsafe fn consume_packed_shared(
-        _value: PackedShared,
+        value: PackedShared,
         shared: *mut SharedArray<u32, 1>,
         out: *mut u32,
     ) {
+        let tag = value.tag;
+        let round_tripped = value.ptr;
         unsafe {
-            (&mut *shared)[0] = (&*shared)[0].wrapping_add(0x0102_0304);
-            out.write(0x22);
+            (&mut *round_tripped)[0] = (&*round_tripped)[0].wrapping_add(0x0102_0304);
+            out.write(u32::from(tag.wrapping_add(1)));
             out.add(1).write((&*shared)[0]);
         }
     }
@@ -126,10 +128,10 @@ mod kernels {
             ptr: raw,
         });
 
-        // Keep the packed AS3 aggregate in SSA across both internal device ABI
-        // boundaries. The raw shared pointer is passed separately for the
-        // observable runtime check so this regression does not require a
-        // target-dependent whole-value packed store/load.
+        // Project both fields from the returned packed value. The compiler-owned
+        // local slot uses the target-stable carrier representation, so the AS3
+        // pointer field is loaded as p0 and reconstructed to p3 before use. The
+        // separate raw pointer makes the round-trip observable at runtime.
         unsafe { consume_packed_shared(value, raw, out) };
     }
 

--- a/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/packed_aggregate_abi/src/main.rs
@@ -5,7 +5,7 @@
 
 //! End-to-end ABI regression coverage for packed aggregates.
 //!
-//! This example exercises eight paths that must agree on the same rustc byte
+//! This example exercises nine paths that must agree on the same rustc byte
 //! layout:
 //!
 //! - packed structs passed by value across the host -> kernel boundary;
@@ -18,6 +18,8 @@
 //!   the same internal device ABI;
 //! - packed structs containing bounded arrays of shared-pointer leaves crossing
 //!   the same internal device ABI;
+//! - recursive/multi-leaf packed-AS3 values materialized in target-stable local
+//!   carriers and projected through structs, tuples, and fixed arrays;
 //! - whole-value stores of packed structs to device memory;
 //! - whole-value loads of packed structs from device memory.
 //!
@@ -74,6 +76,16 @@ pub struct PackedNestedShared {
 
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
+pub struct PackedSharedTuple {
+    pub tag: u8,
+    pub pair: (
+        *mut SharedArray<u32, 1>,
+        *mut SharedArray<u32, 1>,
+    ),
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
 pub struct PackedSharedArray {
     pub tag: u8,
     pub ptrs: [*mut SharedArray<u32, 1>; 2],
@@ -118,6 +130,12 @@ mod kernels {
     #[inline(never)]
     #[device]
     fn bounce_packed_nested_shared(value: PackedNestedShared) -> PackedNestedShared {
+        value
+    }
+
+    #[inline(never)]
+    #[device]
+    fn bounce_packed_shared_tuple(value: PackedSharedTuple) -> PackedSharedTuple {
         value
     }
 
@@ -312,6 +330,88 @@ mod kernels {
     }
 
     #[kernel]
+    pub unsafe fn packed_shared_recursive_locals(out: *mut u32) {
+        static mut LEFT: SharedArray<u32, 1> = SharedArray::UNINIT;
+        static mut RIGHT: SharedArray<u32, 1> = SharedArray::UNINIT;
+
+        let left = &raw mut LEFT;
+        let right = &raw mut RIGHT;
+
+        unsafe {
+            (&mut *left)[0] = 10;
+            (&mut *right)[0] = 20;
+        }
+        let pair = bounce_packed_shared_pair(PackedSharedPair {
+            tag: 0x61,
+            left,
+            right,
+        });
+        let pair_left = pair.left;
+        let pair_right = pair.right;
+        unsafe {
+            (&mut *pair_left)[0] = (&*pair_left)[0].wrapping_add(1);
+            (&mut *pair_right)[0] = (&*pair_right)[0].wrapping_add(2);
+            out.write(u32::from(pair.tag));
+            out.add(1).write((&*pair_left)[0]);
+            out.add(2).write((&*pair_right)[0]);
+        }
+
+        unsafe {
+            (&mut *left)[0] = 100;
+            (&mut *right)[0] = 200;
+        }
+        let nested = bounce_packed_nested_shared(PackedNestedShared {
+            tag: 0x71,
+            pair: SharedPair { left, right },
+        });
+        let nested_left = nested.pair.left;
+        let nested_right = nested.pair.right;
+        unsafe {
+            (&mut *nested_left)[0] = (&*nested_left)[0].wrapping_add(3);
+            (&mut *nested_right)[0] = (&*nested_right)[0].wrapping_add(4);
+            out.add(3).write(u32::from(nested.tag));
+            out.add(4).write((&*nested_left)[0]);
+            out.add(5).write((&*nested_right)[0]);
+        }
+
+        unsafe {
+            (&mut *left)[0] = 1000;
+            (&mut *right)[0] = 2000;
+        }
+        let tuple = bounce_packed_shared_tuple(PackedSharedTuple {
+            tag: 0x81,
+            pair: (left, right),
+        });
+        let tuple_left = tuple.pair.0;
+        let tuple_right = tuple.pair.1;
+        unsafe {
+            (&mut *tuple_left)[0] = (&*tuple_left)[0].wrapping_add(5);
+            (&mut *tuple_right)[0] = (&*tuple_right)[0].wrapping_add(6);
+            out.add(6).write(u32::from(tuple.tag));
+            out.add(7).write((&*tuple_left)[0]);
+            out.add(8).write((&*tuple_right)[0]);
+        }
+
+        unsafe {
+            (&mut *left)[0] = 10_000;
+            (&mut *right)[0] = 20_000;
+        }
+        let array = bounce_packed_shared_array(PackedSharedArray {
+            tag: 0x91,
+            ptrs: [left, right],
+        });
+        let array_left = array.ptrs[0];
+        let array_right = array.ptrs[1];
+        unsafe {
+            (&mut *array_left)[0] = (&*array_left)[0].wrapping_add(7);
+            (&mut *array_right)[0] = (&*array_right)[0].wrapping_add(8);
+            out.add(9).write(u32::from(array.tag));
+            out.add(10).write((&*array_left)[0]);
+            out.add(11).write((&*array_right)[0]);
+        }
+    }
+
+    #[kernel]
     pub unsafe fn store_packed1(value: Packed1, dst: *mut Packed1) {
         // SAFETY: `dst` points to device storage large enough for one Packed1.
         unsafe { dst.write(value) };
@@ -461,6 +561,14 @@ fn assert_host_layout() {
     assert_eq!(core::mem::offset_of!(PackedNestedShared, pair), 1);
 
     assert_eq!(
+        core::mem::size_of::<PackedSharedTuple>(),
+        1 + core::mem::size_of::<(*mut SharedArray<u32, 1>, *mut SharedArray<u32, 1>)>()
+    );
+    assert_eq!(core::mem::align_of::<PackedSharedTuple>(), 1);
+    assert_eq!(core::mem::offset_of!(PackedSharedTuple, tag), 0);
+    assert_eq!(core::mem::offset_of!(PackedSharedTuple, pair), 1);
+
+    assert_eq!(
         core::mem::size_of::<PackedSharedArray>(),
         1 + 2 * core::mem::size_of::<usize>()
     );
@@ -495,6 +603,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let packed_shared_pair_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let packed_nested_shared_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
     let packed_shared_array_out = DeviceBuffer::<u32>::zeroed(&stream, 3)?;
+    let packed_shared_recursive_locals_out = DeviceBuffer::<u32>::zeroed(&stream, 12)?;
     let load1_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let load2_out = DeviceBuffer::<u32>::zeroed(&stream, 2)?;
     let storage1 = DeviceBuffer::<u8>::zeroed(&stream, core::mem::size_of::<Packed1>())?;
@@ -557,6 +666,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             config,
             packed_shared_array_out.cu_deviceptr() as *mut u32,
         )?;
+        module.packed_shared_recursive_locals(
+            &stream,
+            config,
+            packed_shared_recursive_locals_out.cu_deviceptr() as *mut u32,
+        )?;
 
         module.store_packed1(
             &stream,
@@ -600,6 +714,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         packed_shared_array_out.to_host_vec(&stream)?,
         [0x52, 0x5566_7788, 0x6677_8899]
     );
+    assert_eq!(
+        packed_shared_recursive_locals_out.to_host_vec(&stream)?,
+        [
+            0x61, 11, 22, 0x71, 103, 204, 0x81, 1005, 2006, 0x91, 10_007, 20_008
+        ]
+    );
     assert_eq!(load1_out.to_host_vec(&stream)?, [0x41, 0x90a0_b0c0]);
     assert_eq!(load2_out.to_host_vec(&stream)?, [0x51, 0xd0e0_f001]);
 
@@ -613,7 +733,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&bytes2[2..6], &0xd0e0_f001u32.to_le_bytes());
 
     println!(
-        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf/bounded-array packed shared internal ABI, whole-value load/store, and PTX parameter shapes)"
+        "packed_aggregate_abi: PASS (runtime values, recursive/multi-leaf/bounded-array packed shared internal ABI, recursive carrier-local projections, whole-value load/store, and PTX parameter shapes)"
     );
     Ok(())
 }


### PR DESCRIPTION
Closes #1094 

Depends on #1064, #1073, and #1092.

> [!NOTE]
> This PR is currently built on a local integration of #1073 and #1092
> (#1073 already includes #1064).
>
> Until those prerequisite PRs merge, GitHub's diff against `main` also
> includes their packed-AS3 internal-ABI and direct carrier-local changes.
> The incremental change in this PR is the recursive/multi-leaf local-storage
> admission and carrier-address provenance needed for nested field and array
> projections.
>
> Once the prerequisites land, this branch will be rebased onto `main` so the
> PR shows only the incremental #1094 changes.

## Summary

Extend packed-AS3 compiler-owned local storage from the narrow direct-field
shape introduced by #1092 to recursive and multi-leaf carrier-backed locals.

Eligible packed locals can now contain:

- multiple direct AS3 pointer leaves;
- AS3 leaves nested inside structs;
- AS3 leaves nested inside tuples;
- bounded fixed arrays containing AS3 leaves.

Nested field and array-element projections preserve the physical carrier
pointee so loads and stores continue to perform the correct semantic <-> carrier
conversion at the memory boundary.

The internal device ABI classifier remains unchanged. Local-storage admission
continues to use its own independent gate.

## Implementation

### Local-storage classifier

`packed_shared_local_storage_info` is widened independently of
`packed_shared_internal_abi_info`.

The local classifier now:

- requires a byte-faithful packed struct root;
- recursively admits scalar and pointer leaves;
- recursively traverses structs and tuples;
- admits fixed arrays;
- accepts one or more AS3 pointer leaves;
- rejects vectors and unrelated aggregate kinds;
- rejects fixed-array expansion above 16 AS3 leaves.

The array bound remains a local-storage policy rather than being inherited from
the internal ABI classifier.

### Carrier address provenance

LLVM pointers are opaque, so nested MIR projections cannot recover the physical
carrier pointee from the pointer type alone.

Carrier-backed local addresses therefore record the physical storage pointee on
the defining allocation/projection.

That provenance is introduced only for compiler-owned locals admitted by
`packed_shared_local_storage_info` and is propagated through:

```text
llvm.alloca
    |
    v
field GEP
    |
    v
nested field GEP
    |
    v
array element GEP
```

This allows a later load/store to distinguish the semantic MIR pointee from the
physical generic-pointer carrier pointee.

### Loads and stores

For carrier-backed local addresses:

```text
store: semantic value -> target-stable carrier value
load:  target-stable carrier value -> semantic value
```

Arbitrary packed-AS3 memory remains fail-closed.

### Field projections

`mir.field_addr` uses the carrier struct as the physical typed-GEP source when
the incoming address carries local-storage provenance.

The projected field address is stamped with the corresponding carrier field
type, allowing recursive projections to continue through nested structs and
tuples.

The existing #859/#1092 addressing behavior for ordinary semantic aggregates is
preserved.

### Array projections

`mir.array_element_addr` uses the physical carrier array type when the incoming
address belongs to a carrier-backed local.

The projected element address inherits the physical carrier element type so an
AS3 semantic element can be physically loaded/stored through its generic-pointer
carrier representation.

## Tests

Added local-storage classifier coverage for:

* multiple direct AS3 leaves;
* nested struct/tuple leaves;
* bounded fixed AS3 arrays;
* acceptance at the exact 16-leaf array bound;
* rejection above the array bound;
* explicit vector rejection.

Added lowering coverage for:

* nested tuple carrier projections;
* carrier array-element projections.

The existing direct packed-AS3 local tests from #1092 remain unchanged.

The existing recursive/multi-leaf/bounded-array internal ABI tests from
#1064/#1073 remain unchanged.

The `packed_aggregate_abi` end-to-end regression now additionally exercises
recursive carrier-local projections for:

```text
multi.left
multi.right

nested.pair.left
nested.pair.right

tuple.pair.0
tuple.pair.1

array.ptrs[0]
array.ptrs[1]
```

Validation performed:

* `cargo fmt --all`
* `cargo fmt --all -- --check`
* `git diff --check`
* focused packed-AS3 local-storage tests
* focused nested tuple projection test
* focused array-element projection test
* packed-AS3 internal ABI tests
* existing packed-AS3 local tests
* `cargo test -p mir-lower --all-targets`
* `cargo clippy -p mir-lower --all-targets -- -D warnings`
* `cargo oxide build packed_aggregate_abi`
* `cargo oxide run packed_aggregate_abi`
* `CUDA_OXIDE_NO_OPT=1 cargo oxide run packed_aggregate_abi`
* `cargo oxide run addressof_sharedarray`

`mir-lower` passes 271 unit tests and 117 lowering tests.

The optimized and no-opt `packed_aggregate_abi` runs both pass, including
recursive/multi-leaf/bounded-array internal ABI coverage and recursive
carrier-local field/array projections.

## Out of scope

This PR intentionally does not add support for:

* AS3 pointer vectors;
* arrays above the explicit 16-leaf local rewrite budget;
* arbitrary packed-AS3 memory;
* device-global packed-AS3 storage;
* kernel-entry ABI changes;
* AS3-containing enums;
* general `mir.ref` carrier materialization.

Those remain separate work.
