### PR TITLE
codegen: accept `char` in device-extern signatures

### DIFF
--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/README.md
@@ -176,7 +176,24 @@ extern "C" __device__ float warp_reduce_sum(float val) {
 | `warp_reduce_sum`    | Warp-level sum          |
 | `warp_ballot`        | Warp ballot             |
 | `simple_add`         | Simple a + b            |
+| `char_to_upper`      | ASCII uppercase, `char` |
 | `clamp_value`        | Clamp to range          |
+
+### `char` in a `#[device]` extern
+
+Rust `char` is a 32-bit Unicode scalar value. It therefore lowers to a plain
+`i32` device-extern parameter, result, or pointer pointee with no `signext` or
+`zeroext` attribute, matching CUDA C++ `unsigned int`:
+
+```text
+.ll:   declare i32 @char_to_upper(i32)      call i32 @char_to_upper(i32 113)
+.ptx:  .extern .func (.param .b32 ...) char_to_upper (.param .b32 ...)
+```
+
+The CUDA function must return a valid Unicode scalar: values above `0x10FFFF`
+and surrogates in `0xD800..=0xDFFF` violate Rust's `char` validity contract.
+Rust's `improper_ctypes` lint also warns because C has no native equivalent;
+callers that deliberately use this mapping may allow that lint on the extern.
 
 ### From `extern-libs/cccl_wrappers.cu` (CUB)
 

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/extern-libs/external_device_funcs.cu
@@ -53,6 +53,22 @@ extern "C" __device__ float simple_add(float a, float b) {
 }
 
 /**
+ * Uppercase one Unicode scalar value in the ASCII range.
+ *
+ * Rust `char` lowers to the same plain 32-bit slot as `unsigned int`. Keep the
+ * result in Rust's Unicode scalar range: an out-of-range value would violate
+ * the Rust caller's validity contract.
+ */
+extern "C" __device__ unsigned int char_to_upper(unsigned int c) {
+    return (c >= 'a' && c <= 'z') ? c - 32u : c;
+}
+
+/** Store one valid Unicode scalar through the pointer form of the same ABI. */
+extern "C" __device__ void char_store(unsigned int *output, unsigned int c) {
+    *output = c;
+}
+
+/**
  * Clamp a value to a range.
  * Pure function - no memory access.
  */

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -672,7 +672,11 @@ fn test_char_ffi_runner(
         println!("    ✓ PASSED ('q' -> 'Q', 'Z' unchanged, pointer -> 'λ')");
         *passed += 1;
     } else {
-        println!("    ✗ FAILED (got {:?}, expected {:?})", &actual[..3], expected);
+        println!(
+            "    ✗ FAILED (got {:?}, expected {:?})",
+            &actual[..3],
+            expected
+        );
         *failed += 1;
     }
 }

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/src/main.rs
@@ -40,6 +40,12 @@ unsafe extern "C" {
     fn warp_reduce_sum(val: f32) -> f32;
     fn warp_ballot(predicate: i32) -> u32;
     fn simple_add(a: f32, b: f32) -> f32;
+    // `char` is a plain 32-bit device-extern slot. Rust still warns because C
+    // has no native `char` equivalent, so acknowledge that contract here.
+    #[allow(improper_ctypes)]
+    fn char_to_upper(c: char) -> char;
+    #[allow(improper_ctypes)]
+    fn char_store(output: *mut char, c: char);
     fn clamp_value(val: f32, min_val: f32, max_val: f32) -> f32;
     fn smem_write_aligned_128(offset: i32, value: f32);
     fn smem_read_aligned_128(offset: i32) -> f32;
@@ -88,6 +94,21 @@ mod kernels {
         if tid.is_multiple_of(32) {
             unsafe {
                 *output.add((tid / 32) as usize) = sum;
+            }
+        }
+    }
+
+    /// Round-trip a `char` through an external CUDA `unsigned int` function.
+    #[kernel]
+    pub fn test_char_ffi(output: *mut u32) {
+        let tid = cuda_device::thread::threadIdx_x();
+        if tid == 0 {
+            let upper = unsafe { char_to_upper('q') };
+            let unchanged = unsafe { char_to_upper('Z') };
+            unsafe {
+                *output = upper as u32;
+                *output.add(1) = unchanged as u32;
+                char_store(output.add(2).cast::<char>(), 'λ');
             }
         }
     }
@@ -526,6 +547,7 @@ fn main() {
     let mut tests_failed = 0;
 
     test_simple_device_funcs_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
+    test_char_ffi_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_cub_warp_reduce_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_mixed_attrs_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
     test_smem_alignment_cross_module_runner(&ctx, &module, &mut tests_passed, &mut tests_failed);
@@ -613,6 +635,44 @@ fn test_simple_device_funcs_runner(
         *passed += 1;
     } else {
         println!("    ✗ FAILED ({} errors)", errors);
+        *failed += 1;
+    }
+}
+
+/// Test: `char` across a `#[device]` extern boundary.
+fn test_char_ffi_runner(
+    ctx: &Arc<CudaContext>,
+    module: &kernels::LoadedModule,
+    passed: &mut i32,
+    failed: &mut i32,
+) {
+    println!("--- Test: test_char_ffi ---");
+
+    let stream = ctx.default_stream();
+    let d_output = DeviceBuffer::<u32>::zeroed(&stream, 3).unwrap();
+    let config = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (1, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    // SAFETY: the launch writes exactly three 32-bit values into d_output.
+    unsafe {
+        module.test_char_ffi(
+            (stream).as_ref(),
+            config,
+            d_output.cu_deviceptr() as *mut u32,
+        )
+    }
+    .expect("Kernel launch failed");
+
+    let actual = d_output.to_host_vec(&stream).unwrap();
+    let expected = [u32::from('Q'), u32::from('Z'), u32::from('λ')];
+    if actual[..3] == expected {
+        println!("    ✓ PASSED ('q' -> 'Q', 'Z' unchanged, pointer -> 'λ')");
+        *passed += 1;
+    } else {
+        println!("    ✗ FAILED (got {:?}, expected {:?})", &actual[..3], expected);
         *failed += 1;
     }
 }

--- a/crates/rustc-codegen-cuda/examples/device_ffi_test/verify-code-shape.sh
+++ b/crates/rustc-codegen-cuda/examples/device_ffi_test/verify-code-shape.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# A runtime q -> Q check cannot distinguish a plain i32 ABI from the plausible
+# but wrong `zeroext i32` mapping: both reach the same PTX and hardware result.
+# Pin the declaration and calls in the emitted LLVM IR before LTO.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ll="${root}/device_ffi_test.ll"
+
+test -s "${ll}"
+
+require_count() {
+    local description="$1"
+    local expected="$2"
+    local pattern="$3"
+    local actual
+    actual="$(grep -Ec "${pattern}" "${ll}" || true)"
+    if [[ "${actual}" -ne "${expected}" ]]; then
+        echo "error: expected ${expected} ${description} in ${ll}, found ${actual}" >&2
+        exit 1
+    fi
+}
+
+require_count "plain char_to_upper declaration" 1 \
+    '^declare i32 @char_to_upper\(i32\)( #[0-9]+)?$'
+require_count "'q' char_to_upper call" 1 \
+    'call i32 @char_to_upper\(i32 113\)'
+require_count "'Z' char_to_upper call" 1 \
+    'call i32 @char_to_upper\(i32 90\)'
+
+# Legacy NVVM IR retains the i32 pointee while modern IR uses opaque `ptr`.
+require_count "plain char_store declaration" 1 \
+    '^declare void @char_store\((i32\*|ptr), i32\)( #[0-9]+)?$'
+require_count "char_store pointer call" 1 \
+    'call void @char_store\((i32\*|ptr) [^,]+, i32 955\)'
+
+char_lines="$(grep -E '(declare|call).*@(char_to_upper|char_store)\(' "${ll}" || true)"
+
+if grep -Eq '\b(signext|zeroext)\b' <<<"${char_lines}"; then
+    echo "error: 32-bit char ABI must not carry an extension attribute" >&2
+    echo "${char_lines}" >&2
+    exit 1
+fi
+
+echo "device_ffi_test char ABI shape: PASS"

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -228,11 +228,7 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 // Rust's `*mut ()` is its common spelling for a void pointer.
                 E::Integer(8)
             } else {
-                rustc_ty_to_device_extern_type(
-                    tcx,
-                    *pointee,
-                    DeviceExternTypePosition::Pointee,
-                )?
+                rustc_ty_to_device_extern_type(tcx, *pointee, DeviceExternTypePosition::Pointee)?
             };
             Ok(E::pointer_to(pointee, 0))
         }
@@ -240,11 +236,8 @@ fn rustc_ty_to_device_extern_type<'tcx>(
             let len = len.try_to_target_usize(tcx).ok_or_else(|| {
                 format!("device-extern array length for `{ty}` is not a concrete constant")
             })?;
-            let element = rustc_ty_to_device_extern_type(
-                tcx,
-                *element,
-                DeviceExternTypePosition::Pointee,
-            )?;
+            let element =
+                rustc_ty_to_device_extern_type(tcx, *element, DeviceExternTypePosition::Pointee)?;
             Ok(E::Array {
                 element: Box::new(element),
                 len,

--- a/crates/rustc-codegen-cuda/src/device_codegen.rs
+++ b/crates/rustc-codegen-cuda/src/device_codegen.rs
@@ -265,9 +265,9 @@ fn rustc_ty_to_device_extern_type<'tcx>(
                 Ok(E::ZeroExtInteger(1))
             }
         }
-        TyKind::Char => Err(
-            "Rust `char` is not supported in device extern signatures; use `u32` in a C-compatible wrapper".to_string(),
-        ),
+        // `char` is already a 32-bit Unicode scalar, so it uses a plain i32
+        // slot without a signext/zeroext attribute in every position.
+        TyKind::Char => unsigned_integer(32),
         TyKind::Never => Err("never-returning device externs are not yet supported".to_string()),
         _ => Err(format!(
             "unsupported device-extern ABI type `{ty}`; use scalar C types or raw pointers to supported scalar/array pointees"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -792,6 +792,37 @@ run_cargo() {
     for noinline in "${NOINLINE_MIR_EXAMPLES[@]}"; do
         [[ "${ex}" == "${noinline}" ]] && EXTRA_RUSTFLAGS="-Zinline-mir=no"
     done
+    # Rust `char` must remain plain i32 in both NVVM dialects. A runtime
+    # round-trip cannot distinguish it from an incorrect zeroext i32 ABI.
+    if [[ ${COMPILE_ONLY} -eq 1 && "${ex}" == "device_ffi_test" ]]; then
+        local shape_check="crates/rustc-codegen-cuda/examples/${ex}/verify-code-shape.sh"
+        local arch
+        for arch in sm_90 sm_100; do
+            local -a char_abi_args=("build" "${ex}" "--emit-nvvm-ir" "--arch=${arch}")
+            if [[ ${VERBOSE} -eq 1 ]]; then
+                invoke_cargo_oxide "${char_abi_args[@]}" 2>&1 | tee -a "${log}"
+                CARGO_EC=${PIPESTATUS[0]}
+            else
+                invoke_cargo_oxide "${char_abi_args[@]}" >>"${log}" 2>&1
+                CARGO_EC=$?
+            fi
+            if [[ ${CARGO_EC} -ne 0 ]]; then
+                return
+            fi
+            local target_file="crates/rustc-codegen-cuda/examples/${ex}/${ex}.target"
+            if ! grep -qx "${arch}" "${target_file}"; then
+                printf '%s expected target %s in %s\n' "${ex}" "${arch}" "${target_file}" >>"${log}"
+                CARGO_EC=1
+                return
+            fi
+            if ! bash "${shape_check}" >>"${log}" 2>&1; then
+                printf '%s failed its char ABI shape assertions for %s\n' "${ex}" "${arch}" >>"${log}"
+                CARGO_EC=1
+                return
+            fi
+        done
+        return
+    fi
     # This exact-target batch must pass both compiler routes. The second build
     # may replace the first artifact, so preserve both exit codes in one gate.
     if [[ "${cat}" == "blackwell-compile" ]]; then


### PR DESCRIPTION
Closes #875.

This independently lands the sound ABI change proposed by @NgoQuocViet2001 in #1049 on a signed maintainer branch; the contributor fork does not allow maintainer edits.

Before, a `#[device] extern "C"` taking or returning Rust `char` was rejected. After, `char` uses the same plain 32-bit slot as CUDA C++ `unsigned int` in parameter, result, and pointee positions.

The device-FFI example now exercises parameter, return, and pointer forms. Its checked-in shape gate builds both the legacy `sm_90` and modern `sm_100` NVVM paths and rejects `signext`/`zeroext`, which the functional round-trip alone cannot detect.

Local checks: 27 rustc-codegen tests, strict clippy for the backend and example, formatting/SPDX/shell checks, and both exact NVVM-IR paths pass.