### PR TITLE
fix(codegen): support char in #[device] extern signatures

### DIFF
--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
@@ -59,6 +59,12 @@ Device: NVIDIA GeForce RTX 5090
 --- Test 3: test_mixed_attrs ---
     ✓ PASSED (outputs are finite)
 
+--- Test 4: test_smem_alignment_cross_module ---
+    ✓ PASSED (same shared memory, values correct)
+
+--- Test 5: test_char_ffi ---
+    ✓ PASSED (char_identity('A') = 'A')
+
 ✓ All tests PASSED!
 ```
 
@@ -177,6 +183,7 @@ extern "C" __device__ float warp_reduce_sum(float val) {
 | `warp_ballot`        | Warp ballot             |
 | `simple_add`         | Simple a + b            |
 | `clamp_value`        | Clamp to range          |
+| `char_identity`      | Rust `char` <-> `unsigned int` round-trip |
 
 ### From `extern-libs/cccl_wrappers.cu` (CUB)
 
@@ -185,6 +192,31 @@ extern "C" __device__ float warp_reduce_sum(float val) {
 | `cub_warp_reduce_sum_f32`   | Warp-level sum reduction  |
 | `cub_warp_reduce_max_f32`   | Warp-level max reduction  |
 | `cub_block_reduce_sum_f32`  | Block-level sum (256 thr) |
+
+---
+
+## Rust `char` Across the FFI Boundary
+
+Rust `char` is a 4-byte Unicode scalar value, so it is ABI-compatible with C's
+`unsigned int`. The device-extern path maps it to a plain 32-bit integer in every
+position — parameter, result, and behind a pointer — with no `signext` or
+`zeroext` attribute, exactly like `u32`.
+
+```rust
+#[device]
+#[allow(improper_ctypes)] // rustc's lint still fires on `char` externs.
+unsafe extern "C" {
+    fn char_identity(c: char) -> char; // implemented as unsigned int in .cu
+}
+```
+
+Two caveats:
+
+- A value passed from C that is **not** a valid Unicode scalar value (above
+  `0x10FFFF`, or a surrogate in `0xD800..=0xDFFF`) is UB on the Rust side —
+  the same caveat family as `bool`'s 0/1 rule.
+- rustc's `improper_ctypes` lint still fires on `char` externs even though the
+  layout matches; callers may `#[allow(improper_ctypes)]` it.
 
 ---
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
@@ -60,6 +60,14 @@ extern "C" __device__ float clamp_value(float val, float min_val, float max_val)
     return fminf(fmaxf(val, min_val), max_val);
 }
 
+/**
+ * char round-trip: Rust `char` is a 4-byte Unicode scalar value,
+ * ABI-compatible with `unsigned int`.
+ */
+extern "C" __device__ unsigned int char_identity(unsigned int c) {
+    return c;
+}
+
 // ============================================================================
 // Example 2: Read-Only Functions
 //

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -41,6 +41,10 @@ unsafe extern "C" {
     fn warp_ballot(predicate: i32) -> u32;
     fn simple_add(a: f32, b: f32) -> f32;
     fn clamp_value(val: f32, min_val: f32, max_val: f32) -> f32;
+    // Rust `char` is ABI-compatible with `u32`; rustc's `improper_ctypes`
+    // lint still fires on the `char` spelling, so allow it on this item.
+    #[allow(improper_ctypes)]
+    fn char_identity(c: char) -> char;
     fn smem_write_aligned_128(offset: i32, value: f32);
     fn smem_read_aligned_128(offset: i32) -> f32;
     fn smem_get_base_addr() -> u64;
@@ -231,6 +235,18 @@ mod kernels {
                 rust_bits,
                 extern_bits
             );
+        }
+    }
+
+    /// Test `char` round-trip across the device FFI boundary.
+    #[kernel]
+    pub fn test_char_ffi(output: *mut i32) {
+        let tid = cuda_device::thread::threadIdx_x();
+        if tid == 0 {
+            let c = unsafe { char_identity('A') };
+            unsafe {
+                *output.add(0) = c as i32;
+            }
         }
     }
 }
@@ -529,6 +545,7 @@ fn main() {
     test_cub_warp_reduce_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_mixed_attrs_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_smem_alignment_cross_module_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
+    test_char_ffi_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
 
     println!("\n=== Summary ===");
     println!("Passed: {}", tests_passed);
@@ -833,6 +850,50 @@ fn test_smem_alignment_cross_module_runner(
         if !values_match {
             println!("      - Values don't match");
         }
+        *failed += 1;
+    }
+}
+
+/// Test 5: `char` round-trip across the device FFI boundary.
+/// Passing `'A'` through `char_identity` must come back as `'A'` (65).
+fn test_char_ffi_runner(
+    ctx: &Arc<CudaContext>,
+    module: &kernels::LoadedModule,
+    passed: &mut i32,
+    failed: &mut i32,
+) {
+    println!("--- Test 5: test_char_ffi ---");
+    println!("    Function: char_identity (Rust `char` <-> C `unsigned int`)");
+
+    let stream = ctx.default_stream();
+    let d_output = DeviceBuffer::<i32>::zeroed(&stream, 1).unwrap();
+
+    let config = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    // SAFETY: launch shape/resources match the kernel; buffer covers its accesses.
+    unsafe {
+        module.test_char_ffi(
+            (stream).as_ref(),
+            config,
+            d_output.cu_deviceptr() as *mut i32,
+        )
+    }
+    .expect("Kernel launch failed");
+
+    let h_output = d_output.to_host_vec(&stream).unwrap();
+
+    if h_output[0] == b'A' as i32 {
+        println!("    ✓ PASSED (char_identity('A') = 'A')");
+        *passed += 1;
+    } else {
+        println!(
+            "    ✗ FAILED (expected {}, got {})",
+            b'A' as i32, h_output[0]
+        );
         *failed += 1;
     }
 }

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -228,11 +228,7 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 // Rust's `*mut ()` is its common spelling for a void pointer.
                 E::Integer(8)
             } else {
-                rustc_ty_to_device_extern_type(
-                    tcx,
-                    *pointee,
-                    DeviceExternTypePosition::Pointee,
-                )?
+                rustc_ty_to_device_extern_type(tcx, *pointee, DeviceExternTypePosition::Pointee)?
             };
             Ok(E::pointer_to(pointee, 0))
         }
@@ -240,11 +236,8 @@ fn rustc_ty_to_device_extern_type<'tcx>(
             let len = len.try_to_target_usize(tcx).ok_or_else(|| {
                 format!("device-extern array length for `{ty}` is not a concrete constant")
             })?;
-            let element = rustc_ty_to_device_extern_type(
-                tcx,
-                *element,
-                DeviceExternTypePosition::Pointee,
-            )?;
+            let element =
+                rustc_ty_to_device_extern_type(tcx, *element, DeviceExternTypePosition::Pointee)?;
             Ok(E::Array {
                 element: Box::new(element),
                 len,
@@ -265,9 +258,7 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 Ok(E::ZeroExtInteger(1))
             }
         }
-        TyKind::Char => Err(
-            "Rust `char` is not supported in device extern signatures; use `u32` in a C-compatible wrapper".to_string(),
-        ),
+        TyKind::Char => unsigned_integer(32),
         TyKind::Never => Err("never-returning device externs are not yet supported".to_string()),
         _ => Err(format!(
             "unsupported device-extern ABI type `{ty}`; use scalar C types or raw pointers to supported scalar/array pointees"


### PR DESCRIPTION
Closes #875

## What

`TyKind::Char` is now mapped through the same `unsigned_integer(32)` helper as `u32` in `rustc_ty_to_device_extern_type`. A `#[device] extern "C"` function can now pass and return `char` instead of failing with the old "Rust `char` is not supported in device extern signatures" error.

Rust `char` is a 4-byte Unicode scalar value, so it is ABI-compatible with `u32`. It crosses the boundary as a plain i32 with no signext/zeroext in parameter, result, and pointee positions.

## Test

Extends `device_ffi_test` with a `char_identity` round-trip:

- CUDA C++ side: `extern "C" __device__ unsigned int char_identity(unsigned int c)`
- Rust side: `unsafe extern "C" { fn char_identity(c: char) -> char; }` with `#[allow(improper_ctypes)]`
- Kernel passes `'A'` and verifies it comes back as `'A'` (65)

Generated NVVM IR:

```
declare i32 @char_identity(i32)
call i32 @char_identity(i32 65)
```

## Local validation (Jetson Orin, sm_87)

Ran the full example on a Jetson Orin with CUDA 12.6:

```
--- Test 5: test_char_ffi ---
    Function: char_identity (Rust `char` <-> C `unsigned int`)
    ✓ PASSED (char_identity('A') = 'A')

=== Summary ===
Passed: 5
Failed: 0

✓ All tests PASSED!
```

The upstream example's LTOIR tools and CCCL wrappers assume CUDA 13 APIs (`NVJITLINK_ERROR_*` enum values and `cuda::minimum` / `cuda::maximum`). To build on this CUDA 12.6 host I used temporary local shims that are not part of this PR. CI on CUDA 13 should exercise the same path.

## Docs

Documents the ABI contract in the `device_ffi_test` README:

- A value from C outside the Unicode scalar range (above 0x10FFFF, or a surrogate in 0xD800..=0xDFFF) is UB on the Rust side, the same caveat family as bool's 0/1 rule.
- rustc's `improper_ctypes` lint still fires on `char` externs; callers may `#[allow(improper_ctypes)]`.

## Note on duplicate PR #1049

PR #1049 also addresses #875. This PR is based on the latest `main` and includes the two changes requested in the review of #1049: `DeviceBuffer::zeroed` instead of `stream.alloc_zeros`, and `#[allow(improper_ctypes)]` on the char extern. It also includes the two rustfmt reflow hunks in `device_codegen.rs` required by `cargo fmt --check`.
