### PR TITLE
fix(intrinsics-gen): fail closed when an unsafe family has no safety renderer

### DIFF
--- a/crates/cuda-device/src/generated/clc.rs
+++ b/crates/cuda-device/src/generated/clc.rs
@@ -12,7 +12,8 @@
 /// Returns the X coordinate from a successful cancellation response.
 ///
 /// # Safety
-/// The response halves must come from a completed CLC request.
+/// `resp_lo` and `resp_hi` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn clc_query_get_first_ctaid_x(resp_lo: u64, resp_hi: u64) -> u32 {
     let _ = (resp_lo, resp_hi);
@@ -22,7 +23,8 @@ pub unsafe fn clc_query_get_first_ctaid_x(resp_lo: u64, resp_hi: u64) -> u32 {
 /// Returns the Y coordinate from a successful cancellation response.
 ///
 /// # Safety
-/// The response halves must come from a completed CLC request.
+/// `resp_lo` and `resp_hi` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn clc_query_get_first_ctaid_y(resp_lo: u64, resp_hi: u64) -> u32 {
     let _ = (resp_lo, resp_hi);
@@ -32,7 +34,8 @@ pub unsafe fn clc_query_get_first_ctaid_y(resp_lo: u64, resp_hi: u64) -> u32 {
 /// Returns the Z coordinate from a successful cancellation response.
 ///
 /// # Safety
-/// The response halves must come from a completed CLC request.
+/// `resp_lo` and `resp_hi` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn clc_query_get_first_ctaid_z(resp_lo: u64, resp_hi: u64) -> u32 {
     let _ = (resp_lo, resp_hi);
@@ -42,7 +45,7 @@ pub unsafe fn clc_query_get_first_ctaid_z(resp_lo: u64, resp_hi: u64) -> u32 {
 /// Returns whether the Cluster Launch Control request was canceled.
 ///
 /// # Safety
-/// The response halves must come from a completed CLC request.
+/// `resp_lo` and `resp_hi` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
 #[inline(never)]
 pub unsafe fn clc_query_is_canceled(resp_lo: u64, resp_hi: u64) -> u32 {
     let _ = (resp_lo, resp_hi);
@@ -52,7 +55,9 @@ pub unsafe fn clc_query_is_canceled(resp_lo: u64, resp_hi: u64) -> u32 {
 /// Requests one pending CTA and writes its response to shared memory.
 ///
 /// # Safety
-/// `response` and `mbar` must be valid, aligned shared-memory objects for this request.
+/// `response` must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and `mbar` must designate a valid, aligned shared-memory mbarrier.
+/// The calling CTA must issue `arrive_expect_tx` for `mbar` with 16 bytes before this request.
+/// This CTA must not have observed a prior CLC try-cancel request fail.
 #[inline(never)]
 pub unsafe fn clc_try_cancel(response: *mut u8, mbar: *mut Barrier) {
     let _ = (response, mbar);
@@ -62,7 +67,10 @@ pub unsafe fn clc_try_cancel(response: *mut u8, mbar: *mut Barrier) {
 /// Requests one pending CTA and multicasts its response across the cluster.
 ///
 /// # Safety
-/// `response` and `mbar` must be valid, aligned shared-memory objects for this request.
+/// `response` must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and `mbar` must designate a valid, aligned shared-memory mbarrier.
+/// Each CTA must issue `arrive_expect_tx` for its own corresponding mbarrier with 16 bytes before this request.
+/// This CTA must not have observed a prior CLC try-cancel request fail.
+/// The response is written to every CTA's shared-memory window and signals every CTA's mbarrier.
 /// Every CTA in the cluster must still be active.
 #[inline(never)]
 pub unsafe fn clc_try_cancel_multicast(response: *mut u8, mbar: *mut Barrier) {

--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -60,7 +60,7 @@ pub fn all_outputs(
             catalog.intrinsic_abi
         )
         .into(),
-        render_raw_abi(catalog, catalog_sha256),
+        render_raw_abi(catalog, catalog_sha256)?,
     );
     outputs.insert(
         "crates/cuda-device/src/generated/register_mma.rs".into(),
@@ -448,40 +448,6 @@ fn validate_renderable(catalog: &CatalogFile) -> Result<()> {
         "catalog contains no intrinsics"
     );
     for record in &catalog.intrinsics {
-        if !record.rust.safe {
-            ensure!(
-                (record.family == "ldmatrix" && record.ldmatrix.is_some())
-                    || record.family == "stmatrix"
-                    || (record.family == "register_mma" && record.register_mma.is_some())
-                    || (record.family == "sparse_mma" && record.sparse_mma.is_some())
-                    || (record.family == "packed_atomic" && record.packed_atomic.is_some())
-                    || (record.family == "redux" && record.redux.is_some())
-                    || (record.family == "vote" && record.vote.is_some())
-                    || (record.family == "warp_match" && record.warp_match.is_some())
-                    || record.family == "elect"
-                    || (record.family == "warp_barrier" && record.warp_barrier.is_some())
-                    || (record.family == "warp_shuffle" && record.warp_shuffle.is_some())
-                    || (record.family == "cp_async_copy" && record.cp_async_copy.is_some())
-                    || (record.family == "cp_async_control" && record.cp_async_control.is_some())
-                    || (record.family == "cp_async_mbarrier" && record.cp_async_mbarrier.is_some())
-                    || (record.family == "mbarrier_basic" && record.mbarrier_basic.is_some())
-                    || (record.family == "movmatrix" && record.movmatrix.is_some())
-                    || (record.family == "mbarrier_extended" && record.mbarrier_extended.is_some())
-                    || (record.family == "cluster_barrier" && record.cluster_barrier.is_some())
-                    || (record.family == "cluster_memory" && record.cluster_memory.is_some())
-                    || (record.family == "clc" && record.clc.is_some())
-                    || (record.family == "wgmma_control" && record.wgmma_control.is_some())
-                    || (record.family == "tma" && record.tma.is_some())
-                    || (record.family == "tcgen05" && record.tcgen05.is_some())
-                    || matches!(
-                        record.family.as_str(),
-                        "counted_barrier" | "grid_dependency" | "register_control"
-                    )
-                    || record.family == "sync",
-                "{} is unsafe but has no dedicated family safety renderer",
-                record.id
-            );
-        }
         match record.family.as_str() {
             "sreg" => {
                 if let Some(special) = &record.special_register {
@@ -2367,6 +2333,58 @@ fn clc_intrinsics(catalog: &CatalogFile) -> impl Iterator<Item = &CatalogIntrins
         .intrinsics
         .iter()
         .filter(|record| record.family == "clc")
+}
+
+#[derive(Clone, Copy)]
+enum ClcSafetyArgNames {
+    RawAbi,
+    Compatibility,
+}
+
+fn clc_safety_lines(operation: ClcOperation, names: ClcSafetyArgNames) -> Vec<String> {
+    let (response, mbar, resp_lo, resp_hi) = match names {
+        ClcSafetyArgNames::RawAbi => ("`_arg0`", "`_arg1`", "`_arg0`", "`_arg1`"),
+        ClcSafetyArgNames::Compatibility => ("`response`", "`mbar`", "`resp_lo`", "`resp_hi`"),
+    };
+    match operation {
+        ClcOperation::TryCancel => vec![
+            format!(
+                "{response} must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and {mbar} must designate a valid, aligned shared-memory mbarrier."
+            ),
+            format!(
+                "The calling CTA must issue `arrive_expect_tx` for {mbar} with 16 bytes before this request."
+            ),
+            "This CTA must not have observed a prior CLC try-cancel request fail.".into(),
+        ],
+        ClcOperation::TryCancelMulticast => vec![
+            format!(
+                "{response} must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and {mbar} must designate a valid, aligned shared-memory mbarrier."
+            ),
+            format!(
+                "Each CTA must issue `arrive_expect_tx` for its own corresponding mbarrier with 16 bytes before this request."
+            ),
+            "This CTA must not have observed a prior CLC try-cancel request fail.".into(),
+            "The response is written to every CTA's shared-memory window and signals every CTA's mbarrier.".into(),
+            "Every CTA in the cluster must still be active.".into(),
+        ],
+        ClcOperation::QueryIsCanceled => vec![format!(
+            "{resp_lo} and {resp_hi} must be the two halves of an opaque response observed complete from a prior CLC try-cancel request."
+        )],
+        ClcOperation::QueryGetFirstCtaidX
+        | ClcOperation::QueryGetFirstCtaidY
+        | ClcOperation::QueryGetFirstCtaidZ => vec![
+            format!(
+                "{resp_lo} and {resp_hi} must be the two halves of an opaque response observed complete from a prior CLC try-cancel request."
+            ),
+            "The result is meaningful only when `clc_query_is_canceled` returned one for this response.".into(),
+        ],
+    }
+}
+
+fn render_clc_safety_lines(output: &mut String, operation: ClcOperation, names: ClcSafetyArgNames) {
+    for line in clc_safety_lines(operation, names) {
+        writeln!(output, "/// {line}").unwrap();
+    }
 }
 
 fn tma_intrinsics(catalog: &CatalogFile) -> impl Iterator<Item = &CatalogIntrinsic> {
@@ -4726,7 +4744,7 @@ fn render_raw_mod(catalog: &CatalogFile, hash: &str) -> String {
     output
 }
 
-fn render_raw_abi(catalog: &CatalogFile, hash: &str) -> String {
+fn render_raw_abi(catalog: &CatalogFile, hash: &str) -> Result<String> {
     let mut output = rust_header(catalog, hash);
     output.push_str("//! Raw ABI functions recognized by cuda-oxide.\n\n");
     for record in &catalog.intrinsics {
@@ -5173,11 +5191,19 @@ fn render_raw_abi(catalog: &CatalogFile, hash: &str) -> String {
                         "/// The caller must satisfy the tcgen05 address, lifetime, and participation rules.\n",
                     );
                 }
-            } else {
+            } else if record.packed_atomic.is_some() {
                 output.push_str(
                     "/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.\n\
                      /// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.\n\
                      /// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.\n",
+                );
+            } else if let Some(clc) = &record.clc {
+                render_clc_safety_lines(&mut output, clc.operation, ClcSafetyArgNames::RawAbi);
+            } else {
+                anyhow::bail!(
+                    "{} ({}) is unsafe but has no dedicated family safety renderer",
+                    record.id,
+                    record.family
                 );
             }
         }
@@ -5211,7 +5237,7 @@ fn render_raw_abi(catalog: &CatalogFile, hash: &str) -> String {
         .unwrap();
         output.push_str("}\n\n");
     }
-    output
+    Ok(output)
 }
 
 fn render_compat_register_mma(catalog: &CatalogFile, hash: &str) -> String {
@@ -5946,12 +5972,9 @@ fn render_compat_clc(catalog: &CatalogFile, hash: &str) -> String {
         let operation = record.clc.as_ref().expect("CLC contract").operation;
         writeln!(output, "/// {}", record.summary).unwrap();
         output.push_str("///\n/// # Safety\n");
+        render_clc_safety_lines(&mut output, operation, ClcSafetyArgNames::Compatibility);
         match operation {
             ClcOperation::TryCancel | ClcOperation::TryCancelMulticast => {
-                output.push_str("/// `response` and `mbar` must be valid, aligned shared-memory objects for this request.\n");
-                if operation == ClcOperation::TryCancelMulticast {
-                    output.push_str("/// Every CTA in the cluster must still be active.\n");
-                }
                 output.push_str("#[inline(never)]\n");
                 writeln!(
                     output,
@@ -5965,8 +5988,6 @@ fn render_compat_clc(catalog: &CatalogFile, hash: &str) -> String {
             | ClcOperation::QueryGetFirstCtaidX
             | ClcOperation::QueryGetFirstCtaidY
             | ClcOperation::QueryGetFirstCtaidZ => {
-                output
-                    .push_str("/// The response halves must come from a completed CLC request.\n");
                 output.push_str("#[inline(never)]\n");
                 writeln!(
                     output,
@@ -20989,7 +21010,7 @@ mod tests {
     #[test]
     fn unsafe_safety_docs_never_reference_missing_addr() {
         let catalog = catalog_with_clc();
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         let offenders = catalog
             .intrinsics
             .iter()
@@ -21014,7 +21035,7 @@ mod tests {
     #[test]
     fn unsafe_safety_blocks_are_exclusive_to_one_family() {
         let catalog = catalog_with_clc();
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         let mut families_by_block = BTreeMap::<&str, BTreeSet<&str>>::new();
         for record in catalog.intrinsics.iter().filter(|record| !record.rust.safe) {
             families_by_block
@@ -21028,7 +21049,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(
             collisions.is_empty(),
-            "unsafe safety blocks shared across families: {collisions:?}"
+            "unsafe safety blocks shared across families: {collisions:?}; render a legitimate shared contract through a shared arm"
         );
     }
 
@@ -21045,7 +21066,7 @@ mod tests {
         assert!(compatibility.contains("__wgmma_wait_group(N as u64);"));
         assert!(compatibility.contains("pub(crate) fn __wgmma_wait_group(_max_pending: u64)"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0317()"));
         assert!(raw.contains("pub unsafe fn i0318()"));
         assert!(raw.contains("pub unsafe fn i0319(_arg0: u64)"));
@@ -21472,7 +21493,7 @@ mod tests {
         }
         assert_eq!(typed_probe_count, 4);
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub fn i0062(_arg0: u32, _arg1: u32, _arg2: u32) -> u32"));
         assert!(raw.contains("pub fn i0071(_arg0: f32, _arg1: f32) -> u32"));
         assert!(raw.contains("pub fn i0072(_arg0: u32, _arg1: u32, _arg2: u32) -> u32"));
@@ -21623,7 +21644,7 @@ mod tests {
         );
         assert!(compatibility.contains("pub fn cvt_rna_tf32_f32(value: f32) -> u32"));
         assert!(compatibility.contains("pub fn cvt_rz_relu_satfinite_tf32_f32(value: f32) -> u32"));
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub fn i0368(_arg0: f32) -> u32"));
         assert!(raw.contains("pub fn i0377(_arg0: f32) -> u32"));
     }
@@ -21728,7 +21749,7 @@ mod tests {
         ));
         assert!(rendered.contains("ldmatrix.sync.aligned.m16n16.x2.trans.shared.b8x16.b6x16_p32"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains(
             "Instruction floor PTX 8.6; the selected target may require a newer PTX version."
         ));
@@ -21807,7 +21828,7 @@ mod tests {
     fn packed_atomic_raw_abi_is_unsafe_and_must_use() {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         let catalog = crate::resolve::resolve(&repo_root).unwrap();
-        let rendered = render_raw_abi(&catalog, "test-hash");
+        let rendered = render_raw_abi(&catalog, "test-hash").unwrap();
         for abi_id in ["i0014", "i0015"] {
             let signature = format!("pub unsafe fn {abi_id}(_arg0: *mut u32, _arg1: u32) -> u32");
             let index = rendered.find(&signature).unwrap();
@@ -21922,7 +21943,7 @@ mod tests {
         let records: Vec<_> = cp_async_mbarriers(&catalog).collect();
         assert_eq!(records.len(), 4);
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0101(_arg0: *mut u64)"));
         assert!(raw.contains("live, initialized, eight-byte-aligned mbarrier"));
         assert!(raw.contains("initial pending count must already include"));
@@ -22059,7 +22080,7 @@ mod tests {
                 .contains("call float @llvm.nvvm.redux.sync.fmin(float %value, i32 %member_mask)")
         );
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         let signature = "pub unsafe fn i0017(_arg0: u32, _arg1: u32) -> u32";
         let index = raw.find(signature).unwrap();
         assert!(raw[..index].ends_with("#[must_use]\n#[inline(never)]\n"));
@@ -22111,7 +22132,7 @@ mod tests {
         assert!(probe.contains("define i32 @probe_ballot_sync_immediate(i1 %predicate)"));
         assert!(probe.contains("i32 -1, i1 %predicate"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         for abi_id in ["i0040", "i0041", "i0042", "i0043"] {
             assert!(raw.contains(&format!("pub unsafe fn {abi_id}")));
         }
@@ -22160,7 +22181,7 @@ mod tests {
         }
         assert!(probe.contains("declare { i32, i1 } @llvm.nvvm.match.all.sync.i32p"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub fn i0044() -> u32"));
         assert!(!raw.contains("pub unsafe fn i0044() -> u32"));
         assert!(raw.contains("pub unsafe fn i0045(_arg0: u32, _arg1: u32) -> u32"));
@@ -22218,7 +22239,7 @@ mod tests {
         assert!(probe.contains("define void @probe_sync_mask_immediate()"));
         assert!(probe.contains("call void @llvm.nvvm.bar.warp.sync(i32 -1)"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0049(_arg0: u32) -> ()"));
         assert!(raw.contains("On `sm_6x` and earlier"));
         assert!(raw.contains("no lane outside `mask` may be active"));
@@ -22352,7 +22373,7 @@ mod tests {
             }
         }
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0050(_arg0: u32, _arg1: u32, _arg2: u32) -> u32"));
         assert!(raw.contains("pub unsafe fn i0057(_arg0: u32, _arg1: f32, _arg2: u32) -> f32"));
         for abi_id in ["i0058", "i0059", "i0060", "i0061"] {
@@ -22427,7 +22448,7 @@ mod tests {
         let record = sync_intrinsics(&catalog).next().unwrap();
         assert_eq!(sync_intrinsics(&catalog).count(), 4);
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0034() -> ()"));
         assert!(raw.contains("Every active thread in the CTA must reach the same barrier"));
 
@@ -22565,7 +22586,7 @@ mod tests {
         let importer = render_importer(&catalog, "test-hash");
         let lowering = render_lowering(&catalog, "test-hash");
         let targets = render_targets(&catalog, "test-hash");
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         for record in mbarrier_basics(&catalog) {
             assert!(dialect.contains(&format!("pub struct {}", record.dialect.op_type)));
             assert!(dialect.contains(&format!("{}::register(ctx)", record.dialect.op_type)));
@@ -22788,7 +22809,7 @@ mod tests {
         let dialect = render_dialect_mbarrier_extended(&catalog, "test-hash");
         let importer = render_importer(&catalog, "test-hash");
         let lowering = render_lowering(&catalog, "test-hash");
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         for record in &records {
             assert!(dialect.contains(&format!("pub struct {}", record.dialect.op_type)));
             assert!(dialect.contains(&format!("{}::register(ctx);", record.dialect.op_type)));
@@ -22888,7 +22909,7 @@ mod tests {
         assert_eq!(generated_records.len(), 149);
         assert_eq!(existing_records.len(), 5);
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         for record in &records {
             assert!(raw.contains(&format!("pub unsafe fn {}(", record.rust.abi_id)));
         }
@@ -23493,7 +23514,7 @@ mod tests {
         );
         assert_eq!(sparse_mma_selector_values(ordered_f8f6f4_f16), &[0]);
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("must be the compile-time constant `0` or `1`"));
         assert!(raw.contains("must be the compile-time constant `0`"));
         for record in &records {
@@ -23878,7 +23899,7 @@ mod tests {
         assert!(read_probe.contains("~{memory}"));
         assert!(read_probe.contains("attributes #0 = { convergent }"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0320(_arg0: *const u8, _arg1: u32) -> *const u8"));
         assert!(raw.contains("pub unsafe fn i0321(_arg0: *const u32, _arg1: u32) -> u32"));
         assert!(raw.contains(
@@ -24388,7 +24409,7 @@ mod tests {
         );
         assert!(!compatibility.contains("tcgen05_mma_ws_f16_with_collector"));
 
-        let raw = render_raw_abi(&catalog, "test-hash");
+        let raw = render_raw_abi(&catalog, "test-hash").unwrap();
         assert!(raw.contains("pub unsafe fn i0578(_arg0: u32, _arg1: u64) -> ()"));
         assert!(raw.contains("pub unsafe fn i0611(_arg0: u32, _arg1: u64) -> ()"));
         assert!(raw.contains("pub unsafe fn i0612(_arg0: u32) -> u32"));

--- a/crates/cuda-intrinsics-gen/src/render.rs
+++ b/crates/cuda-intrinsics-gen/src/render.rs
@@ -20966,6 +20966,72 @@ mod tests {
         catalog
     }
 
+    fn raw_abi_item<'a>(raw: &'a str, id: &str) -> &'a str {
+        let marker = format!("Catalog ID: `{id}`");
+        let marker_offset = raw.find(&marker).unwrap();
+        let start = raw[..marker_offset]
+            .rfind("\n\n")
+            .map_or(0, |offset| offset + 2);
+        let end = raw[marker_offset..]
+            .find("\n}\n")
+            .map_or(raw.len(), |offset| marker_offset + offset + 3);
+        &raw[start..end]
+    }
+
+    fn raw_abi_safety_block<'a>(raw: &'a str, id: &str) -> &'a str {
+        let item = raw_abi_item(raw, id);
+        let marker = "/// # Safety\n";
+        let start = item.find(marker).unwrap() + marker.len();
+        let end = item[start..].find("#[").unwrap() + start;
+        &item[start..end]
+    }
+
+    #[test]
+    fn unsafe_safety_docs_never_reference_missing_addr() {
+        let catalog = catalog_with_clc();
+        let raw = render_raw_abi(&catalog, "test-hash");
+        let offenders = catalog
+            .intrinsics
+            .iter()
+            .filter(|record| !record.rust.safe)
+            .filter(|record| raw_abi_item(&raw, &record.id).contains("/// `addr`"))
+            .filter(|record| {
+                !record
+                    .rust
+                    .arguments
+                    .iter()
+                    .any(|argument| argument.starts_with('*'))
+            })
+            .map(|record| record.id.as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            offenders.is_empty(),
+            "unsafe safety docs reference `addr` without a pointer argument: {}",
+            offenders.join(", ")
+        );
+    }
+
+    #[test]
+    fn unsafe_safety_blocks_are_exclusive_to_one_family() {
+        let catalog = catalog_with_clc();
+        let raw = render_raw_abi(&catalog, "test-hash");
+        let mut families_by_block = BTreeMap::<&str, BTreeSet<&str>>::new();
+        for record in catalog.intrinsics.iter().filter(|record| !record.rust.safe) {
+            families_by_block
+                .entry(raw_abi_safety_block(&raw, &record.id))
+                .or_default()
+                .insert(&record.family);
+        }
+        let collisions = families_by_block
+            .values()
+            .filter(|families| families.len() != 1)
+            .collect::<Vec<_>>();
+        assert!(
+            collisions.is_empty(),
+            "unsafe safety blocks shared across families: {collisions:?}"
+        );
+    }
+
     #[test]
     fn wgmma_controls_render_closed_compatibility_and_backend_routes() {
         let catalog = catalog_with_wgmma_controls();

--- a/crates/cuda-intrinsics/src/generated/abi_v1.rs
+++ b/crates/cuda-intrinsics/src/generated/abi_v1.rs
@@ -644,9 +644,8 @@ pub fn i0296() -> () {
 /// Available on `sm_100+` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` and `_arg1` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn i0325(_arg0: u64, _arg1: u64) -> u32 {
     unreachable!(
@@ -660,9 +659,8 @@ pub unsafe fn i0325(_arg0: u64, _arg1: u64) -> u32 {
 /// Available on `sm_100+` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` and `_arg1` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn i0326(_arg0: u64, _arg1: u64) -> u32 {
     unreachable!(
@@ -676,9 +674,8 @@ pub unsafe fn i0326(_arg0: u64, _arg1: u64) -> u32 {
 /// Available on `sm_100+` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` and `_arg1` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
+/// The result is meaningful only when `clc_query_is_canceled` returned one for this response.
 #[inline(never)]
 pub unsafe fn i0327(_arg0: u64, _arg1: u64) -> u32 {
     unreachable!(
@@ -692,9 +689,7 @@ pub unsafe fn i0327(_arg0: u64, _arg1: u64) -> u32 {
 /// Available on `sm_100+` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` and `_arg1` must be the two halves of an opaque response observed complete from a prior CLC try-cancel request.
 #[inline(never)]
 pub unsafe fn i0324(_arg0: u64, _arg1: u64) -> u32 {
     unreachable!(
@@ -708,9 +703,9 @@ pub unsafe fn i0324(_arg0: u64, _arg1: u64) -> u32 {
 /// Available on `sm_100+` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and `_arg1` must designate a valid, aligned shared-memory mbarrier.
+/// The calling CTA must issue `arrive_expect_tx` for `_arg1` with 16 bytes before this request.
+/// This CTA must not have observed a prior CLC try-cancel request fail.
 #[inline(never)]
 pub unsafe fn i0322(_arg0: *mut u8, _arg1: *mut u64) -> () {
     unreachable!(
@@ -724,9 +719,11 @@ pub unsafe fn i0322(_arg0: *mut u8, _arg1: *mut u64) -> () {
 /// Available on `sm_100a or sm_101a or sm_103a or sm_110a or sm_120a or sm_121a` targets from PTX 8.6.
 ///
 /// # Safety
-/// `addr` must designate four writable bytes in global memory and be naturally aligned to four bytes.
-/// Do not overlap this operation with a whole-word atomic or any non-atomic access to either 16-bit lane.
-/// Racing atomics must use scopes that include each other; this relaxed GPU-scope operation is not atomic with host/system access.
+/// `_arg0` must designate a writable, 16-byte-aligned 16-byte region in `shared::cta` memory, and `_arg1` must designate a valid, aligned shared-memory mbarrier.
+/// Each CTA must issue `arrive_expect_tx` for its own corresponding mbarrier with 16 bytes before this request.
+/// This CTA must not have observed a prior CLC try-cancel request fail.
+/// The response is written to every CTA's shared-memory window and signals every CTA's mbarrier.
+/// Every CTA in the cluster must still be active.
 #[inline(never)]
 pub unsafe fn i0323(_arg0: *mut u8, _arg1: *mut u64) -> () {
     unreachable!(


### PR DESCRIPTION
## Summary

Fixes #1152. The unsafe-family guard checked a hand-maintained family allowlist rather than whether `render_raw_abi` had a matching safety renderer, allowing CLC intrinsics to inherit the terminal packed-atomic contract. This change makes raw-ABI safety rendering fail closed and gives CLC shared safety contracts across the raw and compatibility renderers.

## Changes

- `b0b57459` adds two rendered-safety invariants. At that commit they are RED: 298 existing tests pass and exactly the two new tests expose the CLC/packed-atomic collision.
- `50a4d0b1` makes the tests GREEN by giving `packed_atomic` an explicit arm, returning a generation error for any unhandled unsafe family, removing the redundant mirrored allowlist, and rendering reviewed CLC contracts through one shared helper.
- Regenerated changes in `abi_v1.rs` and `clc.rs` are doc comments only; comparison confirmed that no non-`///` line changed. No catalog, ABI ledger, PTX, or lowering file is touched, so runtime/GPU validation is not applicable.

## Testing

- [x] `just check` passes (the local mirror of CI: fmt, clippy, tests, CUDA-linked tests, guards, generated-intrinsic checks, rustdoc, and doctests). Exit 0 on the commits in this PR, with CUDA 12.9.86 and the pinned toolchain; 90 test binaries pass and none fail.
  - A fork-internal CI dry run of these identical commits passed all 50 applicable checks, including examples-compile, CodeQL, and the book gates; only `deploy` was skipped, as it is on every pull request.
- [ ] `cargo oxide run <example>` passes, or `scripts/smoketest.sh -o '^<example>$'` (not applicable: documentation-only generated changes; no runtime, PTX, or lowering change)
- [ ] New example added (not applicable)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new source files)

