### PR TITLE
ptx-schedule: classify the asynchronous proxy pipeline as schedule sites

### DIFF
--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -30,6 +30,7 @@ places where another thread's progress can be observed:
 | `Fence` | `fence.*` / `membar.*` ordering |
 | `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
+| `AsyncProxy` | the asynchronous proxy pipeline: `cp.async.*`, `wgmma.*`, `tcgen05.*` and `clusterlaunchcontrol.*` -- the bulk-copy and matrix issues and the commit/wait pairs that order them |
 | `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |
 
 Each site keeps its ordinal, enclosing callable, byte span, the instruction

--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -30,7 +30,7 @@ places where another thread's progress can be observed:
 | `Fence` | `fence.*` / `membar.*` ordering |
 | `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
-| `AsyncProxy` | the asynchronous proxy pipeline: `cp.async.*`, `wgmma.*`, `tcgen05.*` and `clusterlaunchcontrol.*` -- the bulk-copy and matrix issues and the commit/wait pairs that order them |
+| `AsyncProxy` | the asynchronous proxy pipeline: `cp.async.*`, `cp.reduce.async.*`, `wgmma.*`, `tcgen05.*` and `clusterlaunchcontrol.*` -- the bulk-copy, bulk-reduce and matrix issues and the commit/wait pairs that order them |
 | `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |
 
 Each site keeps its ordinal, enclosing callable, byte span, the instruction

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -41,6 +41,7 @@ pub enum SiteKind {
     Fence,
     OrderedMemory,
     WarpCollective,
+    AsyncProxy,
     Backedge,
 }
 
@@ -333,6 +334,29 @@ fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
     .any(|prefix| head.starts_with(prefix))
     {
         return Some(SiteKind::WarpCollective);
+    }
+
+    // The asynchronous proxy pipeline: the bulk-copy and matrix issues, and
+    // the commit/wait pairs that order them against the synchronous proxy.
+    // None of the arms above reach these. `cp.async.bulk.tensor...` carries
+    // `mbarrier::complete_tx::bytes` in its qualifier list but does not start
+    // with `mbarrier.`, so the barrier arm walks past it; `wgmma.fence` is a
+    // fence that does not start with `fence.`; and `tcgen05.ld` splits to a
+    // base of `tcgen05` rather than `ld`, so the ordered-memory arm below
+    // returns before seeing it. `clusterlaunchcontrol.try_cancel.async`
+    // completes through an mbarrier exactly as the bulk-tensor copy does, and
+    // its `query_cancel` reads that result, so the family is taken whole --
+    // the same shape as the three above.
+    //
+    // An opcode that classifies as nothing is not a site of any kind, so it
+    // receives no injection and never appears in a report. That left the
+    // pipeline a Hopper or Blackwell kernel is built around as the part a
+    // campaign could not reach.
+    if ["cp.async", "wgmma.", "tcgen05.", "clusterlaunchcontrol."]
+        .iter()
+        .any(|prefix| head.starts_with(prefix))
+    {
+        return Some(SiteKind::AsyncProxy);
     }
 
     let mut parts = head.split('.');
@@ -657,5 +681,123 @@ L_loop:
         .unwrap();
         assert_eq!(rewrite.report.sites_injected, 0);
         assert!(!rewrite.ptx.contains("nanosleep.u32"));
+    }
+
+    /// Every spelling here is one the backend actually emits: they were taken
+    /// verbatim from the `.ptx` the example corpus builds, not hand-written.
+    /// `mbarrier.arrive` and `fence.proxy.async` sit alongside them on purpose,
+    /// as the controls for the two arms this classification could have stolen
+    /// from.
+    const ASYNC_PROXY: &str = r#".version 8.7
+.target sm_100a
+.address_size 64
+
+.visible .entry async_proxy(
+    .param .u64 data
+)
+{
+    .reg .pred %p0;
+    .reg .b32 %r0;
+    .reg .b64 %rd1;
+    cp.async.ca.shared.global [%r0], [%rd1], 4;
+    cp.async.commit_group;
+    cp.async.wait_all;
+    cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [%r0], [%rd1], [%r0];
+    wgmma.fence.sync.aligned;
+    wgmma.commit_group.sync.aligned;
+    wgmma.wait_group.sync.aligned 0;
+    tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%r0];
+    tcgen05.ld.sync.aligned.16x256b.x1.b32 %r0, [%r0];
+    tcgen05.wait::ld.sync.aligned;
+    tcgen05.dealloc.cta_group::1.sync.aligned.b32 %r0, 32;
+    tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;
+    clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128 [%r0], [%r0];
+    clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 %p0, %rd1;
+    mbarrier.arrive.shared.b64 %rd1, [%r0];
+    fence.proxy.async.shared::cta;
+    ret;
+}
+"#;
+
+    #[test]
+    fn async_proxy_pipeline_instructions_are_sites() {
+        let analysis = analyze_ptx(ASYNC_PROXY).unwrap();
+        let async_sites: Vec<_> = analysis
+            .sites()
+            .iter()
+            .filter(|site| site.kind == SiteKind::AsyncProxy)
+            .collect();
+        // The fourteen async-proxy instructions in the fixture: three
+        // cp.async, one bulk-tensor issue, three wgmma, five tcgen05 and two
+        // clusterlaunchcontrol.
+        assert_eq!(async_sites.len(), 14, "{:?}", async_sites);
+        for prefix in ["cp.async", "wgmma.", "tcgen05.", "clusterlaunchcontrol."] {
+            assert!(
+                async_sites.iter().any(|site| site.head.starts_with(prefix)),
+                "no AsyncProxy site for {prefix}"
+            );
+        }
+    }
+
+    /// The two arms this sits between, and which of them could actually take
+    /// one of these instructions away.
+    ///
+    /// `wgmma.fence.sync.aligned` is the live collision: it contains
+    /// `fence.`, so relaxing the fence arm from a prefix test to a substring
+    /// test silently reclassifies it, and this test fails when that is done.
+    ///
+    /// The barrier arm is not a collision, and the reason is worth recording:
+    /// `cp.async.bulk.tensor...mbarrier::complete_tx::bytes` spells that
+    /// qualifier with `::`, so it never contains the `mbarrier.` the barrier
+    /// arm looks for. The assertions on `mbarrier.` and `fence.` below are
+    /// there to pin that the two real instructions keep their own kinds.
+    #[test]
+    fn async_proxy_classification_leaves_mbarrier_and_fence_alone() {
+        let analysis = analyze_ptx(ASYNC_PROXY).unwrap();
+        let kind_of = |prefix: &str| {
+            analysis
+                .sites()
+                .iter()
+                .find(|site| site.head.starts_with(prefix))
+                .map(|site| site.kind)
+        };
+        assert_eq!(kind_of("mbarrier."), Some(SiteKind::Barrier));
+        assert_eq!(kind_of("fence."), Some(SiteKind::Fence));
+        assert_eq!(kind_of("wgmma.fence"), Some(SiteKind::AsyncProxy));
+    }
+
+    /// A campaign has to be able to reach the pipeline, which is the whole
+    /// point of classifying it.
+    #[test]
+    fn an_async_proxy_site_can_be_perturbed() {
+        let rewrite = perturb_ptx(
+            ASYNC_PROXY,
+            &InjectionOptions {
+                seed: 7,
+                intensity: 1.0,
+                ..InjectionOptions::default()
+            },
+        )
+        .unwrap();
+        let injected = rewrite
+            .report
+            .decisions
+            .iter()
+            .filter(|decision| decision.site.kind == SiteKind::AsyncProxy)
+            .filter(|decision| decision.before_ns > 0 || decision.after_ns > 0)
+            .count();
+        assert!(injected > 0, "{:?}", rewrite.report.decisions);
+        assert!(rewrite.ptx.contains("nanosleep.u32"));
+        // The rewrite must still be analyzable, and must not have dropped or
+        // corrupted the instructions it wrapped.
+        let reanalyzed = analyze_ptx(&rewrite.ptx).unwrap();
+        assert!(
+            reanalyzed
+                .sites()
+                .iter()
+                .filter(|site| site.kind == SiteKind::AsyncProxy)
+                .count()
+                >= 14
+        );
     }
 }

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -352,9 +352,20 @@ fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
     // receives no injection and never appears in a report. That left the
     // pipeline a Hopper or Blackwell kernel is built around as the part a
     // campaign could not reach.
-    if ["cp.async", "wgmma.", "tcgen05.", "clusterlaunchcontrol."]
-        .iter()
-        .any(|prefix| head.starts_with(prefix))
+    //
+    // * `cp.reduce.async` needs its own prefix: the TMA reduce path emits
+    //   `cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.tile.bulk_group`,
+    //   and `cp.async` does not match it (reduce sits before async), yet its
+    //   commit/wait pair does match `cp.async` -- half-covered without this.
+    if [
+        "cp.async",
+        "cp.reduce.async",
+        "wgmma.",
+        "tcgen05.",
+        "clusterlaunchcontrol.",
+    ]
+    .iter()
+    .any(|prefix| head.starts_with(prefix))
     {
         return Some(SiteKind::AsyncProxy);
     }
@@ -685,6 +696,9 @@ L_loop:
 
     /// Every spelling here is one the backend actually emits: they were taken
     /// verbatim from the `.ptx` the example corpus builds, not hand-written.
+    /// The one exception is `cp.reduce.async.bulk.tensor...`, which no example
+    /// emits today; its spelling is the mir-lower TMA-reduce inline-asm
+    /// template, verbatim.
     /// `mbarrier.arrive` and `fence.proxy.async` sit alongside them on purpose,
     /// as the controls for the two arms this classification could have stolen
     /// from.
@@ -703,6 +717,7 @@ L_loop:
     cp.async.commit_group;
     cp.async.wait_all;
     cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [%r0], [%rd1], [%r0];
+    cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.tile.bulk_group [%rd1, {%r0, %r0}], [%r0];
     wgmma.fence.sync.aligned;
     wgmma.commit_group.sync.aligned;
     wgmma.wait_group.sync.aligned 0;
@@ -727,11 +742,17 @@ L_loop:
             .iter()
             .filter(|site| site.kind == SiteKind::AsyncProxy)
             .collect();
-        // The fourteen async-proxy instructions in the fixture: three
-        // cp.async, one bulk-tensor issue, three wgmma, five tcgen05 and two
-        // clusterlaunchcontrol.
-        assert_eq!(async_sites.len(), 14, "{:?}", async_sites);
-        for prefix in ["cp.async", "wgmma.", "tcgen05.", "clusterlaunchcontrol."] {
+        // The fifteen async-proxy instructions in the fixture: three
+        // cp.async, one bulk-tensor issue, one bulk-tensor reduce, three
+        // wgmma, five tcgen05 and two clusterlaunchcontrol.
+        assert_eq!(async_sites.len(), 15, "{:?}", async_sites);
+        for prefix in [
+            "cp.async",
+            "cp.reduce.async",
+            "wgmma.",
+            "tcgen05.",
+            "clusterlaunchcontrol.",
+        ] {
             assert!(
                 async_sites.iter().any(|site| site.head.starts_with(prefix)),
                 "no AsyncProxy site for {prefix}"
@@ -797,7 +818,7 @@ L_loop:
                 .iter()
                 .filter(|site| site.kind == SiteKind::AsyncProxy)
                 .count()
-                >= 14
+                >= 15
         );
     }
 }


### PR DESCRIPTION
Closes #1113.

`classify_instruction` covered the synchronous ordering primitives and nothing from the asynchronous proxy. An opcode that classifies as nothing is not a site of any kind, so it received no injection and never appeared in a report — the pipeline a Hopper or Blackwell kernel is built around was the part a campaign could not reach.

## Why none of the existing arms reached these

Each family misses for its own reason, which is why this was not a one-line oversight:

| instruction | why it fell through |
|---|---|
| `cp.async.bulk.tensor...mbarrier::complete_tx::bytes` | carries `mbarrier` in its qualifiers but spells it `mbarrier::`, so it never matches the barrier arm's `mbarrier.` |
| `wgmma.fence.sync.aligned` | a fence that does not start with `fence.` |
| `tcgen05.ld.sync.aligned...` | splits to a base of `tcgen05`, so the ordered-memory arm returns before the `ld`/`st` test |
| `clusterlaunchcontrol.try_cancel.async` | completes through an mbarrier like the bulk copy, and matches nothing at all |

Adds `SiteKind::AsyncProxy` and one prefix arm for the four families. Taking each family whole matches how `bar.`/`mbarrier.` and the warp collectives are already handled, and keeps the consumer halves (`tcgen05.ld`, `clusterlaunchcontrol.query_cancel`) as sites alongside the issues and waits they read.

## Two corrections to the issue, both making the gap larger

**372 instructions, not the 227 I filed.** That figure came from a line-anchored `grep`; 120 of these sit inside single-line inline-asm blocks, which the parser finds and the grep did not. Measured with `analyze_ptx` over the 167 `.ptx` the corpus builds:

```
before:  total_sites=2093   async_proxy_sites=0
after:   total_sites=2465   async_proxy_sites=372
```

Per example: `gemm_sol` 206, `gemm_sol_final` 118, `tcgen05_matmul` 14, `cp_async_zfill` 3, `wgmma` 3, `tma_copy` 2, `tma_multicast` 1.

**`clusterlaunchcontrol.*` is a fourth family** the issue did not name — 25 instructions, same pipeline. Splitting it out would have meant two PRs editing the same match arms, so it is folded in and the issue is updated.

## The perturbed PTX still assembles

The real risk in classifying these is emitting something `ptxas` rejects, and it is a risk I cannot answer by running the kernels: every affected example needs sm_80 or above, and the six Hopper/Blackwell ones cannot execute anywhere I have access to. So I assembled instead. Each of the 7 affected examples was perturbed at `intensity 1.0` under 3 seeds and fed to `ptxas` **for its own target**:

```
perturbed:  21/21 assembled   (sm_80, sm_90a, sm_100, sm_100a)
originals:   7/7  assembled   (control)
```

Negative control, so the 21/21 is not vacuous — corrupting one injected instruction makes `ptxas` reject it:

```
$ sed 's/nanosleep\.u32/nanosleep.BOGUS/' wgmma__7.ptx | ptxas -arch=sm_90a
ptxas line 36; error : Unknown modifier '.BOGUS'
ptxas line 36; error : Unexpected instruction types specified for 'nanosleep'
```

## Tests

Three, following `redux_is_a_warp_collective_and_red_is_still_a_reduction` — the closest precedent, since it also added a classification and had to prove it did not steal from a neighbour. Every opcode spelling in the fixture is taken verbatim from PTX the backend emits, not hand-written.

Mutations, each applied to the fixed tree:

| mutation | result |
|---|---|
| drop `cp.async` from the prefix list | **caught** |
| drop `wgmma.` | **caught** |
| drop `tcgen05.` | **caught** |
| drop `clusterlaunchcontrol.` | **caught** |
| add `ld.` (would swallow ordered memory) | **caught** |
| relax the *fence* arm to `contains()` (would steal `wgmma.fence`) | **caught** |

That last one is what the negative-control test is for. I checked the symmetric case too and am reporting it accurately rather than claiming more: relaxing the *barrier* arm to `contains()` changes nothing, because the bulk-tensor opcode spells the qualifier `mbarrier::` and so never contains `mbarrier.`. The test's comment says so.

## Scope

- The crate README carries the `SiteKind` table, so it gains the row in the same position; the two lists agree in order and content.
- `SiteKind` has no exhaustive `match` anywhere, so the new variant breaks no caller; it is additive in the serialized report.
- **No GPU evidence.** `cp_async_zfill` (sm_80) is the only affected example that could run on hardware I can reach, and g5 spot capacity was exhausted in both permitted regions throughout this session; the T4 alternative is sm_75, below what `cp.async` needs. Rather than claim a run I did not make, the validity argument rests on the `ptxas` assembly above, which covers all four affected targets — including the two no one here can execute.

## Test plan

- `cargo test -p ptx-schedule` — 19 passed (16 pre-existing + 3 new), plus the 3 binary tests.
- `cargo clippy -p ptx-schedule --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ptx-schedule` — clean.
