### PR TITLE
Bump pliron to 823d9d8 and adopt upstream SyncScopeAttr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,9 +732,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -736,6 +740,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1017,13 +1026,13 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "awint",
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -1044,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "combine",
  "convert_case",
@@ -1058,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ repository = "https://github.com/NVlabs/cuda-oxide.git"
 # cuda-oxide consumes the dialect modeling only, not the FFI bridge.
 # `crates/rustc-codegen-cuda/Cargo.toml` MUST stay on this same rev, or pliron
 # resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "8447aa426e2f090dc8b7b9383c5035db7bc70b62" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "8447aa426e2f090dc8b7b9383c5035db7bc70b62" }
-pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "8447aa426e2f090dc8b7b9383c5035db7bc70b62", default-features = false, features = [
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
+pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564", default-features = false, features = [
     "std",
 ] }
 

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -27,9 +27,9 @@ use pliron::{
 use crate::{
     attributes::{
         AtomicOrderingAttr, AtomicRmwKindAttr, FCmpPredicateAttr, FPHalfAttr, FastmathFlags,
-        FastmathFlagsAttr, GepIndexAttr, ICmpPredicateAttr,
+        FastmathFlagsAttr, GepIndexAttr, ICmpPredicateAttr, SyncScopeAttr,
     },
-    op_interfaces::{ATTR_KEY_FAST_MATH_FLAGS, PointerTypeResult},
+    op_interfaces::{ATTR_KEY_FAST_MATH_FLAGS, PointerTypeResult, SyncScopeInterface},
     ops,
     types::{ArrayType, FuncType, HalfType, PointerType, VoidType},
 };
@@ -1213,7 +1213,7 @@ impl<'a> ModuleExportState<'a> {
         let ptr = op_ref.get_operand(0);
         let res_name = value_names.get(&res).unwrap();
         let ty = res.get_type(self.ctx);
-        let syncscope = fmt_syncscope(op.get_attr_llvm_ld_syncscope(self.ctx));
+        let syncscope = fmt_syncscope(op.syncscope(self.ctx));
         let ordering = fmt_ordering(op.get_attr_llvm_ld_ordering(self.ctx));
         let addrspace = addrspace_of(ptr.get_type(self.ctx), self.ctx);
         let pointer_name =
@@ -1252,7 +1252,7 @@ impl<'a> ModuleExportState<'a> {
         let op_ref = op.get_operation().deref(self.ctx);
         let val = op_ref.get_operand(0);
         let ptr = op_ref.get_operand(1);
-        let syncscope = fmt_syncscope(op.get_attr_llvm_st_syncscope(self.ctx));
+        let syncscope = fmt_syncscope(op.syncscope(self.ctx));
         let ordering = fmt_ordering(op.get_attr_llvm_st_ordering(self.ctx));
         let addrspace = addrspace_of(ptr.get_type(self.ctx), self.ctx);
         let val_ty = val.get_type(self.ctx);
@@ -1295,7 +1295,7 @@ impl<'a> ModuleExportState<'a> {
         let val = op_ref.get_operand(1);
         let res_name = value_names.get(&res).unwrap();
         let rmw_kind = fmt_rmw_kind(op.get_attr_llvm_rmw_kind(self.ctx));
-        let syncscope = fmt_syncscope(op.get_attr_llvm_rmw_syncscope(self.ctx));
+        let syncscope = fmt_syncscope(op.syncscope(self.ctx));
         let ordering = fmt_ordering(op.get_attr_llvm_rmw_ordering(self.ctx));
         let addrspace = addrspace_of(ptr.get_type(self.ctx), self.ctx);
         let val_ty = val.get_type(self.ctx);
@@ -1333,7 +1333,7 @@ impl<'a> ModuleExportState<'a> {
         let res_name = value_names.get(&res).unwrap();
         let success_ord = fmt_ordering(op.get_attr_llvm_cas_success_ordering(self.ctx));
         let failure_ord = fmt_ordering(op.get_attr_llvm_cas_failure_ordering(self.ctx));
-        let syncscope = fmt_syncscope(op.get_attr_llvm_cas_syncscope(self.ctx));
+        let syncscope = fmt_syncscope(op.syncscope(self.ctx));
         let val_ty = cmp.get_type(self.ctx);
         let addrspace = addrspace_of(ptr.get_type(self.ctx), self.ctx);
         let pointer_name =
@@ -1363,7 +1363,7 @@ impl<'a> ModuleExportState<'a> {
     }
 
     fn emit_fence(&self, op: &ops::FenceOp, output: &mut String) -> Result<(), String> {
-        let syncscope = fmt_syncscope(op.get_attr_llvm_fence_syncscope(self.ctx));
+        let syncscope = fmt_syncscope(op.syncscope(self.ctx));
         let ordering = fmt_ordering(op.get_attr_llvm_fence_ordering(self.ctx));
         writeln!(output, "  fence{syncscope} {ordering}").unwrap();
         Ok(())
@@ -2239,12 +2239,15 @@ fn fmt_rmw_kind(kind: Option<Ref<AtomicRmwKindAttr>>) -> &'static str {
     }
 }
 
-/// Format a syncscope suffix. pliron stores syncscope as a free-form string
-/// (absent = system scope); any value passes through verbatim.
-fn fmt_syncscope(scope: Option<Ref<StringAttr>>) -> String {
-    match scope.map(|s| String::from((*s).clone())) {
-        Some(s) if !s.is_empty() => format!(" syncscope(\"{s}\")"),
-        _ => String::new(),
+/// Format a syncscope suffix from pliron-llvm's dedicated [`SyncScopeAttr`].
+fn fmt_syncscope(scope: SyncScopeAttr) -> String {
+    // `SyncScopeAttr::to_name` returns the LLVM-IR scope name; the system
+    // scope is unnamed (empty string) and is omitted entirely in textual IR.
+    let name = scope.to_name();
+    if name.is_empty() {
+        String::new()
+    } else {
+        format!(" syncscope(\"{name}\")")
     }
 }
 

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -9,7 +9,7 @@
 //! upstream in [`pliron_llvm`]; this crate is a thin shim that re-exports it so
 //! existing `llvm_export::{ops,types,attributes,op_interfaces}` paths keep
 //! resolving, plus the small set of GPU-specific extensions pliron-llvm does
-//! not carry (named address spaces, syncscope enum, fp16 bit helpers). The
+//! not carry (named address spaces, fp16 bit helpers). The
 //! pure-Rust textual `.ll` exporter ([`export`]) stays here: pliron-llvm only
 //! emits real `.ll` via an `llvm-sys` bridge, which is exactly what cuda-oxide
 //! is avoiding.
@@ -116,8 +116,8 @@ pub mod types {
     }
 }
 
-/// LLVM attributes: re-exported from pliron-llvm, plus the syncscope enum and
-/// the cuda-oxide names for atomic ordering / rmw-kind.
+/// LLVM attributes: re-exported from pliron-llvm, plus the cuda-oxide names
+/// for atomic ordering / rmw-kind.
 pub mod attributes {
     pub use pliron_llvm::attributes::*;
 
@@ -129,31 +129,6 @@ pub mod attributes {
     pub use pliron_llvm::attributes::{
         AtomicOrderingAttr as LlvmAtomicOrdering, AtomicRmwKindAttr as LlvmAtomicRmwKind,
     };
-
-    /// Synchronization scope for atomics. pliron-llvm models syncscope as a
-    /// free-form `Option<String>` (None = system); cuda-oxide only emits these
-    /// three scopes, so we keep the enum at the lowering boundary and translate
-    /// to pliron's representation via [`LlvmSyncScope::to_pliron`].
-    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-    pub enum LlvmSyncScope {
-        /// System-wide scope (`syncscope("")` / default).
-        System,
-        /// Device (GPU) scope.
-        Device,
-        /// Block / CTA scope.
-        Block,
-    }
-
-    impl LlvmSyncScope {
-        /// Map to pliron's free-form syncscope string (`None` = system).
-        pub fn to_pliron(self) -> Option<String> {
-            match self {
-                LlvmSyncScope::System => None,
-                LlvmSyncScope::Device => Some("device".to_string()),
-                LlvmSyncScope::Block => Some("block".to_string()),
-            }
-        }
-    }
 }
 
 /// LLVM ops: re-exported from pliron-llvm, plus the builtin `ConstantOp` and

--- a/crates/mir-lower/src/convert/intrinsics/atomic.rs
+++ b/crates/mir-lower/src/convert/intrinsics/atomic.rs
@@ -55,12 +55,13 @@ use dialect_nvvm::ops::atomic::{
     NvvmAtomicCmpxchgOp, NvvmAtomicFenceOp, NvvmAtomicLoadOp, NvvmAtomicOpInterface,
     NvvmAtomicRmwOp, NvvmAtomicStoreOp,
 };
-use llvm_export::attributes::{LlvmAtomicOrdering, LlvmAtomicRmwKind, LlvmSyncScope};
+use llvm_export::attributes::{LlvmAtomicOrdering, LlvmAtomicRmwKind, SyncScopeAttr};
 use llvm_export::op_interfaces::CastOpInterface;
 use llvm_export::ops as llvm;
 use llvm_export::ops::{AsmKind, InlineAsmOpExt};
 use llvm_export::types as llvm_types;
 
+use pliron::builtin::attributes::StringAttr;
 use pliron::builtin::types::{FP32Type, FP64Type, IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
 use pliron::irbuild::dialect_conversion::{DialectConversionRewriter, OperandsInfo};
@@ -75,11 +76,14 @@ use pliron::r#type::Typed;
 // Scope / Ordering Mapping
 // =============================================================================
 
-fn map_scope(scope: &NvvmScope) -> LlvmSyncScope {
+/// Map an NVVM scope to the upstream [`SyncScopeAttr`]. Device and block are
+/// named scopes in LLVM-IR (`syncscope("device")` / `syncscope("block")`);
+/// system is LLVM's unnamed default.
+fn map_scope(scope: &NvvmScope) -> SyncScopeAttr {
     match scope {
-        NvvmScope::Device => LlvmSyncScope::Device,
-        NvvmScope::Block => LlvmSyncScope::Block,
-        NvvmScope::System => LlvmSyncScope::System,
+        NvvmScope::Device => SyncScopeAttr::NamedScope(StringAttr::new("device".to_string())),
+        NvvmScope::Block => SyncScopeAttr::NamedScope(StringAttr::new("block".to_string())),
+        NvvmScope::System => SyncScopeAttr::System,
     }
 }
 
@@ -233,12 +237,12 @@ fn emit_fence(
     rewriter: &mut DialectConversionRewriter,
     op: Ptr<Operation>,
     ordering: LlvmAtomicOrdering,
-    syncscope: LlvmSyncScope,
+    syncscope: &NvvmScope,
 ) -> Result<()> {
     let scope = match syncscope {
-        LlvmSyncScope::Device => "gl",
-        LlvmSyncScope::Block => "cta",
-        LlvmSyncScope::System => "sys",
+        NvvmScope::Device => "gl",
+        NvvmScope::Block => "cta",
+        NvvmScope::System => "sys",
     };
 
     if matches!(ordering, LlvmAtomicOrdering::SeqCst) {
@@ -256,11 +260,7 @@ fn emit_fence(
     }
 
     // Acquire, Release and AcqRel all lower to the same PTX fence.
-    let ptx_scope = match syncscope {
-        LlvmSyncScope::Device => "gpu",
-        LlvmSyncScope::Block => "cta",
-        LlvmSyncScope::System => "sys",
-    };
+    let ptx_scope = ptx_scope(syncscope);
     let void_ty = llvm_types::VoidType::get(ctx);
     let asm = llvm::InlineAsmOp::build(
         ctx,
@@ -295,7 +295,7 @@ pub(crate) fn convert_atomic_fence(
         rewriter,
         op,
         map_ordering(&ordering),
-        map_scope(&fence.scope(ctx)),
+        &fence.scope(ctx),
     )?;
     rewriter.erase_operation(ctx, op);
     Ok(())
@@ -427,7 +427,7 @@ pub(crate) fn convert_atomic_rmw(
 ) -> Result<()> {
     let nvvm_op = NvvmAtomicRmwOp::new(op);
     let nvvm_ordering = nvvm_op.ordering(ctx);
-    let syncscope = map_scope(&nvvm_op.scope(ctx));
+    let nvvm_scope = nvvm_op.scope(ctx);
     let rmw_kind = map_rmw_kind(&nvvm_op.rmw_kind(ctx));
 
     let operands: Vec<_> = op.deref(ctx).operands().collect();
@@ -442,10 +442,10 @@ pub(crate) fn convert_atomic_rmw(
     // Pre-fence (if needed)
     match nvvm_ordering {
         NvvmOrdering::Release | NvvmOrdering::AcqRel => {
-            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::Release, syncscope)?;
+            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::Release, &nvvm_scope)?;
         }
         NvvmOrdering::SeqCst => {
-            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::SeqCst, syncscope)?;
+            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::SeqCst, &nvvm_scope)?;
         }
         NvvmOrdering::Relaxed | NvvmOrdering::Acquire => {}
     }
@@ -457,17 +457,17 @@ pub(crate) fn convert_atomic_rmw(
         val,
         rmw_kind,
         LlvmAtomicOrdering::Monotonic,
-        syncscope.to_pliron(),
+        map_scope(&nvvm_scope),
     );
     rewriter.insert_operation(ctx, llvm_rmw.get_operation());
 
     // Post-fence (if needed)
     match nvvm_ordering {
         NvvmOrdering::Acquire | NvvmOrdering::AcqRel => {
-            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::Acquire, syncscope)?;
+            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::Acquire, &nvvm_scope)?;
         }
         NvvmOrdering::SeqCst => {
-            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::SeqCst, syncscope)?;
+            emit_fence(ctx, rewriter, op, LlvmAtomicOrdering::SeqCst, &nvvm_scope)?;
         }
         NvvmOrdering::Relaxed | NvvmOrdering::Release => {}
     }
@@ -496,15 +496,8 @@ pub(crate) fn convert_atomic_cmpxchg(
     let ptr = operands[0];
     let cmp = operands[1];
     let new_val = operands[2];
-    let llvm_cmpxchg = llvm::AtomicCmpxchgOp::new(
-        ctx,
-        ptr,
-        cmp,
-        new_val,
-        success_ord,
-        failure_ord,
-        syncscope.to_pliron(),
-    );
+    let llvm_cmpxchg =
+        llvm::AtomicCmpxchgOp::new(ctx, ptr, cmp, new_val, success_ord, failure_ord, syncscope);
     rewriter.insert_operation(ctx, llvm_cmpxchg.get_operation());
 
     // Upstream `cmpxchg` returns `{ T, i1 }`, but the NVVM op models only the

--- a/crates/nvvm-transforms/src/legalize.rs
+++ b/crates/nvvm-transforms/src/legalize.rs
@@ -14,11 +14,11 @@ use std::num::NonZeroUsize;
 use llvm_export::{
     attributes::{
         AtomicOrderingAttr, AtomicRmwKindAttr, FCmpPredicateAttr, FastmathFlagsAttr,
-        ICmpPredicateAttr, IntegerOverflowFlagsAttr,
+        ICmpPredicateAttr, IntegerOverflowFlagsAttr, SyncScopeAttr,
     },
     op_interfaces::{
         BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
-        IntBinArithOpWithOverflowFlag,
+        IntBinArithOpWithOverflowFlag, SyncScopeInterface,
     },
     ops as llvm,
     ops::{AsmKind, InlineAsmOpExt},
@@ -342,11 +342,11 @@ enum LegacyAtomicScope {
 }
 
 impl LegacyAtomicScope {
-    fn from_syncscope(scope: Option<&str>) -> Option<Self> {
+    fn from_syncscope(scope: &SyncScopeAttr) -> Option<Self> {
         match scope {
-            Some("device") => Some(Self::Device),
-            Some("block") => Some(Self::Block),
-            None => Some(Self::System),
+            SyncScopeAttr::NamedScope(name) if name.as_str() == "device" => Some(Self::Device),
+            SyncScopeAttr::NamedScope(name) if name.as_str() == "block" => Some(Self::Block),
+            SyncScopeAttr::System => Some(Self::System),
             _ => None,
         }
     }
@@ -382,10 +382,10 @@ struct IntegerCmpxchgRewrite {
 fn legacy_atomic_scope(
     ctx: &Context,
     op: Ptr<Operation>,
-    syncscope: Option<String>,
+    syncscope: &SyncScopeAttr,
     operation: &str,
 ) -> Result<LegacyAtomicScope> {
-    LegacyAtomicScope::from_syncscope(syncscope.as_deref()).ok_or_else(|| {
+    LegacyAtomicScope::from_syncscope(syncscope).ok_or_else(|| {
         pliron::input_error!(
             op.deref(ctx).loc(),
             "legacy NVVM {operation} has an unsupported synchronization scope"
@@ -583,10 +583,8 @@ fn validate_integer_atomic_rmw(
         );
     }
 
-    let syncscope = rmw
-        .get_attr_llvm_rmw_syncscope(ctx)
-        .map(|scope| String::from((*scope).clone()));
-    let scope = legacy_atomic_scope(ctx, op, syncscope, "integer atomic RMW")?;
+    let syncscope = rmw.syncscope(ctx);
+    let scope = legacy_atomic_scope(ctx, op, &syncscope, "integer atomic RMW")?;
 
     if !scope.needs_scoped_rewrite() {
         return Ok(None);
@@ -721,10 +719,8 @@ fn validate_integer_cmpxchg(
         );
     }
 
-    let syncscope = cas
-        .get_attr_llvm_cas_syncscope(ctx)
-        .map(|scope| String::from((*scope).clone()));
-    let scope = legacy_atomic_scope(ctx, op, syncscope, "compare-exchange")?;
+    let syncscope = cas.syncscope(ctx);
+    let scope = legacy_atomic_scope(ctx, op, &syncscope, "compare-exchange")?;
     // A validated pair never has a failure ordering stronger than its success
     // ordering, so the success check also covers every ordered failure
     // ordering. Any ordered form routes to the scoped PTX rewrite: the inline
@@ -839,10 +835,8 @@ fn validate_float_atomic_add(
             "legacy NVVM floating-point atomic add requires monotonic ordering"
         );
     }
-    let syncscope = rmw
-        .get_attr_llvm_rmw_syncscope(ctx)
-        .map(|scope| String::from((*scope).clone()));
-    if syncscope.as_deref() != Some("device") {
+    let syncscope = rmw.syncscope(ctx);
+    if syncscope.to_name() != "device" {
         return pliron::input_err!(
             op.deref(ctx).loc(),
             "legacy NVVM floating-point atomic add requires device synchronization scope"
@@ -1957,6 +1951,12 @@ mod tests {
         printable::Printable,
     };
 
+    fn named_scope(name: &str) -> SyncScopeAttr {
+        SyncScopeAttr::NamedScope(pliron::builtin::attributes::StringAttr::new(
+            name.to_string(),
+        ))
+    }
+
     fn module_block(ctx: &Context, module: &ModuleOp) -> Ptr<BasicBlock> {
         module
             .get_operation()
@@ -2427,7 +2427,7 @@ mod tests {
         address_space: u32,
         value_ty: TypeHandle,
         ordering: AtomicOrderingAttr,
-        scope: Option<String>,
+        scope: SyncScopeAttr,
     ) -> llvm::FuncOp {
         let ptr_ty: TypeHandle = PointerType::get(ctx, address_space).into();
         let (func, entry) = function(ctx, module, name, value_ty, vec![ptr_ty, value_ty]);
@@ -2451,7 +2451,7 @@ mod tests {
         width: u32,
         kind: AtomicRmwKindAttr,
         ordering: AtomicOrderingAttr,
-        scope: Option<String>,
+        scope: SyncScopeAttr,
     ) -> llvm::FuncOp {
         let ptr_ty: TypeHandle = PointerType::get(ctx, address_space).into();
         let value_ty: TypeHandle = IntegerType::get(ctx, width, Signedness::Signless).into();
@@ -2476,7 +2476,7 @@ mod tests {
         width: u32,
         success_ordering: AtomicOrderingAttr,
         failure_ordering: AtomicOrderingAttr,
-        scope: Option<String>,
+        scope: SyncScopeAttr,
     ) -> llvm::FuncOp {
         let ptr_ty: TypeHandle = PointerType::get(ctx, address_space).into();
         let value_ty: TypeHandle = IntegerType::get(ctx, width, Signedness::Signless).into();
@@ -2528,7 +2528,7 @@ mod tests {
                     address_space,
                     value_ty,
                     AtomicOrderingAttr::Monotonic,
-                    Some("device".to_string()),
+                    named_scope("device"),
                 );
                 functions.push(function);
             }
@@ -2613,9 +2613,9 @@ mod tests {
     #[test]
     fn legacy_float_atomic_add_rejects_semantics_the_intrinsic_cannot_preserve() {
         for (address_space, scope, expected) in [
-            (7, Some("device".to_string()), "address space 7"),
-            (1, Some("block".to_string()), "device synchronization scope"),
-            (1, None, "device synchronization scope"),
+            (7, named_scope("device"), "address space 7"),
+            (1, named_scope("block"), "device synchronization scope"),
+            (1, SyncScopeAttr::System, "device synchronization scope"),
         ] {
             let mut ctx = Context::new();
             let module = ModuleOp::new(&mut ctx, "atomic_add".try_into().unwrap());
@@ -2647,7 +2647,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Acquire,
-            Some("device".to_string()),
+            named_scope("device"),
         );
 
         let error = legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 90).unwrap_err();
@@ -2676,7 +2676,7 @@ mod tests {
             1,
             f64_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
 
         let error = legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 52).unwrap_err();
@@ -2708,7 +2708,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
 
         legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 52).unwrap();
@@ -2747,7 +2747,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
 
         let error = legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 90).unwrap_err();
@@ -2791,7 +2791,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
         module.get_operation().deref(&ctx).verify(&ctx).unwrap();
 
@@ -2829,7 +2829,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
         module.get_operation().deref(&ctx).verify(&ctx).unwrap();
 
@@ -2863,7 +2863,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
         atomic_add_function(
             &mut ctx,
@@ -2872,7 +2872,7 @@ mod tests {
             1,
             f32_ty,
             AtomicOrderingAttr::Monotonic,
-            Some("block".to_string()),
+            named_scope("block"),
         );
 
         let error = legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 90).unwrap_err();
@@ -2915,7 +2915,7 @@ mod tests {
                     width,
                     AtomicRmwKindAttr::Add,
                     AtomicOrderingAttr::Monotonic,
-                    Some("device".to_string()),
+                    named_scope("device"),
                 );
             }
         }
@@ -2986,7 +2986,7 @@ mod tests {
                 32,
                 kind,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
             );
         }
 
@@ -3017,7 +3017,7 @@ mod tests {
                     width,
                     AtomicOrderingAttr::Monotonic,
                     AtomicOrderingAttr::Monotonic,
-                    Some("device".to_string()),
+                    named_scope("device"),
                 );
             }
         }
@@ -3076,8 +3076,8 @@ mod tests {
         let mut expected = Vec::new();
         for width in [32, 64] {
             for (scope_name, scope, ptx_scope) in [
-                ("block", Some("block".to_string()), "cta"),
-                ("system", None, "sys"),
+                ("block", named_scope("block"), "cta"),
+                ("system", SyncScopeAttr::System, "sys"),
             ] {
                 for address_space in [0, 1, 3] {
                     integer_atomic_rmw_function(
@@ -3151,7 +3151,7 @@ mod tests {
                 32,
                 (*kind).clone(),
                 AtomicOrderingAttr::Monotonic,
-                Some("block".to_string()),
+                named_scope("block"),
             );
         }
 
@@ -3185,7 +3185,7 @@ mod tests {
             32,
             AtomicRmwKindAttr::Add,
             AtomicOrderingAttr::Monotonic,
-            Some("block".to_string()),
+            named_scope("block"),
         );
 
         let before = module.get_operation().deref(&ctx).disp(&ctx).to_string();
@@ -3211,7 +3211,7 @@ mod tests {
             32,
             AtomicOrderingAttr::AcqRel,
             AtomicOrderingAttr::Acquire,
-            Some("device".to_string()),
+            named_scope("device"),
         );
         integer_cmpxchg_function(
             &mut ctx,
@@ -3221,7 +3221,7 @@ mod tests {
             32,
             AtomicOrderingAttr::AcqRel,
             AtomicOrderingAttr::Monotonic,
-            Some("block".to_string()),
+            named_scope("block"),
         );
         integer_cmpxchg_function(
             &mut ctx,
@@ -3231,7 +3231,7 @@ mod tests {
             64,
             AtomicOrderingAttr::Acquire,
             AtomicOrderingAttr::Acquire,
-            None,
+            SyncScopeAttr::System,
         );
         integer_cmpxchg_function(
             &mut ctx,
@@ -3241,7 +3241,7 @@ mod tests {
             32,
             AtomicOrderingAttr::SeqCst,
             AtomicOrderingAttr::SeqCst,
-            Some("device".to_string()),
+            named_scope("device"),
         );
 
         legalize_for_legacy_nvvm(&mut ctx, module.get_operation(), 90).unwrap();
@@ -3298,7 +3298,7 @@ mod tests {
                 width,
                 success,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
             );
         }
 
@@ -3334,9 +3334,9 @@ mod tests {
     #[test]
     fn legacy_integer_cmpxchg_ptx_rewrite_requires_sm70() {
         for (scope, failure) in [
-            (Some("block".to_string()), AtomicOrderingAttr::Monotonic),
-            (Some("device".to_string()), AtomicOrderingAttr::Acquire),
-            (Some("device".to_string()), AtomicOrderingAttr::Monotonic),
+            (named_scope("block"), AtomicOrderingAttr::Monotonic),
+            (named_scope("device"), AtomicOrderingAttr::Acquire),
+            (named_scope("device"), AtomicOrderingAttr::Monotonic),
         ] {
             let mut ctx = Context::new();
             let module = ModuleOp::new(&mut ctx, "integer_cas_floor".try_into().unwrap());
@@ -3369,7 +3369,7 @@ mod tests {
                 16,
                 1,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 AtomicRmwKindAttr::Add,
                 "only i32 and i64",
             ),
@@ -3377,7 +3377,7 @@ mod tests {
                 128,
                 1,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 AtomicRmwKindAttr::Add,
                 "only i32 and i64",
             ),
@@ -3385,7 +3385,7 @@ mod tests {
                 32,
                 7,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 AtomicRmwKindAttr::Add,
                 "address space 7",
             ),
@@ -3393,7 +3393,7 @@ mod tests {
                 32,
                 1,
                 AtomicOrderingAttr::Acquire,
-                Some("device".to_string()),
+                named_scope("device"),
                 AtomicRmwKindAttr::Add,
                 "monotonic ordering",
             ),
@@ -3401,7 +3401,7 @@ mod tests {
                 32,
                 1,
                 AtomicOrderingAttr::Monotonic,
-                Some("cluster".to_string()),
+                named_scope("cluster"),
                 AtomicRmwKindAttr::Add,
                 "unsupported synchronization scope",
             ),
@@ -3409,7 +3409,7 @@ mod tests {
                 32,
                 1,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 AtomicRmwKindAttr::Nand,
                 "does not support this operation kind",
             ),
@@ -3445,7 +3445,7 @@ mod tests {
                 1,
                 AtomicOrderingAttr::AcqRel,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 "only i32 and i64",
             ),
             (
@@ -3453,7 +3453,7 @@ mod tests {
                 1,
                 AtomicOrderingAttr::AcqRel,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 "only i32 and i64",
             ),
             (
@@ -3461,7 +3461,7 @@ mod tests {
                 7,
                 AtomicOrderingAttr::AcqRel,
                 AtomicOrderingAttr::Monotonic,
-                Some("device".to_string()),
+                named_scope("device"),
                 "address space 7",
             ),
             (
@@ -3469,7 +3469,7 @@ mod tests {
                 1,
                 AtomicOrderingAttr::AcqRel,
                 AtomicOrderingAttr::Monotonic,
-                Some("cluster".to_string()),
+                named_scope("cluster"),
                 "unsupported synchronization scope",
             ),
             (
@@ -3477,7 +3477,7 @@ mod tests {
                 1,
                 AtomicOrderingAttr::Release,
                 AtomicOrderingAttr::Acquire,
-                Some("device".to_string()),
+                named_scope("device"),
                 "invalid success/failure ordering pair",
             ),
         ] {
@@ -3516,7 +3516,7 @@ mod tests {
             32,
             AtomicRmwKindAttr::Add,
             AtomicOrderingAttr::Monotonic,
-            Some("device".to_string()),
+            named_scope("device"),
         );
         integer_cmpxchg_function(
             &mut ctx,
@@ -3526,7 +3526,7 @@ mod tests {
             32,
             AtomicOrderingAttr::AcqRel,
             AtomicOrderingAttr::Monotonic,
-            Some("cluster".to_string()),
+            named_scope("cluster"),
         );
 
         let before = module.get_operation().deref(&ctx).disp(&ctx).to_string();
@@ -3554,8 +3554,13 @@ mod tests {
         let void_ty: TypeHandle = VoidType::get(&ctx).into();
         let (_func, entry) = function(&mut ctx, &module, "atomic_load", void_ty, vec![ptr_ty]);
         let ptr = entry.deref(&ctx).get_argument(0);
-        let load =
-            llvm::AtomicLoadOp::new(&mut ctx, ptr, i32_ty, AtomicOrderingAttr::Monotonic, None);
+        let load = llvm::AtomicLoadOp::new(
+            &mut ctx,
+            ptr,
+            i32_ty,
+            AtomicOrderingAttr::Monotonic,
+            SyncScopeAttr::System,
+        );
         load.get_operation().insert_at_back(entry, &ctx);
         llvm::ReturnOp::new(&mut ctx, None)
             .get_operation()

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -314,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +346,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -350,6 +354,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hi_sparse_bitset"
@@ -580,13 +589,13 @@ dependencies = [
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "awint",
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -607,7 +616,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "combine",
  "convert_case",
@@ -621,7 +630,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=8447aa426e2f090dc8b7b9383c5035db7bc70b62#8447aa426e2f090dc8b7b9383c5035db7bc70b62"
+source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
 dependencies = [
  "bitflags",
  "log",

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -33,8 +33,8 @@ cuda-artifact-finalizer = { path = "../cuda-artifact-finalizer" }
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml
 # [workspace.dependencies] section. Source MUST match the root (same git + rev),
 # or pliron resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "8447aa426e2f090dc8b7b9383c5035db7bc70b62" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "8447aa426e2f090dc8b7b9383c5035db7bc70b62" }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
 linkme = "0.3"            # must match workspace
 combine = "4.6"           # must match workspace
 once_cell = "1.18"        # must match workspace

--- a/cuda-oxide-book/compiler/mlir-dialects.md
+++ b/cuda-oxide-book/compiler/mlir-dialects.md
@@ -164,8 +164,8 @@ pliron operation, and the types map directly to LLVM's type system. The
 dialect itself (ops, types, attributes, op-interfaces) is defined upstream in
 the `pliron-llvm` crate; cuda-oxide consumes it and re-exports it through the
 thin `llvm-export` crate, which also carries the textual `.ll` exporter and a
-few GPU-specific extensions (named address spaces, a syncscope enum, fp16 bit
-helpers) that pliron-llvm does not ship.
+few GPU-specific extensions (named address spaces, fp16 bit helpers) that
+pliron-llvm does not ship.
 
 ### Types
 


### PR DESCRIPTION
## What this is

Bump pliron from `8447aa42` to upstream master `823d9d8` (6 commits). One commit matters to us, and it lets us delete code:

```text
upstream pliron 8447aa42 ──► 823d9d8 (6 commits)
  #240 dedicated SyncScopeAttr        ◄── the only one with fallout
  #239 rename llvm.extract_elment     ── zero references in our tree
  #238 debug_info.rs move             ── we never import it
  #235 ScalarOrVector interfaces      ── internal upstream refactor
  #237 From<fmt::Error> for Error     ── additive
  #234 decontextualization utils      ── additive
```

## The SyncScope migration

Until now cuda-oxide carried a local syncscope extension because pliron modeled the scope as a free-form `Option<String>`. Upstream's new `SyncScopeAttr` is a strict superset of it, so per the framework-first rule the shim is gone:

```text
before:  llvm-export's local LlvmSyncScope enum ──► Option<String>
         (System | Device | Block)                  on every atomic op

after:   pliron's SyncScopeAttr ─────────────────► first-class attribute
         (System | SingleThread | NamedScope)       + SyncScopeInterface

emission unchanged:  atomicrmw add ... syncscope("device") monotonic
                     atomicrmw add ... syncscope("block") monotonic
```

- llvm-export's exporter now reads scopes via `SyncScopeInterface`; mir-lower builds `SyncScopeAttr` directly; nvvm-transforms' legacy-atomic legalization matches on the attribute (SingleThread and unknown named scopes still rejected as unsupported, same as before).
- Fence scope selection for the PTX `membar` path now keys off the NVVM-dialect scope enum directly instead of round-tripping through the deleted LLVM-level enum.
- Bonus from upstream: the new ordering verifiers (fence not monotonic, cmpxchg-failure not release/acq_rel, atomic load/store ordering limits) now check our IR; every emission path already complies.

9 files, +151/−157.

## Regression sweep: every example, before vs after

All 219 examples rebuilt on main and on this branch, device IR compared:

```text
216 .ll pairs
  │  normalize build-identity noise (crate-disambiguator hashes,
  │  kernel emission order, _TID_/__shared_mem_N/__device_global_N/!N
  │  numbering that follows it)
  ▼
208 byte-identical as sets
  8 residual diffs ──► all numbering noise from build identity,
  ▼                    none caused by this bump
GPU execution (RTX 5090), branch build:
  all 6 atomic examples        ──► PASS  (atomics, atomic_f16,
                                          scoped_atomic_load_store,
                                          packed_atomic_add,
                                          legacy_atomic_fadd,
                                          legacy_atomic_rmw_cas)
  all 8 residual-diff examples ──► PASS  (numeric asserts)
  hashmap_v3 (15 tests)        ──► PASS, output byte-identical to main
```

- syncscope emission histograms identical main vs branch: `atomics` 24 occurrences both sides, `atomic_f16` 4 both sides, same device/block mix.

## Validation

- `cargo test --workspace`: 101 suites, 5287 tests, 0 failures (on the branch rebased onto current main).
- `scripts/smoketest.sh --compile-only` from a cold shared cache: **219/219 pass**.
- fmt + clippy clean on the touched crates (`llvm-export`, `mir-lower`, `nvvm-transforms`).
- Example lockfiles untouched (device examples don't depend on pliron); the workspace locks pick up pliron's hashbrown 0.15→0.17 + foldhash 0.2 rides-along.

## One behavior note for reviewers

Upstream's `SyncScopeInterface::syncscope` panics if the attribute is missing rather than returning a `Result`. Every cuda-oxide construction path goes through upstream constructors that always set it, and the interface verifier rejects IR without it, but raw `Operation` builders added in the future would hit the panic first.
