### PR TITLE
fix(finalizer): reject links that drop expected kernels

### DIFF
--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -130,6 +130,18 @@ pub enum FinalizerError {
     #[error("nvJitLink returned an empty PTX artifact")]
     EmptyPtx,
 
+    /// A kernel root cannot be represented safely as an nvJitLink option.
+    #[error("expected CUDA kernel name is empty or contains an interior NUL byte: {name:?}")]
+    InvalidExpectedKernelName { name: String },
+
+    /// The linked image could not provide a structural kernel-entry inventory.
+    #[error("could not inspect linked {output} kernel entry inventory")]
+    LinkedKernelInventoryUnavailable { output: &'static str },
+
+    /// nvJitLink succeeded but one or more required kernel entry points vanished.
+    #[error("nvJitLink output is missing expected CUDA kernels: {missing:?}")]
+    MissingExpectedKernels { missing: Vec<String> },
+
     /// A pinned CUDA compilation tool changed around an operation. Its output can
     /// no longer be attributed to the provenance used by Cargo or a cache key.
     #[error(
@@ -195,12 +207,24 @@ impl Finalizer {
         nvvm_ir: &[u8],
         options: &FinalizationOptions,
     ) -> Result<Vec<u8>, FinalizerError> {
+        self.materialize_nvvm_ir_with_expected_kernels(module_name, nvvm_ir, &[], options)
+    }
+
+    /// Compile NVVM IR while rooting and verifying every expected kernel.
+    pub fn materialize_nvvm_ir_with_expected_kernels(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+    ) -> Result<Vec<u8>, FinalizerError> {
         let ltoir = self
             .compiler
             .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
         let ltoir_name = format!("{module_name}.ltoir");
-        self.linker.link_ltoir(
+        self.linker.link_ltoir_with_expected_kernels(
             &[NamedInput::new(&ltoir_name, &ltoir)],
+            expected_kernels,
             options,
             FinalizerOutput::Cubin,
         )
@@ -218,12 +242,29 @@ impl Finalizer {
         nvvm_ir: &[u8],
         options: &FinalizationOptions,
     ) -> Result<LinkReport, FinalizerError> {
+        self.materialize_nvvm_ir_with_report_and_expected_kernels(
+            module_name,
+            nvvm_ir,
+            &[],
+            options,
+        )
+    }
+
+    /// Compile NVVM IR with diagnostics while rooting and verifying kernels.
+    pub fn materialize_nvvm_ir_with_report_and_expected_kernels(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+    ) -> Result<LinkReport, FinalizerError> {
         let ltoir = self
             .compiler
             .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
         let ltoir_name = format!("{module_name}.ltoir");
-        self.linker.link_ltoir_with_report(
+        self.linker.link_ltoir_with_report_and_expected_kernels(
             &[NamedInput::new(&ltoir_name, &ltoir)],
+            expected_kernels,
             options,
             FinalizerOutput::Cubin,
         )
@@ -236,7 +277,19 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
-        self.linker.link_ltoir(inputs, options, output)
+        self.link_ltoir_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link ordered LTOIR modules while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        self.linker
+            .link_ltoir_with_expected_kernels(inputs, expected_kernels, options, output)
     }
 
     /// Link ordered LTOIR modules while collecting ptxas resource diagnostics.
@@ -251,7 +304,23 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<LinkReport, FinalizerError> {
-        self.linker.link_ltoir_with_report(inputs, options, output)
+        self.link_ltoir_with_report_and_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR with diagnostics while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_report_and_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.linker.link_ltoir_with_report_and_expected_kernels(
+            inputs,
+            expected_kernels,
+            options,
+            output,
+        )
     }
 
     /// Compiler component, including exact libdevice bytes and provenance.
@@ -292,10 +361,31 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Option<[u8; 32]> {
-        nvvm_ir_artifact_digest_with_provenance(
+        self.nvvm_ir_artifact_digest_with_expected_kernels(
             module_name,
             ltoir_module_name,
             nvvm_ir,
+            &[],
+            options,
+            output,
+        )
+    }
+
+    /// Digest NVVM IR finalization including the expected-kernel root set.
+    pub fn nvvm_ir_artifact_digest_with_expected_kernels(
+        &self,
+        module_name: &str,
+        ltoir_module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
+        nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+            module_name,
+            ltoir_module_name,
+            nvvm_ir,
+            expected_kernels,
             options,
             output,
             self.provenance(),
@@ -315,6 +405,27 @@ pub fn nvvm_ir_artifact_digest_with_provenance(
     output: FinalizerOutput,
     provenance: ToolProvenance,
 ) -> Option<[u8; 32]> {
+    nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+        module_name,
+        ltoir_module_name,
+        nvvm_ir,
+        &[],
+        options,
+        output,
+        provenance,
+    )
+}
+
+/// Digest a complete finalization plan including expected kernel roots.
+pub fn nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+    module_name: &str,
+    ltoir_module_name: &str,
+    nvvm_ir: &[u8],
+    expected_kernels: &[&str],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    provenance: ToolProvenance,
+) -> Option<[u8; 32]> {
     let compiler_digest = nvvm::nvvm_ir_artifact_digest_parts(
         module_name,
         nvvm_ir,
@@ -324,6 +435,7 @@ pub fn nvvm_ir_artifact_digest_with_provenance(
     );
     let linker_digest = link::ltoir_artifact_digest_parts(
         &[NamedInput::new(ltoir_module_name, &compiler_digest)],
+        expected_kernels,
         options,
         output,
         &provenance.nvjitlink_sha256?,
@@ -345,7 +457,24 @@ pub fn ltoir_artifact_digest_with_provenance(
     output: FinalizerOutput,
     nvjitlink_sha256: &[u8; 32],
 ) -> [u8; 32] {
-    link::ltoir_artifact_digest_parts(inputs, options, output, nvjitlink_sha256)
+    ltoir_artifact_digest_with_provenance_and_expected_kernels(
+        inputs,
+        &[],
+        options,
+        output,
+        nvjitlink_sha256,
+    )
+}
+
+/// Digest an ordered LTOIR link including the expected-kernel root set.
+pub fn ltoir_artifact_digest_with_provenance_and_expected_kernels(
+    inputs: &[NamedInput<'_>],
+    expected_kernels: &[&str],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    nvjitlink_sha256: &[u8; 32],
+) -> [u8; 32] {
+    link::ltoir_artifact_digest_parts(inputs, expected_kernels, options, output, nvjitlink_sha256)
 }
 
 fn validate_name(name: &str) -> Result<(), FinalizerError> {
@@ -362,23 +491,23 @@ fn validate_name(name: &str) -> Result<(), FinalizerError> {
 mod live_tests {
     use super::*;
 
-    /// `@llvm.used` keeps the kernel alive through LTO, exactly as cuda-oxide's
-    /// NVVM exporter emits it for real kernels. Without it nvJitLink's link-time
-    /// optimizer dead-strips the annotation-marked kernel as unreachable and
-    /// links an empty module: the pipeline still succeeds, so every assertion
-    /// below passed while nothing was being compiled. Measured on CUDA 13.3
-    /// before this line existed, the linked PTX was 202 bytes with zero
-    /// functions and the cubin had no entry points.
+    /// Legacy-dialect NVVM IR with the kernel retained through libNVVM.
+    ///
+    /// cuda-oxide's real LLVM exporter roots externally consumed function
+    /// definitions in `@llvm.used`, so this fixture mirrors the production
+    /// contract up to the LTOIR boundary. The finalizer then adds
+    /// `-kernels-used=kernel` at nvJitLink and independently inventories the
+    /// linked PTX/cubin to prove the expected entry survived the final link.
     const LEGACY_NVVM_IR: &[u8] = br#"
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
-
-@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @kernel to i8*)], section "llvm.metadata"
 
 define void @kernel() {
 entry:
   ret void
 }
+
+@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @kernel to i8*)], section "llvm.metadata"
 
 !nvvm.annotations = !{!0}
 !nvvmir.version = !{!1}
@@ -408,34 +537,32 @@ entry:
             assert!(!ltoir.is_empty());
             let input = [NamedInput::new("kernel.ltoir", &ltoir)];
             let cubin = finalizer
-                .link_ltoir(&input, &options, FinalizerOutput::Cubin)
+                .link_ltoir_with_expected_kernels(
+                    &input,
+                    &["kernel"],
+                    &options,
+                    FinalizerOutput::Cubin,
+                )
                 .unwrap();
             assert!(is_valid_cubin(&cubin));
-            // A cubin whose kernel was stripped is still a well-formed ELF, so
-            // `is_valid_cubin` alone cannot tell the two apart. Require the
-            // kernel's name to survive into the image.
-            assert!(
-                cubin.windows(b"kernel".len()).any(|part| part == b"kernel"),
-                "cubin has no `kernel` symbol ({} bytes): the kernel was \
-                 dead-stripped and this test is validating an empty module",
-                cubin.len()
-            );
+            let cubin_entries = crate::validation::cubin_kernel_entries(&cubin).unwrap();
+            assert_eq!(cubin_entries, vec!["kernel"]);
             let ptx = finalizer
-                .link_ltoir(&input, &options, FinalizerOutput::Ptx)
+                .link_ltoir_with_expected_kernels(
+                    &input,
+                    &["kernel"],
+                    &options,
+                    FinalizerOutput::Ptx,
+                )
                 .unwrap();
             assert!(
                 ptx.windows(b".version".len())
                     .any(|part| part == b".version")
             );
             // `.version` is in the header of even an empty module, so it proves
-            // only that something was emitted. The entry point is what proves
-            // the kernel made it through libNVVM and nvJitLink.
-            let ptx_text = String::from_utf8_lossy(&ptx);
-            assert!(
-                ptx_text.contains(".entry kernel"),
-                "linked PTX has no `.entry kernel` ({} bytes):\n{ptx_text}",
-                ptx.len()
-            );
+            // only that something was emitted. Inventory the entry explicitly.
+            let ptx_entries = crate::validation::ptx_kernel_entries(&ptx).unwrap();
+            assert_eq!(ptx_entries, vec!["kernel"]);
         }
     }
 
@@ -515,7 +642,12 @@ entry:
         let input = [NamedInput::new("spill.ltoir", &ltoir)];
 
         let report = finalizer
-            .link_ltoir_with_report(&input, &options, FinalizerOutput::Cubin)
+            .link_ltoir_with_report_and_expected_kernels(
+                &input,
+                &["spill_kernel"],
+                &options,
+                FinalizerOutput::Cubin,
+            )
             .unwrap();
         assert!(is_valid_cubin(&report.image));
 

--- a/crates/cuda-artifact-finalizer/src/link.rs
+++ b/crates/cuda-artifact-finalizer/src/link.rs
@@ -10,7 +10,7 @@ use crate::provenance::{
     PinnedToolProvenance, StableDigest, linker_provenance_digest, recipe_digest,
     with_revalidated_tool_identity,
 };
-use crate::validation::is_valid_cubin;
+use crate::validation::{cubin_kernel_entries, is_valid_cubin, ptx_kernel_entries};
 use crate::{FinalizerError, validate_name};
 use nvjitlink_sys::{InputType, LibNvJitLink, LinkOutput, Linker, NvJitLinkError};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -87,7 +87,20 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
-        Ok(self.link_ltoir_impl(inputs, options, output, false)?.image)
+        self.link_ltoir_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR while rooting and verifying every host-visible kernel.
+    pub fn link_ltoir_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        Ok(self
+            .link_ltoir_impl(inputs, expected_kernels, options, output, false)?
+            .image)
     }
 
     /// Link LTOIR while collecting non-semantic ptxas resource diagnostics.
@@ -113,20 +126,34 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<LinkReport, FinalizerError> {
-        self.link_ltoir_impl(inputs, options, output, true)
+        self.link_ltoir_with_report_and_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR with diagnostics while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_report_and_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.link_ltoir_impl(inputs, expected_kernels, options, output, true)
     }
 
     fn link_ltoir_impl(
         &self,
         inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
     ) -> Result<LinkReport, FinalizerError> {
         validate_inputs(inputs)?;
+        validate_expected_kernels(expected_kernels)?;
         self.link_inputs(
             inputs,
             InputType::Ltoir,
+            expected_kernels,
             options,
             output,
             collect_resource_usage,
@@ -149,6 +176,7 @@ impl LtoLinker {
             .link_inputs(
                 std::slice::from_ref(&input),
                 InputType::Ptx,
+                &[],
                 options,
                 FinalizerOutput::Cubin,
                 false,
@@ -160,6 +188,7 @@ impl LtoLinker {
         &self,
         inputs: &[NamedInput<'_>],
         input_type: InputType,
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
@@ -169,7 +198,14 @@ impl LtoLinker {
             self.tool.digest,
             || current_linker_tool_digest(&self.tool),
             || {
-                match self.run_link(inputs, input_type, options, output, collect_resource_usage) {
+                match self.run_link(
+                    inputs,
+                    input_type,
+                    expected_kernels,
+                    options,
+                    output,
+                    collect_resource_usage,
+                ) {
                     // Older nvJitLink versions reject the diagnostic-only
                     // reporting options with NVJITLINK_ERROR_UNRECOGNIZED_OPTION.
                     // The caller asked for the same program plus a best-effort
@@ -178,7 +214,7 @@ impl LtoLinker {
                     Err(FinalizerError::NvJitLink(error))
                         if collect_resource_usage && error.is_unrecognized_option() =>
                     {
-                        self.run_link(inputs, input_type, options, output, false)
+                        self.run_link(inputs, input_type, expected_kernels, options, output, false)
                     }
                     result => result,
                 }
@@ -190,6 +226,7 @@ impl LtoLinker {
         &self,
         inputs: &[NamedInput<'_>],
         input_type: InputType,
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
@@ -199,6 +236,9 @@ impl LtoLinker {
         } else {
             options.nvjitlink_ltoir_options(output)
         };
+        if input_type == InputType::Ltoir {
+            option_storage.extend(expected_kernel_options(expected_kernels));
+        }
         if collect_resource_usage {
             option_storage.extend(options.nvjitlink_diagnostic_options(output));
         }
@@ -221,6 +261,7 @@ impl LtoLinker {
         if output == FinalizerOutput::Ptx && image.is_empty() {
             return Err(FinalizerError::EmptyPtx);
         }
+        verify_expected_kernels(&image, output, expected_kernels)?;
 
         let resource_usage = if collect_resource_usage {
             info_log
@@ -244,9 +285,24 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Option<[u8; 32]> {
+        self.artifact_digest_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Digest an LTOIR link including the complete expected-kernel root set.
+    pub fn artifact_digest_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
         let nvjitlink = self.nvjitlink_digest()?;
         Some(ltoir_artifact_digest_parts(
-            inputs, options, output, &nvjitlink,
+            inputs,
+            expected_kernels,
+            options,
+            output,
+            &nvjitlink,
         ))
     }
 
@@ -266,6 +322,65 @@ impl LtoLinker {
             options,
             &nvjitlink,
         )))
+    }
+}
+
+fn validate_expected_kernels(expected_kernels: &[&str]) -> Result<(), FinalizerError> {
+    for kernel in expected_kernels {
+        if kernel.is_empty() || kernel.as_bytes().contains(&0) {
+            return Err(FinalizerError::InvalidExpectedKernelName {
+                name: (*kernel).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn normalized_expected_kernels<'a>(expected_kernels: &[&'a str]) -> Vec<&'a str> {
+    let mut kernels = expected_kernels.to_vec();
+    kernels.sort_unstable();
+    kernels.dedup();
+    kernels
+}
+
+fn expected_kernel_options(expected_kernels: &[&str]) -> Vec<String> {
+    normalized_expected_kernels(expected_kernels)
+        .into_iter()
+        .map(|kernel| format!("-kernels-used={kernel}"))
+        .collect()
+}
+
+fn verify_expected_kernels(
+    image: &[u8],
+    output: FinalizerOutput,
+    expected_kernels: &[&str],
+) -> Result<(), FinalizerError> {
+    if expected_kernels.is_empty() {
+        return Ok(());
+    }
+    let actual = match output {
+        FinalizerOutput::Cubin => cubin_kernel_entries(image),
+        FinalizerOutput::Ptx => ptx_kernel_entries(image),
+    }
+    .ok_or(FinalizerError::LinkedKernelInventoryUnavailable {
+        output: match output {
+            FinalizerOutput::Cubin => "cubin",
+            FinalizerOutput::Ptx => "PTX",
+        },
+    })?;
+    let missing = normalized_expected_kernels(expected_kernels)
+        .into_iter()
+        .filter(|kernel| {
+            actual
+                .binary_search_by(|entry| entry.as_str().cmp(kernel))
+                .is_err()
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(FinalizerError::MissingExpectedKernels { missing })
     }
 }
 
@@ -341,6 +456,7 @@ fn load_linker_tool(
 
 pub(crate) fn ltoir_artifact_digest_parts(
     inputs: &[NamedInput<'_>],
+    expected_kernels: &[&str],
     options: &FinalizationOptions,
     output: FinalizerOutput,
     nvjitlink_digest: &[u8; 32],
@@ -357,6 +473,9 @@ pub(crate) fn ltoir_artifact_digest_parts(
         digest = digest
             .field("ltoir-name", input.name.as_bytes())
             .field("ltoir", input.bytes);
+    }
+    for kernel in normalized_expected_kernels(expected_kernels) {
+        digest = digest.field("expected-kernel", kernel.as_bytes());
     }
     for option in options.nvjitlink_ltoir_options(output) {
         digest = digest.field("nvjitlink-option", option.as_bytes());
@@ -394,15 +513,16 @@ mod tests {
         let a = NamedInput::new("a.ltoir", b"a");
         let b = NamedInput::new("b.ltoir", b"b");
         let baseline =
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[7; 32]);
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Cubin, &[7; 32]);
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[b, a], &options, FinalizerOutput::Cubin, &[7; 32])
+            ltoir_artifact_digest_parts(&[b, a], &[], &options, FinalizerOutput::Cubin, &[7; 32])
         );
         assert_ne!(
             baseline,
             ltoir_artifact_digest_parts(
                 &[NamedInput::new("renamed.ltoir", b"a"), b],
+                &[],
                 &options,
                 FinalizerOutput::Cubin,
                 &[7; 32]
@@ -412,6 +532,7 @@ mod tests {
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &FinalizationOptions::new("sm_90".parse().unwrap()),
                 FinalizerOutput::Cubin,
                 &[7; 32]
@@ -421,6 +542,7 @@ mod tests {
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &options
                     .clone()
                     .with_debug_policy(crate::DebugPolicy::LineTables),
@@ -430,21 +552,89 @@ mod tests {
         );
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[8; 32])
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Cubin, &[8; 32])
         );
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Ptx, &[7; 32])
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Ptx, &[7; 32])
         );
         assert_ne!(
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &options.clone().with_fma_contraction(false),
                 FinalizerOutput::Cubin,
                 &[7; 32]
             )
         );
+    }
+
+    #[test]
+    fn link_digest_covers_expected_kernel_set_without_order_or_duplicate_noise() {
+        let options = FinalizationOptions::new("sm_120".parse().unwrap());
+        let input = [NamedInput::new("a.ltoir", b"a")];
+        let baseline = ltoir_artifact_digest_parts(
+            &input,
+            &["kernel_a", "kernel_b"],
+            &options,
+            FinalizerOutput::Cubin,
+            &[7; 32],
+        );
+        assert_eq!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &input,
+                &["kernel_b", "kernel_a", "kernel_a"],
+                &options,
+                FinalizerOutput::Cubin,
+                &[7; 32],
+            )
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &input,
+                &["kernel_a"],
+                &options,
+                FinalizerOutput::Cubin,
+                &[7; 32],
+            )
+        );
+    }
+
+    #[test]
+    fn expected_kernel_options_are_complete_canonical_roots() {
+        assert_eq!(
+            expected_kernel_options(&["kernel_b", "kernel_a", "kernel_a"]),
+            vec![
+                "-kernels-used=kernel_a".to_string(),
+                "-kernels-used=kernel_b".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn expected_kernel_validation_and_missing_inventory_fail_closed() {
+        assert!(matches!(
+            validate_expected_kernels(&[""]),
+            Err(FinalizerError::InvalidExpectedKernelName { .. })
+        ));
+        assert!(matches!(
+            validate_expected_kernels(&["bad\0kernel"]),
+            Err(FinalizerError::InvalidExpectedKernelName { .. })
+        ));
+        let error = verify_expected_kernels(
+            b".version 8.9\n.visible .entry kernel_a() { ret; }\n",
+            FinalizerOutput::Ptx,
+            &["kernel_a", "kernel_b"],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            FinalizerError::MissingExpectedKernels { ref missing }
+                if missing == &["kernel_b".to_string()]
+        ));
     }
 
     #[test]

--- a/crates/cuda-artifact-finalizer/src/validation.rs
+++ b/crates/cuda-artifact-finalizer/src/validation.rs
@@ -9,6 +9,11 @@ const ELF64_SECTION_HEADER_LENGTH: u16 = 64;
 const ELF_VERSION_CURRENT: u32 = 1;
 const CUDA_ABI_RUNTIME_JIT_LINK: u8 = 7;
 const CUDA_12_TOOLKIT_VERSIONS: std::ops::RangeInclusive<u32> = 120..=129;
+const ELF_SECTION_TYPE_SYMTAB: u32 = 2;
+const ELF_SECTION_TYPE_DYNSYM: u32 = 11;
+const ELF_SYMBOL_TYPE_FUNCTION: u8 = 2;
+const CUDA_SYMBOL_OTHER_ENTRY: u8 = 0x10;
+const ELF64_SYMBOL_LENGTH: u64 = 24;
 
 /// Check that bytes are a complete 64-bit little-endian CUDA executable ELF.
 ///
@@ -148,6 +153,184 @@ pub fn is_valid_cubin(bytes: &[u8]) -> bool {
     }
 
     has_meaningful_contents
+}
+
+/// Collect kernel entry names from linked PTX.
+///
+/// This is intentionally a small structural lexer rather than a substring
+/// search: comments and quoted strings cannot satisfy the final-link guard.
+pub(crate) fn ptx_kernel_entries(bytes: &[u8]) -> Option<Vec<String>> {
+    let bytes = bytes.strip_suffix(b"\0").unwrap_or(bytes);
+    if bytes.contains(&0) {
+        return None;
+    }
+    let text = std::str::from_utf8(bytes).ok()?;
+    let tokens = ptx_tokens(text)?;
+    let mut entries = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index] == ".entry" {
+            let name = tokens.get(index + 1)?;
+            if name.is_empty() {
+                return None;
+            }
+            entries.push((*name).to_string());
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    entries.sort();
+    entries.dedup();
+    Some(entries)
+}
+
+fn ptx_tokens(text: &str) -> Option<Vec<&str>> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b if b.is_ascii_whitespace() => index += 1,
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index += 2;
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index += 2;
+                let mut closed = false;
+                while index + 1 < bytes.len() {
+                    if bytes[index] == b'*' && bytes[index + 1] == b'/' {
+                        index += 2;
+                        closed = true;
+                        break;
+                    }
+                    index += 1;
+                }
+                if !closed {
+                    return None;
+                }
+            }
+            b'"' => {
+                index += 1;
+                let mut escaped = false;
+                let mut closed = false;
+                while index < bytes.len() {
+                    let byte = bytes[index];
+                    index += 1;
+                    if escaped {
+                        escaped = false;
+                    } else if byte == b'\\' {
+                        escaped = true;
+                    } else if byte == b'"' {
+                        closed = true;
+                        break;
+                    }
+                }
+                if !closed {
+                    return None;
+                }
+            }
+            b'(' | b')' | b'{' | b'}' | b',' | b';' => index += 1,
+            _ => {
+                let start = index;
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b if b.is_ascii_whitespace() => break,
+                        b'(' | b')' | b'{' | b'}' | b',' | b';' | b'"' => break,
+                        b'/' if matches!(bytes.get(index + 1), Some(b'/') | Some(b'*')) => {
+                            break;
+                        }
+                        _ => index += 1,
+                    }
+                }
+                if start == index {
+                    return None;
+                }
+                tokens.push(&text[start..index]);
+            }
+        }
+    }
+    Some(tokens)
+}
+
+/// Collect CUDA kernel entry symbols from a linked cubin.
+///
+/// nvdisasm represents kernel entries as defined `STT_FUNC` symbols carrying
+/// `STO_CUDA_ENTRY` in `st_other`. Walking `.symtab`/`.dynsym` therefore
+/// distinguishes real entries from device functions and incidental strings.
+pub(crate) fn cubin_kernel_entries(bytes: &[u8]) -> Option<Vec<String>> {
+    if !is_valid_cubin(bytes) {
+        return None;
+    }
+    let section_offset = usize::try_from(read_u64(bytes, 40)?).ok()?;
+    let section_entry_size = usize::from(read_u16(bytes, 58)?);
+    let section_count = usize::from(read_u16(bytes, 60)?);
+    if section_count == 0 || section_entry_size != usize::from(ELF64_SECTION_HEADER_LENGTH) {
+        return None;
+    }
+
+    let mut entries = Vec::new();
+    let mut found_symbol_table = false;
+    for section_index in 0..section_count {
+        let header = section_offset.checked_add(section_index.checked_mul(section_entry_size)?)?;
+        let section_type = read_u32(bytes, header + 4)?;
+        if !matches!(
+            section_type,
+            ELF_SECTION_TYPE_SYMTAB | ELF_SECTION_TYPE_DYNSYM
+        ) {
+            continue;
+        }
+        found_symbol_table = true;
+        let symbols_offset = usize::try_from(read_u64(bytes, header + 24)?).ok()?;
+        let symbols_size = usize::try_from(read_u64(bytes, header + 32)?).ok()?;
+        let string_section_index = usize::try_from(read_u32(bytes, header + 40)?).ok()?;
+        let symbol_entry_size = read_u64(bytes, header + 56)?;
+        if symbol_entry_size < ELF64_SYMBOL_LENGTH
+            || symbols_size % usize::try_from(symbol_entry_size).ok()? != 0
+            || string_section_index >= section_count
+        {
+            return None;
+        }
+        let strings_header =
+            section_offset.checked_add(string_section_index.checked_mul(section_entry_size)?)?;
+        let strings_offset = usize::try_from(read_u64(bytes, strings_header + 24)?).ok()?;
+        let strings_size = usize::try_from(read_u64(bytes, strings_header + 32)?).ok()?;
+        let strings = bytes.get(strings_offset..strings_offset.checked_add(strings_size)?)?;
+        let symbol_entry_size = usize::try_from(symbol_entry_size).ok()?;
+        let symbols = bytes.get(symbols_offset..symbols_offset.checked_add(symbols_size)?)?;
+        for symbol in symbols.chunks_exact(symbol_entry_size) {
+            let name_offset = usize::try_from(read_u32(symbol, 0)?).ok()?;
+            let info = *symbol.get(4)?;
+            let other = *symbol.get(5)?;
+            let section_index = read_u16(symbol, 6)?;
+            if info & 0x0f != ELF_SYMBOL_TYPE_FUNCTION
+                || other & CUDA_SYMBOL_OTHER_ENTRY == 0
+                || section_index == 0
+                || name_offset == 0
+            {
+                continue;
+            }
+            let name = read_c_string(strings, name_offset)?;
+            if !name.is_empty() {
+                entries.push(name.to_string());
+            }
+        }
+    }
+    if !found_symbol_table {
+        return None;
+    }
+    entries.sort();
+    entries.dedup();
+    Some(entries)
+}
+
+fn read_c_string(bytes: &[u8], offset: usize) -> Option<&str> {
+    let tail = bytes.get(offset..)?;
+    let length = tail.iter().position(|&byte| byte == 0)?;
+    std::str::from_utf8(&tail[..length]).ok()
 }
 
 fn has_supported_cuda_elf_version(abi_version: u8, file_version: Option<u32>) -> bool {
@@ -301,5 +484,94 @@ mod tests {
                 "ABI version {abi_version}, file version {file_version}"
             );
         }
+    }
+
+    fn cubin_with_kernel_symbols(symbols: &[(&str, bool)]) -> Vec<u8> {
+        const SECTION_COUNT: usize = 4;
+        let section_table_length = SECTION_COUNT * usize::from(ELF64_SECTION_HEADER_LENGTH);
+        let strings = {
+            let mut strings = vec![0_u8];
+            for (name, _) in symbols {
+                strings.extend_from_slice(name.as_bytes());
+                strings.push(0);
+            }
+            strings
+        };
+        let symbol_table_length = (symbols.len() + 1) * ELF64_SYMBOL_LENGTH as usize;
+        let strings_offset = ELF64_HEADER_LENGTH + section_table_length;
+        let symbols_offset = strings_offset + strings.len();
+        let text_offset = symbols_offset + symbol_table_length;
+        let mut bytes = vec![0_u8; text_offset + 4];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[6] = 1;
+        bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&190_u16.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[40..48].copy_from_slice(&(ELF64_HEADER_LENGTH as u64).to_le_bytes());
+        bytes[52..54].copy_from_slice(&(ELF64_HEADER_LENGTH as u16).to_le_bytes());
+        bytes[58..60].copy_from_slice(&ELF64_SECTION_HEADER_LENGTH.to_le_bytes());
+        bytes[60..62].copy_from_slice(&(SECTION_COUNT as u16).to_le_bytes());
+
+        let strtab = ELF64_HEADER_LENGTH + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[strtab + 4..strtab + 8].copy_from_slice(&3_u32.to_le_bytes());
+        bytes[strtab + 24..strtab + 32].copy_from_slice(&(strings_offset as u64).to_le_bytes());
+        bytes[strtab + 32..strtab + 40].copy_from_slice(&(strings.len() as u64).to_le_bytes());
+
+        let symtab = strtab + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[symtab + 4..symtab + 8].copy_from_slice(&ELF_SECTION_TYPE_SYMTAB.to_le_bytes());
+        bytes[symtab + 24..symtab + 32].copy_from_slice(&(symbols_offset as u64).to_le_bytes());
+        bytes[symtab + 32..symtab + 40]
+            .copy_from_slice(&(symbol_table_length as u64).to_le_bytes());
+        bytes[symtab + 40..symtab + 44].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[symtab + 56..symtab + 64].copy_from_slice(&ELF64_SYMBOL_LENGTH.to_le_bytes());
+
+        let text = symtab + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[text + 4..text + 8].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[text + 24..text + 32].copy_from_slice(&(text_offset as u64).to_le_bytes());
+        bytes[text + 32..text + 40].copy_from_slice(&4_u64.to_le_bytes());
+        bytes[text_offset..text_offset + 4].copy_from_slice(b"CUDA");
+        bytes[strings_offset..strings_offset + strings.len()].copy_from_slice(&strings);
+
+        let mut name_offset = 1_u32;
+        for (index, (name, is_kernel)) in symbols.iter().enumerate() {
+            let symbol = symbols_offset + (index + 1) * ELF64_SYMBOL_LENGTH as usize;
+            bytes[symbol..symbol + 4].copy_from_slice(&name_offset.to_le_bytes());
+            bytes[symbol + 4] = 0x12;
+            bytes[symbol + 5] = if *is_kernel {
+                CUDA_SYMBOL_OTHER_ENTRY
+            } else {
+                0
+            };
+            bytes[symbol + 6..symbol + 8].copy_from_slice(&3_u16.to_le_bytes());
+            name_offset += u32::try_from(name.len() + 1).unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn ptx_entry_inventory_ignores_comments_and_strings() {
+        let ptx = br#"
+.version 8.9
+// .entry fake_comment() {}
+.const .b8 text[] = {0}; // ".entry fake_string"
+.visible .entry kernel_a() { ret; }
+.entry
+kernel_b() { ret; }
+"#;
+        assert_eq!(
+            ptx_kernel_entries(ptx).unwrap(),
+            vec!["kernel_a".to_string(), "kernel_b".to_string()]
+        );
+        assert!(ptx_kernel_entries(b".entry kernel() {}\0").is_some());
+        assert!(ptx_kernel_entries(b".entry kernel() {}\0garbage").is_none());
+    }
+
+    #[test]
+    fn cubin_entry_inventory_uses_cuda_entry_symbol_flag() {
+        let cubin = cubin_with_kernel_symbols(&[("kernel_a", true), ("helper", false)]);
+        assert!(is_valid_cubin(&cubin));
+        assert_eq!(cubin_kernel_entries(&cubin).unwrap(), vec!["kernel_a"]);
     }
 }

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -15,6 +15,10 @@ use cuda_core::{CudaContext, CudaModule, DriverError};
 use std::sync::Arc;
 use thiserror::Error;
 
+// ArtifactEntryKind::Kernel wire tag. cuda-core re-exports OwnedArtifactBundle
+// but not the enum itself, so deferred loading reads the stable encoded tag.
+const ARTIFACT_ENTRY_KIND_KERNEL: u16 = 1;
+
 /// Errors while discovering, building, or loading an embedded CUDA module.
 #[derive(Debug, Error)]
 pub enum EmbeddedModuleError {
@@ -155,6 +159,12 @@ fn load_bundle(
     ctx: &Arc<CudaContext>,
     bundle: &OwnedArtifactBundle,
 ) -> Result<Arc<CudaModule>, EmbeddedModuleError> {
+    let expected_kernels = bundle
+        .entries
+        .iter()
+        .filter(|entry| entry.kind.to_u16() == ARTIFACT_ENTRY_KIND_KERNEL)
+        .map(|entry| entry.symbol.as_str())
+        .collect::<Vec<_>>();
     if let Some(cubin) = bundle.payload(ArtifactPayloadKind::Cubin) {
         return Ok(ctx.load_module_from_image(cubin)?);
     }
@@ -167,18 +177,24 @@ fn load_bundle(
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::build_cubin_from_nvvm_ir_with_compile_options(
-                nvvm_ir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::build_ptx_from_nvvm_ir_with_compile_options(
-                nvvm_ir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
+            ltoir::ExecutionRoute::Cubin => {
+                ltoir::build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+                    nvvm_ir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
+            ltoir::ExecutionRoute::PtxBridge => {
+                ltoir::build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+                    nvvm_ir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }
@@ -187,18 +203,24 @@ fn load_bundle(
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::link_ltoir_to_cubin_with_compile_options(
-                ltoir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::link_ltoir_to_ptx_with_compile_options(
-                ltoir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
+            ltoir::ExecutionRoute::Cubin => {
+                ltoir::link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+                    ltoir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
+            ltoir::ExecutionRoute::PtxBridge => {
+                ltoir::link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+                    ltoir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -358,9 +358,32 @@ pub fn build_cubin_from_nvvm_ir_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+        nvvm_ir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
     let options = finalization_options(&arch, compile_options);
-    Ok(Finalizer::discover()?.materialize_nvvm_ir(module_name, nvvm_ir, &options)?)
+    Ok(
+        Finalizer::discover()?.materialize_nvvm_ir_with_expected_kernels(
+            module_name,
+            nvvm_ir,
+            expected_kernels,
+            &options,
+        )?,
+    )
 }
 
 /// Compile NVVM IR bytes to forward-compatible PTX.
@@ -404,6 +427,22 @@ pub fn build_ptx_from_nvvm_ir_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+        nvvm_ir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
     let finalizer = Finalizer::discover()?;
     let options = finalization_options(&arch, compile_options);
@@ -411,8 +450,9 @@ pub fn build_ptx_from_nvvm_ir_with_compile_options(
         .compiler()
         .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, &options)?;
     let ltoir_name = format!("{module_name}.ltoir");
-    Ok(finalizer.link_ltoir(
+    Ok(finalizer.link_ltoir_with_expected_kernels(
         &[NamedInput::new(&ltoir_name, &ltoir)],
+        expected_kernels,
         &options,
         FinalizerOutput::Ptx,
     )?)
@@ -454,8 +494,30 @@ pub fn link_ltoir_to_cubin_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+        ltoir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+    ltoir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_cubin_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
+    link_ltoir_to_cubin_parsed_with_compile_options(
+        ltoir,
+        module_name,
+        expected_kernels,
+        &arch,
+        compile_options,
+    )
 }
 
 /// Link one LTOIR payload to forward-compatible PTX.
@@ -498,19 +560,43 @@ pub fn link_ltoir_to_ptx_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+        ltoir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+    ltoir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_ptx_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
+    link_ltoir_to_ptx_parsed_with_compile_options(
+        ltoir,
+        module_name,
+        expected_kernels,
+        &arch,
+        compile_options,
+    )
 }
 
 fn link_ltoir_to_cubin_parsed_with_compile_options(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
     link_ltoir_with_shared_finalizer(
         ltoir,
         module_name,
+        expected_kernels,
         arch,
         compile_options,
         FinalizerOutput::Cubin,
@@ -520,12 +606,14 @@ fn link_ltoir_to_cubin_parsed_with_compile_options(
 fn link_ltoir_to_ptx_parsed_with_compile_options(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
     link_ltoir_with_shared_finalizer(
         ltoir,
         module_name,
+        expected_kernels,
         arch,
         compile_options,
         FinalizerOutput::Ptx,
@@ -535,13 +623,15 @@ fn link_ltoir_to_ptx_parsed_with_compile_options(
 fn link_ltoir_with_shared_finalizer(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
     output: FinalizerOutput,
 ) -> Result<Vec<u8>, LtoirError> {
     let options = finalization_options(arch, compile_options);
-    Ok(LtoLinker::discover()?.link_ltoir(
+    Ok(LtoLinker::discover()?.link_ltoir_with_expected_kernels(
         &[NamedInput::new(module_name, ltoir)],
+        expected_kernels,
         &options,
         output,
     )?)
@@ -893,6 +983,7 @@ pub fn load_kernel_module(
                 ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_compile_options(
                     &bytes,
                     &ltoir.display().to_string(),
+                    &[],
                     &emitted,
                     compile_options,
                 )?,

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -846,6 +846,7 @@ fn write_device_artifact_object(
         &bundle_name,
         result,
         artifact,
+        functions,
     )?;
     if let Some(materialized) = materialized_artifact.as_ref() {
         emit_launch_bounds_spill_warnings(tcx, result, functions, &materialized.resource_usage);
@@ -978,10 +979,16 @@ fn materialize_artifact_for_embedding(
     bundle_name: &str,
     result: &device_codegen::DeviceCodegenResult,
     artifact: &device_codegen::DeviceCodegenArtifact,
+    functions: &[collector::CollectedFunction<'_>],
 ) -> Result<Option<MaterializedDeviceArtifact>, Box<dyn std::error::Error>> {
     let Some(request) = request else {
         return Ok(None);
     };
+    let expected_kernels = functions
+        .iter()
+        .filter(|function| function.is_kernel)
+        .map(|function| function.export_name.as_str())
+        .collect::<Vec<_>>();
     let debug_policy = match result.debug_kind {
         llvm_export::export::DebugKind::Off => cuda_artifact_finalizer::DebugPolicy::None,
         llvm_export::export::DebugKind::LineTables => {
@@ -994,6 +1001,7 @@ fn materialize_artifact_for_embedding(
             request,
             &artifact.bytes,
             bundle_name,
+            &expected_kernels,
             &result.target,
             result.allow_fma_contraction,
             debug_policy,
@@ -1002,6 +1010,7 @@ fn materialize_artifact_for_embedding(
             request,
             &artifact.bytes,
             &artifact.name,
+            &expected_kernels,
             &result.target,
             result.allow_fma_contraction,
             debug_policy,

--- a/crates/rustc-codegen-cuda/src/materialize.rs
+++ b/crates/rustc-codegen-cuda/src/materialize.rs
@@ -194,13 +194,19 @@ pub(crate) fn nvvm_ir_to_cubin(
     request: MaterializationRequest,
     nvvm_ir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     target: &str,
     allow_fma_contraction: bool,
     debug_policy: DebugPolicy,
 ) -> Result<MaterializedCubin, MaterializeError> {
     let options = options(target, allow_fma_contraction, debug_policy)?;
     let finalizer = checked_finalizer(request)?;
-    let report = finalizer.materialize_nvvm_ir_with_report(module_name, nvvm_ir, &options)?;
+    let report = finalizer.materialize_nvvm_ir_with_report_and_expected_kernels(
+        module_name,
+        nvvm_ir,
+        expected_kernels,
+        &options,
+    )?;
     Ok(MaterializedCubin {
         bytes: report.image,
         resource_usage: report.resource_usage,
@@ -211,14 +217,16 @@ pub(crate) fn ltoir_to_cubin(
     request: MaterializationRequest,
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     target: &str,
     allow_fma_contraction: bool,
     debug_policy: DebugPolicy,
 ) -> Result<MaterializedCubin, MaterializeError> {
     let options = options(target, allow_fma_contraction, debug_policy)?;
     let finalizer = checked_finalizer(request)?;
-    let report = finalizer.link_ltoir_with_report(
+    let report = finalizer.link_ltoir_with_report_and_expected_kernels(
         &[NamedInput::new(module_name, ltoir)],
+        expected_kernels,
         &options,
         FinalizerOutput::Cubin,
     )?;


### PR DESCRIPTION
Closes #1166 
Part of #1071.

## Summary

This adds a final-link safety invariant for expected CUDA kernels.

A successful `nvJitLink` call is no longer considered sufficient when the
caller knows which kernel entry points must survive. The finalizer now roots
those kernels during linking and verifies that they are present in the emitted
PTX or cubin.

## What changed

- Added expected-kernel-aware finalization APIs while preserving the existing
  public entry points.
- Passed expected kernel names to `nvJitLink` as repeated
  `-kernels-used=<name>` options.
- Canonicalized the expected-kernel set for deterministic linker options and
  artifact digests.
- Included expected kernels in LTOIR finalization artifact identity.
- Added structural PTX entry-point inventory rather than substring matching.
- Added cubin kernel inventory by inspecting ELF symbol tables and CUDA entry
  symbols.
- Added explicit errors for:
  - invalid expected kernel names,
  - unavailable final kernel inventory,
  - missing expected kernels.
- Propagated known kernel metadata through:
  - build-time NVVM IR/LTOIR materialization,
  - embedded deferred NVVM IR/LTOIR finalization.
- Kept existing raw/file-backed finalization APIs compatible when no expected
  kernel metadata is available.

The enforced invariant is:

> `nvJitLink` success + missing expected kernel = error

## Validation

The following pass locally:

```text
cargo fmt --all -- --check
cargo test -p cuda-artifact-finalizer --all-targets
cargo test -p cuda-host --all-targets
cargo clippy -p cuda-artifact-finalizer --all-targets -- -D warnings
cargo clippy -p cuda-host --all-targets -- -D warnings
```

The CUDA Toolkit live regressions also pass:

```text
live_tests::live_pipeline_accepts_toolkit_cubins_and_emits_ptx_for_both_fma_policies
live_tests::live_link_report_parses_ptxas_resource_usage_for_a_spilling_kernel
```

And the broader validation passes:

```text
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
```

`rustc-codegen-cuda` was also validated independently with formatting, unit
tests, and Clippy.

## Scope

This is intentionally limited to the final-link safety portion of #1071.

It does not add `libcudadevrt` discovery/linking and does not implement the
public CUDA Graph API. Those remain separate follow-up changes.
