### PR TITLE
fix(ptx-schedule): classify async issue and wait sites

### DIFF
--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -27,7 +27,9 @@ places where another thread's progress can be observed:
 | `Atomic` | an atomic read-modify-write |
 | `Reduction` | a `red.*` reduction with no returned value |
 | `Barrier` | `bar.*` / `barrier.*` / `mbarrier.*` synchronization |
-| `Fence` | `fence.*` / `membar.*` ordering |
+| `Fence` | `fence.*` / `membar.*` / `wgmma.fence.*` ordering |
+| `AsyncIssue` | asynchronous work issue or commit points (`cp.async`, `wgmma.commit_group`, `tcgen05.ld` / `tcgen05.commit`) |
+| `AsyncWait` | waits for asynchronous pipeline progress (`cp.async`, `wgmma`, `tcgen05`) |
 | `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
 | `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -39,6 +39,8 @@ pub enum SiteKind {
     Reduction,
     Barrier,
     Fence,
+    AsyncIssue,
+    AsyncWait,
     OrderedMemory,
     WarpCollective,
     Backedge,
@@ -291,7 +293,10 @@ fn injection_points(source: &str, site: &ScheduleSite) -> (usize, usize) {
 }
 
 fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
-    let head = instruction.head();
+    classify_head(instruction.head())
+}
+
+fn classify_head(head: &str) -> Option<SiteKind> {
     if head.starts_with("atom.") {
         return Some(SiteKind::Atomic);
     }
@@ -311,9 +316,47 @@ fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
     {
         return Some(SiteKind::Barrier);
     }
-    if head.starts_with("membar.") || head.starts_with("fence.") {
+    if head.starts_with("membar.") || head.starts_with("fence.") || head.starts_with("wgmma.fence.")
+    {
         return Some(SiteKind::Fence);
     }
+
+    // Waits must be classified before the broader cp.async.bulk issue prefix.
+    if [
+        "cp.async.wait_group",
+        "cp.async.wait_all",
+        "cp.async.bulk.wait_group",
+        "wgmma.wait_group",
+        "tcgen05.wait",
+    ]
+    .iter()
+    .any(|prefix| head.starts_with(prefix))
+    {
+        return Some(SiteKind::AsyncWait);
+    }
+
+    // AsyncIssue covers both work submission and commit boundaries. A commit
+    // orders work into a group but does not block for completion, so treating
+    // it as a fence or barrier would erase the distinction the campaign needs.
+    if [
+        "cp.async.ca.",
+        "cp.async.cg.",
+        "cp.async.commit_group",
+        "cp.async.bulk.",
+        "wgmma.commit_group",
+        "tcgen05.ld.",
+        "tcgen05.commit.",
+    ]
+    .iter()
+    .any(|prefix| head.starts_with(prefix))
+    {
+        return Some(SiteKind::AsyncIssue);
+    }
+
+    // `tcgen05.dealloc` and `tcgen05.relinquish_alloc_permit` are resource
+    // lifecycle operations, not issue/wait points. Keep them unclassified
+    // rather than widening the async categories by mnemonic family alone.
+
     // `redux.` needs its own entry: it is a warp-wide register reduction with
     // the same participation contract as the rest of this list, and the `red.`
     // arm above does not reach it -- that prefix carries the dot, so
@@ -642,6 +685,81 @@ L_loop:
             .filter(|decision| decision.before_ns > 0 || decision.after_ns > 0)
             .count();
         assert!(redux_injected > 0, "{:?}", rewrite.report.decisions);
+        assert!(rewrite.ptx.contains("nanosleep.u32"));
+    }
+
+    #[test]
+    fn async_pipeline_heads_have_distinct_issue_wait_and_fence_kinds() {
+        for (head, expected) in [
+            ("wgmma.fence.sync.aligned", SiteKind::Fence),
+            ("cp.async.ca.shared.global", SiteKind::AsyncIssue),
+            ("cp.async.cg.shared.global", SiteKind::AsyncIssue),
+            ("cp.async.bulk.tensor.2d.shared", SiteKind::AsyncIssue),
+            ("cp.async.commit_group", SiteKind::AsyncIssue),
+            ("wgmma.commit_group.sync.aligned", SiteKind::AsyncIssue),
+            (
+                "tcgen05.ld.sync.aligned.16x256b.x1.b32",
+                SiteKind::AsyncIssue,
+            ),
+            ("tcgen05.commit.cta_group", SiteKind::AsyncIssue),
+            ("cp.async.wait_group", SiteKind::AsyncWait),
+            ("cp.async.wait_all", SiteKind::AsyncWait),
+            ("cp.async.bulk.wait_group.read", SiteKind::AsyncWait),
+            ("wgmma.wait_group.sync.aligned", SiteKind::AsyncWait),
+            ("tcgen05.wait", SiteKind::AsyncWait),
+        ] {
+            assert_eq!(classify_head(head), Some(expected), "{head}");
+        }
+    }
+
+    #[test]
+    fn tcgen05_resource_lifecycle_is_not_folded_into_async_pipeline_sites() {
+        for head in [
+            "tcgen05.dealloc.cta_group",
+            "tcgen05.relinquish_alloc_permit.cta_group",
+        ] {
+            assert_eq!(classify_head(head), None, "{head}");
+        }
+    }
+
+    const ASYNC_PIPELINE: &str = r#".version 8.0
+.target sm_80
+.address_size 64
+
+.visible .entry async_pipeline()
+{
+    cp.async.commit_group;
+    cp.async.wait_all;
+    ret;
+}
+"#;
+
+    #[test]
+    fn async_pipeline_sites_can_be_perturbed() {
+        let analysis = analyze_ptx(ASYNC_PIPELINE).unwrap();
+        assert_eq!(analysis.sites().len(), 2);
+        assert_eq!(analysis.sites()[0].kind, SiteKind::AsyncIssue);
+        assert_eq!(analysis.sites()[1].kind, SiteKind::AsyncWait);
+
+        let rewrite = perturb_ptx(
+            ASYNC_PIPELINE,
+            &InjectionOptions {
+                seed: 7,
+                intensity: 1.0,
+                focus: Some("cp.async".to_string()),
+                ..InjectionOptions::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            rewrite
+                .report
+                .decisions
+                .iter()
+                .any(|decision| decision.before_ns > 0 || decision.after_ns > 0),
+            "{:?}",
+            rewrite.report.decisions
+        );
         assert!(rewrite.ptx.contains("nanosleep.u32"));
     }
 

--- a/crates/ptx-schedule/tests/cli.rs
+++ b/crates/ptx-schedule/tests/cli.rs
@@ -17,16 +17,18 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
+        Self::with_source(
+            ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n  bar.sync 0;\n  ret;\n}\n",
+        )
+    }
+
+    fn with_source(source: &str) -> Self {
         let id = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
         let dir =
             std::env::temp_dir().join(format!("ptx-schedule-cli-{}-{id}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
         let input = dir.join("input.ptx");
-        fs::write(
-            &input,
-            ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n  bar.sync 0;\n  ret;\n}\n",
-        )
-        .unwrap();
+        fs::write(&input, source).unwrap();
         Self { dir, input }
     }
 
@@ -106,4 +108,43 @@ fn both_valid_modes_execute() {
     let rewritten = fixture.run(&["--seed", "7", "--output", output_path.to_str().unwrap()]);
     assert!(rewritten.status.success(), "{rewritten:?}");
     assert!(output_path.is_file());
+}
+
+#[test]
+fn async_site_kinds_are_stable_in_cli_json() {
+    let fixture = Fixture::with_source(
+        ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n  cp.async.commit_group;\n  cp.async.wait_all;\n  ret;\n}\n",
+    );
+
+    let listed = fixture.run(&["--list-sites"]);
+    assert!(listed.status.success(), "{listed:?}");
+    let sites: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    let kinds = sites
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|site| site["kind"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(kinds, vec!["AsyncIssue", "AsyncWait"]);
+
+    let output_path = fixture.output();
+    let decisions_path = fixture.dir.join("decisions.json");
+    let rewritten = fixture.run(&[
+        "--seed",
+        "7",
+        "--output",
+        output_path.to_str().unwrap(),
+        "--decisions-json",
+        decisions_path.to_str().unwrap(),
+    ]);
+    assert!(rewritten.status.success(), "{rewritten:?}");
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(decisions_path).unwrap()).unwrap();
+    let decision_kinds = report["decisions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|decision| decision["site"]["kind"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(decision_kinds, vec!["AsyncIssue", "AsyncWait"]);
 }


### PR DESCRIPTION
Fixes #1113

## Summary

Classify async proxy pipeline instructions in `ptx-schedule` so they become visible
to schedule analysis and perturbation campaigns.

## Changes

- Add `SiteKind::AsyncIssue`.
- Add `SiteKind::AsyncWait`.
- Classify the async issue/commit forms identified in #1113 as `AsyncIssue`.
- Classify the corresponding completion/wait forms as `AsyncWait`.
- Classify `wgmma.fence.*` as the existing `Fence` kind.
- Keep `tcgen05` resource-lifecycle operations outside the async pipeline taxonomy.
- Add unit coverage for classification and perturbation.
- Add CLI integration coverage for the serialized `AsyncIssue` / `AsyncWait` names.
- Update the README `SiteKind` inventory.

The campaign reporting path requires no additional changes because site counts are
derived dynamically from the `SiteKind` debug names.

## Validation

```text
cargo fmt --all -- --check
cargo test -p ptx-schedule --all-targets
cargo clippy -p ptx-schedule --all-targets -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc -p ptx-schedule --no-deps --document-private-items
git diff --check
```

Results:

* 19 unit tests passed.
* 4 CLI integration tests passed.
* Clippy passed with warnings denied.
* Rustdoc passed with warnings denied.
* `git diff --check` passed.

Manual CLI validation also confirms that both `--list-sites` and
`--decisions-json` serialize the new kinds as:

```text
AsyncIssue
AsyncWait
```
