### PR TITLE
fix(backend): the forbidden-crate diagnostic panics on a non-ASCII path

### DIFF
--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -559,6 +559,32 @@ pub fn is_fully_monomorphized<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>)
 /// are not part of `core_float_math`; `sin`/`cos` are listed defensively in
 /// case a build ever takes the `std` route too. Only `std::`-prefixed names
 /// belong here; `core`-based shims are already allowed.
+/// Fit a function path into the forbidden-crate diagnostic box.
+///
+/// The box pads this field with `{:<48}`, which counts characters, so the
+/// budget is a character budget. Two things follow, and the previous
+/// `if fn_path.len() > 48 { &fn_path[..45] }` got both wrong for a path that
+/// is not pure ASCII:
+///
+/// * `len()` is bytes. A 30-character path spelled with multi-byte characters
+///   can exceed 48 bytes and be truncated even though it would have fit.
+/// * `&fn_path[..45]` is a byte index. When byte 45 lands inside a multi-byte
+///   character it panics with "byte index 45 is not a char boundary" -- so
+///   emitting the diagnostic for a forbidden call would abort the compiler
+///   instead of printing the error the box exists to print. Rust identifiers
+///   may be non-ASCII, so a path can reach here in that shape.
+///
+/// Truncation keeps `width - 3` characters and appends an ellipsis, so the
+/// result never exceeds `width` characters.
+fn truncate_path_for_box(fn_path: &str, width: usize) -> String {
+    debug_assert!(width > 3, "the ellipsis needs room");
+    if fn_path.chars().count() <= width {
+        return fn_path.to_owned();
+    }
+    let kept: String = fn_path.chars().take(width - 3).collect();
+    format!("{kept}...")
+}
+
 fn is_intrinsic_lowered_cmath_shim(fn_path: &str) -> bool {
     matches!(
         fn_path,
@@ -1400,12 +1426,7 @@ impl<'tcx> DeviceCollector<'tcx> {
                 let border = "═".repeat(68);
                 let empty_line = format!("║{:68}║", "");
 
-                // Truncate fn_path if too long (max 48 chars to fit in box)
-                let fn_display = if fn_path.len() > 48 {
-                    format!("{}...", &fn_path[..45])
-                } else {
-                    fn_path.clone()
-                };
+                let fn_display = truncate_path_for_box(&fn_path, 48);
 
                 // Build the "From crate" line with proper padding
                 let crate_line = format!("║ From crate: '{}'", crate_name);
@@ -2433,7 +2454,8 @@ pub fn dump_device_mir_info<'tcx>(tcx: TyCtxt<'tcx>, functions: &[CollectedFunct
 #[cfg(test)]
 mod tests {
     use super::{
-        device_runtime_checks_target, is_kernel_entry_def_path, unsupported_codegen_protocol_root,
+        device_runtime_checks_target, is_kernel_entry_def_path, truncate_path_for_box,
+        unsupported_codegen_protocol_root,
     };
     use reserved_oxide_symbols::{
         DEVICE_PREFIX, KERNEL_PREFIX, LEGACY_DEVICE_PREFIX, LEGACY_KERNEL_PREFIX,
@@ -2553,5 +2575,52 @@ mod tests {
             "my_crate::helpers::prefix{KERNEL_PREFIX}vecadd"
         )));
         assert!(!is_kernel_entry_def_path(""));
+    }
+
+    /// The box pads this field with `{:<48}`, so the budget is characters.
+    ///
+    /// The previous code tested `fn_path.len() > 48` (bytes) and then sliced
+    /// `&fn_path[..45]` (a byte index). A path whose byte 45 falls inside a
+    /// multi-byte character panicked with "byte index 45 is not a char
+    /// boundary", which aborted the compiler while it was trying to print the
+    /// forbidden-crate error.
+    #[test]
+    fn truncating_a_path_for_the_box_respects_char_boundaries() {
+        // 'é' is two bytes, so every char boundary sits at an even index and
+        // byte 45 lands mid-character.
+        let path = "é".repeat(60);
+        assert!(path.chars().count() > 48, "fixture must exceed the budget");
+        assert!(!path.is_char_boundary(45), "fixture must straddle byte 45");
+
+        let shown = truncate_path_for_box(&path, 48);
+
+        assert!(shown.ends_with("..."));
+        assert_eq!(shown.chars().count(), 48);
+        assert!(path.starts_with(shown.trim_end_matches('.')));
+    }
+
+    #[test]
+    fn a_path_that_fits_is_left_alone() {
+        let path = "core::fmt::Debug::fmt";
+        assert_eq!(truncate_path_for_box(path, 48), path);
+    }
+
+    /// Bytes are not characters: a path of 30 characters spelled with
+    /// multi-byte characters exceeds 48 bytes, and the old byte test truncated
+    /// it even though it fits the box.
+    #[test]
+    fn a_multibyte_path_within_the_char_budget_is_not_truncated() {
+        let path = "é".repeat(30);
+        assert!(path.len() > 48, "fixture must exceed the byte budget");
+        assert_eq!(path.chars().count(), 30);
+        assert_eq!(truncate_path_for_box(&path, 48), path);
+    }
+
+    #[test]
+    fn truncation_never_exceeds_the_width() {
+        for count in [49, 60, 200] {
+            let ascii = "a".repeat(count);
+            assert_eq!(truncate_path_for_box(&ascii, 48).chars().count(), 48);
+        }
     }
 }

--- a/crates/rustc-codegen-cuda/src/collector.rs
+++ b/crates/rustc-codegen-cuda/src/collector.rs
@@ -539,26 +539,6 @@ pub fn is_fully_monomorphized<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>)
     true
 }
 
-/// `std::sys::cmath::*` names we allow in device code and rewrite to GPU math.
-///
-/// When you call `x.tan()` (also `atan`, `acos`, `cbrt`, the hyperbolics,
-/// `exp_m1`, `ln_1p`, `hypot`, ...), the compiler turns it into a call to a
-/// tiny `std` wrapper like `std::sys::cmath::tan`, which on a CPU forwards to
-/// the system C math library. The GPU has no such library, and device code
-/// may not call into `std`, so our "no std on the GPU" guard would normally
-/// reject the call.
-///
-/// We never actually run `std` here: mir-importer rewrites each of these
-/// names to the matching NVIDIA libdevice function (`__nv_tan`, `__nv_sinh`,
-/// ...). This list just tells the guard "these are fine, we handle them."
-/// Keep it in sync with the `std::sys::cmath` matches in float_math.rs.
-///
-/// A few functions (`sin`, `cos`, `exp`, ...) take a different, allowed route
-/// on this toolchain: the compiler lowers them to a builtin in `core`, so
-/// they never reach here. The ones below still go through `std` because they
-/// are not part of `core_float_math`; `sin`/`cos` are listed defensively in
-/// case a build ever takes the `std` route too. Only `std::`-prefixed names
-/// belong here; `core`-based shims are already allowed.
 /// Fit a function path into the forbidden-crate diagnostic box.
 ///
 /// The box pads this field with `{:<48}`, which counts characters, so the
@@ -585,6 +565,26 @@ fn truncate_path_for_box(fn_path: &str, width: usize) -> String {
     format!("{kept}...")
 }
 
+/// `std::sys::cmath::*` names we allow in device code and rewrite to GPU math.
+///
+/// When you call `x.tan()` (also `atan`, `acos`, `cbrt`, the hyperbolics,
+/// `exp_m1`, `ln_1p`, `hypot`, ...), the compiler turns it into a call to a
+/// tiny `std` wrapper like `std::sys::cmath::tan`, which on a CPU forwards to
+/// the system C math library. The GPU has no such library, and device code
+/// may not call into `std`, so our "no std on the GPU" guard would normally
+/// reject the call.
+///
+/// We never actually run `std` here: mir-importer rewrites each of these
+/// names to the matching NVIDIA libdevice function (`__nv_tan`, `__nv_sinh`,
+/// ...). This list just tells the guard "these are fine, we handle them."
+/// Keep it in sync with the `std::sys::cmath` matches in float_math.rs.
+///
+/// A few functions (`sin`, `cos`, `exp`, ...) take a different, allowed route
+/// on this toolchain: the compiler lowers them to a builtin in `core`, so
+/// they never reach here. The ones below still go through `std` because they
+/// are not part of `core_float_math`; `sin`/`cos` are listed defensively in
+/// case a build ever takes the `std` route too. Only `std::`-prefixed names
+/// belong here; `core`-based shims are already allowed.
 fn is_intrinsic_lowered_cmath_shim(fn_path: &str) -> bool {
     matches!(
         fn_path,


### PR DESCRIPTION
## What is wrong

The collector renders `CUDA-OXIDE: FORBIDDEN CRATE IN DEVICE CODE` in a boxed error. Fitting the function path into that box was:

```rust
// Truncate fn_path if too long (max 48 chars to fit in box)
let fn_display = if fn_path.len() > 48 {
    format!("{}...", &fn_path[..45])
} else {
    fn_path.clone()
};
```

The comment says characters, and the box pads the field with `{:<48}`, which counts characters. Both operations here are on bytes, and each is wrong in its own way.

**`&fn_path[..45]` aborts the compiler.** It is a byte index, so when byte 45 falls inside a multi-byte character it panics. Rust identifiers may be non-ASCII (stable since 1.53), so a path can reach here in that shape — and the result is an abort *while emitting a user error*. The diagnostic this box exists to print is replaced by an ICE. Reproduced against the old expression:

```
path = "é".repeat(60)   // 120 bytes, 60 chars, byte 45 mid-character
byte index 45 is not a char boundary; it is inside 'é' (bytes 44..46 of string)
```

**`fn_path.len() > 48` measures the wrong thing.** A 48-character path spelled partly with multi-byte characters is 51 bytes, so it was truncated even though it fits the box:

```
path = "a" * 45 + "é" * 3   // 48 chars, 51 bytes, byte 45 is a boundary
old -> truncated to 45 chars + "..."      new -> left alone
```

## The change

Both go through one character-based helper, extracted so it is testable. `truncate_path_for_box` returns the path unchanged when it fits the character budget, and otherwise keeps `width - 3` characters and appends an ellipsis, so the result never exceeds `width` characters and never splits one.

The other `CollectDecision::Forbidden` arm formats the full path with no slicing and is unaffected.

## Scope

I swept the tree for the same shape — a format width specifier in a file that also guards on `.len() > N` — and `collector.rs` is the only hit. `local_memory_diagnostic.rs:464` (`&full[..40]`) is inside a `#[test]` over ASCII input; `ptx_asm.rs:403` (`&value[1..]`) indexes a fixed constraint set.

## Tests

Four, in `collector`'s existing `mod tests`:

| test | pins |
|---|---|
| `truncating_a_path_for_the_box_respects_char_boundaries` | the panic. Asserts the fixture really does straddle byte 45 (`!path.is_char_boundary(45)`), so the test cannot silently stop covering the bug |
| `a_path_that_fits_is_left_alone` | short paths untouched |
| `a_multibyte_path_within_the_char_budget_is_not_truncated` | the bytes-vs-chars half: 30 chars / 60 bytes must not truncate |
| `truncation_never_exceeds_the_width` | 49/60/200-char inputs all come out at exactly 48 |

## Verification

All local, no GPU needed.

- `cargo test --lib` in `crates/rustc-codegen-cuda`: **27 passed, 0 failed**. CI runs this same command in its `cargo test --lib (rustc-codegen-cuda)` job.
- `cargo fmt --all --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`: clean

One file, `crates/rustc-codegen-cuda/src/collector.rs`. I checked every open PR's file list via `gh api --paginate .../pulls/N/files` — no open PR touches it.
