### PR TITLE
debug: keep generated kernel prologue off attribute lines

### DIFF
--- a/crates/cuda-device/tests/compile_fail/thread_index_device_return.stderr
+++ b/crates/cuda-device/tests/compile_fail/thread_index_device_return.stderr
@@ -1,7 +1,8 @@
-error[E0515]: cannot return reference to temporary value
- --> tests/compile_fail/thread_index_device_return.rs:8:1
-  |
-8 | #[device]
-  | ^^^^^^^^^ returns a reference to data owned by the current function
-  |
-  = note: this error originates in the attribute macro `device` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0515]: cannot return value referencing temporary value
+  --> tests/compile_fail/thread_index_device_return.rs:10:5
+   |
+ 8 | #[device]
+   | --------- temporary value created here
+ 9 | pub fn bad_device_return<'a>() -> cuda_device::thread::ThreadIndex<'a> {
+10 |     cuda_device::thread::index_1d()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function

--- a/crates/cuda-device/tests/compile_fail/thread_index_shared_borrow_laundering.stderr
+++ b/crates/cuda-device/tests/compile_fail/thread_index_shared_borrow_laundering.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> tests/compile_fail/thread_index_shared_borrow_laundering.rs:11:1
    |
 11 | #[device]
-   | ^^^^^^^^^
-   | |
-   | creates a temporary value which is freed while still in use
-   | assignment requires that borrow lasts for `'static`
+   | ^^^^^^^^^ creates a temporary value which is freed while still in use
+...
+14 |         COURIER[0] = cuda_device::thread::index_1d();
+   |         -------------------------------------------- assignment requires that borrow lasts for `'static`
 ...
 17 | }
    | - temporary value is freed at the end of this statement

--- a/crates/cuda-device/tests/compile_fail/thread_index_shared_laundering.stderr
+++ b/crates/cuda-device/tests/compile_fail/thread_index_shared_laundering.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> tests/compile_fail/thread_index_shared_laundering.rs:11:1
    |
 11 | #[device]
-   | ^^^^^^^^^
-   | |
-   | creates a temporary value which is freed while still in use
-   | assignment requires that borrow lasts for `'static`
+   | ^^^^^^^^^ creates a temporary value which is freed while still in use
+...
+14 |         COURIER[0] = cuda_device::thread::index_1d();
+   |         -------------------------------------------- assignment requires that borrow lasts for `'static`
 ...
 18 | }
    | - temporary value is freed at the end of this statement

--- a/crates/cuda-macros/src/lib.rs
+++ b/crates/cuda-macros/src/lib.rs
@@ -177,7 +177,7 @@ use syn::{
     Ident, Item, ItemFn, ItemForeignMod, ItemMod, LitStr, Pat, Path, PathArguments, Stmt, Token,
     Type, bracketed, parenthesized,
     parse::{Parse, ParseStream},
-    parse_macro_input, parse_quote,
+    parse_macro_input, parse_quote, parse_quote_spanned,
     punctuated::Punctuated,
     spanned::Spanned,
     visit::{self, Visit},
@@ -4664,11 +4664,18 @@ fn is_thread_index_path(path: &Path, name: &str) -> bool {
 /// ```text
 /// index_1d()                           →  ::cuda_device::thread::__internal::index_1d(&scope)
 /// ```
-fn internal_thread_path(user_path: &Path, name: &str, arguments: syn::PathArguments) -> Path {
-    let ident = format_ident!("{}", name);
+fn internal_thread_path(
+    user_path: &Path,
+    name: &str,
+    arguments: syn::PathArguments,
+    call_span: proc_macro2::Span,
+) -> Path {
+    let ident = Ident::new(name, call_span);
+    let internal = Ident::new("__internal", call_span);
 
     if user_path.segments.len() == 1 {
-        let mut absolute: Path = parse_quote! { ::cuda_device::thread::__internal::#ident };
+        let mut absolute: Path =
+            parse_quote_spanned! { call_span => ::cuda_device::thread::#internal::#ident };
         if let Some(last) = absolute.segments.last_mut() {
             last.arguments = arguments;
         }
@@ -4681,8 +4688,9 @@ fn internal_thread_path(user_path: &Path, name: &str, arguments: syn::PathArgume
         .iter()
         .take(user_path.segments.len() - 1)
         .collect();
-    let mut rewritten: Path =
-        parse_quote! { #leading_colon #(#prefix_segments)::* :: __internal :: #ident };
+    let mut rewritten: Path = parse_quote_spanned! {
+        call_span => #leading_colon #(#prefix_segments)::* :: #internal :: #ident
+    };
     if let Some(last) = rewritten.segments.last_mut() {
         last.arguments = arguments;
     }
@@ -4752,13 +4760,21 @@ struct ThreadIndexCallRewriter {
     rewrote_index_call: bool,
 }
 
+fn ident_located_at(ident: &Ident, location: proc_macro2::Span) -> Ident {
+    let mut relocated = ident.clone();
+    relocated.set_span(ident.span().located_at(location));
+    relocated
+}
+
 impl VisitMut for ThreadIndexCallRewriter {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         visit_mut::visit_expr_mut(self, expr);
 
         match expr {
-            Expr::Call(ExprCall { func, args, .. }) => {
-                let Expr::Path(ExprPath { path, .. }) = &**func else {
+            Expr::Call(call) => {
+                let call_span = call.span();
+                let ExprCall { func, args, .. } = call;
+                let Expr::Path(ExprPath { path, .. }) = &mut **func else {
                     return;
                 };
                 let Some(intrinsic) = SCOPED_INTRINSICS
@@ -4778,30 +4794,36 @@ impl VisitMut for ThreadIndexCallRewriter {
                 } else {
                     syn::PathArguments::None
                 };
-                let internal_path = internal_thread_path(path, intrinsic.name, path_args);
-                let scope_ident = &self.scope_ident;
-                let scope_arg = if self.borrow_scope {
-                    quote! { &#scope_ident }
+                *path = internal_thread_path(path, intrinsic.name, path_args, call_span);
+                // Keep the binding's name-resolution hygiene, but make this
+                // generated reference part of the user's indexing expression
+                // for diagnostics and line-table purposes.
+                let scope_ident = ident_located_at(&self.scope_ident, call_span);
+                let scope_arg: Expr = if self.borrow_scope {
+                    parse_quote_spanned! { call_span => &#scope_ident }
                 } else {
-                    quote! { #scope_ident }
+                    parse_quote_spanned! { call_span => #scope_ident }
                 };
 
-                *expr = if intrinsic.forward_args {
-                    parse_quote! { #internal_path(#scope_arg, #args) }
+                if intrinsic.forward_args {
+                    args.insert(0, scope_arg);
                 } else {
-                    parse_quote! { #internal_path(#scope_arg) }
-                };
+                    args.clear();
+                    args.push(scope_arg);
+                }
                 self.rewrote_index_call = true;
             }
-            Expr::MethodCall(ExprMethodCall { method, args, .. }) => {
+            Expr::MethodCall(method_call) => {
+                let call_span = method_call.span();
+                let ExprMethodCall { method, args, .. } = method_call;
                 if !is_scoped_method(method) || !args.is_empty() {
                     return;
                 }
-                let scope_ident = &self.scope_ident;
+                let scope_ident = ident_located_at(&self.scope_ident, call_span);
                 if self.borrow_scope {
-                    args.push(parse_quote! { &#scope_ident });
+                    args.push(parse_quote_spanned! { call_span => &#scope_ident });
                 } else {
-                    args.push(parse_quote! { #scope_ident });
+                    args.push(parse_quote_spanned! { call_span => #scope_ident });
                 }
                 self.rewrote_index_call = true;
             }
@@ -8676,6 +8698,82 @@ mod tests {
             .splice(0..0, explicit_kernel_scope_bindings(&scope));
         let two_dimensional = quote!(#two_dimensional).to_string().replace(' ', "");
         assert!(two_dimensional.contains("make_kernel_scope::<::cuda_device::thread::__internal::Domain2,::cuda_device::thread::__internal::U32Coordinates>"));
+    }
+
+    #[test]
+    fn thread_index_rewrite_preserves_the_user_call_span_with_multiple_attributes() {
+        let mut input: ItemFn = syn::parse_str(
+            r#"
+/// The documentation and neighboring attributes must not become line-table
+/// locations for the first executable indexing expression.
+#[allow(dead_code)]
+#[launch_bounds(256, 2)]
+fn documented_kernel() {
+    let idx = thread::index_1d();
+    consume(idx);
+}
+"#,
+        )
+        .unwrap();
+        let source_attr_count = input.attrs.len();
+
+        let Stmt::Local(original_local) = &input.block.stmts[0] else {
+            panic!("fixture starts with a local")
+        };
+        let original_call = original_local
+            .init
+            .as_ref()
+            .map(|init| &*init.expr)
+            .and_then(|expr| match expr {
+                Expr::Call(call) => Some(call),
+                _ => None,
+            })
+            .expect("fixture local is initialized by a call");
+        let user_call_start = original_call.span().start();
+        assert!(
+            user_call_start.line > 5,
+            "fixture must distinguish attributes"
+        );
+
+        inject_thread_index_scope(&mut input);
+
+        assert_eq!(
+            input.attrs.len(),
+            source_attr_count,
+            "all source attributes stay on the item"
+        );
+        let Stmt::Local(rewritten_local) = &input.block.stmts[1] else {
+            panic!("the user local follows the generated scope binding")
+        };
+        let rewritten_call = rewritten_local
+            .init
+            .as_ref()
+            .map(|init| &*init.expr)
+            .and_then(|expr| match expr {
+                Expr::Call(call) => Some(call),
+                _ => None,
+            })
+            .expect("rewritten local remains a call expression");
+
+        assert_eq!(
+            rewritten_call.span().start(),
+            user_call_start,
+            "rewriting must not relocate the user expression onto an attribute"
+        );
+        let Expr::Path(path) = &*rewritten_call.func else {
+            panic!("rewritten callee remains a path")
+        };
+        assert!(
+            path.path
+                .segments
+                .iter()
+                .any(|segment| segment.ident == "__internal")
+        );
+        assert_eq!(
+            rewritten_call.args[0].span().start(),
+            user_call_start,
+            "the injected scope reference belongs to the user's call site"
+        );
     }
 
     #[test]

--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -93,17 +93,21 @@ impl<'a> ModuleExportState<'a> {
         let Some(scope) = scope else {
             return;
         };
-        let location_id = self.debug_location_for_scope(scope, loc).or_else(|| {
-            if allow_scope_fallback {
-                // LLVM rejects inlinable calls inside a debug-scoped function
-                // unless the call itself has a location. When rustc/pliron did
-                // not give the call one, point it at the function line instead
-                // of letting opt discard the whole debug graph.
-                self.debug_fallback_location_for_scope(scope)
-            } else {
-                None
-            }
-        });
+        let location_id = if crate::is_artificial_debug_location(loc) {
+            Some(self.ensure_artificial_debug_location(scope))
+        } else {
+            self.debug_location_for_scope(scope, loc).or_else(|| {
+                if allow_scope_fallback {
+                    // LLVM rejects inlinable calls inside a debug-scoped function
+                    // unless the call itself has a location. When rustc/pliron did
+                    // not give the call one, point it at the function line instead
+                    // of letting opt discard the whole debug graph.
+                    self.debug_fallback_location_for_scope(scope)
+                } else {
+                    None
+                }
+            })
+        };
         let Some(location_id) = location_id else {
             return;
         };
@@ -862,6 +866,21 @@ impl<'a> ModuleExportState<'a> {
     fn debug_fallback_location_for_scope(&mut self, scope: usize) -> Option<usize> {
         let (line, column) = self.debug_subprogram_fallbacks.get(&scope).copied()?;
         self.ensure_debug_location(scope, SourcePosition { line, column }, None)
+    }
+
+    fn ensure_artificial_debug_location(&mut self, scope: usize) -> usize {
+        let key = (scope, 0, 0, None);
+        if let Some(id) = self.debug_locations.get(&key).copied() {
+            return id;
+        }
+
+        let id = self.alloc_metadata_id();
+        self.debug_nodes.push((
+            id,
+            format!("!DILocation(line: 0, column: 0, scope: !{scope})"),
+        ));
+        self.debug_locations.insert(key, id);
+        id
     }
 
     fn local_variable_position_from_location(

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -21,6 +21,33 @@
 
 pub mod export;
 
+/// Stable marker used when an operation must remain in a debug-scoped LLVM
+/// function but does not correspond to user-written source.
+pub const ARTIFICIAL_DEBUG_LOCATION_NAME: &str = "cuda_oxide.artificial";
+
+/// Build a location which the textual LLVM exporter emits as line zero.
+///
+/// LLVM requires calls in a debug-scoped, inlinable function to carry a
+/// `DILocation`. An ordinary [`pliron::location::Location::Unknown`] therefore
+/// falls back to the function's source line. This explicit marker distinguishes
+/// compiler-generated setup which must have a location for LLVM validity but
+/// must not create a user-visible line-table entry.
+pub fn artificial_debug_location() -> pliron::location::Location {
+    pliron::location::Location::Named {
+        name: ARTIFICIAL_DEBUG_LOCATION_NAME.into(),
+        child_loc: Box::new(pliron::location::Location::Unknown),
+    }
+}
+
+/// Whether `loc` carries the explicit artificial-debug marker.
+pub fn is_artificial_debug_location(loc: &pliron::location::Location) -> bool {
+    matches!(
+        loc,
+        pliron::location::Location::Named { name, .. }
+            if name == ARTIFICIAL_DEBUG_LOCATION_NAME
+    )
+}
+
 /// LLVM types: re-exported from pliron-llvm, plus GPU address-space helpers.
 pub mod types {
     pub use pliron_llvm::types::*;

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -3755,6 +3755,66 @@ fn line_table_debug_metadata_adds_fallback_locations_to_calls() {
     );
 }
 
+#[test]
+fn line_table_debug_metadata_emits_explicit_artificial_calls_at_line_zero() {
+    let mut ctx = Context::new();
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_region = module.get_operation().deref(&ctx).get_region(0);
+    let module_block = {
+        let region = module_region.deref(&ctx);
+        region.iter(&ctx).next().unwrap()
+    };
+
+    let i32_ty = IntegerType::get(&ctx, 32, Signedness::Signless);
+    let void_ty = VoidType::get(&ctx);
+    let helper_ty = FuncType::get(&ctx, i32_ty.to_handle(), vec![], false);
+    let helper = FuncOp::new(&mut ctx, "helper".try_into().unwrap(), helper_ty);
+    helper.get_operation().insert_at_back(module_block, &ctx);
+
+    let caller_ty = FuncType::get(&ctx, void_ty.to_handle(), vec![], false);
+    let caller = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), caller_ty);
+    let caller_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 20, 3);
+    caller.get_operation().deref_mut(&ctx).set_loc(caller_loc);
+
+    let entry = caller.get_or_create_entry_block(&mut ctx);
+    let call = CallOp::new(
+        &mut ctx,
+        CallOpCallable::Direct("helper".try_into().unwrap()),
+        helper_ty,
+        vec![],
+    );
+    call.get_operation()
+        .deref_mut(&ctx)
+        .set_loc(llvm_export::artificial_debug_location());
+    call.get_operation().insert_at_back(entry, &ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+
+    caller.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = DebugConfig {
+        inner: PtxExportConfig,
+        debug_kind: DebugKind::LineTables,
+    };
+    let ir =
+        export_module_to_string_with_config(&ctx, &module, &config).expect("debug export succeeds");
+
+    let call_line = ir
+        .lines()
+        .find(|line| line.contains("call i32 @helper()"))
+        .expect("call instruction");
+    assert!(
+        call_line.contains(", !dbg !"),
+        "LLVM still requires an artificial call location:\n{ir}"
+    );
+    assert!(
+        ir.contains("!DILocation(line: 0, column: 0, scope: !"),
+        "artificial setup must not reuse the caller's user line:\n{ir}"
+    );
+}
+
 /// Scans the textual LLVM IR and asserts that every `%vN` token appearing in
 /// an operand position has a corresponding `%vN = ...` definition somewhere
 /// in the module. Operates on `%v` temporaries only because that's the

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -976,6 +976,7 @@ fn translate_call(
 
     // Extract function info
     let (pattern_name, call_name, substs_args, type_substs) = extract_func_info(func, &loc)?;
+    let loc = call_debug_location(pattern_name.as_deref(), loc);
 
     // Is the trait-method Self type SharedArray? Shared with
     // `values::classify_call` so intrinsic dispatch and destination-slot
@@ -1436,6 +1437,44 @@ fn ensure_foreign_callee_is_not_variadic(
         );
     }
     Ok(())
+}
+
+// stable-MIR reports the function's canonical definition path rather than the
+// `cuda_device::thread::__internal` re-export spelling emitted by the macro.
+const KERNEL_SCOPE_CONSTRUCTOR: &str = "cuda_device::__internal::make_kernel_scope";
+
+// These start-of-kernel calls are compiler metadata, not source statements.
+// They are removed during import, but the replacement control-flow edge must
+// also stay off the attribute line which caused the macro to inject them.
+const KERNEL_METADATA_MARKERS: &[&str] = &[
+    "cuda_device::__launch_bounds_config",
+    "cuda_device::thread::__launch_bounds_config",
+    "cuda_device::__launch_contract_config",
+    "cuda_device::thread::__launch_contract_config",
+    "cuda_device::__launch_contract_block_config",
+    "cuda_device::thread::__launch_contract_block_config",
+    "cuda_device::__unchecked_indexing_config",
+    "cuda_device::thread::__unchecked_indexing_config",
+    "cuda_device::cluster::__cluster_config",
+    "cuda_device::shared::__dynamic_shared_alignment",
+];
+
+/// Keep the macro-injected launch-context constructor out of user line tables.
+///
+/// Its Rust span intentionally stays at the proc-macro invocation so any
+/// type-checker or borrow-checker diagnostic points into the user's item. The
+/// call itself is compiler-generated setup, though, and must not make a
+/// function breakpoint stop on `#[kernel]` (or whichever adjacent attribute
+/// happened to invoke the macro). Separating the debug location here lets the
+/// diagnostic span and runtime line table serve those different purposes.
+fn call_debug_location(pattern_name: Option<&str>, loc: Location) -> Location {
+    if pattern_name.is_some_and(|name| {
+        name == KERNEL_SCOPE_CONSTRUCTOR || KERNEL_METADATA_MARKERS.contains(&name)
+    }) {
+        llvm_export::artificial_debug_location()
+    } else {
+        loc
+    }
 }
 
 /// Handle `FnOnce::call_once`, `FnMut::call_mut`, or `Fn::call` when the
@@ -3278,6 +3317,35 @@ mod tests {
     fn foreign_signature_rejects_c_variadic_before_claiming_an_exact_abi() {
         assert!(ensure_foreign_callee_is_not_variadic("fixed", false).is_ok());
         assert!(ensure_foreign_callee_is_not_variadic("variadic", true).is_err());
+    }
+
+    #[test]
+    fn generated_kernel_setup_calls_have_no_user_debug_location() {
+        let user_location = Location::Named {
+            name: "kernel attribute".into(),
+            child_loc: Box::new(Location::Unknown),
+        };
+
+        assert_eq!(
+            call_debug_location(Some(KERNEL_SCOPE_CONSTRUCTOR), user_location.clone()),
+            llvm_export::artificial_debug_location()
+        );
+        assert_eq!(
+            call_debug_location(
+                Some("cuda_device::__launch_bounds_config"),
+                user_location.clone()
+            ),
+            llvm_export::artificial_debug_location(),
+            "zero-cost launch metadata must not leave an attribute line behind"
+        );
+        assert_eq!(
+            call_debug_location(
+                Some("cuda_device::thread::__internal::index_1d"),
+                user_location.clone()
+            ),
+            user_location,
+            "user-written indexing calls keep their source locations"
+        );
     }
 
     /// A `SwitchInt` arm keeps its whole value at 128 bits, and narrower

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -1440,8 +1440,13 @@ fn ensure_foreign_callee_is_not_variadic(
 }
 
 // stable-MIR reports the function's canonical definition path rather than the
-// `cuda_device::thread::__internal` re-export spelling emitted by the macro.
-const KERNEL_SCOPE_CONSTRUCTOR: &str = "cuda_device::__internal::make_kernel_scope";
+// `cuda_device::thread::__internal` re-export spelling emitted by the macro,
+// but accept both spellings like the metadata markers below so a toolchain
+// bump changing visible-path selection cannot silently drop the match.
+const KERNEL_SCOPE_CONSTRUCTORS: &[&str] = &[
+    "cuda_device::__internal::make_kernel_scope",
+    "cuda_device::thread::__internal::make_kernel_scope",
+];
 
 // These start-of-kernel calls are compiler metadata, not source statements.
 // They are removed during import, but the replacement control-flow edge must
@@ -1469,7 +1474,7 @@ const KERNEL_METADATA_MARKERS: &[&str] = &[
 /// diagnostic span and runtime line table serve those different purposes.
 fn call_debug_location(pattern_name: Option<&str>, loc: Location) -> Location {
     if pattern_name.is_some_and(|name| {
-        name == KERNEL_SCOPE_CONSTRUCTOR || KERNEL_METADATA_MARKERS.contains(&name)
+        KERNEL_SCOPE_CONSTRUCTORS.contains(&name) || KERNEL_METADATA_MARKERS.contains(&name)
     }) {
         llvm_export::artificial_debug_location()
     } else {
@@ -3326,10 +3331,12 @@ mod tests {
             child_loc: Box::new(Location::Unknown),
         };
 
-        assert_eq!(
-            call_debug_location(Some(KERNEL_SCOPE_CONSTRUCTOR), user_location.clone()),
-            llvm_export::artificial_debug_location()
-        );
+        for constructor in KERNEL_SCOPE_CONSTRUCTORS {
+            assert_eq!(
+                call_debug_location(Some(constructor), user_location.clone()),
+                llvm_export::artificial_debug_location()
+            );
+        }
         assert_eq!(
             call_debug_location(
                 Some("cuda_device::__launch_bounds_config"),

--- a/crates/rustc-codegen-cuda/examples/debug/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/debug/src/main.rs
@@ -29,10 +29,10 @@ mod kernels {
     use super::*;
 
     /// Test kernel: measures clock and global timer ticks for a simple operation.
-    #[kernel]
-    #[launch_bounds(256, 2)] // Max 256 threads/block, min 2 blocks/SM
+    #[kernel] // CUDA_OXIDE_DEBUG_KERNEL_ATTRIBUTE_LINE
+    #[launch_bounds(256, 2)] // CUDA_OXIDE_DEBUG_LAUNCH_BOUNDS_ATTRIBUTE_LINE
     pub fn clock_test(mut output: DisjointSlice<u64>) {
-        let idx = thread::index_1d();
+        let idx = thread::index_1d(); // CUDA_OXIDE_DEBUG_KERNEL_ENTRY_LINE
         if let Some(output_elem) = output.get_mut(idx) {
             let start_cycles = debug::clock64();
             let start_timer = debug::globaltimer();

--- a/crates/rustc-codegen-cuda/examples/debug/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/debug/verify-code-shape.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build first with full device debug information:
+#
+#   cargo oxide build debug --device-debug
+#
+# This pins the kernel-entry line-table contract in both emitted LLVM IR and
+# PTX. Source lines come from a same-line marker, never an assumed offset from
+# `#[kernel]`; the fixture deliberately has documentation plus multiple
+# attributes before the function.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_file="${root}/src/main.rs"
+llvm_ir="${root}/debug.ll"
+ptx="${root}/debug.ptx"
+
+test -s "${llvm_ir}"
+test -s "${ptx}"
+
+entry_line="$(grep -nF 'CUDA_OXIDE_DEBUG_KERNEL_ENTRY_LINE' "${source_file}" | cut -d: -f1)"
+kernel_attr_line="$(grep -nF 'CUDA_OXIDE_DEBUG_KERNEL_ATTRIBUTE_LINE' "${source_file}" | cut -d: -f1)"
+launch_bounds_attr_line="$(grep -nF 'CUDA_OXIDE_DEBUG_LAUNCH_BOUNDS_ATTRIBUTE_LINE' "${source_file}" | cut -d: -f1)"
+test -n "${entry_line}"
+test -n "${kernel_attr_line}"
+test -n "${launch_bounds_attr_line}"
+
+llvm_body="$(awk '
+    /^define ptx_kernel void @clock_test\(/ { in_function = 1 }
+    in_function { print }
+    in_function && /^}/ { exit }
+' "${llvm_ir}")"
+test -n "${llvm_body}"
+
+scope_debug_id="$(
+    grep -m1 'call void @.*make_kernel_scope' <<<"${llvm_body}" |
+        sed -nE 's/.*!dbg !([0-9]+).*/\1/p'
+)"
+index_debug_id="$(
+    grep -m1 'call i64 @.*index_1d' <<<"${llvm_body}" |
+        sed -nE 's/.*!dbg !([0-9]+).*/\1/p'
+)"
+test -n "${scope_debug_id}"
+test -n "${index_debug_id}"
+
+if ! grep -Eq "^!${scope_debug_id} = !DILocation\\(line: 0, column: 0," "${llvm_ir}"; then
+    echo "error: generated kernel-scope call does not use an artificial LLVM location" >&2
+    exit 1
+fi
+if ! grep -Eq "^!${index_debug_id} = !DILocation\\(line: ${entry_line}, column:" "${llvm_ir}"; then
+    echo "error: rewritten index call lost source line ${entry_line} in LLVM IR" >&2
+    exit 1
+fi
+
+ptx_body="$(awk '
+    !emit && !candidate && /[.]entry[[:space:]]+clock_test\(/ { candidate = 1 }
+    candidate && /^[[:space:]]*;[[:space:]]*$/ {
+        candidate = 0
+        next
+    }
+    candidate && /^[[:space:]]*\{[[:space:]]*$/ {
+        emit = 1
+        candidate = 0
+    }
+    emit { print }
+    emit && /End function/ { exit }
+' "${ptx}")"
+test -n "${ptx_body}"
+
+ptx_prologue="$(awk '
+    { print }
+    /call[.]uni .*index_1d/ { exit }
+' <<<"${ptx_body}")"
+if grep -Eq "^[[:space:]]*[.]loc[[:space:]]+[0-9]+[[:space:]]+(${kernel_attr_line}|${launch_bounds_attr_line})([[:space:]]|$)" <<<"${ptx_prologue}"; then
+    echo "error: synthetic kernel prologue still maps to a macro attribute" >&2
+    exit 1
+fi
+
+if ! awk -v expected_index_line="${entry_line}" '
+    $1 == ".loc" { current_line = $3 }
+    /call[.]uni .*make_kernel_scope/ {
+        saw_scope = 1
+        scope_is_artificial = (current_line == 0)
+    }
+    /call[.]uni .*index_1d/ {
+        saw_index = 1
+        index_is_user_line = (current_line == expected_index_line)
+    }
+    END {
+        exit !(saw_scope && scope_is_artificial && saw_index && index_is_user_line)
+    }
+' <<<"${ptx_body}"; then
+    echo "error: PTX kernel prologue/index .loc state does not match the source contract" >&2
+    exit 1
+fi
+
+echo "debug kernel-entry lineinfo shape: PASS"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -1552,6 +1552,11 @@ run_cargo() {
         # Build at the instruction floor; the host check skips before module loading.
         args+=("--arch=sm_75")
     fi
+    if [[ "${ex}" == "debug" ]]; then
+        # Its code-shape gate checks LLVM/PTX source locations, which only
+        # exist when the example is compiled with full device debug metadata.
+        args+=("--device-debug")
+    fi
     if [[ ${COMPILE_ONLY} -eq 1 ]]; then
         case "${ex}" in
             cluster) args+=("--arch=sm_90") ;;


### PR DESCRIPTION
## Summary

Kernel-name breakpoints no longer treat `#[kernel]` as executable source.
Compiler-generated setup uses an artificial line, while the user's index call
keeps its real span.

```text
Before                              After
#[kernel]  line 13                  #[kernel]  line 13
   │                                   │
   └─ generated setup: .loc 13         └─ generated setup: line 0
      index_1d():      .loc 13            index_1d():      line 15
      cuda-gdb may show line 13            cuda-gdb shows line 15
```

Closes #1117.

## Changes

- Rewrite thread-index calls in place so their original spans survive.
- Mark injected kernel setup as artificial instead of falling back to the
  attribute line.
- Add a PTX/LLVM shape check with docs and multiple attributes.
- Update three affected compile-fail snapshots to the new diagnostic spans.

## Testing

- Full macro/importer/exporter/lowering suites passed on `af66e381`.
- Final head `63ce7c7e` passes `cargo test -p cuda-device --all-targets`,
  including all 29 thread-index compile-fail cases; the hosted check that
  exposed the stale snapshots is now green.
- The debug compile-only smoketest and PTX shape gate pass.
- CUDA 13.3 / RTX 5090: the T01 shape stops on the first body expression; the
  multi-attribute control stops on line 35, not lines 32/33.

- [ ] `just check` passes (affected suites and targeted smoketest pass)
- [x] Live GPU debugger regression exercised
- [x] New example added (existing debug example extended)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files

---
> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).
