### PR TITLE
feat(wgmma): add register-resident TF32 counted K-loop lowering

### DIFF
--- a/crates/cuda-device/src/wgmma.rs
+++ b/crates/cuda-device/src/wgmma.rs
@@ -20,7 +20,8 @@
 //!
 //! The `m64n64k16.f32.f16.f16` variant supports canonical linear full-drain
 //! regions and the canonical counted K-loop. The `m64n64k8.f32.tf32.tf32`
-//! variant uses the canonical linear full-drain carrier only. The
+//! variant supports the same canonical linear full-drain and counted-loop
+//! shapes. The
 //! `m64n128k16.f32.bf16.bf16` variant supports canonical linear full-drain
 //! regions with a 64-value `[[f32; 8]; 8]` accumulator. Every accepted
 //! asynchronous lifetime is fused into one convergent inline-PTX scope and ends
@@ -87,8 +88,8 @@
 //!   pipeline for F16.
 //! - **TF32 linear full drain:** `m64n64k8.f32.tf32.tf32` uses the same
 //!   canonical accumulator and full-drain lifetime. TF32 has no pointer
-//!   fallback, counted-loop lowering, or partial-wait pipeline.
-//! - **Canonical counted K-loop:** one BF16 or F16 m64n64 MMA per iteration,
+//!   fallback or partial-wait pipeline.
+//! - **Canonical counted K-loop:** one BF16, F16, or TF32 m64n64 MMA per iteration,
 //!   compile-time trip count, and `u64` descriptor recurrences of the form `desc + const`. The
 //!   fence-to-final-wait lifetime is fused so the accumulator is loaded and
 //!   stored once for the whole loop rather than once per iteration.
@@ -101,7 +102,7 @@
 //! - Unsupported BF16 full-drain accumulator pointer shapes retain the deferred
 //!   pointer-form lowering. Dynamic partial waits, unsupported control flow,
 //!   malformed pipeline schedules, F16 partial-wait/pipelined shapes, TF32
-//!   counted-loop or partial-wait shapes, and the legacy K=16 TF32
+//!   partial-wait/pipelined shapes, and the legacy K=16 TF32
 //!   compatibility entry point are rejected.
 //!
 //! # Hardware Support
@@ -310,10 +311,10 @@ pub unsafe fn wgmma_mma_m64n64k16_f32_f16(acc: &mut [[f32; 8]; 4], desc_a: u64, 
 
 /// WGMMA with f32 accumulator and TF32 inputs.
 ///
-/// This variant supports only the canonical linear full-drain region:
-/// `fence -> one or more MMA -> commit_group -> wait_group<0>`. TF32 uses the
-/// hardware K=8 shape; counted loops, partial waits, and non-canonical pointer
-/// fallback remain unsupported.
+/// This variant supports canonical linear full-drain regions and canonical
+/// counted K-loops. TF32 uses the hardware K=8 shape; counted loops require
+/// compile-time trip counts and affine `u64` descriptor recurrences. Partial
+/// waits and non-canonical pointer fallback remain unsupported.
 ///
 /// # PTX
 ///

--- a/crates/cuda-oxide-codegen/tests/wgmma_counted_loop_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_counted_loop_ptx.rs
@@ -11,7 +11,7 @@
 //! branches. This probe builds the canonical pointer-form K-loop (trip count
 //! 4, one MMA in the latch, affine descriptor recurrences), lets the deferred
 //! accumulator fusion rewrite it into the counted-loop asm scope, and then
-//! requires `llc` and `ptxas -arch=sm_90a` to accept both BF16 and F16 forms
+//! requires `llc` and `ptxas -arch=sm_90a` to accept BF16, F16, and TF32 forms
 //! with zero spill bytes while all 32 accumulator values stay live.
 
 #![cfg(unix)]
@@ -25,8 +25,8 @@ use dialect_mir::{
     types::{MirArrayType, MirPtrType},
 };
 use dialect_nvvm::ops::{
-    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaWaitGroupSyncAlignedOp,
+    WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaM64N64K8F32Tf32Op,
+    WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 use pliron::builtin::attributes::IntegerAttr;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -55,13 +55,15 @@ const DESC_B_STEP: u64 = 32;
 enum WgmmaInputKind {
     Bf16,
     F16,
+    Tf32,
 }
 
 impl WgmmaInputKind {
-    fn ptx_suffix(self) -> &'static str {
+    fn ptx_mnemonic(self) -> &'static str {
         match self {
-            Self::Bf16 => "bf16.bf16",
-            Self::F16 => "f16.f16",
+            Self::Bf16 => "wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16",
+            Self::F16 => "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16",
+            Self::Tf32 => "wgmma.mma_async.sync.aligned.m64n64k8.f32.tf32.tf32",
         }
     }
 }
@@ -214,6 +216,7 @@ fn build_wgmma_counted_loop_kernel(module: &mut CodegenModule, input_kind: Wgmma
         let mma_op_info = match input_kind {
             WgmmaInputKind::Bf16 => WgmmaMmaM64N64K16F32Bf16Op::get_concrete_op_info(),
             WgmmaInputKind::F16 => WgmmaMmaM64N64K16F32F16Op::get_concrete_op_info(),
+            WgmmaInputKind::Tf32 => WgmmaMmaM64N64K8F32Tf32Op::get_concrete_op_info(),
         };
         Operation::new(
             ctx,
@@ -364,12 +367,9 @@ fn assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(input_kin
         1,
         "the counted loop must contain exactly one fence:\n{text}",
     );
-    let expected_mma = format!(
-        "wgmma.mma_async.sync.aligned.m64n64k16.f32.{}",
-        input_kind.ptx_suffix()
-    );
+    let expected_mma = input_kind.ptx_mnemonic();
     assert_eq!(
-        text.matches(&expected_mma).count(),
+        text.matches(expected_mma).count(),
         1,
         "the loop body must contain exactly one {input_kind:?} MMA:\n{text}",
     );
@@ -460,4 +460,9 @@ fn bf16_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
 #[test]
 fn f16_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
     assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(WgmmaInputKind::F16);
+}
+
+#[test]
+fn tf32_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a() {
+    assert_counted_k_loop_wgmma_template_compiles_spill_free_for_sm_90a(WgmmaInputKind::Tf32);
 }

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -21,11 +21,10 @@
 //! depths can keep committed groups in flight without exposing an in-flight
 //! accumulator to LLVM. The pointer-form group remains the deferred fallback.
 //!
-//! F16 uses the same 32-value accumulator model for canonical linear
-//! full-drain regions and the canonical counted K-loop. TF32 uses the same
-//! carrier only for canonical linear full-drain regions, with the hardware
+//! F16 and TF32 use the same 32-value accumulator model for canonical linear
+//! full-drain regions and the canonical counted K-loop. TF32 uses the hardware
 //! `m64n64k8` shape. Neither F16 nor TF32 has a deferred pointer-form group or
-//! partial-wait pipeline carrier, and TF32 has no counted-loop carrier.
+//! partial-wait pipeline carrier.
 
 use dialect_mir::types::{MirPtrType, address_space};
 use pliron::{
@@ -1027,6 +1026,120 @@ impl Verify for WgmmaMmaLoopValuesM64N64K16F32F16Op {
     }
 }
 
+/// Value-form TF32 WGMMA counted loop with 32 SSA accumulator values.
+///
+/// Operand layout:
+///
+/// ```text
+/// [
+///   acc_0, ..., acc_31,
+///   desc_a_base, desc_b_base,
+///   desc_a_step, desc_b_step,
+///   trip_count,
+/// ]
+/// ```
+///
+/// Result layout:
+///
+/// ```text
+/// [acc_0', ..., acc_31']
+/// ```
+///
+/// The operation owns one complete asynchronous WGMMA lifetime. It fences the
+/// accumulator registers, executes one MMA per counted-loop iteration while
+/// advancing both descriptors by their supplied descriptor deltas,
+/// commits the resulting group, and performs a final `wait_group<0>` before the
+/// 32 accumulator values become visible to LLVM again.
+#[pliron_op(name = "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32", format)]
+pub struct WgmmaMmaLoopValuesM64N64K8F32Tf32Op;
+
+impl WgmmaMmaLoopValuesM64N64K8F32Tf32Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+
+    /// Build a counted-loop group from 32 accumulators and loop-control values.
+    pub fn build(
+        ctx: &mut Context,
+        accumulators: Vec<Value>,
+        desc_a_base: Value,
+        desc_b_base: Value,
+        desc_a_step: Value,
+        desc_b_step: Value,
+        trip_count: Value,
+    ) -> Ptr<Operation> {
+        let f32_ty = FP32Type::get(ctx);
+        let mut operands =
+            Vec::with_capacity(accumulators.len() + WGMMA_COUNTED_LOOP_CONTROL_COUNT);
+        operands.extend(accumulators);
+        operands.extend([
+            desc_a_base,
+            desc_b_base,
+            desc_a_step,
+            desc_b_step,
+            trip_count,
+        ]);
+
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![f32_ty.into(); WGMMA_M64N64_F32_ACCUMULATOR_COUNT],
+            operands,
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for WgmmaMmaLoopValuesM64N64K8F32Tf32Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let expected_operands =
+            WGMMA_M64N64_F32_ACCUMULATOR_COUNT + WGMMA_COUNTED_LOOP_CONTROL_COUNT;
+
+        if op.get_num_operands() != expected_operands {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32 requires 32 f32 accumulators and exactly five u64 loop-control operands"
+            );
+        }
+
+        if op.get_num_results() != WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32 requires exactly 32 f32 results"
+            );
+        }
+
+        for accumulator_index in 0..WGMMA_M64N64_F32_ACCUMULATOR_COUNT {
+            if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32 accumulator operands must be f32"
+                );
+            }
+            if !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32 results must be f32"
+                );
+            }
+        }
+
+        for control_index in WGMMA_M64N64_F32_ACCUMULATOR_COUNT..expected_operands {
+            if !is_u64(ctx, op.get_operand(control_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_loop_values_m64n64k8_f32_tf32 descriptor bases, descriptor steps, and trip count must be u64"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Value-form BF16 WGMMA counted loop with independent accumulator slots.
 ///
 /// This deliberately narrow carrier supports the production counted-loop
@@ -1351,6 +1464,7 @@ pub(super) fn register(ctx: &mut Context) {
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op::register(ctx);
     WgmmaMmaLoopValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaLoopValuesM64N64K16F32F16Op::register(ctx);
+    WgmmaMmaLoopValuesM64N64K8F32Tf32Op::register(ctx);
     WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op::register(ctx);
 }

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -41,10 +41,10 @@ use dialect_nvvm::ops::{
     WgmmaMakeSmemDescOp, WgmmaMaxPendingAttr, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
-    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K8F32Tf32Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
 #[test]
@@ -104,6 +104,7 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K8F32Tf32Op"),
         ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32F16Op"),
+        ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K8F32Tf32Op"),
         ("wgmma.rs", "WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaPipelineValuesM64N64K16F32Bf16Op"),
     ];
@@ -4954,6 +4955,43 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
         WgmmaMmaLoopValuesM64N64K16F32F16Op::new(f16_loop_group)
             .verify(&ctx)
             .is_ok()
+    );
+
+    let tf32_loop_group = WgmmaMmaLoopValuesM64N64K8F32Tf32Op::build(
+        &mut ctx,
+        vec![f32_value; 32],
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+        u64_value,
+    );
+    {
+        let loop_group_ref = tf32_loop_group.deref(&ctx);
+        assert_eq!(loop_group_ref.get_num_operands(), 37);
+        assert_eq!(loop_group_ref.get_num_results(), 32);
+    }
+    assert!(
+        WgmmaMmaLoopValuesM64N64K8F32Tf32Op::new(tf32_loop_group)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let mut tf32_wrong_loop_control_operands = vec![f32_value; 32];
+    tf32_wrong_loop_control_operands
+        .extend([u64_value, u64_value, u32_value, u64_value, u64_value]);
+    let tf32_wrong_loop_control = Operation::new(
+        &mut ctx,
+        WgmmaMmaLoopValuesM64N64K8F32Tf32Op::get_concrete_op_info(),
+        vec![f32_ty.into(); 32],
+        tf32_wrong_loop_control_operands,
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaLoopValuesM64N64K8F32Tf32Op::new(tf32_wrong_loop_control)
+            .verify(&ctx)
+            .is_err()
     );
 
     let mut f16_wrong_loop_control_operands = vec![f32_value; 32];

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wgmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wgmma.rs
@@ -272,9 +272,9 @@ pub fn emit_wgmma_mma_m64n128k16_f32_bf16(
 
 /// Emit F16 m64n64k16 WGMMA pointer form.
 ///
-/// `mir-lower` accepts this variant only in a canonical linear full-drain
-/// region ending in `wait_group<0>`. Counted loops and partial-wait pipelines
-/// remain BF16-only.
+/// `mir-lower` accepts this variant in canonical linear full-drain regions
+/// ending in `wait_group<0>` and in the canonical counted K-loop. Partial-wait
+/// pipelines and pointer fallback remain unsupported for F16.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_wgmma_mma_m64n64k16_f32_f16(
     ctx: &mut Context,
@@ -313,9 +313,9 @@ pub fn emit_wgmma_mma_m64n64k16_f32_f16(
 
 /// Emit TF32 m64n64k8 WGMMA pointer form.
 ///
-/// `mir-lower` accepts this variant only in a canonical linear full-drain
-/// region ending in `wait_group<0>`. Counted loops, partial-wait pipelines,
-/// and pointer fallback remain BF16-only.
+/// `mir-lower` accepts this variant in a canonical linear full-drain region
+/// ending in `wait_group<0>` or the canonical counted K-loop. Partial-wait
+/// pipelines and pointer fallback remain unsupported for TF32.
 pub fn emit_wgmma_mma_m64n64k8_f32_tf32(
     ctx: &mut Context,
     body: &mir::Body,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -42,10 +42,10 @@ use dialect_nvvm::ops::{
     ReadPtxSregNclusterIdOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
-    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K8F32Tf32Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
 // ---- Arithmetic ops --------------------------------------------------------
@@ -1221,6 +1221,23 @@ impl MirToLlvmConversion for WgmmaMmaLoopValuesM64N64K16F32F16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma_loop_values_f16(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaLoopValuesM64N64K8F32Tf32Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma_loop_values_tf32(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -34,16 +34,6 @@ enum WgmmaInputKind {
     Tf32,
 }
 
-impl WgmmaInputKind {
-    fn ptx_suffix(self) -> &'static str {
-        match self {
-            Self::Bf16 => "bf16.bf16",
-            Self::F16 => "f16.f16",
-            Self::Tf32 => unreachable!("TF32 has no counted K-loop lowering"),
-        }
-    }
-}
-
 /// Convert WGMMA make_smem_desc to inline PTX.
 pub(crate) fn convert_make_smem_desc(
     ctx: &mut Context,
@@ -208,10 +198,23 @@ fn counted_loop_template(input_kind: WgmmaInputKind) -> String {
     template.push_str("    setp.eq.u64 %loop_more, %remaining, 0;\n");
     template.push_str("    @%loop_more bra.uni L__wgmma_done_${:uid};\n");
     template.push_str("L__wgmma_loop_${:uid}:\n");
-    let input_types = input_kind.ptx_suffix();
+    let (mnemonic, controls) = match input_kind {
+        WgmmaInputKind::Bf16 => (
+            "wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16",
+            "1, 1, 1, 0, 0",
+        ),
+        WgmmaInputKind::F16 => (
+            "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16",
+            "1, 1, 1, 0, 0",
+        ),
+        WgmmaInputKind::Tf32 => (
+            "wgmma.mma_async.sync.aligned.m64n64k8.f32.tf32.tf32",
+            "1, 1, 1",
+        ),
+    };
     template.push_str(&format!(
-        "    wgmma.mma_async.sync.aligned.m64n64k16.f32.{input_types} \
-         {{{accumulators}}}, %desc_a, %desc_b, 1, 1, 1, 0, 0;\n"
+        "    {mnemonic} \
+         {{{accumulators}}}, %desc_a, %desc_b, {controls};\n"
     ));
     template.push_str(&format!("    add.u64 %desc_a, %desc_a, ${desc_a_step};\n"));
     template.push_str(&format!("    add.u64 %desc_b, %desc_b, ${desc_b_step};\n"));
@@ -526,6 +529,16 @@ pub(crate) fn convert_mma_loop_values_f16(
     _operands_info: &OperandsInfo,
 ) -> Result<()> {
     convert_mma_loop_values_for_kind(ctx, rewriter, op, WgmmaInputKind::F16)
+}
+
+/// Lower a counted TF32 WGMMA K-loop to one multi-result inline-PTX scope.
+pub(crate) fn convert_mma_loop_values_tf32(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    convert_mma_loop_values_for_kind(ctx, rewriter, op, WgmmaInputKind::Tf32)
 }
 
 /// Lower one counted WGMMA K-loop to a tied-register inline-PTX scope.
@@ -965,6 +978,32 @@ mod tests {
         assert!(template.contains("add.u64 %desc_a, %desc_a, $66;"));
         assert!(template.contains("add.u64 %desc_b, %desc_b, $67;"));
         assert!(template.contains("mov.u64 %remaining, $68;"));
+        assert!(!template.contains("ld.f32"));
+        assert!(!template.contains("st.f32"));
+        assert!(!template.contains(".reg .f32"));
+    }
+
+    #[test]
+    fn tf32_counted_loop_template_uses_k8_without_transpose_operands() {
+        let template = counted_loop_template(WgmmaInputKind::Tf32);
+        assert_eq!(template.matches("wgmma.mma_async").count(), 1);
+        assert!(template.contains("m64n64k8.f32.tf32.tf32"));
+        assert!(!template.contains("m64n64k16"));
+        assert!(!template.contains(".bf16.bf16"));
+        assert!(!template.contains(".f16.f16"));
+        assert!(template.contains("%desc_a, %desc_b, 1, 1, 1;"));
+        assert!(!template.contains("1, 1, 1, 0, 0"));
+        assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+        assert_eq!(
+            template.matches("wgmma.commit_group.sync.aligned").count(),
+            1
+        );
+        assert_eq!(
+            template.matches("wgmma.wait_group.sync.aligned 0").count(),
+            1
+        );
+        assert!(template.contains("L__wgmma_loop_${:uid}:"));
+        assert!(template.contains("L__wgmma_done_${:uid}:"));
         assert!(!template.contains("ld.f32"));
         assert!(!template.contains("st.f32"));
         assert!(!template.contains(".reg .f32"));

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Fuse sound BF16 WGMMA sequences, canonical F16 full-drain and counted
-//! K-loop regions, and canonical TF32 full-drain regions before MIR-to-LLVM
+//! Fuse sound BF16 WGMMA sequences and canonical F16/TF32 full-drain and
+//! counted K-loop regions before MIR-to-LLVM
 //! conversion.
 //!
 //! The public MMA operation exposes its accumulator through a pointer, but PTX
@@ -15,9 +15,8 @@
 //! values. BF16 m64n128 linear full drains use a canonical `[[f32; 8]; 8]`
 //! accumulator and 64 scalar SSA values. Unsupported m64n64 BF16 accumulator
 //! shapes retain the existing deferred pointer fallback.
-//! F16 m64n64 is accepted for the canonical accumulator in linear full-drain
-//! regions and the canonical single-slot counted K-loop. TF32 is accepted only
-//! for the canonical m64n64 accumulator in a linear full-drain region, using
+//! F16 and TF32 m64n64 are accepted for the canonical accumulator in linear
+//! full-drain regions and the canonical single-slot counted K-loop. TF32 uses
 //! the hardware `m64n64k8.f32.tf32.tf32` shape. BF16 m64n128 is accepted only
 //! for canonical linear full-drain regions. Partial waits, counted pipelines,
 //! and pointer fallback remain m64n64-BF16-only.
@@ -33,7 +32,7 @@
 //! wgmma.wait_group<0>
 //! ```
 //!
-//! A BF16 or F16 counted K-loop may place the fence in the loop preheader, one
+//! A BF16, F16, or TF32 counted K-loop may place the fence in the loop preheader, one
 //! pointer-form MMA in the unique latch, and the commit/final `wait_group<0>` in
 //! the unique exit. The loop must have a compile-time trip count and two `u64`
 //! descriptor block arguments whose back-edge values are either unchanged or `arg + const`.
@@ -67,10 +66,11 @@ use dialect_nvvm::ops::{
     WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
-    WgmmaMmaPipelineValuesM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
+    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K8F32Tf32Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaWaitGroupSyncAlignedOp,
 };
 use mir_transforms::analyses::{induction, loop_info::LoopInfo};
 use pliron::{
@@ -761,8 +761,11 @@ fn match_counted_loop(
     let [(mma, kind)] = mmas.as_slice() else {
         return Ok(None);
     };
-    if !matches!(*kind, WgmmaMmaKind::Bf16M64N64 | WgmmaMmaKind::F16M64N64) {
-        // Only BF16/F16 m64n64 have counted-loop carriers; leave the region
+    if !matches!(
+        *kind,
+        WgmmaMmaKind::Bf16M64N64 | WgmmaMmaKind::F16M64N64 | WgmmaMmaKind::Tf32M64N64
+    ) {
+        // Only m64n64 BF16/F16/TF32 have counted-loop carriers; leave the region
         // for the linear matcher, which rejects unsupported shapes.
         return Ok(None);
     }
@@ -1464,7 +1467,16 @@ fn apply_counted_loop_plan(ctx: &mut Context, plan: CountedLoopPlan) {
             desc_b_step,
             trip_count,
         ),
-        WgmmaMmaKind::Tf32M64N64 | WgmmaMmaKind::Bf16M64N128 => {
+        WgmmaMmaKind::Tf32M64N64 => WgmmaMmaLoopValuesM64N64K8F32Tf32Op::build(
+            ctx,
+            accumulator_values,
+            desc_a_base,
+            desc_b_base,
+            desc_a_step,
+            desc_b_step,
+            trip_count,
+        ),
+        WgmmaMmaKind::Bf16M64N128 => {
             unreachable!("counted-loop matching rejects this variant before planning")
         }
     };

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -11314,12 +11314,14 @@ fn test_f16_wgmma_counted_k_loop_stays_register_resident() -> Result<(), anyhow:
 }
 
 #[test]
-fn test_tf32_wgmma_counted_k_loop_remains_unsupported() -> Result<(), anyhow::Error> {
+fn test_tf32_wgmma_counted_k_loop_stays_register_resident() -> Result<(), anyhow::Error> {
     use dialect_mir::types::{MirArrayType, MirPtrType};
     use pliron::basic_block::BasicBlock;
     use pliron::builtin::op_interfaces::OperandSegmentInterface;
     use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
 
+    const ACCUMULATOR_LEN: usize = 32;
+    const LOOP_CONTROL_COUNT: usize = 5;
     const TRIP_COUNT: u64 = 4;
     const DESC_A_STEP: u64 = 16;
     const DESC_B_STEP: u64 = 32;
@@ -11464,11 +11466,134 @@ fn test_tf32_wgmma_counted_k_loop_remains_unsupported() -> Result<(), anyhow::Er
     append_wgmma_wait_group_constant(&mut ctx, exit, 0);
     append_return(&mut ctx, exit);
 
-    assert_wgmma_lowering_rejected(
-        &mut ctx,
-        module_ptr,
-        "WGMMA MMA reached lowering without deferred accumulator fusion",
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let body = lowered_kernel_body(&ctx, module_ptr);
+    let matching = body
+        .iter()
+        .copied()
+        .filter_map(|operation| {
+            Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx)
+                .map(|inline_asm| (operation, inline_asm))
+        })
+        .filter(|(_, asm)| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("L__wgmma_loop_${:uid}:"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one fused TF32 counted-loop WGMMA asm"
     );
+
+    let (asm_operation, asm) = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("TF32 counted-loop WGMMA template");
+
+    assert_eq!(template.matches("wgmma.fence.sync.aligned").count(), 1);
+    assert_eq!(
+        template
+            .matches("wgmma.mma_async.sync.aligned.m64n64k8.f32.tf32.tf32")
+            .count(),
+        1,
+        "the TF32 counted-loop template must contain exactly one TF32 MMA"
+    );
+    assert!(!template.contains("m64n64k16"));
+    assert!(!template.contains(".bf16.bf16"));
+    assert!(!template.contains(".f16.f16"));
+    assert!(template.contains("%desc_a, %desc_b, 1, 1, 1;"));
+    assert!(!template.contains("1, 1, 1, 0, 0"));
+    assert_eq!(
+        template.matches("wgmma.commit_group.sync.aligned").count(),
+        1
+    );
+    assert_eq!(
+        template.matches("wgmma.wait_group.sync.aligned 0").count(),
+        1
+    );
+    assert!(template.contains("mov.u64 %desc_a, $64;"));
+    assert!(template.contains("mov.u64 %desc_b, $65;"));
+    assert!(template.contains("add.u64 %desc_a, %desc_a, $66;"));
+    assert!(template.contains("add.u64 %desc_b, %desc_b, $67;"));
+    assert!(template.contains("mov.u64 %remaining, $68;"));
+    assert!(template.contains("@%loop_more bra.uni L__wgmma_done_${:uid};"));
+    assert!(template.contains("@%loop_more bra.uni L__wgmma_loop_${:uid};"));
+    assert!(template.contains("L__wgmma_done_${:uid}:"));
+    assert!(
+        !template.contains(".reg .f32")
+            && !template.contains("ld.f32")
+            && !template.contains("st.f32"),
+        "TF32 counted-loop WGMMA must keep accumulator memory outside asm: {template}"
+    );
+
+    let mut expected_constraints = vec!["=f".to_owned(); ACCUMULATOR_LEN];
+    expected_constraints.extend((0..ACCUMULATOR_LEN).map(|index| index.to_string()));
+    expected_constraints.extend((0..LOOP_CONTROL_COUNT).map(|_| "l".to_owned()));
+    expected_constraints.push("~{memory}".to_owned());
+    let expected_constraints = expected_constraints.join(",");
+    assert_eq!(
+        asm.get_attr_inline_asm_constraints(&ctx)
+            .map(|value| String::from((*value).clone()))
+            .as_deref(),
+        Some(expected_constraints.as_str())
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+    assert_eq!(
+        asm_operation.deref(&ctx).get_num_operands(),
+        ACCUMULATOR_LEN + LOOP_CONTROL_COUNT
+    );
+
+    let asm_position = body
+        .iter()
+        .position(|operation| operation == asm_operation)
+        .expect("TF32 counted-loop WGMMA asm must be in the lowered kernel body");
+
+    let load_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::LoadOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        load_positions.len(),
+        ACCUMULATOR_LEN,
+        "TF32 K-loop accumulator must be loaded exactly once"
+    );
+    assert!(load_positions.iter().all(|index| *index < asm_position));
+
+    let store_positions = body
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| {
+            Operation::get_op::<llvm::StoreOp>(*operation, &ctx)
+                .is_some()
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        store_positions.len(),
+        ACCUMULATOR_LEN,
+        "TF32 K-loop accumulator must be stored exactly once after the final wait"
+    );
+    assert!(store_positions.iter().all(|index| *index > asm_position));
+
+    assert_eq!(
+        body.iter()
+            .filter(
+                |operation| Operation::get_op::<llvm::ExtractValueOp>(**operation, &ctx).is_some()
+            )
+            .count(),
+        ACCUMULATOR_LEN
+    );
+
     Ok(())
 }
 

--- a/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
+++ b/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
@@ -124,10 +124,10 @@ hardware shape uses K=8.
 ### Current cuda-oxide WGMMA lowering
 
 The compiler supports `m64n64k16.f32.bf16.bf16` across three conservative
-lowering shapes, `m64n64k16.f32.f16.f16` for canonical linear full-drain and
-counted K-loop regions, `m64n64k8.f32.tf32.tf32` for canonical linear
-full-drain regions only, and `m64n128k16.f32.bf16.bf16` for canonical linear
-full-drain regions. In every accepted case, the entire asynchronous
+lowering shapes, `m64n64k16.f32.f16.f16` and `m64n64k8.f32.tf32.tf32` for
+canonical linear full-drain and counted K-loop regions, and
+`m64n128k16.f32.bf16.bf16` for canonical linear full-drain regions. In every
+accepted case, the entire asynchronous
 accumulator lifetime stays inside one convergent inline-PTX statement so LLVM
 cannot insert a spill boundary while a WGMMA group is pending.
 
@@ -144,7 +144,7 @@ carried as 64 tied SSA `f32` values through one or more homogeneous
 inline-PTX scope instead of being kept live across it. This shape has no
 pointer-form fallback, counted-loop lowering, or partial-wait pipeline lowering.
 
-**Canonical counted K-loop.** For a compile-time counted BF16 or F16 m64n64
+**Canonical counted K-loop.** For a compile-time counted BF16, F16, or TF32 m64n64
 loop with one MMA per iteration and affine `u64` descriptor recurrences,
 cuda-oxide moves the loop control and descriptor arithmetic into the same
 convergent PTX region as the WGMMA instruction. The accumulator is therefore
@@ -172,7 +172,7 @@ escapes the fused region.
 
 Selection is intentionally fail-closed. Dynamic partial waits, unsupported
 control flow, malformed accumulator schedules, F16 partial-wait shapes, TF32
-counted-loop or partial-wait shapes, m64n128 counted-loop or partial-wait
+partial-wait shapes, m64n128 counted-loop or partial-wait
 shapes, F16/TF32/m64n128 non-canonical accumulators, and the legacy K=16 TF32
 compatibility entry point are rejected instead of exposing an in-flight
 accumulator to LLVM.

--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -297,7 +297,7 @@ they become `call` instructions to `@llvm.nvvm.*` intrinsics.
 ### Architecture Coverage
 
 At catalog SHA-256 `00372dfe` (the stamp in every `ops/generated/` file
-header), the dialect holds 575 operations across 42 modules, and they come
+header), the dialect holds 576 operations across 42 modules, and they come
 from two different places. The split is the first thing to know about it,
 because it decides where -- and whether -- you would add one. If the header
 stamp no longer starts with `00372dfe`, the counts on this page predate the
@@ -305,7 +305,7 @@ catalog you are reading.
 
 **Hand-written**, directly under `crates/dialect-nvvm/src/ops/`. These are the
 ops with bespoke verification or lowering that the intrinsic catalog does not
-describe. There are seven modules and 26 operations:
+describe. There are seven modules and 27 operations:
 
 | Module    | Description                                                 | Ops |
 | :-------- | :---------------------------------------------------------- | --: |
@@ -315,7 +315,7 @@ describe. There are seven modules and 26 operations:
 | `debug`   | `assertfail`, `vprintf`                                     |   2 |
 | `grid`    | Cooperative `grid_sync`                                     |   1 |
 | `memory`  | Generic-to-shared address conversion with a byte offset     |   1 |
-| `wgmma`   | Warpgroup MMA descriptors; bf16/f16 at m64n64k16, bf16 at m64n128k16, tf32 at m64n64k8 |  14 |
+| `wgmma`   | Warpgroup MMA descriptors; bf16/f16 at m64n64k16, bf16 at m64n128k16, tf32 at m64n64k8 |  15 |
 
 **Generated**, under `ops/generated/`, from `intrinsics/catalog.json` by
 `cuda-intrinsics-gen`. Every file there opens with `// @generated ... DO NOT


### PR DESCRIPTION
Closes #1146 

## Summary

Adds register-resident counted K-loop lowering for canonical TF32 `m64n64k8` WGMMA.

This extends the existing BF16/F16 counted-loop infrastructure to:

```text
wgmma.mma_async.sync.aligned.m64n64k8.f32.tf32.tf32
```

while preserving the current fail-closed behavior for unsupported TF32 pipeline shapes.

## What changed

* adds an internal TF32 counted-loop value carrier:

  * `WgmmaMmaLoopValuesM64N64K8F32Tf32Op`
* allows `Tf32M64N64` in the canonical single-slot counted-loop recognizer
* lowers the carrier through one convergent inline PTX region
* uses the TF32-specific K8 mnemonic and control operands:

  * `m64n64k8.f32.tf32.tf32`
  * `1, 1, 1`
* keeps the 32 `f32` accumulators register-resident across the counted loop
* adds dialect, lowering, and backend regression coverage
* updates WGMMA documentation and handwritten dialect operation counts

The counted-loop PTX generation was made shape-aware rather than extending the existing BF16/F16 suffix logic, since TF32 differs in both K dimension and control operands.

## Supported shape

The new lowering accepts the same canonical counted-loop topology as the existing BF16/F16 path:

* `[[f32; 8]; 4]` accumulator
* one TF32 WGMMA per iteration
* positive compile-time trip count
* affine `u64` A/B descriptor recurrences
* one final `commit_group`
* one final `wait_group 0`

## Intentionally unsupported

This PR does not enable:

* TF32 partial waits
* TF32 multi-slot counted pipelines
* dynamic trip counts
* arbitrary CFG loops
* non-canonical accumulator layouts
* non-canonical pointer fallback
* legacy K16 TF32 lowering
* wider TF32 WGMMA shapes

Those paths continue to fail closed.

## Validation

Validated with:

```text
cargo fmt --all -- --check
git diff --check

cargo clippy \
  -p dialect-nvvm \
  -p mir-lower \
  -p cuda-device \
  -p cuda-oxide-codegen \
  --all-targets -- -D warnings
```

Targeted lowering tests:

```text
test_tf32_wgmma_counted_k_loop_stays_register_resident ... ok
test_tf32_wgmma_partial_wait_remains_unsupported ... ok
```

Backend validation:

```text
cargo test -p cuda-oxide-codegen \
  --test wgmma_counted_loop_ptx \
  -- --nocapture
```

Results on `sm_90a`:

```text
TF32: 58 registers, 0-byte stack frame, 0 spill stores, 0 spill loads
BF16: 58 registers, 0-byte stack frame, 0 spill stores, 0 spill loads
F16: 58 registers, 0-byte stack frame, 0 spill stores, 0 spill loads
```

All three counted-loop backend probes pass.

The book/catalog consistency guard also passes:

```text
OK: cuda-oxide-book/compiler/mlir-dialects.md stamps 00372dfe,
matching intrinsics/catalog.json and crates/dialect-nvvm/src/ops/generated.
```
