### PR TITLE
feat(fuzzer): generate Static and StaticMut operands

### DIFF
--- a/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
+++ b/crates/fuzzer/rustlantis/generate/src/generation/mod.rs
@@ -10,7 +10,7 @@ use mir::serialize::Serialize;
 use mir::syntax::{
     AggregateKind, BasicBlock, BasicBlockData, BinOp, Body, Callee, Function, IntTy, Literal,
     Local, LocalDecls, Mutability, Operand, Place, Program, ProjectionElem, Rvalue, Statement,
-    SwitchTargets, Terminator, TyId, TyKind, UnOp, VariantIdx,
+    StaticDecl, SwitchTargets, Terminator, TyId, TyKind, UnOp, VariantIdx,
 };
 use mir::tyctxt::TyCtxt;
 use rand::{Rng, RngCore, SeedableRng, seq::IteratorRandom};
@@ -107,6 +107,30 @@ impl GenerationCtx {
             }
         })
     }
+
+    fn choose_static_operand(&self, ty: TyId) -> Result<Operand> {
+        let candidates = self
+            .program
+            .statics
+            .iter_enumerated()
+            .filter_map(|(id, decl)| match ty.kind(&self.tcx) {
+                TyKind::Ref(pointee, Mutability::Not)
+                    if decl.mutability == Mutability::Not && decl.ty == *pointee =>
+                {
+                    Some(Operand::Static(id, ty))
+                }
+                TyKind::RawPtr(pointee, Mutability::Mut)
+                    if decl.mutability == Mutability::Mut && decl.ty == *pointee =>
+                {
+                    Some(Operand::StaticMut(id, ty))
+                }
+                _ => None,
+            });
+
+        candidates
+            .choose(&mut *self.rng.borrow_mut())
+            .ok_or(SelectionError::Exhausted)
+    }
 }
 
 // Rvalue
@@ -122,7 +146,14 @@ impl GenerationCtx {
             lhs.serialize_value(&self.tcx),
             lhs.ty(self.current_decls(), &self.tcx).serialize(&self.tcx)
         );
-        let operand = self.choose_operand(&[lhs.ty(self.current_decls(), &self.tcx)], lhs)?;
+        let ty = lhs.ty(self.current_decls(), &self.tcx);
+        let operand = self.make_choice([false, true].into_iter(), |use_static| {
+            if use_static {
+                self.choose_static_operand(ty)
+            } else {
+                self.choose_operand(&[ty], lhs)
+            }
+        })?;
         Ok(Rvalue::Use(operand))
     }
 
@@ -1156,13 +1187,46 @@ impl GenerationCtx {
         seed_tys(&mut tcx, &mut *rng.borrow_mut());
         let tcx = Rc::new(tcx);
         let ty_weights = TySelect::new(&tcx);
+        let mut program = Program::new(debug_dump);
+        let mut pt = PlaceGraph::new(tcx.clone());
+
+        let static_specs: Vec<(TyId, Mutability)> = tcx
+            .indices()
+            .filter_map(|ty| match ty.kind(&tcx) {
+                TyKind::Ref(pointee, Mutability::Not)
+                    if <dyn RngCore>::is_literalble(*pointee, &tcx) =>
+                {
+                    Some((*pointee, Mutability::Not))
+                }
+                TyKind::RawPtr(pointee, Mutability::Mut)
+                    if <dyn RngCore>::is_literalble(*pointee, &tcx) =>
+                {
+                    Some((*pointee, Mutability::Mut))
+                }
+                _ => None,
+            })
+            .collect();
+
+        for (ty, mutability) in static_specs {
+            let init = rng
+                .borrow_mut()
+                .gen_literal(ty, &tcx)
+                .expect("static pointee type is literalble");
+            let id = program.push_static(StaticDecl {
+                ty,
+                mutability,
+                init,
+            });
+            pt.allocate_static(id, ty, init);
+        }
+
         // TODO: don't zero-initialize current_function and current_bb
         Self {
             rng,
             tcx: tcx.clone(),
             ty_weights,
-            program: Program::new(debug_dump),
-            pt: PlaceGraph::new(tcx.clone()),
+            program,
+            pt,
             return_stack: vec![],
             cursor: Cursor {
                 function: Function::new(0),
@@ -1340,6 +1404,12 @@ impl GenerationCtx {
                                 pt.assign_literal(lhs, Some(*lit));
                             }));
                         }
+                        Operand::Static(id, _) | Operand::StaticMut(id, _) => {
+                            let static_place = self.pt.static_place(*id);
+                            actions.push(Box::new(move |pt| {
+                                pt.set_ref(lhs, static_place, None);
+                            }));
+                        }
                     },
                     agg @ Rvalue::Aggregate(agg_kind, ..) => {
                         if self.pt.ty(lhs).kind(&self.tcx).is_enum() {
@@ -1361,6 +1431,12 @@ impl GenerationCtx {
                                 Operand::Constant(lit) => {
                                     actions.push(Box::new(move |pt| {
                                         pt.assign_literal(target, Some(*lit));
+                                    }));
+                                }
+                                Operand::Static(id, _) | Operand::StaticMut(id, _) => {
+                                    let static_place = self.pt.static_place(*id);
+                                    actions.push(Box::new(move |pt| {
+                                        pt.set_ref(target, static_place, None);
                                     }));
                                 }
                             }

--- a/crates/fuzzer/rustlantis/generate/src/pgraph.rs
+++ b/crates/fuzzer/rustlantis/generate/src/pgraph.rs
@@ -9,8 +9,8 @@ use bimap::BiHashMap;
 use index_vec::IndexVec;
 use mir::{
     syntax::{
-        Body, FieldIdx, Literal, Local, Mutability, Operand, Place, ProjectionElem, Rvalue, TyId,
-        TyKind, UintTy, VariantIdx,
+        Body, FieldIdx, Literal, Local, Mutability, Operand, Place, ProjectionElem, Rvalue, Static,
+        TyId, TyKind, UintTy, VariantIdx,
     },
     tyctxt::TyCtxt,
 };
@@ -87,6 +87,9 @@ impl PlaceOperand {
                 PlaceOperand::Move(index)
             }
             Operand::Constant(lit) => PlaceOperand::Constant(*lit),
+            Operand::Static(..) | Operand::StaticMut(..) => {
+                unreachable!("static operands are only generated as direct rvalue sources")
+            }
         }
     }
 }
@@ -98,6 +101,7 @@ pub struct PlaceGraph {
     frames: Vec<Frame>,
     index_candidates: HashMap<usize, SmallVec<[Local; 1]>>,
     pointer_tags: IndexVec<Tag, BTreeSet<PlaceIndex>>,
+    statics: IndexVec<Static, PlaceIndex>,
 
     places: Graph,
     memory: BasicMemory,
@@ -181,6 +185,7 @@ impl PlaceGraph {
             )],
             index_candidates: HashMap::new(),
             pointer_tags: IndexVec::new(),
+            statics: IndexVec::new(),
             places: StableGraph::default(),
             memory: BasicMemory::new(),
             tcx,
@@ -390,6 +395,23 @@ impl PlaceGraph {
         });
         self.current_frame_mut().add_local(local, pidx);
         pidx
+    }
+
+    pub fn allocate_static(&mut self, id: Static, ty: TyId, init: Literal) -> PlaceIndex {
+        let mut pidx = Default::default();
+        self.memory.allocate_with_builder(|builder| {
+            pidx = Self::add_place(&mut self.places, ty, &self.tcx, builder, None);
+        });
+        let inserted = self.statics.push(pidx);
+        assert_eq!(inserted, id);
+        self.mark_place_init(pidx);
+        self.assign_literal(pidx, Some(init));
+        self.update_complexity(pidx, 1);
+        pidx
+    }
+
+    pub fn static_place(&self, id: Static) -> PlaceIndex {
+        self.statics[id]
     }
 
     pub fn deallocate_local(&mut self, local: Local) {
@@ -1459,7 +1481,7 @@ impl HasComplexity for Operand {
     fn complexity(&self, pt: &PlaceGraph) -> usize {
         match self {
             Operand::Copy(place) | Operand::Move(place) => place.complexity(pt),
-            Operand::Constant(_) => 1,
+            Operand::Constant(_) | Operand::Static(..) | Operand::StaticMut(..) => 1,
         }
     }
 }
@@ -1498,8 +1520,8 @@ mod tests {
     use config::TyConfig;
     use mir::{
         syntax::{
-            BinOp, FieldIdx, Literal, Local, Mutability, Operand, Place, ProjectionElem, Rvalue,
-            TyId, TyKind, UintTy,
+            BinOp, FieldIdx, IntTy, Literal, Local, Mutability, Operand, Place, ProjectionElem,
+            Rvalue, Static, TyId, TyKind, UintTy,
         },
         tyctxt::TyCtxt,
     };
@@ -1768,6 +1790,34 @@ mod tests {
         let one_zero = pt.get_node(&one_zero).unwrap();
         assert_eq!(pt.places[one_zero].ty, TyCtxt::I32);
         assert_eq!(pt.places[local_pidx].alloc_id, pt.places[one_zero].alloc_id);
+    }
+
+    #[test]
+    fn static_allocation_is_persistent() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let t_ref = tcx.push(TyKind::Ref(TyCtxt::I32, Mutability::Not));
+        let mut pt = PlaceGraph::new(Rc::new(tcx));
+
+        let static_id = Static::new(0);
+        let static_place = pt.allocate_static(static_id, TyCtxt::I32, 7_i32.into());
+        assert!(pt.is_place_init(static_place));
+        assert!(matches!(
+            pt.known_val(static_place),
+            Some(&Literal::Int(7, IntTy::I32))
+        ));
+        assert!(pt.current_frame().get_by_index(static_place).is_none());
+        assert_eq!(pt.get_complexity(static_place), 1);
+
+        let reference = Local::new(1);
+        pt.allocate_local(reference, t_ref);
+        pt.mark_place_init(reference);
+        pt.set_ref(reference, static_place, None);
+
+        assert_eq!(pt.static_place(static_id), static_place);
+        assert_eq!(
+            pt.pointee(reference.to_place_index(&pt).unwrap()),
+            Some(static_place)
+        );
     }
 
     #[test]

--- a/crates/fuzzer/rustlantis/mir/src/serialize.rs
+++ b/crates/fuzzer/rustlantis/mir/src/serialize.rs
@@ -157,6 +157,8 @@ impl Serialize for Operand {
             Operand::Copy(place) => place.serialize_value(tcx),
             Operand::Move(place) => format!("Move({})", place.serialize_value(tcx)),
             Operand::Constant(lit) => lit.serialize(tcx),
+            Operand::Static(id, _) => format!("Static({})", id.identifier()),
+            Operand::StaticMut(id, _) => format!("StaticMut({})", id.identifier()),
         }
     }
 }
@@ -376,6 +378,19 @@ impl Program {
             program += Program::DUMPER;
         }
 
+        program.extend(self.statics.iter_enumerated().map(|(idx, decl)| {
+            let keyword = match decl.mutability {
+                Mutability::Not => "static",
+                Mutability::Mut => "static mut",
+            };
+            format!(
+                "{keyword} {}: {} = {};\n",
+                idx.identifier(),
+                decl.ty.serialize(tcx),
+                decl.init.serialize(tcx)
+            )
+        }));
+
         program.extend(self.functions.iter_enumerated().map(|(idx, body)| {
             let args_list: String = body
                 .args_iter()
@@ -436,7 +451,7 @@ impl Program {
 
 #[cfg(test)]
 mod tests {
-    use super::Serialize;
+    use super::{CallSynatx, Serialize};
     use crate::{syntax::*, tyctxt::TyCtxt};
     use config::TyConfig;
 
@@ -461,5 +476,42 @@ mod tests {
 
         let inf = Literal::Float(f32::INFINITY as f64, FloatTy::F32);
         assert_eq!(inf.serialize(&tcx), "f32::INFINITY");
+    }
+
+    #[test]
+    fn serialize_static_operands() {
+        let mut tcx = TyCtxt::from_primitives(TyConfig::default());
+        let shared_ref = tcx.push(TyKind::Ref(TyCtxt::I32, Mutability::Not));
+        let mut_ptr = tcx.push(TyKind::RawPtr(TyCtxt::I64, Mutability::Mut));
+        let mut program = Program::new(false);
+        let immutable = program.push_static(StaticDecl {
+            ty: TyCtxt::I32,
+            mutability: Mutability::Not,
+            init: 1_i32.into(),
+        });
+        let mutable = program.push_static(StaticDecl {
+            ty: TyCtxt::I64,
+            mutability: Mutability::Mut,
+            init: 2_i64.into(),
+        });
+
+        assert_eq!(
+            Operand::Static(immutable, shared_ref).serialize(&tcx),
+            "Static(static0)"
+        );
+        assert_eq!(
+            Operand::StaticMut(mutable, mut_ptr).serialize(&tcx),
+            "StaticMut(static1)"
+        );
+
+        let mut body = Body::new(&[], TyCtxt::UNIT, true);
+        body.new_basic_block(BasicBlockData {
+            statements: vec![],
+            terminator: Terminator::Return,
+        });
+        program.push_fn(body);
+        let source = program.serialize(&tcx, CallSynatx::V4);
+        assert!(source.contains("static static0: i32 = 1_i32;"));
+        assert!(source.contains("static mut static1: i64 = 2_i64;"));
     }
 }

--- a/crates/fuzzer/rustlantis/mir/src/syntax.rs
+++ b/crates/fuzzer/rustlantis/mir/src/syntax.rs
@@ -7,9 +7,18 @@ use crate::tyctxt::TyCtxt;
 
 #[derive(Clone)]
 pub struct Program {
+    pub statics: IndexVec<Static, StaticDecl>,
     pub functions: IndexVec<Function, Body>,
     pub entry_args: Vec<Literal>,
     pub use_debug_dumper: bool,
+}
+
+define_index_type! {pub struct Static = u32;}
+#[derive(Clone)]
+pub struct StaticDecl {
+    pub ty: TyId,
+    pub mutability: Mutability,
+    pub init: Literal,
 }
 
 pub type LocalDecls = IndexVec<Local, LocalDecl>;
@@ -241,9 +250,10 @@ pub enum Operand {
     // define!("mir_move", fn Move<T>(place: T) -> T);
     Move(Place),
     Constant(Literal),
-    // TODO: the following
     // define!("mir_static", fn Static<T>(s: T) -> &'static T);
+    Static(Static, TyId),
     // define!("mir_static_mut", fn StaticMut<T>(s: T) -> *mut T);
+    StaticMut(Static, TyId),
 }
 
 impl Operand {
@@ -251,13 +261,14 @@ impl Operand {
         match self {
             Operand::Copy(place) | Operand::Move(place) => place.ty(local_decls, tcx),
             Operand::Constant(lit) => lit.ty(),
+            Operand::Static(_, ty) | Operand::StaticMut(_, ty) => *ty,
         }
     }
 
     pub fn place(&self) -> Option<&Place> {
         match self {
             Operand::Copy(place) | Operand::Move(place) => Some(place),
-            Operand::Constant(..) => None,
+            Operand::Constant(..) | Operand::Static(..) | Operand::StaticMut(..) => None,
         }
     }
 }
@@ -768,10 +779,15 @@ impl Program {
     // A new, empty function
     pub fn new(debug: bool) -> Self {
         Self {
+            statics: IndexVec::default(),
             functions: IndexVec::default(),
             entry_args: vec![],
             use_debug_dumper: debug,
         }
+    }
+
+    pub fn push_static(&mut self, decl: StaticDecl) -> Static {
+        self.statics.push(decl)
     }
 
     pub fn push_fn(&mut self, body: Body) -> Function {
@@ -780,6 +796,12 @@ impl Program {
 
     pub fn set_entry_args(&mut self, args: &[Literal]) {
         self.entry_args = Vec::from(args);
+    }
+}
+
+impl Static {
+    pub fn identifier(&self) -> String {
+        format!("static{}", self.index())
     }
 }
 


### PR DESCRIPTION
Closes #1162 

## Summary

Add support for generating custom MIR `Static` and `StaticMut` operands in Rustlantis.

This extends the existing operand model beyond `Copy`, `Move`, and `Constant` and allows generated MIR programs to reference static allocations.

## Changes

- add static declarations to the MIR syntax model
- add `Static` and `StaticMut` operand variants
- serialize top-level `static` and `static mut` declarations
- serialize `Static(...)` and `StaticMut(...)` custom MIR operands
- generate scalar static allocations for compatible reference and raw pointer types
- keep static allocations alive independently of function frames
- connect static-derived pointers to the existing place graph and aliasing model
- add tests for static operand serialization and static allocation lifetime

## Scope

The implementation currently focuses on scalar static initializers.

More complex static initializers and additional static-related MIR constructs are intentionally left out of scope.

## Validation

The following checks pass:

- `cargo fmt --all -- --check`
- `cargo test -p mir`
- `cargo test -p generate`
- `cargo check --workspace`
- `cargo test --workspace`

Generated programs were also verified to contain both:

```text
Static(...)
StaticMut(...)
```

End-to-end differential testing was performed with two LLVM configurations:

* `-Zmir-opt-level=0`
* `-Zmir-opt-level=4 -Copt-level=3 -Ctarget-cpu=native`

100 generated seeds passed with:

```text
Passed: 100
Failed: 0
```
