### PR TITLE
fix(rustlantis): validate projection chains at construction

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
+++ b/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
@@ -343,7 +343,12 @@ impl GenerationCtx {
             .except(lhs);
         if let Some(_) = self.pt.pointee(lhs.to_place_index(&self.pt).unwrap()) {
             // The MIR linter doesn't like it if we do x = &(*x)
-            selector = selector.except(lhs.clone().project(ProjectionElem::Deref));
+            let local_ty = self.current_decls()[lhs.local()].ty;
+            selector = selector.except(lhs.clone().project(
+                local_ty,
+                ProjectionElem::Deref,
+                &self.tcx,
+            ));
         }
         let (candidates, weights) = selector
             .into_weighted(&self.pt)

--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -1322,7 +1322,9 @@ impl PlacePath {
             .collect();
         Place::from_projected(
             pt.current_frame().get_by_index(self.source).unwrap(),
+            pt.ty(self.source),
             &projs,
+            &pt.tcx,
         )
     }
 
@@ -1529,17 +1531,40 @@ mod tests {
         let local = Local::new(1);
         pt.allocate_local(local, t_root);
 
-        let a = Place::from_projected(local, &[ProjectionElem::TupleField(FieldIdx::new(0))]);
-        let b = Place::from_projected(local, &[ProjectionElem::TupleField(FieldIdx::new(1))]);
-        let c = Place::from_projected(local, &[ProjectionElem::TupleField(FieldIdx::new(2))]);
+        let a = Place::from_projected(
+            local,
+            t_root,
+            &[ProjectionElem::TupleField(FieldIdx::new(0))],
+            &pt.tcx,
+        );
+        let b = Place::from_projected(
+            local,
+            t_root,
+            &[ProjectionElem::TupleField(FieldIdx::new(1))],
+            &pt.tcx,
+        );
+        let c = Place::from_projected(
+            local,
+            t_root,
+            &[ProjectionElem::TupleField(FieldIdx::new(2))],
+            &pt.tcx,
+        );
 
         let d = b
             .clone()
-            .project(ProjectionElem::TupleField(FieldIdx::new(0)))
+            .project(
+                t_root,
+                ProjectionElem::TupleField(FieldIdx::new(0)),
+                &pt.tcx,
+            )
             .clone();
         let e = b
             .clone()
-            .project(ProjectionElem::TupleField(FieldIdx::new(1)))
+            .project(
+                t_root,
+                ProjectionElem::TupleField(FieldIdx::new(1)),
+                &pt.tcx,
+            )
             .clone();
         (pt, local, a, b, c, d, e)
     }
@@ -1604,7 +1629,9 @@ mod tests {
         // root -[Deref]-> tuple -[Field(0)]-> tuple.0 -[Deref]-> int
         let tuple_0 = Place::from_projected(
             tuple,
+            inner_ty,
             &[ProjectionElem::TupleField(FieldIdx::from_usize(0))],
+            &pt.tcx,
         );
         pt.set_ref(tuple_0.clone(), int, None);
 
@@ -1760,10 +1787,12 @@ mod tests {
         // local[one].0
         let one_zero = Place::from_projected(
             local,
+            ty,
             &[
                 ProjectionElem::Index(one),
                 ProjectionElem::TupleField(FieldIdx::new(0)),
             ],
+            &pt.tcx,
         );
         let one_zero = pt.get_node(&one_zero).unwrap();
         assert_eq!(pt.places[one_zero].ty, TyCtxt::I32);
@@ -1784,12 +1813,22 @@ mod tests {
         pt.allocate_local(root, t_i16_i32);
         pt.mark_place_init(root);
 
-        let root_0 = Place::from_projected(root, &[ProjectionElem::TupleField(FieldIdx::new(0))])
-            .to_place_index(&pt)
-            .unwrap();
-        let root_1 = Place::from_projected(root, &[ProjectionElem::TupleField(FieldIdx::new(1))])
-            .to_place_index(&pt)
-            .unwrap();
+        let root_0 = Place::from_projected(
+            root,
+            t_i16_i32,
+            &[ProjectionElem::TupleField(FieldIdx::new(0))],
+            &pt.tcx,
+        )
+        .to_place_index(&pt)
+        .unwrap();
+        let root_1 = Place::from_projected(
+            root,
+            t_i16_i32,
+            &[ProjectionElem::TupleField(FieldIdx::new(1))],
+            &pt.tcx,
+        )
+        .to_place_index(&pt)
+        .unwrap();
 
         // root_ptr1 = addr_of!(root)
         let root_ptr1 = Local::new(2);
@@ -1822,7 +1861,9 @@ mod tests {
         pt.place_written(
             &Place::from_projected(
                 root_ptr1,
+                t_ptr,
                 &[ProjectionElem::Deref, ProjectionElem::TupleField(0.into())],
+                &pt.tcx,
             ),
             pt.places[root_ptr1_p].tag,
         );

--- a/crates/fuzzer/rustlantis/mir/src/syntax.rs
+++ b/crates/fuzzer/rustlantis/mir/src/syntax.rs
@@ -92,7 +92,13 @@ impl Place {
         }
     }
 
-    pub fn from_projected(local: Local, projections: &[ProjectionElem]) -> Self {
+    pub fn from_projected(
+        local: Local,
+        local_ty: TyId,
+        projections: &[ProjectionElem],
+        tcx: &TyCtxt,
+    ) -> Self {
+        local_ty.projected_ty(tcx, projections);
         Place {
             local,
             projection: SmallVec::from(projections),
@@ -107,8 +113,9 @@ impl Place {
         &self.projection
     }
 
-    pub fn project(&mut self, proj: ProjectionElem) -> &mut Self {
-        // TODO: validation
+    pub fn project(&mut self, local_ty: TyId, proj: ProjectionElem, tcx: &TyCtxt) -> &mut Self {
+        let current_ty = local_ty.projected_ty(tcx, self.projection());
+        current_ty.projected_ty(tcx, &[proj]);
         self.projection.push(proj);
         self
     }
@@ -349,39 +356,90 @@ impl TyId {
         self.kind(tcx).is_scalar()
     }
 
-    pub fn projected_ty(self, tcx: &TyCtxt, projs: &[ProjectionElem]) -> Self {
-        match projs {
-            [] => self,
-            [head, tail @ ..] => {
-                let projected = match head {
-                    ProjectionElem::Deref => match self.kind(tcx) {
-                        TyKind::RawPtr(pointee, ..) | TyKind::Ref(pointee, ..) => *pointee,
-                        _ => panic!("not a reference"),
-                    },
-                    ProjectionElem::TupleField(idx) => {
-                        self.tuple_elems(tcx).expect("is a tuple")[idx.index()]
-                    }
-                    ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. } => {
-                        match self.kind(tcx) {
-                            TyKind::Array(ty, ..) => *ty,
-                            _ => panic!("not an array"),
-                        }
-                    }
-                    ProjectionElem::Field(fid) => match self.kind(tcx) {
-                        TyKind::Adt(adt) => {
-                            let fields = &adt.variants.first().expect("adt is a struct").fields;
-                            fields[*fid]
-                        }
-                        _ => panic!("not an adt"),
-                    },
-                    ProjectionElem::DowncastField(vid, fid, _) => match self.kind(tcx) {
-                        TyKind::Adt(adt) => adt.variants[*vid].fields[*fid],
-                        _ => panic!("not an adt"),
-                    },
-                };
-                projected.projected_ty(tcx, tail)
-            }
+    fn project_ty(self, tcx: &TyCtxt, proj: ProjectionElem) -> Self {
+        match proj {
+            ProjectionElem::Deref => match self.kind(tcx) {
+                TyKind::RawPtr(pointee, ..) | TyKind::Ref(pointee, ..) => *pointee,
+                kind => panic!("cannot dereference projected type {kind:?}"),
+            },
+            ProjectionElem::TupleField(idx) => match self.kind(tcx) {
+                TyKind::Tuple(fields) => {
+                    assert!(
+                        idx.index() < fields.len(),
+                        "tuple projection index {} out of bounds for {} fields",
+                        idx.index(),
+                        fields.len()
+                    );
+                    fields[idx.index()]
+                }
+                kind => panic!("tuple-field projection requires a tuple, got {kind:?}"),
+            },
+            ProjectionElem::Index(_) => match self.kind(tcx) {
+                TyKind::Array(ty, ..) => *ty,
+                kind => panic!("index projection requires an array, got {kind:?}"),
+            },
+            ProjectionElem::ConstantIndex { offset } => match self.kind(tcx) {
+                TyKind::Array(ty, len) => {
+                    assert!(
+                        offset < *len as u64,
+                        "constant index {offset} out of bounds for array of length {len}"
+                    );
+                    *ty
+                }
+                kind => panic!("constant-index projection requires an array, got {kind:?}"),
+            },
+            ProjectionElem::Field(fid) => match self.kind(tcx) {
+                TyKind::Adt(adt) if !adt.is_enum() => {
+                    let fields = &adt
+                        .variants
+                        .first()
+                        .expect("struct ADT has one variant")
+                        .fields;
+                    assert!(
+                        fid.index() < fields.len(),
+                        "field projection index {} out of bounds for {} fields",
+                        fid.index(),
+                        fields.len()
+                    );
+                    fields[fid]
+                }
+                TyKind::Adt(_) => panic!("field projection on an enum requires a downcast"),
+                kind => panic!("field projection requires an ADT, got {kind:?}"),
+            },
+            ProjectionElem::DowncastField(vid, fid, declared_ty) => match self.kind(tcx) {
+                TyKind::Adt(adt) if adt.is_enum() => {
+                    assert!(
+                        vid.index() < adt.variants.len(),
+                        "downcast variant index {} out of bounds for {} variants",
+                        vid.index(),
+                        adt.variants.len()
+                    );
+                    let fields = &adt.variants[vid].fields;
+                    assert!(
+                        fid.index() < fields.len(),
+                        "downcast field index {} out of bounds for {} fields in variant {}",
+                        fid.index(),
+                        fields.len(),
+                        vid.index()
+                    );
+                    let actual_ty = fields[fid];
+                    assert_eq!(
+                        declared_ty, actual_ty,
+                        "downcast field type does not match the selected enum field"
+                    );
+                    actual_ty
+                }
+                TyKind::Adt(_) => panic!("downcast-field projection requires an enum ADT"),
+                kind => panic!("downcast-field projection requires an ADT, got {kind:?}"),
+            },
         }
+    }
+
+    pub fn projected_ty(self, tcx: &TyCtxt, projs: &[ProjectionElem]) -> Self {
+        projs
+            .iter()
+            .copied()
+            .fold(self, |ty, proj| ty.project_ty(tcx, proj))
     }
 
     pub fn contains<P>(self, tcx: &TyCtxt, predicate: P) -> bool
@@ -931,5 +989,146 @@ impl UnOp {
             UnOp::Not => "!",
             UnOp::Neg => "-",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use config::TyConfig;
+
+    use crate::tyctxt::{AdtMeta, TyCtxt};
+
+    use super::*;
+
+    fn adt_meta() -> AdtMeta {
+        AdtMeta { copy: true }
+    }
+
+    #[test]
+    fn place_construction_validates_projection_chain() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let array_ty = tcx.push(TyKind::Array(TyCtxt::I32, 2));
+        let tuple_ty = tcx.push(TyKind::Tuple(vec![TyCtxt::I8, array_ty]));
+        let ptr_ty = tcx.push(TyKind::RawPtr(tuple_ty, Mutability::Not));
+        let projections = [
+            ProjectionElem::Deref,
+            ProjectionElem::TupleField(FieldIdx::new(1)),
+            ProjectionElem::ConstantIndex { offset: 1 },
+        ];
+
+        let place = Place::from_projected(Local::new(1), ptr_ty, &projections, &tcx);
+
+        assert_eq!(place.projection(), &projections);
+        assert_eq!(ptr_ty.projected_ty(&tcx, &projections), TyCtxt::I32);
+    }
+
+    #[test]
+    fn project_rejects_invalid_projection_before_mutating_place() {
+        let tcx = TyCtxt::from_primitives(TyConfig::default());
+        let mut place = Place::from_local(Local::new(1));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            place.project(TyCtxt::I32, ProjectionElem::Deref, &tcx);
+        }));
+
+        assert!(result.is_err());
+        assert!(place.projection().is_empty());
+    }
+
+    #[test]
+    fn place_construction_rejects_out_of_bounds_projection() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let array_ty = tcx.push(TyKind::Array(TyCtxt::I32, 2));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            Place::from_projected(
+                Local::new(1),
+                array_ty,
+                &[ProjectionElem::ConstantIndex { offset: 2 }],
+                &tcx,
+            );
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn enum_projections_require_downcast_and_matching_field_type() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let enum_ty = tcx.push_adt(
+            Adt {
+                variants: IndexVec::from_vec(vec![
+                    VariantDef {
+                        fields: IndexVec::from_vec(vec![TyCtxt::I32]),
+                    },
+                    VariantDef {
+                        fields: IndexVec::from_vec(vec![TyCtxt::I64]),
+                    },
+                ]),
+            },
+            adt_meta(),
+        );
+
+        let direct_field = catch_unwind(AssertUnwindSafe(|| {
+            Place::from_projected(
+                Local::new(1),
+                enum_ty,
+                &[ProjectionElem::Field(FieldIdx::new(0))],
+                &tcx,
+            );
+        }));
+        assert!(direct_field.is_err());
+
+        let mismatched_type = catch_unwind(AssertUnwindSafe(|| {
+            Place::from_projected(
+                Local::new(1),
+                enum_ty,
+                &[ProjectionElem::DowncastField(
+                    VariantIdx::new(1),
+                    FieldIdx::new(0),
+                    TyCtxt::I32,
+                )],
+                &tcx,
+            );
+        }));
+        assert!(mismatched_type.is_err());
+
+        let valid = Place::from_projected(
+            Local::new(1),
+            enum_ty,
+            &[ProjectionElem::DowncastField(
+                VariantIdx::new(1),
+                FieldIdx::new(0),
+                TyCtxt::I64,
+            )],
+            &tcx,
+        );
+        assert_eq!(enum_ty.projected_ty(&tcx, valid.projection()), TyCtxt::I64);
+    }
+
+    #[test]
+    fn struct_field_projection_rejects_out_of_bounds_field() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let struct_ty = tcx.push_adt(
+            Adt {
+                variants: IndexVec::from_vec(vec![VariantDef {
+                    fields: IndexVec::from_vec(vec![TyCtxt::I32]),
+                }]),
+            },
+            adt_meta(),
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            Place::from_projected(
+                Local::new(1),
+                struct_ty,
+                &[ProjectionElem::Field(FieldIdx::new(1))],
+                &tcx,
+            );
+        }));
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Closes #1160 

## Summary

Validate Rustlantis `Place` projection chains when they are constructed instead of relying on `Place::ty()` to detect invalid projections later.

This updates both `Place::from_projected` and `Place::project` so malformed projection chains fail immediately.

The projection semantics are centralized in the type projection logic and reused by both construction-time validation and `TyId::projected_ty()`.

Validation now covers:

- `Deref` on pointer/reference types
- tuple field bounds
- struct field bounds
- array projection source types and constant-index bounds
- enum variant and field bounds
- `DowncastField` type consistency

Call sites that construct projected places were updated to provide the base type and type context required for validation.

## Tests

Added regression coverage for:

- valid projection-chain construction
- out-of-bounds projections
- invalid projections rejected before mutating a `Place`
- struct field bounds
- enum downcast validation
- mismatched `DowncastField` field types

Validation performed from `crates/fuzzer/rustlantis`:

```text
cargo fmt --all -- --check
cargo test -p mir
cargo test -p generate
cargo check --workspace --all-targets
cargo test --workspace
```

Additionally, from the repository root:

```text
git diff --check
```

Results:

```text
mir tests:                  7 passed
generate tests:            17 passed
Rustlantis workspace tests: passed
Rustlantis workspace check: passed
```