### PR TITLE
debug: preserve supported thin-pointer pointee types

### DIFF
--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -462,6 +462,22 @@ impl<'a> ModuleExportState<'a> {
                      baseType: null, size: {size_bits})"
                 )
             }
+            DebugLocalTypeKind::TypedPointer {
+                name,
+                size_bits,
+                pointee,
+            } => {
+                assert!(
+                    pointee.is_valid_typed_pointer_pointee(),
+                    "typed pointer cannot export an opaque or composite pointee descendant"
+                );
+                let base = self.ensure_debug_type(pointee);
+                let name = escape_debug_string(name);
+                format!(
+                    "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"{name}\", \
+                     baseType: !{base}, size: {size_bits})"
+                )
+            }
             DebugLocalTypeKind::Struct {
                 name,
                 size_bits,

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -493,8 +493,25 @@ pub mod ops {
             size_bits: u64,
             encoding: &'static str,
         },
-        /// A pointer/reference `DIDerivedType`.
+        /// An opaque compatibility pointer/reference `DIDerivedType`.
+        ///
+        /// This is the pre-existing representation for pointer shapes whose
+        /// pointee cannot yet be described safely. Its null `baseType` keeps
+        /// the source variable visible, although debuggers may render it as
+        /// `*mut ()`.
         Pointer { name: String, size_bits: u64 },
+        /// A thin pointer/reference with a safely bounded pointee type.
+        ///
+        /// The finite pointee tree is required so the exporter never emits a
+        /// pointer with a null `baseType`, which debuggers present
+        /// misleadingly as `*mut ()`. Recursive composite graphs are not
+        /// represented by this tree-shaped model and must be rejected by the
+        /// importer.
+        TypedPointer {
+            name: String,
+            size_bits: u64,
+            pointee: Box<DebugLocalTypeKind>,
+        },
         /// A struct or tuple `DICompositeType` (`DW_TAG_structure_type`).
         ///
         /// Member offsets come from rustc's real layout, not declaration order,
@@ -565,9 +582,31 @@ pub mod ops {
             match self {
                 DebugLocalTypeKind::Basic { size_bits, .. }
                 | DebugLocalTypeKind::Pointer { size_bits, .. }
+                | DebugLocalTypeKind::TypedPointer { size_bits, .. }
                 | DebugLocalTypeKind::Struct { size_bits, .. }
                 | DebugLocalTypeKind::Enum { size_bits, .. }
                 | DebugLocalTypeKind::Array { size_bits, .. } => *size_bits,
+            }
+        }
+
+        /// Whether this type belongs to the acyclic subset accepted beneath a
+        /// [`DebugLocalTypeKind::TypedPointer`].
+        ///
+        /// Opaque pointers and source composites are excluded recursively so a
+        /// typed pointer can never hide a null-base descendant or smuggle a
+        /// recursive type graph into this tree-shaped representation.
+        pub(crate) fn is_valid_typed_pointer_pointee(&self) -> bool {
+            match self {
+                DebugLocalTypeKind::Basic { .. } => true,
+                DebugLocalTypeKind::TypedPointer { pointee, .. } => {
+                    pointee.is_valid_typed_pointer_pointee()
+                }
+                DebugLocalTypeKind::Array { element, .. } => {
+                    element.is_valid_typed_pointer_pointee()
+                }
+                DebugLocalTypeKind::Pointer { .. }
+                | DebugLocalTypeKind::Struct { .. }
+                | DebugLocalTypeKind::Enum { .. } => false,
             }
         }
     }
@@ -613,6 +652,20 @@ pub mod ops {
                 out.push('p');
                 put_u64(out, *size_bits);
                 put_str(out, name);
+            }
+            DebugLocalTypeKind::TypedPointer {
+                name,
+                size_bits,
+                pointee,
+            } => {
+                assert!(
+                    pointee.is_valid_typed_pointer_pointee(),
+                    "typed pointer pointee must contain only basic, typed-pointer, or array nodes"
+                );
+                out.push('t');
+                put_u64(out, *size_bits);
+                put_str(out, name);
+                serialize_debug_type(pointee, out);
             }
             DebugLocalTypeKind::Struct {
                 name,
@@ -721,6 +774,19 @@ pub mod ops {
                 let size_bits = take_u64(bytes, pos)?;
                 let name = take_str(bytes, pos)?;
                 Some(DebugLocalTypeKind::Pointer { name, size_bits })
+            }
+            b't' => {
+                let size_bits = take_u64(bytes, pos)?;
+                let name = take_str(bytes, pos)?;
+                let pointee = Box::new(deserialize_debug_type(bytes, pos)?);
+                if !pointee.is_valid_typed_pointer_pointee() {
+                    return None;
+                }
+                Some(DebugLocalTypeKind::TypedPointer {
+                    name,
+                    size_bits,
+                    pointee,
+                })
             }
             b's' => {
                 let size_bits = take_u64(bytes, pos)?;
@@ -2093,9 +2159,14 @@ pub mod ops {
                     DebugTypeMember {
                         name: "data".to_string(),
                         offset_bits: 64,
-                        ty: DebugLocalTypeKind::Pointer {
+                        ty: DebugLocalTypeKind::TypedPointer {
                             name: "*mut u64".to_string(),
                             size_bits: 64,
+                            pointee: Box::new(DebugLocalTypeKind::Basic {
+                                name: "u64".to_string(),
+                                size_bits: 64,
+                                encoding: "DW_ATE_unsigned",
+                            }),
                         },
                     },
                     DebugTypeMember {
@@ -2142,9 +2213,14 @@ pub mod ops {
                         members: vec![DebugTypeMember {
                             name: "0".to_string(),
                             offset_bits: 0,
-                            ty: DebugLocalTypeKind::Pointer {
+                            ty: DebugLocalTypeKind::TypedPointer {
                                 name: "&u32".to_string(),
                                 size_bits: 64,
+                                pointee: Box::new(DebugLocalTypeKind::Basic {
+                                    name: "u32".to_string(),
+                                    size_bits: 32,
+                                    encoding: "DW_ATE_unsigned",
+                                }),
                             },
                         }],
                     },
@@ -2157,11 +2233,102 @@ pub mod ops {
         #[test]
         fn round_trips_names_with_delimiters() {
             // Length-prefixing must survive names containing spaces/digits/braces.
-            let ty = DebugLocalTypeKind::Pointer {
+            let ty = DebugLocalTypeKind::TypedPointer {
                 name: "&[(u32, u32); 4] {x: 1}".to_string(),
                 size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::Basic {
+                    name: "u8".to_string(),
+                    size_bits: 8,
+                    encoding: "DW_ATE_unsigned",
+                }),
             };
             assert_eq!(round_trip(&ty), ty);
+        }
+
+        #[test]
+        fn round_trips_nested_pointer_pointees() {
+            let ty = DebugLocalTypeKind::TypedPointer {
+                name: "*const *mut i32".to_string(),
+                size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::TypedPointer {
+                    name: "*mut i32".to_string(),
+                    size_bits: 64,
+                    pointee: Box::new(DebugLocalTypeKind::Basic {
+                        name: "i32".to_string(),
+                        size_bits: 32,
+                        encoding: "DW_ATE_signed",
+                    }),
+                }),
+            };
+            assert_eq!(round_trip(&ty), ty);
+        }
+
+        #[test]
+        fn opaque_pointer_preserves_the_legacy_encoding() {
+            let ty = DebugLocalTypeKind::Pointer {
+                name: "*mut i32".to_string(),
+                size_bits: 64,
+            };
+            let mut encoded = String::new();
+            serialize_debug_type(&ty, &mut encoded);
+            assert_eq!(encoded, "p64 8 *mut i32");
+            assert_eq!(round_trip(&ty), ty);
+        }
+
+        #[test]
+        fn rejects_typed_pointer_without_a_serialized_pointee() {
+            // Unlike the legacy `p` record, the new `t` record requires a
+            // recursive pointee type and must reject a truncated payload.
+            let encoded = b"t64 8 *mut i32";
+            let mut pos = 0;
+            assert!(deserialize_debug_type(encoded, &mut pos).is_none());
+        }
+
+        #[test]
+        fn decoder_rejects_typed_pointer_with_forbidden_descendants() {
+            let invalid = [
+                // Direct legacy opaque pointer descendant.
+                "t64 8 *const _p64 8 *mut i32",
+                // The opaque pointer is hidden beneath a fixed array.
+                "t64 8 *const _a64 8 [ptr; 1]1 p64 8 *mut i32",
+                // Source composites are outside the acyclic typed subset.
+                "t64 8 *const _s64 3 Foo0 ",
+                "t64 8 *const _e64 3 Foo0 0 ",
+                // Composite descendants cannot be hidden below an otherwise
+                // accepted array or typed-pointer node either.
+                "t64 8 *const _a64 8 [Foo; 1]1 s64 3 Foo0 ",
+                "t64 15 *const *const _t64 8 *const _e64 3 Foo0 0 ",
+            ];
+
+            for encoded in invalid {
+                let mut pos = 0;
+                assert!(
+                    deserialize_debug_type(encoded.as_bytes(), &mut pos).is_none(),
+                    "accepted invalid typed pointer payload {encoded:?}"
+                );
+            }
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "typed pointer pointee must contain only basic, typed-pointer, or array nodes"
+        )]
+        fn serializer_rejects_hand_built_typed_pointer_with_opaque_descendant() {
+            let invalid = DebugLocalTypeKind::TypedPointer {
+                name: "*const [*mut _; 1]".to_string(),
+                size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::Array {
+                    name: "[*mut _; 1]".to_string(),
+                    size_bits: 64,
+                    element: Box::new(DebugLocalTypeKind::Pointer {
+                        name: "*mut _".to_string(),
+                        size_bits: 64,
+                    }),
+                    count: 1,
+                }),
+            };
+            let mut encoded = String::new();
+            serialize_debug_type(&invalid, &mut encoded);
         }
 
         #[test]

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -101,6 +101,13 @@ fn module_top_block(ctx: &mut Context, module: &ModuleOp) -> Ptr<BasicBlock> {
     block
 }
 
+fn metadata_id<'a>(ir: &'a str, needle: &str) -> &'a str {
+    ir.lines()
+        .find(|line| line.contains(needle))
+        .and_then(|line| line.split_once(" = ").map(|(id, _)| id))
+        .unwrap_or_else(|| panic!("missing metadata node containing {needle:?}:\n{ir}"))
+}
+
 #[test]
 fn export_volatile_load_prints_keyword() {
     let mut ctx = Context::new();
@@ -2707,16 +2714,100 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
         DebugLocalVariableInfo {
             name: "ptr".to_string(),
             argument_index: None,
-            ty: DebugLocalTypeKind::Pointer {
+            ty: DebugLocalTypeKind::TypedPointer {
                 name: "*mut f32".to_string(),
                 size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::Basic {
+                    name: "f32".to_string(),
+                    size_bits: 32,
+                    encoding: "DW_ATE_float",
+                }),
             },
         },
     );
     ptr.get_operation().insert_at_back(entry, &ctx);
 
+    let nested_ptr = AllocaOp::new(&mut ctx, ptr_ty.into(), one_val);
+    let nested_ptr_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 33, 9);
+    nested_ptr
+        .get_operation()
+        .deref_mut(&ctx)
+        .set_loc(nested_ptr_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        nested_ptr.get_operation(),
+        DebugLocalVariableInfo {
+            name: "nested_ptr".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::TypedPointer {
+                name: "*const *mut i32".to_string(),
+                size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::TypedPointer {
+                    name: "*mut i32".to_string(),
+                    size_bits: 64,
+                    pointee: Box::new(DebugLocalTypeKind::Basic {
+                        name: "i32".to_string(),
+                        size_bits: 32,
+                        encoding: "DW_ATE_signed",
+                    }),
+                }),
+            },
+        },
+    );
+    nested_ptr.get_operation().insert_at_back(entry, &ctx);
+
+    let array_ptr = AllocaOp::new(&mut ctx, ptr_ty.into(), one_val);
+    let array_ptr_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 34, 9);
+    array_ptr
+        .get_operation()
+        .deref_mut(&ctx)
+        .set_loc(array_ptr_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        array_ptr.get_operation(),
+        DebugLocalVariableInfo {
+            name: "array_ptr".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::TypedPointer {
+                name: "*const [u16; 4]".to_string(),
+                size_bits: 64,
+                pointee: Box::new(DebugLocalTypeKind::Array {
+                    name: "[u16; 4]".to_string(),
+                    size_bits: 64,
+                    element: Box::new(DebugLocalTypeKind::Basic {
+                        name: "u16".to_string(),
+                        size_bits: 16,
+                        encoding: "DW_ATE_unsigned",
+                    }),
+                    count: 4,
+                }),
+            },
+        },
+    );
+    array_ptr.get_operation().insert_at_back(entry, &ctx);
+
+    let opaque_ptr = AllocaOp::new(&mut ctx, ptr_ty.into(), one_val);
+    let opaque_ptr_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 35, 9);
+    opaque_ptr
+        .get_operation()
+        .deref_mut(&ctx)
+        .set_loc(opaque_ptr_loc);
+    llvm_export::ops::set_debug_local_variable(
+        &mut ctx,
+        opaque_ptr.get_operation(),
+        DebugLocalVariableInfo {
+            name: "opaque_ptr".to_string(),
+            argument_index: None,
+            ty: DebugLocalTypeKind::Pointer {
+                name: "*const _".to_string(),
+                size_bits: 64,
+            },
+        },
+    );
+    opaque_ptr.get_operation().insert_at_back(entry, &ctx);
+
     let ret = ReturnOp::new(&mut ctx, None);
-    let ret_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 33, 1);
+    let ret_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 36, 1);
     ret.get_operation().deref_mut(&ctx).set_loc(ret_loc);
     ret.get_operation().insert_at_back(entry, &ctx);
 
@@ -2757,11 +2848,95 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
         ir.contains("!DIBasicType(name: \"u32\", size: 32, encoding: DW_ATE_unsigned)"),
         "basic integer variables should get DIBasicType metadata:\n{ir}"
     );
+    let f32_id = metadata_id(
+        &ir,
+        "!DIBasicType(name: \"f32\", size: 32, encoding: DW_ATE_float)",
+    );
+    assert!(
+        ir.contains(&format!(
+            "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*mut f32\", baseType: {f32_id}, size: 64)"
+        )),
+        "pointer variables should reference their pointee DIType:\n{ir}"
+    );
+    let i32_id = metadata_id(
+        &ir,
+        "!DIBasicType(name: \"i32\", size: 32, encoding: DW_ATE_signed)",
+    );
+    let inner_pointer = format!(
+        "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*mut i32\", baseType: {i32_id}, size: 64)"
+    );
+    let inner_pointer_id = metadata_id(&ir, &inner_pointer);
+    assert!(
+        ir.contains(&format!(
+            "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*const *mut i32\", baseType: {inner_pointer_id}, size: 64)"
+        )),
+        "nested pointer metadata must preserve the complete base-type chain:\n{ir}"
+    );
+
+    let u16_id = metadata_id(
+        &ir,
+        "!DIBasicType(name: \"u16\", size: 16, encoding: DW_ATE_unsigned)",
+    );
+    let subrange_id = metadata_id(&ir, "!DISubrange(count: 4)");
+    let subrange_tuple_id = metadata_id(&ir, &format!("!{{{subrange_id}}}"));
+    let array_type = format!(
+        "!DICompositeType(tag: DW_TAG_array_type, baseType: {u16_id}, size: 64, elements: {subrange_tuple_id})"
+    );
+    let array_type_id = metadata_id(&ir, &array_type);
+    assert!(
+        ir.contains(&format!(
+            "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*const [u16; 4]\", baseType: {array_type_id}, size: 64)"
+        )),
+        "array pointer metadata must reference the exact element/subrange graph:\n{ir}"
+    );
+
+    assert!(
+        ir.contains("!DILocalVariable(name: \"opaque_ptr\", scope: !"),
+        "unsupported pointers must remain visible as source variables:\n{ir}"
+    );
     assert!(
         ir.contains(
-            "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*mut f32\", baseType: null, size: 64)"
+            "!DIDerivedType(tag: DW_TAG_pointer_type, name: \"*const _\", baseType: null, size: 64)"
         ),
-        "pointer variables should get a pointer DIType:\n{ir}"
+        "the compatibility pointer must retain its legacy null-base metadata:\n{ir}"
+    );
+    let null_base_pointer_count = ir
+        .lines()
+        .filter(|line| line.contains("DW_TAG_pointer_type") && line.contains("baseType: null"))
+        .count();
+    assert!(
+        null_base_pointer_count == 1,
+        "only the explicit opaque compatibility pointer may have a null baseType:\n{ir}"
+    );
+
+    let Some(llvm_as) = ["llvm-as-22", "llvm-as-21", "llvm-as"]
+        .into_iter()
+        .find(|tool| {
+            std::process::Command::new(tool)
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success())
+        })
+    else {
+        eprintln!("skipping pointer-debug llvm-as parse gate: no supported llvm-as on PATH");
+        return;
+    };
+    let ll_path = std::env::temp_dir().join(format!(
+        "cuda_oxide_pointer_debug_parse_gate_{}.ll",
+        std::process::id()
+    ));
+    std::fs::write(&ll_path, &ir).expect("write pointer-debug temp .ll");
+    let output = std::process::Command::new(llvm_as)
+        .arg("-o")
+        .arg("/dev/null")
+        .arg(&ll_path)
+        .output()
+        .expect("run llvm-as for pointer debug metadata");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = std::fs::remove_file(&ll_path);
+    assert!(
+        output.status.success(),
+        "{llvm_as} rejected pointer debug metadata:\n{stderr}\n--- module ---\n{ir}"
     );
 }
 
@@ -2863,9 +3038,14 @@ fn full_debug_metadata_emits_rust_enum_variant_parts() {
                         members: vec![llvm_export::ops::DebugTypeMember {
                             name: "0".to_string(),
                             offset_bits: 0,
-                            ty: DebugLocalTypeKind::Pointer {
+                            ty: DebugLocalTypeKind::TypedPointer {
                                 name: "&u32".to_string(),
                                 size_bits: 64,
+                                pointee: Box::new(DebugLocalTypeKind::Basic {
+                                    name: "u32".to_string(),
+                                    size_bits: 32,
+                                    encoding: "DW_ATE_unsigned",
+                                }),
                             },
                         }],
                     },

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -999,16 +999,22 @@ fn debug_type_for_ty_at(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
             encoding: "DW_ATE_float",
         }),
         TyKind::RigidTy(RigidTy::RawPtr(pointee, mutability)) => {
-            Some(DebugLocalTypeKind::Pointer {
-                name: raw_pointer_name(pointee, mutability),
-                size_bits: 64,
-            })
+            debug_typed_pointer_type(ty, &pointee, DebugPointerKind::Raw(mutability), depth)
+                .or_else(|| {
+                    Some(DebugLocalTypeKind::Pointer {
+                        name: raw_pointer_name(pointee, mutability),
+                        size_bits: 64,
+                    })
+                })
         }
         TyKind::RigidTy(RigidTy::Ref(_, pointee, mutability)) => {
-            Some(DebugLocalTypeKind::Pointer {
-                name: reference_name(pointee, mutability),
-                size_bits: 64,
-            })
+            debug_typed_pointer_type(ty, &pointee, DebugPointerKind::Reference(mutability), depth)
+                .or_else(|| {
+                    Some(DebugLocalTypeKind::Pointer {
+                        name: reference_name(pointee, mutability),
+                        size_bits: 64,
+                    })
+                })
         }
         TyKind::RigidTy(RigidTy::Closure(closure_def, substs)) if depth < MAX_DEBUG_TYPE_DEPTH => {
             let upvar_tys = types::closure_upvar_tys(&substs)?;
@@ -1059,6 +1065,125 @@ fn debug_type_for_ty_at(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
                 name: format!("[{}; {count}]", short_ty_name(&elem_ty)),
                 size_bits,
                 element: Box::new(element),
+                count,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Describe a one-word pointer/reference and its safely bounded pointee.
+///
+/// Rust references and raw pointers to dynamically-sized types are fat
+/// pointers. Encoding those as a typed `DW_TAG_pointer_type` would discard
+/// their metadata word, so this helper declines them and lets the caller retain
+/// the legacy opaque pointer metadata. The same fallback applies when a pointee
+/// is unsupported or exceeds the recursion bound. Composite pointees are
+/// deliberately excluded here: `DebugLocalTypeKind` is currently a tree, so
+/// following an ADT such as `Node { next: *const Node }` would recursively
+/// unroll the same type instead of representing the cyclic DWARF graph.
+#[derive(Clone, Copy)]
+enum DebugPointerKind {
+    Raw(mir::Mutability),
+    Reference(mir::Mutability),
+}
+
+fn debug_typed_pointer_type(
+    pointer: &Ty,
+    pointee: &Ty,
+    kind: DebugPointerKind,
+    depth: usize,
+) -> Option<DebugLocalTypeKind> {
+    if depth >= MAX_DEBUG_TYPE_DEPTH {
+        return None;
+    }
+
+    let size_bits = layout_size_bits(pointer)?;
+    let pointer_word_bits =
+        rustc_public::target::MachineInfo::target_pointer_width().bytes() as u64 * 8;
+    if size_bits != pointer_word_bits {
+        return None;
+    }
+
+    // Build and validate the bounded pointee first. The source-facing pointer
+    // name is then derived from that accepted tree, so rejected pathological
+    // source types cannot recurse or grow a name before the depth gate fires.
+    let pointee = debug_pointer_pointee_type(pointee, depth + 1)?;
+    let name = debug_pointer_name(kind, &pointee);
+    Some(DebugLocalTypeKind::TypedPointer {
+        name,
+        size_bits,
+        pointee: Box::new(pointee),
+    })
+}
+
+fn debug_pointer_name(kind: DebugPointerKind, pointee: &DebugLocalTypeKind) -> String {
+    let pointee = typed_pointer_pointee_display_name(pointee);
+    match kind {
+        DebugPointerKind::Raw(mir::Mutability::Mut) => format!("*mut {pointee}"),
+        DebugPointerKind::Raw(mir::Mutability::Not) => format!("*const {pointee}"),
+        DebugPointerKind::Reference(mir::Mutability::Mut) => format!("&mut {pointee}"),
+        DebugPointerKind::Reference(mir::Mutability::Not) => format!("&{pointee}"),
+    }
+}
+
+fn typed_pointer_pointee_display_name(ty: &DebugLocalTypeKind) -> &str {
+    match ty {
+        DebugLocalTypeKind::Basic { name, .. }
+        | DebugLocalTypeKind::TypedPointer { name, .. }
+        | DebugLocalTypeKind::Array { name, .. } => name,
+        DebugLocalTypeKind::Pointer { .. }
+        | DebugLocalTypeKind::Struct { .. }
+        | DebugLocalTypeKind::Enum { .. } => {
+            unreachable!("typed pointer pointees use only the bounded typed subset")
+        }
+    }
+}
+
+/// Build the finite subset that is safe to embed beneath a pointer node.
+///
+/// Primitive leaves, fixed arrays whose elements stay inside this subset, and
+/// nested thin pointers/references form an acyclic tree. Tuples, ADTs, enums,
+/// closures, and every other composite are rejected even when the general
+/// local-variable debug path can describe part of them. `char` and unit are
+/// also rejected until `DebugLocalTypeKind` has an accurate encoding for them;
+/// treating either as an integer or null-base pointer would be misleading.
+fn debug_pointer_pointee_type(ty: &Ty, depth: usize) -> Option<DebugLocalTypeKind> {
+    match ty.kind() {
+        TyKind::RigidTy(RigidTy::Bool) => Some(DebugLocalTypeKind::Basic {
+            name: "bool".to_string(),
+            size_bits: 8,
+            encoding: "DW_ATE_boolean",
+        }),
+        TyKind::RigidTy(RigidTy::Int(int_ty)) => Some(DebugLocalTypeKind::Basic {
+            name: int_name(int_ty).to_string(),
+            size_bits: (int_ty.num_bytes() * 8) as u64,
+            encoding: "DW_ATE_signed",
+        }),
+        TyKind::RigidTy(RigidTy::Uint(uint_ty)) => Some(DebugLocalTypeKind::Basic {
+            name: uint_name(uint_ty).to_string(),
+            size_bits: (uint_ty.num_bytes() * 8) as u64,
+            encoding: "DW_ATE_unsigned",
+        }),
+        TyKind::RigidTy(RigidTy::Float(float_ty)) => Some(DebugLocalTypeKind::Basic {
+            name: float_name(float_ty).to_string(),
+            size_bits: float_size_bits(float_ty),
+            encoding: "DW_ATE_float",
+        }),
+        TyKind::RigidTy(RigidTy::RawPtr(pointee, mutability)) => {
+            debug_typed_pointer_type(ty, &pointee, DebugPointerKind::Raw(mutability), depth)
+        }
+        TyKind::RigidTy(RigidTy::Ref(_, pointee, mutability)) => {
+            debug_typed_pointer_type(ty, &pointee, DebugPointerKind::Reference(mutability), depth)
+        }
+        TyKind::RigidTy(RigidTy::Array(element, len)) if depth < MAX_DEBUG_TYPE_DEPTH => {
+            let count = array_len_const(&len)?;
+            let element_debug = debug_pointer_pointee_type(&element, depth + 1)?;
+            let element_name = typed_pointer_pointee_display_name(&element_debug);
+            Some(DebugLocalTypeKind::Array {
+                name: format!("[{element_name}; {count}]"),
+                size_bits: layout_size_bits(ty)?,
+                element: Box::new(element_debug),
                 count,
             })
         }
@@ -2319,6 +2444,219 @@ pub fn scalarized_pair(a: u32, b: u64) -> u64 {
             result.1,
             "debug_fragment must reject non-field composite projections"
         );
+    }
+
+    /// Thin pointers preserve a finite pointee debug tree, while composites,
+    /// fat pointers, and unsupported pointees retain the opaque fallback.
+    #[test]
+    fn pointer_debug_types_type_safe_pointees_and_preserve_opaque_fallbacks() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_pointer_debug_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("pointer_debug_fixture.rs");
+        std::fs::write(
+            &fixture,
+            r#"
+pub struct Pair {
+    pub first: u32,
+    pub second: u64,
+}
+
+pub struct Node {
+    pub next: *const Node,
+    pub value: u32,
+}
+
+pub fn pointer_debug_types(
+    _thin: *mut u32,
+    _reference: &u64,
+    _nested: *const *mut i32,
+    _array: *const [u16; 4],
+    _composite: *const Pair,
+    _tuple: *const (u32, u64),
+    _fat: *const [u8],
+    _fat_reference: &str,
+    _unsupported: *const fn(),
+    _unit: *const (),
+    _char: *const char,
+    _self_referential: *const Node,
+) {}
+"#,
+        )
+        .unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=pointer_debug_fixture".to_string(),
+            "--emit=metadata".to_string(),
+            "-Zmir-opt-level=0".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        let debug_types = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    let body = rustc_public::all_local_items()
+                        .into_iter()
+                        .find_map(|item| item.body())
+                        .expect("fixture function has a body");
+                    let debug_types = body
+                        .locals()
+                        .iter()
+                        .skip(1) // return place
+                        .take(12)
+                        .map(|decl| debug_type_for_ty(&decl.ty))
+                        .collect::<Vec<_>>();
+                    std::ops::ControlFlow::<(), _>::Continue(debug_types)
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        std::fs::remove_dir_all(&root).ok();
+        assert_eq!(debug_types.len(), 12, "one debug type result per argument");
+
+        let Some(DebugLocalTypeKind::TypedPointer {
+            name,
+            size_bits,
+            pointee,
+        }) = &debug_types[0]
+        else {
+            panic!(
+                "thin raw pointer must be described, got {:?}",
+                debug_types[0]
+            );
+        };
+        assert_eq!(name, "*mut u32");
+        assert_eq!(*size_bits, 64);
+        assert!(matches!(
+            pointee.as_ref(),
+            DebugLocalTypeKind::Basic {
+                name,
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            } if name == "u32"
+        ));
+
+        let Some(DebugLocalTypeKind::TypedPointer {
+            name,
+            size_bits,
+            pointee,
+        }) = &debug_types[1]
+        else {
+            panic!("thin reference must be described, got {:?}", debug_types[1]);
+        };
+        assert_eq!(name, "&u64");
+        assert_eq!(*size_bits, 64);
+        assert!(matches!(
+            pointee.as_ref(),
+            DebugLocalTypeKind::Basic {
+                name,
+                size_bits: 64,
+                encoding: "DW_ATE_unsigned",
+            } if name == "u64"
+        ));
+
+        let Some(DebugLocalTypeKind::TypedPointer {
+            name,
+            size_bits,
+            pointee,
+        }) = &debug_types[2]
+        else {
+            panic!(
+                "nested thin pointer must be described, got {:?}",
+                debug_types[2]
+            );
+        };
+        assert_eq!(name, "*const *mut i32");
+        assert_eq!(*size_bits, 64);
+        assert!(matches!(
+            pointee.as_ref(),
+            DebugLocalTypeKind::TypedPointer {
+                name,
+                size_bits: 64,
+                pointee,
+            } if name == "*mut i32" && matches!(
+                pointee.as_ref(),
+                DebugLocalTypeKind::Basic {
+                    name,
+                    size_bits: 32,
+                    encoding: "DW_ATE_signed",
+                } if name == "i32"
+            )
+        ));
+
+        let Some(DebugLocalTypeKind::TypedPointer {
+            name,
+            size_bits,
+            pointee,
+        }) = &debug_types[3]
+        else {
+            panic!(
+                "pointer to fixed array must be described, got {:?}",
+                debug_types[3]
+            );
+        };
+        assert_eq!(name, "*const [u16; 4]");
+        assert_eq!(*size_bits, 64);
+        assert!(matches!(
+            pointee.as_ref(),
+            DebugLocalTypeKind::Array {
+                name,
+                size_bits: 64,
+                count: 4,
+                element,
+            } if name == "[u16; 4]" && matches!(
+                element.as_ref(),
+                DebugLocalTypeKind::Basic {
+                    name,
+                    size_bits: 16,
+                    encoding: "DW_ATE_unsigned",
+                } if name == "u16"
+            )
+        ));
+
+        fn assert_opaque_pointer(ty: &Option<DebugLocalTypeKind>, expected_name: &str) {
+            let Some(DebugLocalTypeKind::Pointer { name, size_bits }) = ty else {
+                panic!("unsupported pointer must retain opaque metadata, got {ty:?}");
+            };
+            assert_eq!(name, expected_name);
+            assert_eq!(*size_bits, 64, "compatibility fallback preserves old width");
+        }
+
+        assert_opaque_pointer(&debug_types[4], "*const _");
+        assert_opaque_pointer(&debug_types[5], "*const _");
+        assert_opaque_pointer(&debug_types[6], "*const _");
+        assert_opaque_pointer(&debug_types[7], "&_");
+        assert_opaque_pointer(&debug_types[8], "*const _");
+        assert_opaque_pointer(&debug_types[9], "*const _");
+        assert_opaque_pointer(&debug_types[10], "*const _");
+        assert_opaque_pointer(&debug_types[11], "*const _");
     }
 
     /// Closure environments must be described as composite debug types with


### PR DESCRIPTION
## Summary

cuda-gdb can now see and dereference the pointee type for the thin pointers we
can describe safely.

| Debugger view | Before | After |
|---|---|---|
| `whatis ptr` | `*mut ()` | `*mut i32` |
| `print *ptr` | void/unknown pointee | `10` |
| pointer address | correct | unchanged |

Closes #1119.

## Changes

- Add a typed-pointer debug node with a required DWARF `baseType`.
- Support primitives, fixed arrays, and finite chains of thin pointers and
  references.
- Keep the old opaque pointer node for fat, composite, cyclic, and unsupported
  pointees so existing variables do not disappear.
- Reject malformed mixed typed/opaque trees during decoding and export.

This is deliberately partial: slices, trait objects, and recursive composite
types still need richer graph/fat-pointer metadata.

## Testing

- `llvm-export` and `mir-importer` full suites, strict Clippy, formatting,
  `llvm-as`, and `opt` passed.
- CUDA 13.3 / RTX 5090: T06/T19 now show `*mut i32` / `*mut f32` and
  dereference correctly; unsupported T07/T15 variables remain visible.

- [ ] `just check` passes (affected suites pass)
- [x] Live GPU debugger regression exercised
- [x] New example added (not needed; focused regression added)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new source files)

---
> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).
