### PR TITLE
fix(nvjitlink): resolve versioned toolkit symbols

### DIFF
--- a/crates/nvjitlink-sys/README.md
+++ b/crates/nvjitlink-sys/README.md
@@ -25,7 +25,7 @@ nvJitLink ships with the standard CUDA Toolkit at `<cuda>/lib64/`. No separate d
 
 ## Symbol naming
 
-`nvJitLink.h` `#define`s every public function to a versioned mangled name (e.g. `nvJitLinkCreate -> __nvJitLinkCreate_13_0`), but the library also exports the unversioned name with default ELF symbol versioning. `dlsym(handle, "nvJitLinkCreate")` resolves to the right function on every CUDA Toolkit version, so this binding does not need to probe per-CUDA-version symbol suffixes.
+`nvJitLink.h` maps every public function to a versioned mangled name (e.g. `nvJitLinkCreate -> __nvJitLinkCreate_13_0`). Toolkit installations may export either the public unsuffixed name or only the mangled name, so the binding probes both forms.
 
 ## Usage
 

--- a/crates/nvjitlink-sys/src/lib.rs
+++ b/crates/nvjitlink-sys/src/lib.rs
@@ -11,12 +11,10 @@
 //!
 //! # Symbol naming
 //!
-//! `nvJitLink.h` `#define`s every public function to a versioned mangled
-//! name, e.g. `nvJitLinkCreate -> __nvJitLinkCreate_13_0`, but the library
-//! also exports the unversioned name with default ELF symbol versioning.
-//! That means `dlsym(handle, "nvJitLinkCreate")` resolves to the right
-//! function on every CUDA Toolkit version, so this binding does not need
-//! to probe per-CUDA-version symbol suffixes.
+//! `nvJitLink.h` maps every public function to a versioned mangled name,
+//! e.g. `nvJitLinkCreate -> __nvJitLinkCreate_13_0`. Toolkit installations
+//! may export either the public unsuffixed name or only the mangled name, so
+//! this binding probes both forms.
 //!
 //! # Example
 //!
@@ -30,7 +28,7 @@
 //! let cubin = linker.finish().unwrap();
 //! ```
 
-use libloading::{Library, Symbol};
+use libloading::Library;
 use std::borrow::Cow;
 use std::ffi::{CString, c_char, c_int, c_void};
 use std::fs::File;
@@ -215,6 +213,16 @@ pub struct LibNvJitLink {
 unsafe impl Send for LibNvJitLink {}
 unsafe impl Sync for LibNvJitLink {}
 
+const NVJITLINK_ABI_SUFFIXES: [&str; 2] = ["_13_0", "_12_0"];
+
+fn symbol_names(name: &str) -> impl Iterator<Item = String> + '_ {
+    std::iter::once(name.to_owned()).chain(
+        NVJITLINK_ABI_SUFFIXES
+            .iter()
+            .map(move |suffix| format!("__{name}{suffix}")),
+    )
+}
+
 /// Resolve a required symbol to a function pointer of inferred type `T`.
 ///
 /// # Safety
@@ -224,12 +232,17 @@ unsafe impl Sync for LibNvJitLink {}
 /// alongside the owning `Library`, so the pointer's lifetime matches the
 /// `LibNvJitLink` instance.
 unsafe fn resolve<T: Copy>(lib: &Library, name: &'static str) -> Result<T, NvJitLinkError> {
-    let sym: Symbol<T> =
-        unsafe { lib.get(name.as_bytes()) }.map_err(|source| NvJitLinkError::SymbolNotFound {
-            symbol: name,
-            source,
-        })?;
-    Ok(unsafe { *sym.into_raw() })
+    let mut last_error = None;
+    for candidate in symbol_names(name) {
+        match unsafe { lib.get::<T>(candidate.as_bytes()) } {
+            Ok(sym) => return Ok(unsafe { *sym.into_raw() }),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(NvJitLinkError::SymbolNotFound {
+        symbol: name,
+        source: last_error.expect("symbol candidate list is nonempty"),
+    })
 }
 
 /// Resolve an optional symbol; returns `None` if missing.
@@ -241,8 +254,12 @@ unsafe fn resolve<T: Copy>(lib: &Library, name: &'static str) -> Result<T, NvJit
 ///
 /// Same as [`resolve`].
 unsafe fn resolve_optional<T: Copy>(lib: &Library, name: &'static str) -> Option<T> {
-    let sym: Symbol<T> = unsafe { lib.get(name.as_bytes()) }.ok()?;
-    Some(unsafe { *sym.into_raw() })
+    for candidate in symbol_names(name) {
+        if let Ok(sym) = unsafe { lib.get::<T>(candidate.as_bytes()) } {
+            return Some(unsafe { *sym.into_raw() });
+        }
+    }
+    None
 }
 
 impl LibNvJitLink {
@@ -794,6 +811,52 @@ fn cuda_roots_from_env(mut get_env: impl FnMut(&str) -> Option<String>) -> Vec<P
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libloading::Symbol;
+
+    #[test]
+    fn symbol_lookup_tries_public_then_vendor_abi_names() {
+        assert_eq!(
+            symbol_names("nvJitLinkCreate").collect::<Vec<_>>(),
+            [
+                "nvJitLinkCreate",
+                "__nvJitLinkCreate_13_0",
+                "__nvJitLinkCreate_12_0",
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_accepts_cuda_12_mangled_symbol() {
+        let nonce = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "nvjitlink-sys-versioned-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let source = directory.join("versioned.c");
+        let library_path = directory.join("libversioned.so");
+        std::fs::write(&source, "int __nvJitLinkCreate_12_0(void) { return 12; }\n").unwrap();
+        let status = std::process::Command::new("cc")
+            .args(["-shared", "-fPIC"])
+            .arg(&source)
+            .arg("-o")
+            .arg(&library_path)
+            .status()
+            .expect("run C compiler for versioned symbol test");
+        assert!(status.success(), "C compiler failed with {status}");
+
+        let library = unsafe { Library::new(&library_path) }.unwrap();
+        let function: unsafe extern "C" fn() -> c_int =
+            unsafe { resolve(&library, "nvJitLinkCreate") }.unwrap();
+        assert_eq!(unsafe { function() }, 12);
+
+        drop(library);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 
     #[cfg(target_os = "linux")]
     fn compile_probe_library(source: &Path, output: &Path, value: i32) {


### PR DESCRIPTION
`nvjitlink-sys` assumed every nvJitLink library exported unsuffixed public entry points. Debian's CUDA 12 package does not:

```text
$ nm -D --defined-only /usr/lib/x86_64-linux-gnu/libnvJitLink.so.12 \
    | grep -E 'nvJitLink(Create|Destroy|AddData|Complete|GetLinkedCubin)'
0000000000226bd0 T __nvJitLinkAddData_12_0@@libnvJitLink.so.12
0000000000226f50 T __nvJitLinkComplete_12_0@@libnvJitLink.so.12
0000000000226010 T __nvJitLinkCreate_12_0@@libnvJitLink.so.12
0000000000226ab0 T __nvJitLinkDestroy_12_0@@libnvJitLink.so.12
0000000000227480 T __nvJitLinkGetLinkedCubinSize_12_0@@libnvJitLink.so.12
00000000002274e0 T __nvJitLinkGetLinkedCubin_12_0@@libnvJitLink.so.12
```

The toolkit header maps each public inline API to those versioned symbols. The crate-level documentation instead said the library also exported unsuffixed names with default ELF symbol versioning, and `LibNvJitLink::load_inner` implemented that claim with unsuffixed-only `dlsym` calls. Loading therefore stopped at `nvJitLinkCreate` on this installation.

Required and optional entry points now resolve the unsuffixed name first, then the CUDA 13.0 and 12.0 mangled names. This preserves existing toolkits and fixes Debian CUDA 12; tests pin the order and resolve a synthetic library that exports only `__nvJitLinkCreate_12_0`. The crate documentation now describes both export shapes.

## Verification

- `cargo test -p nvjitlink-sys --all-targets` — 12 passed, 3 live-toolkit tests ignored.
- `CUDA_TOOLKIT_PATH=/usr cargo test -p nvjitlink-sys -- --ignored` — all 3 live-toolkit tests passed against Debian CUDA 12.
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo test --doc --workspace --exclude cuda-bindings`
- `cargo fmt --all -- --check`
- `cargo oxide build vecadd --materialize-cubin --arch sm_86` completed with the Debian CUDA 12 libNVVM and nvJitLink libraries selected by exact paths.
- SPDX, dependency-policy, crate-inventory, and test-matrix guards pass.
