### PR TITLE
docs: repoint the three source references the module split invalidated

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -443,7 +443,7 @@ crates/cargo-oxide/
     ├── main.rs       # CLI definitions (clap) + dispatch
     ├── backend.rs    # Backend discovery + build logic
     ├── artifact_identity.rs  # Embedded artifact identity/provenance
-    └── commands.rs   # All command implementations
+    └── commands/     # Command implementations, one module per command group
 ```
 
 ## Future Commands

--- a/crates/cuda-intrinsics-gen/src/render/families/packed.rs
+++ b/crates/cuda-intrinsics-gen/src/render/families/packed.rs
@@ -380,7 +380,7 @@ pub(in crate::render) fn packed_conversion_constraint(record: &CatalogIntrinsic)
 
 /// Whether the conversion lowers through a typed NVVM intrinsic call rather
 /// than inline PTX. Only the scalar-`f32` pair narrowed to FP8 does; see the
-/// matching predicate in `resolve.rs` for why.
+/// matching predicate in `resolve/families/packed_conversion.rs` for why.
 fn packed_conversion_uses_typed_nvvm(record: &CatalogIntrinsic) -> bool {
     let conversion = record
         .packed_conversion

--- a/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
+++ b/crates/cuda-oxide-codegen/tests/spine_kernel_ptx.rs
@@ -18,11 +18,12 @@
 //! carrying a `gpu_kernel` *attribute* on the func op. There is no calling
 //! convention to set by hand and no naming convention. The chain is:
 //!
-//!   1. `mir-lower`'s `is_kernel_func` (crates/mir-lower/src/convert/types.rs)
+//!   1. `mir-lower`'s `is_kernel_func`
+//!      (crates/mir-lower/src/convert/types/func_abi.rs)
 //!      returns `true` iff the func op's `attributes` contain a `StringAttr`
 //!      under the identifier `gpu_kernel`. The *value* is not inspected, only
 //!      presence; the rest of the pipeline writes `"true"`.
-//!   2. During lowering (lowering.rs:132) `propagate_kernel_attrs` copies a
+//!   2. During lowering, `lowering.rs`'s `propagate_kernel_attrs` copies a
 //!      `gpu_kernel="true"` `StringAttr` onto the produced `llvm::FuncOp` (plus
 //!      any optional `cluster_dim_*`/`maxntid`/`minctasm` ints).
 //!   3. `llvm-export`'s `PtxExportConfig::emit_ptx_kernel_keyword()` is `true`,

--- a/crates/mir-importer/src/translator/layout.rs
+++ b/crates/mir-importer/src/translator/layout.rs
@@ -5,8 +5,9 @@
 //!
 //! Both the type importer (`translator/types.rs`, which records tag and
 //! field byte offsets on `MirEnumType`) and constant decoding
-//! (`translator/rvalue.rs`, which slices payload bytes out of constant
-//! allocations) need the same offset lookups. Keeping them here means the
+//! (`translator/rvalue/const_enum.rs` and `const_alloc.rs`, which slice
+//! payload bytes out of constant allocations) need the same offset
+//! lookups. Keeping them here means the
 //! two consumers cannot drift apart on how an offset is derived.
 
 use pliron::location::Location;

--- a/crates/mir-importer/src/translator/terminator/intrinsics/indexing.rs
+++ b/crates/mir-importer/src/translator/terminator/intrinsics/indexing.rs
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(block.deref(&ctx).iter(&ctx).count(), 0);
     }
 
-    /// The sreg reads behind `index_1d` are dispatched from `generated.rs`,
+    /// The sreg reads behind `index_1d` are dispatched from `generated/sreg.rs`,
     /// which stamps each op with a marker literal. Assert the three markers
     /// against the target table the backend reads back at verification time,
     /// so a renumbering that reached only one of the two generated artifacts

--- a/crates/mir-importer/src/translator/types.rs
+++ b/crates/mir-importer/src/translator/types.rs
@@ -393,7 +393,7 @@ fn translate_pointer_like(
             // (ptr, len), `PtrMetadata` extraction, fat-value copies) all
             // applies unchanged. Field access through the fat pointer
             // extracts the data pointer (the struct's address) first; see
-            // the place-address walker in `rvalue.rs`.
+            // the place-address walker in `rvalue/place_addr.rs`.
             let struct_model = translate_type(ctx, pointee)?;
             Ok(facts::mint_slice_type(ctx, struct_model, origin).into())
         }

--- a/crates/mir-lower/README.md
+++ b/crates/mir-lower/README.md
@@ -98,10 +98,10 @@ For each `MirFuncOp`, `convert_func` (in `lowering.rs`):
 
 ### GPU Intrinsic Converters (`convert/intrinsics/`)
 
-Anything `intrinsics/catalog.json` describes is lowered by
-`convert/generated_intrinsics.rs` -- one level up, beside `intrinsics/`, not
-inside it. The modules below are the hand-written converters that sit next to
-it, one row per file:
+Anything `intrinsics/catalog.json` describes is lowered by the generated
+`convert/generated_intrinsics/` module (one file per intrinsic family) --
+one level up, beside `intrinsics/`, not inside it. The modules below are
+the hand-written converters that sit next to it, one row per file:
 
 | Module                   | Purpose (from each module's own doc comment)                              |
 |--------------------------|--------------------------------------------------------------------------|

--- a/crates/mir-lower/src/convert/ops/arithmetic.rs
+++ b/crates/mir-lower/src/convert/ops/arithmetic.rs
@@ -863,7 +863,8 @@ fn emit_discriminant_const(
     Ok(const_op.deref(ctx).get_result(0))
 }
 
-// Conversion coverage: `tests/lowering_test.rs::test_cmp_predicate_lowering`
+// Conversion coverage: `test_cmp_predicate_lowering` in
+// `tests/lowering_test/calls_and_values.rs`
 // locks the comparison predicate table end-to-end; the two unit tests in
 // this module lock the contract-only fast-math flag on float arithmetic.
 

--- a/crates/mir-lower/src/convert/ops/memory/tests/mod.rs
+++ b/crates/mir-lower/src/convert/ops/memory/tests/mod.rs
@@ -10,7 +10,7 @@
 //! driver and not constructible standalone. So each test builds a small
 //! MIR module, runs the full `lower_mir_to_llvm` pass on it, and asserts
 //! the lowered module contains the expected `dialect-llvm` shape — same
-//! pattern as `tests/lowering_test.rs`.
+//! pattern as the `tests/lowering_test/` integration suite.
 
 // Tests build kinded fixture types directly; production minting lives in mir-importer's facts.rs.
 #![allow(clippy::disallowed_methods)]

--- a/crates/mir-lower/tests/lowering_test/calls_and_values.rs
+++ b/crates/mir-lower/tests/lowering_test/calls_and_values.rs
@@ -450,7 +450,7 @@ fn test_cmp_predicate_lowering() -> Result<(), anyhow::Error> {
 
     // One comparison op per table row, in a fixed program order. The raw
     // `Operation::new` construction mirrors how the importer builds these
-    // ops (mir-importer translator/rvalue.rs BinaryOp arm).
+    // ops (mir-importer translator/rvalue/expr.rs, `Rvalue::BinaryOp` arm).
     let cmp_infos = [
         // Floats: all six predicates.
         (mir::MirEqOp::get_concrete_op_info(), fa, fb),

--- a/crates/rustc-codegen-cuda/examples/abi_hmm/README.md
+++ b/crates/rustc-codegen-cuda/examples/abi_hmm/README.md
@@ -235,8 +235,8 @@ Rust is different:
 |---------------|-------------------------------------------|------------------------------------------------|
 | Layout query  | `mir-importer/src/translator/types.rs`    | Query `fields_by_offset_order()` and `offsets` |
 | MIR type      | `dialect-mir/src/types.rs`                | Store offsets in `MirStructType`               |
-| LLVM lowering | `mir-lower/src/convert/types.rs`          | Build struct with explicit padding             |
-| Field access  | `mir-lower/src/convert/ops/aggregate.rs`  | Map declaration → memory index                 |
+| LLVM lowering | `mir-lower/src/convert/types/struct_layout.rs` | Build struct with explicit padding        |
+| Field access  | `mir-lower/src/convert/ops/aggregate/fields.rs` | Map declaration → memory index           |
 
 ### Pipeline Output
 

--- a/crates/rustc-codegen-cuda/examples/cast_tests/README.md
+++ b/crates/rustc-codegen-cuda/examples/cast_tests/README.md
@@ -42,7 +42,7 @@ Rvalue::Cast         ──►    MirCastOp                ──► Specific LL
  operand, ty)               (semantic intent)
 
 mir-importer/               dialect-mir/                 mir-lower/
-rvalue.rs                   ops/cast.rs                  convert/ops/cast.rs
+rvalue/expr.rs              ops/cast.rs                  convert/ops/cast.rs
                             attributes.rs
 ```
 

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -130,12 +130,15 @@ runtime `Index`.
 
 ## Root cause
 
-In `crates/mir-importer/src/translator/rvalue.rs`, the `Rvalue::Ref` arm has
-five cases. Case 2 (`[Deref, Field, …]`) emits a `MirFieldAddrOp` for the
-first field, then walks the remaining projections in an inner loop that only
-handles further `Field`s — every other variant hits `_ => break`. After the
-loop, the function unconditionally returns the partial field address,
-**silently discarding** any tail projections, including a runtime `Index`.
+Before this fix, the `Rvalue::Ref` arm had five cases. Case 2
+(`[Deref, Field, …]`) emitted a `MirFieldAddrOp` for the first field, then
+walked the remaining projections in an inner loop that only handled further
+`Field`s — every other variant hit `_ => break`. After the loop, the function
+unconditionally returned the partial field address, **silently discarding**
+any tail projections, including a runtime `Index`.
+
+That arm lives in `crates/mir-importer/src/translator/rvalue/expr.rs`, and the
+address walk it delegates to in `…/rvalue/place_addr.rs`.
 
 The fix delegates the tail walk to the existing
 `translate_place_addr_from_slot` helper (which is now also extended to handle

--- a/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
+++ b/crates/rustc-codegen-cuda/examples/ref_index_projections/README.md
@@ -133,7 +133,7 @@ runtime `Index`.
 Before this fix, the `Rvalue::Ref` arm had five cases. Case 2
 (`[Deref, Field, …]`) emitted a `MirFieldAddrOp` for the first field, then
 walked the remaining projections in an inner loop that only handled further
-`Field`s — every other variant hit `_ => break`. After the loop, the function
+`Field`s; every other variant hit `_ => break`. After the loop, the function
 unconditionally returned the partial field address, **silently discarding**
 any tail projections, including a runtime `Index`.
 

--- a/crates/rustc-codegen-cuda/examples/subslice_projection/README.md
+++ b/crates/rustc-codegen-cuda/examples/subslice_projection/README.md
@@ -7,7 +7,7 @@ Rustc emits `Subslice` for the `middle @ ..` portion of array and slice patterns
 - arrays use `Subslice { from, to, from_end: false }`; the result is the sized array place `[T; to - from]` starting at element `from`;
 - slices use `Subslice { from, to, from_end: true }`; the result keeps a data pointer advanced by `from` elements and metadata `old_len - from - to`.
 
-Before this fix, `crates/mir-importer/src/translator/rvalue.rs` had no `Subslice` lowering. The value walker reported `Projection element ... not yet implemented in iterative mode`, while the address walker returned `Ok(None)`. Mutable borrows then failed loudly because falling back to a reference to a copy would lose write-through semantics.
+Before this fix, the place walkers under `crates/mir-importer/src/translator/rvalue/` had no `Subslice` lowering. The value walker reported `Projection element ... not yet implemented in iterative mode`, while the address walker returned `Ok(None)`. Mutable borrows then failed loudly because falling back to a reference to a copy would lose write-through semantics.
 
 ## Coverage
 

--- a/cuda-oxide-book/compiler/lowering-pipeline.md
+++ b/cuda-oxide-book/compiler/lowering-pipeline.md
@@ -81,9 +81,9 @@ The conversion functions are organized into modules by category:
 | Category      | Module                        | What It Handles                                                                  |
 | :------------ | :---------------------------- | :--------------------------------------------------------------------------------|
 | Arithmetic    | `convert/ops/arithmetic.rs`   | `add`→`add`, `sub`→`sub`, `checked_add`→`add`+`extractvalue`                     |
-| Memory        | `convert/ops/memory.rs`       | `mir.load`→`load`, `mir.store`→`store`, `shared_alloc`→global + `addrspacecast`  |
+| Memory        | `convert/ops/memory/*.rs`     | `mir.load`→`load`, `mir.store`→`store`, `shared_alloc`→global + `addrspacecast`  |
 | Control Flow  | `convert/ops/control_flow.rs` | `mir.goto`→`br`, `mir.cond_br`→`cond_br`, `mir.return`→`return`                  |
-| Aggregate     | `convert/ops/aggregate.rs`    | Struct/tuple field access → GEP or `extractvalue`/`insertvalue`                  |
+| Aggregate     | `convert/ops/aggregate/*.rs`  | Struct/tuple field access → GEP or `extractvalue`/`insertvalue`                  |
 | Cast          | `convert/ops/cast.rs`         | `IntToInt`→`zext`/`sext`/`trunc`, `FloatToFloat`→`fpext`/`fptrunc`, etc.         |
 | Call          | `convert/ops/call.rs`         | `mir.call`→`call`, with argument flattening and `::` to `__` name conversion     |
 | GPU Intrinsic | `convert/intrinsics/*.rs`     | NVVM ops → LLVM intrinsic calls or inline PTX                                    |


### PR DESCRIPTION
Closes #1196.

#1190 split several large files into module directories. Three references still point at paths that no longer exist.

| where | pointed at | now |
|---|---|---|
| `cuda-oxide-codegen/tests/spine_kernel_ptx.rs` | `mir-lower/src/convert/types.rs` | `convert/types/func_abi.rs` |
| `examples/ref_index_projections/README.md` | `mir-importer/src/translator/rvalue.rs` | `translator/rvalue/expr.rs` (+ `rvalue/place_addr.rs` for the address walk) |
| `examples/subslice_projection/README.md` | `mir-importer/src/translator/rvalue.rs` | the walkers under `translator/rvalue/` |

## Two needed the sentence fixed, not just the path

Repointing alone would have left a reference that resolves and still misleads.

**A line number that had also moved.** The same doc comment cites `lowering.rs:132` for `propagate_kernel_attrs`; it is at line 336. Rather than swap one rotting number for another, this names the function in its file — the form that survives the next edit.

**A present-tense claim about code that changed.** `ref_index_projections/README.md` says the `Rvalue::Ref` arm "has five cases" and describes case 2's inner loop breaking on non-`Field` projections. It has two labelled cases today; five is what it had *before* the fix that README documents. The passage is now past tense, and points at where that arm and its address walk live.

## Verified, not assumed

- Every claim was re-read against the code before repointing: `is_kernel_func` still returns `true` iff the func op carries a `gpu_kernel` `StringAttr`, and `translate_place_addr_from_slot` (named in the README) still exists, at `rvalue/place_addr.rs:610`.
- Re-ran a tree-wide sweep for source paths in tracked docs and comments that do not exist. After this change the only remaining hits are deliberate: synthetic fixture names inside tests (`intrinsics/probes/removed.ll`, `intrinsics/overlay/test.toml`), two paths that `cuda-intrinsics-gen` render tests assert are *absent*, and the `mktemp` canary in `check-reserved-prefixes.sh`.

## Deliberately not changed

`examples/atomics/README.md` names `intrinsics/atomic.rs` and `ops/atomic.rs` in a pipeline diagram. Those are crate-relative shorthand and both resolve (`crates/mir-importer/src/translator/terminator/intrinsics/atomic.rs`, `crates/dialect-nvvm/src/ops/atomic.rs`), so rewriting them would add noise, not accuracy.

I did not add a guard for this. A check that every path-shaped string in the docs exists would need an allowlist for the four synthetic fixtures above, and an allowlist is where that kind of guard goes soft. Happy to build one if you want it, but I would rather agree the shape with you than ship a check that can be green while wrong.

## Test plan

- `cargo test -p cuda-oxide-codegen --test spine_kernel_ptx` — 1 passed (the edited file is that test's module doc).
- `cargo fmt --check` — clean.
- `scripts/check-spdx-headers.sh`, `scripts/check-book-api-names.sh` — pass.
- Confirmed all four newly-named paths exist.
