### PR TITLE
fix(mir-lower): legalize cluster-shared slice fat-pointer casts in SSA

### DIFF
--- a/crates/mir-lower/src/convert/ops/cast.rs
+++ b/crates/mir-lower/src/convert/ops/cast.rs
@@ -59,7 +59,7 @@ use crate::convert::types::{
 use crate::helpers;
 use dialect_mir::attributes::MirCastKindAttr;
 use dialect_mir::ops::MirCastOp;
-use dialect_mir::types::{MirArrayType, MirPtrType, address_space};
+use dialect_mir::types::{MirArrayType, MirPtrType};
 use llvm_export::op_interfaces::{CastOpInterface, CastOpWithNNegInterface};
 use llvm_export::ops as llvm;
 use llvm_export::types::{FuncType, PointerType, PointerTypeExt};
@@ -495,8 +495,7 @@ fn slice_fat_pointer_fields(
 /// The data-pointer half carries address-space semantics and is converted with
 /// `addrspacecast` when the source and destination spaces differ. The integer
 /// metadata half is copied unchanged. No aggregate bytes are materialized in
-/// memory, so an addrspace(3) pointer is never exposed as its target-dependent
-/// physical representation.
+/// memory, so the pointer's address-space semantics remain explicit in SSA.
 fn try_emit_slice_fat_pointer_cast(
     ctx: &mut Context,
     rewriter: &mut DialectConversionRewriter,
@@ -528,13 +527,6 @@ fn try_emit_slice_fat_pointer_cast(
         .downcast_ref::<PointerType>()
         .expect("slice fat-pointer data field must be a pointer")
         .address_space();
-
-    // Cluster-shared pointers have distinct lowering semantics and are intentionally
-    // outside this legalization. Preserve the existing aggregate fallback for AS7.
-    if src_data_as == address_space::CLUSTER_SHARED || dst_data_as == address_space::CLUSTER_SHARED
-    {
-        return Ok(None);
-    }
 
     let extract_data = llvm::ExtractValueOp::new(ctx, val, vec![0])
         .map_err(|e| pliron::input_error_noloc!("slice pointer cast data extraction: {e}"))?;
@@ -1983,7 +1975,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_shared_slice_fat_pointer_cast_keeps_existing_fallback() {
+    fn cluster_shared_slice_fat_pointer_cast_rebuilds_in_ssa() {
         for cluster_shared_is_source in [true, false] {
             let mut ctx = make_ctx();
             let cluster_shared = dialect_mir::types::address_space::CLUSTER_SHARED;
@@ -2006,9 +1998,37 @@ mod tests {
                 lower_single_cast(&mut ctx, source, destination, MirCastKindAttr::PtrToPtr);
             let body = kernel_blocks(&ctx, module);
 
+            assert_eq!(
+                count_ops::<llvm::AllocaOp>(&ctx, &body),
+                0,
+                "cluster-shared slice fat-pointer casts must stay in SSA"
+            );
+            assert_eq!(
+                count_ops::<llvm::StoreOp>(&ctx, &body),
+                0,
+                "cluster-shared slice fat-pointer casts must not expose aggregate bytes"
+            );
+            assert_eq!(
+                count_ops::<llvm::LoadOp>(&ctx, &body),
+                0,
+                "cluster-shared slice fat-pointer casts must not reload aggregate bytes"
+            );
             assert!(
-                count_ops::<llvm::AllocaOp>(&ctx, &body) > 0,
-                "cluster-shared slice-shaped casts must keep the existing aggregate fallback"
+                count_ops::<llvm::ExtractValueOp>(&ctx, &body) >= 2,
+                "cluster-shared slice fat-pointer casts must extract data and metadata"
+            );
+            assert!(
+                count_ops::<llvm::InsertValueOp>(&ctx, &body) >= 2,
+                "cluster-shared slice fat-pointer casts must rebuild data and metadata"
+            );
+
+            let casts = find_all::<llvm::AddrSpaceCastOp>(&ctx, &body);
+            assert!(
+                casts.iter().any(|cast| {
+                    let result = cast.get_operation().deref(&ctx).get_result(0);
+                    pointer_addrspace(&ctx, result.get_type(&ctx)) == destination_space
+                }),
+                "cluster-shared slice data pointer must be addrspacecast into the destination space"
             );
         }
     }

--- a/crates/rustc-codegen-cuda/examples/cluster/README.md
+++ b/crates/rustc-codegen-cuda/examples/cluster/README.md
@@ -12,6 +12,7 @@ Demonstrates Thread Block Clusters, a Hopper feature that enables direct shared 
 4. **test_dsmem_ring_exchange**: Distributed shared memory read through `map_shared_rank` + dereference
 5. **test_dsmem_reduction**: All-to-one reduction using `dsmem_read_u32`
 6. **test_dsmem_mapped_store**: Distributed shared memory write through `map_shared_rank_mut` + dereference
+7. **test_dsmem_slice_fat_pointer_cast**: Cluster-shared `addrspace(7)` slice fat-pointer cast followed by ordinary remote dereference
 
 ## Key Concepts Demonstrated
 
@@ -110,6 +111,25 @@ let neighbor_value =
 
 Both approaches require the target CTA to remain live and require cluster synchronization appropriate to the data dependency.
 
+### AS7 Slice Fat-Pointer Casts
+
+`map_shared_rank` also provides the reachable source for cluster-shared slice fat pointers. The mapped `addrspace(7)` data pointer can be widened into a slice, reinterpreted as another slice element type, and then dereferenced normally:
+
+```rust
+let neighbor_ptr =
+    cluster::map_shared_rank(addr_of!(SHMEM) as *const u32, neighbor_rank);
+
+let remote_slice = core::ptr::slice_from_raw_parts(neighbor_ptr, 2);
+let recast_slice = cast_cluster_slice_elements(remote_slice);
+let recast_len = unsafe { (&*recast_slice).len() };
+let recast_data = recast_slice as *const i32;
+
+let first = unsafe { recast_data.read() };
+let second = unsafe { recast_data.add(1).read() };
+```
+
+The compiler keeps the slice cast in SSA: it preserves the integer metadata and converts only the data-pointer field with `addrspacecast` when needed. The resulting remote loads must still lower to `ld.shared::cluster`, rather than decaying to generic or CTA-local shared-memory accesses.
+
 ## Build and Run
 
 ```bash
@@ -157,7 +177,15 @@ Results (each block observes the write from its previous rank):
   Block 3: got 3002, expected 3002 ✓
 ✓ DSMEM mapped remote store PASSED
 
-🎉 All cluster + DSMEM tests PASSED!
+=== Test 6: DSMEM AS7 Slice Fat-Pointer Cast (cluster launch) ===
+Results (sum of neighbor pair, preserved slice length):
+  Block 0: sum=8021, expected=8021, len=2 ✓
+  Block 1: sum=8041, expected=8041, len=2 ✓
+  Block 2: sum=8061, expected=8061, len=2 ✓
+  Block 3: sum=8001, expected=8001, len=2 ✓
+✓ DSMEM AS7 slice fat-pointer cast PASSED
+
+All cluster + DSMEM tests PASSED!
 ```
 
 ### On Pre-Hopper (sm_80 and earlier):
@@ -240,6 +268,12 @@ A mutable mapped pointer similarly selects a cluster-shared store:
 ```ptx
 mapa.shared::cluster.u64 %rd_mapped, %rd_local_shmem, %r_neighbor_rank;
 st.shared::cluster.u32 [%rd_mapped], %r_value;
+```
+
+A remote dereference after the AS7 slice fat-pointer cast must keep the same cluster-shared access form:
+
+```ptx
+ld.shared::cluster.u32 %r_result, [%rd_mapped];
 ```
 
 ## Potential Errors

--- a/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/cluster/src/main.rs
@@ -15,7 +15,7 @@
 //! Uses unified compilation: single `cargo oxide run cluster`
 
 use core::ptr::{addr_of, addr_of_mut};
-use cuda_device::{DisjointSlice, SharedArray, cluster, cluster_launch, kernel, thread};
+use cuda_device::{DisjointSlice, SharedArray, cluster, cluster_launch, device, kernel, thread};
 use cuda_host::cuda_module;
 
 // ============================================================================
@@ -24,6 +24,16 @@ use cuda_host::cuda_module;
 #[cuda_module]
 mod kernels {
     use super::*;
+
+    /// Reinterpret a slice fat pointer while preserving its data-pointer address space.
+    ///
+    /// Keeping this in a separate non-inlined device function gives the cast a distinct
+    /// device-function boundary so the semantic fat-pointer cast is exercised independently.
+    #[inline(never)]
+    #[device]
+    fn cast_cluster_slice_elements(pointer: *const [u32]) -> *const [i32] {
+        pointer as *const [i32]
+    }
 
     /// Keeps the generated cluster-grid helper path in the compiled module.
     #[kernel]
@@ -250,6 +260,60 @@ mod kernels {
             }
         }
 
+        cluster::cluster_sync();
+    }
+
+    // ============================================================================
+    // Test 6: Distributed Shared Memory (AS7 Slice Fat-Pointer Cast)
+    // ============================================================================
+
+    /// Test a slice fat-pointer cast whose data pointer is cluster-shared (`addrspace(7)`).
+    ///
+    /// The mapped pointer is widened into a two-element slice, reinterpreted from
+    /// `[u32]` to `[i32]`, and then read through the recast data pointer. The cast
+    /// must preserve both the AS7 data-pointer semantics and the slice length.
+    #[kernel]
+    #[cluster_launch(4, 1, 1)]
+    pub fn test_dsmem_slice_fat_pointer_cast(mut output: DisjointSlice<u32>) {
+        static mut SHMEM: SharedArray<u32, 2> = SharedArray::UNINIT;
+
+        let tid = thread::threadIdx_x();
+        let my_rank = cluster::block_rank();
+        let cluster_size = cluster::cluster_size();
+
+        if tid == 0 {
+            let base = addr_of_mut!(SHMEM) as *mut u32;
+            unsafe {
+                base.write(4000 + my_rank * 10);
+                base.add(1).write(4001 + my_rank * 10);
+            }
+        }
+        thread::sync_threads();
+        cluster::cluster_sync();
+
+        if tid == 0 {
+            let neighbor_rank = (my_rank + 1) % cluster_size;
+            let neighbor_ptr =
+                unsafe { cluster::map_shared_rank(addr_of!(SHMEM) as *const u32, neighbor_rank) };
+
+            let remote_slice = core::ptr::slice_from_raw_parts(neighbor_ptr, 2);
+            let recast_slice = cast_cluster_slice_elements(remote_slice);
+            let recast_len = unsafe { (&*recast_slice).len() };
+            let recast_data = recast_slice as *const i32;
+
+            let first = unsafe { recast_data.read() } as u32;
+            let second = unsafe { recast_data.add(1).read() } as u32;
+
+            let base = (my_rank as usize) * 2;
+            if base + 1 < output.len() {
+                unsafe {
+                    *output.get_unchecked_mut(base) = first + second;
+                    *output.get_unchecked_mut(base + 1) = recast_len as u32;
+                }
+            }
+        }
+
+        // Keep every target CTA alive until all remote reads have completed.
         cluster::cluster_sync();
     }
 }
@@ -606,6 +670,80 @@ fn main() {
     }
 
     // ====================================================================
+    // Test 6: DSMEM AS7 slice fat-pointer cast
+    // ====================================================================
+
+    println!("=== Test 6: DSMEM AS7 Slice Fat-Pointer Cast (cluster launch) ===\n");
+
+    let slice_cast_pass = if dsmem_context_error {
+        println!("⚠ Skipped - CUDA context corrupted by previous DSMEM error\n");
+        false
+    } else {
+        let mut slice_output =
+            DeviceBuffer::<u32>::zeroed(&stream, (cluster_size as usize) * 2).unwrap();
+
+        println!("Launching test_dsmem_slice_fat_pointer_cast via cuLaunchKernelEx");
+        println!("  Grid: 4x1x1, Block: 32, Cluster: 4x1x1");
+        println!("  Each block reads a two-element AS7 slice from its next rank after a fat-pointer cast\n");
+
+        let slice_result = unsafe {
+            module.test_dsmem_slice_fat_pointer_cast(
+                (stream).as_ref(),
+                LaunchConfig {
+                    grid_dim: (cluster_size, 1, 1),
+                    block_dim: (32, 1, 1),
+                    shared_mem_bytes: 0,
+                },
+                &mut slice_output,
+            )
+        };
+
+        match slice_result {
+            Ok(_) => match stream.synchronize() {
+                Ok(()) => {
+                    let results: Vec<u32> = slice_output.to_host_vec(&stream).unwrap();
+                    println!("Results (sum of neighbor pair, preserved slice length):");
+                    for rank in 0..cluster_size as usize {
+                        let neighbor_rank = (rank as u32 + 1) % cluster_size;
+                        let expected_sum = 8001 + neighbor_rank * 20;
+                        let got_sum = results[rank * 2];
+                        let got_len = results[rank * 2 + 1];
+                        let status = if got_sum == expected_sum && got_len == 2 {
+                            "✓"
+                        } else {
+                            "?"
+                        };
+                        println!(
+                            "  Block {}: sum={}, expected={}, len={} {}",
+                            rank, got_sum, expected_sum, got_len, status
+                        );
+                    }
+
+                    (0..cluster_size as usize).all(|rank| {
+                        let neighbor_rank = (rank as u32 + 1) % cluster_size;
+                        results[rank * 2] == 8001 + neighbor_rank * 20
+                            && results[rank * 2 + 1] == 2
+                    })
+                }
+                Err(e) => {
+                    println!("⚠ DSMEM slice-cast synchronize failed: {:?}", e);
+                    false
+                }
+            },
+            Err(e) => {
+                println!("⚠ Cluster launch failed: {:?}", e);
+                false
+            }
+        }
+    };
+
+    if slice_cast_pass {
+        println!("✓ DSMEM AS7 slice fat-pointer cast PASSED\n");
+    } else if !dsmem_context_error {
+        println!("⚠ DSMEM AS7 slice fat-pointer cast failed\n");
+    }
+
+    // ====================================================================
     // Summary
     // ====================================================================
 
@@ -615,7 +753,8 @@ fn main() {
     println!("  .explicitcluster");
     println!("  .reqnctapercluster 4, 1, 1\n");
 
-    let all_pass = ct_pass && sync_pass && ring_pass && reduce_pass && store_pass;
+    let all_pass =
+        ct_pass && sync_pass && ring_pass && reduce_pass && store_pass && slice_cast_pass;
     if all_pass {
         println!("All cluster + DSMEM tests PASSED!");
     } else {
@@ -640,6 +779,10 @@ fn main() {
         println!(
             "  Test 5 (DSMEM mapped store):     {}",
             if store_pass { "PASS" } else { "FAIL" }
+        );
+        println!(
+            "  Test 6 (AS7 slice fat-pointer):  {}",
+            if slice_cast_pass { "PASS" } else { "FAIL" }
         );
         std::process::exit(1);
     }

--- a/crates/rustc-codegen-cuda/examples/cluster/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/cluster/verify-code-shape.sh
@@ -6,9 +6,10 @@
 # cluster-shared address space end to end. If the mapped pointer decays to a
 # generic pointer, an ordinary Rust deref compiles to a CTA-local access and
 # the remote read/write silently targets the wrong shared memory. Assert the
-# LLVM IR loads and stores through `ptr addrspace(7)` and that the two
-# plain-deref kernels emit `ld.shared::cluster` / `st.shared::cluster`, so a
-# regression to generic accesses cannot pass compile-only CI.
+# LLVM IR loads and stores through `ptr addrspace(7)` and that the plain-deref
+# kernels, including the AS7 slice-fat-pointer regression, emit
+# `ld.shared::cluster` / `st.shared::cluster`, so a regression to generic
+# accesses cannot pass compile-only CI.
 
 set -euo pipefail
 
@@ -70,5 +71,10 @@ require_entry_shape test_dsmem_ring_exchange \
     "cluster-shared remote load" 'ld\.shared::cluster\.'
 require_entry_shape test_dsmem_mapped_store \
     "cluster-shared remote store" 'st\.shared::cluster\.'
+
+# Rebuilding and reinterpreting an AS7 slice fat pointer must preserve the
+# cluster-shared data-pointer semantics through the eventual dereference.
+require_entry_shape test_dsmem_slice_fat_pointer_cast \
+    "cluster-shared load after AS7 slice fat-pointer cast" 'ld\.shared::cluster\.'
 
 echo "cluster code shape: PASS"


### PR DESCRIPTION
Closes #1177 

## Summary

Extend the existing slice fat-pointer SSA legalization to cluster-shared `addrspace(7)` pointers.

#1061 introduced fieldwise lowering for canonical slice-shaped pointer casts, but intentionally excluded AS7 so that cluster-shared semantics could be audited separately.

This follow-up removes that exclusion after validating the path end to end through `map_shared_rank`.

A canonical slice fat pointer is lowered semantically as:

```text
{ data pointer, metadata }
        |
        +-- extract data pointer
        |       |
        |       +-- addrspacecast when required
        |
        +-- extract metadata unchanged
        |
        +-- reconstruct destination aggregate in SSA
```

No aggregate bytes are materialized in memory.

## Why

Cluster DSMEM mappings produced by `map_shared_rank` carry `addrspace(7)` semantics.

Those pointers can reach a slice fat-pointer cast through ordinary Rust code:

```text
map_shared_rank
    ↓
addrspace(7)
    ↓
slice_from_raw_parts
    ↓
*const [u32] → *const [i32]
```

Before this change, `try_emit_slice_fat_pointer_cast` explicitly rejected casts involving `addrspace(7)`, causing the canonical slice case to fall back to the generic aggregate `alloca` + `store` + `load` path.

There is no need to reinterpret a slice fat pointer as aggregate bytes. Its data pointer and metadata have independent semantics: the data pointer can be converted with `addrspacecast`, while the integer metadata is preserved unchanged.

Keeping the conversion in SSA also makes the cluster-shared address-space semantics explicit through lowering.

## Implementation

* Remove the `CLUSTER_SHARED` early return from `try_emit_slice_fat_pointer_cast`.
* Reuse the existing canonical `{ pointer, integer metadata }` legalization for AS7.
* Preserve the existing narrow shape and metadata checks.
* Replace the previous AS7 fallback regression with coverage that verifies:

  * no `alloca`
  * no `store`
  * no `load`
  * data and metadata extraction
  * SSA reconstruction
  * the required destination `addrspacecast`
* Extend the `cluster` example with an end-to-end AS7 slice fat-pointer test.
* Extend `verify-code-shape.sh` to require `ld.shared::cluster` after the fat-pointer cast.
* Document the new regression in the cluster example README.

## End-to-end regression

The cluster test exercises:

```text
map_shared_rank
    ↓
cluster-shared addrspace(7) pointer
    ↓
slice_from_raw_parts(..., 2)
    ↓
non-inlined slice element-type cast
    ↓
metadata extraction + data-pointer dereference
    ↓
remote DSMEM loads
```

On `sm_120`, each block successfully reads a two-element slice from its neighbor rank after the fat-pointer cast:

```text
Block 0: sum=8021, expected=8021, len=2 ✓
Block 1: sum=8041, expected=8041, len=2 ✓
Block 2: sum=8061, expected=8061, len=2 ✓
Block 3: sum=8001, expected=8001, len=2 ✓
```

The code-shape regression also confirms that the post-cast dereference emits `ld.shared::cluster`.

## Scope

This remains the same narrow slice legalization introduced by #1061.

It does not extend to:

* arbitrary aggregate shapes
* trait-object-like `{ ptr, ptr }` aggregates
* aggregate `Transmute`
* unrelated pointer-cast memory fallbacks

## Validation

```text
cargo fmt --all -- --check
PASS

git diff --check
PASS

cargo test -p mir-lower
270 unit tests passed
129 lowering tests passed

cargo clippy -p mir-lower --all-targets -- -D warnings
PASS

cargo oxide run cluster
PASS

test_dsmem_slice_fat_pointer_cast
Block 0: sum=8021, expected=8021, len=2
Block 1: sum=8041, expected=8041, len=2
Block 2: sum=8061, expected=8061, len=2
Block 3: sum=8001, expected=8001, len=2

crates/rustc-codegen-cuda/examples/cluster/verify-code-shape.sh
cluster code shape: PASS
```

Related: #883
Follow-up to: #1061
