### PR TITLE
docs(ptx): both PTX crates' consumer inventories predate ptx-schedule

### DIFF
--- a/crates/dialect-ptx/README.md
+++ b/crates/dialect-ptx/README.md
@@ -44,14 +44,19 @@ the same version ceiling as the CFG. Rename plans also fail closed on
 vector-element uses of a renamed register (`v.x` lexes as one word) and on
 rename targets that would capture a label or callable name.
 
-## First consumers
+## Consumers
 
-The first in-tree consumers of the native CFG are IKET PTX instrumentation
-(`dialect-iket`), which needs verified block boundaries and successor edges to
-place probes, and the Tile-to-SIMT interop epic (#96), which splices SIMT
-regions into externally produced PTX. Longer term the raised dialect is the
-substrate for a direct-to-PTX emission path that bypasses textual `.ll`
-round-trips entirely.
+`ptx-schedule` is the in-tree consumer of the native CFG today, and the only
+crate that depends on this one. `analyze_ptx` takes `ControlFlow::analyze`'s
+blocks and successor edges to find back-edges, which is what lets a schedule
+campaign perturb a spin loop whatever its label, predicate or branch spelling.
+
+Two more are planned and do not depend on this crate yet: IKET PTX
+instrumentation (`dialect-iket`), which needs verified block boundaries and
+successor edges to place probes, and the Tile-to-SIMT interop epic (#96), which
+splices SIMT regions into externally produced PTX. Longer term the raised
+dialect is the substrate for a direct-to-PTX emission path that bypasses
+textual `.ll` round-trips entirely.
 
 ## Transform conventions
 

--- a/crates/ptx-parse/README.md
+++ b/crates/ptx-parse/README.md
@@ -85,6 +85,7 @@ re-parsing.
 | `cuda-intrinsics-gen` | Checking the PTX each generated intrinsic emits            |
 | `cargo-oxide`         | Inspecting PTX for the CLI                                 |
 | `dialect-ptx`         | Projecting parsed source into the structured dialect       |
+| `ptx-schedule`        | Finding schedule-sensitive sites and inserting sleeps      |
 
 ## License
 


### PR DESCRIPTION
`ptx-schedule` landed in #1065 and depends on both PTX crates. Neither one's README says so, and one of them is now wrong rather than merely short.

## `ptx-parse` — a table five of six long

The Consumers table lists `cuda-oxide-codegen`, `cuda-host`, `cuda-intrinsics-gen`, `cargo-oxide`, `dialect-ptx`. Six crates declare `ptx-parse` as a dependency; that is five of them. `ptx-schedule` takes `Document`, `EditScript`, `Instruction` and `ParseError` — as central a use as any row already there.

Every other row checks out, including the file-level detail: `export.rs` and `ptx.rs` in `cuda-oxide-codegen`, and `embedded.rs` in `cuda-host`, all three exist and all three reference `ptx_parse`.

## `dialect-ptx` — a section that names two non-consumers

The section headed "First consumers" reads:

> The first in-tree consumers of the native CFG are IKET PTX instrumentation (`dialect-iket`), which needs verified block boundaries and successor edges to place probes, and the Tile-to-SIMT interop epic (#96) ...

Neither is a consumer:

- `dialect-iket` does not depend on `dialect-ptx`. Its `[dependencies]` are `pliron`, `pliron-derive`, `thiserror`, `linkme`, `combine`, `dyn-clone`, and the crate contains no reference to `dialect_ptx` at all.
- #96 is still an open tracking issue.

Meanwhile the one crate that *does* depend on `dialect-ptx` — `ptx-schedule`, and it depends on nothing else from it but `cfg::ControlFlow` — goes unmentioned. `dialect-ptx` has exactly one in-tree dependent, and the section pointed the reader at two crates that are not it.

So the section states a plan in the present tense. Renamed to "Consumers", naming `ptx-schedule` and what it uses the CFG for (back-edge discovery, which is what makes a spin loop perturbable whatever its label, predicate or branch spelling), and keeping the other two where they belong — as planned work that does not depend on the crate yet.

## Verification

- `check-book-api-names.sh`: OK across 159 READMEs
- no relative links added, so crates.io rendering is unaffected (the correction from #981's review)

Two files, both README-only. Checked against every open PR's file list — no overlap.
