### PR TITLE
feat(cuda-device): add scalar bf16_to_f32

### DIFF
--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -44,6 +44,16 @@ pub fn f32_to_bf16_rne(value: f32) -> u16 {
     (bits.wrapping_add(0x7FFF + retained_lsb) >> 16) as u16
 }
 
+/// Widens raw `bf16` bits to `f32` by placing them in the high 16 bits.
+///
+/// This is the inverse of [`f32_to_bf16`] for values that are already exact
+/// in bf16: the low 16 bits of the `f32` become zero.
+#[must_use]
+#[inline(always)]
+pub fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits(u32::from(bits) << 16)
+}
+
 /// Packs two raw `bf16` bit patterns into a `u32`, low half first.
 #[must_use]
 #[inline(always)]
@@ -219,6 +229,9 @@ mod tests {
         assert_eq!(f32_to_bf16(-0.0), 0x8000);
         assert_eq!(f32_to_bf16(f32::INFINITY), 0x7F80);
         assert_eq!(f32_to_bf16(f32::NEG_INFINITY), 0xFF80);
+        assert_eq!(bf16_to_f32(0x3F80), 1.0);
+        assert_eq!(bf16_to_f32(0x8000).to_bits(), (-0.0_f32).to_bits());
+        assert_eq!(bf16_to_f32(f32_to_bf16(1.0)), 1.0);
 
         // Exact tie with an even retained LSB rounds down; an odd one rounds up.
         assert_eq!(f32_to_bf16_rne(f32::from_bits(0x3F80_8000)), 0x3F80);

--- a/crates/cuda-device/src/convert.rs
+++ b/crates/cuda-device/src/convert.rs
@@ -278,4 +278,18 @@ mod tests {
             );
         }
     }
+
+    /// Every bf16 bit pattern must survive the trip through the f32 widen,
+    /// NaNs included: `bf16_to_f32` places the bits in the high half and
+    /// `f32_to_bf16` truncates them back out bit-identically.
+    #[test]
+    fn every_bf16_pattern_round_trips() {
+        for bits in 0u16..=u16::MAX {
+            assert_eq!(
+                f32_to_bf16(bf16_to_f32(bits)),
+                bits,
+                "round-trip mismatch for bf16 bits {bits:#06x}"
+            );
+        }
+    }
 }

--- a/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol/src/main.rs
@@ -50,7 +50,7 @@ use cuda_device::clc::{
     clc_query_get_first_ctaid_x, clc_query_is_canceled, clc_try_cancel, clc_try_cancel_multicast,
 };
 use cuda_device::cluster;
-use cuda_device::convert::cvt_bf16x2_f32;
+use cuda_device::convert::{bf16_to_f32, cvt_bf16x2_f32};
 use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
@@ -6727,8 +6727,4 @@ fn unpack_bf16_pair(packed: u32) -> (f32, f32) {
     let lo = (packed & 0xFFFF) as u16;
     let hi = ((packed >> 16) & 0xFFFF) as u16;
     (bf16_to_f32(lo), bf16_to_f32(hi))
-}
-
-fn bf16_to_f32(h: u16) -> f32 {
-    f32::from_bits((h as u32) << 16)
 }

--- a/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/gemm_sol_final/src/main.rs
@@ -31,7 +31,7 @@ use cuda_device::clc::{
     clc_query_get_first_ctaid_x, clc_query_is_canceled, clc_try_cancel_multicast,
 };
 use cuda_device::cluster;
-use cuda_device::convert::cvt_bf16x2_f32;
+use cuda_device::convert::{bf16_to_f32, cvt_bf16x2_f32};
 use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
@@ -1139,10 +1139,6 @@ fn create_tma_descriptor_f16_swizzled_box(
     }
 
     Ok(unsafe { tensor_map.assume_init() })
-}
-
-fn bf16_to_f32(h: u16) -> f32 {
-    f32::from_bits((h as u32) << 16)
 }
 
 #[cfg(test)]

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/src/main.rs
@@ -24,7 +24,7 @@ use cuda_device::barrier::{
     Barrier, fence_proxy_async_shared_cta, mbarrier_arrive_expect_tx, mbarrier_init,
     mbarrier_inval, mbarrier_try_wait, mbarrier_try_wait_parity,
 };
-use cuda_device::convert::cvt_bf16x2_f32;
+use cuda_device::convert::{bf16_to_f32, cvt_bf16x2_f32};
 use cuda_device::shared::{SharedArray, cvta_generic_to_shared_offset};
 use cuda_device::tcgen05::{
     Tcgen05AccumulatorType, Tcgen05ElementType, Tcgen05InstructionDescriptor, Tcgen05MmaShape,
@@ -498,8 +498,4 @@ fn unpack_bf16_pair(packed: u32) -> (f32, f32) {
     let lo = (packed & 0xFFFF) as u16;
     let hi = ((packed >> 16) & 0xFFFF) as u16;
     (bf16_to_f32(lo), bf16_to_f32(hi))
-}
-
-fn bf16_to_f32(h: u16) -> f32 {
-    f32::from_bits((h as u32) << 16)
 }


### PR DESCRIPTION
`cuda_device::convert` has `f32_to_bf16` but not the scalar inverse, so reading a raw bf16 means open-coding the high-half widen at each call site:

```rust
f32::from_bits(u32::from(bits) << 16)
```

## Added

| Function | Purpose |
|---|---|
| `bf16_to_f32(u16) -> f32` | inverse of `f32_to_bf16` for values already exact in bf16 |

This is the same bit-shift already used by the packed bf16 unpackers (`cvt_f32x2_bf16x2` and friends). The low 16 bits of the `f32` become zero.

## Why no generator / no GPU example

This is not a new PTX intrinsic. There is nothing for the generator to admit, and no new GPU example — the same as existing `f32_to_bf16`, which is also a host-side bit reinterpret.

## Tests

- **1.0** — `0x3F80` widens to `1.0`
- **Sign of zero** — `0x8000` widens to `-0.0` (bit-identical)
- **Round-trip** — `bf16_to_f32(f32_to_bf16(1.0)) == 1.0`

Host unit tests only; `fmt --check` clean.