### PR TITLE
docs(ptx-schedule): the one published crate with no README

### DIFF
--- a/crates/ptx-schedule/Cargo.toml
+++ b/crates/ptx-schedule/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Structural PTX schedule analysis and deterministic perturbation"
+readme = "README.md"
 
 [dependencies]
 dialect-ptx = { workspace = true }

--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -5,17 +5,17 @@ Structural PTX schedule analysis and deterministic perturbation.
 A kernel that races only under one interleaving passes every run until it does
 not. This crate makes that interleaving reachable on purpose: it finds the
 points in a PTX module where thread progress is observable, then inserts a
-seeded `nanosleep.u32` at a subset of them so the same seed always produces the
-same schedule.
+seeded `nanosleep.u32` at a subset of them so the same seed always produces
+the same rewrite.
 
-## What it deliberately does not do
+## What the analyzer deliberately does not do
 
-It owns neither CUDA execution nor an input generator. It reads PTX text and
-writes PTX text. Building, launching, watchdogging and verdict assignment are
-the campaign driver's job, and the kernel inputs stay whatever the example
-already uses. Static site discovery, mutation and triage therefore all read
-the same source model, so a site named in a finding is the site the analyzer
-found.
+`analyze_ptx` and `perturb_ptx` own neither CUDA execution nor an input
+generator: they read PTX text and write PTX text. Building, launching,
+watchdogging and verdict assignment live one layer up in `campaign.rs`
+(described below), and the kernel inputs stay whatever the example already
+uses. Static site discovery, mutation and triage therefore all read the same
+source model, so a site named in a finding is the site the analyzer found.
 
 ## The model
 
@@ -26,23 +26,31 @@ places where another thread's progress can be observed:
 |:-----------|:--------------|
 | `Atomic` | an atomic read-modify-write |
 | `Reduction` | a `red.*` reduction with no returned value |
-| `Barrier` | `bar.*` / `barrier.*` synchronization |
+| `Barrier` | `bar.*` / `barrier.*` / `mbarrier.*` synchronization |
 | `Fence` | `fence.*` / `membar.*` ordering |
-| `OrderedMemory` | a load or store carrying an explicit ordering or scope |
+| `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
-| `Backedge` | a branch back to a dominating label, i.e. a loop |
+| `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |
 
-Each site keeps its ordinal, enclosing callable, byte span, basic block, the
-instruction text and any guarding predicate, so a rewrite can be described
-without re-parsing.
+Each site keeps its ordinal, enclosing callable, byte span, the instruction
+text and any guarding predicate (a back-edge also records its block index),
+so a rewrite can be described without re-parsing.
 
-`perturb_ptx` then applies `InjectionOptions` -- `seed`, `intensity` (the
-fraction of sites to touch), `max_sleep_ns` (default
-`DEFAULT_MAX_SLEEP_NS`, 64 µs) and an optional `focus` substring to restrict
-the search to one callable -- and returns the rewritten module plus an
-`InjectionDecision` per site. Nothing is inserted when the intensity selects
-no site, so a seed that changes nothing is reported rather than silently
-producing the original text.
+`perturb_ptx` then applies `InjectionOptions` and returns the rewritten module
+plus an `InjectionDecision` per site:
+
+- `seed` -- the whole rewrite is a deterministic function of it;
+- `intensity` -- a probability dial, not a fraction: each site is touched
+  with chance `0.75 × intensity`, and the same dial scales how long the
+  inserted sleeps run;
+- `max_sleep_ns` -- the delay ceiling (default `DEFAULT_MAX_SLEEP_NS`, 64 µs);
+- `focus` -- an optional substring matched against each site's opcode and
+  instruction text. Matching sites become very likely (`0.95 × intensity`),
+  everything else very unlikely (`0.15 × intensity`), so a sweep leans toward
+  one area without excluding the rest.
+
+Nothing is inserted when the draw selects no site, and a seed that changes
+nothing is reported rather than silently producing the original text.
 
 ## Structure
 
@@ -56,13 +64,14 @@ src/
 ## Campaign verdicts
 
 `campaign::run_campaign` sweeps a seed range and classifies each run. A
-finding is re-run (`confirm_runs`) before it is reported, so a one-off is not
-mistaken for a reproducible schedule bug:
+finding is re-run (`confirm_runs` times in total) and reported with how many
+of those runs reproduced it, so a one-off shows up as a one-off instead of
+being mistaken for a reproducible schedule bug:
 
 | `RunKind` | meaning |
 |:----------|:--------|
 | `Pass` | the perturbed build behaved like the baseline |
-| `Skipped` | the seed inserted nothing, or the example declined to run |
+| `Skipped` | the example declined to run and printed a skip marker |
 | `Hang` | the watchdog fired |
 | `Crash` | the process died |
 | `Mismatch` | the example reported its own failure |

--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -1,0 +1,89 @@
+# ptx-schedule
+
+Structural PTX schedule analysis and deterministic perturbation.
+
+A kernel that races only under one interleaving passes every run until it does
+not. This crate makes that interleaving reachable on purpose: it finds the
+points in a PTX module where thread progress is observable, then inserts a
+seeded `nanosleep.u32` at a subset of them so the same seed always produces the
+same schedule.
+
+## What it deliberately does not do
+
+It owns neither CUDA execution nor an input generator. It reads PTX text and
+writes PTX text. Building, launching, watchdogging and verdict assignment are
+the campaign driver's job, and the kernel inputs stay whatever the example
+already uses. Static site discovery, mutation and triage therefore all read
+the same source model, so a site named in a finding is the site the analyzer
+found.
+
+## The model
+
+`analyze_ptx` turns a module into an ordered list of `ScheduleSite`s -- the
+places where another thread's progress can be observed:
+
+| `SiteKind` | what it marks |
+|:-----------|:--------------|
+| `Atomic` | an atomic read-modify-write |
+| `Reduction` | a `red.*` reduction with no returned value |
+| `Barrier` | `bar.*` / `barrier.*` synchronization |
+| `Fence` | `fence.*` / `membar.*` ordering |
+| `OrderedMemory` | a load or store carrying an explicit ordering or scope |
+| `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
+| `Backedge` | a branch back to a dominating label, i.e. a loop |
+
+Each site keeps its ordinal, enclosing callable, byte span, basic block, the
+instruction text and any guarding predicate, so a rewrite can be described
+without re-parsing.
+
+`perturb_ptx` then applies `InjectionOptions` -- `seed`, `intensity` (the
+fraction of sites to touch), `max_sleep_ns` (default
+`DEFAULT_MAX_SLEEP_NS`, 64 µs) and an optional `focus` substring to restrict
+the search to one callable -- and returns the rewritten module plus an
+`InjectionDecision` per site. Nothing is inserted when the intensity selects
+no site, so a seed that changes nothing is reported rather than silently
+producing the original text.
+
+## Structure
+
+```text
+src/
+├── lib.rs       # site discovery (analyze_ptx) and injection (perturb_ptx)
+├── campaign.rs  # the seed-sweep driver: build, run, watchdog, confirm
+└── main.rs      # single-file CLI over one .ptx
+```
+
+## Campaign verdicts
+
+`campaign::run_campaign` sweeps a seed range and classifies each run. A
+finding is re-run (`confirm_runs`) before it is reported, so a one-off is not
+mistaken for a reproducible schedule bug:
+
+| `RunKind` | meaning |
+|:----------|:--------|
+| `Pass` | the perturbed build behaved like the baseline |
+| `Skipped` | the seed inserted nothing, or the example declined to run |
+| `Hang` | the watchdog fired |
+| `Crash` | the process died |
+| `Mismatch` | the example reported its own failure |
+| `OutputChanged` | stdout differed with no explicit failure marker (opt-in) |
+| `GpuWedged` | the device stopped responding |
+| `HarnessError` | the campaign itself failed, not the kernel |
+
+## Consumers
+
+| Crate | Uses it for |
+|:------|:------------|
+| `cargo-oxide` | `cargo oxide fuzz-schedule <example>`, the user-facing campaign |
+
+The crate also ships a `ptx-schedule` binary for one PTX file at a time:
+
+```bash
+ptx-schedule kernel.ptx --list-sites
+ptx-schedule kernel.ptx --seed 7 --intensity 0.5 -o perturbed.ptx \
+    --decisions-json decisions.json
+```
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/NVlabs/cuda-oxide/blob/main/LICENSE).


### PR DESCRIPTION
`ptx-schedule` arrived with #1065 and is the only publishable crate in the workspace with neither a `readme` key nor a `README.md` on disk. Checked across `cargo metadata`: every other publishable member has both. crates.io renders that file as the package page, so this one would publish with an empty body.

Same gap #981 closed for `ptx-parse`, and this README follows that one's shape.

## Content is taken from the crate, not the commit that added it

- The purpose and the *"owns neither CUDA execution nor an input generator"* boundary come from `lib.rs`'s module header.
- The seven `SiteKind` variants and the eight campaign `RunKind` verdicts are each enumerated **in full** — a partial list of a closed enum is exactly the thing that rots (#978, #1045, #1056).
- `InjectionOptions`' four fields, `DEFAULT_MAX_SLEEP_NS` (64 µs), the `nanosleep.u32` insertion, and the `confirm_runs` re-run before a finding is reported are all as implemented.
- `cargo oxide fuzz-schedule` is named as the user-facing entry point, with the crate's own binary shown for single-file work; the flags in that example come from `main.rs`'s usage string.

## One detail carried from #981's review

The License link is absolute rather than `../../LICENSE`, because crates.io rewrites relative README links against the repository root and the relative form 404s there. `ptx-parse`'s README was corrected the same way.

## Verification

- `cargo metadata` now reports `readme: README.md` for the crate and the file resolves.
- All seven `SiteKind` and all eight `RunKind` names appear; the four `InjectionOptions` fields appear; no relative `../` links remain.
- `check-crate-inventory.sh`, `check-spdx-headers.sh` and `check-book-api-names.sh` pass; `cargo fmt --all --check` clean; `RUSTDOCFLAGS="-D warnings" cargo doc -p ptx-schedule` clean.