### PR TITLE
docs(book): the event-timing snippet's import does not compile

### DIFF
--- a/cuda-oxide-book/async-programming/scheduling-and-streams.md
+++ b/cuda-oxide-book/async-programming/scheduling-and-streams.md
@@ -297,7 +297,9 @@ timing requires events created **without** `CU_EVENT_DISABLE_TIMING` -- pass
 explicit flags to enable timing:
 
 ```rust
-use cuda_bindings::CUevent_flags_enum::CU_EVENT_DEFAULT;
+// bindgen flattens the CUDA enums, so the constant is a crate-root item
+// named after its enum, not a variant inside a module.
+use cuda_bindings::CUevent_flags_enum_CU_EVENT_DEFAULT as CU_EVENT_DEFAULT;
 
 let start = stream.record_event(Some(CU_EVENT_DEFAULT))?;
 // SAFETY: config and arguments satisfy my_kernel's requirements.


### PR DESCRIPTION
## What is wrong

`scheduling-and-streams.md` opens the only event-timing example in the book with:

```rust
use cuda_bindings::CUevent_flags_enum::CU_EVENT_DEFAULT;
```

Pasting that line fails:

```
error[E0432]: unresolved import `cuda_bindings::CUevent_flags_enum`
  `CUevent_flags_enum` is a type alias, not a module
```

bindgen flattens CUDA's enums. The generated bindings are:

```rust
pub type CUevent_flags_enum = ::std::os::raw::c_uint;
pub const CUevent_flags_enum_CU_EVENT_DEFAULT: CUevent_flags_enum = 0;
pub use self::CUevent_flags_enum as CUevent_flags;
```

so the constant is a crate-root item whose name embeds its enum — there is no module to path through. It is the first line of the snippet, so the whole example is unusable, and it is the one place the book shows how to time a kernel.

## The change

Import the real name and alias it. That leaves the rest of the snippet and the surrounding prose (`CU_EVENT_DEFAULT`, `CU_EVENT_DISABLE_TIMING`) unchanged, and matches how `cuda-core`'s own rustdoc on `CudaContext::new_event` names these flags. A comment records the flattening so the next reader does not retry the module path.

Everything else the snippet asserts checks out:

- `CudaStream::record_event` takes `Option<cuda_bindings::CUevent_flags>` — `crates/cuda-core/src/stream.rs:178`
- `CudaEvent::synchronize` and `CudaEvent::elapsed_ms(&self, end: &Self) -> Result<f32, _>` both exist — `event.rs:106`, `event.rs:134`
- `new_event` really does default to `CU_EVENT_DISABLE_TIMING` when passed `None`, as the paragraph below the block says — `event.rs:69`

## How it was found, and why nothing caught it

I extracted every `use cuda_*::...;` path from every ` ```rust ` block in the book — 75 after brace expansion — put them in a probe crate against `cuda-device`, `cuda-core`, `cuda-host`, `cuda-async` and `cuda-bindings`, and compiled. **74 resolve; this is the one that does not.** The corrected line compiles, and `record_event(Some(CU_EVENT_DEFAULT))` type-checks against the parameter type.

I ran the same probe over the 158 crate and example READMEs (23 distinct `use` paths) and over inline fully-qualified paths in both — all clean, so this is the only instance.

`check-book-api-names.sh` cannot see it. Its scope note says host APIs are *"checked by rustdoc, which builds under `-D warnings`"*, and that is true of doc comments in Rust sources but not of a fenced block in a markdown page, which rustdoc never reads. Happy to turn the probe into a guard as a follow-up if you want one, though it needs `cuda-bindings` to build, which the book job does not currently do.

## Verification

- `sphinx-build -W --keep-going -b html cuda-oxide-book` succeeds
- `check-book-api-names.sh`: OK over 468 Rust blocks
- the corrected import compiles and type-checks against `record_event`

One file. Checked against every open PR's file list — no overlap.
