### PR TITLE
cargo-oxide: make `cargo oxide new` emit rustfmt-clean projects

### DIFF
--- a/crates/cargo-oxide/src/commands/scaffold.rs
+++ b/crates/cargo-oxide/src/commands/scaffold.rs
@@ -137,11 +137,11 @@ cuda-core = {{ git = "{GIT_REPO}" }}
 
 fn scaffold_main_rs(async_mode: bool) -> String {
     if async_mode {
-        r#"use cuda_device::{kernel, thread, DisjointSlice};
-use cuda_host::cuda_module;
-use cuda_async::device_context::init_device_contexts;
+        r#"use cuda_async::device_context::init_device_contexts;
 use cuda_async::device_operation::DeviceOperation;
 use cuda_core::LaunchConfig;
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
 
 #[cuda_module]
 mod kernels {
@@ -231,9 +231,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 "#
         .to_string()
     } else {
-        r#"use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};
+        r#"use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
+use cuda_device::{DisjointSlice, kernel, launch_bounds, launch_contract, thread};
 use cuda_host::cuda_module;
-use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
 
 #[cuda_module]
 mod kernels {

--- a/crates/cargo-oxide/src/commands/tests.rs
+++ b/crates/cargo-oxide/src/commands/tests.rs
@@ -4065,9 +4065,10 @@ fn scaffold_sync_template_uses_launch_contract_and_docs() {
     assert!(files.gitignore.contains("/target/"));
     // The template uses the launch_bounds / launch_contract attribute
     // macros, so the cuda_device import must bring them in; a scaffolded
-    // project fails to compile without this exact line.
-    assert!(files.main_rs.starts_with(
-        "use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};"
+    // project fails to compile without these names. The order is rustfmt's,
+    // pinned by `scaffold_templates_are_rustfmt_clean`.
+    assert!(files.main_rs.contains(
+        "use cuda_device::{DisjointSlice, kernel, launch_bounds, launch_contract, thread};"
     ));
     assert!(
         files
@@ -4094,6 +4095,57 @@ fn scaffold_async_template_keeps_async_deps_and_docs() {
     assert!(files.main_rs.contains("vecadd_async"));
     assert!(files.main_rs.contains("use cuda_host::cuda_module;"));
     assert!(!files.main_rs.contains("use cuda_device::{cuda_module"));
+}
+
+/// A scaffolded project must already be `rustfmt`-clean.
+///
+/// CONTRIBUTING points contributors at `cargo oxide fmt`, so a template that is
+/// not canonical makes a brand-new project fail its very first format check on
+/// code the user never wrote.
+///
+/// This runs the real `rustfmt` over the rendered template instead of
+/// re-deriving its import ordering here. A hand-written ordering check would
+/// agree with a stale template as readily as with a correct one, and would not
+/// notice drift anywhere else in the file --
+/// `release_depfile_path_matches_real_cargo_uplift_for_hyphenated_bin` shells
+/// out to real `cargo` for the same reason.
+///
+/// The edition is read back out of the scaffolded `Cargo.toml` so this cannot
+/// drift from the manifest it is meant to describe.
+#[test]
+fn scaffold_templates_are_rustfmt_clean() {
+    for (async_mode, label) in [(false, "sync"), (true, "async")] {
+        let files = scaffold_files("demo_kernel", async_mode);
+
+        let edition = files
+            .cargo_toml
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("edition = "))
+            .map(|value| value.trim().trim_matches('"').to_string())
+            .unwrap_or_else(|| panic!("{label} scaffold Cargo.toml declares no edition"));
+
+        let root = unique_temp_dir(&format!("cargo_oxide_scaffold_fmt_{label}"));
+        std::fs::create_dir_all(&root).unwrap();
+        let main_rs = root.join("main.rs");
+        std::fs::write(&main_rs, &files.main_rs).unwrap();
+
+        // A scaffolded project carries no rustfmt.toml, so plain defaults for
+        // its edition are exactly what `cargo fmt` applies there.
+        let check = Command::new("rustfmt")
+            .args(["--edition", edition.as_str(), "--check"])
+            .arg(&main_rs)
+            .output()
+            .expect("failed to run rustfmt; it is in rust-toolchain.toml's component list");
+
+        let diff = String::from_utf8_lossy(&check.stdout).into_owned();
+        std::fs::remove_dir_all(&root).unwrap();
+
+        assert!(
+            check.status.success() && diff.is_empty(),
+            "the {label} scaffold template is not rustfmt-clean, so `cargo oxide fmt \
+             --check` fails in a freshly scaffolded project:\n{diff}"
+        );
+    }
 }
 
 #[test]

--- a/cuda-oxide-book/getting-started/hello-gpu.md
+++ b/cuda-oxide-book/getting-started/hello-gpu.md
@@ -211,11 +211,11 @@ The `--async` flag generates a project with `tokio` and `cuda-async` dependencie
 Here's the generated async vecadd template (with minor formatting edits for readability):
 
 ```rust
-use cuda_device::{kernel, thread, DisjointSlice};
-use cuda_host::cuda_module;
 use cuda_async::device_context::init_device_contexts;
 use cuda_async::device_operation::DeviceOperation;
 use cuda_core::LaunchConfig;
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
 
 #[cuda_module]
 mod kernels {


### PR DESCRIPTION
Closes #1192.

Both `cargo oxide new` templates emitted `use` statements in an order `rustfmt` does not produce, so a freshly scaffolded project failed its own format check on code the user never wrote. CONTRIBUTING points contributors at `cargo oxide fmt`, so this is the first thing a new project is told to run.

## Before / after

**Before** — sync template, straight after `cargo oxide new demo`:

```
$ cargo oxide fmt --check
Diff in src/main.rs:1:
-use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};
-use cuda_host::cuda_module;
 use cuda_core::{CudaContext, DeviceBuffer, LaunchConfig1D};
+use cuda_device::{DisjointSlice, kernel, launch_bounds, launch_contract, thread};
+use cuda_host::cuda_module;

❌ Some files need formatting. Run: cargo oxide fmt
```

**Before** — `--async`, wrong in two places rather than one:

```
Diff in src/main.rs:1:
-use cuda_device::{kernel, thread, DisjointSlice};
-use cuda_host::cuda_module;
 use cuda_async::device_context::init_device_contexts;
 use cuda_async::device_operation::DeviceOperation;
 use cuda_core::LaunchConfig;
Diff in src/main.rs:6:
+use cuda_device::{DisjointSlice, kernel, thread};
+use cuda_host::cuda_module;
```

**After** — both templates:

```
$ cargo oxide new dsync           && (cd dsync  && cargo fmt --check) && echo CLEAN
CLEAN
$ cargo oxide new dasync --async  && (cd dasync && cargo fmt --check) && echo CLEAN
CLEAN
```

## Two independent orderings were wrong

1. **Crate order** — `cuda_device` / `cuda_host` preceded `cuda_core`, and in the async template also `cuda_async`.
2. **Order inside the braces** — `DisjointSlice` trailed the lowercase items; under the scaffold's `edition = "2024"` it sorts first.

## Why nothing caught it

The templates are string constants, so the repository's own `fmt` job formats the file that *holds* them and never their contents, and no gate runs `cargo oxide new`.

The existing test also pinned the defect in place:

```rust
assert!(files.main_rs.starts_with(
    "use cuda_device::{kernel, launch_bounds, launch_contract, thread, DisjointSlice};"
));
```

It now asserts the canonical line and leaves ordering to the new test.

## The test runs real rustfmt

`scaffold_templates_are_rustfmt_clean` renders each template and runs the real `rustfmt` over it, taking the edition back out of the scaffolded `Cargo.toml` so the check cannot drift from the manifest it describes.

I deliberately did not re-derive rustfmt's import ordering in the test: such a check agrees with a stale template exactly as readily as with a correct one, and sees nothing outside the import block. `release_depfile_path_matches_real_cargo_uplift_for_hyphenated_bin` shells out to real `cargo` for the same reason, so this follows that precedent. If `rustfmt` is absent the test fails loudly rather than passing quietly; it is in `rust-toolchain.toml`'s component list.

## Mutations (each applied to the fixed tree, each caught)

| mutation | result |
|---|---|
| sync template reverted to the old import order | **caught** |
| async template reverted to the old import order | **caught** |
| non-import drift — one line of the sync body re-indented | **caught** |
| trailing whitespace after a sync import | **caught** |
| control: unmodified fixed tree | passes |

The third and fourth matter: they are drift a hand-written ordering check would sail past.

## The book moves with it

`getting-started/hello-gpu.md` presents the async listing as "the generated async vecadd template". #548 exists precisely to keep it in step with `scaffold_main_rs(true)`, and nothing automated holds them together, so leaving it would have silently re-opened that issue. Parity is verified by checking the scaffold's rendered import block appears verbatim in the page.

The book's other `use cuda_device::{...}` blocks are hand-written examples rather than scaffold output, so they are out of scope here — book code blocks are not formatted by anything today, which is a separate gap I am happy to file if wanted.

## Scope

- No device code, so there is no GPU evidence to attach; import order cannot change semantics, and `rustfmt` parsing both templates establishes they are still syntactically valid.
- Independent of #1187/#1188, which concern `fmt` building the backend rather than what the scaffold emits.

## Test plan

- `cargo test -p cargo-oxide` — 186 passed, 0 failed (185 + the new test).
- `cargo clippy -p cargo-oxide --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p cargo-oxide` — clean.
- `sphinx-build -W --keep-going -b html cuda-oxide-book` — build succeeded.
- Guard scripts (`check-book-api-names`, `check-cli-doc-coverage`, `check-crate-inventory`, `check-spdx-headers`, `check-toolchain-parity`, `check-test-matrix-coverage`, `check-error-example-status`, `check-example-license-policy`, `check-reserved-prefixes`, `check-book-catalog-stamp`) — all pass.
- End to end: scaffolded both templates with the built binary and confirmed `cargo fmt --check` is clean in each.
