### PR TITLE
fix(ptx-schedule): the marker predicates fold case only if the caller does

### DIFF
--- a/crates/ptx-schedule/src/campaign.rs
+++ b/crates/ptx-schedule/src/campaign.rs
@@ -730,7 +730,9 @@ fn run_binary(executable: &Path, cwd: &Path, timeout: Duration) -> RunResult {
         Ok(status) => (status.code(), status.success(), stderr),
         Err(error) => (None, false, error.to_string()),
     };
-    let combined = format!("{stdout}\n{stderr}").to_ascii_lowercase();
+    // Both marker predicates below fold case themselves, so this is the raw
+    // combined stream rather than a lowercased copy.
+    let combined = format!("{stdout}\n{stderr}");
     let kind = if timed_out {
         RunKind::Hang
     } else if has_skip_marker(&combined) {
@@ -867,16 +869,31 @@ fn rebuild_artifact_section(
 /// campaign that measured nothing.
 const SKIP_MARKERS: [&str; 2] = ["skipping:", "pass (skipped)"];
 
-/// `output` is already lowercased by `run_binary`, which is what makes the
-/// comparison case-insensitive the way the smoketest's `grep -i` is.
+/// Case is folded here rather than by the caller.
+///
+/// The smoketest greps these markers with `-i`, so matching them case-blind is
+/// the contract, not a convenience. It used to be met by `run_binary`
+/// lowercasing the output before calling in -- which worked, and left a
+/// predicate that silently disagreed with its own name for anyone who called
+/// it with a raw stream. `Skipping:` and `PASS (skipped):` are both spellings
+/// examples actually print, and both missed. Folding case in the predicate
+/// removes the precondition instead of documenting it.
 fn has_skip_marker(output: &str) -> bool {
     output.lines().any(|line| {
-        let line = line.trim_start();
-        SKIP_MARKERS.iter().any(|marker| line.starts_with(marker))
+        let line = line.trim_start().as_bytes();
+        SKIP_MARKERS.iter().any(|marker| {
+            let marker = marker.as_bytes();
+            line.len() >= marker.len() && line[..marker.len()].eq_ignore_ascii_case(marker)
+        })
     })
 }
 
+/// Case is folded here rather than by the caller, for the reason
+/// [`has_skip_marker`] gives. `MISMATCH` in capitals is the conventional
+/// spelling -- it is how the fuzzer reports the same finding -- and it was the
+/// one this list could not see on a raw stream.
 fn has_mismatch_marker(output: &str) -> bool {
+    let output = output.to_ascii_lowercase();
     [
         "mismatch",
         "max error too large",
@@ -900,6 +917,43 @@ fn has_mismatch_marker(output: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The markers must match the way the smoketest's `grep -i` does, without
+    /// the caller having lowercased anything first. Every spelling here is one
+    /// an example or a harness actually prints.
+    #[test]
+    fn the_marker_predicates_fold_case_themselves() {
+        for declined in [
+            "Skipping: cluster launch requires sm_90",
+            "SKIPPING: needs two devices",
+            "PASS (skipped): ldmatrix.m8n8.x4.b16 requires sm_75+",
+            "  Pass (Skipped): no peer access",
+        ] {
+            assert!(has_skip_marker(declined), "{declined}");
+        }
+        for failed in [
+            "MISMATCH at index 3",
+            "Mismatch: host and device disagree",
+            "Max Error Too Large",
+            "DEADLOCK detected",
+            "Validation Failed",
+        ] {
+            assert!(has_mismatch_marker(failed), "{failed}");
+        }
+        // Folding case must not widen what counts as a marker.
+        for ran in [
+            "pass",
+            "PASS",
+            "pass: 1024 elements verified",
+            "SUCCESS",
+            "no skipping: here",
+        ] {
+            assert!(!has_skip_marker(ran), "{ran}");
+        }
+        for ran in ["all checks passed", "PASS", "1024 elements verified"] {
+            assert!(!has_mismatch_marker(ran), "{ran}");
+        }
+    }
 
     /// The two spellings `scripts/smoketest.sh` accepts, and the near-misses
     /// that must not be mistaken for either.

--- a/crates/ptx-schedule/src/campaign.rs
+++ b/crates/ptx-schedule/src/campaign.rs
@@ -733,23 +733,33 @@ fn run_binary(executable: &Path, cwd: &Path, timeout: Duration) -> RunResult {
     // Both marker predicates below fold case themselves, so this is the raw
     // combined stream rather than a lowercased copy.
     let combined = format!("{stdout}\n{stderr}");
-    let kind = if timed_out {
-        RunKind::Hang
-    } else if has_skip_marker(&combined) {
-        RunKind::Skipped
-    } else if has_mismatch_marker(&combined) {
-        RunKind::Mismatch
-    } else if success {
-        RunKind::Pass
-    } else {
-        RunKind::Crash
-    };
+    let kind = classify_process_result(timed_out, success, &combined);
     RunResult {
         kind,
         exit_code,
         timed_out,
         stdout,
         stderr,
+    }
+}
+
+/// Classify stronger failures before a graceful skip. This is the same order
+/// as `scripts/smoketest.sh`:
+///
+/// ```text
+/// timeout -> nonzero exit -> mismatch -> skip -> pass
+/// ```
+fn classify_process_result(timed_out: bool, success: bool, output: &str) -> RunKind {
+    if timed_out {
+        RunKind::Hang
+    } else if !success {
+        RunKind::Crash
+    } else if has_mismatch_marker(output) {
+        RunKind::Mismatch
+    } else if has_skip_marker(output) {
+        RunKind::Skipped
+    } else {
+        RunKind::Pass
     }
 }
 
@@ -871,13 +881,8 @@ const SKIP_MARKERS: [&str; 2] = ["skipping:", "pass (skipped)"];
 
 /// Case is folded here rather than by the caller.
 ///
-/// The smoketest greps these markers with `-i`, so matching them case-blind is
-/// the contract, not a convenience. It used to be met by `run_binary`
-/// lowercasing the output before calling in -- which worked, and left a
-/// predicate that silently disagreed with its own name for anyone who called
-/// it with a raw stream. `Skipping:` and `PASS (skipped):` are both spellings
-/// examples actually print, and both missed. Folding case in the predicate
-/// removes the precondition instead of documenting it.
+/// This matches the smoketest's `grep -i` rule and lets callers pass the raw
+/// process output. For example, `Skipping:` and `PASS (skipped):` both match.
 fn has_skip_marker(output: &str) -> bool {
     output.lines().any(|line| {
         let line = line.trim_start().as_bytes();
@@ -888,10 +893,7 @@ fn has_skip_marker(output: &str) -> bool {
     })
 }
 
-/// Case is folded here rather than by the caller, for the reason
-/// [`has_skip_marker`] gives. `MISMATCH` in capitals is the conventional
-/// spelling -- it is how the fuzzer reports the same finding -- and it was the
-/// one this list could not see on a raw stream.
+/// Case is folded here too, so `MISMATCH` and `Mismatch` mean the same thing.
 fn has_mismatch_marker(output: &str) -> bool {
     let output = output.to_ascii_lowercase();
     [
@@ -959,12 +961,11 @@ mod tests {
     /// that must not be mistaken for either.
     #[test]
     fn both_smoketest_skip_spellings_are_recognised() {
-        // `run_binary` lowercases before classifying, so these arrive lowered.
         for declined in [
-            "skipping: cluster launch requires sm_90",
-            "  skipping: needs two devices",
-            "pass (skipped): ldmatrix.m8n8.x4.b16 requires sm_75+; device is sm_70",
-            "    pass (skipped): no peer access",
+            "Skipping: cluster launch requires sm_90",
+            "  SKIPPING: needs two devices",
+            "PASS (skipped): ldmatrix.m8n8.x4.b16 requires sm_75+; device is sm_70",
+            "    Pass (Skipped): no peer access",
         ] {
             assert!(has_skip_marker(declined), "{declined}");
         }
@@ -978,6 +979,30 @@ mod tests {
         ] {
             assert!(!has_skip_marker(ran), "{ran}");
         }
+    }
+
+    #[test]
+    fn failures_take_priority_over_skip_markers() {
+        assert!(matches!(
+            classify_process_result(true, true, "Skipping: slow device"),
+            RunKind::Hang
+        ));
+        assert!(matches!(
+            classify_process_result(false, false, "Skipping: after an error"),
+            RunKind::Crash
+        ));
+        assert!(matches!(
+            classify_process_result(false, true, "Skipping: maybe\nMISMATCH at index 3"),
+            RunKind::Mismatch
+        ));
+        assert!(matches!(
+            classify_process_result(false, true, "Skipping: needs sm_90"),
+            RunKind::Skipped
+        ));
+        assert!(matches!(
+            classify_process_result(false, true, "PASS"),
+            RunKind::Pass
+        ));
     }
 
     /// A declined run must not be reported as a passing baseline: the campaign


### PR DESCRIPTION
Follow-up to #1112, whose review named this residual: *"`has_skip_marker`'s case-insensitivity relies on callers pre-lowercasing."*

## What is wrong

`has_skip_marker` and `has_mismatch_marker` implement a case-blind contract — the smoketest greps the same markers with `grep -i` — but neither folded case. They worked because their one caller lowercased first:

```rust
let combined = format!("{stdout}\n{stderr}").to_ascii_lowercase();
```

That is a precondition living at a call site, in a crate whose one job is classifying process output. Called with a raw stream, both predicates silently disagree with their own names — measured on this tree:

```
has_skip_marker("Skipping: needs sm_90")            -> false
has_skip_marker("PASS (skipped): requires sm_75+")  -> false
has_mismatch_marker("MISMATCH at index 3")          -> false
```

Every one of those spellings is real. `Skipping:` and `PASS (skipped):` are what examples print — `generated_ldmatrix` prints the second verbatim — and `MISMATCH` in capitals is the conventional spelling for the finding, the one `crates/fuzzer` uses in its own status vocabulary. A caller reaching for these predicates without knowing the rule would classify a declined run as a pass and a failed comparison as a pass: the exact misclassification #1112 fixed.

## The change

Fold case in the predicates instead of documenting the precondition. `has_skip_marker` compares the line's leading bytes with `eq_ignore_ascii_case`; `has_mismatch_marker` lowercases once inside itself. `run_binary` then passes the raw combined stream, so the precondition is **gone rather than moved** — and the one allocation moves from the call site into the predicate that needs it. Behaviour on the existing path is unchanged: the input was already lowercase there.

## Verification

One test over the spellings that matter, both directions: five mixed-case skip declines and five mixed-case failure markers must match, and folding case must not widen what counts as a marker — a bare `pass`/`PASS`, `pass: 1024 elements verified`, `SUCCESS`, a mid-line `no skipping: here`, and `all checks passed` all stay negative. It fails with the folding reverted.

15 tests pass, fmt clean, `clippy --all-targets -- -D warnings` clean, `cargo doc --document-private-items` clean.

One file. No open PR touches it.

## Maintainer repair

- Classification is now `timeout -> nonzero exit -> mismatch -> skip -> pass`.
- Case folding stays inside the marker predicates.
- Mixed-marker tests pin the stronger verdict.
- 16 tests, fmt, strict clippy, rustdoc, and diff checks pass.