### PR TITLE
fix(ptx-schedule): the usage string omits the --output spelling it accepts

### DIFF
--- a/crates/ptx-schedule/src/main.rs
+++ b/crates/ptx-schedule/src/main.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 fn usage() -> ! {
     eprintln!(
-        "usage: ptx-schedule INPUT.ptx [--list-sites] [--seed N] [--intensity F] [--max-sleep-ns N] [--focus TEXT] [-o OUTPUT] [--decisions-json FILE]"
+        "usage: ptx-schedule INPUT.ptx [--list-sites] [--seed N] [--intensity F] [--max-sleep-ns N] [--focus TEXT] [-o|--output OUTPUT] [--decisions-json FILE]"
     );
     std::process::exit(2);
 }


### PR DESCRIPTION
`main.rs` parses the output path as `"-o" | "--output"`, but its usage line shows only `[-o OUTPUT]`:

```
usage: ptx-schedule INPUT.ptx [--list-sites] [--seed N] [--intensity F]
       [--max-sleep-ns N] [--focus TEXT] [-o OUTPUT] [--decisions-json FILE]
```

Every other flag the loop accepts appears there, so `--output` is the one working spelling a reader cannot discover. Nothing is broken — both forms work — but this usage text is the only help the binary has, since it hand-rolls its argument parsing rather than deriving `--help` from clap.

Name both, as the match arm does.

## The rest of the tree is clean on this

I compared every hand-written usage string's flags against the flags its parser accepts. `ptx-schedule` was the only real mismatch:

- `smoketest.sh` documents all eight of its flags.
- The `cargo-oxide` and `cuda-intrinsics-gen` binaries derive help from clap, so there is no hand-written string to drift from.
- The `--output-file` / `--verbose` / `--version` strings in `cuda-artifact-finalizer` are arguments it passes to **ptxas**, not flags of its own.

**Verified:** the documented set and the parsed set are now equal in both directions; fmt clean, `clippy --all-targets -- -D warnings` clean, and the crate's 9 tests pass.