### PR TITLE
debug: separate function source and linkage names

### DIFF
--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -35,6 +35,7 @@ impl<'a> ModuleExportState<'a> {
     pub(super) fn debug_subprogram_for_function(
         &mut self,
         name: &str,
+        linkage_name: &str,
         loc: &Location,
     ) -> Option<usize> {
         if !self.debug_kind.line_tables_enabled() {
@@ -46,13 +47,15 @@ impl<'a> ModuleExportState<'a> {
         let file_id = self.ensure_debug_file(&path);
         let subroutine_type_id = self.ensure_debug_subroutine_type();
         let name = escape_debug_string(name);
+        let linkage_name = escape_debug_string(linkage_name);
         let line = pos.line;
         let id = self.alloc_metadata_id();
 
         self.debug_nodes.push((
             id,
             format!(
-                "distinct !DISubprogram(name: \"{name}\", scope: !{file_id}, file: !{file_id}, \
+                "distinct !DISubprogram(name: \"{name}\", linkageName: \"{linkage_name}\", \
+                 scope: !{file_id}, file: !{file_id}, \
                  line: {line}, type: !{subroutine_type_id}, scopeLine: {line}, \
                  spFlags: DISPFlagDefinition, unit: !{cu_id}, retainedNodes: !{{}})"
             ),

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -779,7 +779,10 @@ impl<'a> ModuleExportState<'a> {
 
         if let Some(entry_block) = entry_block_opt {
             let func_loc = func.get_operation().deref(self.ctx).loc();
-            let debug_scope = self.debug_subprogram_for_function(&fixed_func_name, &func_loc);
+            let debug_name = ops::debug_function_name(self.ctx, func.get_operation())
+                .unwrap_or_else(|| fixed_func_name.clone());
+            let debug_scope =
+                self.debug_subprogram_for_function(&debug_name, &fixed_func_name, &func_loc);
             if let Some(scope_id) = debug_scope {
                 self.register_debug_source_scopes_for_function(scope_id, func.get_operation());
             }

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -931,6 +931,13 @@ pub mod ops {
     const DEBUG_PROJECTED_COUNT_KEY: &str = "cuda_oxide_debug_projected_count";
     const DEBUG_FRAGMENT_COUNT_KEY: &str = "cuda_oxide_debug_fragment_count";
     const DEBUG_VALUE_EXPRESSION_KEY: &str = "cuda_oxide_debug_value_expression";
+    /// Source-facing name of a function, kept separate from its emitted symbol.
+    ///
+    /// Non-generic device functions use legalized Rust paths as their physical
+    /// symbols and generic functions use Rust's mangled symbol.  Neither is the
+    /// name users write in source or pass to a debugger, so the importer carries
+    /// that spelling explicitly for `DISubprogram::name`.
+    const DEBUG_FUNCTION_NAME_KEY: &str = "cuda_oxide_debug_function_name";
     const DEBUG_SOURCE_SCOPE_COUNT_KEY: &str = "cuda_oxide_debug_scope_count";
     const DEBUG_SOURCE_SCOPE_LOCATION_COUNT_KEY: &str = "cuda_oxide_debug_scope_location_count";
     /// Op-attribute key for ordinary volatile `load` / `store` operations.
@@ -974,6 +981,24 @@ pub mod ops {
             .attributes
             .get::<AlignmentAttr>(&key)
             .map(|a| a.0)
+    }
+
+    /// Attach the source-facing name of a function to a MIR/LLVM function op.
+    pub fn set_debug_function_name(ctx: &mut Context, op: Ptr<Operation>, name: &str) {
+        set_string_attr(ctx, op, DEBUG_FUNCTION_NAME_KEY, name.to_string());
+    }
+
+    /// Read the source-facing name attached to a MIR/LLVM function op.
+    pub fn debug_function_name(ctx: &Context, op: Ptr<Operation>) -> Option<String> {
+        get_string_attr(ctx, op, DEBUG_FUNCTION_NAME_KEY)
+    }
+
+    /// Copy a function's source-facing debug name during MIR-to-LLVM lowering.
+    pub fn copy_debug_function_name(ctx: &mut Context, from: Ptr<Operation>, to: Ptr<Operation>) {
+        let Some(name) = debug_function_name(ctx, from) else {
+            return;
+        };
+        set_debug_function_name(ctx, to, &name);
     }
 
     /// Stamp whether an inline asm op has side effects beyond its operands.

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -2243,6 +2243,11 @@ fn line_table_debug_metadata_emits_function_scope_and_instruction_locations() {
     let void_ty = VoidType::get(&ctx);
     let func_ty = FuncType::get(&ctx, void_ty.to_handle(), vec![], false);
     let func = FuncOp::new(&mut ctx, "debug_kernel".try_into().unwrap(), func_ty);
+    llvm_export::ops::set_debug_function_name(
+        &mut ctx,
+        func.get_operation(),
+        "source_crate::debug_kernel",
+    );
     let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/kernel.rs", 7, 1);
     func.get_operation().deref_mut(&ctx).set_loc(func_loc);
 
@@ -2296,12 +2301,57 @@ fn line_table_debug_metadata_emits_function_scope_and_instruction_locations() {
         "debug export should describe the Rust compile unit:\n{ir}"
     );
     assert!(
-        ir.contains("distinct !DISubprogram(name: \"debug_kernel\""),
-        "function definition should get a DISubprogram:\n{ir}"
+        ir.contains(
+            "distinct !DISubprogram(name: \"source_crate::debug_kernel\", linkageName: \"debug_kernel\""
+        ),
+        "function definition should separate its source name from its physical linkage name:\n{ir}"
     );
     assert!(
         ir.contains("!DILocation(line: 8, column: 5, scope: !"),
         "instruction location should preserve the source line and column:\n{ir}"
+    );
+}
+
+#[test]
+fn full_debug_metadata_keeps_generic_source_name_separate_from_mangled_symbol() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+
+    let void_ty = VoidType::get(&ctx);
+    let func_ty = FuncType::get(&ctx, void_ty.to_handle(), vec![], false);
+    let linkage_name = "_RNvMCexampleINtCsource7WrapperjE7get_mut";
+    let func = FuncOp::new(&mut ctx, linkage_name.try_into().unwrap(), func_ty);
+    llvm_export::ops::set_debug_function_name(
+        &mut ctx,
+        func.get_operation(),
+        "source_crate::Wrapper::<u16>::get_mut",
+    );
+    let func_loc = src_location(&mut ctx, "/tmp/cuda-oxide/tests/generic.rs", 19, 1);
+    func.get_operation().deref_mut(&ctx).set_loc(func_loc);
+
+    let entry = func.get_or_create_entry_block(&mut ctx);
+    ReturnOp::new(&mut ctx, None)
+        .get_operation()
+        .insert_at_back(entry, &ctx);
+    func.get_operation().insert_at_back(module_block, &ctx);
+
+    let config = DebugConfig {
+        inner: PtxExportConfig,
+        debug_kind: DebugKind::Full,
+    };
+    let ir =
+        export_module_to_string_with_config(&ctx, &module, &config).expect("debug export succeeds");
+
+    assert!(
+        ir.contains(&format!("define void @{linkage_name}()")),
+        "debug naming must not change the physical function symbol:\n{ir}"
+    );
+    assert!(
+        ir.contains(&format!(
+            "distinct !DISubprogram(name: \"source_crate::Wrapper::<u16>::get_mut\", linkageName: \"{linkage_name}\""
+        )),
+        "generic debug metadata must carry both source and linkage spellings:\n{ir}"
     );
 }
 

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -1772,6 +1772,15 @@ pub fn translate_body(
     };
     mir_func_op.set_symbol_name(ctx, legaliser.legalise(&name_str));
 
+    // Keep the Rust/source-facing name independent of the physical symbol.
+    // Kernels deliberately retain their user-visible export name: their MIR
+    // instance is the macro-generated device implementation, whose diagnostic
+    // name is not the name callers launch or set breakpoints on.  Device
+    // helpers use stable MIR's fully specialized diagnostic name, while their
+    // physical symbol may be legalized (non-generic) or mangled (generic).
+    let debug_name = function_debug_name(instance, is_kernel, &name_str);
+    llvm_export::ops::set_debug_function_name(ctx, op_ptr, &debug_name);
+
     // Check if the function has the #[cuda_oxide::kernel] attribute (passed via is_kernel flag)
     if is_kernel {
         // Add "gpu_kernel" attribute to the mir.func operation.
@@ -2053,6 +2062,20 @@ pub fn translate_body(
     Ok(op_ptr)
 }
 
+/// Choose the debugger-visible spelling independently of a function's symbol.
+///
+/// Device-helper names intentionally keep concrete generic arguments. Erasing
+/// them would make distinct monomorphizations indistinguishable. Supporting a
+/// shorthand such as `Type::method` for every specialization requires proper
+/// namespace/type DIEs (or a separately agreed alias policy), not lossy names.
+fn function_debug_name(instance: &mono::Instance, is_kernel: bool, export_name: &str) -> String {
+    if is_kernel {
+        export_name.to_string()
+    } else {
+        instance.name().to_string()
+    }
+}
+
 /// Propagate `#[inline(always)]` as an LLVM `alwaysinline` function
 /// attribute. Kernel entry points are excluded because they're `.entry` in PTX
 /// and never callees, so marking them `alwaysinline` would be a no-op at best
@@ -2129,6 +2152,163 @@ mod tests {
     }
 
     #[test]
+    fn stable_mir_function_names_are_source_facing_and_specialized() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_function_debug_name_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("function_debug_name_fixture.rs");
+        std::fs::write(
+            &fixture,
+            r#"
+#[inline(never)]
+pub fn plain(value: u32) -> u32 { value + 1 }
+
+#[inline(never)]
+pub fn generic<T>(value: T) -> T { value }
+
+pub struct Wrapper<T>(pub T);
+
+impl<T> Wrapper<T> {
+    #[inline(never)]
+    pub fn get_mut(&mut self) -> &mut T { &mut self.0 }
+}
+
+#[inline(never)]
+pub fn cuda_oxide_device_generated_kernel(mut wrapped: Wrapper<u16>) -> u32 {
+    let _ = generic::<u64>(3);
+    let _ = wrapped.get_mut();
+    plain(7)
+}
+"#,
+        )
+        .unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=function_debug_name_fixture".to_string(),
+            "--emit=metadata".to_string(),
+            "-Zmir-opt-level=0".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        let names = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    let item = rustc_public::all_local_items()
+                        .into_iter()
+                        .find(|item| {
+                            item.name()
+                                .ends_with("::cuda_oxide_device_generated_kernel")
+                        })
+                        .expect("fixture entry item");
+                    let instance = mono::Instance::try_from(item).expect("entry instance");
+                    let body = instance.body().expect("entry body");
+                    let mut callees = Vec::new();
+
+                    for block in &body.blocks {
+                        let mir::TerminatorKind::Call { func, .. } = &block.terminator.kind else {
+                            continue;
+                        };
+                        let mir::Operand::Constant(constant) = func else {
+                            continue;
+                        };
+                        let ConstantKind::ZeroSized = constant.const_.kind() else {
+                            continue;
+                        };
+                        let TyKind::RigidTy(RigidTy::FnDef(definition, args)) =
+                            constant.const_.ty().kind()
+                        else {
+                            continue;
+                        };
+                        let Some(callee) = mono::Instance::resolve(definition, &args).ok() else {
+                            continue;
+                        };
+                        callees.push((
+                            callee.name().to_string(),
+                            callee.def.name().to_string(),
+                            callee.mangled_name().to_string(),
+                        ));
+                    }
+
+                    std::ops::ControlFlow::<(), _>::Continue((
+                        instance.name().to_string(),
+                        function_debug_name(&instance, true, "visible_kernel"),
+                        callees,
+                    ))
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        std::fs::remove_dir_all(&root).ok();
+
+        assert_eq!(
+            names.0,
+            "function_debug_name_fixture::cuda_oxide_device_generated_kernel"
+        );
+        assert_eq!(names.1, "visible_kernel");
+        let source_names: std::collections::BTreeSet<_> = names
+            .2
+            .iter()
+            .map(|(source, _, _)| source.as_str())
+            .collect();
+        assert_eq!(
+            source_names,
+            std::collections::BTreeSet::from([
+                "function_debug_name_fixture::Wrapper::<u16>::get_mut",
+                "function_debug_name_fixture::generic::<u64>",
+                "function_debug_name_fixture::plain",
+            ])
+        );
+        let definition_names: std::collections::BTreeSet<_> = names
+            .2
+            .iter()
+            .map(|(_, definition, _)| definition.as_str())
+            .collect();
+        assert_eq!(
+            definition_names,
+            std::collections::BTreeSet::from([
+                "function_debug_name_fixture::Wrapper::<T>::get_mut",
+                "function_debug_name_fixture::generic",
+                "function_debug_name_fixture::plain",
+            ]),
+            "definition names are not specialized enough for debugger overloads"
+        );
+        for (source_name, _, mangled_name) in names.2 {
+            assert_ne!(source_name, mangled_name);
+            assert!(
+                mangled_name.starts_with("_R"),
+                "expected a Rust linkage symbol, got {mangled_name}"
+            );
+        }
+    }
+
+    #[test]
     fn inline_always_flag_reaches_llvm_func_attr_before_export() {
         let mut ctx = Context::new();
         crate::translator::register_dialects(&mut ctx);
@@ -2167,6 +2347,11 @@ mod tests {
         };
 
         set_alwaysinline_attr_from_flag(&mut ctx, &mir_func, false, true);
+        llvm_export::ops::set_debug_function_name(
+            &mut ctx,
+            mir_func.get_operation(),
+            "source_crate::inline_helper",
+        );
         mir_func.get_operation().insert_at_back(module_block, &ctx);
 
         mir_lower::register(&mut ctx);
@@ -2190,6 +2375,11 @@ mod tests {
                 .0
                 .contains_key(&key),
             "`is_inline_always` must become an LLVM dialect alwaysinline attribute before export",
+        );
+        assert_eq!(
+            llvm_export::ops::debug_function_name(&ctx, llvm_func.get_operation()).as_deref(),
+            Some("source_crate::inline_helper"),
+            "MIR-to-LLVM lowering must preserve the source-facing function name",
         );
     }
 

--- a/crates/mir-lower/src/lowering.rs
+++ b/crates/mir-lower/src/lowering.rs
@@ -266,6 +266,7 @@ pub fn convert_func(
         function_return_abi_alignment(ctx, func_type, llvm_func_type).map_err(anyhow_to_pliron)?;
 
     let llvm_func = llvm::FuncOp::new(ctx, name, llvm_func_type);
+    llvm::copy_debug_function_name(ctx, op, llvm_func.get_operation());
     llvm::copy_debug_source_scope_map(ctx, op, llvm_func.get_operation());
 
     if is_kernel {


### PR DESCRIPTION
## Summary

Device functions now carry both the Rust-facing name a developer wants to
break on and the physical symbol the linker needs.

```text
Before
DISubprogram.name = debuginfo__deep_outer
DISubprogram.linkageName = <missing>
break debuginfo::deep_outer  ──> pending

After
DISubprogram.name = debuginfo::deep_outer
DISubprogram.linkageName = debuginfo__deep_outer
break debuginfo::deep_outer  ──> hit
```

Closes #1122.

## Changes

- Carry stable MIR's fully specialized source name through MIR and LLVM.
- Emit that spelling as `DISubprogram.name`.
- Keep the exact existing symbol as `linkageName`; ABI and export names do not
  change.
- Keep explicit kernel export names as their debugger-facing names.

Generic names stay specialized so monomorphizations remain distinct. The
shortened T02 spelling `cuda_device::DisjointSlice::get_mut` is still pending;
the canonical `cuda_device::DisjointSlice::<'_, u32>::get_mut` works.

## Testing

- Full exporter/lowering/importer suites, strict Clippy, formatting, and LLVM
  verification passed.
- CUDA 13.3 / RTX 5090: qualified non-generic and canonical generic
  breakpoints hit with readable arguments and caller frames.

- [ ] `just check` passes (affected suites pass)
- [x] Live GPU debugger regression exercised
- [x] New example added (not needed; focused regression added)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new source files)

---
> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).
