### PR TITLE
fix(mir-importer): support chained projected call destinations

### DIFF
--- a/crates/mir-importer/src/translator/payload_store.rs
+++ b/crates/mir-importer/src/translator/payload_store.rs
@@ -124,7 +124,6 @@ pub(crate) fn classify(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn rebuild_and_store(
     ctx: &mut Context,
-    body: &mir::Body,
     value_map: &ValueMap,
     store: &CanonicalPayloadStore,
     new_value: Value,
@@ -136,7 +135,6 @@ pub(crate) fn rebuild_and_store(
 
     let Some((enum_ptr, prev)) = rvalue::translate_place_address(
         ctx,
-        body,
         value_map,
         &store.enum_place,
         /* is_mutable */ true,

--- a/crates/mir-importer/src/translator/rvalue.rs
+++ b/crates/mir-importer/src/translator/rvalue.rs
@@ -815,7 +815,6 @@ pub fn translate_rvalue(
             // through the borrow mutate the borrowed place.
             if let Some((result_val, last_inserted)) = translate_place_address(
                 ctx,
-                body,
                 value_map,
                 place,
                 is_mutable,
@@ -909,7 +908,6 @@ pub fn translate_rvalue(
             // composes field + element addresses, ...).
             if let Some((result_val, last_inserted)) = translate_place_address(
                 ctx,
-                body,
                 value_map,
                 place,
                 is_mutable,
@@ -2883,7 +2881,6 @@ pub fn translate_place(
         PlaceReadStrategy::Address => {
             if let Some((value, last_op)) = translate_place_load_from_address(
                 ctx,
-                body,
                 place,
                 value_map,
                 block_ptr,
@@ -3157,7 +3154,6 @@ fn classify_place_read_strategy(
 #[allow(clippy::too_many_arguments)]
 fn translate_place_load_from_address(
     ctx: &mut Context,
-    body: &mir::Body,
     place: &mir::Place,
     value_map: &ValueMap,
     block_ptr: Ptr<BasicBlock>,
@@ -3166,7 +3162,6 @@ fn translate_place_load_from_address(
 ) -> TranslationResult<Option<(Value, Option<Ptr<Operation>>)>> {
     let Some((addr, addr_prev_op)) = translate_place_address(
         ctx,
-        body,
         value_map,
         place,
         /* is_mutable */ false,
@@ -4054,10 +4049,12 @@ fn apply_enum_field_projection(
 /// of projected assignments (indexed `(*ptr)[i]` writes and 3+ element
 /// projection chains), where the same "walk the chain, then act through
 /// the address" logic applies with a store instead of a borrow.
+///
+/// Runtime `Index` projections load the index local directly from `ValueMap`,
+/// so address materialisation does not require the surrounding `mir::Body`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn translate_place_address(
     ctx: &mut Context,
-    body: &mir::Body,
     value_map: &ValueMap,
     place: &mir::Place,
     is_mutable: bool,
@@ -4070,7 +4067,6 @@ pub(crate) fn translate_place_address(
     };
     translate_place_addr_from_slot(
         ctx,
-        body,
         value_map,
         slot,
         &place.projection,
@@ -4588,7 +4584,6 @@ fn emit_array_subslice_value(
 /// final result pointer also carries this mutability.
 fn translate_place_addr_from_slot(
     ctx: &mut Context,
-    body: &mir::Body,
     value_map: &ValueMap,
     slot: Value,
     projection: &[mir::ProjectionElem],
@@ -5279,21 +5274,18 @@ fn translate_place_addr_from_slot(
                 if entered_as_slice_data {
                     pointee_kind = PointeeKind::Direct;
                 }
-
-                let index_place = mir::Place {
-                    local: *index_local,
-                    projection: vec![],
+                let Some((index_load, index_val)) =
+                    value_map.load_local(ctx, *index_local, block_ptr, current_prev_op)
+                else {
+                    return input_err!(
+                        loc,
+                        TranslationErr::unsupported(format!(
+                            "runtime Index local {} has no alloca slot",
+                            Into::<usize>::into(*index_local)
+                        ))
+                    );
                 };
-                let (index_val, next_prev_op) = translate_place(
-                    ctx,
-                    body,
-                    &index_place,
-                    value_map,
-                    block_ptr,
-                    current_prev_op,
-                    loc.clone(),
-                )?;
-                current_prev_op = next_prev_op;
+                current_prev_op = Some(index_load);
 
                 let (addr_op, next_current) = emit_indexed_element_addr(
                     ctx,

--- a/crates/mir-importer/src/translator/statement.rs
+++ b/crates/mir-importer/src/translator/statement.rs
@@ -1002,7 +1002,6 @@ pub fn translate_statement(
             // Get the address of the enum place.
             let (enum_ptr, addr_prev) = match rvalue::translate_place_address(
                 ctx,
-                body,
                 value_map,
                 place,
                 /* is_mutable */ true,
@@ -1099,7 +1098,6 @@ fn store_through_place_address(
     if let Some(payload_store) = payload_store::classify(ctx, body, place)?
         && let Some(result) = payload_store::rebuild_and_store(
             ctx,
-            body,
             value_map,
             &payload_store,
             result_value,
@@ -1114,7 +1112,6 @@ fn store_through_place_address(
     // The destination is written through, so request a mutable address.
     let walked = rvalue::translate_place_address(
         ctx,
-        body,
         value_map,
         place,
         /* is_mutable */ true,

--- a/crates/mir-importer/src/translator/terminator/drop_glue.rs
+++ b/crates/mir-importer/src/translator/terminator/drop_glue.rs
@@ -144,7 +144,6 @@ pub fn drop_instance_is_noop(instance: &Instance) -> bool {
 #[allow(clippy::too_many_arguments)]
 pub(super) fn emit_drop_glue(
     ctx: &mut Context,
-    body: &mir::Body,
     place: &mir::Place,
     dropped_ty: Ty,
     target: mir::BasicBlockIdx,
@@ -170,7 +169,7 @@ pub(super) fn emit_drop_glue(
     // For a simple local `_N`, this is just the alloca slot pointer.
     // For a projected place like `_N.field`, we compute the field address.
     let (place_ptr, last_op) =
-        compute_drop_place_address(ctx, body, place, value_map, block_ptr, prev_op, loc.clone())?;
+        compute_drop_place_address(ctx, place, value_map, block_ptr, prev_op, loc.clone())?;
 
     // The return type of drop_in_place is `()` (unit / void).
     let unit_ty = dialect_mir::types::MirTupleType::get(ctx, vec![]);
@@ -222,7 +221,6 @@ pub(super) fn emit_drop_glue(
 /// via `translate_place_address`.
 fn compute_drop_place_address(
     ctx: &mut Context,
-    body: &mir::Body,
     place: &mir::Place,
     value_map: &ValueMap,
     block_ptr: Ptr<BasicBlock>,
@@ -232,7 +230,6 @@ fn compute_drop_place_address(
     // Try the full projection-aware address computation first.
     if let Some((addr, last_op)) = rvalue::translate_place_address(
         ctx,
-        body,
         value_map,
         place,
         /* is_mutable */ true,

--- a/crates/mir-importer/src/translator/terminator/helpers.rs
+++ b/crates/mir-importer/src/translator/terminator/helpers.rs
@@ -9,7 +9,7 @@
 //!
 //! - [`emit_goto`]: Unconditional zero-operand branch to a target block.
 //! - [`emit_store_result_and_goto`]: Write an intrinsic result to the
-//!   destination local's slot, then branch to the success target.
+//!   destination place, then branch to the success target.
 //! - [`emit_function_call`]: General function call emission.
 //! - [`emit_generated_nvvm_intrinsic`]: Zero-operand NVVM intrinsic emission
 //!   for a catalog intrinsic, carrying its generated ABI marker.
@@ -58,17 +58,17 @@ pub fn emit_goto(
     goto_op
 }
 
-/// Writes `value` into `destination`, honouring a projection on it.
+/// Writes `value` into `destination`, honouring its full projection chain.
 ///
-/// A bare local goes to its slot, as before. A projected destination needs the
-/// address of the place rather than of the local, because storing to the local
-/// would overwrite the whole aggregate (or the pointer itself) instead of the
-/// part the call names.
+/// A bare local goes to its slot, as before. A projected destination is lowered
+/// through the same place-address walker used by references and projected
+/// assignments, then written with one `mir.store`. This keeps call-result
+/// storage aligned with the normal MIR place semantics instead of maintaining
+/// a second projection dispatcher here.
 ///
-/// Only the single-element projections a call destination is observed to carry
-/// are modelled. Anything else is refused rather than written to the wrong
-/// place, since a store aimed at the wrong address is a miscompile and an
-/// unsupported-construct error is not.
+/// If the shared walker cannot materialize a writable address, fail closed.
+/// Falling back to the base local would overwrite the wrong storage and is a
+/// miscompile.
 ///
 /// Known fidelity gap: rustc evaluates the destination address *before* the
 /// call, but this path materializes it *after* the call op. The difference is
@@ -76,7 +76,6 @@ pub fn emit_goto(
 /// base local through a `&mut` argument.
 pub fn store_result_to_place(
     ctx: &mut Context,
-    body: &mir::Body,
     destination: &mir::Place,
     value: Value,
     value_map: &mut ValueMap,
@@ -84,202 +83,47 @@ pub fn store_result_to_place(
     prev_op: Ptr<Operation>,
     loc: Location,
 ) -> TranslationResult<Ptr<Operation>> {
-    use crate::translator::statement::{
-        emit_array_element_store, pointer_address_space, pointer_is_mutable,
-        reject_raw_field_index_on_enum_pointee, slot_array_element_ty,
-    };
-    use dialect_mir::ops::{MirFieldAddrOp, MirStoreOp};
+    use dialect_mir::ops::MirStoreOp;
 
-    match destination.projection.as_slice() {
-        [] => Ok(value_map
+    if destination.projection.is_empty() {
+        return Ok(value_map
             .store_local(ctx, destination.local, value, block_ptr, Some(prev_op))
-            .unwrap_or(prev_op)),
+            .unwrap_or(prev_op));
+    }
 
-        [mir::ProjectionElem::Deref] => {
-            let base_place = mir::Place {
-                local: destination.local,
-                projection: vec![],
-            };
-            let (ptr_val, after_ptr) = rvalue::translate_place(
-                ctx,
-                body,
-                &base_place,
-                value_map,
-                block_ptr,
-                Some(prev_op),
-                loc.clone(),
-            )?;
-            let store_op = Operation::new(
-                ctx,
-                MirStoreOp::get_concrete_op_info(),
-                vec![],
-                vec![ptr_val, value],
-                vec![],
-                0,
-            );
-            store_op.deref_mut(ctx).set_loc(loc);
-            store_op.insert_after(ctx, after_ptr.unwrap_or(prev_op));
-            Ok(store_op)
-        }
-
-        [mir::ProjectionElem::Field(field_idx, field_ty)] => {
-            let Some(slot) = value_map.get_slot(destination.local) else {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "Local {:?} has no alloca slot for a field destination",
-                        destination.local
-                    ))
-                );
-            };
-            reject_raw_field_index_on_enum_pointee(ctx, slot, &destination.projection, &loc)?;
-
-            let field_type = crate::translator::types::translate_type(ctx, field_ty)?;
-            let field_ptr_ty = dialect_mir::types::MirPtrType::get(
-                ctx,
-                field_type,
-                pointer_is_mutable(ctx, slot),
-                pointer_address_space(ctx, slot),
-            )
-            .into();
-            let field_addr_op = Operation::new(
-                ctx,
-                MirFieldAddrOp::get_concrete_op_info(),
-                vec![field_ptr_ty],
-                vec![slot],
-                vec![],
-                0,
-            );
-            field_addr_op.deref_mut(ctx).set_loc(loc.clone());
-            MirFieldAddrOp::new(field_addr_op).set_attr_field_index(
-                ctx,
-                dialect_mir::attributes::FieldIndexAttr(*field_idx as u32),
-            );
-            field_addr_op.insert_after(ctx, prev_op);
-            let field_ptr = field_addr_op.deref(ctx).get_result(0);
-
-            let store_op = Operation::new(
-                ctx,
-                MirStoreOp::get_concrete_op_info(),
-                vec![],
-                vec![field_ptr, value],
-                vec![],
-                0,
-            );
-            store_op.deref_mut(ctx).set_loc(loc);
-            store_op.insert_after(ctx, field_addr_op);
-            Ok(store_op)
-        }
-
-        [mir::ProjectionElem::Index(index_local)] => {
-            let Some(arr_ptr) = value_map.get_slot(destination.local) else {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "Local {:?} has no alloca slot for a runtime index destination",
-                        destination.local
-                    ))
-                );
-            };
-            let index_place = mir::Place {
-                local: *index_local,
-                projection: vec![],
-            };
-            let (index_value, after_index) = rvalue::translate_place(
-                ctx,
-                body,
-                &index_place,
-                value_map,
-                block_ptr,
-                Some(prev_op),
-                loc.clone(),
-            )?;
-            let (element_ty, address_space) = slot_array_element_ty(ctx, arr_ptr, &loc)?;
-            Ok(emit_array_element_store(
-                ctx,
-                arr_ptr,
-                index_value,
-                value,
-                element_ty,
-                address_space,
-                block_ptr,
-                after_index,
-                loc,
-            ))
-        }
-
-        [
-            mir::ProjectionElem::ConstantIndex {
-                offset,
-                min_length: _,
-                from_end,
-            },
-        ] => {
-            if *from_end {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(
-                        "ConstantIndex with from_end=true is not supported for a call destination"
-                            .to_string()
-                    )
-                );
-            }
-            let Some(arr_ptr) = value_map.get_slot(destination.local) else {
-                return input_err!(
-                    loc,
-                    TranslationErr::unsupported(format!(
-                        "Local {:?} has no alloca slot for an array element destination",
-                        destination.local
-                    ))
-                );
-            };
-            let (element_ty, address_space) = slot_array_element_ty(ctx, arr_ptr, &loc)?;
-
-            let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
-            let index_attr = pliron::builtin::attributes::IntegerAttr::new(
-                i64_ty,
-                pliron::utils::apint::APInt::from_i64(
-                    *offset as i64,
-                    std::num::NonZeroUsize::new(64).unwrap(),
-                ),
-            );
-            let const_op = Operation::new(
-                ctx,
-                dialect_mir::ops::MirConstantOp::get_concrete_op_info(),
-                vec![i64_ty.into()],
-                vec![],
-                vec![],
-                0,
-            );
-            const_op.deref_mut(ctx).set_loc(loc.clone());
-            dialect_mir::ops::MirConstantOp::new(const_op).set_attr_value(ctx, index_attr);
-            const_op.insert_after(ctx, prev_op);
-            let index_value = const_op.deref(ctx).get_result(0);
-
-            Ok(emit_array_element_store(
-                ctx,
-                arr_ptr,
-                index_value,
-                value,
-                element_ty,
-                address_space,
-                block_ptr,
-                Some(const_op),
-                loc,
-            ))
-        }
-
-        projection => input_err!(
+    let Some((destination_address, address_prev)) = rvalue::translate_place_address(
+        ctx,
+        value_map,
+        destination,
+        /* is_mutable */ true,
+        block_ptr,
+        Some(prev_op),
+        loc.clone(),
+    )?
+    else {
+        return input_err!(
             loc,
             TranslationErr::unsupported(format!(
-                "call destination with projection {:?} is not supported",
-                projection
+                "cannot compute writable address for call destination projection {:?}",
+                destination.projection
             ))
-        ),
-    }
+        );
+    };
+
+    let store_op = Operation::new(
+        ctx,
+        MirStoreOp::get_concrete_op_info(),
+        vec![],
+        vec![destination_address, value],
+        vec![],
+        0,
+    );
+    store_op.deref_mut(ctx).set_loc(loc);
+    store_op.insert_after(ctx, address_prev.unwrap_or(prev_op));
+    Ok(store_op)
 }
 
-/// Stores `result_value` into `destination`'s slot and emits a branch to
+/// Stores `result_value` through `destination` and emits a branch to
 /// `target`.
 ///
 /// Shared "write result + branch to success block" epilogue for intrinsic
@@ -299,30 +143,16 @@ pub fn emit_store_result_and_goto(
     loc: Location,
     no_target_msg: &str,
 ) -> TranslationResult<Ptr<Operation>> {
-    // This epilogue has no `body`, so it cannot compute the address of a
-    // projected place the way [`store_result_to_place`] does. Refusing is the
-    // alternative to storing to `destination.local`, which for `x.0 = f()` or
-    // `(*p) = f()` writes the result over the whole aggregate or over the
-    // pointer. Most callers are generated, so the signature stays as it is.
-    if !destination.projection.is_empty() {
-        return input_err!(
-            loc,
-            TranslationErr::unsupported(format!(
-                "intrinsic result written to a projected destination {:?} is not supported",
-                destination.projection
-            ))
-        );
-    }
-
-    let goto_prev = value_map
-        .store_local(
-            ctx,
-            destination.local,
-            result_value,
-            block_ptr,
-            Some(prev_op),
-        )
-        .unwrap_or(prev_op);
+    // Keep every intrinsic-result path on the same place-address grammar.
+    let goto_prev = store_result_to_place(
+        ctx,
+        destination,
+        result_value,
+        value_map,
+        block_ptr,
+        prev_op,
+        loc.clone(),
+    )?;
 
     if let Some(target_idx) = target {
         Ok(emit_goto(ctx, *target_idx, goto_prev, block_map, loc))
@@ -412,7 +242,7 @@ pub fn bundle_generated_u32_results_as_array(
 ///
 /// 1. Translate all MIR arguments to Pliron IR values
 /// 2. Create a `mir.call` operation carrying the callee's name attribute
-/// 3. Store the result into the destination local's slot
+/// 3. Store the result through the destination place
 /// 4. Emit a zero-operand goto to the call's success target
 ///
 /// Reference arguments (`&mut local`) are handed the local's alloca slot
@@ -473,7 +303,6 @@ pub fn emit_function_call(
 
     let goto_prev = store_result_to_place(
         ctx,
-        body,
         destination,
         result_value,
         value_map,
@@ -593,15 +422,15 @@ fn emit_nvvm_integer_intrinsic(
 
     let result_value = nvvm_op.deref(ctx).get_result(0);
 
-    let goto_prev = value_map
-        .store_local(
-            ctx,
-            destination.local,
-            result_value,
-            block_ptr,
-            Some(last_op),
-        )
-        .unwrap_or(last_op);
+    let goto_prev = store_result_to_place(
+        ctx,
+        destination,
+        result_value,
+        value_map,
+        block_ptr,
+        last_op,
+        loc.clone(),
+    )?;
 
     if let Some(target_idx) = target {
         Ok(emit_goto(ctx, *target_idx, goto_prev, block_map, loc))
@@ -643,9 +472,15 @@ pub fn emit_unit_noop_intrinsic(
     insert_op(ctx, unit_op, block_ptr, prev_op);
 
     let unit_val = unit_op.deref(ctx).get_result(0);
-    let goto_prev = value_map
-        .store_local(ctx, destination.local, unit_val, block_ptr, Some(unit_op))
-        .unwrap_or(unit_op);
+    let goto_prev = store_result_to_place(
+        ctx,
+        destination,
+        unit_val,
+        value_map,
+        block_ptr,
+        unit_op,
+        loc.clone(),
+    )?;
 
     if let Some(target_idx) = target {
         Ok(emit_goto(ctx, *target_idx, goto_prev, block_map, loc))
@@ -738,6 +573,114 @@ mod tests {
         assert_eq!(
             bundle.deref(&ctx).get_operand(1),
             producer.deref(&ctx).get_result(1)
+        );
+    }
+
+    fn projected_result_fixture(
+        ctx: &mut Context,
+    ) -> (
+        Ptr<BasicBlock>,
+        Ptr<BasicBlock>,
+        ValueMap,
+        Ptr<Operation>,
+        mir::Place,
+    ) {
+        dialect_mir::register(ctx);
+
+        let module = ModuleOp::new(ctx, "test".try_into().unwrap());
+        let function_type = FunctionType::get(ctx, vec![], vec![]);
+        let function = Operation::new(
+            ctx,
+            MirFuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            1,
+        );
+        let function_op = MirFuncOp::new(ctx, function, TypeAttr::new(function_type.into()));
+        function_op.set_symbol_name(ctx, "kernel".try_into().unwrap());
+        module.append_operation(ctx, function, 0);
+
+        let region: Ptr<Region> = function.deref(ctx).get_region(0);
+        let block = BasicBlock::new(ctx, None, vec![]);
+        block.insert_at_back(region, ctx);
+        let target = BasicBlock::new(ctx, None, vec![]);
+        target.insert_at_back(region, ctx);
+
+        let u32_ty: TypeHandle = IntegerType::get(ctx, 32, Signedness::Unsigned).into();
+        let array_ty: TypeHandle = MirArrayType::get(ctx, u32_ty, 2).into();
+        let mut value_map = ValueMap::new(1);
+        let (alloca, slot) = ValueMap::emit_alloca(ctx, array_ty, block, None);
+        value_map.set_slot(0, slot);
+
+        let destination = mir::Place {
+            local: 0,
+            projection: vec![mir::ProjectionElem::ConstantIndex {
+                offset: 1,
+                min_length: 2,
+                from_end: false,
+            }],
+        };
+
+        (block, target, value_map, alloca, destination)
+    }
+
+    #[test]
+    fn store_result_epilogue_accepts_projected_destination() {
+        use dialect_mir::ops::MirUndefOp;
+
+        let mut ctx = Context::new();
+        let (block, target, mut value_map, alloca, destination) =
+            projected_result_fixture(&mut ctx);
+
+        let u32_ty: TypeHandle = IntegerType::get(&ctx, 32, Signedness::Unsigned).into();
+        let producer = MirUndefOp::new(&mut ctx, u32_ty).get_operation();
+        producer.insert_after(&ctx, alloca);
+        let result_value = producer.deref(&ctx).get_result(0);
+
+        let result = emit_store_result_and_goto(
+            &mut ctx,
+            &destination,
+            result_value,
+            &Some(1),
+            block,
+            producer,
+            &mut value_map,
+            &[block, target],
+            Location::Unknown,
+            "test intrinsic without target",
+        );
+
+        assert!(
+            result.is_ok(),
+            "shared intrinsic epilogue must store through projected destinations"
+        );
+    }
+
+    #[test]
+    fn generated_nvvm_helper_accepts_projected_destination() {
+        use dialect_mir::ops::MirUndefOp;
+
+        let mut ctx = Context::new();
+        let (block, target, mut value_map, alloca, destination) =
+            projected_result_fixture(&mut ctx);
+
+        let result = emit_generated_nvvm_intrinsic(
+            &mut ctx,
+            MirUndefOp::get_concrete_op_info(),
+            "test.generated.projected",
+            &destination,
+            &Some(1),
+            block,
+            Some(alloca),
+            &mut value_map,
+            &[block, target],
+            Location::Unknown,
+        );
+
+        assert!(
+            result.is_ok(),
+            "generated zero-operand intrinsic must store through projected destinations"
         );
     }
 }

--- a/crates/mir-importer/src/translator/terminator/intrinsics/float_math.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/float_math.rs
@@ -594,7 +594,6 @@ pub fn emit_sincos(
     // store aimed at the wrong address.
     let goto_prev = helpers::store_result_to_place(
         ctx,
-        body,
         destination,
         tuple_val,
         value_map,

--- a/crates/mir-importer/src/translator/terminator/intrinsics/layout.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/layout.rs
@@ -618,7 +618,6 @@ pub fn emit_rust_layout_intrinsic(
 
     let store_op = helpers::store_result_to_place(
         ctx,
-        body,
         destination,
         result,
         value_map,

--- a/crates/mir-importer/src/translator/terminator/mod.rs
+++ b/crates/mir-importer/src/translator/terminator/mod.rs
@@ -854,8 +854,7 @@ fn translate_drop(
 
     // Fallback: emit a device-side call to drop_in_place::<T>(ptr).
     drop_glue::emit_drop_glue(
-        ctx, body, place, dropped_ty, target, block_ptr, prev_op, value_map, block_map, legaliser,
-        loc,
+        ctx, place, dropped_ty, target, block_ptr, prev_op, value_map, block_map, legaliser, loc,
     )
 }
 
@@ -1493,7 +1492,6 @@ fn translate_function_item_call(
     let result_value = call_op.deref(ctx).get_result(0);
     let last_inserted = helpers::store_result_to_place(
         ctx,
-        body,
         destination,
         result_value,
         value_map,
@@ -1730,7 +1728,6 @@ fn translate_closure_call(
     let result_value = call_op.deref(ctx).get_result(0);
     let last_inserted = helpers::store_result_to_place(
         ctx,
-        body,
         destination,
         result_value,
         value_map,

--- a/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/Cargo.lock
+++ b/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/Cargo.lock
@@ -162,6 +162,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-intrinsics"
+version = "0.1.0"
+
+[[package]]
 name = "cuda-macros"
 version = "0.2.1"
 dependencies = [
@@ -315,6 +319,7 @@ dependencies = [
  "cuda-core",
  "cuda-device",
  "cuda-host",
+ "cuda-intrinsics",
  "libm",
 ]
 

--- a/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 #   cargo oxide run mir_projected_call_destination
 
 [dependencies]
+cuda-intrinsics = { path = "../../../cuda-intrinsics" }
 cuda-device = { path = "../../../cuda-device" }
 cuda-host = { path = "../../../cuda-host" }
 cuda-core = { path = "../../../cuda-core" }

--- a/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/mir_projected_call_destination/src/main.rs
@@ -13,14 +13,18 @@
     clippy::unit_arg
 )]
 
-//! An intrinsic call writing through a projected destination.
+//! Intrinsic calls writing through projected destinations.
 //!
 //! rustc lowers an ordinary call whose destination carries a projection into a
 //! call to a temporary followed by a store, so the projection never reaches
-//! code generation. An intrinsic keeps its destination, which leaves three
-//! shapes to translate: a dereferenced pointer, a struct field, and an array
-//! element. Each is written here in custom MIR, since surface Rust cannot
-//! produce them.
+//! code generation. An intrinsic keeps its destination. The original regression
+//! covers a dereferenced pointer, a struct field, and an array element. The
+//! chained cases additionally exercise `Field -> Index`, `Deref -> Field`, and
+//! `Index -> Field`, which must all use the same generic place-address walker.
+//! A final `Field -> Index` case calls the generated `block_dim_x` catalog
+//! intrinsic directly, proving the generated dispatcher uses that same store
+//! path. Each is written here in custom MIR, since surface Rust cannot produce
+//! them.
 //!
 //! Three translation paths build or store the call result themselves and so
 //! have store sites of their own, exercised separately: a float-math
@@ -34,9 +38,10 @@
 //! the bodies are `inline(never)` and the sincos pointer arrives as an
 //! opaque argument.
 //!
-//! Each case runs on the device and on the host from the same body, and the
-//! two results must agree. A result that landed at the wrong address shows up
-//! as a difference, since the host reads what the device wrote back.
+//! The first ten cases run on the device and on the host from the same body.
+//! The generated special-register case is device-only; its host-side expected
+//! value comes from the fixed launch contract below. A result that landed at
+//! the wrong address therefore still changes the folded device result.
 //!
 //! Build and run with:
 //!   cargo oxide run mir_projected_call_destination
@@ -98,6 +103,95 @@ fn through_index(mut _1: usize) -> [i32; 3] {
             Call(RET[_1] = core::intrinsics::bswap(451059808_i32), ReturnTo(bb1), UnwindUnreachable())
         }
         bb1 = {
+            Return()
+        }
+    }
+}
+
+/// `RET.1[i] = bswap(x)`: a field projection followed by a runtime index.
+///
+/// This is the first chained-destination regression. The call result must be
+/// stored through the complete `Field -> Index` chain rather than treating
+/// the field as the final destination.
+#[custom_mir(dialect = "runtime", phase = "initial")]
+#[inline(never)]
+fn through_field_index(mut _1: usize) -> (u64, [u32; 3]) {
+    mir! {
+        type RET = (u64, [u32; 3]);
+        {
+            RET.1 = [3_u32, 5_u32, 7_u32];
+            Call(RET.1[_1] = core::intrinsics::bswap(0x01020304_u32), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            RET.0 = 11_u64;
+            Return()
+        }
+    }
+}
+
+/// `(*p).1 = bswap(x)`: a dereference followed by a field projection.
+///
+/// The base pointer names the whole tuple, but the result belongs in only its
+/// second field. The importer therefore has to preserve the full
+/// `Deref -> Field` chain when materialising the writable address.
+#[custom_mir(dialect = "runtime", phase = "initial")]
+#[inline(never)]
+fn through_deref_field(mut _1: (u64, u32)) -> (u64, u32) {
+    mir! {
+        type RET = (u64, u32);
+        let _2: *mut (u64, u32);
+        {
+            _2 = core::ptr::addr_of_mut!(_1);
+            Call((*_2).1 = core::intrinsics::bswap(0x0a0b0c0d_u32), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            RET = _1;
+            Return()
+        }
+    }
+}
+
+/// `RET[i].1 = bswap(x)`: a runtime index followed by a field projection.
+///
+/// This is the converse chained aggregate shape to `through_field_index` and
+/// ensures the result store does not impose its own projection grammar.
+#[custom_mir(dialect = "runtime", phase = "initial")]
+#[inline(never)]
+fn through_index_field(mut _1: usize) -> [(u32, u32); 3] {
+    mir! {
+        type RET = [(u32, u32); 3];
+        let _2: (u32, u32);
+        let _3: (u32, u32);
+        let _4: (u32, u32);
+        {
+            _2 = (1_u32, 2_u32);
+            _3 = (3_u32, 4_u32);
+            _4 = (5_u32, 6_u32);
+            RET = [_2, _3, _4];
+            Call(RET[_1].1 = core::intrinsics::bswap(0x11121314_u32), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            Return()
+        }
+    }
+}
+
+/// `RET.1[i] = block_dim_x()`: a generated catalog intrinsic through a chain.
+///
+/// `block_dim_x` is generated from the `sreg` catalog and lowers through the
+/// generated zero-operand NVVM path. Keeping its destination projected proves
+/// the real generated dispatch reaches the shared result-store path.
+#[custom_mir(dialect = "runtime", phase = "initial")]
+#[inline(never)]
+fn through_generated_sreg_field_index(mut _1: usize) -> (u64, [u32; 2]) {
+    mir! {
+        type RET = (u64, [u32; 2]);
+        {
+            RET.1 = [0x13579bdf_u32, 0x2468ace0_u32];
+            Call(RET.1[_1] = cuda_intrinsics::sreg::block_dim_x(), ReturnTo(bb1), UnwindUnreachable())
+        }
+        bb1 = {
+            RET.0 = 0x0123456789abcdef_u64;
             Return()
         }
     }
@@ -200,10 +294,10 @@ fn through_deref_sincos(_1: *mut (f32, f32), _2: f32) {
     }
 }
 
-/// Folds the seven results into one word per case, so the device can report
+/// Folds the ten results into one word per case, so the device can report
 /// them through a `u64` slice and the host can compare without a layout
 /// assumption.
-fn case_results() -> [u64; 7] {
+fn case_results() -> [u64; 10] {
     let deref = through_deref(0) as u32 as u64;
 
     let field = through_field();
@@ -213,6 +307,23 @@ fn case_results() -> [u64; 7] {
     let index = (indexed[0] as u32 as u64)
         ^ ((indexed[1] as u32 as u64) << 8)
         ^ ((indexed[2] as u32 as u64) << 16);
+
+    let field_indexed = through_field_index(1);
+    let field_index = field_indexed.0
+        ^ u64::from(field_indexed.1[0])
+        ^ u64::from(field_indexed.1[1]).rotate_left(13)
+        ^ u64::from(field_indexed.1[2]).rotate_left(29);
+
+    let deref_field = through_deref_field((13_u64, 17_u32));
+    let deref_field = deref_field.0 ^ u64::from(deref_field.1).rotate_left(21);
+
+    let indexed_field = through_index_field(2);
+    let index_field = u64::from(indexed_field[0].0)
+        ^ u64::from(indexed_field[0].1).rotate_left(7)
+        ^ u64::from(indexed_field[1].0).rotate_left(14)
+        ^ u64::from(indexed_field[1].1).rotate_left(21)
+        ^ u64::from(indexed_field[2].0).rotate_left(28)
+        ^ u64::from(indexed_field[2].1).rotate_left(35);
 
     let field_float = through_field_float(2.0_f32);
     let field_float = field_float.0 ^ u64::from(field_float.1.to_bits());
@@ -233,6 +344,9 @@ fn case_results() -> [u64; 7] {
         deref,
         field,
         index,
+        field_index,
+        deref_field,
+        index_field,
         field_float,
         index_float,
         field_fn,
@@ -247,36 +361,59 @@ mod kernels {
     #[kernel]
     pub fn projected_destinations(mut out: DisjointSlice<u64>) {
         let results = case_results();
+        let generated = through_generated_sreg_field_index(1);
+        let generated = generated.0
+            ^ u64::from(generated.1[0]).rotate_left(9)
+            ^ u64::from(generated.1[1]).rotate_left(27);
         if let Some(slot) = out.get_mut(thread::index_1d()) {
             *slot = results[0]
-                ^ results[1].rotate_left(8)
-                ^ results[2].rotate_left(16)
-                ^ results[3].rotate_left(24)
-                ^ results[4].rotate_left(32)
-                ^ results[5].rotate_left(40)
-                ^ results[6].rotate_left(48);
+                ^ results[1].rotate_left(6)
+                ^ results[2].rotate_left(12)
+                ^ results[3].rotate_left(18)
+                ^ results[4].rotate_left(24)
+                ^ results[5].rotate_left(30)
+                ^ results[6].rotate_left(36)
+                ^ results[7].rotate_left(42)
+                ^ results[8].rotate_left(48)
+                ^ results[9].rotate_left(54)
+                ^ generated.rotate_left(59);
         }
     }
 }
 
 fn main() {
     let host = case_results();
-    let host_folded = host[0]
-        ^ host[1].rotate_left(8)
-        ^ host[2].rotate_left(16)
-        ^ host[3].rotate_left(24)
-        ^ host[4].rotate_left(32)
-        ^ host[5].rotate_left(40)
-        ^ host[6].rotate_left(48);
+    let host_projected_folded = host[0]
+        ^ host[1].rotate_left(6)
+        ^ host[2].rotate_left(12)
+        ^ host[3].rotate_left(18)
+        ^ host[4].rotate_left(24)
+        ^ host[5].rotate_left(30)
+        ^ host[6].rotate_left(36)
+        ^ host[7].rotate_left(42)
+        ^ host[8].rotate_left(48)
+        ^ host[9].rotate_left(54);
+
+    // The launch below uses block_dim.x = 1. The generated catalog intrinsic
+    // is device-only, so compute the host-side expected value from that launch
+    // contract instead of executing the intrinsic on the host.
+    let generated_catalog_expected = 0x0123456789abcdef_u64
+        ^ u64::from(0x13579bdf_u32).rotate_left(9)
+        ^ u64::from(1_u32).rotate_left(27);
+    let host_folded = host_projected_folded ^ generated_catalog_expected.rotate_left(59);
 
     println!("=== intrinsic calls writing through a projected destination ===\n");
-    println!("host  deref case:       0x{:016x}", host[0]);
-    println!("host  field case:       0x{:016x}", host[1]);
-    println!("host  index case:       0x{:016x}", host[2]);
-    println!("host  float field case: 0x{:016x}", host[3]);
-    println!("host  float index case: 0x{:016x}", host[4]);
-    println!("host  fn field case:    0x{:016x}", host[5]);
-    println!("host  sincos case:      0x{:016x}", host[6]);
+    println!("host  deref case:        0x{:016x}", host[0]);
+    println!("host  field case:        0x{:016x}", host[1]);
+    println!("host  index case:        0x{:016x}", host[2]);
+    println!("host  field->index case: 0x{:016x}", host[3]);
+    println!("host  deref->field case: 0x{:016x}", host[4]);
+    println!("host  index->field case: 0x{:016x}", host[5]);
+    println!("host  float field case:  0x{:016x}", host[6]);
+    println!("host  float index case:  0x{:016x}", host[7]);
+    println!("host  fn field case:     0x{:016x}", host[8]);
+    println!("host  sincos case:       0x{:016x}", host[9]);
+    println!("host  generated sreg case: 0x{generated_catalog_expected:016x}");
 
     let ctx = CudaContext::new(0).expect("failed to create CUDA context");
     let stream = ctx.default_stream();
@@ -298,7 +435,7 @@ fn main() {
     println!("device folded:    0x{device_folded:016x}");
 
     if device_folded == host_folded {
-        println!("\nPASS: device and host agree on all seven projections");
+        println!("\nPASS: device and host expectation agree on all eleven projected destinations");
     } else {
         println!("\nFAIL: device and host disagree");
         std::process::exit(1);


### PR DESCRIPTION
Closes #1164 

## Summary

Unify call and intrinsic result storage with the existing projected-place address lowering.

Previously, `store_result_to_place` maintained its own projection dispatcher and only supported a limited set of single-element destinations. Other result paths also stored directly into `destination.local` or rejected projected destinations.

This change routes projected result destinations through `translate_place_address`, so result storage now supports the same writable projection chains as the existing place-address walker.

## What changed

- Keep the existing fast path for bare local destinations.
- Route projected call/intrinsic destinations through `translate_place_address`.
- Remove the result-store-specific handling for individual `Deref`, `Field`, `Index`, and `ConstantIndex` projections.
- Route shared intrinsic epilogues, generated NVVM result paths, unit-result paths, ordinary function calls, closure calls, float-math results, and layout intrinsic results through `store_result_to_place`.
- Make place-address materialization independent of `mir::Body`.
  - Runtime `Index` projections now load their index local directly from `ValueMap`, matching the previous bare-local load path.
- Fail closed when the shared walker cannot materialize a writable address.

Generated intrinsic sources are not modified.

## Regression coverage

The projected-call-destination example now exercises:

```text
Deref
Field
Index
Field -> Index
Deref -> Field
Index -> Field
float result -> Field
float result -> Index
function result -> Field
sincos projected result
generated catalog intrinsic -> Field -> Index
```

The generated-catalog regression calls `cuda_intrinsics::sreg::block_dim_x()` directly with a `Field -> Index` destination, exercising the real generated intrinsic dispatch and result-store path on the GPU.

## Validation

```text
cargo fmt --all -- --check
git diff --check

cargo test -p mir-importer --all-targets
cargo clippy -p mir-importer --all-targets -- -D warnings

scripts/smoketest.sh \
  --compile-only \
  -o '^mir_projected_call_destination$'

cargo oxide run mir_projected_call_destination

cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

`mir-importer`:

```text
1110 passed; 0 failed
```

Projected-destination GPU regression:

```text
PASS: device and host expectation agree on all eleven projected destinations
```

## Scope

This does not add new MIR projection semantics. It reuses the projection semantics already implemented by `translate_place_address`.

A projected result destination is supported if that existing walker can materialize it as a writable address; otherwise lowering fails closed.

## Known limitation

rustc evaluates a call destination address before performing the call. This importer currently materializes the projected destination address after emitting the call operation.

That pre-call vs post-call evaluation difference predates this change and is intentionally left out of scope.
