### PR TITLE
refactor(rustlantis): clarify ProjectionIter traversal invariant

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -1353,8 +1353,12 @@ impl PlacePath {
     }
 }
 
-/// A depth-first iterator over all reachable projections from a local variable
-/// FIXME: this breaks if there's a reference cycle in the graph
+/// A depth-first iterator over all reachable projection paths from a local variable.
+///
+/// The root may be followed through any outgoing projection, including `Deref`.
+/// Subsequent traversal only follows `subfield_edges`, which contain structural
+/// projections created by `add_place`. Reference cycles therefore cannot be
+/// re-entered by this iterator.
 #[derive(Clone)]
 pub struct ProjectionIter<'pt> {
     pt: &'pt PlaceGraph,
@@ -1419,6 +1423,11 @@ impl<'pt> Iterator for ProjectionIter<'pt> {
             let new_edges = self.pt.places[target].subfield_edges.iter();
             self.to_visit.extend(new_edges.filter_map(|&eidx| {
                 let e = self.pt.places[eidx];
+                debug_assert!(
+                    !e.is_deref(),
+                    "subfield_edges must not contain Deref projections"
+                );
+
                 // Only downcast to current variants
                 if let ProjectionElem::DowncastField(vid, _, _) = e
                     && self.pt.known_variant(target) != Some(vid)

--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -1636,6 +1636,38 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "subfield_edges must not contain Deref projections")]
+    fn deref_in_subfield_edges_panics() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        // *const i32
+        let ptr = tcx.push(TyKind::RawPtr(TyCtxt::I32, Mutability::Not));
+        // (*const i32,)
+        let ty = tcx.push(TyKind::Tuple(vec![ptr]));
+
+        let mut pt = PlaceGraph::new(Rc::new(tcx));
+        let root = Local::new(1);
+        let root_pidx = pt.allocate_local(root, ty);
+
+        let int = Local::new(2);
+        pt.allocate_local(int, TyCtxt::I32);
+
+        // root -[TupleField(0)]-> root.0 -[Deref]-> int
+        let root_0 = Place::from_projected(root, &[ProjectionElem::TupleField(FieldIdx::new(0))]);
+        pt.set_ref(root_0.clone(), int, None);
+
+        // Violate the ProjectionIter invariant: subfield_edges must only
+        // contain structural projections created by add_place, but we inject
+        // the Deref edge created by set_ref.
+        let root_0_pidx = root_0.to_place_index(&pt).unwrap();
+        let deref_edge = pt.ref_edge(root_0_pidx).unwrap();
+        pt.places[root_0_pidx].subfield_edges.push(deref_edge);
+
+        // Traversing past root.0 consumes its subfield_edges and must trip
+        // the debug_assert.
+        let _ = pt.reachable_from_node(root_pidx).count();
+    }
+
+    #[test]
     fn tuple_projection() {
         let mut tcx = TyCtxt::from_primitives(TyConfig::default());
         let ty = tcx.push(TyKind::Tuple(vec![TyCtxt::I8, TyCtxt::I32]));


### PR DESCRIPTION
Closes #1156

## Summary

Replace a stale `ProjectionIter` reference-cycle FIXME with documentation of
the traversal invariant that currently prevents the problem.

`ProjectionIter::new()` may start from any outgoing projection of the root,
including `Deref`, but subsequent traversal follows only
`PlaceNode::subfield_edges`.

`subfield_edges` contains structural projections created by `add_place()`.
Reference edges created by `set_ref()` are added to the graph but are not added
to `subfield_edges`.

Therefore, reference cycles in `PlaceGraph` cannot currently be re-entered by
`ProjectionIter`.

## Changes

- Replace the stale reference-cycle FIXME with documentation of the actual
  traversal invariant.
- Add a debug assertion that descendant `subfield_edges` do not contain
  `Deref` projections.
- Preserve the existing traversal behavior.

## Testing

```text
cargo fmt --all -- --check
cargo test -p generate
cargo test --workspace
git diff --check
```

All Rustlantis workspace tests pass.
