### PR TITLE
debug: describe AS1 device globals

### DIFF
--- a/crates/dialect-mir/src/ops/memory.rs
+++ b/crates/dialect-mir/src/ops/memory.rs
@@ -1151,6 +1151,39 @@ impl Verify for MirSharedAllocOp {
 // MirGlobalAllocOp
 // ============================================================================
 
+const RUST_STATIC_GLOBAL_KEY_PREFIX: &str = "cuda-oxide:rust-static:v1:";
+const PROMOTED_GLOBAL_KEY_PREFIX: &str = "cuda-oxide:promoted:v1:";
+
+fn encode_device_global_key(prefix: &str, payload: &str) -> String {
+    format!("{prefix}{}:{payload}", payload.len())
+}
+
+/// Encode rustc's opaque static symbol as a domain-tagged lowering key.
+///
+/// The tag keeps a user-controlled `#[export_name]` from aliasing a
+/// compiler-made promoted allocation with the same string fingerprint. The
+/// length prefix makes the symbol payload unambiguous even when it contains
+/// punctuation.
+pub fn encode_rust_static_global_key(symbol: &str) -> String {
+    encode_device_global_key(RUST_STATIC_GLOBAL_KEY_PREFIX, symbol)
+}
+
+/// Encode one compiler-made promoted allocation fingerprint.
+pub fn encode_promoted_global_key(fingerprint: &str) -> String {
+    encode_device_global_key(PROMOTED_GLOBAL_KEY_PREFIX, fingerprint)
+}
+
+/// Recover the exact rustc symbol payload from a tagged static key.
+///
+/// Constant-memory globals use the payload as their externally visible
+/// linkage name; the tagged key itself remains internal to lowering and
+/// relocation lookup.
+pub fn rust_static_symbol_from_global_key(key: &str) -> Option<&str> {
+    let encoded = key.strip_prefix(RUST_STATIC_GLOBAL_KEY_PREFIX)?;
+    let (length, symbol) = encoded.split_once(':')?;
+    (length.parse::<usize>().ok()? == symbol.len()).then_some(symbol)
+}
+
 /// MIR device-global address operation.
 ///
 /// Represents the address of an ordinary Rust `static` / `static mut` reachable
@@ -1165,7 +1198,7 @@ impl Verify for MirSharedAllocOp {
 /// | Name            | Type        | Description                      |
 /// |-----------------|-------------|----------------------------------|
 /// | `global_type`   | TypeAttr    | Type stored in the global        |
-/// | `global_key`    | StringAttr  | Stable key for deduplication     |
+/// | `global_key`    | StringAttr  | Domain-tagged deduplication key  |
 /// | `global_alignment` | IntegerAttr | Optional alignment            |
 /// | `global_immutable` | UnitAttr | Storage is never written         |
 /// ```
@@ -1273,6 +1306,36 @@ impl Verify for MirGlobalAllocOp {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod device_global_key_tests {
+    use super::{
+        encode_promoted_global_key, encode_rust_static_global_key,
+        rust_static_symbol_from_global_key,
+    };
+
+    #[test]
+    fn static_and_promoted_key_domains_cannot_alias() {
+        let adversarial = "__cuda_oxide_promoted_type_collision:with:punctuation";
+        let static_key = encode_rust_static_global_key(adversarial);
+        let promoted_key = encode_promoted_global_key(adversarial);
+
+        assert_ne!(static_key, promoted_key);
+        assert_eq!(
+            rust_static_symbol_from_global_key(&static_key),
+            Some(adversarial)
+        );
+        assert_eq!(rust_static_symbol_from_global_key(&promoted_key), None);
+    }
+
+    #[test]
+    fn malformed_static_key_length_fails_closed() {
+        assert_eq!(
+            rust_static_symbol_from_global_key("cuda-oxide:rust-static:v1:999:short"),
+            None
+        );
     }
 }
 

--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -22,7 +22,8 @@ use pliron::{
 };
 
 use crate::ops::{
-    DebugLocalTypeKind, DebugLocalVariableInfo, DebugProjectedVariableInfo, DebugSourcePosition,
+    DebugGlobalVariableInfo, DebugLocalTypeKind, DebugLocalVariableInfo,
+    DebugProjectedVariableInfo, DebugSourcePosition,
 };
 
 use super::state::{ModuleExportState, ResolvedDebugScope};
@@ -136,6 +137,8 @@ impl<'a> ModuleExportState<'a> {
             return;
         };
 
+        self.finalize_debug_globals(cu_id);
+
         let dwarf_version_id = self.alloc_metadata_id();
         let debug_info_version_id = self.alloc_metadata_id();
 
@@ -159,6 +162,140 @@ impl<'a> ModuleExportState<'a> {
         for (id, node) in &self.debug_nodes {
             writeln!(output, "!{id} = {node}").unwrap();
         }
+    }
+
+    /// Create a global-variable expression for one source Rust static.
+    ///
+    /// `linkage_name` is the actual generated LLVM symbol, while `info.ty` is
+    /// the semantic Rust type. Keeping those independent is required for
+    /// initialized globals whose physical storage is `[N x i8]`.
+    pub(super) fn debug_global_variable(
+        &mut self,
+        linkage_name: &str,
+        alignment_bytes: Option<u64>,
+        info: &DebugGlobalVariableInfo,
+    ) -> Result<Option<usize>, String> {
+        if !self.debug_kind.variables_enabled() {
+            return Ok(None);
+        }
+        if info.name.is_empty()
+            || info.namespace.is_empty()
+            || info.namespace.iter().any(String::is_empty)
+            || info.declaration.file.as_os_str().is_empty()
+            || info.declaration.line <= 0
+            || info.declaration.column <= 0
+        {
+            return Ok(None);
+        }
+        if self.debug_globals_finalized {
+            return Err(format!(
+                "cannot add debug global `{linkage_name}` after compile-unit finalization"
+            ));
+        }
+        if let Some((previous, expression_id)) = self.debug_global_variables.get(linkage_name) {
+            if previous == info {
+                return Ok(Some(*expression_id));
+            }
+            return Err(format!(
+                "conflicting debug identities for LLVM global `@{linkage_name}`: {:?} versus {:?}",
+                previous, info
+            ));
+        }
+
+        self.ensure_debug_compile_unit(&info.declaration.file);
+        let file_id = self.ensure_debug_file(&info.declaration.file);
+        let type_id = self.ensure_debug_type(&info.ty);
+        let scope_id = self
+            .ensure_debug_namespace(&info.namespace)
+            .expect("validated non-empty namespace must yield a scope");
+        let name = escape_debug_string(&info.name);
+        let escaped_linkage_name = escape_debug_string(linkage_name);
+        let alignment = alignment_bytes
+            .filter(|alignment| *alignment != 0)
+            .and_then(|alignment| alignment.checked_mul(8))
+            .map(|alignment_bits| format!(", align: {alignment_bits}"))
+            .unwrap_or_default();
+
+        let variable_id = self.alloc_metadata_id();
+        self.debug_nodes.push((
+            variable_id,
+            format!(
+                "distinct !DIGlobalVariable(name: \"{name}\", linkageName: \"{escaped_linkage_name}\", \
+                 scope: !{scope_id}, file: !{file_id}, line: {}, type: !{type_id}, \
+                 isLocal: {}, isDefinition: true{alignment})",
+                info.declaration.line, info.is_local_to_unit
+            ),
+        ));
+
+        let expression_id = self.alloc_metadata_id();
+        self.debug_nodes.push((
+            expression_id,
+            format!("!DIGlobalVariableExpression(var: !{variable_id}, expr: !DIExpression())"),
+        ));
+        self.debug_global_expressions.push(expression_id);
+        self.debug_global_variables
+            .insert(linkage_name.to_string(), (info.clone(), expression_id));
+        Ok(Some(expression_id))
+    }
+
+    fn ensure_debug_namespace(&mut self, segments: &[String]) -> Option<usize> {
+        let mut parent = None;
+        for segment in segments {
+            let key = (parent, segment.clone());
+            if let Some(existing) = self.debug_namespaces.get(&key) {
+                parent = Some(*existing);
+                continue;
+            }
+
+            let id = self.alloc_metadata_id();
+            let scope = parent
+                .map(|parent| format!("!{parent}"))
+                .unwrap_or_else(|| "null".to_string());
+            let name = escape_debug_string(segment);
+            self.debug_nodes.push((
+                id,
+                format!("!DINamespace(name: \"{name}\", scope: {scope})"),
+            ));
+            self.debug_namespaces.insert(key, id);
+            parent = Some(id);
+        }
+        parent
+    }
+
+    /// Add the global-expression tuple to the already-reserved compile unit.
+    ///
+    /// Compile units are allocated as soon as the first source object is seen,
+    /// but the complete global list is only known after top-level export. LLVM
+    /// metadata permits the resulting forward reference.
+    fn finalize_debug_globals(&mut self, cu_id: usize) {
+        if self.debug_globals_finalized {
+            return;
+        }
+        self.debug_globals_finalized = true;
+        if self.debug_global_expressions.is_empty() {
+            return;
+        }
+
+        let expressions = self
+            .debug_global_expressions
+            .iter()
+            .map(|id| format!("!{id}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let globals_id = self.alloc_metadata_id();
+        self.debug_nodes
+            .push((globals_id, format!("!{{{expressions}}}")));
+
+        let Some((_, compile_unit)) = self.debug_nodes.iter_mut().find(|(id, _)| *id == cu_id)
+        else {
+            debug_assert!(false, "reserved debug compile unit must exist");
+            return;
+        };
+        let Some(prefix) = compile_unit.strip_suffix(')') else {
+            debug_assert!(false, "debug compile unit must end in ')'");
+            return;
+        };
+        *compile_unit = format!("{prefix}, globals: !{globals_id})");
     }
 
     pub(super) fn debug_local_variable_for_scope(
@@ -968,6 +1105,24 @@ mod tests {
     use combine::stream::position::SourcePosition;
     use pliron::{context::Context, location::Source};
 
+    fn global_info() -> DebugGlobalVariableInfo {
+        DebugGlobalVariableInfo {
+            name: "COUNTER".to_string(),
+            namespace: vec!["collision_crate".to_string(), "left".to_string()],
+            ty: DebugLocalTypeKind::Basic {
+                name: "u64".to_string(),
+                size_bits: 64,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/collision.rs"),
+                line: 7,
+                column: 5,
+            },
+            is_local_to_unit: true,
+        }
+    }
+
     #[test]
     fn debug_strings_use_llvm_metadata_escapes() {
         assert_eq!(escape_debug_string("a\\b\"c\n\t"), "a\\5Cb\\22c\\0A\\09");
@@ -1012,5 +1167,38 @@ mod tests {
         assert_eq!(path, PathBuf::from("/tmp/kernel.rs"));
         assert_eq!(pos.line, 12);
         assert_eq!(pos.column, 4);
+    }
+
+    #[test]
+    fn global_expressions_and_namespaces_are_uniqued_and_conflicts_rejected() {
+        let ctx = Context::new();
+        let mut state =
+            ModuleExportState::new(&ctx, true, super::super::config::DebugKind::Full, None);
+        let info = global_info();
+
+        let first = state
+            .debug_global_variable("__device_global_0", Some(8), &info)
+            .expect("first identity is valid")
+            .expect("full debug emits an expression");
+        let repeated = state
+            .debug_global_variable("__device_global_0", Some(8), &info)
+            .expect("identical repeated identity is valid")
+            .expect("full debug emits an expression");
+        assert_eq!(first, repeated);
+        assert_eq!(state.debug_global_expressions, vec![first]);
+        assert_eq!(state.debug_namespaces.len(), 2);
+
+        let mut conflict = info;
+        conflict.is_local_to_unit = false;
+        let error = state
+            .debug_global_variable("__device_global_0", Some(8), &conflict)
+            .expect_err("one linkage name cannot describe two source identities");
+        assert!(error.contains("conflicting debug identities"), "{error}");
+
+        let cu_id = state.debug_compile_unit.expect("compile unit reserved");
+        state.finalize_debug_globals(cu_id);
+        let node_count = state.debug_nodes.len();
+        state.finalize_debug_globals(cu_id);
+        assert_eq!(state.debug_nodes.len(), node_count);
     }
 }

--- a/crates/llvm-export/src/export/function.rs
+++ b/crates/llvm-export/src/export/function.rs
@@ -124,6 +124,18 @@ impl<'a> ModuleExportState<'a> {
                 8 // Default alignment
             }
         });
+        let debug_attachment =
+            if !is_external && address_space == crate::types::address_space::GLOBAL {
+                match ops::debug_global_variable(self.ctx, global.get_operation()) {
+                    Some(info) => self
+                        .debug_global_variable(name.as_ref(), Some(alignment), &info)?
+                        .map(|id| format!(", !dbg !{id}"))
+                        .unwrap_or_default(),
+                    None => String::new(),
+                }
+            } else {
+                String::new()
+            };
 
         if is_external {
             // External linkage: declaration with size determined elsewhere.
@@ -133,7 +145,7 @@ impl<'a> ModuleExportState<'a> {
             )
             .unwrap();
             self.export_type(ty, output)?;
-            writeln!(output, ", align {alignment}").unwrap();
+            writeln!(output, ", align {alignment}{debug_attachment}").unwrap();
         } else {
             self.public_globals.push(name.to_string());
             // Defined static storage in the global's address space. The LLVM
@@ -166,12 +178,12 @@ impl<'a> ModuleExportState<'a> {
                 let bytes = decode_hex_initializer(&hex)?;
                 write!(output, " ").unwrap();
                 self.export_relocated_initializer(ty, &bytes, &encoded, output)?;
-                writeln!(output, ", align {alignment}").unwrap();
+                writeln!(output, ", align {alignment}{debug_attachment}").unwrap();
             } else if let Some(hex) = global.initializer_hex(self.ctx) {
                 let bytes = decode_hex_initializer(&hex)?;
                 write!(output, " ").unwrap();
                 self.export_byte_initializer(ty, &bytes, output)?;
-                writeln!(output, ", align {alignment}").unwrap();
+                writeln!(output, ", align {alignment}{debug_attachment}").unwrap();
             } else {
                 // NVVM forbids initialized shared variables. `undef` denotes
                 // uninitialized shared storage and is required by both legacy and
@@ -182,7 +194,11 @@ impl<'a> ModuleExportState<'a> {
                 } else {
                     "zeroinitializer"
                 };
-                writeln!(output, " {initializer}, align {alignment}").unwrap();
+                writeln!(
+                    output,
+                    " {initializer}, align {alignment}{debug_attachment}"
+                )
+                .unwrap();
             }
         }
 

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -10,7 +10,9 @@ use rustc_hash::FxHashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use crate::ops::{DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourceScopeMap};
+use crate::ops::{
+    DebugGlobalVariableInfo, DebugLocalTypeKind, DebugLocalVariableInfo, DebugSourceScopeMap,
+};
 
 use super::{
     config::{DebugKind, NvvmIrDialect},
@@ -163,6 +165,15 @@ pub(super) struct ModuleExportState<'a> {
     pub(super) debug_locations: FxHashMap<(usize, i32, i32, Option<usize>), usize>,
     /// `DIType` nodes keyed by the simple debug type they describe.
     pub(super) debug_types: FxHashMap<DebugLocalTypeKind, usize>,
+    /// Uniqued nested `DINamespace` nodes, keyed by parent scope and segment.
+    pub(super) debug_namespaces: FxHashMap<(Option<usize>, String), usize>,
+    /// Global expressions already created for a physical linkage name.
+    /// A repeated linkage must carry the exact same source identity.
+    pub(super) debug_global_variables: FxHashMap<String, (DebugGlobalVariableInfo, usize)>,
+    /// Module globals retained by the compile unit.
+    pub(super) debug_global_expressions: Vec<usize>,
+    /// Whether the compile unit's immutable globals tuple has been finalized.
+    pub(super) debug_globals_finalized: bool,
     /// `DILocalVariable` nodes keyed by scope, source line, and local identity.
     pub(super) debug_local_variables:
         FxHashMap<(usize, PathBuf, i32, DebugLocalVariableInfo), usize>,
@@ -219,6 +230,10 @@ impl<'a> ModuleExportState<'a> {
             debug_resolved_source_scopes: FxHashMap::default(),
             debug_locations: FxHashMap::default(),
             debug_types: FxHashMap::default(),
+            debug_namespaces: FxHashMap::default(),
+            debug_global_variables: FxHashMap::default(),
+            debug_global_expressions: Vec::new(),
+            debug_globals_finalized: false,
             debug_local_variables: FxHashMap::default(),
             debug_nodes: Vec::new(),
             debug_declare_used: false,

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -732,12 +732,43 @@ pub mod ops {
         }
     }
 
+    const MAX_DEBUG_ATTRIBUTE_BYTES: usize = 1024 * 1024;
+    const MAX_DEBUG_STRING_BYTES: usize = 64 * 1024;
+    const MAX_DEBUG_TYPE_CHILDREN: usize = 16 * 1024;
+    const MAX_DEBUG_TYPE_DEPTH: usize = 64;
+
     /// Reverse of [`serialize_debug_type`]. Returns `None` on malformed input.
     fn deserialize_debug_type(bytes: &[u8], pos: &mut usize) -> Option<DebugLocalTypeKind> {
+        if bytes.len() > MAX_DEBUG_ATTRIBUTE_BYTES {
+            return None;
+        }
+        let mut entries = 0;
+        deserialize_debug_type_at(bytes, pos, 0, &mut entries)
+    }
+
+    fn deserialize_debug_type_at(
+        bytes: &[u8],
+        pos: &mut usize,
+        depth: usize,
+        entries: &mut usize,
+    ) -> Option<DebugLocalTypeKind> {
+        *entries = entries.checked_add(1)?;
+        if depth > MAX_DEBUG_TYPE_DEPTH || *entries > MAX_DEBUG_TYPE_CHILDREN {
+            return None;
+        }
+
+        fn charge(entries: &mut usize, count: usize) -> Option<()> {
+            *entries = entries.checked_add(count)?;
+            (*entries <= MAX_DEBUG_TYPE_CHILDREN).then_some(())
+        }
+
         fn take_u64(bytes: &[u8], pos: &mut usize) -> Option<u64> {
             let start = *pos;
             while *pos < bytes.len() && bytes[*pos] != b' ' {
                 *pos += 1;
+            }
+            if start == *pos || *pos >= bytes.len() {
+                return None;
             }
             let n: u64 = std::str::from_utf8(&bytes[start..*pos])
                 .ok()?
@@ -747,7 +778,10 @@ pub mod ops {
             Some(n)
         }
         fn take_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
-            let len = take_u64(bytes, pos)? as usize;
+            let len = usize::try_from(take_u64(bytes, pos)?).ok()?;
+            if len > MAX_DEBUG_STRING_BYTES {
+                return None;
+            }
             let end = pos.checked_add(len)?;
             if end > bytes.len() {
                 return None;
@@ -791,12 +825,13 @@ pub mod ops {
             b's' => {
                 let size_bits = take_u64(bytes, pos)?;
                 let name = take_str(bytes, pos)?;
-                let member_count = take_u64(bytes, pos)? as usize;
+                let member_count = usize::try_from(take_u64(bytes, pos)?).ok()?;
+                charge(entries, member_count)?;
                 let mut members = Vec::with_capacity(member_count);
                 for _ in 0..member_count {
                     let member_name = take_str(bytes, pos)?;
                     let offset_bits = take_u64(bytes, pos)?;
-                    let ty = deserialize_debug_type(bytes, pos)?;
+                    let ty = deserialize_debug_type_at(bytes, pos, depth + 1, entries)?;
                     members.push(DebugTypeMember {
                         name: member_name,
                         offset_bits,
@@ -816,12 +851,14 @@ pub mod ops {
                     0 => None,
                     1 => {
                         let offset_bits = take_u64(bytes, pos)?;
-                        let ty = Box::new(deserialize_debug_type(bytes, pos)?);
+                        let ty =
+                            Box::new(deserialize_debug_type_at(bytes, pos, depth + 1, entries)?);
                         Some(DebugEnumDiscriminant { offset_bits, ty })
                     }
                     _ => return None,
                 };
-                let variant_count = take_u64(bytes, pos)? as usize;
+                let variant_count = usize::try_from(take_u64(bytes, pos)?).ok()?;
+                charge(entries, variant_count)?;
                 let mut variants = Vec::with_capacity(variant_count);
                 for _ in 0..variant_count {
                     let variant_name = take_str(bytes, pos)?;
@@ -830,12 +867,13 @@ pub mod ops {
                         1 => Some(take_u64(bytes, pos)?),
                         _ => return None,
                     };
-                    let member_count = take_u64(bytes, pos)? as usize;
+                    let member_count = usize::try_from(take_u64(bytes, pos)?).ok()?;
+                    charge(entries, member_count)?;
                     let mut members = Vec::with_capacity(member_count);
                     for _ in 0..member_count {
                         let member_name = take_str(bytes, pos)?;
                         let offset_bits = take_u64(bytes, pos)?;
-                        let ty = deserialize_debug_type(bytes, pos)?;
+                        let ty = deserialize_debug_type_at(bytes, pos, depth + 1, entries)?;
                         members.push(DebugTypeMember {
                             name: member_name,
                             offset_bits,
@@ -859,7 +897,7 @@ pub mod ops {
                 let size_bits = take_u64(bytes, pos)?;
                 let name = take_str(bytes, pos)?;
                 let count = take_u64(bytes, pos)?;
-                let element = Box::new(deserialize_debug_type(bytes, pos)?);
+                let element = Box::new(deserialize_debug_type_at(bytes, pos, depth + 1, entries)?);
                 Some(DebugLocalTypeKind::Array {
                     name,
                     size_bits,
@@ -877,6 +915,224 @@ pub mod ops {
         pub name: String,
         pub argument_index: Option<u16>,
         pub ty: DebugLocalTypeKind,
+    }
+
+    /// Source identity and semantic type for a module-scope Rust static.
+    ///
+    /// The physical LLVM global may use a generated symbol and byte-array
+    /// storage, so neither its symbol name nor its LLVM value type can recover
+    /// this information at export time.
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    pub struct DebugGlobalVariableInfo {
+        /// Source-level leaf name (`COUNTER`, not its qualified path or LLVM symbol).
+        pub name: String,
+        /// Crate/module/function namespace components, from outermost to innermost.
+        pub namespace: Vec<String>,
+        pub ty: DebugLocalTypeKind,
+        pub declaration: DebugSourcePosition,
+        /// Mirrors rustc's `!tcx.is_reachable_non_generic(def_id)` decision.
+        pub is_local_to_unit: bool,
+    }
+
+    const MAX_DEBUG_NAMESPACE_SEGMENTS: usize = 128;
+
+    /// Serialize the complete global identity as one versioned attribute.
+    ///
+    /// Every string (including the semantic type blob) is byte-length-prefixed;
+    /// this keeps source names and paths opaque and makes truncation detectable.
+    fn encode_debug_global_info(info: &DebugGlobalVariableInfo) -> Option<String> {
+        fn put_u64(out: &mut String, value: u64) {
+            out.push_str(&value.to_string());
+            out.push(' ');
+        }
+
+        fn put_str(out: &mut String, value: &str) {
+            put_u64(out, value.len() as u64);
+            out.push_str(value);
+        }
+
+        fn charge(entries: &mut usize, count: usize) -> bool {
+            let Some(next) = entries.checked_add(count) else {
+                return false;
+            };
+            if next > MAX_DEBUG_TYPE_CHILDREN {
+                return false;
+            }
+            *entries = next;
+            true
+        }
+
+        fn type_is_bounded(ty: &DebugLocalTypeKind, depth: usize, entries: &mut usize) -> bool {
+            if depth > MAX_DEBUG_TYPE_DEPTH || !charge(entries, 1) {
+                return false;
+            }
+            let bounded = |value: &str| value.len() <= MAX_DEBUG_STRING_BYTES;
+            match ty {
+                DebugLocalTypeKind::Basic { name, encoding, .. } => {
+                    bounded(name) && bounded(encoding)
+                }
+                DebugLocalTypeKind::Pointer { name, .. } => bounded(name),
+                DebugLocalTypeKind::TypedPointer { name, pointee, .. } => {
+                    bounded(name) && type_is_bounded(pointee, depth + 1, entries)
+                }
+                DebugLocalTypeKind::Struct { name, members, .. } => {
+                    bounded(name)
+                        && charge(entries, members.len())
+                        && members.iter().all(|member| {
+                            bounded(&member.name) && type_is_bounded(&member.ty, depth + 1, entries)
+                        })
+                }
+                DebugLocalTypeKind::Enum {
+                    name,
+                    discriminant,
+                    variants,
+                    ..
+                } => {
+                    bounded(name)
+                        && charge(entries, variants.len())
+                        && discriminant.as_ref().is_none_or(|discriminant| {
+                            type_is_bounded(&discriminant.ty, depth + 1, entries)
+                        })
+                        && variants.iter().all(|variant| {
+                            bounded(&variant.name)
+                                && charge(entries, variant.members.len())
+                                && variant.members.iter().all(|member| {
+                                    bounded(&member.name)
+                                        && type_is_bounded(&member.ty, depth + 1, entries)
+                                })
+                        })
+                }
+                DebugLocalTypeKind::Array { name, element, .. } => {
+                    bounded(name) && type_is_bounded(element, depth + 1, entries)
+                }
+            }
+        }
+
+        let file = info.declaration.file.to_str()?;
+        let mut type_entries = 0;
+        if info.name.is_empty()
+            || info.name.len() > MAX_DEBUG_STRING_BYTES
+            || info.namespace.is_empty()
+            || info.namespace.len() > MAX_DEBUG_NAMESPACE_SEGMENTS
+            || info
+                .namespace
+                .iter()
+                .any(|segment| segment.is_empty() || segment.len() > MAX_DEBUG_STRING_BYTES)
+            || file.is_empty()
+            || file.len() > MAX_DEBUG_STRING_BYTES
+            || info.declaration.line <= 0
+            || info.declaration.column <= 0
+            || !type_is_bounded(&info.ty, 0, &mut type_entries)
+        {
+            return None;
+        }
+
+        let mut encoded_ty = String::new();
+        serialize_debug_type(&info.ty, &mut encoded_ty);
+        if encoded_ty.len() > MAX_DEBUG_ATTRIBUTE_BYTES {
+            return None;
+        }
+
+        let mut out = String::from("v1 ");
+        put_str(&mut out, &info.name);
+        put_u64(&mut out, info.namespace.len() as u64);
+        for segment in &info.namespace {
+            put_str(&mut out, segment);
+        }
+        put_u64(&mut out, u64::from(info.is_local_to_unit));
+        put_str(&mut out, file);
+        put_u64(&mut out, info.declaration.line as u64);
+        put_u64(&mut out, info.declaration.column as u64);
+        put_str(&mut out, &encoded_ty);
+        (out.len() <= MAX_DEBUG_ATTRIBUTE_BYTES).then_some(out)
+    }
+
+    fn decode_debug_global_info(encoded: &str) -> Option<DebugGlobalVariableInfo> {
+        fn take_u64(bytes: &[u8], pos: &mut usize) -> Option<u64> {
+            let start = *pos;
+            while *pos < bytes.len() && bytes[*pos] != b' ' {
+                *pos += 1;
+            }
+            if start == *pos || *pos >= bytes.len() {
+                return None;
+            }
+            let value = std::str::from_utf8(&bytes[start..*pos])
+                .ok()?
+                .parse()
+                .ok()?;
+            *pos += 1;
+            Some(value)
+        }
+
+        fn take_bytes<'a>(bytes: &'a [u8], pos: &mut usize, max_len: usize) -> Option<&'a [u8]> {
+            let len = usize::try_from(take_u64(bytes, pos)?).ok()?;
+            if len > max_len {
+                return None;
+            }
+            let end = (*pos).checked_add(len)?;
+            let value = bytes.get(*pos..end)?;
+            *pos = end;
+            Some(value)
+        }
+
+        fn take_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
+            std::str::from_utf8(take_bytes(bytes, pos, MAX_DEBUG_STRING_BYTES)?)
+                .ok()
+                .map(ToOwned::to_owned)
+        }
+
+        if encoded.len() > MAX_DEBUG_ATTRIBUTE_BYTES {
+            return None;
+        }
+        let bytes = encoded.as_bytes();
+        if !bytes.starts_with(b"v1 ") {
+            return None;
+        }
+        let mut pos = 3;
+        let name = take_str(bytes, &mut pos)?;
+        if name.is_empty() {
+            return None;
+        }
+
+        let namespace_count = usize::try_from(take_u64(bytes, &mut pos)?).ok()?;
+        if namespace_count == 0 || namespace_count > MAX_DEBUG_NAMESPACE_SEGMENTS {
+            return None;
+        }
+        let mut namespace = Vec::with_capacity(namespace_count);
+        for _ in 0..namespace_count {
+            let segment = take_str(bytes, &mut pos)?;
+            if segment.is_empty() {
+                return None;
+            }
+            namespace.push(segment);
+        }
+
+        let is_local_to_unit = match take_u64(bytes, &mut pos)? {
+            0 => false,
+            1 => true,
+            _ => return None,
+        };
+        let file = PathBuf::from(take_str(bytes, &mut pos)?);
+        let line = i32::try_from(take_u64(bytes, &mut pos)?).ok()?;
+        let column = i32::try_from(take_u64(bytes, &mut pos)?).ok()?;
+        if file.as_os_str().is_empty() || line <= 0 || column <= 0 {
+            return None;
+        }
+
+        let ty_bytes = take_bytes(bytes, &mut pos, MAX_DEBUG_ATTRIBUTE_BYTES)?;
+        let mut ty_pos = 0;
+        let ty = deserialize_debug_type(ty_bytes, &mut ty_pos)?;
+        if ty_pos != ty_bytes.len() || pos != bytes.len() {
+            return None;
+        }
+
+        Some(DebugGlobalVariableInfo {
+            name,
+            namespace,
+            ty,
+            declaration: DebugSourcePosition { file, line, column },
+            is_local_to_unit,
+        })
     }
 
     /// One scalarized fragment of a source variable.
@@ -994,6 +1250,7 @@ pub mod ops {
     const DEBUG_LOCAL_DECL_LINE_KEY: &str = "cuda_oxide_debug_local_decl_line";
     const DEBUG_LOCAL_DECL_COLUMN_KEY: &str = "cuda_oxide_debug_local_decl_column";
     const DEBUG_LOCAL_SCOPE_KEY: &str = "cuda_oxide_debug_local_scope";
+    const DEBUG_GLOBAL_INFO_KEY: &str = "cuda_oxide_debug_global_info";
     const DEBUG_PROJECTED_COUNT_KEY: &str = "cuda_oxide_debug_projected_count";
     const DEBUG_FRAGMENT_COUNT_KEY: &str = "cuda_oxide_debug_fragment_count";
     const DEBUG_VALUE_EXPRESSION_KEY: &str = "cuda_oxide_debug_value_expression";
@@ -1119,6 +1376,32 @@ pub mod ops {
             argument_index,
             ty,
         })
+    }
+
+    /// Attach the source identity and semantic type of a Rust static to an op.
+    ///
+    /// This is usable on both `mir.global_alloc` and the lowered LLVM global,
+    /// which lets the information cross dialect conversion without coupling
+    /// either dialect's generated attribute schema to the debug representation.
+    pub fn set_debug_global_variable(
+        ctx: &mut Context,
+        op: Ptr<Operation>,
+        info: &DebugGlobalVariableInfo,
+    ) {
+        if let Some(encoded) = encode_debug_global_info(info) {
+            set_string_attr(ctx, op, DEBUG_GLOBAL_INFO_KEY, encoded);
+        }
+    }
+
+    /// Read source-level debug metadata for a Rust static, if complete.
+    ///
+    /// Malformed or partial attributes fail closed.
+    pub fn debug_global_variable(
+        ctx: &Context,
+        op: Ptr<Operation>,
+    ) -> Option<DebugGlobalVariableInfo> {
+        let encoded = get_string_attr(ctx, op, DEBUG_GLOBAL_INFO_KEY)?;
+        decode_debug_global_info(&encoded)
     }
 
     /// Attach every source variable described by a static projection of this slot.
@@ -2149,10 +2432,14 @@ pub mod ops {
     #[cfg(test)]
     mod tests {
         use super::{
-            DebugEnumDiscriminant, DebugEnumVariant, DebugLocalTypeKind, DebugTypeMember,
-            GlobalInitializerRelocation, decode_global_initializer_relocations,
-            deserialize_debug_type, encode_global_initializer_relocations, serialize_debug_type,
+            DebugEnumDiscriminant, DebugEnumVariant, DebugGlobalVariableInfo, DebugLocalTypeKind,
+            DebugSourcePosition, DebugTypeMember, GlobalInitializerRelocation,
+            MAX_DEBUG_NAMESPACE_SEGMENTS, MAX_DEBUG_STRING_BYTES, MAX_DEBUG_TYPE_DEPTH,
+            decode_debug_global_info, decode_global_initializer_relocations,
+            deserialize_debug_type, encode_debug_global_info,
+            encode_global_initializer_relocations, serialize_debug_type,
         };
+        use std::path::PathBuf;
 
         fn round_trip(ty: &DebugLocalTypeKind) -> DebugLocalTypeKind {
             let mut encoded = String::new();
@@ -2407,6 +2694,96 @@ pub mod ops {
             encoded.truncate(encoded.len() - 1);
             let mut pos = 0;
             assert!(deserialize_debug_type(encoded.as_bytes(), &mut pos).is_none());
+        }
+
+        #[test]
+        fn global_debug_identity_round_trips_structured_namespace_and_visibility() {
+            let info = DebugGlobalVariableInfo {
+                name: "COUNTER with spaces".to_string(),
+                namespace: vec![
+                    "collision_crate".to_string(),
+                    "module with spaces".to_string(),
+                    "function".to_string(),
+                ],
+                ty: DebugLocalTypeKind::Basic {
+                    name: "u32".to_string(),
+                    size_bits: 32,
+                    encoding: "DW_ATE_unsigned",
+                },
+                declaration: DebugSourcePosition {
+                    file: PathBuf::from("/tmp/path with spaces/kernel.rs"),
+                    line: 41,
+                    column: 9,
+                },
+                is_local_to_unit: false,
+            };
+            let encoded = encode_debug_global_info(&info).expect("valid identity encodes");
+            assert_eq!(decode_debug_global_info(&encoded), Some(info));
+        }
+
+        #[test]
+        fn global_debug_identity_rejects_malformed_namespace_and_visibility() {
+            assert!(
+                decode_debug_global_info("v1 1 X0 ").is_none(),
+                "an empty namespace must not degrade to scope:null"
+            );
+            assert!(
+                decode_debug_global_info("v1 1 X129 ").is_none(),
+                "namespace allocation must be bounded"
+            );
+            assert!(
+                decode_debug_global_info("v1 1 X1 1 n2 ").is_none(),
+                "visibility accepts only the exact 0/1 encoding"
+            );
+
+            let info = DebugGlobalVariableInfo {
+                name: "X".to_string(),
+                namespace: vec!["crate".to_string()],
+                ty: DebugLocalTypeKind::Basic {
+                    name: "u8".to_string(),
+                    size_bits: 8,
+                    encoding: "DW_ATE_unsigned",
+                },
+                declaration: DebugSourcePosition {
+                    file: PathBuf::from("/tmp/x.rs"),
+                    line: 1,
+                    column: 1,
+                },
+                is_local_to_unit: true,
+            };
+            let mut trailing = encode_debug_global_info(&info).expect("valid identity encodes");
+            trailing.push('x');
+            assert!(decode_debug_global_info(&trailing).is_none());
+
+            let mut truncated = encode_debug_global_info(&info).expect("valid identity encodes");
+            truncated.pop();
+            assert!(decode_debug_global_info(&truncated).is_none());
+
+            let mut too_many_namespaces = info.clone();
+            too_many_namespaces.namespace =
+                vec!["scope".to_string(); MAX_DEBUG_NAMESPACE_SEGMENTS + 1];
+            assert!(encode_debug_global_info(&too_many_namespaces).is_none());
+
+            let mut oversized_name = info.clone();
+            oversized_name.name = "x".repeat(MAX_DEBUG_STRING_BYTES + 1);
+            assert!(encode_debug_global_info(&oversized_name).is_none());
+
+            let mut too_deep = DebugLocalTypeKind::Basic {
+                name: "u8".to_string(),
+                size_bits: 8,
+                encoding: "DW_ATE_unsigned",
+            };
+            for depth in 0..=MAX_DEBUG_TYPE_DEPTH {
+                too_deep = DebugLocalTypeKind::Array {
+                    name: format!("depth_{depth}"),
+                    size_bits: 8,
+                    element: Box::new(too_deep),
+                    count: 1,
+                };
+            }
+            let mut excessive_nesting = info;
+            excessive_nesting.ty = too_deep;
+            assert!(encode_debug_global_info(&excessive_nesting).is_none());
         }
     }
 }

--- a/crates/llvm-export/tests/export_test.rs
+++ b/crates/llvm-export/tests/export_test.rs
@@ -15,11 +15,12 @@ use llvm_export::{
     ops::{
         AddrSpaceCastOp, AddressOfOp, AllocaOp, BitcastOp, BrOp, CallOp, CondBrOp, ConstantOp,
         DebugEnumDiscriminant, DebugEnumVariant, DebugFragment, DebugFragmentVariableInfo,
-        DebugLocalTypeKind, DebugLocalVariableInfo, DebugProjectedVariableInfo,
-        DebugSourcePosition, DebugSourceScope, DebugSourceScopeLocation, DebugSourceScopeMap,
-        DebugValueExpression, DebugValueExpressionOp, DebugValueListOp, DebugValueOp, FuncOp,
-        GepIndex, GetElementPtrOp, GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp,
-        LoadOp, ReturnOp, SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
+        DebugGlobalVariableInfo, DebugLocalTypeKind, DebugLocalVariableInfo,
+        DebugProjectedVariableInfo, DebugSourcePosition, DebugSourceScope,
+        DebugSourceScopeLocation, DebugSourceScopeMap, DebugValueExpression,
+        DebugValueExpressionOp, DebugValueListOp, DebugValueOp, FuncOp, GepIndex, GetElementPtrOp,
+        GlobalInitializerRelocation, GlobalOp, GlobalOpExt, InlineAsmOp, LoadOp, ReturnOp,
+        SelectOp, StoreOp, UndefOp, encode_global_initializer_relocations,
     },
     types::{ArrayType, FuncType, HalfType, PointerType, StructLayout, StructType, VoidType},
 };
@@ -2987,6 +2988,407 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
     assert!(
         output.status.success(),
         "{llvm_as} rejected pointer debug metadata:\n{stderr}\n--- module ---\n{ir}"
+    );
+}
+
+#[test]
+fn full_debug_metadata_describes_as1_global_with_semantic_rust_type() {
+    let mut ctx = Context::new();
+
+    let module = ModuleOp::new(&mut ctx, "test_module".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+    let i8_ty = IntegerType::get(&ctx, 8, Signedness::Signless);
+    let storage_ty = ArrayType::get(&ctx, i8_ty.into(), 8);
+    let global = GlobalOp::new_with_alignment(
+        &mut ctx,
+        "__device_global_7".try_into().unwrap(),
+        storage_ty.into(),
+        8,
+    );
+    global.set_address_space(&mut ctx, llvm_export::types::address_space::GLOBAL);
+    global.set_initializer_hex(&mut ctx, "0000000000000000");
+    llvm_export::ops::set_debug_global_variable(
+        &mut ctx,
+        global.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "GLOBAL_COUNTER".to_string(),
+            namespace: vec!["debuginfo".to_string(), "state".to_string()],
+            ty: DebugLocalTypeKind::Basic {
+                name: "u64".to_string(),
+                size_bits: 64,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/kernel.rs"),
+                line: 90,
+                column: 1,
+            },
+            is_local_to_unit: true,
+        },
+    );
+    global.get_operation().insert_at_back(module_block, &ctx);
+
+    let full = export_module_to_string_with_config(
+        &ctx,
+        &module,
+        &DebugConfig {
+            inner: PtxExportConfig,
+            debug_kind: DebugKind::Full,
+        },
+    )
+    .expect("full debug export succeeds");
+
+    let definition = full
+        .lines()
+        .find(|line| line.starts_with("@__device_global_7 = "))
+        .expect("device-global definition");
+    assert!(
+        definition.contains("addrspace(1) global [8 x i8] c\"\\00\\00\\00\\00\\00\\00\\00\\00\"")
+            && definition.contains(", align 8, !dbg !"),
+        "the physical byte storage should retain a global debug attachment:\n{full}"
+    );
+    assert!(
+        full.contains(
+            "distinct !DIGlobalVariable(name: \"GLOBAL_COUNTER\", linkageName: \"__device_global_7\""
+        ),
+        "DWARF should separate the source name from the generated linkage name:\n{full}"
+    );
+    assert!(
+        full.contains("!DINamespace(name: \"debuginfo\", scope: null)")
+            && full.contains("!DINamespace(name: \"state\", scope: !")
+            && full.contains("scope: !"),
+        "the source crate/module hierarchy should scope the leaf name:\n{full}"
+    );
+    assert!(
+        full.contains("isLocal: true, isDefinition: true"),
+        "private Rust statics should remain local to the compile unit:\n{full}"
+    );
+    assert!(
+        full.contains("file: !")
+            && full.contains("line: 90, type: !")
+            && full.contains("align: 64)"),
+        "the declaration location and source alignment should be retained:\n{full}"
+    );
+    assert!(
+        full.contains("!DIBasicType(name: \"u64\", size: 64, encoding: DW_ATE_unsigned)"),
+        "the debug type must be semantic u64, not the physical [8 x i8] storage:\n{full}"
+    );
+    assert!(
+        full.contains("!DIGlobalVariableExpression(var: !")
+            && full.contains("expr: !DIExpression())")
+            && full.contains("emissionKind: FullDebug, globals: !"),
+        "the global expression should be retained by the compile unit:\n{full}"
+    );
+
+    let off = export_module_to_string_with_config(
+        &ctx,
+        &module,
+        &DebugConfig {
+            inner: PtxExportConfig,
+            debug_kind: DebugKind::Off,
+        },
+    )
+    .expect("non-debug export succeeds");
+    let line_tables = export_module_to_string_with_config(
+        &ctx,
+        &module,
+        &DebugConfig {
+            inner: PtxExportConfig,
+            debug_kind: DebugKind::LineTables,
+        },
+    )
+    .expect("line-table export succeeds");
+    assert_eq!(
+        line_tables, off,
+        "a global-only module must not gain variable metadata outside full debug"
+    );
+}
+
+#[test]
+fn full_debug_globals_preserve_qualified_identity_visibility_and_relocations() {
+    let mut ctx = Context::new();
+    let module = ModuleOp::new(&mut ctx, "global_debug_adversarial".try_into().unwrap());
+    let module_block = module_top_block(&mut ctx, &module);
+    let i8_ty = IntegerType::get(&ctx, 8, Signedness::Signless);
+    let i64_ty = IntegerType::get(&ctx, 64, Signedness::Signless);
+
+    let left_ty = ArrayType::get(&ctx, i8_ty.into(), 4);
+    let left = GlobalOp::new_with_alignment(
+        &mut ctx,
+        "__device_global_20".try_into().unwrap(),
+        left_ty.into(),
+        4,
+    );
+    left.set_address_space(&mut ctx, llvm_export::types::address_space::GLOBAL);
+    left.set_initializer_hex(&mut ctx, "01000000");
+    llvm_export::ops::set_debug_global_variable(
+        &mut ctx,
+        left.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "SAME_LEAF".to_string(),
+            namespace: vec!["qualified_fixture".to_string(), "left".to_string()],
+            ty: DebugLocalTypeKind::Basic {
+                name: "u32".to_string(),
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/qualified.rs"),
+                line: 20,
+                column: 5,
+            },
+            is_local_to_unit: true,
+        },
+    );
+    left.get_operation().insert_at_back(module_block, &ctx);
+
+    let right_ty = ArrayType::get(&ctx, i8_ty.into(), 8);
+    let right = GlobalOp::new_with_alignment(
+        &mut ctx,
+        "__device_global_21".try_into().unwrap(),
+        right_ty.into(),
+        8,
+    );
+    right.set_address_space(&mut ctx, llvm_export::types::address_space::GLOBAL);
+    right.set_initializer_hex(&mut ctx, "0200000000000000");
+    llvm_export::ops::set_debug_global_variable(
+        &mut ctx,
+        right.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "SAME_LEAF".to_string(),
+            namespace: vec!["qualified_fixture".to_string(), "right".to_string()],
+            ty: DebugLocalTypeKind::Basic {
+                name: "u64".to_string(),
+                size_bits: 64,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/qualified.rs"),
+                line: 24,
+                column: 5,
+            },
+            is_local_to_unit: false,
+        },
+    );
+    right.get_operation().insert_at_back(module_block, &ctx);
+
+    let target_ty = ArrayType::get(&ctx, i8_ty.into(), 4);
+    let target = GlobalOp::new_with_alignment(
+        &mut ctx,
+        "__device_global_22".try_into().unwrap(),
+        target_ty.into(),
+        4,
+    );
+    target.set_address_space(&mut ctx, llvm_export::types::address_space::GLOBAL);
+    target.set_source_global_key(&mut ctx, "qualified_fixture::RELOCATION_TARGET");
+    target.set_initializer_hex(&mut ctx, "78563412");
+    llvm_export::ops::set_debug_global_variable(
+        &mut ctx,
+        target.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "RELOCATION_TARGET".to_string(),
+            namespace: vec!["qualified_fixture".to_string()],
+            ty: DebugLocalTypeKind::Basic {
+                name: "u32".to_string(),
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/qualified.rs"),
+                line: 30,
+                column: 1,
+            },
+            is_local_to_unit: true,
+        },
+    );
+    target.get_operation().insert_at_back(module_block, &ctx);
+
+    let references_ty = StructType::get_unnamed(
+        &ctx,
+        (vec![i64_ty.into(), i64_ty.into()], StructLayout::Unpacked),
+    );
+    let references = GlobalOp::new_with_alignment(
+        &mut ctx,
+        "__device_global_23".try_into().unwrap(),
+        references_ty.into(),
+        8,
+    );
+    references.set_address_space(&mut ctx, llvm_export::types::address_space::GLOBAL);
+    references.set_source_global_key(&mut ctx, "qualified_fixture::REFERENCES");
+    references.set_initializer_hex(&mut ctx, "00000000000000000000000000000000");
+    references.set_initializer_relocations(
+        &mut ctx,
+        &encode_global_initializer_relocations(&[
+            GlobalInitializerRelocation {
+                source_offset: 0,
+                width_bytes: 8,
+                target_address_space: llvm_export::types::address_space::GLOBAL,
+                target_addend: 0,
+                target_key: "qualified_fixture::RELOCATION_TARGET".to_string(),
+            },
+            GlobalInitializerRelocation {
+                source_offset: 8,
+                width_bytes: 8,
+                target_address_space: llvm_export::types::address_space::GLOBAL,
+                target_addend: 0,
+                target_key: "qualified_fixture::RELOCATION_TARGET".to_string(),
+            },
+        ]),
+    );
+    llvm_export::ops::set_debug_global_variable(
+        &mut ctx,
+        references.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "REFERENCES".to_string(),
+            namespace: vec!["qualified_fixture".to_string()],
+            ty: DebugLocalTypeKind::Array {
+                name: "[&u32; 2]".to_string(),
+                size_bits: 128,
+                element: Box::new(DebugLocalTypeKind::Pointer {
+                    name: "&u32".to_string(),
+                    size_bits: 64,
+                }),
+                count: 2,
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/qualified.rs"),
+                line: 31,
+                column: 1,
+            },
+            is_local_to_unit: true,
+        },
+    );
+    references
+        .get_operation()
+        .insert_at_back(module_block, &ctx);
+
+    let export = |debug_kind| {
+        export_module_to_string_with_config(
+            &ctx,
+            &module,
+            &DebugConfig {
+                inner: PtxExportConfig,
+                debug_kind,
+            },
+        )
+        .expect("global debug export succeeds")
+    };
+    let full = export(DebugKind::Full);
+
+    let metadata_id = |needle: &str| {
+        full.lines()
+            .find(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("missing `{needle}` in:\n{full}"))
+            .split_once(" = ")
+            .expect("metadata definition")
+            .0
+            .trim_start_matches('!')
+            .to_string()
+    };
+    let left_scope = metadata_id("!DINamespace(name: \"left\"");
+    let right_scope = metadata_id("!DINamespace(name: \"right\"");
+    let left_variable = full
+        .lines()
+        .find(|line| {
+            line.contains("!DIGlobalVariable(name: \"SAME_LEAF\"")
+                && line.contains("linkageName: \"__device_global_20\"")
+        })
+        .expect("left source global");
+    let right_variable = full
+        .lines()
+        .find(|line| {
+            line.contains("!DIGlobalVariable(name: \"SAME_LEAF\"")
+                && line.contains("linkageName: \"__device_global_21\"")
+        })
+        .expect("right source global");
+    assert!(left_variable.contains(&format!("scope: !{left_scope}")));
+    assert!(left_variable.contains("line: 20") && left_variable.contains("isLocal: true"));
+    assert!(right_variable.contains(&format!("scope: !{right_scope}")));
+    assert!(right_variable.contains("line: 24") && right_variable.contains("isLocal: false"));
+
+    let target_definition = full
+        .lines()
+        .find(|line| line.starts_with("@__device_global_22 = "))
+        .expect("relocation-only target definition");
+    assert!(target_definition.contains("[4 x i8]") && target_definition.contains("!dbg !"));
+    let target_variable = full
+        .lines()
+        .find(|line| line.contains("!DIGlobalVariable(name: \"RELOCATION_TARGET\""))
+        .expect("relocation-only target source identity");
+    assert!(
+        target_variable.contains("linkageName: \"__device_global_22\"")
+            && target_variable.contains("line: 30")
+    );
+
+    let reference_definition = full
+        .lines()
+        .find(|line| line.starts_with("@__device_global_23 = "))
+        .expect("relocation-backed definition");
+    assert_eq!(
+        reference_definition.matches("@__device_global_22").count(),
+        2,
+        "both initializer references must target the same one physical global"
+    );
+    assert!(
+        full.contains("!DICompositeType(tag: DW_TAG_array_type, baseType: !")
+            && full.contains("size: 128, elements: !")
+            && full.contains("!DIDerivedType(tag: DW_TAG_pointer_type, name: \"&u32\"")
+    );
+
+    assert_eq!(
+        full.matches("!DIGlobalVariableExpression(var:").count(),
+        4,
+        "one expression per physical source global, despite repeated relocations"
+    );
+    let compile_unit = full
+        .lines()
+        .find(|line| line.contains("!DICompileUnit("))
+        .expect("debug compile unit");
+    let globals_id = compile_unit
+        .split("globals: !")
+        .nth(1)
+        .and_then(|tail| tail.strip_suffix(')'))
+        .expect("compile-unit globals tuple");
+    let globals_tuple = full
+        .lines()
+        .find(|line| line.starts_with(&format!("!{globals_id} = !{{")))
+        .expect("compile-unit globals tuple definition");
+    assert_eq!(globals_tuple.matches('!').count() - 2, 4, "{globals_tuple}");
+
+    assert_eq!(
+        export(DebugKind::LineTables),
+        export(DebugKind::Off),
+        "initialized and relocation-backed globals must not gain metadata outside Full debug"
+    );
+
+    let Some(llvm_as) = ["llvm-as-22", "llvm-as-21", "llvm-as"]
+        .into_iter()
+        .find(|tool| {
+            std::process::Command::new(tool)
+                .arg("--version")
+                .output()
+                .is_ok_and(|out| out.status.success())
+        })
+    else {
+        eprintln!("skipping global-debug parse gate: no llvm-as on PATH");
+        return;
+    };
+    let ll_path = std::env::temp_dir().join(format!(
+        "cuda_oxide_global_debug_parse_gate_{}.ll",
+        std::process::id()
+    ));
+    std::fs::write(&ll_path, &full).expect("write temp .ll");
+    let output = std::process::Command::new(llvm_as)
+        .arg("-o")
+        .arg("/dev/null")
+        .arg(&ll_path)
+        .output()
+        .expect("run llvm-as");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = std::fs::remove_file(&ll_path);
+    assert!(
+        output.status.success(),
+        "{llvm_as} rejected global debug metadata:\n{stderr}\n--- module ---\n{full}"
     );
 }
 

--- a/crates/mir-importer/src/lib.rs
+++ b/crates/mir-importer/src/lib.rs
@@ -103,9 +103,9 @@ pub(crate) mod translator;
 
 pub use error::{TranslationErr, TranslationResult};
 pub use pipeline::{
-    CollectedFunction, CompilationArtifactKind, CompilationResult, DeviceExternAttrs,
-    DeviceExternDecl, DeviceExternType, KernelLaunchBounds, PipelineConfig, PipelineError,
-    run_pipeline,
+    CollectedFunction, CompilationArtifactKind, CompilationResult, DebugGlobalVariableIdentity,
+    DeviceExternAttrs, DeviceExternDecl, DeviceExternType, KernelLaunchBounds, PipelineConfig,
+    PipelineError, build_debug_global_variable_info, device_static_global_key, run_pipeline,
 };
 pub use translator::facts::KnownDefs;
 pub use translator::terminator::drop_glue::{drop_glue_is_noop, drop_instance_is_noop};

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -44,11 +44,16 @@ use cuda_oxide_codegen::__private::{
 pub use cuda_oxide_codegen::__private::{DeviceExternAttrs, DeviceExternDecl, PipelineError};
 use llvm_export::export::DebugKind;
 pub use llvm_export::export::DeviceExternType;
+use llvm_export::ops::{DebugGlobalVariableInfo, DebugSourcePosition};
 use pliron::context::Context;
 use pliron::identifier::Legaliser;
+use pliron::linked_list::ContainsLinkedList;
 use pliron::op::Op;
+use pliron::operation::Operation;
 use pliron::printable::Printable;
+use pliron::r#type::Typed;
 use rustc_public::mir::mono::Instance;
+use rustc_public::ty::Ty;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -181,6 +186,13 @@ pub struct PipelineConfig {
     pub device_arch_hint: Option<String>,
     /// Device debug metadata tier.
     pub debug_kind: DebugKind,
+    /// Source identities and semantic types for ordinary device statics,
+    /// keyed by [`device_static_global_key`].
+    ///
+    /// The rustc frontend populates this only for full debug builds. Keeping
+    /// the map module-scoped lets every per-function reference receive the
+    /// same identity before MIR lowering deduplicates physical globals.
+    pub debug_global_variables: BTreeMap<String, DebugGlobalVariableInfo>,
     /// Whether ordinary floating-point multiply/add or multiply/subtract
     /// expressions may contract into fused operations.
     ///
@@ -201,7 +213,109 @@ impl Default for PipelineConfig {
             target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            debug_global_variables: BTreeMap::new(),
             allow_fma_contraction: true,
+        }
+    }
+}
+
+/// Rustc-owned source identity for one static, captured before entering the
+/// stable-MIR closure. The semantic type is converted separately inside that
+/// closure so it remains the Rust type even when initialized storage later
+/// lowers to a physical byte array.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DebugGlobalVariableIdentity {
+    pub name: String,
+    pub namespace: Vec<String>,
+    pub declaration: DebugSourcePosition,
+    pub is_local_to_unit: bool,
+}
+
+/// Return the opaque, per-compilation identity used for one device static.
+///
+/// `StaticDef::name()` is a display path, not an identity: two same-named
+/// statics in sibling blocks can have the same path. For ordinary Rust
+/// symbols, rustc's codegen symbol includes the DefPath disambiguator needed
+/// to keep those allocations distinct and retains upstream crate identity. An
+/// explicit `#[export_name]` is preserved verbatim. The symbol is wrapped in a
+/// domain tag so neither form can alias a compiler-made promoted key, then used
+/// only as a join key within one compilation; source-facing debug names and
+/// namespaces are carried separately.
+pub fn device_static_global_key(static_def: &rustc_public::mir::mono::StaticDef) -> String {
+    let symbol = rustc_public::mir::mono::Instance::from(*static_def)
+        .mangled_name()
+        .to_string();
+    dialect_mir::ops::encode_rust_static_global_key(&symbol)
+}
+
+/// Combine rustc-owned identity with a stable-MIR semantic type.
+pub fn build_debug_global_variable_info(
+    identity: DebugGlobalVariableIdentity,
+    ty: &Ty,
+) -> Option<DebugGlobalVariableInfo> {
+    let debug_ty = crate::translator::body::debug_type_for_ty(ty)?;
+    let semantic_size_bits = ty.layout().ok()?.shape().size.bytes() as u64 * 8;
+    if debug_ty.size_bits() != semantic_size_bits {
+        // The shared local-variable type builder currently spells every
+        // reference as one machine pointer. That is exact for thin references,
+        // but not for slices/trait objects. A global DIE whose type size does
+        // not match rustc's semantic layout would be actively misleading, so
+        // omit it until the richer fat-pointer representation exists.
+        return None;
+    }
+    Some(DebugGlobalVariableInfo {
+        name: identity.name,
+        namespace: identity.namespace,
+        ty: debug_ty,
+        declaration: identity.declaration,
+        is_local_to_unit: identity.is_local_to_unit,
+    })
+}
+
+/// Attach module-owned static identities to every per-function materialization.
+/// MIR lowering subsequently uniques these operations by `global_key`.
+fn attach_debug_global_variables(
+    ctx: &mut Context,
+    func_op: pliron::context::Ptr<Operation>,
+    globals: &BTreeMap<String, DebugGlobalVariableInfo>,
+) {
+    if globals.is_empty() {
+        return;
+    }
+
+    let region = func_op.deref(ctx).get_region(0);
+    let blocks: Vec<_> = region.deref(ctx).iter(ctx).collect();
+    let operations: Vec<_> = blocks
+        .iter()
+        .flat_map(|block| block.deref(ctx).iter(ctx))
+        .collect();
+
+    for op in operations {
+        let Some(global) = Operation::get_op::<dialect_mir::ops::MirGlobalAllocOp>(op, ctx) else {
+            continue;
+        };
+        let result_ty = global
+            .get_operation()
+            .deref(ctx)
+            .get_result(0)
+            .get_type(ctx);
+        let is_as1 = result_ty
+            .deref(ctx)
+            .downcast_ref::<dialect_mir::types::MirPtrType>()
+            .is_some_and(|pointer| {
+                pointer.address_space == dialect_mir::types::address_space::GLOBAL
+            });
+        if !is_as1 {
+            continue;
+        }
+        let Some(key) = global
+            .get_attr_global_key(ctx)
+            .map(|key| String::from(key.clone()))
+        else {
+            continue;
+        };
+        if let Some(info) = globals.get(&key) {
+            llvm_export::ops::set_debug_global_variable(ctx, op, info);
         }
     }
 }
@@ -330,6 +444,10 @@ pub fn run_pipeline(
             // Use .disp(&ctx) for rich error formatting with location and backtrace
             PipelineError::Translation(format!("{}: {}", func.export_name, e.disp(&ctx)))
         })?;
+
+        if config.debug_kind.variables_enabled() {
+            attach_debug_global_variables(&mut ctx, func_op_ptr, &config.debug_global_variables);
+        }
 
         // Dump the per-function IR BEFORE verification so users can see
         // what the translator produced even when verification fails. If we
@@ -545,6 +663,261 @@ mod tests {
     }
 
     #[test]
+    fn global_debug_types_fail_closed_for_unions_and_fat_references() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_global_debug_types_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("global_debug_types.rs");
+        fs::write(
+            &fixture,
+            r#"
+#![allow(dead_code)]
+
+union Word {
+    value: u32,
+    bytes: [u8; 4],
+}
+
+static SCALAR: u64 = 7;
+static UNION_VALUE: Word = Word { value: 11 };
+static SLICE_VIEW: &[u8] = &[1, 2, 3];
+"#,
+        )
+        .unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=global_debug_types".to_string(),
+            "--emit=metadata".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        let supported = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    use rustc_public::CrateDef as _;
+
+                    let results = rustc_public::local_crate()
+                        .statics()
+                        .into_iter()
+                        .map(|static_def| {
+                            let qualified_name = static_def.name().to_string();
+                            let identity = DebugGlobalVariableIdentity {
+                                name: "FIXTURE_STATIC".to_string(),
+                                namespace: vec!["global_debug_types".to_string()],
+                                declaration: DebugSourcePosition {
+                                    file: std::path::PathBuf::from("global_debug_types.rs"),
+                                    line: 1,
+                                    column: 1,
+                                },
+                                is_local_to_unit: true,
+                            };
+                            (
+                                qualified_name,
+                                build_debug_global_variable_info(identity, &static_def.ty())
+                                    .is_some(),
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    std::ops::ControlFlow::<(), _>::Continue(results)
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        fs::remove_dir_all(&root).ok();
+        let status = |leaf: &str| {
+            supported
+                .iter()
+                .find(|(name, _)| name.ends_with(&format!("::{leaf}")))
+                .unwrap_or_else(|| panic!("fixture static `{leaf}` was not found"))
+                .1
+        };
+        assert!(status("SCALAR"), "a scalar semantic type is exact");
+        assert!(
+            !status("UNION_VALUE"),
+            "unsupported unions must not acquire a misleading byte-storage DIE"
+        );
+        assert!(
+            !status("SLICE_VIEW"),
+            "a fat reference must be omitted while the shared type builder describes only one pointer word"
+        );
+    }
+
+    #[test]
+    fn device_static_global_keys_distinguish_same_path_block_statics() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_static_global_keys_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let fixture = root.join("static_global_keys.rs");
+        fs::write(
+            &fixture,
+            r#"
+#![allow(dead_code)]
+
+fn opposite_blocks(select_left: bool) -> u64 {
+    if select_left {
+        static VALUE: u64 = 11;
+        VALUE + VALUE
+    } else {
+        static VALUE: u64 = 29;
+        VALUE + VALUE
+    }
+}
+
+fn adversarial_export_name() -> u64 {
+    #[unsafe(export_name = "__cuda_oxide_promoted_type_collision")]
+    static EXPORTED: u64 = 41;
+    EXPORTED
+}
+"#,
+        )
+        .unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let sysroot_output = std::process::Command::new(rustc)
+            .args(["--print", "sysroot"])
+            .output()
+            .expect("query rustc sysroot");
+        assert!(sysroot_output.status.success(), "rustc --print sysroot");
+        let sysroot = String::from_utf8(sysroot_output.stdout)
+            .expect("sysroot path is UTF-8")
+            .trim()
+            .to_string();
+        let args = vec![
+            "rustc".to_string(),
+            "--edition=2024".to_string(),
+            "--crate-type=rlib".to_string(),
+            "--crate-name=static_global_keys".to_string(),
+            "--emit=metadata".to_string(),
+            "-Zmir-opt-level=0".to_string(),
+            format!("--out-dir={}", root.display()),
+            format!("--sysroot={sysroot}"),
+            fixture.display().to_string(),
+        ];
+
+        let (identities, exported) = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || {
+                rustc_public::run!(&args, || {
+                    use rustc_public::CrateDef as _;
+
+                    let statics = rustc_public::local_crate().statics();
+                    let results = statics
+                        .iter()
+                        .copied()
+                        .filter(|static_def| {
+                            static_def.name().ends_with("::opposite_blocks::VALUE")
+                        })
+                        .map(|static_def| {
+                            let source_name = static_def.name();
+                            let mangled = rustc_public::mir::mono::Instance::from(static_def)
+                                .mangled_name()
+                                .to_string();
+                            let key = device_static_global_key(&static_def);
+                            let repeated_key = device_static_global_key(&static_def);
+                            let initializer = static_def
+                                .eval_initializer()
+                                .expect("evaluate block-local static")
+                                .read_uint()
+                                .expect("read u64 block-local static");
+                            (source_name, mangled, key, repeated_key, initializer)
+                        })
+                        .collect::<Vec<_>>();
+                    let exported = statics
+                        .into_iter()
+                        .find(|static_def| static_def.name().ends_with("::EXPORTED"))
+                        .map(|static_def| {
+                            let symbol = rustc_public::mir::mono::Instance::from(static_def)
+                                .mangled_name()
+                                .to_string();
+                            let static_key = device_static_global_key(&static_def);
+                            let promoted_key =
+                                dialect_mir::ops::encode_promoted_global_key(&symbol);
+                            (symbol, static_key, promoted_key)
+                        })
+                        .expect("find adversarial exported static");
+                    std::ops::ControlFlow::<(), _>::Continue((results, exported))
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+            .expect("in-process fixture compilation succeeds");
+
+        fs::remove_dir_all(&root).ok();
+        assert_eq!(identities.len(), 2, "both block statics must be discovered");
+        assert_eq!(
+            identities[0].0, identities[1].0,
+            "the regression requires the two source display paths to collide"
+        );
+        let mut values = identities
+            .iter()
+            .map(|identity| identity.4)
+            .collect::<Vec<_>>();
+        values.sort_unstable();
+        assert_eq!(values, [11, 29], "the statics have distinct storage values");
+        for (_, mangled, key, repeated_key, _) in &identities {
+            assert_eq!(
+                dialect_mir::ops::rust_static_symbol_from_global_key(key),
+                Some(mangled.as_str()),
+                "the tagged carrier must preserve rustc's exact symbol identity"
+            );
+            assert_eq!(
+                repeated_key, key,
+                "repeated references to one definition must reuse its key"
+            );
+        }
+        assert_ne!(
+            identities[0].2, identities[1].2,
+            "DefPath disambiguators must keep same-path statics distinct"
+        );
+        assert_eq!(
+            exported.0, "__cuda_oxide_promoted_type_collision",
+            "rustc must expose the user-controlled export name as its symbol"
+        );
+        assert_eq!(
+            dialect_mir::ops::rust_static_symbol_from_global_key(&exported.1),
+            Some(exported.0.as_str())
+        );
+        assert_ne!(
+            exported.1, exported.2,
+            "static and promoted origins must remain distinct for an identical payload"
+        );
+    }
+
+    #[test]
     fn stale_artifact_invalidation_removes_every_competing_output() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -585,6 +958,7 @@ mod tests {
             target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            debug_global_variables: BTreeMap::new(),
             allow_fma_contraction: true,
         };
         let result = run_pipeline(&[], &[], &config, Default::default()).expect("pipeline run");
@@ -637,6 +1011,7 @@ mod tests {
             target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            debug_global_variables: BTreeMap::new(),
             allow_fma_contraction: true,
         };
 
@@ -727,6 +1102,7 @@ mod tests {
             target_arch_source: "PipelineConfig::target_arch",
             device_arch_hint: None,
             debug_kind: DebugKind::Off,
+            debug_global_variables: BTreeMap::new(),
             allow_fma_contraction: true,
         };
         let externs = [DeviceExternDecl {

--- a/crates/mir-importer/src/translator/body.rs
+++ b/crates/mir-importer/src/translator/body.rs
@@ -975,7 +975,7 @@ fn local_memory_provenance(local_idx: usize, name: &str, ty: &Ty) -> LocalMemory
 /// the inner detail rather than recurse without bound.
 const MAX_DEBUG_TYPE_DEPTH: usize = 8;
 
-fn debug_type_for_ty(ty: &Ty) -> Option<DebugLocalTypeKind> {
+pub(crate) fn debug_type_for_ty(ty: &Ty) -> Option<DebugLocalTypeKind> {
     debug_type_for_ty_at(ty, 0)
 }
 

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -8657,9 +8657,25 @@ enum UnionConstantStorageKind {
     },
 }
 
+/// How a classified union constant is consumed by its caller.
+///
+/// SSA reconstruction materializes the carrier field's own reference type, so
+/// a reference minted for the wrong alternative could claim validity for a
+/// pointee the program never wrote. Device-static physical storage emits the
+/// exact evaluated bytes plus one integer-width relocation slot and never
+/// mints a typed reference, so same-kind reference alternatives may keep
+/// different pointee views there; device code reads the storage through its
+/// own field types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UnionConstantUse {
+    SsaReconstruction,
+    PhysicalStorage,
+}
+
 fn classify_union_constant_storage(
     ctx: &Context,
     union_ty: TypeHandle,
+    usage: UnionConstantUse,
 ) -> Result<UnionConstantStorageKind, String> {
     let (name, field_types) = {
         let ty_ref = union_ty.deref(ctx);
@@ -8740,7 +8756,10 @@ fn classify_union_constant_storage(
                 && carrier_kind == pointer_kind
                 && carrier_mutability == is_mutable =>
             {
-                if pointer_kind == MirPointerKind::SharedRef && carrier_field_ty != field_ty {
+                if usage == UnionConstantUse::SsaReconstruction
+                    && pointer_kind == MirPointerKind::SharedRef
+                    && carrier_field_ty != field_ty
+                {
                     return Err(format!(
                         "Initialized union constant `{name}` mixes reference pointee types; \
                          rustc's evaluated allocation does not retain the active union field, \
@@ -8912,12 +8931,15 @@ fn validate_device_static_union_storage(
         )
     };
 
-    let storage_kind = classify_union_constant_storage(ctx, union_ty).map_err(|message| {
-        format!(
-            "union `{union_name}` whose initializer cannot preserve pointer provenance: \
-             {message}"
-        )
-    })?;
+    let storage_kind =
+        classify_union_constant_storage(ctx, union_ty, UnionConstantUse::PhysicalStorage).map_err(
+            |message| {
+                format!(
+                    "union `{union_name}` whose initializer cannot preserve pointer provenance: \
+                 {message}"
+                )
+            },
+        )?;
     if !matches!(storage_kind, UnionConstantStorageKind::ThinPointer { .. }) {
         return Err(format!(
             "union `{union_name}` without thin-pointer storage; device-global union \
@@ -9113,8 +9135,9 @@ fn translate_union_constant_from_alloc(
         );
     }
 
-    let storage_kind = classify_union_constant_storage(ctx, union_ty)
-        .map_err(|message| input_error!(loc.clone(), TranslationErr::unsupported(message)))?;
+    let storage_kind =
+        classify_union_constant_storage(ctx, union_ty, UnionConstantUse::SsaReconstruction)
+            .map_err(|message| input_error!(loc.clone(), TranslationErr::unsupported(message)))?;
 
     match storage_kind {
         UnionConstantStorageKind::ByteImage => {
@@ -14311,10 +14334,10 @@ mod promotable_array_element_tests {
 #[allow(clippy::disallowed_methods)]
 mod aggregate_relocation_tests {
     use super::{
-        UnionConstantStorageKind, classify_union_constant_storage, constant_type_contains_pointer,
-        decode_relocation_addend, find_unconsumed_relocation, match_thin_pointer_relocation,
-        provenance_starts_in_range, relocation_free_pointer_integer_union_storage_field,
-        relocation_offsets_overlapping_range,
+        UnionConstantStorageKind, UnionConstantUse, classify_union_constant_storage,
+        constant_type_contains_pointer, decode_relocation_addend, find_unconsumed_relocation,
+        match_thin_pointer_relocation, provenance_starts_in_range,
+        relocation_free_pointer_integer_union_storage_field, relocation_offsets_overlapping_range,
         translate_pointer_integer_union_constant_from_storage, validate_array_value_element_type,
         validate_device_static_union_storage, validate_slice_relocation_shape,
     };
@@ -14611,7 +14634,11 @@ mod aggregate_relocation_tests {
             "pointer-only union constants must use typed reconstruction"
         );
         assert_eq!(
-            classify_union_constant_storage(&ctx, pointer_only_union_ty),
+            classify_union_constant_storage(
+                &ctx,
+                pointer_only_union_ty,
+                UnionConstantUse::SsaReconstruction
+            ),
             Ok(UnionConstantStorageKind::ThinPointer {
                 field_index: 0,
                 field_ty: pointer_field_ty,
@@ -14638,8 +14665,12 @@ mod aggregate_relocation_tests {
             8,
         )
         .into();
-        let pointer_integer_error = classify_union_constant_storage(&ctx, pointer_integer_union_ty)
-            .expect_err("the provenance-aware classifier must keep pointer/integer overlap closed");
+        let pointer_integer_error = classify_union_constant_storage(
+            &ctx,
+            pointer_integer_union_ty,
+            UnionConstantUse::SsaReconstruction,
+        )
+        .expect_err("the provenance-aware classifier must keep pointer/integer overlap closed");
         assert!(
             pointer_integer_error.contains("pointer/integer union constants"),
             "diagnostic must explain the provenance-vs-bits conflict: {pointer_integer_error}"
@@ -14684,8 +14715,12 @@ mod aggregate_relocation_tests {
             8,
         )
         .into();
-        let fat_pointer_error = classify_union_constant_storage(&ctx, fat_pointer_union_ty)
-            .expect_err("fat-pointer union storage must remain fail-closed");
+        let fat_pointer_error = classify_union_constant_storage(
+            &ctx,
+            fat_pointer_union_ty,
+            UnionConstantUse::SsaReconstruction,
+        )
+        .expect_err("fat-pointer union storage must remain fail-closed");
         assert!(
             fat_pointer_error.contains("not a thin pointer"),
             "diagnostic must identify unsupported fat/nested storage: {fat_pointer_error}"
@@ -14829,7 +14864,8 @@ mod aggregate_relocation_tests {
         )
         .into();
         assert!(
-            classify_union_constant_storage(&ctx, raw_views).is_ok(),
+            classify_union_constant_storage(&ctx, raw_views, UnionConstantUse::SsaReconstruction)
+                .is_ok(),
             "same-kind raw pointers may safely use different pointee views"
         );
 
@@ -14855,13 +14891,40 @@ mod aggregate_relocation_tests {
                 8,
             )
             .into();
-            let error = classify_union_constant_storage(&ctx, union_ty)
-                .expect_err("ambiguous pointer semantics must fail closed");
+            let error = classify_union_constant_storage(
+                &ctx,
+                union_ty,
+                UnionConstantUse::SsaReconstruction,
+            )
+            .expect_err("ambiguous pointer semantics must fail closed");
             assert!(
                 error.contains(expected),
                 "{name} diagnostic must identify {expected}: {error}"
             );
         }
+
+        // Physical device-static storage emits exact bytes plus one
+        // integer-width relocation slot and never mints a typed reference, so
+        // same-kind reference alternatives with different pointee views stay
+        // supported there (e.g. `union { word: &'static u32, byte: &'static u8 }`).
+        let mixed_reference_pointees: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "MixedReferencePointees".into(),
+            vec!["first".into(), "second".into()],
+            vec![shared_u32, shared_u8],
+            8,
+            8,
+        )
+        .into();
+        assert!(
+            classify_union_constant_storage(
+                &ctx,
+                mixed_reference_pointees,
+                UnionConstantUse::PhysicalStorage
+            )
+            .is_ok(),
+            "physical initializer storage must keep mixed-pointee reference unions supported"
+        );
     }
 
     #[test]
@@ -14956,6 +15019,39 @@ mod aggregate_relocation_tests {
             Ok(()),
             "one naturally aligned pointer word with one anchored relocation is the \
              accepted shape"
+        );
+
+        // The example shape `union { word: &'static u32, byte: &'static u8 }`:
+        // same-kind references with different pointee views. The storage gate
+        // emits bytes plus one relocation slot and never mints a typed
+        // reference, so this stays supported even though SSA reconstruction
+        // of the same union fails closed.
+        let shared_word_ty: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, u32_ty, false, MirPointerKind::SharedRef)
+                .into();
+        let shared_byte_ty: TypeHandle =
+            MirPtrType::get_generic_with_kind(&mut ctx, u8_ty, false, MirPointerKind::SharedRef)
+                .into();
+        let mixed_reference_union_ty: TypeHandle = MirUnionType::get(
+            &mut ctx,
+            "MixedReferenceWord".into(),
+            vec!["word".into(), "byte".into()],
+            vec![shared_word_ty, shared_byte_ty],
+            8,
+            8,
+        )
+        .into();
+        assert_eq!(
+            validate_device_static_union_storage(
+                &ctx,
+                mixed_reference_union_ty,
+                8,
+                8,
+                8,
+                &[(0, 8)]
+            ),
+            Ok(()),
+            "mixed-pointee reference unions remain valid device-static storage"
         );
 
         let byte_image_error =

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -11167,7 +11167,7 @@ fn static_target_from_allocation_at(
 /// One pointer-width relocation inside an evaluated Rust static initializer.
 ///
 /// The source and target offsets are byte offsets. `target_key` is the same
-/// stable rustc identity stored on the target `MirGlobalAllocOp`.
+/// domain-tagged rustc identity stored on the target `MirGlobalAllocOp`.
 struct GlobalInitializerRelocation {
     source_offset: u64,
     width_bytes: u32,
@@ -11189,14 +11189,7 @@ pub(crate) struct GlobalInitializerData {
 }
 
 fn static_global_key(static_def: &rustc_public::mir::mono::StaticDef) -> String {
-    let static_ty = static_def.ty();
-    if is_constant_wrapper_type(&static_ty) {
-        rustc_public::mir::mono::Instance::from(*static_def)
-            .mangled_name()
-            .to_string()
-    } else {
-        static_def.name()
-    }
+    crate::device_static_global_key(static_def)
 }
 
 fn static_global_address_space(static_def: &rustc_public::mir::mono::StaticDef) -> u32 {
@@ -11610,12 +11603,13 @@ fn promoted_constant_dedup_key_from_parts(
     // storage requirements or provenance targets cannot alias.
     let ty = ty.deref(ctx).disp(ctx).to_string();
     let bytes = bytes_to_hex(bytes);
-    format!(
+    let fingerprint = format!(
         "__cuda_oxide_promoted_type{}:{ty}:bytes{}:{bytes}:align{alignment}:relocs{}:{relocations}",
         ty.len(),
         bytes.len() / 2,
         relocations.len()
-    )
+    );
+    dialect_mir::ops::encode_promoted_global_key(&fingerprint)
 }
 
 /// Detect zero-addend array→slice unsize: static `[T; N]` viewed as `[T]`.

--- a/crates/mir-lower/src/context.rs
+++ b/crates/mir-lower/src/context.rs
@@ -12,6 +12,7 @@
 use rustc_hash::FxHashMap;
 
 use crate::LoweringOptions;
+use llvm_export::ops::DebugGlobalVariableInfo;
 use pliron::{context::Context, identifier::Identifier, r#type::TypeHandle};
 
 mod options_storage {
@@ -104,6 +105,8 @@ pub struct DeviceGlobalDeclaration {
     pub initializer_hex: Option<String>,
     /// Encoded symbolic relocations within the initializer, when present.
     pub initializer_relocations: Option<String>,
+    /// Source-level debug identity carried on the allocation, when present.
+    pub debug_info: Option<DebugGlobalVariableInfo>,
     /// Whether lowering exports the storage as immutable.
     pub immutable: bool,
 }
@@ -122,7 +125,8 @@ pub struct DeviceGlobalRecord {
 /// Ordinary Rust `static` / `static mut` values used from device code live in
 /// CUDA global memory (address space 1), not shared memory. A key names one
 /// allocation; conflicting declarations fail instead of silently reusing a
-/// symbol with the wrong type, alignment, address space, or initializer.
+/// symbol with the wrong type, alignment, address space, initializer, or
+/// debug identity.
 pub type DeviceGlobalsMap = FxHashMap<String, DeviceGlobalRecord>;
 
 /// Tracking for dynamic shared memory alignment per lowered function.

--- a/crates/mir-lower/src/convert/ops/memory.rs
+++ b/crates/mir-lower/src/convert/ops/memory.rs
@@ -963,6 +963,7 @@ pub fn convert_global_alloc_dc(
         initializer_hex,
         initializer_relocations,
         immutable,
+        debug_info,
     ) = {
         let global_op = dialect_mir::ops::MirGlobalAllocOp::new(op);
         let op_ref = op.deref(ctx);
@@ -996,6 +997,7 @@ pub fn convert_global_alloc_dc(
             .attributes
             .get::<StringAttr>(&"global_initializer_relocations".try_into().unwrap())
             .map(|attr| String::from((*attr).clone()));
+        let debug_info = llvm::debug_global_variable(ctx, op);
 
         // Read the address space the op's result already carries — set by
         // mir-importer based on the static's type (`ConstantMemory<T>` → 4,
@@ -1025,6 +1027,7 @@ pub fn convert_global_alloc_dc(
             initializer_hex,
             initializer_relocations,
             global_op.is_immutable(ctx),
+            debug_info,
         )
     };
 
@@ -1034,6 +1037,7 @@ pub fn convert_global_alloc_dc(
         addr_space,
         initializer_hex: initializer_hex.clone(),
         initializer_relocations: initializer_relocations.clone(),
+        debug_info: debug_info.clone(),
         immutable,
     };
 
@@ -1058,6 +1062,7 @@ pub fn convert_global_alloc_dc(
                 addr_space,
                 initializer_hex: initializer_hex.as_deref(),
                 initializer_relocations: initializer_relocations.as_deref(),
+                debug_info: debug_info.as_ref(),
                 immutable,
             },
         )?
@@ -1077,6 +1082,7 @@ struct DeviceGlobalSpec<'a> {
     addr_space: u32,
     initializer_hex: Option<&'a str>,
     initializer_relocations: Option<&'a str>,
+    debug_info: Option<&'a llvm::DebugGlobalVariableInfo>,
     /// Nothing writes this storage, so it exports as LLVM `constant`. Set only
     /// for the compiler's own promoted constants; see `MirGlobalAllocOp`.
     immutable: bool,
@@ -1137,10 +1143,17 @@ fn create_device_global(
     // are private to the kernel and get a counter-based unique name.
     let name: pliron::identifier::Identifier =
         if spec.addr_space == llvm_export::types::address_space::CONSTANT {
-            spec.key.try_into().map_err(|e| {
+            let symbol = dialect_mir::ops::rust_static_symbol_from_global_key(spec.key)
+                .ok_or_else(|| {
+                    anyhow_to_pliron(anyhow::anyhow!(
+                        "constant global_key {:?} is not a tagged Rust static identity",
+                        spec.key
+                    ))
+                })?;
+            symbol.try_into().map_err(|e| {
                 anyhow_to_pliron(anyhow::anyhow!(
-                    "constant global_key {:?} is not a valid identifier: {e:?}",
-                    spec.key
+                    "constant Rust static symbol {:?} is not a valid identifier: {e:?}",
+                    symbol
                 ))
             })?
         } else {
@@ -1156,6 +1169,11 @@ fn create_device_global(
     };
     global_op.set_address_space(ctx, spec.addr_space);
     global_op.set_source_global_key(ctx, spec.key);
+    if spec.addr_space == llvm_export::types::address_space::GLOBAL
+        && let Some(info) = spec.debug_info
+    {
+        llvm::set_debug_global_variable(ctx, global_op.get_operation(), info);
+    }
     if let Some(initializer_hex) = spec.initializer_hex {
         global_op.set_initializer_hex(ctx, initializer_hex);
     }
@@ -1189,6 +1207,7 @@ fn create_device_global(
                 addr_space: spec.addr_space,
                 initializer_hex: spec.initializer_hex.map(str::to_owned),
                 initializer_relocations: spec.initializer_relocations.map(str::to_owned),
+                debug_info: spec.debug_info.cloned(),
                 immutable: spec.immutable,
             },
         },
@@ -3971,6 +3990,7 @@ mod tests {
             addr_space: llvm_addr::GLOBAL,
             initializer_hex: Some("00000000".to_string()),
             initializer_relocations: Some("reloc-a".to_string()),
+            debug_info: None,
             immutable: true,
         };
 
@@ -3990,6 +4010,23 @@ mod tests {
         changed.initializer_relocations = Some("reloc-b".to_string());
         assert!(base != changed);
         changed = base.clone();
+        changed.debug_info = Some(llvm::DebugGlobalVariableInfo {
+            name: "COUNTER".to_string(),
+            namespace: vec!["my_crate".to_string()],
+            ty: llvm::DebugLocalTypeKind::Basic {
+                name: "u32".to_string(),
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: llvm::DebugSourcePosition {
+                file: PathBuf::from("/tmp/global.rs"),
+                line: 7,
+                column: 1,
+            },
+            is_local_to_unit: true,
+        });
+        assert!(base != changed);
+        changed = base.clone();
         changed.immutable = false;
         assert!(base != changed);
     }
@@ -3999,7 +4036,8 @@ mod tests {
         let mut ctx = make_ctx();
         let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
         append_global_alloc(&mut ctx, block, "ordinary_static", false);
-        append_global_alloc(&mut ctx, block, "_ZN7my_mod3KEYE", true);
+        let constant_key = dialect_mir::ops::encode_rust_static_global_key("_ZN7my_mod3KEYE");
+        append_global_alloc(&mut ctx, block, &constant_key, true);
         append_mir_return(&mut ctx, block, vec![]);
 
         crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
@@ -4025,7 +4063,7 @@ mod tests {
         assert_eq!(
             global_addr_const.get_symbol_name(&ctx).to_string(),
             "_ZN7my_mod3KEYE",
-            "constant globals must keep the mangled global_key as symbol name"
+            "constant globals must keep the raw rustc symbol payload as their name"
         );
         assert!(
             global_addr_global
@@ -4033,6 +4071,63 @@ mod tests {
                 .to_string()
                 .starts_with("__device_global_"),
             "ordinary device globals get the __device_global_ prefix"
+        );
+    }
+
+    #[test]
+    fn ordinary_global_debug_info_survives_lowering_but_constant_memory_stays_out_of_scope() {
+        let mut ctx = make_ctx();
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+        let ordinary = append_global_alloc(&mut ctx, block, "crate::GLOBAL_COUNTER", false);
+        let constant_key = dialect_mir::ops::encode_rust_static_global_key("_ZN5crate5COEFFE");
+        let constant = append_global_alloc(&mut ctx, block, &constant_key, true);
+        let info = llvm::DebugGlobalVariableInfo {
+            name: "GLOBAL_COUNTER".to_string(),
+            namespace: vec!["crate".to_string(), "state".to_string()],
+            ty: llvm::DebugLocalTypeKind::Basic {
+                name: "u32".to_string(),
+                size_bits: 32,
+                encoding: "DW_ATE_unsigned",
+            },
+            declaration: llvm::DebugSourcePosition {
+                file: PathBuf::from("/tmp/global.rs"),
+                line: 7,
+                column: 1,
+            },
+            is_local_to_unit: true,
+        };
+        llvm::set_debug_global_variable(&mut ctx, ordinary, &info);
+        // Deliberately tag AS4 too: the AS1-only implementation must not
+        // accidentally expand its behavior merely because the generic debug
+        // carrier can be attached to any op.
+        llvm::set_debug_global_variable(&mut ctx, constant, &info);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+        let top = module_top_block(&ctx, module_ptr);
+        let globals: Vec<_> = top
+            .deref(&ctx)
+            .iter(&ctx)
+            .filter_map(|op| Operation::get_op::<llvm::GlobalOp>(op, &ctx))
+            .collect();
+        let ordinary = globals
+            .iter()
+            .find(|global| global.address_space(&ctx) == llvm_addr::GLOBAL)
+            .expect("ordinary global");
+        let constant = globals
+            .iter()
+            .find(|global| global.address_space(&ctx) == llvm_addr::CONSTANT)
+            .expect("constant global");
+
+        assert_eq!(
+            llvm::debug_global_variable(&ctx, ordinary.get_operation()),
+            Some(info),
+            "source identity and semantic type must survive MIR-to-LLVM lowering"
+        );
+        assert!(
+            llvm::debug_global_variable(&ctx, constant.get_operation()).is_none(),
+            "AS4 debug metadata is a separate feature and must not leak into this AS1 change"
         );
     }
 
@@ -4073,6 +4168,26 @@ mod tests {
             !by_key("plain_static").is_immutable(&ctx),
             "lowering must not infer immutability; only the promoted-constant \
              sites may claim it"
+        );
+    }
+
+    #[test]
+    fn convert_global_alloc_rejects_conflicting_immutability() {
+        // A plain static and a promoted constant that end up sharing one key
+        // differ only in the immutable flag; that alone must fail closed
+        // instead of silently reusing the first allocation's storage.
+        let mut ctx = make_ctx();
+        let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+        append_global_alloc(&mut ctx, block, "collision", false);
+        let promoted = append_global_alloc(&mut ctx, block, "collision", false);
+        mir::MirGlobalAllocOp::new(promoted).mark_immutable(&mut ctx);
+        append_mir_return(&mut ctx, block, vec![]);
+
+        let error = crate::lower_mir_to_llvm(&mut ctx, module_ptr)
+            .expect_err("a shared string with different origins must fail closed");
+        assert!(
+            error.to_string().contains("incompatible declaration"),
+            "{error}"
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/device_global/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_global/README.md
@@ -10,12 +10,30 @@ Run with:
 cargo oxide run device_global
 ```
 
+To validate the emitted AS1 DWARF shape (including same-path block statics,
+duplicate leaf names, reachability, relocation-only targets, semantic types,
+CU retention, and LLVM verification), build with full device debug and run the
+shape gate:
+
+```bash
+CUDA_OXIDE_DEBUG=full cargo oxide build device_global --arch sm_120
+./crates/rustc-codegen-cuda/examples/device_global/verify-debug-info.sh
+```
+
 The first kernel updates two ordinary device statics:
 
 ```rust
 static mut DEVICE_COUNTER: u64 = 0;
 static mut DEVICE_MARKER: u32 = 0;
 ```
+
+The block-local identity kernel calls a non-inlined device helper that places
+`static VALUE` and `static VALUE_REF` in opposite blocks of one function. The
+two definitions of each leaf have the same source display path but different
+rustc DefPath disambiguators. Their values (11 and 29), addresses, physical
+globals, debug DIEs, and reference initializer relocations must stay distinct;
+repeated reads of each reference must still deduplicate to one physical
+definition.
 
 The other kernels read non-zero immutable statics. One reads both the base
 address and an interior constant pointer (`&STATIC_WEIGHTS[2]`, a 16-byte

--- a/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_global/src/main.rs
@@ -14,6 +14,18 @@ use cuda_host::cuda_module;
 
 static mut DEVICE_COUNTER: u64 = 0;
 static mut DEVICE_MARKER: u32 = 0;
+
+mod debug_left {
+    pub(super) static mut SAME_LEAF: u32 = 1; // CUDA_OXIDE_DEBUG_GLOBAL_LEFT
+}
+
+mod debug_right {
+    pub(super) static mut SAME_LEAF: u64 = 2; // CUDA_OXIDE_DEBUG_GLOBAL_RIGHT
+}
+
+#[unsafe(no_mangle)]
+pub static mut DEBUG_REACHABLE: u32 = 3; // CUDA_OXIDE_DEBUG_GLOBAL_REACHABLE
+static mut DEBUG_PRIVATE: u32 = 4; // CUDA_OXIDE_DEBUG_GLOBAL_PRIVATE
 static STATIC_WEIGHTS: [[f32; 2]; 4] = [[0.25, 0.5], [1.0, 2.0], [4.0, 8.0], [16.0, 32.0]];
 static STATIC_NAN: f32 = f32::from_bits(0x7fc0_1234);
 
@@ -151,6 +163,25 @@ fn get_static_weights_end() -> *const [f32; 2] {
     STATIC_WEIGHTS_END
 }
 
+#[inline(never)]
+fn block_local_static_values(select_left: bool) -> (u64, u64) {
+    if select_left {
+        static VALUE: u64 = 11; // CUDA_OXIDE_DEBUG_BLOCK_LOCAL_LEFT_VALUE
+        static VALUE_REF: &u64 = &VALUE; // CUDA_OXIDE_DEBUG_BLOCK_LOCAL_LEFT_REFERENCE
+        (
+            *VALUE_REF + *VALUE_REF,
+            VALUE_REF as *const u64 as usize as u64,
+        )
+    } else {
+        static VALUE: u64 = 29; // CUDA_OXIDE_DEBUG_BLOCK_LOCAL_RIGHT_VALUE
+        static VALUE_REF: &u64 = &VALUE; // CUDA_OXIDE_DEBUG_BLOCK_LOCAL_RIGHT_REFERENCE
+        (
+            *VALUE_REF + *VALUE_REF,
+            VALUE_REF as *const u64 as usize as u64,
+        )
+    }
+}
+
 #[cuda_module]
 mod kernels {
     use super::*;
@@ -167,6 +198,46 @@ mod kernels {
             DEVICE_COUNTER += 1;
             DEVICE_MARKER = 0x00C0_FFEE;
             *out = DEVICE_COUNTER ^ (DEVICE_MARKER as u64);
+        }
+    }
+
+    /// Materialize adversarial source identities for the global-debug shape
+    /// verifier: duplicate leaves in distinct modules and reachable/private
+    /// definitions. A second read of the left static also checks that repeated
+    /// references still produce one physical global and one CU entry.
+    #[kernel]
+    pub unsafe fn debug_global_identity(out: *mut u64) {
+        unsafe {
+            let left = debug_left::SAME_LEAF;
+            let left_again = debug_left::SAME_LEAF;
+            let right = debug_right::SAME_LEAF;
+            DEBUG_REACHABLE += 1;
+            DEBUG_PRIVATE += 1;
+            *out = left as u64
+                + left_again as u64
+                + right
+                + DEBUG_REACHABLE as u64
+                + DEBUG_PRIVATE as u64;
+        }
+    }
+
+    /// Exercise two same-named block statics, and the relocations that point
+    /// to them, which must remain physically distinct. Their source display
+    /// paths are identical; only rustc's DefPath-disambiguated symbol identity
+    /// separates them.
+    #[kernel]
+    pub unsafe fn block_local_static_identity(out: *mut u64) {
+        let thread = cuda_device::thread::threadIdx_x();
+        if thread >= 2 {
+            return;
+        }
+
+        let (value, address) = block_local_static_values(thread == 0);
+        let offset = thread as usize * 2;
+
+        unsafe {
+            *out.add(offset) = value;
+            *out.add(offset + 1) = address;
         }
     }
 
@@ -323,6 +394,40 @@ fn main() {
             eprintln!("FAILED: expected {expected:#x}, got {result:#x}");
             std::process::exit(1);
         }
+    }
+
+    let block_local_out_dev = DeviceBuffer::<u64>::zeroed(&stream, 4)
+        .expect("Failed to allocate block-local static output");
+    unsafe {
+        module.block_local_static_identity(
+            &stream,
+            LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (2, 1, 1),
+                shared_mem_bytes: 0,
+            },
+            block_local_out_dev.cu_deviceptr() as *mut u64,
+        )
+    }
+    .expect("Block-local static identity kernel launch failed");
+    let block_local_result = block_local_out_dev
+        .to_host_vec(&stream)
+        .expect("Failed to copy block-local static output");
+
+    println!(
+        "Block-local statics: values = [{}, {}], addresses = [{:#x}, {:#x}]",
+        block_local_result[0], block_local_result[2], block_local_result[1], block_local_result[3]
+    );
+    if block_local_result[0] != 22
+        || block_local_result[2] != 58
+        || block_local_result[1] == 0
+        || block_local_result[3] == 0
+        || block_local_result[1] == block_local_result[3]
+    {
+        eprintln!(
+            "FAILED: expected distinct block-local values 22/58 and non-zero distinct addresses, got {block_local_result:?}"
+        );
+        std::process::exit(1);
     }
 
     let static_out_dev =
@@ -557,6 +662,6 @@ fn main() {
     }
 
     println!(
-        "\nSUCCESS: device globals preserved storage, initializer bytes, aligned, packed, nested packed, and union pointer relocations, slice relocations, pointer addends, and subobject addresses."
+        "\nSUCCESS: device globals preserved same-path static identities, storage, initializer bytes, aligned, packed, nested packed, and union pointer relocations, slice relocations, pointer addends, and subobject addresses."
     );
 }

--- a/crates/rustc-codegen-cuda/examples/device_global/verify-debug-info.sh
+++ b/crates/rustc-codegen-cuda/examples/device_global/verify-debug-info.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_file="${root}/src/main.rs"
+llvm_ir="${root}/device_global.ll"
+
+test -s "${llvm_ir}"
+
+definition_line() {
+    local marker="$1"
+    grep -nF "${marker}" "${source_file}" | cut -d: -f1
+}
+
+metadata_id() {
+    local pattern="$1"
+    local line
+    line="$(grep -F "${pattern}" "${llvm_ir}")"
+    [[ -n "${line}" ]]
+    [[ "$(printf '%s\n' "${line}" | wc -l)" -eq 1 ]]
+    printf '%s\n' "${line}" | sed -E 's/^!([0-9]+) = .*/\1/'
+}
+
+unique_global_die() {
+    local source_name="$1"
+    local line
+    line="$(grep -F "!DIGlobalVariable(name: \"${source_name}\"" "${llvm_ir}")"
+    [[ -n "${line}" ]]
+    [[ "$(printf '%s\n' "${line}" | wc -l)" -eq 1 ]]
+    printf '%s\n' "${line}"
+}
+
+named_global_die_at_marker() {
+    local source_name="$1"
+    local marker="$2"
+    local source_line line
+    source_line="$(definition_line "${marker}")"
+    line="$(grep -F "!DIGlobalVariable(name: \"${source_name}\"" "${llvm_ir}" | grep -F "line: ${source_line},")"
+    [[ -n "${line}" ]]
+    [[ "$(printf '%s\n' "${line}" | wc -l)" -eq 1 ]]
+    printf '%s\n' "${line}"
+}
+
+linkage_name() {
+    sed -E 's/.*linkageName: "([^"]+)".*/\1/'
+}
+
+require_cu_expression() {
+    local die="$1"
+    local die_id expression expression_id cu globals_id tuple
+    die_id="$(printf '%s\n' "${die}" | sed -E 's/^!([0-9]+) = .*/\1/')"
+    expression="$(grep -F "!DIGlobalVariableExpression(var: !${die_id}," "${llvm_ir}")"
+    [[ -n "${expression}" ]]
+    [[ "$(printf '%s\n' "${expression}" | wc -l)" -eq 1 ]]
+    expression_id="$(printf '%s\n' "${expression}" | sed -E 's/^!([0-9]+) = .*/\1/')"
+    cu="$(grep -F '!DICompileUnit(' "${llvm_ir}")"
+    [[ -n "${cu}" ]]
+    [[ "$(printf '%s\n' "${cu}" | wc -l)" -eq 1 ]]
+    globals_id="$(printf '%s\n' "${cu}" | sed -E 's/.*globals: !([0-9]+)\).*/\1/')"
+    tuple="$(grep -E "^!${globals_id} = !\\{" "${llvm_ir}")"
+    [[ -n "${tuple}" ]]
+    grep -Fq "!${expression_id}" <<<"${tuple}"
+}
+
+crate_scope="$(metadata_id '!DINamespace(name: "device_global", scope: null)')"
+left_scope="$(metadata_id "!DINamespace(name: \"debug_left\", scope: !${crate_scope})")"
+right_scope="$(metadata_id "!DINamespace(name: \"debug_right\", scope: !${crate_scope})")"
+
+mapfile -t same_leaf_dies < <(grep -F '!DIGlobalVariable(name: "SAME_LEAF"' "${llvm_ir}")
+[[ "${#same_leaf_dies[@]}" -eq 2 ]]
+left_die="$(printf '%s\n' "${same_leaf_dies[@]}" | grep -F "scope: !${left_scope}")"
+right_die="$(printf '%s\n' "${same_leaf_dies[@]}" | grep -F "scope: !${right_scope}")"
+grep -Fq "line: $(definition_line CUDA_OXIDE_DEBUG_GLOBAL_LEFT)," <<<"${left_die}"
+grep -Fq "line: $(definition_line CUDA_OXIDE_DEBUG_GLOBAL_RIGHT)," <<<"${right_die}"
+grep -Fq 'isLocal: true' <<<"${left_die}"
+grep -Fq 'isLocal: true' <<<"${right_die}"
+
+left_linkage="$(printf '%s\n' "${left_die}" | linkage_name)"
+right_linkage="$(printf '%s\n' "${right_die}" | linkage_name)"
+[[ "${left_linkage}" != "${right_linkage}" ]]
+[[ "$(grep -Ec "^@${left_linkage} = " "${llvm_ir}")" -eq 1 ]]
+[[ "$(grep -Ec "^@${right_linkage} = " "${llvm_ir}")" -eq 1 ]]
+require_cu_expression "${left_die}"
+require_cu_expression "${right_die}"
+
+# Two statics in opposite blocks of one function deliberately have identical
+# `StaticDef::name()` display paths. Their DefPath-disambiguated identity keys
+# must produce separate storage and DIEs, and each reference initializer must
+# retain provenance to the matching value rather than the other block's value.
+block_local_scope="$(metadata_id "!DINamespace(name: \"block_local_static_values\", scope: !${crate_scope})")"
+
+mapfile -t block_value_dies < <(grep -F '!DIGlobalVariable(name: "VALUE"' "${llvm_ir}")
+mapfile -t block_reference_dies < <(grep -F '!DIGlobalVariable(name: "VALUE_REF"' "${llvm_ir}")
+[[ "${#block_value_dies[@]}" -eq 2 ]]
+[[ "${#block_reference_dies[@]}" -eq 2 ]]
+
+left_value_die="$(named_global_die_at_marker VALUE CUDA_OXIDE_DEBUG_BLOCK_LOCAL_LEFT_VALUE)"
+right_value_die="$(named_global_die_at_marker VALUE CUDA_OXIDE_DEBUG_BLOCK_LOCAL_RIGHT_VALUE)"
+left_reference_die="$(named_global_die_at_marker VALUE_REF CUDA_OXIDE_DEBUG_BLOCK_LOCAL_LEFT_REFERENCE)"
+right_reference_die="$(named_global_die_at_marker VALUE_REF CUDA_OXIDE_DEBUG_BLOCK_LOCAL_RIGHT_REFERENCE)"
+
+for die in "${left_value_die}" "${right_value_die}" "${left_reference_die}" "${right_reference_die}"; do
+    grep -Fq "scope: !${block_local_scope}" <<<"${die}"
+    grep -Fq 'isLocal: true' <<<"${die}"
+    require_cu_expression "${die}"
+done
+
+left_value_linkage="$(printf '%s\n' "${left_value_die}" | linkage_name)"
+right_value_linkage="$(printf '%s\n' "${right_value_die}" | linkage_name)"
+left_reference_linkage="$(printf '%s\n' "${left_reference_die}" | linkage_name)"
+right_reference_linkage="$(printf '%s\n' "${right_reference_die}" | linkage_name)"
+
+[[ "${left_value_linkage}" != "${right_value_linkage}" ]]
+[[ "${left_reference_linkage}" != "${right_reference_linkage}" ]]
+for linkage in "${left_value_linkage}" "${right_value_linkage}" "${left_reference_linkage}" "${right_reference_linkage}"; do
+    [[ "$(grep -Ec "^@${linkage} = " "${llvm_ir}")" -eq 1 ]]
+done
+
+left_value_definition="$(grep -E "^@${left_value_linkage} = " "${llvm_ir}")"
+right_value_definition="$(grep -E "^@${right_value_linkage} = " "${llvm_ir}")"
+grep -Fq '[8 x i8] c"\0B\00\00\00\00\00\00\00"' <<<"${left_value_definition}"
+grep -Fq '[8 x i8] c"\1D\00\00\00\00\00\00\00"' <<<"${right_value_definition}"
+
+[[ "$(grep -Ec "^@${left_reference_linkage} = .*@${left_value_linkage}.*!dbg !" "${llvm_ir}")" -eq 1 ]]
+[[ "$(grep -Ec "^@${right_reference_linkage} = .*@${right_value_linkage}.*!dbg !" "${llvm_ir}")" -eq 1 ]]
+! grep -Eq "^@${left_reference_linkage} = .*@${right_value_linkage}" "${llvm_ir}"
+! grep -Eq "^@${right_reference_linkage} = .*@${left_value_linkage}" "${llvm_ir}"
+
+left_value_type="$(printf '%s\n' "${left_value_die}" | sed -E 's/.*type: !([0-9]+).*/\1/')"
+right_value_type="$(printf '%s\n' "${right_value_die}" | sed -E 's/.*type: !([0-9]+).*/\1/')"
+[[ "${left_value_type}" == "${right_value_type}" ]]
+grep -Eq "^!${left_value_type} = !DIBasicType\(name: \"u64\", size: 64, encoding: DW_ATE_unsigned\)" "${llvm_ir}"
+
+left_reference_type="$(printf '%s\n' "${left_reference_die}" | sed -E 's/.*type: !([0-9]+).*/\1/')"
+right_reference_type="$(printf '%s\n' "${right_reference_die}" | sed -E 's/.*type: !([0-9]+).*/\1/')"
+[[ "${left_reference_type}" == "${right_reference_type}" ]]
+grep -Eq "^!${left_reference_type} = !DIDerivedType\(tag: DW_TAG_pointer_type, name: \"&u64\", .*size: 64\)" "${llvm_ir}"
+
+reachable_die="$(unique_global_die DEBUG_REACHABLE)"
+private_die="$(unique_global_die DEBUG_PRIVATE)"
+grep -Fq "line: $(definition_line CUDA_OXIDE_DEBUG_GLOBAL_REACHABLE)," <<<"${reachable_die}"
+grep -Fq "line: $(definition_line CUDA_OXIDE_DEBUG_GLOBAL_PRIVATE)," <<<"${private_die}"
+grep -Fq 'isLocal: false' <<<"${reachable_die}"
+grep -Fq 'isLocal: true' <<<"${private_die}"
+require_cu_expression "${reachable_die}"
+require_cu_expression "${private_die}"
+
+target_die="$(unique_global_die RELOCATION_TARGET_A)"
+reference_die="$(unique_global_die RELOCATION_REFERENCE)"
+target_line="$(grep -nF 'static RELOCATION_TARGET_A:' "${source_file}" | cut -d: -f1)"
+reference_line="$(grep -nF 'static RELOCATION_REFERENCE:' "${source_file}" | cut -d: -f1)"
+grep -Fq "line: ${target_line}," <<<"${target_die}"
+grep -Fq "line: ${reference_line}," <<<"${reference_die}"
+target_linkage="$(printf '%s\n' "${target_die}" | linkage_name)"
+reference_linkage="$(printf '%s\n' "${reference_die}" | linkage_name)"
+[[ "$(grep -Ec "^@${target_linkage} = .*\\[4 x i8\\].*!dbg !" "${llvm_ir}")" -eq 1 ]]
+[[ "$(grep -Ec "^@${reference_linkage} = .*@${target_linkage}.*!dbg !" "${llvm_ir}")" -eq 1 ]]
+reference_type="$(printf '%s\n' "${reference_die}" | sed -E 's/.*type: !([0-9]+).*/\1/')"
+grep -Eq "^!${reference_type} = !DIDerivedType\\(tag: DW_TAG_pointer_type, name: \"&u32\", .*size: 64\\)" "${llvm_ir}"
+require_cu_expression "${target_die}"
+require_cu_expression "${reference_die}"
+
+# The shared semantic type builder cannot yet describe unions or fat
+# references exactly. Those individual globals fail closed; their physical
+# storage remains present and Full debug still succeeds for every supported
+# AS1 neighbor.
+! grep -Fq '!DIGlobalVariable(name: "UNION_RELOCATION"' "${llvm_ir}"
+! grep -Fq '!DIGlobalVariable(name: "SLICE_RELOCATION_VIEW"' "${llvm_ir}"
+
+if command -v llvm-as >/dev/null 2>&1; then
+    bitcode="$(mktemp --suffix=.bc)"
+    trap 'rm -f "${bitcode}"' EXIT
+    llvm-as -o "${bitcode}" "${llvm_ir}"
+    if command -v opt >/dev/null 2>&1; then
+        opt -passes=verify -disable-output "${bitcode}"
+    fi
+fi
+
+echo "device-global debug-info shape verified"

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -98,12 +98,18 @@ use llvm_export::ops::{
     DebugInlinedScope, DebugSourcePosition, DebugSourceScope, DebugSourceScopeLocation,
     DebugSourceScopeMap,
 };
+use rustc_hir::def::DefKind;
+use rustc_middle::mir::interpret::{AllocId, GlobalAlloc, Scalar};
+use rustc_middle::mir::mono::MonoItem;
+use rustc_middle::mir::visit::Visitor;
+use rustc_middle::mir::{ConstOperand, ConstValue, Location};
 use rustc_middle::ty::layout::{LayoutCx, LayoutOf};
-use rustc_middle::ty::{EarlyBinder, InstanceKind, TypingEnv};
+use rustc_middle::ty::{EarlyBinder, Instance, InstanceKind, TypingEnv};
 use rustc_middle::ty::{Ty, TyCtxt, TyKind};
 use rustc_session::config::DebugInfo;
-use rustc_span::{Span, hygiene};
-use std::collections::BTreeMap;
+use rustc_span::def_id::DefId;
+use rustc_span::{DUMMY_SP, Span, hygiene};
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -445,13 +451,187 @@ fn debug_position_from_span(tcx: TyCtxt<'_>, span: Span) -> Option<DebugSourcePo
     })
 }
 
+#[derive(Clone, Debug)]
+struct OwnedStaticDebugIdentity {
+    def_id: DefId,
+    identity: mir_importer::DebugGlobalVariableIdentity,
+}
+
+/// Full-debug-only provenance walk for statics reachable by device code.
+///
+/// Every direct static reference begins as a constant in one of the already
+/// collected, monomorphized device instances. Following that constant's CTFE
+/// allocation graph finds both its static definition and targets reached only
+/// through initializer relocations. Unlike seeding from every host CGU static,
+/// this does not attempt to build debug types for unrelated host-only statics;
+/// it also covers upstream statics, which are intentionally absent from local
+/// CGUs when rustc decides they need not be codegenerated locally.
+struct StaticDebugProvenance<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    current_instance: Option<Instance<'tcx>>,
+    statics: HashSet<DefId>,
+    pending_allocations: Vec<AllocId>,
+    seen_allocations: HashSet<AllocId>,
+}
+
+impl<'tcx> StaticDebugProvenance<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            current_instance: None,
+            statics: HashSet::new(),
+            pending_allocations: Vec::new(),
+            seen_allocations: HashSet::new(),
+        }
+    }
+
+    fn record_static(&mut self, def_id: DefId) {
+        if !self.statics.insert(def_id) {
+            return;
+        }
+        if let Ok(initializer) = self.tcx.eval_static_initializer(def_id) {
+            self.pending_allocations.extend(
+                initializer
+                    .inner()
+                    .provenance()
+                    .ptrs()
+                    .values()
+                    .map(|provenance| provenance.alloc_id()),
+            );
+        }
+    }
+
+    fn record_const_value(&mut self, value: ConstValue) {
+        match value {
+            ConstValue::Scalar(Scalar::Ptr(pointer, _)) => {
+                self.pending_allocations.push(pointer.provenance.alloc_id());
+            }
+            ConstValue::Indirect { alloc_id, .. } => self.pending_allocations.push(alloc_id),
+            ConstValue::Slice { alloc_id, .. } => self.pending_allocations.push(alloc_id),
+            ConstValue::Scalar(_) | ConstValue::ZeroSized => {}
+        }
+    }
+
+    fn drain_allocations(&mut self) {
+        while let Some(alloc_id) = self.pending_allocations.pop() {
+            if !self.seen_allocations.insert(alloc_id) {
+                continue;
+            }
+
+            match self.tcx.global_alloc(alloc_id) {
+                GlobalAlloc::Static(def_id) => self.record_static(def_id),
+                GlobalAlloc::Memory(allocation) => self.pending_allocations.extend(
+                    allocation
+                        .inner()
+                        .provenance()
+                        .ptrs()
+                        .values()
+                        .map(|provenance| provenance.alloc_id()),
+                ),
+                GlobalAlloc::Function { .. }
+                | GlobalAlloc::VTable(..)
+                | GlobalAlloc::TypeId { .. } => {}
+            }
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for StaticDebugProvenance<'tcx> {
+    fn visit_const_operand(&mut self, constant: &ConstOperand<'tcx>, location: Location) {
+        let instance = self
+            .current_instance
+            .expect("static provenance visitor must be bound to an instance");
+        let constant_value = instance.instantiate_mir_and_normalize_erasing_regions(
+            self.tcx,
+            TypingEnv::fully_monomorphized(),
+            EarlyBinder::bind(constant.const_),
+        );
+        if let Ok(value) =
+            constant_value.eval(self.tcx, TypingEnv::fully_monomorphized(), constant.span)
+        {
+            self.record_const_value(value);
+        }
+        self.super_const_operand(constant, location);
+    }
+}
+
+fn static_debug_namespace(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Vec<String>> {
+    let mut reversed = Vec::new();
+    let mut current = tcx.parent(def_id);
+
+    loop {
+        let key = tcx.def_key(current);
+        let mut segment = String::new();
+        rustc_codegen_ssa::debuginfo::type_names::push_item_name(tcx, current, false, &mut segment);
+        if segment.is_empty() {
+            return None;
+        }
+        reversed.push(segment);
+
+        let Some(parent) = key.parent else {
+            break;
+        };
+        current = DefId {
+            krate: current.krate,
+            index: parent,
+        };
+    }
+
+    reversed.reverse();
+    Some(reversed)
+}
+
+fn collect_static_debug_identities<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    functions: &[CollectedFunction<'tcx>],
+) -> Result<Vec<OwnedStaticDebugIdentity>, DeviceCodegenError> {
+    let mut provenance = StaticDebugProvenance::new(tcx);
+
+    for function in functions {
+        provenance.current_instance = Some(function.instance);
+        provenance.visit_body(tcx.instance_mir(function.instance.def));
+    }
+    provenance.current_instance = None;
+    provenance.drain_allocations();
+
+    let mut statics: Vec<_> = provenance.statics.into_iter().collect();
+    statics.sort_by_key(|def_id| tcx.def_path_str(*def_id));
+    statics
+        .into_iter()
+        .filter(|def_id| matches!(tcx.def_kind(*def_id), DefKind::Static { nested: false, .. }))
+        .map(|def_id| {
+            let name = tcx.item_name(def_id).to_string();
+            let namespace = static_debug_namespace(tcx, def_id).ok_or_else(|| {
+                DeviceCodegenError::Translation(format!(
+                    "cannot represent the source namespace for device static `{}`",
+                    tcx.def_path_str(def_id)
+                ))
+            })?;
+            let declaration_span = hygiene::walk_chain_collapsed(tcx.def_span(def_id), DUMMY_SP);
+            let declaration = debug_position_from_span(tcx, declaration_span).ok_or_else(|| {
+                DeviceCodegenError::Translation(format!(
+                    "cannot represent the definition span for device static `{}`",
+                    tcx.def_path_str(def_id)
+                ))
+            })?;
+            Ok(OwnedStaticDebugIdentity {
+                def_id,
+                identity: mir_importer::DebugGlobalVariableIdentity {
+                    name,
+                    namespace,
+                    declaration,
+                    is_local_to_unit: !tcx.is_reachable_non_generic(def_id),
+                },
+            })
+        })
+        .collect()
+}
+
 /// Errors that can occur during device code generation.
 ///
-/// `Translation` is part of the taxonomy and has a `Display` arm, but nothing
-/// constructs it today: translation failures arrive as
-/// `cuda_oxide_codegen::PipelineError` and are reported through that. Kept so
-/// the variant set still mirrors the pipeline's, rather than deleted and
-/// re-added the next time it is needed.
+/// Most translation failures arrive as `cuda_oxide_codegen::PipelineError`;
+/// `Translation` reports failures while preparing rustc-owned side tables at
+/// the frontend boundary.
 #[derive(Debug)]
 pub enum DeviceCodegenError {
     /// No kernels were found to compile.
@@ -459,10 +639,6 @@ pub enum DeviceCodegenError {
     /// Failed to enter or exit stable_mir context.
     StableMirError(String),
     /// MIR to Pliron IR translation failed.
-    #[expect(
-        dead_code,
-        reason = "mirrors PipelineError's taxonomy, not constructed here"
-    )]
     Translation(String),
     /// PTX generation (llc invocation) failed.
     PtxGeneration(String),
@@ -647,6 +823,11 @@ pub fn generate_device_code<'tcx>(
     let show_mir = config.dump_mir_dialect;
     let show_llvm = config.dump_llvm_dialect;
     let debug_kind = device_debug_kind(tcx.sess.opts.debuginfo);
+    let static_debug_identities = if debug_kind.variables_enabled() {
+        collect_static_debug_identities(tcx, functions)?
+    } else {
+        Vec::new()
+    };
 
     // Print raw rustc MIR if requested (before conversion to stable_mir)
     if show_rustc_mir {
@@ -722,6 +903,34 @@ pub fn generate_device_code<'tcx>(
         .collect();
 
     let result = rustc_internal::run(tcx, || {
+        let mut debug_global_variables = BTreeMap::new();
+        for owned in &static_debug_identities {
+            let stable_item = rustc_internal::stable(MonoItem::Static(owned.def_id));
+            let rustc_public::mir::mono::MonoItem::Static(static_def) = stable_item else {
+                unreachable!("internal static MonoItem must remain a stable static MonoItem")
+            };
+            let Some(info) = mir_importer::build_debug_global_variable_info(
+                owned.identity.clone(),
+                &static_def.ty(),
+            ) else {
+                // The local-variable debug path is deliberately best-effort
+                // for semantic types it cannot yet describe (notably unions).
+                // Globals must fail closed in the same way: omitting this one
+                // DIE is preferable to attaching the physical byte-array type,
+                // and an unsupported static must not disable correct metadata
+                // for every other AS1 global in the module.
+                continue;
+            };
+            let key = mir_importer::device_static_global_key(&static_def);
+            if let Some(previous) = debug_global_variables.insert(key.clone(), info.clone())
+                && previous != info
+            {
+                return Err(mir_importer::PipelineError::Translation(format!(
+                    "conflicting debug identities for device static `{key}`"
+                )));
+            }
+        }
+
         // Convert internal Instance<'tcx> to stable_mir Instance.
         // Drop glue instances whose bodies are provably no-ops are filtered
         // out: the mir-importer's translate_drop fast-path emits a plain
@@ -804,6 +1013,7 @@ pub fn generate_device_code<'tcx>(
             target_arch_source: "CUDA_OXIDE_TARGET",
             device_arch_hint,
             debug_kind,
+            debug_global_variables,
             allow_fma_contraction,
         };
 


### PR DESCRIPTION
## Summary

Ordinary Rust device statics now keep their source name and Rust type all the
way to the generated AS1 storage, so cuda-gdb can inspect them by their
qualified name.

```text
Before
debuginfo::GLOBAL_COUNTER ──> @__device_global_0 ──> no DWARF name/type
cuda-gdb: No symbol

After
debuginfo::GLOBAL_COUNTER ──> @__device_global_0 + DIGlobalVariable
cuda-gdb: @global u64 = 0
```

Closes #1120.

## Changes

- Carry the source leaf, namespace, definition span, locality, and semantic
  Rust type through the full-debug pipeline.
- Use an exact tagged mangled identity for storage, relocations, and debug joins
  so same-leaf statics and promoted constants cannot collide.
- Emit retained AS1 global DWARF with the generated symbol as `linkageName`.
- Fail closed per unsupported type without removing the real global.

Qualified lookup is the correctness boundary. Unqualified lookup is contextual
in cuda-gdb; AS3 shared and AS4 constant-memory debug metadata stay separate.

## Testing

- Importer, lowering, exporter, backend, strict Clippy, LLVM-verifier, and
  debug-mode checks passed on `ac0282c4`.
- Final head `a57bc934` only formats the device-global example; the exact
  per-example formatter gate now passes.
- CUDA 13.3 / RTX 5090: `debuginfo::GLOBAL_COUNTER` is `@global u64 = 0`.
- Same-leaf and opposite-block controls keep distinct values, addresses,
  relocations, and DIEs; repeated references deduplicate.

- [ ] `just check` passes (affected suites and validators pass)
- [x] Live GPU debugger regression exercised
- [x] New example added (existing device-global example extended)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files

---
> Questions about the review? Ping us in [#contributors on Discord](https://discord.gg/ZUEr4AhH5C).
