### PR TITLE
fix(ptx-schedule): the usage line brackets an option the CLI requires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,7 @@ version = "0.1.0"
 name = "ptx-schedule"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "dialect-ptx",
  "oxide-artifacts",
  "ptx-parse",

--- a/crates/ptx-schedule/Cargo.toml
+++ b/crates/ptx-schedule/Cargo.toml
@@ -12,6 +12,7 @@ description = "Structural PTX schedule analysis and deterministic perturbation"
 readme = "README.md"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 dialect-ptx = { workspace = true }
 oxide-artifacts = { workspace = true, features = ["object-read"] }
 ptx-parse = { workspace = true }

--- a/crates/ptx-schedule/src/main.rs
+++ b/crates/ptx-schedule/src/main.rs
@@ -8,16 +8,44 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+/// The two invocation forms, one per line.
+///
+/// A single bracketed list cannot state this CLI's shape: `--output` is
+/// required to perturb and meaningless to list, and bracketing it read as
+/// optional in both. One line per form is what `cuda-intrinsics-gen`'s usage
+/// text does for the same reason.
+const USAGE: &str = "usage:
+  ptx-schedule INPUT.ptx --list-sites
+        print the schedule-sensitive sites as JSON; the options below are ignored
+  ptx-schedule INPUT.ptx -o|--output OUTPUT [--seed N] [--intensity F]
+        [--max-sleep-ns N] [--focus TEXT] [--decisions-json FILE]
+        write a perturbed copy of INPUT.ptx to OUTPUT";
+
 fn usage() -> ! {
-    eprintln!(
-        "usage: ptx-schedule INPUT.ptx [--list-sites] [--seed N] [--intensity F] [--max-sleep-ns N] [--focus TEXT] [-o|--output OUTPUT] [--decisions-json FILE]"
-    );
+    eprintln!("{USAGE}");
     std::process::exit(2);
+}
+
+/// Exit with the usage text, having first said what was wrong with the command
+/// line. Without the reason, a missing `--output` and an unknown flag print the
+/// same wall of text and leave the reader to spot the difference.
+fn usage_because(reason: &str) -> ! {
+    eprintln!("error: {reason}");
+    usage();
+}
+
+/// The value that must follow `flag`, or the usage text saying it is missing.
+fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> String {
+    args.next()
+        .unwrap_or_else(|| usage_because(&format!("{flag} needs a value")))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = env::args().skip(1);
-    let input = PathBuf::from(args.next().unwrap_or_else(|| usage()));
+    let input = PathBuf::from(
+        args.next()
+            .unwrap_or_else(|| usage_because("an input PTX file is required")),
+    );
     let mut options = InjectionOptions::default();
     let mut list_sites = false;
     let mut output = None;
@@ -26,19 +54,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(argument) = args.next() {
         match argument.as_str() {
             "--list-sites" => list_sites = true,
-            "--seed" => options.seed = args.next().unwrap_or_else(|| usage()).parse()?,
-            "--intensity" => options.intensity = args.next().unwrap_or_else(|| usage()).parse()?,
+            "--seed" => options.seed = next_value(&mut args, "--seed").parse()?,
+            "--intensity" => options.intensity = next_value(&mut args, "--intensity").parse()?,
             "--max-sleep-ns" => {
-                options.max_sleep_ns = args.next().unwrap_or_else(|| usage()).parse()?
+                options.max_sleep_ns = next_value(&mut args, "--max-sleep-ns").parse()?
             }
-            "--focus" => options.focus = Some(args.next().unwrap_or_else(|| usage())),
-            "-o" | "--output" => {
-                output = Some(PathBuf::from(args.next().unwrap_or_else(|| usage())))
-            }
+            "--focus" => options.focus = Some(next_value(&mut args, "--focus")),
+            "-o" | "--output" => output = Some(PathBuf::from(next_value(&mut args, "--output"))),
             "--decisions-json" => {
-                decisions_json = Some(PathBuf::from(args.next().unwrap_or_else(|| usage())))
+                decisions_json = Some(PathBuf::from(next_value(&mut args, "--decisions-json")))
             }
-            _ => usage(),
+            other => usage_because(&format!("unrecognized argument {other:?}")),
         }
     }
 
@@ -48,7 +74,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", serde_json::to_string_pretty(analysis.sites())?);
         return Ok(());
     }
-    let output = output.unwrap_or_else(|| usage());
+    let output = output
+        .unwrap_or_else(|| usage_because("-o|--output is required unless --list-sites is given"));
     let rewrite = perturb_ptx(&source, &options)?;
     fs::write(output, &rewrite.ptx)?;
     if let Some(path) = decisions_json {
@@ -63,4 +90,76 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rewrite.report.injected_ns_per_visit
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::USAGE;
+
+    /// The bidirectional parity #1109 established, now asserted rather than
+    /// checked by hand: the usage text names exactly the long flags the parser
+    /// accepts.
+    #[test]
+    fn the_usage_text_names_every_flag_the_parser_accepts() {
+        let source = include_str!("main.rs");
+        // Match arms, minus the `other =>` catch-all.
+        // An arm can name several spellings -- `"-o" | "--output" =>` -- so take
+        // every quoted flag on the line, not just the first.
+        let mut parsed: Vec<&str> = source
+            .lines()
+            .map(str::trim_start)
+            .filter(|line| line.starts_with('"') && line.contains("=>"))
+            .flat_map(|line| {
+                line.split('"')
+                    .skip(1)
+                    .step_by(2)
+                    .filter(|flag| flag.starts_with('-'))
+            })
+            .collect();
+        parsed.sort_unstable();
+        parsed.dedup();
+        assert!(parsed.len() >= 7, "{parsed:?}");
+        for flag in &parsed {
+            assert!(
+                USAGE.contains(flag),
+                "{flag} is accepted but not in the usage text"
+            );
+        }
+        for word in USAGE.split_whitespace() {
+            let word = word.trim_start_matches('[').trim_end_matches(']');
+            for flag in word.split('|') {
+                if flag.starts_with('-') {
+                    assert!(
+                        parsed.contains(&flag),
+                        "{flag} is in the usage text but not parsed"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `--output` is required to perturb and ignored when listing, so it must
+    /// not be shown bracketed the way the genuinely optional flags are. That
+    /// bracketing is what #1109's review flagged.
+    #[test]
+    fn output_is_shown_as_required_on_the_form_that_requires_it() {
+        let write_form = USAGE
+            .lines()
+            .find(|line| line.contains("--output"))
+            .expect("a form naming --output");
+        assert!(
+            !write_form.contains("[-o|--output"),
+            "--output is bracketed as optional: {write_form}"
+        );
+        assert!(write_form.contains("-o|--output OUTPUT"), "{write_form}");
+
+        let list_form = USAGE
+            .lines()
+            .find(|line| line.contains("--list-sites"))
+            .expect("a form naming --list-sites");
+        assert!(
+            !list_form.contains("--output"),
+            "the listing form should not name --output: {list_form}"
+        );
+    }
 }

--- a/crates/ptx-schedule/src/main.rs
+++ b/crates/ptx-schedule/src/main.rs
@@ -3,82 +3,106 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use clap::{ArgGroup, Parser};
 use ptx_schedule::{InjectionOptions, analyze_ptx, perturb_ptx};
-use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-/// The two invocation forms, one per line.
-///
-/// A single bracketed list cannot state this CLI's shape: `--output` is
-/// required to perturb and meaningless to list, and bracketing it read as
-/// optional in both. One line per form is what `cuda-intrinsics-gen`'s usage
-/// text does for the same reason.
-const USAGE: &str = "usage:
-  ptx-schedule INPUT.ptx --list-sites
-        print the schedule-sensitive sites as JSON; the options below are ignored
-  ptx-schedule INPUT.ptx -o|--output OUTPUT [--seed N] [--intensity F]
-        [--max-sleep-ns N] [--focus TEXT] [--decisions-json FILE]
-        write a perturbed copy of INPUT.ptx to OUTPUT";
+#[derive(Debug, Parser)]
+#[command(
+    name = "ptx-schedule",
+    about = "Inspect or perturb one PTX file",
+    override_usage = "ptx-schedule <INPUT.ptx> --list-sites\n       ptx-schedule <INPUT.ptx> -o <OUTPUT> [OPTIONS]",
+    group(ArgGroup::new("mode").required(true).multiple(false).args(["list_sites", "output"]))
+)]
+struct Cli {
+    /// PTX module to inspect or rewrite.
+    #[arg(value_name = "INPUT.ptx")]
+    input: PathBuf,
 
-fn usage() -> ! {
-    eprintln!("{USAGE}");
-    std::process::exit(2);
-}
+    /// Print schedule-sensitive sites as JSON.
+    #[arg(long, group = "mode")]
+    list_sites: bool,
 
-/// Exit with the usage text, having first said what was wrong with the command
-/// line. Without the reason, a missing `--output` and an unknown flag print the
-/// same wall of text and leave the reader to spot the difference.
-fn usage_because(reason: &str) -> ! {
-    eprintln!("error: {reason}");
-    usage();
-}
+    /// Write a perturbed PTX module.
+    #[arg(short = 'o', long, value_name = "OUTPUT", group = "mode")]
+    output: Option<PathBuf>,
 
-/// The value that must follow `flag`, or the usage text saying it is missing.
-fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> String {
-    args.next()
-        .unwrap_or_else(|| usage_because(&format!("{flag} needs a value")))
+    /// Deterministic perturbation seed.
+    #[arg(
+        long,
+        value_name = "N",
+        requires = "output",
+        conflicts_with = "list_sites"
+    )]
+    seed: Option<u64>,
+
+    /// Fraction of eligible sites to perturb.
+    #[arg(
+        long,
+        value_name = "F",
+        requires = "output",
+        conflicts_with = "list_sites"
+    )]
+    intensity: Option<f64>,
+
+    /// Maximum sleep inserted at one site.
+    #[arg(
+        long,
+        value_name = "N",
+        requires = "output",
+        conflicts_with = "list_sites"
+    )]
+    max_sleep_ns: Option<u32>,
+
+    /// Prefer sites whose instruction contains this text.
+    #[arg(
+        long,
+        value_name = "TEXT",
+        requires = "output",
+        conflicts_with = "list_sites"
+    )]
+    focus: Option<String>,
+
+    /// Save the injection decisions as JSON.
+    #[arg(
+        long,
+        value_name = "FILE",
+        requires = "output",
+        conflicts_with = "list_sites"
+    )]
+    decisions_json: Option<PathBuf>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = env::args().skip(1);
-    let input = PathBuf::from(
-        args.next()
-            .unwrap_or_else(|| usage_because("an input PTX file is required")),
-    );
-    let mut options = InjectionOptions::default();
-    let mut list_sites = false;
-    let mut output = None;
-    let mut decisions_json = None;
-
-    while let Some(argument) = args.next() {
-        match argument.as_str() {
-            "--list-sites" => list_sites = true,
-            "--seed" => options.seed = next_value(&mut args, "--seed").parse()?,
-            "--intensity" => options.intensity = next_value(&mut args, "--intensity").parse()?,
-            "--max-sleep-ns" => {
-                options.max_sleep_ns = next_value(&mut args, "--max-sleep-ns").parse()?
-            }
-            "--focus" => options.focus = Some(next_value(&mut args, "--focus")),
-            "-o" | "--output" => output = Some(PathBuf::from(next_value(&mut args, "--output"))),
-            "--decisions-json" => {
-                decisions_json = Some(PathBuf::from(next_value(&mut args, "--decisions-json")))
-            }
-            other => usage_because(&format!("unrecognized argument {other:?}")),
-        }
-    }
-
-    let source = fs::read_to_string(&input)?;
-    if list_sites {
+    let cli = Cli::parse();
+    let source = fs::read_to_string(&cli.input)?;
+    if cli.list_sites {
         let analysis = analyze_ptx(&source)?;
         println!("{}", serde_json::to_string_pretty(analysis.sites())?);
         return Ok(());
     }
-    let output = output
-        .unwrap_or_else(|| usage_because("-o|--output is required unless --list-sites is given"));
+
+    let mut options = InjectionOptions::default();
+    if let Some(seed) = cli.seed {
+        options.seed = seed;
+    }
+    if let Some(intensity) = cli.intensity {
+        options.intensity = intensity;
+    }
+    if let Some(max_sleep_ns) = cli.max_sleep_ns {
+        options.max_sleep_ns = max_sleep_ns;
+    }
+    if let Some(focus) = cli.focus {
+        options.focus = Some(focus);
+    }
+
+    let output = cli
+        .output
+        .expect("clap requires either --list-sites or --output");
     let rewrite = perturb_ptx(&source, &options)?;
     fs::write(output, &rewrite.ptx)?;
-    if let Some(path) = decisions_json {
+    if let Some(path) = cli.decisions_json {
         fs::write(path, serde_json::to_string_pretty(&rewrite.report)?)?;
     }
     println!(
@@ -90,76 +114,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rewrite.report.injected_ns_per_visit
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::USAGE;
-
-    /// The bidirectional parity #1109 established, now asserted rather than
-    /// checked by hand: the usage text names exactly the long flags the parser
-    /// accepts.
-    #[test]
-    fn the_usage_text_names_every_flag_the_parser_accepts() {
-        let source = include_str!("main.rs");
-        // Match arms, minus the `other =>` catch-all.
-        // An arm can name several spellings -- `"-o" | "--output" =>` -- so take
-        // every quoted flag on the line, not just the first.
-        let mut parsed: Vec<&str> = source
-            .lines()
-            .map(str::trim_start)
-            .filter(|line| line.starts_with('"') && line.contains("=>"))
-            .flat_map(|line| {
-                line.split('"')
-                    .skip(1)
-                    .step_by(2)
-                    .filter(|flag| flag.starts_with('-'))
-            })
-            .collect();
-        parsed.sort_unstable();
-        parsed.dedup();
-        assert!(parsed.len() >= 7, "{parsed:?}");
-        for flag in &parsed {
-            assert!(
-                USAGE.contains(flag),
-                "{flag} is accepted but not in the usage text"
-            );
-        }
-        for word in USAGE.split_whitespace() {
-            let word = word.trim_start_matches('[').trim_end_matches(']');
-            for flag in word.split('|') {
-                if flag.starts_with('-') {
-                    assert!(
-                        parsed.contains(&flag),
-                        "{flag} is in the usage text but not parsed"
-                    );
-                }
-            }
-        }
-    }
-
-    /// `--output` is required to perturb and ignored when listing, so it must
-    /// not be shown bracketed the way the genuinely optional flags are. That
-    /// bracketing is what #1109's review flagged.
-    #[test]
-    fn output_is_shown_as_required_on_the_form_that_requires_it() {
-        let write_form = USAGE
-            .lines()
-            .find(|line| line.contains("--output"))
-            .expect("a form naming --output");
-        assert!(
-            !write_form.contains("[-o|--output"),
-            "--output is bracketed as optional: {write_form}"
-        );
-        assert!(write_form.contains("-o|--output OUTPUT"), "{write_form}");
-
-        let list_form = USAGE
-            .lines()
-            .find(|line| line.contains("--list-sites"))
-            .expect("a form naming --list-sites");
-        assert!(
-            !list_form.contains("--output"),
-            "the listing form should not name --output: {list_form}"
-        );
-    }
 }

--- a/crates/ptx-schedule/tests/cli.rs
+++ b/crates/ptx-schedule/tests/cli.rs
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
+
+struct Fixture {
+    dir: PathBuf,
+    input: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let id = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("ptx-schedule-cli-{}-{id}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("input.ptx");
+        fs::write(
+            &input,
+            ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n  bar.sync 0;\n  ret;\n}\n",
+        )
+        .unwrap();
+        Self { dir, input }
+    }
+
+    fn output(&self) -> PathBuf {
+        self.dir.join("output.ptx")
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_ptx-schedule"))
+            .arg(&self.input)
+            .args(args)
+            .output()
+            .unwrap()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn run_without_input(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ptx-schedule"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_usage_error(output: Output, fragment: &str, absent: Option<&Path>) {
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(stderr(&output).contains(fragment), "{}", stderr(&output));
+    if let Some(path) = absent {
+        assert!(!path.exists(), "unexpected output at {}", path.display());
+    }
+}
+
+#[test]
+fn help_shows_the_two_exclusive_forms() {
+    let output = run_without_input(&["--help"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ptx-schedule <INPUT.ptx> --list-sites"));
+    assert!(stdout.contains("ptx-schedule <INPUT.ptx> -o <OUTPUT> [OPTIONS]"));
+}
+
+#[test]
+fn malformed_commands_are_named_usage_errors() {
+    assert_usage_error(run_without_input(&[]), "<INPUT.ptx>", None);
+
+    let fixture = Fixture::new();
+    let output_path = fixture.output();
+    for (args, fragment) in [
+        (vec!["--seed"], "value is required"),
+        (vec!["--focus", "--list-sites"], "value is required"),
+        (vec!["--seed", "abc", "-o", "unused.ptx"], "invalid value"),
+        (vec!["--bogus"], "unexpected argument"),
+        (vec!["--list-sites", "--seed", "1"], "cannot be used with"),
+        (vec!["--seed", "1"], "required"),
+    ] {
+        assert_usage_error(fixture.run(&args), fragment, Some(&output_path));
+    }
+}
+
+#[test]
+fn both_valid_modes_execute() {
+    let fixture = Fixture::new();
+    let listed = fixture.run(&["--list-sites"]);
+    assert!(listed.status.success(), "{listed:?}");
+    assert!(String::from_utf8_lossy(&listed.stdout).contains("bar.sync 0"));
+
+    let output_path = fixture.output();
+    let rewritten = fixture.run(&["--seed", "7", "--output", output_path.to_str().unwrap()]);
+    assert!(rewritten.status.success(), "{rewritten:?}");
+    assert!(output_path.is_file());
+}


### PR DESCRIPTION
Follow-up to #1109, whose review flagged it: *"the brackets mark the flag optional, but outside `--list-sites` the output path is required (main.rs exits with the usage message when it is missing). Candidate for a later polish pass."*

## What is wrong

```
usage: ptx-schedule INPUT.ptx [--list-sites] ... [-o|--output OUTPUT] ...
```

One bracketed list cannot state this CLI's shape: `--output` is required to perturb and meaningless when listing, so bracketing it is wrong in one mode and misleading in the other.

It becomes one line per invocation form, which is what `cuda-intrinsics-gen`'s usage text already does for the same reason:

```
usage:
  ptx-schedule INPUT.ptx --list-sites
        print the schedule-sensitive sites as JSON; the options below are ignored
  ptx-schedule INPUT.ptx -o|--output OUTPUT [--seed N] [--intensity F]
        [--max-sleep-ns N] [--focus TEXT] [--decisions-json FILE]
        write a perturbed copy of INPUT.ptx to OUTPUT
```

## The second half of the same problem

Every way to get the command line wrong printed the identical block with nothing said about which way. `usage_because` prefixes the reason, and the six copies of `args.next().unwrap_or_else(|| usage())` — each meaning "this flag needs a value", none saying so — become one `next_value` helper that names the flag. Before, all four of these printed the same wall of text:

```
ptx-schedule                   error: an input PTX file is required
ptx-schedule x.ptx --seed      error: --seed needs a value
ptx-schedule x.ptx --bogus     error: unrecognized argument "--bogus"
ptx-schedule x.ptx --seed 7    error: -o|--output is required unless --list-sites is given
```

Exit code stays 2 in every case. Both working forms are unchanged, verified against a real module: `--list-sites` prints the JSON, and `--seed 7 -o out.ptx` reports `sites=2 injected=2`.

## Verification

Two tests. The first turns #1109's hand-checked parity into an assertion: the usage text names exactly the long flags the parser accepts, both directions, reading the arms out of the source — an arm can name two spellings (`"-o" | "--output"`), so it takes every quoted flag on the line. The second pins the shape this PR is about: `--output` is not bracketed on the form that requires it, and does not appear on the listing form. They fail respectively when a flag is dropped from the text and when the brackets are put back.

The README needs no change — its two examples are already the two forms, one with `-o` and one without.

16 tests pass, fmt clean, `clippy --all-targets -- -D warnings` clean, `cargo doc --document-private-items` clean. One file; no open PR touches it.

## Maintainer repair

- Clap models exactly two forms: list sites, or rewrite to an output file.
- Malformed, missing, and conflicting arguments exit 2 before file access.
- 14 crate tests and 3 CLI integration tests pass, with fmt, strict clippy, rustdoc, and diff checks.