### PR TITLE
perf(llvm): emit proven Rust reference validity attrs

### DIFF
--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -87,16 +87,31 @@ declared by rustc.
 but does not attempt to model dynamic Stacked Borrows / Tree Borrows tags or
 retag epochs.
 
-MIR-to-LLVM lowering deliberately erases `MirPointerKind`. All four Rust source
-categories keep the same LLVM pointer/fat-pointer representation, and this
-change does not emit `noalias`, `readonly`, `dereferenceable`, or related
-metadata. Any future alias metadata requires a separate audited policy; it must
-not be inferred from `is_mutable` alone.
+MIR-to-LLVM type conversion still erases `MirPointerKind`; all four Rust source
+categories keep the same physical LLVM pointer/fat-pointer representation.
+Function arguments carry separate, audited proof markers when rustc's own type
+semantics justify LLVM parameter attributes:
 
-For GPU-specific abstractions such as `SharedArray`, the Rust reference kind is
-still retained when the source type is a reference, while the CUDA address
-space remains an independent property. The compiler does not currently turn a
-`UniqueRef` to shared memory into cross-thread LLVM alias guarantees.
+| Source argument | Additional proof | LLVM parameter attributes |
+|-----------------|------------------|---------------------------|
+| `&T` / `&[T]` | pointee is `Freeze` | `noalias readonly` |
+| `&mut T` / `&mut [T]` | pointee is `Unpin` | `noalias` |
+| raw pointer | none | none |
+| erased/compiler pointer | none | none |
+
+The importer computes these facts while the original rustc `Ty` and trait
+queries are available and stores them on `mir.func` by source argument index.
+`mir-lower` remaps those indices after ABI flattening, so a slice applies the
+attributes only to its pointer component and never to its length. The LLVM
+exporter serializes the resulting proof bits without inferring anything from
+mutability, address space, or pointer kind on its own. In particular, a shared
+reference containing `UnsafeCell` is not `readonly`, and raw `*mut T` never
+acquires `noalias` merely because it is writable.
+
+`dereferenceable` and other provenance-sensitive attributes remain outside this
+policy. For GPU-specific abstractions such as `SharedArray`, CUDA address space
+remains independent from Rust reference kind and from these function-boundary
+proofs.
 
 ### Address Spaces
 

--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -92,6 +92,8 @@ categories keep the same physical LLVM pointer/fat-pointer representation.
 Function arguments carry separate, audited proof markers when rustc's own type
 semantics justify LLVM parameter attributes:
 
+Alias facts follow rustc's conservative reference policy:
+
 | Source argument | Additional proof | LLVM parameter attributes |
 |-----------------|------------------|---------------------------|
 | `&T` / `&[T]` | pointee is `Freeze` | `noalias readonly` |
@@ -99,19 +101,33 @@ semantics justify LLVM parameter attributes:
 | raw pointer | none | none |
 | erased/compiler pointer | none | none |
 
-The importer computes these facts while the original rustc `Ty` and trait
-queries are available and stores them on `mir.func` by source argument index.
-`mir-lower` remaps those indices after ABI flattening, so a slice applies the
-attributes only to its pointer component and never to its length. The LLVM
-exporter serializes the resulting proof bits without inferring anything from
-mutability, address space, or pointer kind on its own. In particular, a shared
-reference containing `UnsafeCell` is not `readonly`, and raw `*mut T` never
-acquires `noalias` merely because it is writable.
+Sized references additionally carry validity facts derived from the rustc
+pointee layout:
 
-`dereferenceable` and other provenance-sensitive attributes remain outside this
-policy. For GPU-specific abstractions such as `SharedArray`, CUDA address space
-remains independent from Rust reference kind and from these function-boundary
-proofs.
+| Source argument | Condition | Additional LLVM attributes |
+|-----------------|-----------|----------------------------|
+| `&T` | `T: Sized` | `nonnull`, and `align N` when `N > 1` |
+| `&mut T` | `T: Sized` | `nonnull`, and `align N` when `N > 1` |
+| `&T` | `T: Sized + Freeze`, `size_of::<T>() > 0` | `dereferenceable(size_of::<T>())` |
+| `&mut T` | `T: Sized + Unpin`, `size_of::<T>() > 0` | `dereferenceable(size_of::<T>())` |
+| unsized reference | any | no validity attributes in this policy |
+| raw pointer | any | no reference-derived validity attributes |
+
+`align 1` is omitted as redundant, and zero-sized pointees never produce
+`dereferenceable(0)`. An over-aligned ZST can therefore carry `nonnull align N`
+without `dereferenceable`.
+
+The importer computes all Rust-semantic facts while the original rustc `Ty`,
+layout, and trait queries are available and stores them on `mir.func` by source
+argument index. `mir-lower` remaps those indices after ABI flattening. For a
+slice, only the alias facts from the first table may reach the pointer component;
+the sized-reference validity policy deliberately does not annotate the slice
+pointer. The LLVM exporter serializes the resulting proof bits without
+inferring anything from mutability, address space, pointer kind, or
+`DisjointSlice` on its own.
+
+For GPU-specific abstractions such as `SharedArray`, CUDA address space remains
+independent from Rust reference kind and from these function-boundary proofs.
 
 ### Address Spaces
 

--- a/crates/dialect-mir/README.md
+++ b/crates/dialect-mir/README.md
@@ -10,17 +10,17 @@ rustc MIR ──► mir-importer ──► dialect-mir ──► mir-lower ─�
 
 The dialect defines nine types that preserve Rust-level semantics:
 
-| Type                  | Description                                        | Example                               |
-|-----------------------|----------------------------------------------------|---------------------------------------|
-| `MirTupleType`        | Heterogeneous tuples                               | `mir.tuple<i32, f32, i64>`            |
-| `MirPtrType`          | Pointers with address space and mutability         | `mir.ptr<f32, mutable, addrspace: 3>` |
-| `MirSliceType`        | Fat pointers (`&[T]` = ptr + len)                  | `mir.slice<f32, addrspace: 1>`        |
-| `MirDisjointSliceType`| `DisjointSlice<T>` -- per-thread unique access     | `mir.disjoint_slice<f32, ...>`        |
-| `MirStructType`       | Named structs with layout metadata                 | `mir.struct<"Point", [f32, f32]>`     |
-| `MirUnionType`        | Rust unions -- each field a view of the same bytes | `mir.union<"Repr", [a, b], [i32, f32], 4, 4>` |
-| `MirEnumType`         | Rust enums with their exact rustc layout           | `mir.enum<"Ordering", i8, ...>`       |
-| `MirArrayType`        | Fixed-size arrays                                  | `mir.array<f32, 256>`                 |
-| `MirFP16Type`         | IEEE 754 binary16 -- Rust's `f16`                  | `mir.fp16`                            |
+| Type                  | Description                                                  | Example                                                               |
+|-----------------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `MirTupleType`        | Heterogeneous tuples                                         | `mir.tuple<i32, f32, i64>`                                            |
+| `MirPtrType`          | Thin pointers with address space, mutability, and source kind | `mir.ptr<f32, mutable: true, addrspace: 3, kind: UniqueRef>`           |
+| `MirSliceType`        | Fat pointers with retained source kind (ptr + len)           | `mir.slice<f32, kind: SharedRef>`                                     |
+| `MirDisjointSliceType`| `DisjointSlice<T>` -- per-thread unique access               | `mir.disjoint_slice<f32, ...>`                                        |
+| `MirStructType`       | Named structs with layout metadata                           | `mir.struct<"Point", [f32, f32]>`                                   |
+| `MirUnionType`        | Rust unions -- each field a view of the same bytes           | `mir.union<"Repr", [a, b], [i32, f32], 4, 4>`                       |
+| `MirEnumType`         | Rust enums with their exact rustc layout                     | `mir.enum<"Ordering", i8, ...>`                                     |
+| `MirArrayType`        | Fixed-size arrays                                            | `mir.array<f32, 256>`                                                 |
+| `MirFP16Type`         | IEEE 754 binary16 -- Rust's `f16`                            | `mir.fp16`                                                            |
 
 `MirEnumType` records the enum's layout the way rustc computed it: Direct,
 Niche, Single, or Empty; the physical integer/pointer carrier and absolute
@@ -47,9 +47,60 @@ For a niche layout such as `Option<&T>`, the carrier is the pointer itself:
 null encodes `None`, and a non-null pointer is the untagged `Some` variant.
 The device never adds a synthetic discriminant.
 
+### Pointer and reference kinds
+
+`MirPtrType` and `MirSliceType` retain the source-level category that produced a
+pointer-like Rust value:
+
+| Rust type | `MirPointerKind` | Meaning |
+|-----------|------------------|---------|
+| `&T` | `SharedRef` | Shared Rust reference |
+| `&mut T` | `UniqueRef` | Mutable/unique Rust reference |
+| `*const T` | `RawConst` | Immutable raw pointer |
+| `*mut T` | `RawMut` | Mutable raw pointer |
+| compiler-generated address | `Erased` | Storage/projection pointer with no Rust alias guarantee |
+
+The existing `is_mutable` bit remains part of `MirPtrType` because operations
+need writeability information, but it is not proof of uniqueness. In
+particular, `RawMut` and `UniqueRef` are both mutable while only the latter
+originates from `&mut T`.
+
+Pointer kind is propagated through Rust type import, references, raw-address
+formation, slices, and compatible casts. Internal alloca/projection addresses
+are created as `Erased`; a new concrete Rust kind may be established only at
+a Rust-typed semantic boundary such as `Rvalue::Ref`, `Rvalue::AddressOf`, an
+explicit rustc cast/coercion, or a compiler-recognized operation whose Rust
+return type is authoritative. For example, the `SharedArray::as_ptr`,
+`as_mut_ptr`, and `as_raw_mut_ptr` intrinsic expansions use their rustc-declared
+`*const T` / `*mut T` result type directly.
+
+Generic representation normalization and local storage may preserve a concrete
+kind or deliberately forget it by converting to `Erased`, but they never
+recover a concrete kind from `Erased` or switch directly between two distinct
+concrete Rust kinds. This prevents `SharedRef -> Erased -> UniqueRef` laundering
+while still allowing legitimate reborrows such as `RawMut -> UniqueRef` at
+`Rvalue::Ref`. A projection of an existing slice preserves the source kind,
+while an explicit reborrow or raw address takes the new Rust result type
+declared by rustc.
+
+`Retag` remains a codegen no-op. The dialect records the static pointer category
+but does not attempt to model dynamic Stacked Borrows / Tree Borrows tags or
+retag epochs.
+
+MIR-to-LLVM lowering deliberately erases `MirPointerKind`. All four Rust source
+categories keep the same LLVM pointer/fat-pointer representation, and this
+change does not emit `noalias`, `readonly`, `dereferenceable`, or related
+metadata. Any future alias metadata requires a separate audited policy; it must
+not be inferred from `is_mutable` alone.
+
+For GPU-specific abstractions such as `SharedArray`, the Rust reference kind is
+still retained when the source type is a reference, while the CUDA address
+space remains an independent property. The compiler does not currently turn a
+`UniqueRef` to shared memory into cross-thread LLVM alias guarantees.
+
 ### Address Spaces
 
-Pointers and slices carry an NVPTX address space:
+Pointers carry an NVPTX address space independently of their source kind:
 
 | Space      | ID | PTX Qualifier | Use                           |
 |------------|----|---------------|-------------------------------|

--- a/crates/dialect-mir/src/ops/function.rs
+++ b/crates/dialect-mir/src/ops/function.rs
@@ -14,7 +14,7 @@ use pliron::{
     attribute::attr_cast,
     builtin::{
         attr_interfaces::TypedAttrInterface,
-        attributes::TypeAttr,
+        attributes::{StringAttr, TypeAttr},
         op_interfaces::{
             ATTR_KEY_SYM_NAME, IsolatedFromAboveInterface, NOpdsInterface, NRegionsInterface,
             NResultsInterface, OneRegionInterface, SymbolOpInterface,
@@ -43,6 +43,18 @@ use pliron::{
 };
 use pliron_derive::pliron_op;
 
+use crate::types::{MirPointerKind, MirPtrType, MirSliceType};
+
+/// Per-source-argument marker populated only after rustc has proved the LLVM
+/// `noalias` contract for that Rust reference. The index is the MIR function
+/// argument index before aggregate flattening.
+pub const MIR_PARAM_NOALIAS_ATTR_PREFIX: &str = "mir_param_noalias_";
+
+/// Per-source-argument marker populated only after rustc has proved the LLVM
+/// `readonly` contract for that Rust shared reference. The index is the MIR
+/// function argument index before aggregate flattening.
+pub const MIR_PARAM_READONLY_ATTR_PREFIX: &str = "mir_param_readonly_";
+
 /// MIR function operation.
 ///
 /// Represents a function in MIR. Contains a single region with basic blocks.
@@ -54,6 +66,8 @@ use pliron_derive::pliron_op;
 /// |----------------|-----------|------------------------------------|
 /// | `sym_name`     | StringAttr| Function name (from SymbolOpInterface) |
 /// | `mir_func_type`| TypeAttr  | Function type (mir.func_type)      |
+/// | `mir_param_noalias_N` | StringAttr | rustc-proven `noalias` for source arg N |
+/// | `mir_param_readonly_N` | StringAttr | rustc-proven `readonly` for source arg N |
 /// ```
 ///
 /// # Verification
@@ -99,6 +113,92 @@ impl MirFuncOp {
             .unwrap()
             .get_type(ctx);
         TypedHandle::from_handle(ty, ctx).unwrap()
+    }
+
+    /// Record rustc-proven aliasing facts for one source-level function argument.
+    ///
+    /// These facts are attached to the MIR argument index, before slices are
+    /// flattened into `(ptr, len)` by `mir-lower`. `readonly` is intentionally
+    /// represented separately from pointer kind: `SharedRef` alone is not
+    /// sufficient when the pointee contains `UnsafeCell`.
+    pub fn set_reference_param_attrs(
+        &self,
+        ctx: &mut Context,
+        index: usize,
+        noalias: bool,
+        readonly: bool,
+    ) {
+        if noalias {
+            set_param_marker(
+                ctx,
+                self.get_operation(),
+                MIR_PARAM_NOALIAS_ATTR_PREFIX,
+                index,
+            );
+        }
+        if readonly {
+            set_param_marker(
+                ctx,
+                self.get_operation(),
+                MIR_PARAM_READONLY_ATTR_PREFIX,
+                index,
+            );
+        }
+    }
+
+    /// Whether rustc proved that this source-level argument may carry LLVM `noalias`.
+    pub fn param_noalias(&self, ctx: &Context, index: usize) -> bool {
+        has_param_marker(
+            ctx,
+            self.get_operation(),
+            MIR_PARAM_NOALIAS_ATTR_PREFIX,
+            index,
+        )
+    }
+
+    /// Whether rustc proved that this source-level argument may carry LLVM `readonly`.
+    pub fn param_readonly(&self, ctx: &Context, index: usize) -> bool {
+        has_param_marker(
+            ctx,
+            self.get_operation(),
+            MIR_PARAM_READONLY_ATTR_PREFIX,
+            index,
+        )
+    }
+}
+
+fn param_marker_key(prefix: &str, index: usize) -> Identifier {
+    format!("{prefix}{index}")
+        .as_str()
+        .try_into()
+        .expect("parameter marker attribute name is valid")
+}
+
+fn set_param_marker(ctx: &mut Context, op: Ptr<Operation>, prefix: &str, index: usize) {
+    let key = param_marker_key(prefix, index);
+    op.deref_mut(ctx)
+        .attributes
+        .set(key, StringAttr::new("true".to_string()));
+}
+
+fn has_param_marker(ctx: &Context, op: Ptr<Operation>, prefix: &str, index: usize) -> bool {
+    let key = param_marker_key(prefix, index);
+    op.deref(ctx).attributes.get::<StringAttr>(&key).is_some()
+}
+
+fn marker_index(key: &Identifier, prefix: &str) -> Option<Result<usize, ()>> {
+    let key = key.to_string();
+    key.strip_prefix(prefix)
+        .map(|suffix| suffix.parse::<usize>().map_err(|_| ()))
+}
+
+fn pointer_kind_for_function_input(ctx: &Context, ty: TypeHandle) -> Option<MirPointerKind> {
+    let ty = ty.deref(ctx);
+    if let Some(pointer) = ty.downcast_ref::<MirPtrType>() {
+        Some(pointer.pointer_kind())
+    } else {
+        ty.downcast_ref::<MirSliceType>()
+            .map(MirSliceType::pointer_kind)
     }
 }
 
@@ -199,14 +299,81 @@ impl Verify for MirFuncOp {
             }
         };
 
+        let inputs = interface.arg_types();
+
+        // Reference-derived optimizer facts are deliberately audited here,
+        // before MIR-to-LLVM flattening. Raw/erased pointers must never acquire
+        // Rust reference guarantees, and `readonly` is only valid for a shared
+        // reference for which the importer also proved `noalias`.
+        for key in op.attributes.0.keys() {
+            let marker = marker_index(key, MIR_PARAM_NOALIAS_ATTR_PREFIX)
+                .map(|index| (index, false))
+                .or_else(|| {
+                    marker_index(key, MIR_PARAM_READONLY_ATTR_PREFIX).map(|index| (index, true))
+                });
+            let Some((index, is_readonly)) = marker else {
+                continue;
+            };
+            let index = match index {
+                Ok(index) => index,
+                Err(()) => {
+                    return verify_err!(
+                        op.loc(),
+                        "MirFuncOp has malformed reference-parameter attribute `{}`",
+                        key
+                    );
+                }
+            };
+            if index >= inputs.len() {
+                return verify_err!(
+                    op.loc(),
+                    "MirFuncOp reference-parameter attribute `{}` indexes argument {}, but the function has only {} arguments",
+                    key,
+                    index,
+                    inputs.len()
+                );
+            }
+
+            let kind = pointer_kind_for_function_input(ctx, inputs[index]);
+            if is_readonly {
+                if kind != Some(MirPointerKind::SharedRef) {
+                    return verify_err!(
+                        op.loc(),
+                        "MirFuncOp readonly proof on argument {} requires a SharedRef pointer kind",
+                        index
+                    );
+                }
+                if !self.param_noalias(ctx, index) {
+                    return verify_err!(
+                        op.loc(),
+                        "MirFuncOp readonly proof on argument {} must carry the matching noalias proof",
+                        index
+                    );
+                }
+            } else if !matches!(
+                kind,
+                Some(MirPointerKind::SharedRef | MirPointerKind::UniqueRef)
+            ) {
+                return verify_err!(
+                    op.loc(),
+                    "MirFuncOp noalias proof on argument {} requires a Rust reference pointer kind",
+                    index
+                );
+            } else if kind == Some(MirPointerKind::SharedRef) && !self.param_readonly(ctx, index) {
+                return verify_err!(
+                    op.loc(),
+                    "MirFuncOp SharedRef noalias proof on argument {} must carry the matching readonly proof",
+                    index
+                );
+            }
+        }
+
         // Verify region arguments match function type inputs
         let region = op.get_region(0).deref(ctx);
 
         // Check if there is an entry block
         if let Some(entry_block_ptr) = region.get_head() {
             let entry_block = entry_block_ptr.deref(ctx);
-            let inputs = interface.arg_types();
-
             if entry_block.get_num_arguments() != inputs.len() {
                 return verify_err!(
                     op.loc(),

--- a/crates/dialect-mir/src/ops/function.rs
+++ b/crates/dialect-mir/src/ops/function.rs
@@ -14,13 +14,13 @@ use pliron::{
     attribute::attr_cast,
     builtin::{
         attr_interfaces::TypedAttrInterface,
-        attributes::{StringAttr, TypeAttr},
+        attributes::{IntegerAttr, StringAttr, TypeAttr},
         op_interfaces::{
             ATTR_KEY_SYM_NAME, IsolatedFromAboveInterface, NOpdsInterface, NRegionsInterface,
             NResultsInterface, OneRegionInterface, SymbolOpInterface,
         },
         type_interfaces::FunctionTypeInterface,
-        types::FunctionType,
+        types::{FunctionType, IntegerType, Signedness},
     },
     common_traits::Verify,
     context::{Context, Ptr},
@@ -39,9 +39,11 @@ use pliron::{
     region::Region,
     result::Error,
     r#type::{TypeHandle, Typed, TypedHandle, type_cast},
+    utils::apint::APInt,
     verify_err,
 };
 use pliron_derive::pliron_op;
+use std::num::NonZero;
 
 use crate::types::{MirPointerKind, MirPtrType, MirSliceType};
 
@@ -54,6 +56,15 @@ pub const MIR_PARAM_NOALIAS_ATTR_PREFIX: &str = "mir_param_noalias_";
 /// `readonly` contract for that Rust shared reference. The index is the MIR
 /// function argument index before aggregate flattening.
 pub const MIR_PARAM_READONLY_ATTR_PREFIX: &str = "mir_param_readonly_";
+
+/// Per-source-argument marker proving that the source Rust reference cannot be null.
+pub const MIR_PARAM_NONNULL_ATTR_PREFIX: &str = "mir_param_nonnull_";
+
+/// Per-source-argument marker carrying the rustc-proven pointee alignment in bytes.
+pub const MIR_PARAM_POINTEE_ALIGN_ATTR_PREFIX: &str = "mir_param_pointee_align_";
+
+/// Per-source-argument marker carrying the rustc-proven dereferenceable byte count.
+pub const MIR_PARAM_DEREFERENCEABLE_ATTR_PREFIX: &str = "mir_param_dereferenceable_";
 
 /// MIR function operation.
 ///
@@ -68,6 +79,9 @@ pub const MIR_PARAM_READONLY_ATTR_PREFIX: &str = "mir_param_readonly_";
 /// | `mir_func_type`| TypeAttr  | Function type (mir.func_type)      |
 /// | `mir_param_noalias_N` | StringAttr | rustc-proven `noalias` for source arg N |
 /// | `mir_param_readonly_N` | StringAttr | rustc-proven `readonly` for source arg N |
+/// | `mir_param_nonnull_N` | StringAttr | rustc-proven `nonnull` for source arg N |
+/// | `mir_param_pointee_align_N` | IntegerAttr | rustc-proven pointee alignment in bytes |
+/// | `mir_param_dereferenceable_N` | IntegerAttr | rustc-proven dereferenceable bytes |
 /// ```
 ///
 /// # Verification
@@ -116,11 +130,6 @@ impl MirFuncOp {
     }
 
     /// Record rustc-proven aliasing facts for one source-level function argument.
-    ///
-    /// These facts are attached to the MIR argument index, before slices are
-    /// flattened into `(ptr, len)` by `mir-lower`. `readonly` is intentionally
-    /// represented separately from pointer kind: `SharedRef` alone is not
-    /// sufficient when the pointee contains `UnsafeCell`.
     pub fn set_reference_param_attrs(
         &self,
         ctx: &mut Context,
@@ -146,7 +155,43 @@ impl MirFuncOp {
         }
     }
 
-    /// Whether rustc proved that this source-level argument may carry LLVM `noalias`.
+    /// Record rustc-proven pointer validity facts for one source-level reference argument.
+    pub fn set_reference_param_validity_attrs(
+        &self,
+        ctx: &mut Context,
+        index: usize,
+        nonnull: bool,
+        pointee_align: Option<u64>,
+        dereferenceable: Option<u64>,
+    ) {
+        if nonnull {
+            set_param_marker(
+                ctx,
+                self.get_operation(),
+                MIR_PARAM_NONNULL_ATTR_PREFIX,
+                index,
+            );
+        }
+        if let Some(align) = pointee_align {
+            set_param_value(
+                ctx,
+                self.get_operation(),
+                MIR_PARAM_POINTEE_ALIGN_ATTR_PREFIX,
+                index,
+                align,
+            );
+        }
+        if let Some(bytes) = dereferenceable {
+            set_param_value(
+                ctx,
+                self.get_operation(),
+                MIR_PARAM_DEREFERENCEABLE_ATTR_PREFIX,
+                index,
+                bytes,
+            );
+        }
+    }
+
     pub fn param_noalias(&self, ctx: &Context, index: usize) -> bool {
         has_param_marker(
             ctx,
@@ -156,12 +201,38 @@ impl MirFuncOp {
         )
     }
 
-    /// Whether rustc proved that this source-level argument may carry LLVM `readonly`.
     pub fn param_readonly(&self, ctx: &Context, index: usize) -> bool {
         has_param_marker(
             ctx,
             self.get_operation(),
             MIR_PARAM_READONLY_ATTR_PREFIX,
+            index,
+        )
+    }
+
+    pub fn param_nonnull(&self, ctx: &Context, index: usize) -> bool {
+        has_param_marker(
+            ctx,
+            self.get_operation(),
+            MIR_PARAM_NONNULL_ATTR_PREFIX,
+            index,
+        )
+    }
+
+    pub fn param_pointee_align(&self, ctx: &Context, index: usize) -> Option<u64> {
+        param_value(
+            ctx,
+            self.get_operation(),
+            MIR_PARAM_POINTEE_ALIGN_ATTR_PREFIX,
+            index,
+        )
+    }
+
+    pub fn param_dereferenceable(&self, ctx: &Context, index: usize) -> Option<u64> {
+        param_value(
+            ctx,
+            self.get_operation(),
+            MIR_PARAM_DEREFERENCEABLE_ATTR_PREFIX,
             index,
         )
     }
@@ -181,9 +252,26 @@ fn set_param_marker(ctx: &mut Context, op: Ptr<Operation>, prefix: &str, index: 
         .set(key, StringAttr::new("true".to_string()));
 }
 
+fn set_param_value(ctx: &mut Context, op: Ptr<Operation>, prefix: &str, index: usize, value: u64) {
+    let key = param_marker_key(prefix, index);
+    let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+    let value = APInt::from_u64(value, NonZero::new(64).unwrap());
+    op.deref_mut(ctx)
+        .attributes
+        .set(key, IntegerAttr::new(u64_ty, value));
+}
+
 fn has_param_marker(ctx: &Context, op: Ptr<Operation>, prefix: &str, index: usize) -> bool {
     let key = param_marker_key(prefix, index);
     op.deref(ctx).attributes.get::<StringAttr>(&key).is_some()
+}
+
+fn param_value(ctx: &Context, op: Ptr<Operation>, prefix: &str, index: usize) -> Option<u64> {
+    let key = param_marker_key(prefix, index);
+    op.deref(ctx)
+        .attributes
+        .get::<IntegerAttr>(&key)
+        .map(|value| value.value().to_u64())
 }
 
 fn marker_index(key: &Identifier, prefix: &str) -> Option<Result<usize, ()>> {
@@ -301,17 +389,22 @@ impl Verify for MirFuncOp {
 
         let inputs = interface.arg_types();
 
-        // Reference-derived optimizer facts are deliberately audited here,
-        // before MIR-to-LLVM flattening. Raw/erased pointers must never acquire
-        // Rust reference guarantees, and `readonly` is only valid for a shared
-        // reference for which the importer also proved `noalias`.
+        // Reference-derived optimizer facts are audited before MIR-to-LLVM flattening.
         for key in op.attributes.0.keys() {
-            let marker = marker_index(key, MIR_PARAM_NOALIAS_ATTR_PREFIX)
-                .map(|index| (index, false))
-                .or_else(|| {
-                    marker_index(key, MIR_PARAM_READONLY_ATTR_PREFIX).map(|index| (index, true))
-                });
-            let Some((index, is_readonly)) = marker else {
+            let mut matched_prefix = None;
+            for (prefix, kind) in [
+                (MIR_PARAM_NOALIAS_ATTR_PREFIX, "noalias"),
+                (MIR_PARAM_READONLY_ATTR_PREFIX, "readonly"),
+                (MIR_PARAM_NONNULL_ATTR_PREFIX, "nonnull"),
+                (MIR_PARAM_POINTEE_ALIGN_ATTR_PREFIX, "align"),
+                (MIR_PARAM_DEREFERENCEABLE_ATTR_PREFIX, "dereferenceable"),
+            ] {
+                if let Some(index) = marker_index(key, prefix) {
+                    matched_prefix = Some((index, kind));
+                    break;
+                }
+            }
+            let Some((index, attr_kind)) = matched_prefix else {
                 continue;
             };
             let index = match index {
@@ -334,37 +427,87 @@ impl Verify for MirFuncOp {
                 );
             }
 
-            let kind = pointer_kind_for_function_input(ctx, inputs[index]);
-            if is_readonly {
-                if kind != Some(MirPointerKind::SharedRef) {
-                    return verify_err!(
-                        op.loc(),
-                        "MirFuncOp readonly proof on argument {} requires a SharedRef pointer kind",
-                        index
-                    );
-                }
-                if !self.param_noalias(ctx, index) {
-                    return verify_err!(
-                        op.loc(),
-                        "MirFuncOp readonly proof on argument {} must carry the matching noalias proof",
-                        index
-                    );
-                }
-            } else if !matches!(
-                kind,
+            let pointer_kind = pointer_kind_for_function_input(ctx, inputs[index]);
+            if !matches!(
+                pointer_kind,
                 Some(MirPointerKind::SharedRef | MirPointerKind::UniqueRef)
             ) {
                 return verify_err!(
                     op.loc(),
-                    "MirFuncOp noalias proof on argument {} requires a Rust reference pointer kind",
+                    "MirFuncOp {} proof on argument {} requires a Rust reference pointer kind",
+                    attr_kind,
                     index
                 );
-            } else if kind == Some(MirPointerKind::SharedRef) && !self.param_readonly(ctx, index) {
-                return verify_err!(
-                    op.loc(),
-                    "MirFuncOp SharedRef noalias proof on argument {} must carry the matching readonly proof",
-                    index
-                );
+            }
+
+            match attr_kind {
+                "readonly" => {
+                    if pointer_kind != Some(MirPointerKind::SharedRef) {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp readonly proof on argument {} requires a SharedRef pointer kind",
+                            index
+                        );
+                    }
+                    if !self.param_noalias(ctx, index) {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp readonly proof on argument {} must carry the matching noalias proof",
+                            index
+                        );
+                    }
+                }
+                "noalias"
+                    if pointer_kind == Some(MirPointerKind::SharedRef)
+                        && !self.param_readonly(ctx, index) =>
+                {
+                    return verify_err!(
+                        op.loc(),
+                        "MirFuncOp SharedRef noalias proof on argument {} must carry the matching readonly proof",
+                        index
+                    );
+                }
+                "noalias" => {}
+                "align" => {
+                    let Some(align) = self.param_pointee_align(ctx, index) else {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp pointee alignment proof on argument {} is not a valid integer",
+                            index
+                        );
+                    };
+                    if align <= 1 || !align.is_power_of_two() {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp pointee alignment proof on argument {} must be a power of two greater than one",
+                            index
+                        );
+                    }
+                }
+                "dereferenceable" => {
+                    let Some(bytes) = self.param_dereferenceable(ctx, index) else {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp dereferenceable proof on argument {} is not a valid integer",
+                            index
+                        );
+                    };
+                    if bytes == 0 {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp dereferenceable proof on argument {} must be non-zero",
+                            index
+                        );
+                    }
+                    if !self.param_nonnull(ctx, index) {
+                        return verify_err!(
+                            op.loc(),
+                            "MirFuncOp dereferenceable proof on argument {} requires the matching nonnull proof",
+                            index
+                        );
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -374,6 +517,7 @@ impl Verify for MirFuncOp {
         // Check if there is an entry block
         if let Some(entry_block_ptr) = region.get_head() {
             let entry_block = entry_block_ptr.deref(ctx);
+
             if entry_block.get_num_arguments() != inputs.len() {
                 return verify_err!(
                     op.loc(),

--- a/crates/dialect-mir/src/types.rs
+++ b/crates/dialect-mir/src/types.rs
@@ -187,10 +187,90 @@ pub mod address_space {
     pub const CLUSTER_SHARED: u32 = 7;
 }
 
-/// A pointer type with mutability and address space tracking.
+/// Source-level pointer/reference category retained by `dialect-mir`.
+///
+/// This is semantic provenance, not a physical representation choice. In
+/// particular, [`MirPointerKind::RawMut`] and [`MirPointerKind::UniqueRef`]
+/// are both mutable pointers at the machine level, but only the latter came
+/// from an `&mut T`-typed Rust value. [`MirPointerKind::Erased`] is used for
+/// compiler-generated storage and temporary addresses that must not acquire
+/// Rust aliasing guarantees merely because they are mutable.
+///
+/// The MIR dialect deliberately does not translate this enum directly into
+/// LLVM `noalias`, `readonly`, or related attributes. It exists so any future
+/// use of Rust aliasing facts has an explicit, auditable source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+#[format]
+pub enum MirPointerKind {
+    /// Compiler-generated or intentionally forgotten pointer provenance.
+    /// Generic normalization must not recover a stronger concrete Rust kind
+    /// from this state; only a new rustc-declared semantic boundary may do so.
+    #[default]
+    Erased,
+    /// Shared Rust reference: `&T`.
+    SharedRef,
+    /// Mutable/unique Rust reference: `&mut T`.
+    UniqueRef,
+    /// Immutable raw pointer: `*const T`.
+    RawConst,
+    /// Mutable raw pointer: `*mut T`.
+    RawMut,
+}
+
+impl MirPointerKind {
+    /// Kind for a Rust reference with the supplied source mutability.
+    pub fn from_reference_mutability(is_mutable: bool) -> Self {
+        if is_mutable {
+            Self::UniqueRef
+        } else {
+            Self::SharedRef
+        }
+    }
+
+    /// Kind for a Rust raw pointer with the supplied source mutability.
+    pub fn from_raw_mutability(is_mutable: bool) -> Self {
+        if is_mutable {
+            Self::RawMut
+        } else {
+            Self::RawConst
+        }
+    }
+
+    /// Whether the kind represents a Rust reference rather than a raw or
+    /// compiler-generated pointer.
+    pub fn is_reference(self) -> bool {
+        matches!(self, Self::SharedRef | Self::UniqueRef)
+    }
+
+    /// Whether the kind originated from `&mut T`.
+    ///
+    /// This is intentionally only a classification query. Downstream code
+    /// must not turn it into LLVM alias metadata without a separate, audited
+    /// policy for the operation/function boundary where the value is used.
+    pub fn is_unique_reference(self) -> bool {
+        self == Self::UniqueRef
+    }
+
+    /// Required `MirPtrType::is_mutable` value for source-level kinds.
+    /// `Erased` accepts either mutability because storage pointers may be
+    /// mutable even when they do not represent a Rust `&mut`/`*mut` value.
+    fn expected_mutability(self) -> Option<bool> {
+        match self {
+            Self::Erased => None,
+            Self::SharedRef | Self::RawConst => Some(false),
+            Self::UniqueRef | Self::RawMut => Some(true),
+        }
+    }
+}
+
+/// A pointer type with mutability, address space, and Rust pointer kind tracking.
 ///
 /// Represents a pointer to a value of a specific type in a specific memory space.
-/// Syntax: `mir.ptr <type, mutable: bool, addrspace: u32>`
+/// Syntax: `mir.ptr <type, mutable: bool, addrspace: u32, kind: MirPointerKind>`
+///
+/// `is_mutable` is a machine-level/source-mutability property only. It is not
+/// proof of uniqueness: `*mut T` is mutable but can alias, while `&mut T` is
+/// represented by the distinct [`MirPointerKind::UniqueRef`] kind.
 ///
 /// Address spaces are critical for GPU memory:
 /// - 0 (generic): Can point to any memory, resolved at runtime
@@ -203,36 +283,60 @@ pub mod address_space {
 ///
 /// # Verification
 /// * Pointee type must be valid.
+/// * Non-erased pointer kinds must agree with `is_mutable`.
 #[pliron_type(
     name = "mir.ptr",
-    format = "`<` $pointee `,` `mutable:` $is_mutable `,` `addrspace:` $address_space `>`"
+    format = "`<` $pointee `,` `mutable:` $is_mutable `,` `addrspace:` $address_space `,` `kind:` $kind `>`"
 )]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirPtrType {
     pub pointee: TypeHandle,
     pub is_mutable: bool,
     pub address_space: u32,
+    pub kind: MirPointerKind,
 }
 
 impl MirPtrType {
-    /// Create a pointer type with explicit address space.
+    /// Create a compiler/internal pointer with explicit address space.
+    ///
+    /// Existing synthetic-pointer call sites intentionally route through this
+    /// constructor and therefore receive `Erased` provenance. Rust-originated
+    /// pointers should use [`Self::get_with_kind`].
     pub fn get(
         ctx: &mut Context,
         pointee: TypeHandle,
         is_mutable: bool,
         address_space: u32,
     ) -> TypedHandle<Self> {
+        Self::get_with_kind(
+            ctx,
+            pointee,
+            is_mutable,
+            address_space,
+            MirPointerKind::Erased,
+        )
+    }
+
+    /// Create a pointer with explicit Rust/source-level pointer kind.
+    pub fn get_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        address_space: u32,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
         Type::instantiate(
             MirPtrType {
                 pointee,
                 is_mutable,
                 address_space,
+                kind,
             },
             ctx,
         )
     }
 
-    /// Create a pointer in generic address space (0).
+    /// Create a compiler/internal pointer in generic address space (0).
     pub fn get_generic(
         ctx: &mut Context,
         pointee: TypeHandle,
@@ -241,13 +345,33 @@ impl MirPtrType {
         Self::get(ctx, pointee, is_mutable, address_space::GENERIC)
     }
 
-    /// Create a pointer in shared memory address space (3).
+    /// Create a Rust/source-level pointer in generic address space (0).
+    pub fn get_generic_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Self::get_with_kind(ctx, pointee, is_mutable, address_space::GENERIC, kind)
+    }
+
+    /// Create a compiler/internal pointer in shared memory address space (3).
     pub fn get_shared(
         ctx: &mut Context,
         pointee: TypeHandle,
         is_mutable: bool,
     ) -> TypedHandle<Self> {
         Self::get(ctx, pointee, is_mutable, address_space::SHARED)
+    }
+
+    /// Create a Rust/source-level pointer in shared memory address space (3).
+    pub fn get_shared_with_kind(
+        ctx: &mut Context,
+        pointee: TypeHandle,
+        is_mutable: bool,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Self::get_with_kind(ctx, pointee, is_mutable, address_space::SHARED, kind)
     }
 
     /// Create a pointer in global memory address space (1).
@@ -290,6 +414,10 @@ impl MirPtrType {
         self.address_space
     }
 
+    pub fn pointer_kind(&self) -> MirPointerKind {
+        self.kind
+    }
+
     /// Check if this pointer is in shared memory (addrspace 3).
     pub fn is_shared(&self) -> bool {
         self.address_space == address_space::SHARED
@@ -308,31 +436,60 @@ impl MirPtrType {
 
 impl Verify for MirPtrType {
     fn verify(&self, _ctx: &Context) -> Result<(), Error> {
-        // Pointer types are valid if their pointee type is valid.
+        if let Some(expected) = self.kind.expected_mutability()
+            && expected != self.is_mutable
+        {
+            return verify_err!(
+                Location::Unknown,
+                "MirPtrType pointer kind {:?} is inconsistent with mutable: {}",
+                self.kind,
+                self.is_mutable
+            );
+        }
         Ok(())
     }
 }
 
-/// A slice type: { ptr: *T, len: usize }
+/// A slice/fat-pointer type: `{ ptr: *T, len: usize }` plus source pointer kind.
 ///
-/// Represents a view into a contiguous sequence of elements.
-/// Syntax: `mir.slice <type>`
+/// Represents a view into a contiguous sequence of elements. References and
+/// raw pointers to `[T]` share the same physical `{ptr, len}` layout, but their
+/// Rust pointer category remains distinct in the MIR type.
+/// Syntax: `mir.slice <type, kind: MirPointerKind>`
+///
+/// Bare `[T]` carriers and compiler-generated fat pointers use
+/// [`MirPointerKind::Erased`].
 ///
 /// # Verification
 /// * Element type must be valid.
-#[pliron_type(name = "mir.slice", format = "`<` $element_ty `>`")]
+#[pliron_type(name = "mir.slice", format = "`<` $element_ty `,` `kind:` $kind `>`")]
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub struct MirSliceType {
     pub element_ty: TypeHandle,
+    pub kind: MirPointerKind,
 }
 
 impl MirSliceType {
+    /// Create a slice carrier with intentionally erased pointer provenance.
     pub fn get(ctx: &mut Context, element_ty: TypeHandle) -> TypedHandle<Self> {
-        Type::instantiate(MirSliceType { element_ty }, ctx)
+        Self::get_with_kind(ctx, element_ty, MirPointerKind::Erased)
+    }
+
+    /// Create a slice/fat-pointer retaining its Rust/source-level pointer kind.
+    pub fn get_with_kind(
+        ctx: &mut Context,
+        element_ty: TypeHandle,
+        kind: MirPointerKind,
+    ) -> TypedHandle<Self> {
+        Type::instantiate(MirSliceType { element_ty, kind }, ctx)
     }
 
     pub fn element_type(&self) -> TypeHandle {
         self.element_ty
+    }
+
+    pub fn pointer_kind(&self) -> MirPointerKind {
+        self.kind
     }
 }
 

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -1045,6 +1045,73 @@ fn test_mir_func_verify() {
 }
 
 #[test]
+fn test_mir_func_reference_param_attrs_verify() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
+    let shared: pliron::r#type::TypeHandle = MirPtrType::get_generic_with_kind(
+        &mut ctx,
+        i32_ty.into(),
+        false,
+        MirPointerKind::SharedRef,
+    )
+    .into();
+    let unique: pliron::r#type::TypeHandle =
+        MirPtrType::get_generic_with_kind(&mut ctx, i32_ty.into(), true, MirPointerKind::UniqueRef)
+            .into();
+    let raw: pliron::r#type::TypeHandle =
+        MirPtrType::get_generic_with_kind(&mut ctx, i32_ty.into(), true, MirPointerKind::RawMut)
+            .into();
+    let func_ty = FunctionType::get(&ctx, vec![shared, unique, raw], vec![]);
+    let func_ty_attr = TypeAttr::new(func_ty.into());
+
+    let make_func = |ctx: &mut Context| {
+        let op = Operation::new(
+            ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let func = MirFuncOp::new(ctx, op, func_ty_attr.clone());
+        let region = func.get_operation().deref(ctx).get_region(0);
+        BasicBlock::new(ctx, None, vec![shared, unique, raw]).insert_at_front(region, ctx);
+        func
+    };
+
+    let valid = make_func(&mut ctx);
+    valid.set_reference_param_attrs(&mut ctx, 0, true, true);
+    valid.set_reference_param_attrs(&mut ctx, 1, true, false);
+    assert!(
+        valid.verify(&ctx).is_ok(),
+        "audited reference facts are valid"
+    );
+
+    let raw_noalias = make_func(&mut ctx);
+    raw_noalias.set_reference_param_attrs(&mut ctx, 2, true, false);
+    assert!(
+        raw_noalias.verify(&ctx).is_err(),
+        "raw pointers must not acquire reference-derived noalias"
+    );
+
+    let unique_readonly = make_func(&mut ctx);
+    unique_readonly.set_reference_param_attrs(&mut ctx, 1, true, true);
+    assert!(
+        unique_readonly.verify(&ctx).is_err(),
+        "readonly is restricted to proven shared references"
+    );
+
+    let out_of_range = make_func(&mut ctx);
+    out_of_range.set_reference_param_attrs(&mut ctx, 3, true, false);
+    assert!(
+        out_of_range.verify(&ctx).is_err(),
+        "parameter proof indices must be in range"
+    );
+}
+
+#[test]
 fn test_mir_assign_verify() {
     let mut ctx = Context::new();
     dialect_mir::register(&mut ctx);

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -1083,17 +1083,19 @@ fn test_mir_func_reference_param_attrs_verify() {
 
     let valid = make_func(&mut ctx);
     valid.set_reference_param_attrs(&mut ctx, 0, true, true);
+    valid.set_reference_param_validity_attrs(&mut ctx, 0, true, Some(4), Some(4));
     valid.set_reference_param_attrs(&mut ctx, 1, true, false);
+    valid.set_reference_param_validity_attrs(&mut ctx, 1, true, Some(4), Some(4));
     assert!(
         valid.verify(&ctx).is_ok(),
         "audited reference facts are valid"
     );
 
-    let raw_noalias = make_func(&mut ctx);
-    raw_noalias.set_reference_param_attrs(&mut ctx, 2, true, false);
+    let raw_nonnull = make_func(&mut ctx);
+    raw_nonnull.set_reference_param_validity_attrs(&mut ctx, 2, true, Some(4), Some(4));
     assert!(
-        raw_noalias.verify(&ctx).is_err(),
-        "raw pointers must not acquire reference-derived noalias"
+        raw_nonnull.verify(&ctx).is_err(),
+        "raw pointers must not acquire reference-derived validity facts"
     );
 
     let unique_readonly = make_func(&mut ctx);
@@ -1103,8 +1105,22 @@ fn test_mir_func_reference_param_attrs_verify() {
         "readonly is restricted to proven shared references"
     );
 
+    let bad_align = make_func(&mut ctx);
+    bad_align.set_reference_param_validity_attrs(&mut ctx, 0, true, Some(3), None);
+    assert!(
+        bad_align.verify(&ctx).is_err(),
+        "pointee alignment must be a power of two greater than one"
+    );
+
+    let deref_without_nonnull = make_func(&mut ctx);
+    deref_without_nonnull.set_reference_param_validity_attrs(&mut ctx, 0, false, None, Some(4));
+    assert!(
+        deref_without_nonnull.verify(&ctx).is_err(),
+        "dereferenceable requires the matching nonnull proof"
+    );
+
     let out_of_range = make_func(&mut ctx);
-    out_of_range.set_reference_param_attrs(&mut ctx, 3, true, false);
+    out_of_range.set_reference_param_validity_attrs(&mut ctx, 3, true, Some(4), Some(4));
     assert!(
         out_of_range.verify(&ctx).is_err(),
         "parameter proof indices must be in range"

--- a/crates/dialect-mir/tests/ops_test.rs
+++ b/crates/dialect-mir/tests/ops_test.rs
@@ -14,8 +14,8 @@ use dialect_mir::{
         MirPtrOffsetOp, MirRemOp, MirReturnOp, MirSetDiscriminantOp, MirStoreOp, MirSubOp,
     },
     types::{
-        EnumVariant, MirDisjointSliceType, MirEnumType, MirPtrType, MirSliceType, MirTupleType,
-        MirUnionType,
+        EnumVariant, MirDisjointSliceType, MirEnumType, MirPointerKind, MirPtrType, MirSliceType,
+        MirTupleType, MirUnionType,
     },
 };
 use pliron::{
@@ -189,6 +189,94 @@ fn test_mir_control_flow_verify() {
         MirAssertOp::new(op_assert_bad).verify(&ctx).is_err(),
         "Assert cond type mismatch"
     );
+}
+
+#[test]
+fn test_mir_pointer_kind_distinguishes_references_from_raw_pointers() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
+    let pointee: pliron::r#type::TypeHandle = i32_ty.into();
+
+    let shared_ref =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::SharedRef);
+    let raw_const =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::RawConst);
+    let unique_ref =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef);
+    let raw_mut =
+        MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::RawMut);
+
+    assert_ne!(
+        shared_ref, raw_const,
+        "&T must remain distinct from *const T"
+    );
+    assert_ne!(
+        unique_ref, raw_mut,
+        "&mut T must remain distinct from *mut T"
+    );
+    assert_ne!(
+        shared_ref, unique_ref,
+        "&T must remain distinct from &mut T"
+    );
+    assert_ne!(
+        raw_const, raw_mut,
+        "*const T must remain distinct from *mut T"
+    );
+
+    assert_eq!(
+        shared_ref.deref(&ctx).pointer_kind(),
+        MirPointerKind::SharedRef
+    );
+    assert_eq!(
+        unique_ref.deref(&ctx).pointer_kind(),
+        MirPointerKind::UniqueRef
+    );
+    assert_eq!(
+        raw_const.deref(&ctx).pointer_kind(),
+        MirPointerKind::RawConst
+    );
+    assert_eq!(raw_mut.deref(&ctx).pointer_kind(), MirPointerKind::RawMut);
+}
+
+#[test]
+fn test_mir_slice_preserves_pointer_kind() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let u8_ty = IntegerType::get(&ctx, 8, Signedness::Unsigned);
+    let element: pliron::r#type::TypeHandle = u8_ty.into();
+
+    let shared = MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef);
+    let raw = MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::RawConst);
+
+    assert_ne!(shared, raw, "&[T] must remain distinct from *const [T]");
+    assert_eq!(shared.deref(&ctx).pointer_kind(), MirPointerKind::SharedRef);
+    assert_eq!(raw.deref(&ctx).pointer_kind(), MirPointerKind::RawConst);
+}
+
+#[test]
+fn test_mir_pointer_kind_mutability_consistency_verify() {
+    let mut ctx = Context::new();
+    dialect_mir::register(&mut ctx);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signed);
+    let invalid_shared = MirPtrType {
+        pointee: i32_ty.into(),
+        is_mutable: true,
+        address_space: 0,
+        kind: MirPointerKind::SharedRef,
+    };
+    let invalid_raw_mut = MirPtrType {
+        pointee: i32_ty.into(),
+        is_mutable: false,
+        address_space: 0,
+        kind: MirPointerKind::RawMut,
+    };
+
+    assert!(invalid_shared.verify(&ctx).is_err());
+    assert!(invalid_raw_mut.verify(&ctx).is_err());
 }
 
 #[test]

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -45,6 +45,9 @@ use super::{
     },
 };
 
+const LLVM_PARAM_NOALIAS_ATTR_PREFIX: &str = "cuda_oxide_param_noalias_";
+const LLVM_PARAM_READONLY_ATTR_PREFIX: &str = "cuda_oxide_param_readonly_";
+
 /// Flatten a descriptive string so it cannot escape a single `;` comment line.
 ///
 /// An LLVM comment runs to end of line, so an embedded newline would turn the
@@ -508,6 +511,52 @@ impl<'a> ModuleExportState<'a> {
         Ok(())
     }
 
+    fn parameter_marker(&self, func: &FuncOp, prefix: &str, index: usize) -> bool {
+        let key: pliron::identifier::Identifier = format!("{prefix}{index}")
+            .as_str()
+            .try_into()
+            .expect("LLVM parameter marker attribute name is valid");
+        func.get_operation()
+            .deref(self.ctx)
+            .attributes
+            .get::<pliron::builtin::attributes::StringAttr>(&key)
+            .is_some()
+    }
+
+    fn export_parameter_attrs(
+        &self,
+        func: &FuncOp,
+        index: usize,
+        arg_ty: pliron::r#type::TypeHandle,
+        output: &mut String,
+    ) -> Result<(), String> {
+        let noalias = self.parameter_marker(func, LLVM_PARAM_NOALIAS_ATTR_PREFIX, index);
+        let readonly = self.parameter_marker(func, LLVM_PARAM_READONLY_ATTR_PREFIX, index);
+        if !noalias && !readonly {
+            return Ok(());
+        }
+        if readonly && !noalias {
+            return Err(format!(
+                "function `@{}` carries readonly without the matching noalias proof on argument {index}",
+                func.get_symbol_name(self.ctx)
+            ));
+        }
+
+        if !arg_ty.deref(self.ctx).is::<PointerType>() {
+            return Err(format!(
+                "function `@{}` carries reference parameter attributes on non-pointer argument {index}",
+                func.get_symbol_name(self.ctx)
+            ));
+        }
+        if noalias {
+            write!(output, " noalias").unwrap();
+        }
+        if readonly {
+            write!(output, " readonly").unwrap();
+        }
+        Ok(())
+    }
+
     pub(super) fn export_function(
         &mut self,
         func: &FuncOp,
@@ -741,6 +790,7 @@ impl<'a> ModuleExportState<'a> {
                 } else {
                     self.export_type(*arg_ty, output)?;
                 }
+                self.export_parameter_attrs(func, i, *arg_ty, output)?;
             }
             write!(output, ")").unwrap();
 
@@ -796,28 +846,18 @@ impl<'a> ModuleExportState<'a> {
 
             let block = entry_block.deref(self.ctx);
             let args = block.arguments();
-            // Parameters are emitted bare: `<type> %vN` with no LLVM parameter
-            // attributes (no `noalias`, `nocapture`, `dereferenceable`, etc.).
-            // This is deliberate and load-bearing for `DisjointSlice`.
-            //
-            // `DisjointSlice::from_raw_parts` is `unsafe fn` whose contract
-            // says callers must not construct two slices over the same range.
-            // Violating that contract creates two `&mut T` to the same byte —
-            // which is simply UB. Today, because we don't tag pointer
-            // parameters with `noalias`, LLVM treats them conservatively and
-            // the violation doesn't *miscompile*; it just runs as written.
-            //
-            // If a future change here adds `noalias` (e.g. for a perf win on
-            // read-only `&[T]` inputs), that property goes away and any code
-            // that double-constructed a `DisjointSlice` starts seeing folded
-            // writes / reordered reads on PTX. Don't add parameter attributes
-            // here without re-auditing the `from_raw_parts` callers.
+            // Rust-derived parameter attributes arrive as explicit LLVM-dialect
+            // marker attributes produced by mir-lower after source-argument ABI
+            // flattening. The exporter does not infer aliasing from pointer type,
+            // mutability, address space, or `DisjointSlice`; it only serializes
+            // the already-audited `noalias` / `readonly` proof bits.
             for (i, arg) in args.enumerate() {
                 if i > 0 {
                     write!(output, ", ").unwrap();
                 }
                 let arg_ty = arg.get_type(self.ctx);
                 self.export_type(arg_ty, output)?;
+                self.export_parameter_attrs(func, i, arg_ty, output)?;
                 let name = format!("%v{next_value_id}");
                 value_names.insert(arg, name.clone());
                 write!(output, " {name}").unwrap();

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -47,6 +47,9 @@ use super::{
 
 const LLVM_PARAM_NOALIAS_ATTR_PREFIX: &str = "cuda_oxide_param_noalias_";
 const LLVM_PARAM_READONLY_ATTR_PREFIX: &str = "cuda_oxide_param_readonly_";
+const LLVM_PARAM_NONNULL_ATTR_PREFIX: &str = "cuda_oxide_param_nonnull_";
+const LLVM_PARAM_POINTEE_ALIGN_ATTR_PREFIX: &str = "cuda_oxide_param_pointee_align_";
+const LLVM_PARAM_DEREFERENCEABLE_ATTR_PREFIX: &str = "cuda_oxide_param_dereferenceable_";
 
 /// Flatten a descriptive string so it cannot escape a single `;` comment line.
 ///
@@ -523,6 +526,18 @@ impl<'a> ModuleExportState<'a> {
             .is_some()
     }
 
+    fn parameter_value(&self, func: &FuncOp, prefix: &str, index: usize) -> Option<u64> {
+        let key: pliron::identifier::Identifier = format!("{prefix}{index}")
+            .as_str()
+            .try_into()
+            .expect("LLVM parameter value attribute name is valid");
+        func.get_operation()
+            .deref(self.ctx)
+            .attributes
+            .get::<pliron::builtin::attributes::IntegerAttr>(&key)
+            .map(|value| value.value().to_u64())
+    }
+
     fn export_parameter_attrs(
         &self,
         func: &FuncOp,
@@ -532,14 +547,14 @@ impl<'a> ModuleExportState<'a> {
     ) -> Result<(), String> {
         let noalias = self.parameter_marker(func, LLVM_PARAM_NOALIAS_ATTR_PREFIX, index);
         let readonly = self.parameter_marker(func, LLVM_PARAM_READONLY_ATTR_PREFIX, index);
-        if !noalias && !readonly {
+        let nonnull = self.parameter_marker(func, LLVM_PARAM_NONNULL_ATTR_PREFIX, index);
+        let pointee_align = self.parameter_value(func, LLVM_PARAM_POINTEE_ALIGN_ATTR_PREFIX, index);
+        let dereferenceable =
+            self.parameter_value(func, LLVM_PARAM_DEREFERENCEABLE_ATTR_PREFIX, index);
+
+        if !noalias && !readonly && !nonnull && pointee_align.is_none() && dereferenceable.is_none()
+        {
             return Ok(());
-        }
-        if readonly && !noalias {
-            return Err(format!(
-                "function `@{}` carries readonly without the matching noalias proof on argument {index}",
-                func.get_symbol_name(self.ctx)
-            ));
         }
 
         if !arg_ty.deref(self.ctx).is::<PointerType>() {
@@ -548,11 +563,49 @@ impl<'a> ModuleExportState<'a> {
                 func.get_symbol_name(self.ctx)
             ));
         }
+        if readonly && !noalias {
+            return Err(format!(
+                "function `@{}` carries readonly without the matching noalias proof on argument {index}",
+                func.get_symbol_name(self.ctx)
+            ));
+        }
+        if let Some(align) = pointee_align
+            && (align <= 1 || !align.is_power_of_two())
+        {
+            return Err(format!(
+                "function `@{}` carries invalid pointee alignment {align} on argument {index}",
+                func.get_symbol_name(self.ctx)
+            ));
+        }
+        if let Some(bytes) = dereferenceable {
+            if bytes == 0 {
+                return Err(format!(
+                    "function `@{}` carries dereferenceable(0) on argument {index}",
+                    func.get_symbol_name(self.ctx)
+                ));
+            }
+            if !nonnull {
+                return Err(format!(
+                    "function `@{}` carries dereferenceable({bytes}) without the matching nonnull proof on argument {index}",
+                    func.get_symbol_name(self.ctx)
+                ));
+            }
+        }
+
         if noalias {
             write!(output, " noalias").unwrap();
         }
         if readonly {
             write!(output, " readonly").unwrap();
+        }
+        if nonnull {
+            write!(output, " nonnull").unwrap();
+        }
+        if let Some(align) = pointee_align {
+            write!(output, " align {align}").unwrap();
+        }
+        if let Some(bytes) = dereferenceable {
+            write!(output, " dereferenceable({bytes})").unwrap();
         }
         Ok(())
     }
@@ -847,10 +900,9 @@ impl<'a> ModuleExportState<'a> {
             let block = entry_block.deref(self.ctx);
             let args = block.arguments();
             // Rust-derived parameter attributes arrive as explicit LLVM-dialect
-            // marker attributes produced by mir-lower after source-argument ABI
-            // flattening. The exporter does not infer aliasing from pointer type,
-            // mutability, address space, or `DisjointSlice`; it only serializes
-            // the already-audited `noalias` / `readonly` proof bits.
+            // markers produced by mir-lower after source-argument ABI flattening.
+            // The exporter never infers Rust semantics from pointer shape,
+            // mutability, address space, or `DisjointSlice`.
             for (i, arg) in args.enumerate() {
                 if i > 0 {
                     write!(output, ", ").unwrap();

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -193,16 +193,32 @@ fn export_reference_parameter_attrs_on_definitions() {
         false,
     );
     let func = FuncOp::new(&mut ctx, "reference_attrs".try_into().unwrap(), func_ty);
+
     for key in [
         "cuda_oxide_param_noalias_0",
         "cuda_oxide_param_readonly_0",
+        "cuda_oxide_param_nonnull_0",
         "cuda_oxide_param_noalias_2",
+        "cuda_oxide_param_nonnull_2",
     ] {
         func.get_operation()
             .deref_mut(&ctx)
             .attributes
             .set(key.try_into().unwrap(), StringAttr::new("true".to_string()));
     }
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    for (key, value) in [
+        ("cuda_oxide_param_pointee_align_0", 16u64),
+        ("cuda_oxide_param_dereferenceable_0", 16u64),
+        ("cuda_oxide_param_pointee_align_2", 4u64),
+        ("cuda_oxide_param_dereferenceable_2", 4u64),
+    ] {
+        func.get_operation().deref_mut(&ctx).attributes.set(
+            key.try_into().unwrap(),
+            IntegerAttr::new(u64_ty, APInt::from_u64(value, NonZero::new(64).unwrap())),
+        );
+    }
+
     let entry = func.get_or_create_entry_block(&mut ctx);
     ReturnOp::new(&mut ctx, None)
         .get_operation()
@@ -212,7 +228,7 @@ fn export_reference_parameter_attrs_on_definitions() {
     let ir = export_module_to_string(&ctx, &module).expect("export succeeds");
     assert!(
         ir.contains(
-            "define void @reference_attrs(ptr noalias readonly %v0, i64 %v1, ptr noalias %v2)"
+            "define void @reference_attrs(ptr noalias readonly nonnull align 16 dereferenceable(16) %v0, i64 %v1, ptr noalias nonnull align 4 dereferenceable(4) %v2)"
         ),
         "{ir}"
     );
@@ -232,12 +248,28 @@ fn legacy_export_reference_parameter_attrs_follow_typed_pointer() {
         "legacy_reference_attrs".try_into().unwrap(),
         func_ty,
     );
-    for key in ["cuda_oxide_param_noalias_0", "cuda_oxide_param_readonly_0"] {
+
+    for key in [
+        "cuda_oxide_param_noalias_0",
+        "cuda_oxide_param_readonly_0",
+        "cuda_oxide_param_nonnull_0",
+    ] {
         func.get_operation()
             .deref_mut(&ctx)
             .attributes
             .set(key.try_into().unwrap(), StringAttr::new("true".to_string()));
     }
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    for (key, value) in [
+        ("cuda_oxide_param_pointee_align_0", 8u64),
+        ("cuda_oxide_param_dereferenceable_0", 8u64),
+    ] {
+        func.get_operation().deref_mut(&ctx).attributes.set(
+            key.try_into().unwrap(),
+            IntegerAttr::new(u64_ty, APInt::from_u64(value, NonZero::new(64).unwrap())),
+        );
+    }
+
     let entry = func.get_or_create_entry_block(&mut ctx);
     ReturnOp::new(&mut ctx, None)
         .get_operation()
@@ -248,7 +280,9 @@ fn legacy_export_reference_parameter_attrs_follow_typed_pointer() {
     let ir = export_module_to_string_with_config(&ctx, &module, &config)
         .expect("legacy export succeeds");
     assert!(
-        ir.contains("define void @legacy_reference_attrs(i8* noalias readonly %v0)"),
+        ir.contains(
+            "define void @legacy_reference_attrs(i8* noalias readonly nonnull align 8 dereferenceable(8) %v0)"
+        ),
         "{ir}"
     );
 }
@@ -264,7 +298,7 @@ fn export_rejects_reference_attrs_on_non_pointer_parameter() {
     let func_ty = FuncType::get(&ctx, void_ty.into(), vec![i32_ty.into()], false);
     let func = FuncOp::new(&mut ctx, "bad_reference_attrs".try_into().unwrap(), func_ty);
     func.get_operation().deref_mut(&ctx).attributes.set(
-        "cuda_oxide_param_noalias_0".try_into().unwrap(),
+        "cuda_oxide_param_nonnull_0".try_into().unwrap(),
         StringAttr::new("true".to_string()),
     );
     let entry = func.get_or_create_entry_block(&mut ctx);
@@ -276,6 +310,35 @@ fn export_rejects_reference_attrs_on_non_pointer_parameter() {
     let error = export_module_to_string(&ctx, &module)
         .expect_err("non-pointer parameter attributes must be rejected");
     assert!(error.contains("non-pointer argument 0"), "{error}");
+}
+
+#[test]
+fn export_rejects_invalid_reference_validity_attrs() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "bad_validity_attrs".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let ptr_ty = PointerType::get(&ctx, 0);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.into(), vec![ptr_ty.into()], false);
+    let func = FuncOp::new(&mut ctx, "bad_validity_attrs".try_into().unwrap(), func_ty);
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    func.get_operation().deref_mut(&ctx).attributes.set(
+        "cuda_oxide_param_dereferenceable_0".try_into().unwrap(),
+        IntegerAttr::new(u64_ty, APInt::from_u64(4, NonZero::new(64).unwrap())),
+    );
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let error = export_module_to_string(&ctx, &module)
+        .expect_err("dereferenceable without nonnull must be rejected");
+    assert!(
+        error.contains("without the matching nonnull proof"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -178,6 +178,107 @@ fn export_volatile_store_prints_keyword() {
 }
 
 #[test]
+fn export_reference_parameter_attrs_on_definitions() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "reference_attrs".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let ptr_ty = PointerType::get(&ctx, 0);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(
+        &ctx,
+        void_ty.into(),
+        vec![ptr_ty.into(), i64_ty.into(), ptr_ty.into()],
+        false,
+    );
+    let func = FuncOp::new(&mut ctx, "reference_attrs".try_into().unwrap(), func_ty);
+    for key in [
+        "cuda_oxide_param_noalias_0",
+        "cuda_oxide_param_readonly_0",
+        "cuda_oxide_param_noalias_2",
+    ] {
+        func.get_operation()
+            .deref_mut(&ctx)
+            .attributes
+            .set(key.try_into().unwrap(), StringAttr::new("true".to_string()));
+    }
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let ir = export_module_to_string(&ctx, &module).expect("export succeeds");
+    assert!(
+        ir.contains(
+            "define void @reference_attrs(ptr noalias readonly %v0, i64 %v1, ptr noalias %v2)"
+        ),
+        "{ir}"
+    );
+}
+
+#[test]
+fn legacy_export_reference_parameter_attrs_follow_typed_pointer() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "legacy_reference_attrs".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let ptr_ty = PointerType::get(&ctx, 0);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.into(), vec![ptr_ty.into()], false);
+    let func = FuncOp::new(
+        &mut ctx,
+        "legacy_reference_attrs".try_into().unwrap(),
+        func_ty,
+    );
+    for key in ["cuda_oxide_param_noalias_0", "cuda_oxide_param_readonly_0"] {
+        func.get_operation()
+            .deref_mut(&ctx)
+            .attributes
+            .set(key.try_into().unwrap(), StringAttr::new("true".to_string()));
+    }
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = NvvmExportConfig::new(NvvmIrDialect::LegacyLlvm7);
+    let ir = export_module_to_string_with_config(&ctx, &module, &config)
+        .expect("legacy export succeeds");
+    assert!(
+        ir.contains("define void @legacy_reference_attrs(i8* noalias readonly %v0)"),
+        "{ir}"
+    );
+}
+
+#[test]
+fn export_rejects_reference_attrs_on_non_pointer_parameter() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "bad_reference_attrs".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.into(), vec![i32_ty.into()], false);
+    let func = FuncOp::new(&mut ctx, "bad_reference_attrs".try_into().unwrap(), func_ty);
+    func.get_operation().deref_mut(&ctx).attributes.set(
+        "cuda_oxide_param_noalias_0".try_into().unwrap(),
+        StringAttr::new("true".to_string()),
+    );
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let error = export_module_to_string(&ctx, &module)
+        .expect_err("non-pointer parameter attributes must be rejected");
+    assert!(error.contains("non-pointer argument 0"), "{error}");
+}
+
+#[test]
 fn legacy_export_uses_one_canonical_pointer_with_multiple_typed_views() {
     let mut ctx = Context::new();
     let module = ModuleOp::new(&mut ctx, "legacy_views".try_into().unwrap());

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -1498,36 +1498,65 @@ fn emit_entry_allocas(
 struct ReferenceParamAttrs {
     noalias: bool,
     readonly: bool,
+    nonnull: bool,
+    pointee_align: Option<u64>,
+    dereferenceable: Option<u64>,
 }
 
-/// Reproduce rustc's reference-derived LLVM argument policy for the two
-/// attributes this backend currently understands. The decision is made while
-/// the original Rust `Ty` and the compiler type context are still available;
-/// downstream passes only propagate the resulting proof bits.
+/// Compute rustc-proven LLVM parameter facts while the original Rust `Ty`
+/// and compiler type context are still available.
 ///
-/// rustc currently permits:
-/// - `&T`: `noalias + readonly` only when `T: Freeze`;
-/// - `&mut T`: `noalias` only when `T: Unpin`;
-/// - raw pointers: neither attribute.
+/// Alias facts follow rustc's conservative `Freeze` / `Unpin` policy.
+/// Validity facts in this follow-up are intentionally restricted to sized
+/// Rust references. Raw pointers and unsized references receive none of
+/// `nonnull`, pointee `align`, or `dereferenceable` here.
 fn reference_param_attrs(ty: &Ty) -> ReferenceParamAttrs {
     let TyKind::RigidTy(RigidTy::Ref(_, pointee, mutability)) = ty.kind() else {
         return ReferenceParamAttrs::default();
     };
 
+    let layout_facts = pointee.layout().ok().and_then(|layout| {
+        let shape = layout.shape();
+        u64::try_from(shape.size.bytes())
+            .ok()
+            .map(|size| (size, shape.abi_align))
+    });
+
     rustc_middle::ty::tls::with(|tcx| {
         let pointee = rustc_public::rustc_internal::internal(tcx, pointee);
         let typing_env = rustc_middle::ty::TypingEnv::fully_monomorphized();
 
-        match mutability {
-            mir::Mutability::Not if pointee.is_freeze(tcx, typing_env) => ReferenceParamAttrs {
-                noalias: true,
-                readonly: true,
-            },
-            mir::Mutability::Mut if pointee.is_unpin(tcx, typing_env) => ReferenceParamAttrs {
-                noalias: true,
-                readonly: false,
-            },
-            _ => ReferenceParamAttrs::default(),
+        let (noalias, readonly) = match mutability {
+            mir::Mutability::Not if pointee.is_freeze(tcx, typing_env) => (true, true),
+            mir::Mutability::Mut if pointee.is_unpin(tcx, typing_env) => (true, false),
+            _ => (false, false),
+        };
+
+        if !pointee.is_sized(tcx, typing_env) {
+            return ReferenceParamAttrs {
+                noalias,
+                readonly,
+                ..ReferenceParamAttrs::default()
+            };
+        }
+
+        let Some((size, align)) = layout_facts else {
+            return ReferenceParamAttrs {
+                noalias,
+                readonly,
+                ..ReferenceParamAttrs::default()
+            };
+        };
+
+        ReferenceParamAttrs {
+            noalias,
+            readonly,
+            nonnull: true,
+            pointee_align: (align > 1).then_some(align),
+            // LLVM `dereferenceable(N)` carries a lifetime/no-free guarantee.
+            // rustc only has that guarantee here under the same `Freeze` /
+            // `Unpin` conditions that justify the alias fact above.
+            dereferenceable: (noalias && size != 0).then_some(size),
         }
     })
 }
@@ -1727,11 +1756,18 @@ pub fn translate_body(
     };
     mir_func_op.set_symbol_name(ctx, legaliser.legalise(&name_str));
 
-    // Keep rustc's aliasing decision attached to the source-level argument
-    // index. Slices are still one MIR argument here; mir-lower remaps the
-    // proof to the pointer component after ABI flattening.
+    // Keep all Rust-semantic decisions attached to the source argument index.
+    // MIR lowering remaps them to physical LLVM pointer arguments after ABI
+    // flattening; llvm-export only serializes the resulting proof facts.
     for (arg_index, attrs) in reference_param_attrs_by_arg.into_iter().enumerate() {
         mir_func_op.set_reference_param_attrs(ctx, arg_index, attrs.noalias, attrs.readonly);
+        mir_func_op.set_reference_param_validity_attrs(
+            ctx,
+            arg_index,
+            attrs.nonnull,
+            attrs.pointee_align,
+            attrs.dereferenceable,
+        );
     }
 
     // Check if the function has the #[cuda_oxide::kernel] attribute (passed via is_kernel flag)
@@ -2156,29 +2192,33 @@ mod tests {
     }
 
     #[test]
-    fn reference_param_attrs_follow_rustc_freeze_and_unpin_rules() {
+    fn reference_param_attrs_follow_rustc_reference_validity_rules() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time before unix epoch")
             .as_nanos();
         let root = std::env::temp_dir().join(format!(
-            "cuda_oxide_reference_attrs_{}_{}",
+            "cuda_oxide_reference_validity_attrs_{}_{}",
             std::process::id(),
             unique
         ));
         std::fs::create_dir_all(&root).unwrap();
-        let fixture = root.join("reference_attrs_fixture.rs");
+        let fixture = root.join("reference_validity_attrs_fixture.rs");
         std::fs::write(
             &fixture,
             r#"
 use core::cell::UnsafeCell;
 use core::marker::PhantomPinned;
 
+#[repr(align(16))]
+pub struct AlignedZst;
+
 pub fn reference_attrs(
     shared: &u32,
     interior_mutable: &UnsafeCell<u32>,
     unique: &mut u32,
     pinned: &mut PhantomPinned,
+    aligned_zst: &AlignedZst,
     shared_slice: &[u32],
     interior_mutable_slice: &[UnsafeCell<u32>],
     unique_slice: &mut [u32],
@@ -2190,6 +2230,7 @@ pub fn reference_attrs(
         interior_mutable,
         unique,
         pinned,
+        aligned_zst,
         shared_slice,
         interior_mutable_slice,
         unique_slice,
@@ -2216,7 +2257,7 @@ pub fn reference_attrs(
             "rustc".to_string(),
             "--edition=2024".to_string(),
             "--crate-type=rlib".to_string(),
-            "--crate-name=reference_attrs_fixture".to_string(),
+            "--crate-name=reference_validity_attrs_fixture".to_string(),
             "--emit=metadata".to_string(),
             "-Zmir-opt-level=0".to_string(),
             format!("--out-dir={}", root.display()),
@@ -2237,7 +2278,7 @@ pub fn reference_attrs(
                         .locals()
                         .iter()
                         .skip(1)
-                        .take(9)
+                        .take(10)
                         .map(|decl| reference_param_attrs(&decl.ty))
                         .collect::<Vec<_>>();
                     std::ops::ControlFlow::<(), _>::Continue(attrs)
@@ -2256,21 +2297,44 @@ pub fn reference_attrs(
                 ReferenceParamAttrs {
                     noalias: true,
                     readonly: true,
+                    nonnull: true,
+                    pointee_align: Some(4),
+                    dereferenceable: Some(4),
                 },
-                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs {
+                    nonnull: true,
+                    pointee_align: Some(4),
+                    ..ReferenceParamAttrs::default()
+                },
                 ReferenceParamAttrs {
                     noalias: true,
-                    readonly: false,
+                    nonnull: true,
+                    pointee_align: Some(4),
+                    dereferenceable: Some(4),
+                    ..ReferenceParamAttrs::default()
                 },
-                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs {
+                    nonnull: true,
+                    ..ReferenceParamAttrs::default()
+                },
                 ReferenceParamAttrs {
                     noalias: true,
                     readonly: true,
+                    nonnull: true,
+                    pointee_align: Some(16),
+                    dereferenceable: None,
+                },
+                // This PR deliberately restricts validity facts to sized
+                // references. #1089 still supplies alias facts for slices.
+                ReferenceParamAttrs {
+                    noalias: true,
+                    readonly: true,
+                    ..ReferenceParamAttrs::default()
                 },
                 ReferenceParamAttrs::default(),
                 ReferenceParamAttrs {
                     noalias: true,
-                    readonly: false,
+                    ..ReferenceParamAttrs::default()
                 },
                 ReferenceParamAttrs::default(),
                 ReferenceParamAttrs::default(),

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -1494,6 +1494,44 @@ fn emit_entry_allocas(
     prev_op
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ReferenceParamAttrs {
+    noalias: bool,
+    readonly: bool,
+}
+
+/// Reproduce rustc's reference-derived LLVM argument policy for the two
+/// attributes this backend currently understands. The decision is made while
+/// the original Rust `Ty` and the compiler type context are still available;
+/// downstream passes only propagate the resulting proof bits.
+///
+/// rustc currently permits:
+/// - `&T`: `noalias + readonly` only when `T: Freeze`;
+/// - `&mut T`: `noalias` only when `T: Unpin`;
+/// - raw pointers: neither attribute.
+fn reference_param_attrs(ty: &Ty) -> ReferenceParamAttrs {
+    let TyKind::RigidTy(RigidTy::Ref(_, pointee, mutability)) = ty.kind() else {
+        return ReferenceParamAttrs::default();
+    };
+
+    rustc_middle::ty::tls::with(|tcx| {
+        let pointee = rustc_public::rustc_internal::internal(tcx, pointee);
+        let typing_env = rustc_middle::ty::TypingEnv::fully_monomorphized();
+
+        match mutability {
+            mir::Mutability::Not if pointee.is_freeze(tcx, typing_env) => ReferenceParamAttrs {
+                noalias: true,
+                readonly: true,
+            },
+            mir::Mutability::Mut if pointee.is_unpin(tcx, typing_env) => ReferenceParamAttrs {
+                noalias: true,
+                readonly: false,
+            },
+            _ => ReferenceParamAttrs::default(),
+        }
+    })
+}
+
 /// Translates a MIR function body to a pliron IR `mir.func` operation.
 ///
 /// # Process
@@ -1568,6 +1606,7 @@ pub fn translate_body(
     // Get function argument types for the first block
     // In MIR, locals[0] is the return value, locals[1..arg_count+1] are function arguments
     let mut arg_types = Vec::new();
+    let mut reference_param_attrs_by_arg = Vec::new();
 
     // Determine argument count from the function type in the instance
     // Get the function signature to determine the number of arguments
@@ -1627,6 +1666,7 @@ pub fn translate_body(
         let ty = &local_decl.ty;
         let arg_type = types::translate_type(ctx, ty)?;
         arg_types.push(arg_type);
+        reference_param_attrs_by_arg.push(reference_param_attrs(ty));
     }
 
     // Get return type (local 0)
@@ -1686,6 +1726,13 @@ pub fn translate_body(
         instance.name().to_string()
     };
     mir_func_op.set_symbol_name(ctx, legaliser.legalise(&name_str));
+
+    // Keep rustc's aliasing decision attached to the source-level argument
+    // index. Slices are still one MIR argument here; mir-lower remaps the
+    // proof to the pointer component after ABI flattening.
+    for (arg_index, attrs) in reference_param_attrs_by_arg.into_iter().enumerate() {
+        mir_func_op.set_reference_param_attrs(ctx, arg_index, attrs.noalias, attrs.readonly);
+    }
 
     // Check if the function has the #[cuda_oxide::kernel] attribute (passed via is_kernel flag)
     if is_kernel {
@@ -2105,6 +2152,129 @@ mod tests {
                 .0
                 .contains_key(&key),
             "`is_inline_always` must become an LLVM dialect alwaysinline attribute before export",
+        );
+    }
+
+    #[test]
+    fn reference_param_attrs_follow_rustc_freeze_and_unpin_rules() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_reference_attrs_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("reference_attrs_fixture.rs");
+        std::fs::write(
+            &fixture,
+            r#"
+use core::cell::UnsafeCell;
+use core::marker::PhantomPinned;
+
+pub fn reference_attrs(
+    shared: &u32,
+    interior_mutable: &UnsafeCell<u32>,
+    unique: &mut u32,
+    pinned: &mut PhantomPinned,
+    shared_slice: &[u32],
+    interior_mutable_slice: &[UnsafeCell<u32>],
+    unique_slice: &mut [u32],
+    raw_const: *const u32,
+    raw_mut: *mut u32,
+) {
+    let _ = (
+        shared,
+        interior_mutable,
+        unique,
+        pinned,
+        shared_slice,
+        interior_mutable_slice,
+        unique_slice,
+        raw_const,
+        raw_mut,
+    );
+}
+"#,
+        )
+        .unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=reference_attrs_fixture".to_string(),
+            "--emit=metadata".to_string(),
+            "-Zmir-opt-level=0".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        let attrs = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    let body = rustc_public::all_local_items()
+                        .into_iter()
+                        .filter_map(|item| item.body())
+                        .next()
+                        .expect("fixture function body");
+                    let attrs = body
+                        .locals()
+                        .iter()
+                        .skip(1)
+                        .take(9)
+                        .map(|decl| reference_param_attrs(&decl.ty))
+                        .collect::<Vec<_>>();
+                    std::ops::ControlFlow::<(), _>::Continue(attrs)
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        std::fs::remove_dir_all(&root).ok();
+
+        assert_eq!(
+            attrs,
+            vec![
+                ReferenceParamAttrs {
+                    noalias: true,
+                    readonly: true,
+                },
+                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs {
+                    noalias: true,
+                    readonly: false,
+                },
+                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs {
+                    noalias: true,
+                    readonly: true,
+                },
+                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs {
+                    noalias: true,
+                    readonly: false,
+                },
+                ReferenceParamAttrs::default(),
+                ReferenceParamAttrs::default(),
+            ]
         );
     }
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -32,7 +32,7 @@
 
 use super::types;
 use crate::error::{TranslationErr, TranslationResult};
-use crate::translator::values::ValueMap;
+use crate::translator::values::{ValueMap, generic_pointer_kind_retype_allowed};
 use dialect_iket::{ops::IketSentinelTokenOp, types::IketRangeTokenType};
 use dialect_mir::attributes::MirCastKindAttr;
 use dialect_mir::attributes::MirFP16Attr;
@@ -43,7 +43,7 @@ use dialect_mir::ops::{
     MirInsertFieldOp, MirLeOp, MirLoadOp, MirLtOp, MirMulOp, MirNeOp, MirNegOp, MirNotOp,
     MirPtrOffsetOp, MirRefOp, MirRemOp, MirShlOp, MirShrOp, MirSubOp, MirUndefOp,
 };
-use dialect_mir::types::MirFP16Type;
+use dialect_mir::types::{MirFP16Type, MirPointerKind};
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -62,18 +62,14 @@ use rustc_public::ty::{AdtKind, ConstantKind};
 use rustc_public_bridge::IndexedVal;
 use std::num::NonZeroUsize;
 
-/// Cast a value to a target type if address spaces differ.
+/// Normalize a pointer-like value without creating new Rust pointer semantics.
 ///
-/// When constructing structs/enums, the field type uses generic address space (0)
-/// because Rust's type system doesn't carry address space info. But the actual
-/// value may have a specific address space (e.g., addrspace:3 for shared memory).
-///
-/// This function inserts a MirCastOp to convert from the specific address space
-/// to the generic address space, following LLVM's model where generic pointers
-/// can hold any address space pointer.
-///
-/// Returns the (possibly casted) value and the last inserted operation.
-fn cast_to_generic_addrspace_if_needed(
+/// This helper is for representation adjustments such as address-space
+/// normalization and aggregate/local type reconciliation. Thin pointers must
+/// have the same pointee and fat slices the same element type. A concrete kind
+/// may be preserved or deliberately erased, but `Erased` cannot regain a
+/// concrete Rust kind and two distinct concrete kinds cannot be interconverted.
+fn cast_to_expected_pointer_type_if_needed(
     ctx: &mut Context,
     value: Value,
     expected_type: TypeHandle,
@@ -82,59 +78,126 @@ fn cast_to_generic_addrspace_if_needed(
     loc: Location,
 ) -> (Value, Option<Ptr<Operation>>) {
     let value_type = value.get_type(ctx);
-
-    // Check if both are pointer types
-    let value_ptr_info: Option<(TypeHandle, bool, u32)> = {
-        let ty_ref = value_type.deref(ctx);
-        ty_ref
-            .downcast_ref::<dialect_mir::types::MirPtrType>()
-            .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space))
-    };
-
-    let expected_ptr_info: Option<(TypeHandle, bool, u32)> = {
-        let ty_ref = expected_type.deref(ctx);
-        ty_ref
-            .downcast_ref::<dialect_mir::types::MirPtrType>()
-            .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space))
-    };
-
-    if let (
-        Some((val_pointee, val_mut, val_addrspace)),
-        Some((exp_pointee, exp_mut, exp_addrspace)),
-    ) = (value_ptr_info, expected_ptr_info)
-    {
-        // Both are pointers - check if address spaces differ
-        if val_addrspace != exp_addrspace && val_pointee == exp_pointee && val_mut == exp_mut {
-            // Need to insert an address space cast
-            // Create the target type (same pointer but with expected address space)
-            let target_ptr_ty =
-                dialect_mir::types::MirPtrType::get(ctx, exp_pointee, exp_mut, exp_addrspace);
-
-            let cast_op = Operation::new(
-                ctx,
-                MirCastOp::get_concrete_op_info(),
-                vec![target_ptr_ty.into()],
-                vec![value],
-                vec![],
-                0,
-            );
-            cast_op.deref_mut(ctx).set_loc(loc);
-            MirCastOp::new(cast_op).set_attr_cast_kind(ctx, MirCastKindAttr::PtrToPtr);
-
-            if let Some(prev) = prev_op {
-                cast_op.insert_after(ctx, prev);
-            } else {
-                cast_op.insert_at_front(block_ptr, ctx);
-            }
-
-            let casted_value = cast_op.deref(ctx).get_result(0);
-            return (casted_value, Some(cast_op));
-        }
+    if value_type == expected_type {
+        return (value, prev_op);
     }
 
-    // No cast needed
-    (value, prev_op)
+    let compatible = {
+        let value_ref = value_type.deref(ctx);
+        let expected_ref = expected_type.deref(ctx);
+
+        match (
+            value_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+            expected_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+        ) {
+            (Some(value_ptr), Some(expected_ptr)) => {
+                value_ptr.pointee == expected_ptr.pointee
+                    && generic_pointer_kind_retype_allowed(value_ptr.kind, expected_ptr.kind)
+            }
+            _ => match (
+                value_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+                expected_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+            ) {
+                (Some(value_slice), Some(expected_slice)) => {
+                    value_slice.element_ty == expected_slice.element_ty
+                        && generic_pointer_kind_retype_allowed(
+                            value_slice.kind,
+                            expected_slice.kind,
+                        )
+                }
+                _ => false,
+            },
+        }
+    };
+
+    if !compatible {
+        return (value, prev_op);
+    }
+
+    let cast_op = Operation::new(
+        ctx,
+        MirCastOp::get_concrete_op_info(),
+        vec![expected_type],
+        vec![value],
+        vec![],
+        0,
+    );
+    cast_op.deref_mut(ctx).set_loc(loc);
+    MirCastOp::new(cast_op).set_attr_cast_kind(ctx, MirCastKindAttr::PtrToPtr);
+
+    match prev_op {
+        Some(prev) => cast_op.insert_after(ctx, prev),
+        None => cast_op.insert_at_front(block_ptr, ctx),
+    }
+
+    (cast_op.deref(ctx).get_result(0), Some(cast_op))
 }
+
+/// Establish the exact pointer/reference type declared by rustc at a semantic boundary.
+///
+/// `Rvalue::Ref` and `Rvalue::AddressOf` are not representation-only
+/// normalizations: they create a new Rust pointer/reference value. The result
+/// type supplied by rustc is therefore authoritative, including legitimate
+/// transitions such as `RawMut -> UniqueRef` for `unsafe { &mut *raw }`. This
+/// helper still requires the same thin-pointee or fat-slice element shape so it
+/// cannot hide an unrelated representation mismatch.
+fn cast_to_declared_rust_pointer_type_if_needed(
+    ctx: &mut Context,
+    value: Value,
+    expected_type: TypeHandle,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    loc: Location,
+) -> (Value, Option<Ptr<Operation>>) {
+    let value_type = value.get_type(ctx);
+    if value_type == expected_type {
+        return (value, prev_op);
+    }
+
+    let compatible = {
+        let value_ref = value_type.deref(ctx);
+        let expected_ref = expected_type.deref(ctx);
+
+        match (
+            value_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+            expected_ref.downcast_ref::<dialect_mir::types::MirPtrType>(),
+        ) {
+            (Some(value_ptr), Some(expected_ptr)) => value_ptr.pointee == expected_ptr.pointee,
+            _ => match (
+                value_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+                expected_ref.downcast_ref::<dialect_mir::types::MirSliceType>(),
+            ) {
+                (Some(value_slice), Some(expected_slice)) => {
+                    value_slice.element_ty == expected_slice.element_ty
+                }
+                _ => false,
+            },
+        }
+    };
+
+    if !compatible {
+        return (value, prev_op);
+    }
+
+    let cast_op = Operation::new(
+        ctx,
+        MirCastOp::get_concrete_op_info(),
+        vec![expected_type],
+        vec![value],
+        vec![],
+        0,
+    );
+    cast_op.deref_mut(ctx).set_loc(loc);
+    MirCastOp::new(cast_op).set_attr_cast_kind(ctx, MirCastKindAttr::PtrToPtr);
+
+    match prev_op {
+        Some(prev) => cast_op.insert_after(ctx, prev),
+        None => cast_op.insert_at_front(block_ptr, ctx),
+    }
+
+    (cast_op.deref(ctx).get_result(0), Some(cast_op))
+}
+
 /// Coerce a raw data pointer so it points to `element_type` in the generic
 /// address space.
 ///
@@ -144,9 +207,8 @@ fn cast_to_generic_addrspace_if_needed(
 /// pre-cast pointee. The fat pointer's data slot must be a generic-address-space
 /// pointer to the slice element type (the same `get_generic` slot every other
 /// data-slot construction uses), so when the pointee differs, emit a `PtrToPtr`
-/// cast to that type. This also normalizes a non-generic address space, composing
-/// with `cast_to_generic_addrspace_if_needed`, which only fires when the pointee
-/// already matched.
+/// cast to that type. This physical carrier is intentionally `Erased`; the
+/// enclosing `MirSliceType` retains the Rust pointer/reference kind.
 fn coerce_slice_data_pointee(
     ctx: &mut Context,
     value: Value,
@@ -215,7 +277,7 @@ fn cast_struct_fields_to_expected_types(
 
     for (i, value) in field_values.into_iter().enumerate() {
         if let Some(expected_type) = field_types.get(i) {
-            let (casted_value, new_prev_op) = cast_to_generic_addrspace_if_needed(
+            let (casted_value, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                 ctx,
                 value,
                 *expected_type,
@@ -270,7 +332,7 @@ fn cast_enum_fields_to_expected_types(
 
     for (i, value) in field_values.into_iter().enumerate() {
         if let Some(expected_type) = variant_field_types.get(i) {
-            let (casted_value, new_prev_op) = cast_to_generic_addrspace_if_needed(
+            let (casted_value, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                 ctx,
                 value,
                 *expected_type,
@@ -756,16 +818,34 @@ pub fn translate_rvalue(
             // no extra allocation is needed. `mem2reg` folds this back into
             // SSA when the borrow doesn't escape.
             //
-            // Mutability: slots are always allocated mutable (we may store
-            // into them regardless of the Rust mutability of the local).
-            // Callers that expect a `*const T` pointer handle the coercion
-            // via `MirCastOp::PointerCoercionMutToConst`; most consumers in
-            // the dialect (FieldAddr, ArrayElementAddr, Load, Store) are
-            // mutability-agnostic at the pliron level.
+            // Slots are always allocated mutable because the importer writes
+            // locals through them. They are compiler storage, not `&mut T`.
+            // The normalization below retypes the physical slot address to the
+            // exact Rust reference kind without treating slot mutability as
+            // evidence of uniqueness.
             let is_mutable = matches!(borrow_kind, mir::BorrowKind::Mut { .. });
+            let pointer_kind = MirPointerKind::from_reference_mutability(is_mutable);
             if place.projection.is_empty() {
                 if let Some(slot) = value_map.get_slot(place.local) {
-                    return Ok((None, slot, prev_op));
+                    // The slot is compiler storage (`Erased`) and is always
+                    // mutable. Taking a Rust borrow is the semantic boundary
+                    // where that physical address acquires the exact `&T` /
+                    // `&mut T` type recorded by rustc.
+                    let rust_result_type = rvalue.ty(body.locals()).map_err(|error| {
+                        input_error_noloc!(TranslationErr::unsupported(format!(
+                            "failed to determine reference rvalue type: {error:?}"
+                        )))
+                    })?;
+                    let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
+                    let (result, last_inserted) = cast_to_declared_rust_pointer_type_if_needed(
+                        ctx,
+                        slot,
+                        expected_ptr_type,
+                        block_ptr,
+                        prev_op,
+                        loc.clone(),
+                    );
+                    return Ok((None, result, last_inserted));
                 }
                 // ZST local (no slot). Synthesise a pointer-to-ZST via
                 // MirRefOp as a fallback so callers still get a well-typed
@@ -789,7 +869,12 @@ pub fn translate_rvalue(
                             loc.clone(),
                         )?
                     };
-                let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, ty_ptr, is_mutable);
+                let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                    ctx,
+                    ty_ptr,
+                    is_mutable,
+                    pointer_kind,
+                );
                 let ref_op = Operation::new(
                     ctx,
                     MirRefOp::get_concrete_op_info(),
@@ -832,7 +917,7 @@ pub fn translate_rvalue(
                 })?;
                 let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
 
-                let (result_val, last_inserted) = cast_to_generic_addrspace_if_needed(
+                let (result_val, last_inserted) = cast_to_declared_rust_pointer_type_if_needed(
                     ctx,
                     result_val,
                     expected_ptr_type,
@@ -872,7 +957,12 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let val_ty = val.get_type(ctx);
-            let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, val_ty, is_mutable);
+            let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                ctx,
+                val_ty,
+                is_mutable,
+                pointer_kind,
+            );
 
             let ref_op = Operation::new(
                 ctx,
@@ -896,12 +986,29 @@ pub fn translate_rvalue(
             // same unified address walker as `Rvalue::Ref` (which also gives
             // raw pointers the runtime-Index / ConstantIndex handling).
             let is_mutable = matches!(mutability, mir::RawPtrKind::Mut);
+            let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
 
-            // Bare local: the alloca slot IS the address.
+            // Bare local: the alloca slot is the physical address, but the
+            // result must carry the exact raw-pointer kind rather than the
+            // slot's compiler-only `Erased` provenance.
             if place.projection.is_empty()
                 && let Some(slot) = value_map.get_slot(place.local)
             {
-                return Ok((None, slot, prev_op));
+                let rust_result_type = rvalue.ty(body.locals()).map_err(|error| {
+                    input_error_noloc!(TranslationErr::unsupported(format!(
+                        "failed to determine address-of rvalue type: {error:?}"
+                    )))
+                })?;
+                let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
+                let (result, last_inserted) = cast_to_declared_rust_pointer_type_if_needed(
+                    ctx,
+                    slot,
+                    expected_ptr_type,
+                    block_ptr,
+                    prev_op,
+                    loc.clone(),
+                );
+                return Ok((None, result, last_inserted));
             }
 
             // Unified address path: full projection walk from the slot
@@ -926,7 +1033,7 @@ pub fn translate_rvalue(
                 })?;
                 let expected_ptr_type = types::translate_type(ctx, &rust_result_type)?;
 
-                let (result_val, last_inserted) = cast_to_generic_addrspace_if_needed(
+                let (result_val, last_inserted) = cast_to_declared_rust_pointer_type_if_needed(
                     ctx,
                     result_val,
                     expected_ptr_type,
@@ -962,7 +1069,12 @@ pub fn translate_rvalue(
                 translate_place(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
 
             let val_ty = val.get_type(ctx);
-            let ptr_ty = dialect_mir::types::MirPtrType::get_generic(ctx, val_ty, is_mutable);
+            let ptr_ty = dialect_mir::types::MirPtrType::get_generic_with_kind(
+                ctx,
+                val_ty,
+                is_mutable,
+                pointer_kind,
+            );
 
             use dialect_mir::ops::MirRefOp;
             let ref_op = Operation::new(
@@ -1260,7 +1372,7 @@ pub fn translate_rvalue(
                             current_prev_op,
                             loc.clone(),
                         )?;
-                        let (val, new_prev_op) = cast_to_generic_addrspace_if_needed(
+                        let (val, new_prev_op) = cast_to_expected_pointer_type_if_needed(
                             ctx,
                             val,
                             element_type,
@@ -1381,6 +1493,7 @@ pub fn translate_rvalue(
                     }
 
                     let is_mutable = matches!(mutability, Mutability::Mut);
+                    let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
 
                     match pointee_ty.kind() {
                         TyKind::RigidTy(RigidTy::Slice(elem_ty)) => {
@@ -1420,14 +1533,15 @@ pub fn translate_rvalue(
                                     is_mutable,
                                 )
                                 .into();
-                            let (data_val, current_prev_op) = cast_to_generic_addrspace_if_needed(
-                                ctx,
-                                data_val,
-                                expected_ptr_ty,
-                                block_ptr,
-                                prev_after_len,
-                                loc.clone(),
-                            );
+                            let (data_val, current_prev_op) =
+                                cast_to_expected_pointer_type_if_needed(
+                                    ctx,
+                                    data_val,
+                                    expected_ptr_ty,
+                                    block_ptr,
+                                    prev_after_len,
+                                    loc.clone(),
+                                );
 
                             // Coerce the data pointer to the slice element type: a
                             // reinterpret cast feeding `from_raw_parts` can leave it
@@ -1443,7 +1557,11 @@ pub fn translate_rvalue(
                                 loc.clone(),
                             );
 
-                            let slice_ty = dialect_mir::types::MirSliceType::get(ctx, element_type);
+                            let slice_ty = dialect_mir::types::MirSliceType::get_with_kind(
+                                ctx,
+                                element_type,
+                                pointer_kind,
+                            );
 
                             use dialect_mir::ops::MirConstructSliceOp;
                             let op = Operation::new(
@@ -1905,8 +2023,10 @@ pub fn translate_operand(
                 // Extract element type, size, and alignment from SharedArray<T, N, ALIGN>
                 let (elem_ty, array_size, alignment) = extract_shared_array_info(ctx, &rust_ty)?;
 
-                // Create a shared memory pointer type
-                let ptr_ty = dialect_mir::types::MirPtrType::get_shared(ctx, elem_ty, true).into();
+                // The constant's Rust type is authoritative for reference/raw-pointer kind.
+                // Preserve that kind directly on the shared-memory producer instead of
+                // relying on a later local-store normalization to recover it from Erased.
+                let ptr_ty = types::translate_type(ctx, &rust_ty)?;
 
                 // Create a MirSharedAllocOp to represent the shared memory allocation
                 // This will be lowered to an LLVM global with addrspace(3)
@@ -1981,7 +2101,8 @@ pub fn translate_operand(
                 .into();
 
                 // Create a shared memory pointer type (addrspace 3)
-                let ptr_ty = dialect_mir::types::MirPtrType::get_shared(ctx, elem_ty, true).into();
+                // Preserve the Rust pointer/reference kind on the producer itself.
+                let ptr_ty = types::translate_type(ctx, &rust_ty)?;
 
                 // Create a MirSharedAllocOp for the barrier
                 use dialect_mir::ops::MirSharedAllocOp;
@@ -2039,7 +2160,7 @@ pub fn translate_operand(
             // statics have already been intercepted above and remain addrspace 3.
             // Statics tagged `#[constant]` (detected by the mangled symbol
             // prefix) instead lower into constant memory (addrspace 4).
-            if let Some((pointee_ty, is_mutable)) = get_static_pointer_info(&rust_ty)
+            if let Some((pointee_ty, is_mutable, pointer_kind)) = get_static_pointer_info(&rust_ty)
                 && let Some(static_target) = static_target_from_constant(constant, loc.clone())?
             {
                 let static_ty = static_target.static_def.ty();
@@ -2077,6 +2198,7 @@ pub fn translate_operand(
                             elem_ty,
                             len,
                             is_mutable,
+                            pointer_kind,
                             0,
                             block_ptr,
                             prev_op,
@@ -2126,6 +2248,7 @@ pub fn translate_operand(
                         elem_ty,
                         len,
                         is_mutable,
+                        pointer_kind,
                         static_target.byte_offset,
                         block_ptr,
                         prev_op,
@@ -2583,7 +2706,7 @@ pub fn translate_operand(
 
                     // The shared materializer needs the pointee's Rust type for
                     // enum-layout queries and ZST detection.
-                    let Some((pointee_rust_ty, _)) = get_static_pointer_info(&rust_ty) else {
+                    let Some((pointee_rust_ty, _, _)) = get_static_pointer_info(&rust_ty) else {
                         return input_err!(
                             loc,
                             TranslationErr::unsupported(format!(
@@ -4373,6 +4496,17 @@ fn emit_slice_subslice_value(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> TranslationResult<(Value, Ptr<Operation>)> {
+    // Subslice is a projection of an existing fat pointer, not a new borrow.
+    // Preserve the source pointer category; callers that explicitly form a
+    // reborrow/raw address normalize the terminal result to their new Rust
+    // type afterwards.
+    let pointer_kind = slice_value
+        .get_type(ctx)
+        .deref(ctx)
+        .downcast_ref::<dialect_mir::types::MirSliceType>()
+        .map(|slice| slice.pointer_kind())
+        .unwrap_or(MirPointerKind::Erased);
+
     use dialect_mir::ops::MirConstructSliceOp;
 
     let Some(trim) = from.checked_add(to) else {
@@ -4444,7 +4578,7 @@ fn emit_slice_subslice_value(
     sub_op.insert_after(ctx, trim_op);
     let new_len = sub_op.deref(ctx).get_result(0);
 
-    let slice_ty = dialect_mir::types::MirSliceType::get(ctx, element_ty);
+    let slice_ty = dialect_mir::types::MirSliceType::get_with_kind(ctx, element_ty, pointer_kind);
     let construct = Operation::new(
         ctx,
         MirConstructSliceOp::get_concrete_op_info(),
@@ -5556,7 +5690,7 @@ fn construct_disjoint_slice_aggregate(
     // verifier expects.
     let expected_ptr_ty: TypeHandle =
         dialect_mir::types::MirPtrType::get_generic(ctx, element_type, true).into();
-    let (data_val, current_prev_op) = cast_to_generic_addrspace_if_needed(
+    let (data_val, current_prev_op) = cast_to_expected_pointer_type_if_needed(
         ctx,
         runtime_fields[0],
         expected_ptr_ty,
@@ -5806,12 +5940,12 @@ pub fn translate_place_iterative(
                     .is::<dialect_mir::types::MirSliceType>();
                 let pointer_info = get_static_pointer_info(&current_rust_ty);
                 let slice_deref_mutability =
-                    pointer_info.as_ref().and_then(|(pointee, is_mutable)| {
+                    pointer_info.as_ref().and_then(|(pointee, is_mutable, _)| {
                         rust_ty_is_slice(pointee).then_some(*is_mutable)
                     });
                 let current_is_slice_tail_ref = pointer_info
                     .as_ref()
-                    .is_some_and(|(pointee, _)| types::slice_tail_element_ty(pointee).is_some());
+                    .is_some_and(|(pointee, _, _)| types::slice_tail_element_ty(pointee).is_some());
 
                 if next_is_slice_subslice
                     && current_is_fat_slice
@@ -6611,7 +6745,7 @@ fn translate_ptr_to_array_constant(
     );
 
     let global_ptr = global_alloc.get_operation().deref(ctx).get_result(0);
-    let (ptr_val, last_op) = cast_to_generic_addrspace_if_needed(
+    let (ptr_val, last_op) = cast_to_declared_rust_pointer_type_if_needed(
         ctx,
         global_ptr,
         const_ty_ptr,
@@ -10017,7 +10151,7 @@ fn translate_union_aggregate(
         prev_op,
         loc.clone(),
     )?;
-    let (active_value, current_prev_op) = cast_to_generic_addrspace_if_needed(
+    let (active_value, current_prev_op) = cast_to_expected_pointer_type_if_needed(
         ctx,
         active_value,
         expected_field_ty,
@@ -11461,6 +11595,7 @@ fn translate_static_array_as_slice(
     elem_ty: rustc_public::ty::Ty,
     len: u64,
     is_mutable: bool,
+    pointer_kind: MirPointerKind,
     byte_offset: u64,
     block_ptr: Ptr<BasicBlock>,
     prev_op: Option<Ptr<Operation>>,
@@ -11539,7 +11674,7 @@ fn translate_static_array_as_slice(
     };
     let len_val = len_op.deref(ctx).get_result(0);
 
-    let slice_ty = MirSliceType::get(ctx, elem_mir_ty);
+    let slice_ty = MirSliceType::get_with_kind(ctx, elem_mir_ty, pointer_kind);
     let construct = Operation::new(
         ctx,
         MirConstructSliceOp::get_concrete_op_info(),
@@ -11839,7 +11974,7 @@ fn translate_slice_at_alloc_offset(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> TranslationResult<(Value, Option<Ptr<Operation>>)> {
-    let Some((pointee_ty, is_mutable)) = get_static_pointer_info(rust_ty) else {
+    let Some((pointee_ty, is_mutable, pointer_kind)) = get_static_pointer_info(rust_ty) else {
         return input_err!(
             loc,
             TranslationErr::unsupported(format!(
@@ -11903,6 +12038,7 @@ fn translate_slice_at_alloc_offset(
         elem_ty,
         len,
         is_mutable,
+        pointer_kind,
         static_target.byte_offset,
         block_ptr,
         prev_op,
@@ -13046,19 +13182,33 @@ fn set_global_initializer_relocations_attr(
 }
 
 /// Check if a type is a pointer/reference to a static allocation.
-/// Returns `(pointee_ty, is_mutable)` when the type can carry a static address.
+/// Returns `(pointee_ty, is_mutable, pointer_kind)` when the type can carry a
+/// static address. Keeping the kind here prevents constant materialization from
+/// collapsing `&T`/`&mut T` and raw pointers before they enter `dialect-mir`.
 use super::values::is_constant_wrapper_type;
 
-fn get_static_pointer_info(ty: &rustc_public::ty::Ty) -> Option<(rustc_public::ty::Ty, bool)> {
+fn get_static_pointer_info(
+    ty: &rustc_public::ty::Ty,
+) -> Option<(rustc_public::ty::Ty, bool, MirPointerKind)> {
     use rustc_public::mir::Mutability;
     use rustc_public::ty::{RigidTy, TyKind};
 
     match ty.kind() {
         TyKind::RigidTy(RigidTy::RawPtr(pointee_ty, mutability)) => {
-            Some((pointee_ty, mutability == Mutability::Mut))
+            let is_mutable = mutability == Mutability::Mut;
+            Some((
+                pointee_ty,
+                is_mutable,
+                MirPointerKind::from_raw_mutability(is_mutable),
+            ))
         }
         TyKind::RigidTy(RigidTy::Ref(_, pointee_ty, mutability)) => {
-            Some((pointee_ty, mutability == Mutability::Mut))
+            let is_mutable = mutability == Mutability::Mut;
+            Some((
+                pointee_ty,
+                is_mutable,
+                MirPointerKind::from_reference_mutability(is_mutable),
+            ))
         }
         _ => None,
     }
@@ -14624,6 +14774,80 @@ mod tests {
     }
 
     #[test]
+    fn expected_pointer_normalization_rejects_concrete_kind_change() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let pointee_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let source_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            false,
+            MirPointerKind::SharedRef,
+        )
+        .into();
+        let target_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            true,
+            MirPointerKind::UniqueRef,
+        )
+        .into();
+        let block = BasicBlock::new(&mut ctx, None, vec![source_ty]);
+        let source = block.deref(&ctx).get_argument(0);
+
+        let (normalized, last_op) = cast_to_expected_pointer_type_if_needed(
+            &mut ctx,
+            source,
+            target_ty,
+            block,
+            None,
+            Location::Unknown,
+        );
+
+        assert_eq!(normalized.get_type(&ctx), source_ty);
+        assert!(
+            last_op.is_none(),
+            "generic normalization must not strengthen SharedRef into UniqueRef"
+        );
+    }
+
+    #[test]
+    fn rust_pointer_boundary_allows_raw_mut_reborrow_to_unique_ref() {
+        let mut ctx = Context::new();
+        crate::translator::register_dialects(&mut ctx);
+
+        let pointee_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let raw_mut_ty: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee_ty, true, MirPointerKind::RawMut)
+                .into();
+        let unique_ref_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            true,
+            MirPointerKind::UniqueRef,
+        )
+        .into();
+        let block = BasicBlock::new(&mut ctx, None, vec![raw_mut_ty]);
+        let raw_mut = block.deref(&ctx).get_argument(0);
+
+        let (reborrow, last_op) = cast_to_declared_rust_pointer_type_if_needed(
+            &mut ctx,
+            raw_mut,
+            unique_ref_ty,
+            block,
+            None,
+            Location::Unknown,
+        );
+
+        assert_eq!(reborrow.get_type(&ctx), unique_ref_ty);
+        assert!(
+            last_op.is_some(),
+            "Rvalue::Ref must trust rustc's declared reborrow result kind"
+        );
+    }
+
+    #[test]
     fn projected_address_normalization_matches_expected_pointer_type() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
@@ -14632,15 +14856,20 @@ mod tests {
 
         let physical_ptr_ty: TypeHandle = MirPtrType::get(&mut ctx, pointee_ty, false, 1).into();
 
-        let expected_rust_ptr_ty: TypeHandle =
-            MirPtrType::get_generic(&mut ctx, pointee_ty, false).into();
+        let expected_rust_ptr_ty: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            pointee_ty,
+            false,
+            MirPointerKind::SharedRef,
+        )
+        .into();
 
         let block = BasicBlock::new(&mut ctx, None, vec![physical_ptr_ty]);
         let physical_pointer = block.deref(&ctx).get_argument(0);
 
         // Rvalue::Ref and Rvalue::AddressOf both use this normalization after
         // computing a projected address in its physical address space.
-        let (normalized_pointer, last_op) = cast_to_generic_addrspace_if_needed(
+        let (normalized_pointer, last_op) = cast_to_declared_rust_pointer_type_if_needed(
             &mut ctx,
             physical_pointer,
             expected_rust_ptr_ty,
@@ -14652,7 +14881,7 @@ mod tests {
         assert_eq!(
             normalized_pointer.get_type(&ctx),
             expected_rust_ptr_ty,
-            "projected addresses must be normalized to the exact Rust pointer type"
+            "projected addresses must be normalized to the exact Rust pointer type and kind"
         );
 
         let cast_op = last_op.expect(

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -872,10 +872,18 @@ pub fn translate_statement(
             Ok(prev_op)
         }
 
-        // Codegen-irrelevant statements: borrow-check / type-system / coverage
-        // hints that have no runtime effect. Skipping is correct.
+        // `Retag` refines rustc's dynamic alias/provenance model but has no
+        // runtime effect. `dialect-mir` preserves the static source category
+        // (`&T`, `&mut T`, `*const T`, `*mut T`) in its pointer types, but it
+        // does not model Stacked/Tree Borrows tags or retag epochs. Therefore
+        // Retag remains an intentional no-op. Any future LLVM alias metadata
+        // must be based on an explicit audited policy, never inferred from the
+        // fact that Retag was skipped or from `MirPtrType::is_mutable`.
+        mir::StatementKind::Retag(..) => Ok(prev_op),
+
+        // Other codegen-irrelevant borrow-check / type-system / coverage hints
+        // have no runtime effect and are intentionally skipped.
         mir::StatementKind::FakeRead(..)
-        | mir::StatementKind::Retag(..)
         | mir::StatementKind::PlaceMention(..)
         | mir::StatementKind::AscribeUserType { .. }
         | mir::StatementKind::Coverage(..)
@@ -1205,6 +1213,9 @@ pub(crate) fn emit_array_element_store(
     prev_op: Option<Ptr<Operation>>,
     loc: Location,
 ) -> Ptr<Operation> {
+    // This is an address produced solely to perform the store, not a Rust
+    // reference/raw-pointer value. The legacy constructor intentionally gives
+    // it `MirPointerKind::Erased` provenance.
     let elem_ptr_ty =
         dialect_mir::types::MirPtrType::get(ctx, element_ty, true, address_space).into();
 
@@ -1243,7 +1254,8 @@ pub(crate) fn emit_array_element_store(
 /// callers of the statement module sometimes thread pointers coming from
 /// other sources (loads, field-addr ops, ...), which may be immutable.
 /// Derived addresses inherit the base pointer's mutability to keep pliron
-/// type checking consistent.
+/// type checking consistent. This bit is not an aliasing or uniqueness proof;
+/// source-level reference kind is tracked separately by `MirPointerKind`.
 pub(crate) fn pointer_is_mutable(ctx: &pliron::context::Context, ptr: Value) -> bool {
     let ty = ptr.get_type(ctx);
     let ty_ref = ty.deref(ctx);

--- a/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/memory.rs
@@ -766,14 +766,13 @@ pub fn emit_shared_array_as_ptr(
         loc.clone(),
     )?;
 
-    // Get the element type from the shared pointer type
-    let elem_ty = {
+    // Validate that the translated receiver is pointer-like. The pointee type is
+    // no longer used to synthesize the result: rustc's declared destination type
+    // is authoritative for the RawConst/RawMut result kind.
+    {
         let shared_ptr_ty = shared_ptr.get_type(ctx);
         let shared_ptr_obj = shared_ptr_ty.deref(ctx);
-
-        if let Some(mir_ptr) = shared_ptr_obj.downcast_ref::<MirPtrType>() {
-            mir_ptr.pointee
-        } else {
+        if shared_ptr_obj.downcast_ref::<MirPtrType>().is_none() {
             return input_err!(
                 loc.clone(),
                 TranslationErr::unsupported(format!(
@@ -782,18 +781,45 @@ pub fn emit_shared_array_as_ptr(
                 ))
             );
         }
-    }; // shared_ptr_obj borrow ends here
+    }
 
-    // Create generic pointer type (addrspace 0) with same element type
-    // For simplicity, we use immutable here - mutability is just a Rust concept
-    let generic_ptr_ty = MirPtrType::get(ctx, elem_ty, false, 0);
+    // This compiler-recognized Rust API is a semantic boundary: rustc's
+    // declared result type is authoritative for raw-pointer kind. `as_ptr`
+    // returns `*const T`, while `as_mut_ptr` and `as_raw_mut_ptr` return
+    // `*mut T`. Preserve that RawConst/RawMut distinction while narrowing
+    // the shared-memory address into the generic address space.
+    let result_rust_ty = match destination.ty(body.locals()) {
+        Ok(ty) => ty,
+        Err(error) => {
+            return input_err!(
+                loc.clone(),
+                TranslationErr::unsupported(format!(
+                    "SharedArray pointer conversion: failed to resolve result type: {error:?}"
+                ))
+            );
+        }
+    };
+    let generic_ptr_ty = types::translate_type(ctx, &result_rust_ty)?;
+    if generic_ptr_ty
+        .deref(ctx)
+        .downcast_ref::<MirPtrType>()
+        .is_none()
+    {
+        return input_err!(
+            loc.clone(),
+            TranslationErr::unsupported(format!(
+                "SharedArray pointer conversion: expected raw-pointer result type, got {:?}",
+                result_rust_ty
+            ))
+        );
+    }
 
     // Emit cast: shared (3) -> generic (0)
     // This is an addrspace cast but we use MirCastOp which is generic enough
     let cast_op = Operation::new(
         ctx,
         MirCastOp::get_concrete_op_info(),
-        vec![generic_ptr_ty.into()],
+        vec![generic_ptr_ty],
         vec![shared_ptr],
         vec![],
         0,

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -17,8 +17,8 @@
 //! | `char`              | `ui32`                              |
 //! | `(A, B, C)`         | `MirTupleType`                      |
 //! | `[T; N]`            | `ArrayType`                         |
-//! | `*const T`, `*mut T`| `MirPtrType` (generic addrspace)    |
-//! | `[T]`, `&[T]`       | `MirSliceType`                      |
+//! | `*const T`, `*mut T`| `MirPtrType` + raw pointer kind     |
+//! | `[T]`, `&[T]`       | `MirSliceType` + pointer kind       |
 //! | `struct S { .. }`   | `MirStructType`                     |
 //! | `union U { .. }`    | `MirUnionType`                      |
 //! | `enum E { .. }`     | `MirEnumType`                       |
@@ -44,8 +44,8 @@ use rustc_public_bridge::IndexedVal;
 
 // Re-export types from dialect_mir for convenience
 pub use dialect_mir::types::{
-    EnumEncoding, EnumVariant, MirDisjointSliceType, MirEnumType, MirPtrType, MirSliceType,
-    MirTupleType, MirUnionType, StructAbiKind,
+    EnumEncoding, EnumVariant, MirDisjointSliceType, MirEnumType, MirPointerKind, MirPtrType,
+    MirSliceType, MirTupleType, MirUnionType, StructAbiKind,
 };
 use rustc_public::mir::Mutability;
 
@@ -314,15 +314,17 @@ pub(super) fn slice_tail_element_ty(ty: &rustc_public::ty::Ty) -> Option<rustc_p
 
 /// Translates a raw-pointer or reference type to its `dialect-mir` equivalent.
 ///
-/// Most pointers become generic-addrspace `MirPtrType`, but a few Rust-level
-/// types are stand-ins for shared-memory objects in a CUDA kernel. We detect
-/// those here and produce the correct `addrspace(3)` pointer so that the
-/// alloca slot for such a local matches the pointer value produced by
-/// shared-memory intrinsics (e.g. `MirSharedAllocOp`). See module docs.
+/// `pointer_kind` is the source-level distinction that must survive this
+/// boundary: `&T`, `&mut T`, `*const T`, and `*mut T` remain different MIR
+/// types even when their physical pointee, mutability bit, and address space
+/// match. Most pointers use the generic address space; CUDA stand-ins such as
+/// `SharedArray` and `Barrier` retain the same source pointer kind while using
+/// their concrete shared-memory address space.
 fn translate_pointer_like(
     ctx: &mut Context,
     pointee: &rustc_public::ty::Ty,
     is_mutable: bool,
+    pointer_kind: MirPointerKind,
 ) -> TranslationResult<TypeHandle> {
     match pointee.kind() {
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Slice(elem_ty)) => {
@@ -333,7 +335,7 @@ fn translate_pointer_like(
             // the alloca slot even though Rust considers these freely
             // interconvertible.
             let elem = translate_type(ctx, &elem_ty)?;
-            Ok(MirSliceType::get(ctx, elem).into())
+            Ok(MirSliceType::get_with_kind(ctx, elem, pointer_kind).into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Str) => {
             // `&str` / `*const str` is a fat pointer (data ptr + length),
@@ -347,7 +349,7 @@ fn translate_pointer_like(
                 pliron::builtin::types::Signedness::Unsigned,
             )
             .into();
-            Ok(MirSliceType::get(ctx, u8_ty).into())
+            Ok(MirSliceType::get_with_kind(ctx, u8_ty, pointer_kind).into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, substs))
             if adt_def.trimmed_name() == "SharedArray" =>
@@ -357,7 +359,13 @@ fn translate_pointer_like(
             // `[T; N]`. Match the intrinsic-emitted shared-alloc pointer so
             // the alloca slot and the rvalue agree on type.
             let elem = shared_array_element_type(ctx, &substs, "SharedArray")?;
-            Ok(dialect_mir::types::MirPtrType::get_shared(ctx, elem, is_mutable).into())
+            Ok(dialect_mir::types::MirPtrType::get_shared_with_kind(
+                ctx,
+                elem,
+                is_mutable,
+                pointer_kind,
+            )
+            .into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, _substs))
             if adt_def.trimmed_name() == "Barrier" =>
@@ -370,7 +378,13 @@ fn translate_pointer_like(
                 pliron::builtin::types::Signedness::Unsigned,
             )
             .into();
-            Ok(dialect_mir::types::MirPtrType::get_shared(ctx, u64_ty, is_mutable).into())
+            Ok(dialect_mir::types::MirPtrType::get_shared_with_kind(
+                ctx,
+                u64_ty,
+                is_mutable,
+                pointer_kind,
+            )
+            .into())
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(..))
             if slice_tail_element_ty(pointee).is_some() =>
@@ -390,11 +404,11 @@ fn translate_pointer_like(
             // extracts the data pointer (the struct's address) first; see
             // the place-address walker in `rvalue.rs`.
             let struct_model = translate_type(ctx, pointee)?;
-            Ok(MirSliceType::get(ctx, struct_model).into())
+            Ok(MirSliceType::get_with_kind(ctx, struct_model, pointer_kind).into())
         }
         _ => {
             let pointee_ty = translate_type(ctx, pointee)?;
-            Ok(MirPtrType::get_generic(ctx, pointee_ty, is_mutable).into())
+            Ok(MirPtrType::get_generic_with_kind(ctx, pointee_ty, is_mutable, pointer_kind).into())
         }
     }
 }
@@ -652,7 +666,8 @@ pub fn translate_type(
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::RawPtr(ty, mutability)) => {
             let is_mutable = mutability == Mutability::Mut;
-            translate_pointer_like(ctx, &ty, is_mutable)
+            let pointer_kind = MirPointerKind::from_raw_mutability(is_mutable);
+            translate_pointer_like(ctx, &ty, is_mutable, pointer_kind)
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Ref(
             _region,
@@ -660,7 +675,8 @@ pub fn translate_type(
             mutability,
         )) => {
             let is_mutable = mutability == Mutability::Mut;
-            translate_pointer_like(ctx, &ty, is_mutable)
+            let pointer_kind = MirPointerKind::from_reference_mutability(is_mutable);
+            translate_pointer_like(ctx, &ty, is_mutable, pointer_kind)
         }
         rustc_public::ty::TyKind::RigidTy(rustc_public::ty::RigidTy::Adt(adt_def, substs)) => {
             // Get the trimmed name (just the type name without path)

--- a/crates/mir-importer/src/translator/values.rs
+++ b/crates/mir-importer/src/translator/values.rs
@@ -17,8 +17,8 @@
 //! # Slot address-space inference
 //!
 //! Rust's reference / raw-pointer types carry no address-space information
-//! (`&mut f32`, `*const u32` all translate to a generic `MirPtrType`). On
-//! GPU, however, intermediate locals frequently end up holding pointers in
+//! (`&mut f32`, `*const u32` are distinct pointer kinds but both default to a
+//! generic-address-space `MirPtrType`). On GPU, however, intermediate locals frequently end up holding pointers in
 //! a concrete address space — e.g. `let p = &mut TILE_A[i]` on a
 //! `SharedArray` produces an `addrspace(3)` pointer, yet the Rust local is
 //! typed `&mut f32` (generic).
@@ -37,7 +37,7 @@
 
 use dialect_mir::attributes::MirCastKindAttr;
 use dialect_mir::ops::{MirAllocaOp, MirCastOp, MirLoadOp, MirStoreOp};
-use dialect_mir::types::{MirPtrType, address_space};
+use dialect_mir::types::{MirPointerKind, MirPtrType, MirSliceType, address_space};
 use pliron::basic_block::BasicBlock;
 use pliron::context::{Context, Ptr};
 use pliron::op::Op;
@@ -157,14 +157,11 @@ impl ValueMap {
     /// Emit `mir.store` of `value` into `local`'s slot. Returns `None` for ZST
     /// / unset locals.
     ///
-    /// When `value` is a pointer whose type differs from the slot's declared
-    /// pointee (mutability, address space, or underlying pointee shape), a
-    /// `mir.cast <PtrToPtr>` is inserted automatically. This bridges the
-    /// common case where an rvalue produces a pointer in a concrete address
-    /// space (e.g. `shared_alloc` returning `*mut T addrspace(3)`) while the
-    /// local's Rust-declared type translates to a generic-addrspace pointer
-    /// (e.g. `*mut SharedArray<T, N>` -> `*mut ()`). All pointers have the
-    /// same runtime layout after lowering, so the cast is free.
+    /// When `value` is pointer-like and its representation differs from the
+    /// slot's declared pointee, a `mir.cast <PtrToPtr>` is inserted only for
+    /// representation-compatible transitions. Local storage does not establish
+    /// Rust pointer/reference semantics: `Erased` cannot regain a concrete kind
+    /// here, and distinct concrete kinds cannot be interconverted.
     pub fn store_local(
         &self,
         ctx: &mut Context,
@@ -189,9 +186,31 @@ impl ValueMap {
     }
 }
 
-/// If `value` is a pointer whose type differs from `target_ty` (also a
-/// pointer), emit a `mir.cast <PtrToPtr>` that converts it. Returns the (new)
-/// value and the (new) anchor op. Otherwise this is a no-op.
+/// Whether generic representation normalization may change `source` into `target`.
+///
+/// Generic helpers may preserve a concrete Rust pointer kind or deliberately
+/// forget it by converting to [`MirPointerKind::Erased`]. They must never
+/// recover a concrete kind from `Erased`, because that would make a sequence
+/// such as `SharedRef -> Erased -> UniqueRef` able to manufacture uniqueness.
+/// Establishing a new concrete kind belongs to an explicit Rust semantic
+/// boundary such as `Rvalue::Ref`, `Rvalue::AddressOf`, or a rustc-declared
+/// cast/coercion.
+pub(crate) fn generic_pointer_kind_retype_allowed(
+    source: MirPointerKind,
+    target: MirPointerKind,
+) -> bool {
+    source == target || target == MirPointerKind::Erased
+}
+
+/// If `value` and `target_ty` are compatible pointer-like MIR types, emit a
+/// `mir.cast <PtrToPtr>` to the exact target type. For thin pointers this
+/// intentionally retains the pre-existing behavior of bridging pointee-type
+/// mismatches; the semantic kind must still be preserved (or explicitly
+/// erased). Fat slices require the same element type and the same kind policy.
+///
+/// This helper performs representation normalization only. It must not create
+/// a Rust reference/raw-pointer category from an `Erased` value or switch
+/// directly between distinct concrete categories.
 pub(crate) fn maybe_ptr_coerce(
     ctx: &mut Context,
     value: Value,
@@ -204,12 +223,31 @@ pub(crate) fn maybe_ptr_coerce(
         return (value, prev_op);
     }
 
-    // Only auto-insert a PtrToPtr cast when both sides are already pointer
-    // types; anything else is a genuine translation mismatch and should be
-    // surfaced by the verifier, not papered over here.
-    let value_is_ptr = value_ty.deref(ctx).downcast_ref::<MirPtrType>().is_some();
-    let target_is_ptr = target_ty.deref(ctx).downcast_ref::<MirPtrType>().is_some();
-    if !(value_is_ptr && target_is_ptr) {
+    let compatible = {
+        let value_ref = value_ty.deref(ctx);
+        let target_ref = target_ty.deref(ctx);
+
+        match (
+            value_ref.downcast_ref::<MirPtrType>(),
+            target_ref.downcast_ref::<MirPtrType>(),
+        ) {
+            (Some(value_ptr), Some(target_ptr)) => {
+                generic_pointer_kind_retype_allowed(value_ptr.kind, target_ptr.kind)
+            }
+            _ => match (
+                value_ref.downcast_ref::<MirSliceType>(),
+                target_ref.downcast_ref::<MirSliceType>(),
+            ) {
+                (Some(value_slice), Some(target_slice)) => {
+                    value_slice.element_ty == target_slice.element_ty
+                        && generic_pointer_kind_retype_allowed(value_slice.kind, target_slice.kind)
+                }
+                _ => false,
+            },
+        }
+    };
+
+    if !compatible {
         return (value, prev_op);
     }
 
@@ -648,19 +686,21 @@ fn propagate_from_local(local: mir::Local, classes: &[SlotAddrSpace]) -> WriteCl
 /// current address space; otherwise return `elem_ty` unchanged.
 ///
 /// Used by `body::emit_entry_allocas` to override a Rust-declared pointer
-/// addrspace with the one inferred by [`SlotAddrSpaceMap`].
+/// addrspace with the one inferred by [`SlotAddrSpaceMap`]. The pointer kind
+/// is preserved exactly: address-space inference must never turn `&mut T` into
+/// an erased/raw pointer, or vice versa.
 pub fn align_pointer_addr_space(ctx: &mut Context, elem_ty: TypeHandle, target: u32) -> TypeHandle {
     let ptr_info = elem_ty
         .deref(ctx)
         .downcast_ref::<MirPtrType>()
-        .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space));
-    let Some((pointee, is_mutable, current)) = ptr_info else {
+        .map(|pt| (pt.pointee, pt.is_mutable, pt.address_space, pt.kind));
+    let Some((pointee, is_mutable, current, kind)) = ptr_info else {
         return elem_ty;
     };
     if current == target {
         return elem_ty;
     }
-    MirPtrType::get(ctx, pointee, is_mutable, target).into()
+    MirPtrType::get_with_kind(ctx, pointee, is_mutable, target, kind).into()
 }
 
 /// Extract a pointer type's address space, or `None` if `elem_ty` is not a
@@ -676,6 +716,167 @@ pub fn pointer_addr_space(ctx: &Context, elem_ty: TypeHandle) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pointer_like_local_coercion_does_not_recover_kind_from_erased() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let element: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let erased: TypeHandle = MirSliceType::get(&mut ctx, element).into();
+        let expected: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef).into();
+
+        let block = BasicBlock::new(&mut ctx, None, vec![erased]);
+        let value = block.deref(&ctx).get_argument(0);
+        let (value, cast) = maybe_ptr_coerce(&mut ctx, value, expected, block, None);
+
+        assert_eq!(value.get_type(&ctx), erased);
+        assert!(
+            cast.is_none(),
+            "generic normalization must not recover SharedRef from Erased"
+        );
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_keeps_thin_pointee_bridge() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let source_pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let target_pointee: TypeHandle = IntegerType::get(&ctx, 64, Signedness::Unsigned).into();
+        let source: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            source_pointee,
+            true,
+            MirPointerKind::RawMut,
+        )
+        .into();
+        let target: TypeHandle = MirPtrType::get_generic_with_kind(
+            &mut ctx,
+            target_pointee,
+            true,
+            MirPointerKind::RawMut,
+        )
+        .into();
+        let block = BasicBlock::new(&mut ctx, None, vec![source]);
+        let value = block.deref(&ctx).get_argument(0);
+
+        let (coerced, cast) = maybe_ptr_coerce(&mut ctx, value, target, block, None);
+
+        assert_eq!(coerced.get_type(&ctx), target);
+        assert!(
+            cast.is_some(),
+            "thin-pointer representation coercion must retain the historical pointee bridge"
+        );
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_cannot_launder_through_erased() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let shared: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::SharedRef)
+                .into();
+        let erased: TypeHandle = MirPtrType::get_generic(&mut ctx, pointee, false).into();
+        let unique: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef)
+                .into();
+        let block = BasicBlock::new(&mut ctx, None, vec![shared]);
+        let value = block.deref(&ctx).get_argument(0);
+
+        let (erased_value, erase_cast) = maybe_ptr_coerce(&mut ctx, value, erased, block, None);
+        assert_eq!(erased_value.get_type(&ctx), erased);
+        assert!(
+            erase_cast.is_some(),
+            "forgetting a concrete kind is allowed"
+        );
+
+        let previous_anchor = erase_cast.expect("erasing the concrete kind must emit a cast");
+        let (laundered, recover_anchor) =
+            maybe_ptr_coerce(&mut ctx, erased_value, unique, block, Some(previous_anchor));
+        assert_eq!(laundered.get_type(&ctx), erased);
+        assert!(
+            recover_anchor.is_some(),
+            "rejected recovery must preserve the previous insertion anchor"
+        );
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_rejects_concrete_kind_changes() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+
+        for (source_kind, source_mutable, target_kind, target_mutable) in [
+            (
+                MirPointerKind::SharedRef,
+                false,
+                MirPointerKind::UniqueRef,
+                true,
+            ),
+            (
+                MirPointerKind::RawConst,
+                false,
+                MirPointerKind::RawMut,
+                true,
+            ),
+            (
+                MirPointerKind::RawConst,
+                false,
+                MirPointerKind::SharedRef,
+                false,
+            ),
+        ] {
+            let source: TypeHandle =
+                MirPtrType::get_generic_with_kind(&mut ctx, pointee, source_mutable, source_kind)
+                    .into();
+            let target: TypeHandle =
+                MirPtrType::get_generic_with_kind(&mut ctx, pointee, target_mutable, target_kind)
+                    .into();
+            let block = BasicBlock::new(&mut ctx, None, vec![source]);
+            let value = block.deref(&ctx).get_argument(0);
+
+            let (coerced, cast) = maybe_ptr_coerce(&mut ctx, value, target, block, None);
+
+            assert_eq!(
+                coerced.get_type(&ctx),
+                source,
+                "generic normalization must not change {source_kind:?} into {target_kind:?}"
+            );
+            assert!(
+                cast.is_none(),
+                "generic normalization must not synthesize a concrete pointer-kind transition"
+            );
+        }
+    }
+
+    #[test]
+    fn pointer_like_local_coercion_rejects_fat_pointer_kind_changes() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let element: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let source: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::RawConst).into();
+        let target: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, element, MirPointerKind::SharedRef).into();
+        let block = BasicBlock::new(&mut ctx, None, vec![source]);
+        let value = block.deref(&ctx).get_argument(0);
+
+        let (coerced, cast) = maybe_ptr_coerce(&mut ctx, value, target, block, None);
+
+        assert_eq!(coerced.get_type(&ctx), source);
+        assert!(cast.is_none());
+    }
 
     #[test]
     fn reachable_unknown_pointer_write_prevents_concrete_narrowing() {
@@ -696,5 +897,27 @@ mod tests {
             propagate_from_local(source, &[SlotAddrSpace::Generic]),
             WriteClass::Classified(space) if space == address_space::GENERIC
         ));
+    }
+
+    #[test]
+    fn address_space_alignment_preserves_pointer_kind() {
+        use pliron::builtin::types::{IntegerType, Signedness};
+
+        let mut ctx = Context::new();
+        dialect_mir::register(&mut ctx);
+        let pointee: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let unique: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef)
+                .into();
+
+        let aligned = align_pointer_addr_space(&mut ctx, unique, address_space::SHARED);
+        let aligned = aligned.deref(&ctx);
+        let aligned = aligned
+            .downcast_ref::<MirPtrType>()
+            .expect("aligned type must remain a MIR pointer");
+
+        assert_eq!(aligned.address_space, address_space::SHARED);
+        assert_eq!(aligned.kind, MirPointerKind::UniqueRef);
+        assert!(aligned.is_mutable);
     }
 }

--- a/crates/mir-lower/src/convert/ops/aggregate.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate.rs
@@ -578,7 +578,9 @@ pub(crate) fn convert_construct_tuple(
 /// `MirSliceType` lowers to the `{ ptr, i64 }` fat-pointer struct, where
 /// field 0 is the data pointer and field 1 is the element count by
 /// construction (the same layout the entry prologue's `reconstruct_slice`
-/// and the Unsize cast path build).
+/// and the Unsize cast path build). `MirSliceType::kind` is intentionally
+/// semantic-only: all reference/raw-pointer kinds share this physical layout
+/// and no LLVM alias metadata is inferred here.
 pub(crate) fn convert_construct_slice(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,

--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -112,6 +112,24 @@ pub fn convert(
     let llvm_ty = convert_type(ctx, mir_result_ty).map_err(|e| pliron::input_error!(loc, "{e}"))?;
     let val_ty = val.get_type(ctx);
 
+    // Rust pointer/reference kind is a MIR semantic distinction, not an LLVM
+    // representation distinction. With opaque LLVM pointers (and the canonical
+    // `{ptr, i64}` slice layout), changing only pointer kind can therefore
+    // produce identical lowered source/destination types. Forward the value
+    // directly instead of manufacturing a bitcast or a struct memory
+    // round-trip. Address-space-changing casts still take the normal path.
+    if val_ty == llvm_ty
+        && matches!(
+            &cast_kind,
+            MirCastKindAttr::PtrToPtr
+                | MirCastKindAttr::PointerCoercionMutToConst
+                | MirCastKindAttr::Subtype
+        )
+    {
+        rewriter.replace_operation_with_values(ctx, op, vec![val]);
+        return Ok(());
+    }
+
     let llvm_op = match &cast_kind {
         MirCastKindAttr::Transmute => emit_transmute(ctx, rewriter, val, val_ty, llvm_ty)?,
 
@@ -1089,8 +1107,8 @@ mod tests {
     use dialect_mir::attributes::MirCastKindAttr;
     use dialect_mir::ops as mir;
     use dialect_mir::types::{
-        EnumCarrierKind, EnumEncoding, EnumLayoutKind, EnumVariant, MirEnumType, MirPtrType,
-        MirStructType,
+        EnumCarrierKind, EnumEncoding, EnumLayoutKind, EnumVariant, MirEnumType, MirPointerKind,
+        MirPtrType, MirStructType,
     };
     use llvm_export::ops as llvm;
     use pliron::builtin::op_interfaces::{CallOpCallable, CallOpInterface, SymbolOpInterface};
@@ -1312,6 +1330,33 @@ mod tests {
                 lower_single_cast(&mut ctx, source, destination, MirCastKindAttr::Transmute);
             assert_physical_transmute_round_trip(&ctx, module);
         }
+    }
+
+    #[test]
+    fn pointer_kind_only_coercion_has_no_llvm_instruction() {
+        let mut ctx = make_ctx();
+        let pointee = int_ty(&mut ctx, 32, Signedness::Unsigned);
+        let unique: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, true, MirPointerKind::UniqueRef)
+                .into();
+        let shared: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, pointee, false, MirPointerKind::SharedRef)
+                .into();
+
+        let module = lower_single_cast(
+            &mut ctx,
+            unique,
+            shared,
+            MirCastKindAttr::PointerCoercionMutToConst,
+        );
+        let body = kernel_blocks(&ctx, module);
+
+        assert_eq!(count_ops::<mir::MirCastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::BitcastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::AddrSpaceCastOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::AllocaOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::StoreOp>(&ctx, &body), 0);
+        assert_eq!(count_ops::<llvm::LoadOp>(&ctx, &body), 0);
     }
 
     #[test]

--- a/crates/mir-lower/src/convert/type_interface_impls.rs
+++ b/crates/mir-lower/src/convert/type_interface_impls.rs
@@ -64,6 +64,8 @@ impl MirConvertibleType for MirSliceType {}
 #[type_interface_impl]
 impl MirTypeConversion for MirSliceType {
     fn converter(&self) -> ConvertMirTypeFn {
+        // `MirPointerKind` is semantic-only. `&[T]`, `&mut [T]`, and raw
+        // slice pointers all keep the same physical `{ptr, i64}` layout.
         |_ty, ctx| Ok(make_slice_struct(ctx))
     }
 }
@@ -75,6 +77,9 @@ impl MirConvertibleType for MirPtrType {}
 impl MirTypeConversion for MirPtrType {
     fn converter(&self) -> ConvertMirTypeFn {
         |ty, ctx| {
+            // Deliberately erase Rust pointer/reference kind here. It is not
+            // a physical LLVM pointer property and is not sufficient by
+            // itself to justify `noalias`, `readonly`, or related metadata.
             let address_space = ty
                 .deref(ctx)
                 .downcast_ref::<MirPtrType>()

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -34,7 +34,7 @@ use crate::convert::types::{
 };
 
 use dialect_mir::ops::MirFuncOp;
-use dialect_mir::types::{MirDisjointSliceType, MirSliceType, MirStructType};
+use dialect_mir::types::{MirDisjointSliceType, MirPtrType, MirSliceType, MirStructType};
 use llvm_export::ops as llvm;
 use pliron::{
     basic_block::BasicBlock,
@@ -59,6 +59,8 @@ const DYNAMIC_SHARED_ALIGNMENT_ATTR: &str = "dynamic_shared_alignment";
 // outside the reserved-oxide-symbols kernel prefix family on purpose.
 const KERNEL_PARAM_ABI_ALIGN_ATTR_PREFIX: &str = "cuda_oxide_param_abi_align_";
 const RETURN_ABI_ALIGN_ATTR: &str = "cuda_oxide_return_abi_align";
+const LLVM_PARAM_NOALIAS_ATTR_PREFIX: &str = "cuda_oxide_param_noalias_";
+const LLVM_PARAM_READONLY_ATTR_PREFIX: &str = "cuda_oxide_param_readonly_";
 
 // ============================================================================
 // Dynamic shared-memory contract propagation
@@ -264,8 +266,16 @@ pub fn convert_func(
     };
     let return_abi_alignment =
         function_return_abi_alignment(ctx, func_type, llvm_func_type).map_err(anyhow_to_pliron)?;
+    let reference_param_mapping = if mir_func_has_reference_param_attrs(ctx, &mir_func) {
+        reference_param_llvm_mapping(ctx, func_type, llvm_func_type, is_kernel)
+            .map_err(anyhow_to_pliron)?
+    } else {
+        Vec::new()
+    };
 
     let llvm_func = llvm::FuncOp::new(ctx, name, llvm_func_type);
+    propagate_reference_param_attrs(ctx, &mir_func, &llvm_func, &reference_param_mapping)
+        .map_err(anyhow_to_pliron)?;
     llvm::copy_debug_source_scope_map(ctx, op, llvm_func.get_operation());
 
     if is_kernel {
@@ -524,6 +534,151 @@ fn propagate_kernel_param_abi_alignments(
             .attributes
             .set(key, IntegerAttr::new(u64_ty, value));
     }
+}
+
+fn mir_func_has_reference_param_attrs(ctx: &Context, mir_func: &MirFuncOp) -> bool {
+    use pliron::builtin::type_interfaces::FunctionTypeInterface;
+
+    let arg_count = mir_func.get_type(ctx).deref(ctx).arg_types().len();
+    (0..arg_count)
+        .any(|index| mir_func.param_noalias(ctx, index) || mir_func.param_readonly(ctx, index))
+}
+
+fn mir_argument_is_reference(ctx: &Context, ty: TypeHandle) -> bool {
+    let ty = ty.deref(ctx);
+    if let Some(pointer) = ty.downcast_ref::<MirPtrType>() {
+        pointer.pointer_kind().is_reference()
+    } else {
+        ty.downcast_ref::<MirSliceType>()
+            .is_some_and(|slice| slice.pointer_kind().is_reference())
+    }
+}
+
+/// Map source-level MIR reference arguments to the physical LLVM pointer
+/// parameter that carries their address after ABI flattening. In particular,
+/// a `MirSliceType` maps only to the first field of `(ptr, len, ...)`.
+fn reference_param_llvm_mapping(
+    ctx: &mut Context,
+    mir_func_type: pliron::r#type::TypedHandle<pliron::builtin::types::FunctionType>,
+    llvm_func_type: pliron::r#type::TypedHandle<llvm_export::types::FuncType>,
+    is_kernel_entry: bool,
+) -> std::result::Result<Vec<Option<usize>>, anyhow::Error> {
+    use pliron::builtin::type_interfaces::FunctionTypeInterface;
+
+    let mir_args = {
+        let func_ref = mir_func_type.deref(ctx);
+        func_ref.arg_types().to_vec()
+    };
+    let llvm_args = {
+        let func_ref = llvm_func_type.deref(ctx);
+        func_ref.arg_types().to_vec()
+    };
+
+    let mut mapping = vec![None; mir_args.len()];
+    let mut llvm_arg_index = 0usize;
+
+    for (mir_index, mir_ty) in mir_args.into_iter().enumerate() {
+        let is_reference = mir_argument_is_reference(ctx, mir_ty);
+        let physical_index = match classify_argument_type(ctx, mir_ty, is_kernel_entry)? {
+            ReconstructKind::Slice { space_fields } => {
+                let index = llvm_arg_index;
+                llvm_arg_index = llvm_arg_index
+                    .checked_add(2 + space_fields)
+                    .ok_or_else(|| anyhow::anyhow!("reference parameter index overflow"))?;
+                is_reference.then_some(index)
+            }
+            ReconstructKind::TransparentScalar | ReconstructKind::None => {
+                let index = llvm_arg_index;
+                llvm_arg_index = llvm_arg_index
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow::anyhow!("reference parameter index overflow"))?;
+                is_reference.then_some(index)
+            }
+            ReconstructKind::Zst => {
+                if is_reference {
+                    return Err(anyhow::anyhow!(
+                        "Rust reference argument {mir_index} unexpectedly lowered as a ZST"
+                    ));
+                }
+                None
+            }
+            ReconstructKind::Struct(field_count) => {
+                if is_reference {
+                    return Err(anyhow::anyhow!(
+                        "Rust reference argument {mir_index} unexpectedly lowered as a flattened struct"
+                    ));
+                }
+                llvm_arg_index = llvm_arg_index
+                    .checked_add(field_count)
+                    .ok_or_else(|| anyhow::anyhow!("reference parameter index overflow"))?;
+                None
+            }
+        };
+
+        if let Some(index) = physical_index {
+            let llvm_ty = *llvm_args.get(index).ok_or_else(|| {
+                anyhow::anyhow!("reference argument {mir_index} maps past LLVM argument {index}")
+            })?;
+            if !llvm_ty.deref(ctx).is::<llvm_export::types::PointerType>() {
+                return Err(anyhow::anyhow!(
+                    "reference argument {mir_index} maps to non-pointer LLVM argument {index}"
+                ));
+            }
+            mapping[mir_index] = Some(index);
+        }
+    }
+
+    if llvm_arg_index != llvm_args.len() {
+        return Err(anyhow::anyhow!(
+            "reference parameter mapping consumed {} LLVM arguments, expected {}",
+            llvm_arg_index,
+            llvm_args.len()
+        ));
+    }
+
+    Ok(mapping)
+}
+
+fn set_llvm_param_marker(ctx: &mut Context, llvm_func: &llvm::FuncOp, prefix: &str, index: usize) {
+    use pliron::builtin::attributes::StringAttr;
+
+    let key: pliron::identifier::Identifier = format!("{prefix}{index}")
+        .as_str()
+        .try_into()
+        .expect("LLVM parameter marker attribute name is valid");
+    llvm_func
+        .get_operation()
+        .deref_mut(ctx)
+        .attributes
+        .set(key, StringAttr::new("true".to_string()));
+}
+
+fn propagate_reference_param_attrs(
+    ctx: &mut Context,
+    mir_func: &MirFuncOp,
+    llvm_func: &llvm::FuncOp,
+    mapping: &[Option<usize>],
+) -> std::result::Result<(), anyhow::Error> {
+    for mir_index in 0..mapping.len() {
+        let noalias = mir_func.param_noalias(ctx, mir_index);
+        let readonly = mir_func.param_readonly(ctx, mir_index);
+        if !noalias && !readonly {
+            continue;
+        }
+
+        let llvm_index = mapping[mir_index].ok_or_else(|| {
+            anyhow::anyhow!(
+                "Rust reference proof on MIR argument {mir_index} has no physical LLVM pointer parameter"
+            )
+        })?;
+        if noalias {
+            set_llvm_param_marker(ctx, llvm_func, LLVM_PARAM_NOALIAS_ATTR_PREFIX, llvm_index);
+        }
+        if readonly {
+            set_llvm_param_marker(ctx, llvm_func, LLVM_PARAM_READONLY_ATTR_PREFIX, llvm_index);
+        }
+    }
+    Ok(())
 }
 
 fn propagate_return_abi_alignment(
@@ -1172,6 +1327,35 @@ mod transparent_scalar_abi_tests {
             llvm_struct.layout(),
             llvm_export::types::StructLayout::Packed
         );
+    }
+
+    #[test]
+    fn reference_param_mapping_targets_only_physical_pointer_components() {
+        use dialect_mir::types::MirPointerKind;
+
+        let mut ctx = make_ctx();
+        let value = u32_ty(&mut ctx);
+        let shared_ref: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, value, false, MirPointerKind::SharedRef)
+                .into();
+        let scalar = u32_ty(&mut ctx);
+        let shared_slice: TypeHandle =
+            MirSliceType::get_with_kind(&mut ctx, value, MirPointerKind::SharedRef).into();
+        let raw_mut: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, value, true, MirPointerKind::RawMut).into();
+
+        let mir_func_type = FunctionType::get(
+            &ctx,
+            vec![shared_ref, scalar, shared_slice, raw_mut],
+            vec![],
+        );
+        let llvm_func_type = convert_function_type(&mut ctx, mir_func_type, true)
+            .expect("reference arguments must lower");
+
+        let mapping = reference_param_llvm_mapping(&mut ctx, mir_func_type, llvm_func_type, true)
+            .expect("reference parameter mapping must succeed");
+
+        assert_eq!(mapping, vec![Some(0), None, Some(2), None]);
     }
 
     #[test]

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -61,6 +61,9 @@ const KERNEL_PARAM_ABI_ALIGN_ATTR_PREFIX: &str = "cuda_oxide_param_abi_align_";
 const RETURN_ABI_ALIGN_ATTR: &str = "cuda_oxide_return_abi_align";
 const LLVM_PARAM_NOALIAS_ATTR_PREFIX: &str = "cuda_oxide_param_noalias_";
 const LLVM_PARAM_READONLY_ATTR_PREFIX: &str = "cuda_oxide_param_readonly_";
+const LLVM_PARAM_NONNULL_ATTR_PREFIX: &str = "cuda_oxide_param_nonnull_";
+const LLVM_PARAM_POINTEE_ALIGN_ATTR_PREFIX: &str = "cuda_oxide_param_pointee_align_";
+const LLVM_PARAM_DEREFERENCEABLE_ATTR_PREFIX: &str = "cuda_oxide_param_dereferenceable_";
 
 // ============================================================================
 // Dynamic shared-memory contract propagation
@@ -540,8 +543,13 @@ fn mir_func_has_reference_param_attrs(ctx: &Context, mir_func: &MirFuncOp) -> bo
     use pliron::builtin::type_interfaces::FunctionTypeInterface;
 
     let arg_count = mir_func.get_type(ctx).deref(ctx).arg_types().len();
-    (0..arg_count)
-        .any(|index| mir_func.param_noalias(ctx, index) || mir_func.param_readonly(ctx, index))
+    (0..arg_count).any(|index| {
+        mir_func.param_noalias(ctx, index)
+            || mir_func.param_readonly(ctx, index)
+            || mir_func.param_nonnull(ctx, index)
+            || mir_func.param_pointee_align(ctx, index).is_some()
+            || mir_func.param_dereferenceable(ctx, index).is_some()
+    })
 }
 
 fn mir_argument_is_reference(ctx: &Context, ty: TypeHandle) -> bool {
@@ -554,9 +562,8 @@ fn mir_argument_is_reference(ctx: &Context, ty: TypeHandle) -> bool {
     }
 }
 
-/// Map source-level MIR reference arguments to the physical LLVM pointer
-/// parameter that carries their address after ABI flattening. In particular,
-/// a `MirSliceType` maps only to the first field of `(ptr, len, ...)`.
+/// Map a source-level MIR reference argument to the physical LLVM pointer
+/// parameter that carries its address after ABI flattening.
 fn reference_param_llvm_mapping(
     ctx: &mut Context,
     mir_func_type: pliron::r#type::TypedHandle<pliron::builtin::types::FunctionType>,
@@ -653,6 +660,31 @@ fn set_llvm_param_marker(ctx: &mut Context, llvm_func: &llvm::FuncOp, prefix: &s
         .set(key, StringAttr::new("true".to_string()));
 }
 
+fn set_llvm_param_value(
+    ctx: &mut Context,
+    llvm_func: &llvm::FuncOp,
+    prefix: &str,
+    index: usize,
+    value: u64,
+) {
+    use pliron::builtin::attributes::IntegerAttr;
+    use pliron::builtin::types::{IntegerType, Signedness};
+    use pliron::utils::apint::APInt;
+    use std::num::NonZero;
+
+    let key: pliron::identifier::Identifier = format!("{prefix}{index}")
+        .as_str()
+        .try_into()
+        .expect("LLVM parameter value attribute name is valid");
+    let u64_ty = IntegerType::get(ctx, 64, Signedness::Unsigned);
+    let value = APInt::from_u64(value, NonZero::new(64).unwrap());
+    llvm_func
+        .get_operation()
+        .deref_mut(ctx)
+        .attributes
+        .set(key, IntegerAttr::new(u64_ty, value));
+}
+
 fn propagate_reference_param_attrs(
     ctx: &mut Context,
     mir_func: &MirFuncOp,
@@ -662,7 +694,12 @@ fn propagate_reference_param_attrs(
     for mir_index in 0..mapping.len() {
         let noalias = mir_func.param_noalias(ctx, mir_index);
         let readonly = mir_func.param_readonly(ctx, mir_index);
-        if !noalias && !readonly {
+        let nonnull = mir_func.param_nonnull(ctx, mir_index);
+        let pointee_align = mir_func.param_pointee_align(ctx, mir_index);
+        let dereferenceable = mir_func.param_dereferenceable(ctx, mir_index);
+
+        if !noalias && !readonly && !nonnull && pointee_align.is_none() && dereferenceable.is_none()
+        {
             continue;
         }
 
@@ -671,11 +708,33 @@ fn propagate_reference_param_attrs(
                 "Rust reference proof on MIR argument {mir_index} has no physical LLVM pointer parameter"
             )
         })?;
+
         if noalias {
             set_llvm_param_marker(ctx, llvm_func, LLVM_PARAM_NOALIAS_ATTR_PREFIX, llvm_index);
         }
         if readonly {
             set_llvm_param_marker(ctx, llvm_func, LLVM_PARAM_READONLY_ATTR_PREFIX, llvm_index);
+        }
+        if nonnull {
+            set_llvm_param_marker(ctx, llvm_func, LLVM_PARAM_NONNULL_ATTR_PREFIX, llvm_index);
+        }
+        if let Some(align) = pointee_align {
+            set_llvm_param_value(
+                ctx,
+                llvm_func,
+                LLVM_PARAM_POINTEE_ALIGN_ATTR_PREFIX,
+                llvm_index,
+                align,
+            );
+        }
+        if let Some(bytes) = dereferenceable {
+            set_llvm_param_value(
+                ctx,
+                llvm_func,
+                LLVM_PARAM_DEREFERENCEABLE_ATTR_PREFIX,
+                llvm_index,
+                bytes,
+            );
         }
     }
     Ok(())


### PR DESCRIPTION
Closes #1098 

This PR is stacked on top of #1089; its actual delta is one commit touching
7 files. Once #1089 lands, I’ll rebase this PR onto `main` so the review diff
contains only the reference-validity attribute changes.

## Summary

Part of #413.

This change extends the Rust-reference parameter attribute pipeline introduced
by #1089 with conservatively proven LLVM `nonnull`, `align`, and
`dereferenceable` attributes.

The policy is intentionally decided at the MIR import boundary, where the
original rustc `Ty`, layout, and trait information are still available.
Downstream lowering only transports and remaps those facts, and `llvm-export`
serializes them mechanically.

## Semantics

| Rust parameter | Condition | Additional LLVM attributes |
| --- | --- | --- |
| `&T` | `T: Sized` | `nonnull`, `align N` when `N > 1` |
| `&mut T` | `T: Sized` | `nonnull`, `align N` when `N > 1` |
| `&T` | `T: Sized + Freeze`, size > 0 | `dereferenceable(size)` |
| `&mut T` | `T: Sized + Unpin`, size > 0 | `dereferenceable(size)` |
| unsized reference | — | none from this validity policy |
| raw pointer | — | none |

`align 1` is omitted.

Zero-sized pointees never produce `dereferenceable(0)`, so an over-aligned ZST
may carry:

```llvm
ptr nonnull align 16
```

without `dereferenceable`.

## Design

The semantic decision remains centralized in `mir-importer`.

For each source-level argument:

1. `mir-importer` checks the original Rust reference type, rustc layout, and
   relevant `Freeze` / `Unpin` conditions.
2. `MirFuncOp` stores the proven facts by source argument index.
3. `mir-lower` remaps source arguments to physical LLVM pointer parameters
   after ABI flattening.
4. `llvm-export` validates the mechanical representation and serializes the
   resulting LLVM attributes.

Neither `mir-lower` nor `llvm-export` derives Rust semantics from pointer
mutability, address space, LLVM pointer shape, or `DisjointSlice`.

## Conservative cases

This PR deliberately does not emit validity attributes for unsized references.

This preserves the slice alias behavior introduced by #1089 while keeping
validity attributes restricted to sized pointees in this follow-up.

In particular:

* `&UnsafeCell<u32>` receives `nonnull align 4`, but not
  `dereferenceable(4)`
* `&mut PhantomPinned` does not receive `dereferenceable`
* over-aligned ZST references receive non-nullness/alignment without
  `dereferenceable(0)`
* raw pointers receive no reference-derived validity attributes
* `DisjointSlice` remains uninterpreted by the exporter

## Validation

Focused coverage includes:

* valid shared and unique sized references
* `UnsafeCell` shared references
* non-`Unpin` mutable references
* over-aligned zero-sized pointees
* shared and mutable slice behavior inherited from #1089
* raw pointers
* invalid MIR validity markers
* physical LLVM argument remapping
* modern opaque-pointer LLVM export
* legacy typed-pointer LLVM export
* rejection of validity attributes on non-pointer LLVM arguments

Validation performed:

```text
cargo fmt --all -- --check

cargo test -p dialect-mir \
  test_mir_func_reference_param_attrs_verify

cargo test -p mir-importer \
  reference_param_attrs_follow_rustc_reference_validity_rules

cargo test -p mir-lower \
  reference_param_mapping_targets_only_physical_pointer_components

cargo test -p llvm-export \
  export_reference_parameter_attrs_on_definitions

cargo test -p llvm-export \
  legacy_export_reference_parameter_attrs_follow_typed_pointer

cargo test -p llvm-export \
  export_rejects_reference_attrs_on_non_pointer_parameter

cargo test -p llvm-export \
  export_rejects_invalid_reference_validity_attrs

cargo test -p dialect-mir --all-targets
cargo test -p mir-importer --all-targets
cargo test -p mir-lower --all-targets
cargo test -p llvm-export --all-targets

cargo clippy --workspace --all-targets -- -D warnings

cargo oxide build vecadd
cargo oxide build addressof_sharedarray

git diff --check
```

The final stacked delta against #1089 is one commit touching 7 files.

## Out of scope

* validity attributes for DST / slice references
* `dereferenceable_or_null`
* recursive provenance analysis
* deriving attributes from `DisjointSlice`
* deriving attributes from raw pointers
* general LLVM-level pointer inference
