### PR TITLE
feat(wgmma): add m64n128 F16 full-drain carrier

### DIFF
--- a/crates/cuda-device/src/wgmma.rs
+++ b/crates/cuda-device/src/wgmma.rs
@@ -21,8 +21,9 @@
 //! The `m64n64k16.f32.f16.f16` variant supports canonical linear full-drain
 //! regions and the canonical counted K-loop. The `m64n64k8.f32.tf32.tf32`
 //! variant uses the canonical linear full-drain carrier only. The
-//! `m64n128k16.f32.bf16.bf16` variant supports canonical linear full-drain
-//! regions with a 64-value `[[f32; 8]; 8]` accumulator. Every accepted
+//! `m64n128k16.f32.bf16.bf16` and `m64n128k16.f32.f16.f16` variants support
+//! canonical linear full-drain regions with a 64-value `[[f32; 8]; 8]`
+//! accumulator. Every accepted
 //! asynchronous lifetime is fused into one convergent inline-PTX scope and ends
 //! in `wait_group<0>` before accumulator values become visible to LLVM again.
 //! Unsupported m64n64 BF16 full-drain pointer shapes retain the deferred
@@ -77,7 +78,7 @@
 //!
 //! - **BF16 linear full drain:** one canonical `[[f32; 8]; 4]` accumulator,
 //!   one commit, and a final `wgmma_wait_group::<0>()`.
-//! - **BF16 m64n128 linear full drain:** one canonical `[[f32; 8]; 8]`
+//! - **BF16/F16 m64n128 linear full drain:** one canonical `[[f32; 8]; 8]`
 //!   accumulator carries 64 `f32` values through one or more homogeneous
 //!   m64n128 MMAs, one commit, and a final `wgmma_wait_group::<0>()`. There is
 //!   no pointer fallback, counted-loop lowering, or partial-wait pipeline for
@@ -278,6 +279,33 @@ pub unsafe fn wgmma_mma_m64n64k16_f32_bf16(acc: &mut [[f32; 8]; 4], desc_a: u64,
 pub unsafe fn wgmma_mma_m64n128k16_f32_bf16(acc: &mut [[f32; 8]; 8], desc_a: u64, desc_b: u64) {
     let _ = (acc, desc_a, desc_b);
     unreachable!("wgmma_mma_m64n128k16_f32_bf16 called outside CUDA kernel context")
+}
+
+/// Warpgroup matrix multiply-accumulate: 64x128x16 F16 with f32 accumulation.
+///
+/// The 64x128 output tile is distributed as 64 `f32` accumulator values per
+/// thread, represented by `[[f32; 8]; 8]`. This variant supports canonical
+/// linear full-drain regions only.
+///
+/// # PTX
+///
+/// ```ptx
+/// wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16
+///     {%f0, %f1, ..., %f63}, %rd_desc_a, %rd_desc_b,
+///     1, 1, 1, 0, 0;
+/// ```
+///
+/// # Safety
+///
+/// - Descriptors must be valid SMEM descriptors
+/// - Must be called by all threads in a warpgroup
+/// - Must be called from within a CUDA kernel context on sm_90a
+/// - `acc` must not be read or written until the region's final
+///   `wgmma_wait_group::<0>()` returns
+#[inline(never)]
+pub unsafe fn wgmma_mma_m64n128k16_f32_f16(acc: &mut [[f32; 8]; 8], desc_a: u64, desc_b: u64) {
+    let _ = (acc, desc_a, desc_b);
+    unreachable!("wgmma_mma_m64n128k16_f32_f16 called outside CUDA kernel context")
 }
 
 /// WGMMA with f32 accumulator and f16 inputs.

--- a/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/wgmma_value_carrier_ptx.rs
@@ -7,7 +7,7 @@
 //! values through one inline-PTX operation and produce spill-free `sm_90a` code.
 //!
 //! The probe covers the 32-value m64n64 BF16/F16/TF32 carriers and the
-//! 64-value m64n128 BF16 carrier, for a single `wgmma.mma_async` and a chain
+//! 64-value m64n128 BF16/F16 carriers, for a single `wgmma.mma_async` and a chain
 //! of several under one fence/commit/wait sequence in the same asm region.
 
 #![cfg(unix)]
@@ -43,13 +43,14 @@ enum WgmmaCarrierKind {
     F16M64N64,
     Tf32M64N64,
     Bf16M64N128,
+    F16M64N128,
 }
 
 impl WgmmaCarrierKind {
     fn accumulator_len(self) -> usize {
         match self {
             Self::Bf16M64N64 | Self::F16M64N64 | Self::Tf32M64N64 => M64N64_ACCUMULATOR_LEN,
-            Self::Bf16M64N128 => M64N128_ACCUMULATOR_LEN,
+            Self::Bf16M64N128 | Self::F16M64N128 => M64N128_ACCUMULATOR_LEN,
         }
     }
 
@@ -59,12 +60,15 @@ impl WgmmaCarrierKind {
             Self::F16M64N64 => "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16",
             Self::Tf32M64N64 => "wgmma.mma_async.sync.aligned.m64n64k8.f32.tf32.tf32",
             Self::Bf16M64N128 => "wgmma.mma_async.sync.aligned.m64n128k16.f32.bf16.bf16",
+            Self::F16M64N128 => "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16",
         }
     }
 
     fn control_operands(self) -> &'static str {
         match self {
-            Self::Bf16M64N64 | Self::F16M64N64 | Self::Bf16M64N128 => "1, 1, 1, 0, 0",
+            Self::Bf16M64N64 | Self::F16M64N64 | Self::Bf16M64N128 | Self::F16M64N128 => {
+                "1, 1, 1, 0, 0"
+            }
             Self::Tf32M64N64 => "1, 1, 1",
         }
     }
@@ -330,7 +334,8 @@ fn assert_spill_free_value_carrier(kind: WgmmaCarrierKind, mma_count: usize) {
     match kind {
         WgmmaCarrierKind::Bf16M64N64
         | WgmmaCarrierKind::F16M64N64
-        | WgmmaCarrierKind::Bf16M64N128 => {
+        | WgmmaCarrierKind::Bf16M64N128
+        | WgmmaCarrierKind::F16M64N128 => {
             assert!(
                 text.contains("1, 1, 1, 0, 0;"),
                 "K=16 WGMMA must carry transpose controls:\n{text}"
@@ -458,6 +463,16 @@ fn bf16_m64n128_wgmma_uses_sixty_four_tied_f32_values_without_spills() {
 #[test]
 fn bf16_m64n128_wgmma_chains_two_mma_async_under_one_commit_without_spills() {
     assert_spill_free_value_carrier(WgmmaCarrierKind::Bf16M64N128, 2);
+}
+
+#[test]
+fn f16_m64n128_wgmma_uses_sixty_four_tied_f32_values_without_spills() {
+    assert_spill_free_value_carrier(WgmmaCarrierKind::F16M64N128, 1);
+}
+
+#[test]
+fn f16_m64n128_wgmma_chains_two_mma_async_under_one_commit_without_spills() {
+    assert_spill_free_value_carrier(WgmmaCarrierKind::F16M64N128, 2);
 }
 
 #[test]

--- a/crates/dialect-nvvm/src/ops/wgmma.rs
+++ b/crates/dialect-nvvm/src/ops/wgmma.rs
@@ -21,8 +21,9 @@
 //! depths can keep committed groups in flight without exposing an in-flight
 //! accumulator to LLVM. The pointer-form group remains the deferred fallback.
 //!
-//! F16 uses the same 32-value accumulator model for canonical linear
-//! full-drain regions and the canonical counted K-loop. TF32 uses the same
+//! F16 uses the same accumulator model as BF16 for canonical linear
+//! full-drain regions, including the 64-value m64n128 carrier, and the
+//! canonical counted K-loop remains limited to m64n64. TF32 uses the same
 //! carrier only for canonical linear full-drain regions, with the hardware
 //! `m64n64k8` shape. Neither F16 nor TF32 has a deferred pointer-form group or
 //! partial-wait pipeline carrier, and TF32 has no counted-loop carrier.
@@ -216,6 +217,52 @@ impl Verify for WgmmaMmaM64N128K16F32Bf16Op {
             return verify_err!(
                 op.loc(),
                 "nvvm.wgmma_mma_m64n128k16_f32_bf16 descriptors must be u64"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Pointer-form F16 m64n128k16 WGMMA operation emitted by `mir-importer`.
+///
+/// This operation is not legal at final lowering. The deferred-accumulator
+/// fusion pass accepts it only in a canonical linear full-drain region and
+/// rewrites it to the 64-value form.
+#[pliron_op(
+    name = "nvvm.wgmma_mma_m64n128k16_f32_f16",
+    format,
+    interfaces = [NOpdsInterface<3>, NResultsInterface<0>],
+)]
+pub struct WgmmaMmaM64N128K16F32F16Op;
+
+impl WgmmaMmaM64N128K16F32F16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+}
+
+impl Verify for WgmmaMmaM64N128K16F32F16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        if op.get_num_operands() != 3 || op.get_num_results() != 0 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_m64n128k16_f32_f16 requires three operands and no results"
+            );
+        }
+        if !is_supported_wgmma_accumulator(ctx, op.get_operand(0)) {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_m64n128k16_f32_f16 accumulator must be a mutable generic MIR pointer"
+            );
+        }
+        if !is_u64(ctx, op.get_operand(1).get_type(ctx))
+            || !is_u64(ctx, op.get_operand(2).get_type(ctx))
+        {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_m64n128k16_f32_f16 descriptors must be u64"
             );
         }
         Ok(())
@@ -580,6 +627,110 @@ impl Verify for WgmmaMmaGroupValuesM64N128K16F32Bf16Op {
                 return verify_err!(
                     op.loc(),
                     "nvvm.wgmma_mma_group_values_m64n128k16_f32_bf16 descriptors must be u64"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Value-form F16 m64n128 WGMMA group with 64 SSA accumulator values.
+///
+/// Operand layout:
+///
+/// ```text
+/// [acc_0, ..., acc_63, desc_a_0, desc_b_0, ..., desc_a_n, desc_b_n]
+/// ```
+///
+/// Result layout:
+///
+/// ```text
+/// [acc_0', ..., acc_63']
+/// ```
+///
+/// The operation represents one canonical linear full-drain lifetime with an
+/// implicit fence, one or more m64n128 F16 MMA instructions, one commit, and
+/// `wait_group<0>`. It does not model pointer fallback, counted loops, or
+/// partial waits.
+#[pliron_op(name = "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16", format)]
+pub struct WgmmaMmaGroupValuesM64N128K16F32F16Op;
+
+impl WgmmaMmaGroupValuesM64N128K16F32F16Op {
+    /// Wrap an existing operation pointer.
+    pub fn new(op: Ptr<Operation>) -> Self {
+        Self { op }
+    }
+
+    /// Build a value-form group from 64 accumulator values and descriptor pairs.
+    pub fn build(
+        ctx: &mut Context,
+        accumulators: Vec<Value>,
+        descriptors: Vec<Value>,
+    ) -> Ptr<Operation> {
+        let f32_ty = FP32Type::get(ctx);
+        let mut operands = Vec::with_capacity(accumulators.len() + descriptors.len());
+        operands.extend(accumulators);
+        operands.extend(descriptors);
+
+        Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![f32_ty.into(); WGMMA_M64N128_F32_ACCUMULATOR_COUNT],
+            operands,
+            vec![],
+            0,
+        )
+    }
+}
+
+impl Verify for WgmmaMmaGroupValuesM64N128K16F32F16Op {
+    fn verify(&self, ctx: &Context) -> Result<(), Error> {
+        let op = self.get_operation().deref(ctx);
+        let operand_count = op.get_num_operands();
+        let result_count = op.get_num_results();
+
+        if result_count != WGMMA_M64N128_F32_ACCUMULATOR_COUNT {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 requires exactly 64 f32 results"
+            );
+        }
+        if operand_count < WGMMA_M64N128_F32_ACCUMULATOR_COUNT + 2 {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 requires 64 f32 accumulators and one or more descriptor pairs"
+            );
+        }
+
+        let descriptor_count = operand_count - WGMMA_M64N128_F32_ACCUMULATOR_COUNT;
+        if !descriptor_count.is_multiple_of(2) {
+            return verify_err!(
+                op.loc(),
+                "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 descriptors must form pairs"
+            );
+        }
+
+        for accumulator_index in 0..WGMMA_M64N128_F32_ACCUMULATOR_COUNT {
+            if !is_f32(ctx, op.get_operand(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 accumulator operands must be f32"
+                );
+            }
+            if !is_f32(ctx, op.get_result(accumulator_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 results must be f32"
+                );
+            }
+        }
+
+        for descriptor_index in WGMMA_M64N128_F32_ACCUMULATOR_COUNT..operand_count {
+            if !is_u64(ctx, op.get_operand(descriptor_index).get_type(ctx)) {
+                return verify_err!(
+                    op.loc(),
+                    "nvvm.wgmma_mma_group_values_m64n128k16_f32_f16 descriptors must be u64"
                 );
             }
         }
@@ -1342,11 +1493,13 @@ pub(super) fn register(ctx: &mut Context) {
     WgmmaMakeSmemDescOp::register(ctx);
     WgmmaMmaM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaM64N128K16F32Bf16Op::register(ctx);
+    WgmmaMmaM64N128K16F32F16Op::register(ctx);
     WgmmaMmaM64N64K16F32F16Op::register(ctx);
     WgmmaMmaM64N64K8F32Tf32Op::register(ctx);
     WgmmaMmaGroupM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaGroupValuesM64N64K16F32Bf16Op::register(ctx);
     WgmmaMmaGroupValuesM64N128K16F32Bf16Op::register(ctx);
+    WgmmaMmaGroupValuesM64N128K16F32F16Op::register(ctx);
     WgmmaMmaGroupValuesM64N64K16F32F16Op::register(ctx);
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op::register(ctx);
     WgmmaMmaLoopValuesM64N64K16F32Bf16Op::register(ctx);

--- a/crates/dialect-nvvm/tests/ops_test.rs
+++ b/crates/dialect-nvvm/tests/ops_test.rs
@@ -41,9 +41,10 @@ use dialect_nvvm::ops::{
     WgmmaMakeSmemDescOp, WgmmaMaxPendingAttr, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N128K16F32F16Op, WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaM64N128K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
@@ -95,11 +96,13 @@ fn handwritten_ops_match_reviewed_allowlist() {
         ("wgmma.rs", "WgmmaMakeSmemDescOp"),
         ("wgmma.rs", "WgmmaMmaM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaM64N128K16F32Bf16Op"),
+        ("wgmma.rs", "WgmmaMmaM64N128K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaM64N64K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaM64N64K8F32Tf32Op"),
         ("wgmma.rs", "WgmmaMmaGroupM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32Bf16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N128K16F32Bf16Op"),
+        ("wgmma.rs", "WgmmaMmaGroupValuesM64N128K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K16F32F16Op"),
         ("wgmma.rs", "WgmmaMmaGroupValuesM64N64K8F32Tf32Op"),
         ("wgmma.rs", "WgmmaMmaLoopValuesM64N64K16F32Bf16Op"),
@@ -4750,6 +4753,42 @@ fn handwritten_ffi_and_wgmma_carriers_verify_exact_shapes() {
     );
     assert!(
         WgmmaMmaGroupValuesM64N128K16F32Bf16Op::new(wide_incomplete_pair)
+            .verify(&ctx)
+            .is_err()
+    );
+
+    let wide_f16_mma = Operation::new(
+        &mut ctx,
+        WgmmaMmaM64N128K16F32F16Op::get_concrete_op_info(),
+        vec![],
+        vec![accumulator_pointer, u64_value, u64_value],
+        vec![],
+        0,
+    );
+    assert!(
+        WgmmaMmaM64N128K16F32F16Op::new(wide_f16_mma)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let wide_f16_value_group = WgmmaMmaGroupValuesM64N128K16F32F16Op::build(
+        &mut ctx,
+        vec![f32_value; 64],
+        vec![u64_value, u64_value],
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N128K16F32F16Op::new(wide_f16_value_group)
+            .verify(&ctx)
+            .is_ok()
+    );
+
+    let wide_f16_too_few = WgmmaMmaGroupValuesM64N128K16F32F16Op::build(
+        &mut ctx,
+        vec![f32_value; 63],
+        vec![u64_value, u64_value],
+    );
+    assert!(
+        WgmmaMmaGroupValuesM64N128K16F32F16Op::new(wide_f16_too_few)
             .verify(&ctx)
             .is_err()
     );

--- a/crates/mir-importer/src/translator/terminator/intrinsics/wgmma.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/wgmma.rs
@@ -13,7 +13,7 @@ use crate::translator::rvalue;
 use crate::translator::values::ValueMap;
 use dialect_nvvm::ops::{
     WgmmaMakeSmemDescOp, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
+    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaM64N128K16F32F16Op,
 };
 use pliron::basic_block::BasicBlock;
 use pliron::builtin::types::{IntegerType, Signedness};
@@ -270,6 +270,46 @@ pub fn emit_wgmma_mma_m64n128k16_f32_bf16(
     )
 }
 
+/// Emit F16 m64n128k16 WGMMA pointer form.
+///
+/// `mir-lower` accepts this variant only in a canonical linear full-drain
+/// region with a `[[f32; 8]; 8]` accumulator and a final `wait_group<0>`.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_wgmma_mma_m64n128k16_f32_f16(
+    ctx: &mut Context,
+    body: &mir::Body,
+    args: &[mir::Operand],
+    target: &Option<usize>,
+    block_ptr: Ptr<BasicBlock>,
+    prev_op: Option<Ptr<Operation>>,
+    value_map: &mut ValueMap,
+    block_map: &[Ptr<BasicBlock>],
+    loc: Location,
+) -> TranslationResult<Ptr<Operation>> {
+    emit_wgmma_mma_pointer_form(
+        ctx,
+        body,
+        args,
+        target,
+        block_ptr,
+        prev_op,
+        value_map,
+        block_map,
+        loc,
+        |ctx, operands| {
+            Operation::new(
+                ctx,
+                WgmmaMmaM64N128K16F32F16Op::get_concrete_op_info(),
+                vec![],
+                operands,
+                vec![],
+                0,
+            )
+        },
+        "wgmma_mma_m64n128k16_f32_f16",
+    )
+}
+
 /// Emit F16 m64n64k16 WGMMA pointer form.
 ///
 /// `mir-lower` accepts this variant only in a canonical linear full-drain
@@ -410,6 +450,7 @@ mod tests {
         for path in [
             "cuda_device::wgmma::wgmma_mma_m64n64k16_f32_bf16",
             "cuda_device::wgmma::wgmma_mma_m64n128k16_f32_bf16",
+            "cuda_device::wgmma::wgmma_mma_m64n128k16_f32_f16",
             "cuda_device::wgmma::wgmma_mma_m64n64k16_f32_f16",
             "cuda_device::wgmma::wgmma_mma_m64n64k8_f32_tf32",
         ] {

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -3000,6 +3000,11 @@ fn try_dispatch_intrinsic(
                 ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
             )?))
         }
+        "cuda_device::wgmma::wgmma_mma_m64n128k16_f32_f16" => {
+            Ok(Some(intrinsics::wgmma::emit_wgmma_mma_m64n128k16_f32_f16(
+                ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,
+            )?))
+        }
         "cuda_device::wgmma::wgmma_mma_m64n64k16_f32_f16" => {
             Ok(Some(intrinsics::wgmma::emit_wgmma_mma_m64n64k16_f32_f16(
                 ctx, body, args, target, block_ptr, prev_op, value_map, block_map, loc,

--- a/crates/mir-lower/src/convert/interface_impls.rs
+++ b/crates/mir-lower/src/convert/interface_impls.rs
@@ -42,9 +42,10 @@ use dialect_nvvm::ops::{
     ReadPtxSregNclusterIdOp, VprintfOp, WgmmaMakeSmemDescOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N128K16F32F16Op, WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaM64N128K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op,
 };
 
@@ -1099,6 +1100,18 @@ impl MirToLlvmConversion for WgmmaMmaM64N128K16F32Bf16Op {
 }
 
 #[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaM64N128K16F32F16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma(ctx, rewriter, self.get_operation(), operands_info)
+    }
+}
+
+#[op_interface_impl]
 impl MirToLlvmConversion for WgmmaMmaM64N64K8F32Tf32Op {
     fn convert(
         &self,
@@ -1170,6 +1183,23 @@ impl MirToLlvmConversion for WgmmaMmaGroupValuesM64N128K16F32Bf16Op {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         super::intrinsics::wgmma::convert_mma_group_values_m64n128_bf16(
+            ctx,
+            rewriter,
+            self.get_operation(),
+            operands_info,
+        )
+    }
+}
+
+#[op_interface_impl]
+impl MirToLlvmConversion for WgmmaMmaGroupValuesM64N128K16F32F16Op {
+    fn convert(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        super::intrinsics::wgmma::convert_mma_group_values_m64n128_f16(
             ctx,
             rewriter,
             self.get_operation(),

--- a/crates/mir-lower/src/convert/intrinsics/wgmma.rs
+++ b/crates/mir-lower/src/convert/intrinsics/wgmma.rs
@@ -167,13 +167,26 @@ fn value_group_template(mma_count: usize, input_kind: WgmmaInputKind) -> String 
     value_group_template_for_mnemonic(mma_count, VALUE_ACCUMULATOR_COUNT, mnemonic, controls)
 }
 
-fn value_group_template_m64n128_bf16(mma_count: usize) -> String {
+fn value_group_template_m64n128(mma_count: usize, input_kind: WgmmaInputKind) -> String {
+    let mnemonic = match input_kind {
+        WgmmaInputKind::Bf16 => "wgmma.mma_async.sync.aligned.m64n128k16.f32.bf16.bf16",
+        WgmmaInputKind::F16 => "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16",
+        WgmmaInputKind::Tf32 => unreachable!("TF32 m64n128 lowering is unsupported"),
+    };
     value_group_template_for_mnemonic(
         mma_count,
         M64N128_VALUE_ACCUMULATOR_COUNT,
-        "wgmma.mma_async.sync.aligned.m64n128k16.f32.bf16.bf16",
+        mnemonic,
         "1, 1, 1, 0, 0",
     )
+}
+
+fn value_group_template_m64n128_bf16(mma_count: usize) -> String {
+    value_group_template_m64n128(mma_count, WgmmaInputKind::Bf16)
+}
+
+fn value_group_template_m64n128_f16(mma_count: usize) -> String {
+    value_group_template_m64n128(mma_count, WgmmaInputKind::F16)
 }
 
 fn value_group_constraints_for_count(accumulator_count: usize, descriptor_count: usize) -> String {
@@ -417,6 +430,22 @@ pub(crate) fn convert_mma_group_values_m64n128_bf16(
         op,
         M64N128_VALUE_ACCUMULATOR_COUNT,
         value_group_template_m64n128_bf16,
+    )
+}
+
+/// Lower a value-form F16 m64n128 WGMMA full-drain group.
+pub(crate) fn convert_mma_group_values_m64n128_f16(
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+    op: Ptr<Operation>,
+    _operands_info: &OperandsInfo,
+) -> Result<()> {
+    convert_mma_group_values_for_shape(
+        ctx,
+        rewriter,
+        op,
+        M64N128_VALUE_ACCUMULATOR_COUNT,
+        value_group_template_m64n128_f16,
     )
 }
 
@@ -776,7 +805,7 @@ mod tests {
         WgmmaInputKind, counted_loop_constraints, counted_loop_template,
         counted_pipeline_constraints, counted_pipeline_template, deferred_group_template,
         pipeline_constraints, pipeline_template, value_group_constraints, value_group_template,
-        value_group_template_m64n128_bf16,
+        value_group_template_m64n128_bf16, value_group_template_m64n128_f16,
     };
 
     #[test]
@@ -861,6 +890,19 @@ mod tests {
         let template = value_group_template_m64n128_bf16(2);
         assert_eq!(template.matches("wgmma.mma_async").count(), 2);
         assert!(template.contains("m64n128k16.f32.bf16.bf16"));
+        assert!(template.contains("{$0, $1, $2"));
+        assert!(template.contains("$63}"));
+        assert!(template.contains("$128, $129"));
+        assert!(template.contains("$130, $131"));
+        assert!(!template.contains("ld.f32"));
+        assert!(!template.contains("st.f32"));
+    }
+
+    #[test]
+    fn m64n128_f16_value_template_uses_sixty_four_tied_accumulators() {
+        let template = value_group_template_m64n128_f16(2);
+        assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+        assert!(template.contains("m64n128k16.f32.f16.f16"));
         assert!(template.contains("{$0, $1, $2"));
         assert!(template.contains("$63}"));
         assert!(template.contains("$128, $129"));

--- a/crates/mir-lower/src/wgmma_deferred_accumulator.rs
+++ b/crates/mir-lower/src/wgmma_deferred_accumulator.rs
@@ -12,14 +12,16 @@
 //! `wgmma.wait_group` completes. This pass recognizes both closed
 //! straight-line regions and one deliberately narrow counted K-loop shape. The
 //! canonical m64n64 `[[f32; 8]; 4]` accumulator is adapted through 32 scalar SSA
-//! values. BF16 m64n128 linear full drains use a canonical `[[f32; 8]; 8]`
+//! values. BF16 and F16 m64n128 linear full drains use a canonical
+//! `[[f32; 8]; 8]`
 //! accumulator and 64 scalar SSA values. Unsupported m64n64 BF16 accumulator
 //! shapes retain the existing deferred pointer fallback.
 //! F16 m64n64 is accepted for the canonical accumulator in linear full-drain
 //! regions and the canonical single-slot counted K-loop. TF32 is accepted only
 //! for the canonical m64n64 accumulator in a linear full-drain region, using
-//! the hardware `m64n64k8.f32.tf32.tf32` shape. BF16 m64n128 is accepted only
-//! for canonical linear full-drain regions. Partial waits, counted pipelines,
+//! the hardware `m64n64k8.f32.tf32.tf32` shape. BF16 and F16 m64n128 are
+//! accepted only for canonical linear full-drain regions. Partial waits, counted
+//! pipelines,
 //! and pointer fallback remain m64n64-BF16-only.
 //!
 //! Straight-line regions keep the existing shape:
@@ -28,7 +30,8 @@
 //! wgmma.fence
 //! one or more homogeneous m64n64k16.f32.bf16.bf16,
 //! m64n64k16.f32.f16.f16, m64n64k8.f32.tf32.tf32, or
-//! m64n128k16.f32.bf16.bf16 MMA operations on one shape-correct accumulator
+//! m64n128k16.f32.bf16.bf16, or m64n128k16.f32.f16.f16 MMA operations on one
+//! shape-correct accumulator
 //! wgmma.commit_group
 //! wgmma.wait_group<0>
 //! ```
@@ -67,9 +70,10 @@ use dialect_nvvm::ops::{
     WgmmaCommitGroupSyncAlignedOp, WgmmaFenceSyncAlignedOp, WgmmaMmaGroupM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K8F32Tf32Op, WgmmaMmaGroupValuesM64N64K16F32Bf16Op,
     WgmmaMmaGroupValuesM64N64K16F32F16Op, WgmmaMmaGroupValuesM64N128K16F32Bf16Op,
-    WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32Bf16Op,
-    WgmmaMmaLoopValuesM64N64K16F32F16Op, WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op,
-    WgmmaMmaM64N64K16F32F16Op, WgmmaMmaM64N128K16F32Bf16Op,
+    WgmmaMmaGroupValuesM64N128K16F32F16Op, WgmmaMmaLoopPipelineValuesM64N64K16F32Bf16Op,
+    WgmmaMmaLoopValuesM64N64K16F32Bf16Op, WgmmaMmaLoopValuesM64N64K16F32F16Op,
+    WgmmaMmaM64N64K8F32Tf32Op, WgmmaMmaM64N64K16F32Bf16Op, WgmmaMmaM64N64K16F32F16Op,
+    WgmmaMmaM64N128K16F32Bf16Op, WgmmaMmaM64N128K16F32F16Op,
     WgmmaMmaPipelineValuesM64N64K16F32Bf16Op, WgmmaWaitGroupSyncAlignedOp,
 };
 use mir_transforms::analyses::{induction, loop_info::LoopInfo};
@@ -113,6 +117,7 @@ enum WgmmaMmaKind {
     F16M64N64,
     Tf32M64N64,
     Bf16M64N128,
+    F16M64N128,
 }
 
 struct FusionPlan {
@@ -915,6 +920,8 @@ fn wgmma_mma_kind(ctx: &Context, operation: Ptr<Operation>) -> Option<WgmmaMmaKi
         Some(WgmmaMmaKind::Tf32M64N64)
     } else if Operation::get_op::<WgmmaMmaM64N128K16F32Bf16Op>(operation, ctx).is_some() {
         Some(WgmmaMmaKind::Bf16M64N128)
+    } else if Operation::get_op::<WgmmaMmaM64N128K16F32F16Op>(operation, ctx).is_some() {
+        Some(WgmmaMmaKind::F16M64N128)
     } else {
         None
     }
@@ -987,7 +994,7 @@ fn linear_accumulator_rows(kind: WgmmaMmaKind) -> usize {
         WgmmaMmaKind::Bf16M64N64 | WgmmaMmaKind::F16M64N64 | WgmmaMmaKind::Tf32M64N64 => {
             ACCUMULATOR_ROWS
         }
-        WgmmaMmaKind::Bf16M64N128 => M64N128_ACCUMULATOR_ROWS,
+        WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128 => M64N128_ACCUMULATOR_ROWS,
     }
 }
 
@@ -1243,7 +1250,8 @@ fn apply_value_plan(
     let rows = linear_accumulator_rows(kind);
     let accumulator_count = rows * ACCUMULATOR_COLUMNS;
     debug_assert!(
-        kind != WgmmaMmaKind::Bf16M64N128 || accumulator_count == M64N128_ACCUMULATOR_LEN
+        !matches!(kind, WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128)
+            || accumulator_count == M64N128_ACCUMULATOR_LEN
     );
     let (element_pointers, accumulator_values) = load_accumulator_values_before_for_rows(
         ctx,
@@ -1268,6 +1276,9 @@ fn apply_value_plan(
         WgmmaMmaKind::Bf16M64N128 => {
             WgmmaMmaGroupValuesM64N128K16F32Bf16Op::build(ctx, accumulator_values, descriptors)
         }
+        WgmmaMmaKind::F16M64N128 => {
+            WgmmaMmaGroupValuesM64N128K16F32F16Op::build(ctx, accumulator_values, descriptors)
+        }
     };
     group.deref_mut(ctx).set_loc(loc.clone());
     let accumulator_results = (0..accumulator_count)
@@ -1275,7 +1286,7 @@ fn apply_value_plan(
         .collect::<Vec<_>>();
     group.insert_before(ctx, wait);
 
-    if kind == WgmmaMmaKind::Bf16M64N128 {
+    if matches!(kind, WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128) {
         store_canonical_accumulator_values_before_for_rows(
             ctx,
             wait,
@@ -1464,7 +1475,7 @@ fn apply_counted_loop_plan(ctx: &mut Context, plan: CountedLoopPlan) {
             desc_b_step,
             trip_count,
         ),
-        WgmmaMmaKind::Tf32M64N64 | WgmmaMmaKind::Bf16M64N128 => {
+        WgmmaMmaKind::Tf32M64N64 | WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128 => {
             unreachable!("counted-loop matching rejects this variant before planning")
         }
     };
@@ -1881,13 +1892,16 @@ fn match_sequence(ctx: &Context, fence: Ptr<Operation>) -> Result<Option<FusionP
                 require_supported_accumulator(ctx, current_accumulator)?;
                 if matches!(
                     current_kind,
-                    WgmmaMmaKind::F16M64N64 | WgmmaMmaKind::Tf32M64N64 | WgmmaMmaKind::Bf16M64N128
+                    WgmmaMmaKind::F16M64N64
+                        | WgmmaMmaKind::Tf32M64N64
+                        | WgmmaMmaKind::Bf16M64N128
+                        | WgmmaMmaKind::F16M64N128
                 ) && linear_value_accumulator_shape(ctx, current_accumulator, current_kind)
                     .is_none()
                 {
                     let expected = match current_kind {
                         WgmmaMmaKind::F16M64N64 | WgmmaMmaKind::Tf32M64N64 => "[[f32; 8]; 4]",
-                        WgmmaMmaKind::Bf16M64N128 => "[[f32; 8]; 8]",
+                        WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128 => "[[f32; 8]; 8]",
                         WgmmaMmaKind::Bf16M64N64 => unreachable!(),
                     };
                     return pliron::input_err_noloc!(
@@ -2074,7 +2088,7 @@ fn apply_plan(ctx: &mut Context, plan: FusionPlan) -> Result<()> {
     } else {
         let expected = match kind {
             WgmmaMmaKind::F16M64N64 | WgmmaMmaKind::Tf32M64N64 => "[[f32; 8]; 4]",
-            WgmmaMmaKind::Bf16M64N128 => "[[f32; 8]; 8]",
+            WgmmaMmaKind::Bf16M64N128 | WgmmaMmaKind::F16M64N128 => "[[f32; 8]; 8]",
             WgmmaMmaKind::Bf16M64N64 => unreachable!(),
         };
         return pliron::input_err_noloc!(

--- a/crates/mir-lower/tests/lowering_test.rs
+++ b/crates/mir-lower/tests/lowering_test.rs
@@ -8392,6 +8392,24 @@ fn append_pointer_wgmma_mma_m64n128(
     .insert_at_back(block, ctx);
 }
 
+fn append_pointer_wgmma_mma_m64n128_f16(
+    ctx: &mut Context,
+    block: pliron::context::Ptr<pliron::basic_block::BasicBlock>,
+    accumulator: pliron::value::Value,
+    desc_a: pliron::value::Value,
+    desc_b: pliron::value::Value,
+) {
+    Operation::new(
+        ctx,
+        nvvm::WgmmaMmaM64N128K16F32F16Op::get_concrete_op_info(),
+        vec![],
+        vec![accumulator, desc_a, desc_b],
+        vec![],
+        0,
+    )
+    .insert_at_back(block, ctx);
+}
+
 fn append_pointer_wgmma_mma_f16(
     ctx: &mut Context,
     block: pliron::context::Ptr<pliron::basic_block::BasicBlock>,
@@ -9366,6 +9384,91 @@ fn test_value_form_m64n128_bf16_wgmma_group_lowers_to_sixty_four_tied_registers(
 }
 
 #[test]
+fn test_value_form_m64n128_f16_wgmma_group_lowers_to_sixty_four_tied_registers()
+-> Result<(), anyhow::Error> {
+    use llvm_export::types as llvm_types;
+    use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
+    use pliron::r#type::Typed;
+
+    const ACCUMULATOR_LEN: usize = 64;
+    const DESCRIPTOR_COUNT: usize = 4;
+
+    let mut ctx = make_test_ctx();
+    let f32_ty = FP32Type::get(&ctx);
+    let u64_ty = IntegerType::get(&ctx, 64, Signedness::Unsigned);
+    let argument_types = (0..ACCUMULATOR_LEN)
+        .map(|_| f32_ty.into())
+        .chain((0..DESCRIPTOR_COUNT).map(|_| u64_ty.into()))
+        .collect::<Vec<pliron::r#type::TypeHandle>>();
+    let (module_ptr, entry) = build_test_kernel(&mut ctx, argument_types);
+
+    let accumulators = (0..ACCUMULATOR_LEN)
+        .map(|index| entry.deref(&ctx).get_argument(index))
+        .collect::<Vec<_>>();
+    let descriptors = (0..DESCRIPTOR_COUNT)
+        .map(|index| entry.deref(&ctx).get_argument(ACCUMULATOR_LEN + index))
+        .collect::<Vec<_>>();
+
+    nvvm::WgmmaMmaGroupValuesM64N128K16F32F16Op::build(&mut ctx, accumulators, descriptors)
+        .insert_at_back(entry, &ctx);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let matching = lowered_kernel_body(&ctx, module_ptr)
+        .into_iter()
+        .filter_map(|operation| Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx))
+        .filter(|asm| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("m64n128k16.f32.f16.f16"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+
+    let asm = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("m64n128 value-form WGMMA template");
+    assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+    assert!(template.contains("m64n128k16.f32.f16.f16"));
+    assert!(template.contains("$128, $129"));
+    assert!(template.contains("$130, $131"));
+    assert!(!template.contains("ld.f32"));
+    assert!(!template.contains("st.f32"));
+
+    let constraints = asm
+        .get_attr_inline_asm_constraints(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("m64n128 value-form WGMMA constraints");
+    assert_eq!(
+        constraints
+            .split(',')
+            .filter(|value| *value == "=f")
+            .count(),
+        64
+    );
+    assert_eq!(
+        constraints.split(',').filter(|value| *value == "l").count(),
+        4
+    );
+    assert!(constraints.ends_with("~{memory}"));
+
+    let aggregate = asm.get_operation().deref(&ctx).get_result(0);
+    let aggregate_ty = aggregate.get_type(&ctx);
+    let aggregate_ty = aggregate_ty.deref(&ctx);
+    let struct_ty = aggregate_ty
+        .downcast_ref::<llvm_types::StructType>()
+        .expect("m64n128 inline asm must return an LLVM struct");
+    assert_eq!(struct_ty.num_fields(), ACCUMULATOR_LEN);
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+
+    Ok(())
+}
+
+#[test]
 fn test_value_form_f16_wgmma_group_lowers_to_tied_register_inline_ptx() -> Result<(), anyhow::Error>
 {
     use pliron::builtin::types::{FP32Type, IntegerType, Signedness};
@@ -9826,6 +9929,77 @@ fn test_pointer_form_m64n128_bf16_linear_full_drain_uses_sixty_four_value_adapte
         .expect("m64n128 pointer-form WGMMA template");
     assert_eq!(template.matches("wgmma.mma_async").count(), 2);
     assert!(template.contains("m64n128k16.f32.bf16.bf16"));
+    assert!(!template.contains("ld.f32"));
+    assert!(!template.contains("st.f32"));
+
+    let constraints = asm
+        .get_attr_inline_asm_constraints(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("m64n128 pointer-form WGMMA constraints");
+    assert_eq!(
+        constraints
+            .split(',')
+            .filter(|value| *value == "=f")
+            .count(),
+        64
+    );
+    assert_eq!(
+        constraints.split(',').filter(|value| *value == "l").count(),
+        4
+    );
+    assert_eq!(llvm::asm_kind(&ctx, asm), llvm::AsmKind::Convergent);
+
+    Ok(())
+}
+
+#[test]
+fn test_pointer_form_m64n128_f16_linear_full_drain_uses_sixty_four_value_adapter()
+-> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let (module_ptr, entry, accumulators, descriptors) =
+        build_wgmma_m64n128_canonical_pointer_test_kernel(&mut ctx, 1, 4);
+    let accumulator = accumulators[0];
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_pointer_wgmma_mma_m64n128_f16(
+        &mut ctx,
+        entry,
+        accumulator,
+        descriptors[0],
+        descriptors[1],
+    );
+    append_pointer_wgmma_mma_m64n128_f16(
+        &mut ctx,
+        entry,
+        accumulator,
+        descriptors[2],
+        descriptors[3],
+    );
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, entry, 0);
+    append_return(&mut ctx, entry);
+
+    mir_lower::lower_mir_to_llvm(&mut ctx, module_ptr)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    let matching = lowered_kernel_body(&ctx, module_ptr)
+        .into_iter()
+        .filter_map(|operation| Operation::get_op::<llvm::InlineAsmOp>(operation, &ctx))
+        .filter(|asm| {
+            asm.get_attr_inline_asm_template(&ctx)
+                .map(|value| String::from((*value).clone()))
+                .is_some_and(|template| template.contains("m64n128k16.f32.f16.f16"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+
+    let asm = &matching[0];
+    let template = asm
+        .get_attr_inline_asm_template(&ctx)
+        .map(|value| String::from((*value).clone()))
+        .expect("m64n128 pointer-form WGMMA template");
+    assert_eq!(template.matches("wgmma.mma_async").count(), 2);
+    assert!(template.contains("m64n128k16.f32.f16.f16"));
     assert!(!template.contains("ld.f32"));
     assert!(!template.contains("st.f32"));
 
@@ -11494,6 +11668,27 @@ fn test_m64n128_wgmma_noncanonical_accumulator_has_no_pointer_fallback() -> Resu
 }
 
 #[test]
+fn test_m64n128_f16_wgmma_noncanonical_accumulator_has_no_pointer_fallback()
+-> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let (module_ptr, entry, accumulators, desc_a, desc_b, _) =
+        build_wgmma_pointer_test_kernel(&mut ctx, 1, vec![]);
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_pointer_wgmma_mma_m64n128_f16(&mut ctx, entry, accumulators[0], desc_a, desc_b);
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, entry, 0);
+    append_return(&mut ctx, entry);
+
+    assert_wgmma_lowering_rejected(
+        &mut ctx,
+        module_ptr,
+        "WGMMA linear full-drain lowering for this variant requires a canonical [[f32; 8]; 8] accumulator",
+    );
+    Ok(())
+}
+
+#[test]
 fn test_f16_wgmma_noncanonical_accumulator_has_no_pointer_fallback() -> Result<(), anyhow::Error> {
     let mut ctx = make_test_ctx();
     let (module_ptr, entry, accumulators, desc_a, desc_b, _) =
@@ -11529,6 +11724,34 @@ fn test_tf32_wgmma_noncanonical_accumulator_has_no_pointer_fallback() -> Result<
         &mut ctx,
         module_ptr,
         "WGMMA linear full-drain lowering for this variant requires a canonical [[f32; 8]; 4] accumulator",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_m64n128_linear_full_drain_rejects_mixed_bf16_and_f16() -> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let (module_ptr, entry, accumulators, descriptors) =
+        build_wgmma_m64n128_canonical_pointer_test_kernel(&mut ctx, 1, 4);
+    let accumulator = accumulators[0];
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_pointer_wgmma_mma_m64n128(&mut ctx, entry, accumulator, descriptors[0], descriptors[1]);
+    append_pointer_wgmma_mma_m64n128_f16(
+        &mut ctx,
+        entry,
+        accumulator,
+        descriptors[2],
+        descriptors[3],
+    );
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, entry, 0);
+    append_return(&mut ctx, entry);
+
+    assert_wgmma_lowering_rejected(
+        &mut ctx,
+        module_ptr,
+        "one linear WGMMA full-drain region cannot mix MMA variants or shapes",
     );
     Ok(())
 }
@@ -11607,6 +11830,33 @@ fn test_f16_wgmma_partial_wait_remains_unsupported() -> Result<(), anyhow::Error
 
     nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
     append_pointer_wgmma_mma_f16(
+        &mut ctx,
+        entry,
+        accumulators[0],
+        descriptors[0],
+        descriptors[1],
+    );
+    nvvm::WgmmaCommitGroupSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_wgmma_wait_group_constant(&mut ctx, entry, 1);
+    append_wgmma_wait_group_constant(&mut ctx, entry, 0);
+    append_return(&mut ctx, entry);
+
+    assert_wgmma_lowering_rejected(
+        &mut ctx,
+        module_ptr,
+        "WGMMA deferred accumulator lowering requires wait_group<0>",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_m64n128_f16_wgmma_partial_wait_remains_unsupported() -> Result<(), anyhow::Error> {
+    let mut ctx = make_test_ctx();
+    let (module_ptr, entry, accumulators, descriptors) =
+        build_wgmma_m64n128_canonical_pointer_test_kernel(&mut ctx, 1, 2);
+
+    nvvm::WgmmaFenceSyncAlignedOp::build(&mut ctx).insert_at_back(entry, &ctx);
+    append_pointer_wgmma_mma_m64n128_f16(
         &mut ctx,
         entry,
         accumulators[0],

--- a/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
+++ b/cuda-oxide-book/advanced/matrix-multiply-accelerators.md
@@ -102,16 +102,16 @@ unsafe {
 // `acc` is now safe to observe.
 ```
 
-The BF16 m64n128 full-drain variant uses the same synchronization contract but
-a 64-value per-thread accumulator:
+The BF16 and F16 m64n128 full-drain variants use the same synchronization
+contract but a 64-value per-thread accumulator:
 
 ```rust
-use cuda_device::wgmma::wgmma_mma_m64n128k16_f32_bf16;
+use cuda_device::wgmma::wgmma_mma_m64n128k16_f32_f16;
 
 let mut wide_acc = [[0.0f32; 8]; 8];
 unsafe {
     wgmma_fence();
-    wgmma_mma_m64n128k16_f32_bf16(&mut wide_acc, a_desc, b_desc);
+    wgmma_mma_m64n128k16_f32_f16(&mut wide_acc, a_desc, b_desc);
     wgmma_commit_group();
     wgmma_wait_group::<0>();
 }
@@ -126,8 +126,9 @@ hardware shape uses K=8.
 The compiler supports `m64n64k16.f32.bf16.bf16` across three conservative
 lowering shapes, `m64n64k16.f32.f16.f16` for canonical linear full-drain and
 counted K-loop regions, `m64n64k8.f32.tf32.tf32` for canonical linear
-full-drain regions only, and `m64n128k16.f32.bf16.bf16` for canonical linear
-full-drain regions. In every accepted case, the entire asynchronous
+full-drain regions only, and both `m64n128k16.f32.bf16.bf16` and
+`m64n128k16.f32.f16.f16` for canonical linear full-drain regions. In every
+accepted case, the entire asynchronous
 accumulator lifetime stays inside one convergent inline-PTX statement so LLVM
 cannot insert a spill boundary while a WGMMA group is pending.
 
@@ -137,9 +138,10 @@ into 32 SSA `f32` values before the WGMMA region and stored once after the final
 Unsupported BF16 full-drain pointer shapes retain the original deferred
 pointer-form lowering; F16 and TF32 do not have a pointer-form fallback.
 
-**m64n128 BF16 linear full drain.** A canonical `[[f32; 8]; 8]` accumulator is
-carried as 64 tied SSA `f32` values through one or more homogeneous
-`m64n128k16.f32.bf16.bf16` instructions, one commit, and a final
+**m64n128 BF16/F16 linear full drain.** A canonical `[[f32; 8]; 8]`
+accumulator is
+carried as 64 tied SSA `f32` values through one or more homogeneous BF16 or F16
+`m64n128k16` instructions, one commit, and a final
 `wait_group<0>`. Accumulator element addresses are recomputed after the fused
 inline-PTX scope instead of being kept live across it. This shape has no
 pointer-form fallback, counted-loop lowering, or partial-wait pipeline lowering.

--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -297,7 +297,7 @@ they become `call` instructions to `@llvm.nvvm.*` intrinsics.
 ### Architecture Coverage
 
 At catalog SHA-256 `00372dfe` (the stamp in every `ops/generated/` file
-header), the dialect holds 575 operations across 42 modules, and they come
+header), the dialect holds 577 operations across 42 modules, and they come
 from two different places. The split is the first thing to know about it,
 because it decides where -- and whether -- you would add one. If the header
 stamp no longer starts with `00372dfe`, the counts on this page predate the
@@ -305,7 +305,7 @@ catalog you are reading.
 
 **Hand-written**, directly under `crates/dialect-nvvm/src/ops/`. These are the
 ops with bespoke verification or lowering that the intrinsic catalog does not
-describe. There are seven modules and 26 operations:
+describe. There are seven modules and 28 operations:
 
 | Module    | Description                                                 | Ops |
 | :-------- | :---------------------------------------------------------- | --: |
@@ -315,7 +315,7 @@ describe. There are seven modules and 26 operations:
 | `debug`   | `assertfail`, `vprintf`                                     |   2 |
 | `grid`    | Cooperative `grid_sync`                                     |   1 |
 | `memory`  | Generic-to-shared address conversion with a byte offset     |   1 |
-| `wgmma`   | Warpgroup MMA descriptors; bf16/f16 at m64n64k16, bf16 at m64n128k16, tf32 at m64n64k8 |  14 |
+| `wgmma`   | Warpgroup MMA descriptors; bf16/f16 at m64n64k16, bf16/f16 at m64n128k16, tf32 at m64n64k8 |  16 |
 
 **Generated**, under `ops/generated/`, from `intrinsics/catalog.json` by
 `cuda-intrinsics-gen`. Every file there opens with `// @generated ... DO NOT


### PR DESCRIPTION
Closes #1148 

## Summary

Adds full-drain lowering support for:

```text
wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16
```

using the existing 64-value deferred-accumulator carrier introduced for BF16 m64n128 WGMMA.

## Changes

* Add the public `cuda-device` API for F16 m64n128 WGMMA.

* Add pointer and 64-result value-form NVVM dialect operations.

* Import the new intrinsic through MIR.

* Extend m64n128 value-group lowering to support F16.

* Represent the canonical `[[f32; 8]; 8]` accumulator as 64 tied `f32` SSA values.

* Fuse homogeneous linear sequences across:

  ```text
  fence -> MMA+ -> commit_group -> wait_group<0>
  ```

* Preserve fail-closed behavior for:

  * noncanonical accumulators
  * partial waits
  * counted-loop lowering
  * mixed BF16/F16 m64n128 groups

* Add lowering and verifier coverage.

* Add `ptxas` probes for one and two chained F16 m64n128 MMA operations.

* Update WGMMA documentation.

## Validation

The targeted validation passes:

* `cargo fmt --all -- --check`
* `git diff --check`
* targeted `cargo check`
* targeted `cargo clippy --all-targets -- -D warnings`
* `dialect-nvvm` tests
* `mir-importer` tests
* `mir-lower` tests
* WGMMA PTX carrier tests
* `just check-guards`
* Sphinx documentation build with `-W --keep-going`

The new F16 m64n128 `ptxas` probes compile successfully on `sm_90a` with:

```text
90 registers
0 bytes stack frame
0 bytes spill stores
0 bytes spill loads
```

for both the single-MMA and two-MMA full-drain cases.

## Scope

This PR intentionally supports only the canonical linear full-drain path. Partial waits, counted loops, pointer fallback, mixed-type groups, and wider WGMMA shapes remain unsupported.
