### PR TITLE
fix(finalizer): reject links that drop expected kernels

### DIFF
--- a/crates/cargo-oxide/src/commands/artifacts.rs
+++ b/crates/cargo-oxide/src/commands/artifacts.rs
@@ -111,6 +111,7 @@ pub(super) const GENERATED_ARTIFACT_SUFFIXES: &[&str] = &[
     "ptx.identity",
     "target",
     "options",
+    "kernels",
     "cubin.target",
 ];
 

--- a/crates/cargo-oxide/src/commands/interop.rs
+++ b/crates/cargo-oxide/src/commands/interop.rs
@@ -314,9 +314,10 @@ pub(super) fn read_interop_recorded_target(ir_path: &Path) -> Result<String, Str
     if target.is_empty() {
         return Err(format!("recorded CUDA target {} is empty", path.display()));
     }
-    match (lines.next(), lines.next()) {
-        (None, None) => Ok(target.to_string()),
-        (Some(marker), None) if marker == oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER => {
+    let markers = lines.collect::<Vec<_>>();
+    match markers.as_slice() {
+        [] => Ok(target.to_string()),
+        [marker] if *marker == oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER => {
             let options_path = ir_path.with_extension("options");
             if !options_path.is_file() {
                 return Err(format!(
@@ -327,12 +328,45 @@ pub(super) fn read_interop_recorded_target(ir_path: &Path) -> Result<String, Str
             }
             Ok(target.to_string())
         }
+        [options_marker, kernels_marker]
+            if *options_marker == oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+                && *kernels_marker == oxide_artifacts::KERNEL_ENTRIES_TARGET_MARKER =>
+        {
+            let options_path = ir_path.with_extension("options");
+            if !options_path.is_file() {
+                return Err(format!(
+                    "recorded CUDA target {} requires the sibling compile options {}, which is missing",
+                    path.display(),
+                    options_path.display()
+                ));
+            }
+            read_interop_kernel_entries(ir_path)?;
+            Ok(target.to_string())
+        }
         _ => Err(format!(
             "recorded CUDA target {} has an unrecognized format: {:?}",
             path.display(),
             text.trim()
         )),
     }
+}
+
+pub(super) fn read_interop_kernel_entries(ir_path: &Path) -> Result<Vec<String>, String> {
+    let path = ir_path.with_extension("kernels");
+    let bytes = std::fs::read(&path).map_err(|error| {
+        format!(
+            "device build did not record its kernel entries at {} ({error})",
+            path.display()
+        )
+    })?;
+    oxide_artifacts::parse_kernel_entries_sidecar(&bytes)
+        .map(|kernels| kernels.into_iter().map(str::to_string).collect())
+        .map_err(|error| {
+            format!(
+                "recorded kernel entries {} are invalid: {error}",
+                path.display()
+            )
+        })
 }
 
 /// Read the `.target sm_XX` directive from an emitted PTX artifact.
@@ -449,8 +483,21 @@ fn finalize_interop_device_artifact(
                 std::process::exit(1);
             });
             let options = finalization_options_from_artifact(&target, compile_options);
+            let expected_kernels = read_interop_kernel_entries(&ir_path).unwrap_or_else(|error| {
+                eprintln!("Error: {error}");
+                std::process::exit(1);
+            });
+            let expected_kernels = expected_kernels
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
             let cubin = finalizer
-                .materialize_nvvm_ir(artifact_name, &ir, &options)
+                .materialize_nvvm_ir_with_expected_kernels(
+                    artifact_name,
+                    &ir,
+                    &expected_kernels,
+                    &options,
+                )
                 .unwrap_or_else(|error| {
                     eprintln!(
                         "Error: could not finalize {} for {}: {error}",

--- a/crates/cargo-oxide/src/commands/ltoir.rs
+++ b/crates/cargo-oxide/src/commands/ltoir.rs
@@ -101,6 +101,21 @@ pub fn emit_ltoir(
         );
         std::process::exit(1);
     });
+    let source_kernels_path = ll_path.with_extension("kernels");
+    let kernel_entries = std::fs::read(&source_kernels_path).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not read emitted kernel entries at {}: {e}",
+            source_kernels_path.display()
+        );
+        std::process::exit(1);
+    });
+    oxide_artifacts::parse_kernel_entries_sidecar(&kernel_entries).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: invalid emitted kernel entries at {}: {e}",
+            source_kernels_path.display()
+        );
+        std::process::exit(1);
+    });
 
     let compute_arch = parsed_arch.compute();
     let ltoir = compile_nvvm_to_ltoir(&ir, example, &parsed_arch, compile_options);
@@ -112,6 +127,7 @@ pub fn emit_ltoir(
     for metadata_path in [
         out_path.with_extension("target"),
         out_path.with_extension("options"),
+        out_path.with_extension("kernels"),
     ] {
         match std::fs::remove_file(&metadata_path) {
             Ok(()) => {}
@@ -140,12 +156,21 @@ pub fn emit_ltoir(
         );
         std::process::exit(1);
     });
+    let kernels_path = out_path.with_extension("kernels");
+    std::fs::write(&kernels_path, kernel_entries).unwrap_or_else(|e| {
+        eprintln!(
+            "Error: could not write LTOIR kernel entries to {}: {e}",
+            kernels_path.display()
+        );
+        std::process::exit(1);
+    });
     let target_path = out_path.with_extension("target");
     std::fs::write(
         &target_path,
         format!(
-            "{sm_arch}\n{}\n",
-            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+            "{sm_arch}\n{}\n{}\n",
+            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER,
+            oxide_artifacts::KERNEL_ENTRIES_TARGET_MARKER,
         ),
     )
     .unwrap_or_else(|e| {

--- a/crates/cargo-oxide/src/commands/tests.rs
+++ b/crates/cargo-oxide/src/commands/tests.rs
@@ -367,7 +367,7 @@ fn generated_file_cleanup_preserves_ltoir_cubin_cache() {
         unique
     ));
     std::fs::create_dir_all(&root).unwrap();
-    for extension in ["ptx", "ll", "ltoir", "cubin", "target"] {
+    for extension in ["ptx", "ll", "ltoir", "cubin", "target", "kernels"] {
         std::fs::write(root.join(format!("my_kernel.{extension}")), b"stale").unwrap();
     }
     let cached_cubin = root.join(".oxide-artifacts/ltoir-cubin-cache/v1/entries/key/image.cubin");
@@ -376,7 +376,7 @@ fn generated_file_cleanup_preserves_ltoir_cubin_cache() {
 
     clean_generated_files(&root, "my-kernel");
 
-    for extension in ["ptx", "ll", "ltoir", "cubin", "target"] {
+    for extension in ["ptx", "ll", "ltoir", "cubin", "target", "kernels"] {
         assert!(!root.join(format!("my_kernel.{extension}")).exists());
     }
     assert_eq!(
@@ -3873,6 +3873,29 @@ fn recorded_target_sidecar_is_the_completion_marker() {
     // ...and the record is trusted once it exists.
     std::fs::write(root.join("device_kernels.options"), "fma=on\ndebug=none\n").unwrap();
     assert_eq!(read_interop_recorded_target(&ir_path).unwrap(), "sm_120a");
+
+    // The current marker additionally requires the exact kernel-entry set.
+    std::fs::write(
+        root.join("device_kernels.target"),
+        format!(
+            "sm_120a\n{}\n{}\n",
+            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER,
+            oxide_artifacts::KERNEL_ENTRIES_TARGET_MARKER,
+        ),
+    )
+    .unwrap();
+    let error = read_interop_recorded_target(&ir_path).unwrap_err();
+    assert!(error.contains("kernel entries"), "{error}");
+    std::fs::write(
+        root.join("device_kernels.kernels"),
+        oxide_artifacts::build_kernel_entries_sidecar(["kernel_b", "kernel_a"]).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(read_interop_recorded_target(&ir_path).unwrap(), "sm_120a");
+    assert_eq!(
+        read_interop_kernel_entries(&ir_path).unwrap(),
+        ["kernel_a", "kernel_b"]
+    );
 
     // Unknown trailing content is rejected, not half-trusted.
     std::fs::write(

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -130,6 +130,18 @@ pub enum FinalizerError {
     #[error("nvJitLink returned an empty PTX artifact")]
     EmptyPtx,
 
+    /// A kernel root cannot be represented safely as an nvJitLink option.
+    #[error("expected CUDA kernel name is empty or contains an interior NUL byte: {name:?}")]
+    InvalidExpectedKernelName { name: String },
+
+    /// The linked image could not provide a structural kernel-entry inventory.
+    #[error("could not inspect linked {output} kernel entry inventory")]
+    LinkedKernelInventoryUnavailable { output: &'static str },
+
+    /// nvJitLink succeeded but one or more required kernel entry points vanished.
+    #[error("nvJitLink output is missing expected CUDA kernels: {missing:?}")]
+    MissingExpectedKernels { missing: Vec<String> },
+
     /// A pinned CUDA compilation tool changed around an operation. Its output can
     /// no longer be attributed to the provenance used by Cargo or a cache key.
     #[error(
@@ -195,12 +207,24 @@ impl Finalizer {
         nvvm_ir: &[u8],
         options: &FinalizationOptions,
     ) -> Result<Vec<u8>, FinalizerError> {
+        self.materialize_nvvm_ir_with_expected_kernels(module_name, nvvm_ir, &[], options)
+    }
+
+    /// Compile NVVM IR while rooting and verifying every expected kernel.
+    pub fn materialize_nvvm_ir_with_expected_kernels(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+    ) -> Result<Vec<u8>, FinalizerError> {
         let ltoir = self
             .compiler
             .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
         let ltoir_name = format!("{module_name}.ltoir");
-        self.linker.link_ltoir(
+        self.linker.link_ltoir_with_expected_kernels(
             &[NamedInput::new(&ltoir_name, &ltoir)],
+            expected_kernels,
             options,
             FinalizerOutput::Cubin,
         )
@@ -218,12 +242,29 @@ impl Finalizer {
         nvvm_ir: &[u8],
         options: &FinalizationOptions,
     ) -> Result<LinkReport, FinalizerError> {
+        self.materialize_nvvm_ir_with_report_and_expected_kernels(
+            module_name,
+            nvvm_ir,
+            &[],
+            options,
+        )
+    }
+
+    /// Compile NVVM IR with diagnostics while rooting and verifying kernels.
+    pub fn materialize_nvvm_ir_with_report_and_expected_kernels(
+        &self,
+        module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+    ) -> Result<LinkReport, FinalizerError> {
         let ltoir = self
             .compiler
             .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, options)?;
         let ltoir_name = format!("{module_name}.ltoir");
-        self.linker.link_ltoir_with_report(
+        self.linker.link_ltoir_with_report_and_expected_kernels(
             &[NamedInput::new(&ltoir_name, &ltoir)],
+            expected_kernels,
             options,
             FinalizerOutput::Cubin,
         )
@@ -236,7 +277,19 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
-        self.linker.link_ltoir(inputs, options, output)
+        self.link_ltoir_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link ordered LTOIR modules while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        self.linker
+            .link_ltoir_with_expected_kernels(inputs, expected_kernels, options, output)
     }
 
     /// Link ordered LTOIR modules while collecting ptxas resource diagnostics.
@@ -251,7 +304,23 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<LinkReport, FinalizerError> {
-        self.linker.link_ltoir_with_report(inputs, options, output)
+        self.link_ltoir_with_report_and_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR with diagnostics while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_report_and_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.linker.link_ltoir_with_report_and_expected_kernels(
+            inputs,
+            expected_kernels,
+            options,
+            output,
+        )
     }
 
     /// Compiler component, including exact libdevice bytes and provenance.
@@ -292,10 +361,31 @@ impl Finalizer {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Option<[u8; 32]> {
-        nvvm_ir_artifact_digest_with_provenance(
+        self.nvvm_ir_artifact_digest_with_expected_kernels(
             module_name,
             ltoir_module_name,
             nvvm_ir,
+            &[],
+            options,
+            output,
+        )
+    }
+
+    /// Digest NVVM IR finalization including the expected-kernel root set.
+    pub fn nvvm_ir_artifact_digest_with_expected_kernels(
+        &self,
+        module_name: &str,
+        ltoir_module_name: &str,
+        nvvm_ir: &[u8],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
+        nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+            module_name,
+            ltoir_module_name,
+            nvvm_ir,
+            expected_kernels,
             options,
             output,
             self.provenance(),
@@ -315,6 +405,27 @@ pub fn nvvm_ir_artifact_digest_with_provenance(
     output: FinalizerOutput,
     provenance: ToolProvenance,
 ) -> Option<[u8; 32]> {
+    nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+        module_name,
+        ltoir_module_name,
+        nvvm_ir,
+        &[],
+        options,
+        output,
+        provenance,
+    )
+}
+
+/// Digest a complete finalization plan including expected kernel roots.
+pub fn nvvm_ir_artifact_digest_with_provenance_and_expected_kernels(
+    module_name: &str,
+    ltoir_module_name: &str,
+    nvvm_ir: &[u8],
+    expected_kernels: &[&str],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    provenance: ToolProvenance,
+) -> Option<[u8; 32]> {
     let compiler_digest = nvvm::nvvm_ir_artifact_digest_parts(
         module_name,
         nvvm_ir,
@@ -324,6 +435,7 @@ pub fn nvvm_ir_artifact_digest_with_provenance(
     );
     let linker_digest = link::ltoir_artifact_digest_parts(
         &[NamedInput::new(ltoir_module_name, &compiler_digest)],
+        expected_kernels,
         options,
         output,
         &provenance.nvjitlink_sha256?,
@@ -345,7 +457,24 @@ pub fn ltoir_artifact_digest_with_provenance(
     output: FinalizerOutput,
     nvjitlink_sha256: &[u8; 32],
 ) -> [u8; 32] {
-    link::ltoir_artifact_digest_parts(inputs, options, output, nvjitlink_sha256)
+    ltoir_artifact_digest_with_provenance_and_expected_kernels(
+        inputs,
+        &[],
+        options,
+        output,
+        nvjitlink_sha256,
+    )
+}
+
+/// Digest an ordered LTOIR link including the expected-kernel root set.
+pub fn ltoir_artifact_digest_with_provenance_and_expected_kernels(
+    inputs: &[NamedInput<'_>],
+    expected_kernels: &[&str],
+    options: &FinalizationOptions,
+    output: FinalizerOutput,
+    nvjitlink_sha256: &[u8; 32],
+) -> [u8; 32] {
+    link::ltoir_artifact_digest_parts(inputs, expected_kernels, options, output, nvjitlink_sha256)
 }
 
 fn validate_name(name: &str) -> Result<(), FinalizerError> {
@@ -362,23 +491,23 @@ fn validate_name(name: &str) -> Result<(), FinalizerError> {
 mod live_tests {
     use super::*;
 
-    /// `@llvm.used` keeps the kernel alive through LTO, exactly as cuda-oxide's
-    /// NVVM exporter emits it for real kernels. Without it nvJitLink's link-time
-    /// optimizer dead-strips the annotation-marked kernel as unreachable and
-    /// links an empty module: the pipeline still succeeds, so every assertion
-    /// below passed while nothing was being compiled. Measured on CUDA 13.3
-    /// before this line existed, the linked PTX was 202 bytes with zero
-    /// functions and the cubin had no entry points.
+    /// Legacy-dialect NVVM IR with the kernel retained through libNVVM.
+    ///
+    /// cuda-oxide's real LLVM exporter roots externally consumed function
+    /// definitions in `@llvm.used`, so this fixture mirrors the production
+    /// contract up to the LTOIR boundary. The finalizer then adds
+    /// `-kernels-used=kernel` at nvJitLink and independently inventories the
+    /// linked PTX/cubin to prove the expected entry survived the final link.
     const LEGACY_NVVM_IR: &[u8] = br#"
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
-
-@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @kernel to i8*)], section "llvm.metadata"
 
 define void @kernel() {
 entry:
   ret void
 }
+
+@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @kernel to i8*)], section "llvm.metadata"
 
 !nvvm.annotations = !{!0}
 !nvvmir.version = !{!1}
@@ -408,34 +537,32 @@ entry:
             assert!(!ltoir.is_empty());
             let input = [NamedInput::new("kernel.ltoir", &ltoir)];
             let cubin = finalizer
-                .link_ltoir(&input, &options, FinalizerOutput::Cubin)
+                .link_ltoir_with_expected_kernels(
+                    &input,
+                    &["kernel"],
+                    &options,
+                    FinalizerOutput::Cubin,
+                )
                 .unwrap();
             assert!(is_valid_cubin(&cubin));
-            // A cubin whose kernel was stripped is still a well-formed ELF, so
-            // `is_valid_cubin` alone cannot tell the two apart. Require the
-            // kernel's name to survive into the image.
-            assert!(
-                cubin.windows(b"kernel".len()).any(|part| part == b"kernel"),
-                "cubin has no `kernel` symbol ({} bytes): the kernel was \
-                 dead-stripped and this test is validating an empty module",
-                cubin.len()
-            );
+            let cubin_entries = crate::validation::cubin_kernel_entries(&cubin).unwrap();
+            assert_eq!(cubin_entries, vec!["kernel"]);
             let ptx = finalizer
-                .link_ltoir(&input, &options, FinalizerOutput::Ptx)
+                .link_ltoir_with_expected_kernels(
+                    &input,
+                    &["kernel"],
+                    &options,
+                    FinalizerOutput::Ptx,
+                )
                 .unwrap();
             assert!(
                 ptx.windows(b".version".len())
                     .any(|part| part == b".version")
             );
             // `.version` is in the header of even an empty module, so it proves
-            // only that something was emitted. The entry point is what proves
-            // the kernel made it through libNVVM and nvJitLink.
-            let ptx_text = String::from_utf8_lossy(&ptx);
-            assert!(
-                ptx_text.contains(".entry kernel"),
-                "linked PTX has no `.entry kernel` ({} bytes):\n{ptx_text}",
-                ptx.len()
-            );
+            // only that something was emitted. Inventory the entry explicitly.
+            let ptx_entries = crate::validation::ptx_kernel_entries(&ptx).unwrap();
+            assert_eq!(ptx_entries, vec!["kernel"]);
         }
     }
 
@@ -515,7 +642,12 @@ entry:
         let input = [NamedInput::new("spill.ltoir", &ltoir)];
 
         let report = finalizer
-            .link_ltoir_with_report(&input, &options, FinalizerOutput::Cubin)
+            .link_ltoir_with_report_and_expected_kernels(
+                &input,
+                &["spill_kernel"],
+                &options,
+                FinalizerOutput::Cubin,
+            )
             .unwrap();
         assert!(is_valid_cubin(&report.image));
 

--- a/crates/cuda-artifact-finalizer/src/lib.rs
+++ b/crates/cuda-artifact-finalizer/src/lib.rs
@@ -515,6 +515,59 @@ entry:
 !1 = !{i32 2, i32 0, i32 3, i32 1}
 "#;
 
+    /// Same annotated kernel without `@llvm.used`. libNVVM emits LTOIR, but an
+    /// unrooted nvJitLink operation succeeds with an empty final image.
+    const UNROOTED_LEGACY_NVVM_IR: &[u8] = br#"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+define void @dropped_without_root() {
+entry:
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!nvvmir.version = !{!1}
+!0 = !{void ()* @dropped_without_root, !"kernel", i32 1}
+!1 = !{i32 2, i32 0, i32 3, i32 1}
+"#;
+
+    #[test]
+    #[ignore = "requires discoverable CUDA Toolkit libNVVM, nvJitLink, and libdevice"]
+    fn live_expected_kernel_root_prevents_a_successful_empty_link() {
+        let finalizer = Finalizer::discover().unwrap();
+        let options = FinalizationOptions::new("sm_86".parse().unwrap());
+        let ltoir = finalizer
+            .compiler()
+            .compile_nvvm_ir_to_ltoir("unrooted.ll", UNROOTED_LEGACY_NVVM_IR, &options)
+            .unwrap();
+        let input = [NamedInput::new("unrooted.ltoir", &ltoir)];
+
+        let unguarded = finalizer
+            .link_ltoir(&input, &options, FinalizerOutput::Cubin)
+            .expect("nvJitLink reports success even after dropping the kernel");
+        assert!(is_valid_cubin(&unguarded));
+        assert!(
+            crate::validation::cubin_kernel_entries(&unguarded)
+                .expect("the unguarded cubin has a readable symbol inventory")
+                .is_empty(),
+            "the negative fixture must reproduce nvJitLink's successful empty output"
+        );
+
+        let guarded = finalizer
+            .link_ltoir_with_expected_kernels(
+                &input,
+                &["dropped_without_root"],
+                &options,
+                FinalizerOutput::Cubin,
+            )
+            .expect("-kernels-used must retain the expected entry");
+        assert_eq!(
+            crate::validation::cubin_kernel_entries(&guarded).unwrap(),
+            ["dropped_without_root"]
+        );
+    }
+
     #[test]
     #[ignore = "requires discoverable CUDA Toolkit libNVVM, nvJitLink, and libdevice"]
     fn live_pipeline_accepts_toolkit_cubins_and_emits_ptx_for_both_fma_policies() {

--- a/crates/cuda-artifact-finalizer/src/link.rs
+++ b/crates/cuda-artifact-finalizer/src/link.rs
@@ -10,7 +10,7 @@ use crate::provenance::{
     PinnedToolProvenance, StableDigest, linker_provenance_digest, recipe_digest,
     with_revalidated_tool_identity,
 };
-use crate::validation::is_valid_cubin;
+use crate::validation::{cubin_kernel_entries, is_valid_cubin, ptx_kernel_entries};
 use crate::{FinalizerError, validate_name};
 use nvjitlink_sys::{InputType, LibNvJitLink, LinkOutput, Linker, NvJitLinkError};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -87,7 +87,20 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<Vec<u8>, FinalizerError> {
-        Ok(self.link_ltoir_impl(inputs, options, output, false)?.image)
+        self.link_ltoir_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR while rooting and verifying every host-visible kernel.
+    pub fn link_ltoir_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<Vec<u8>, FinalizerError> {
+        Ok(self
+            .link_ltoir_impl(inputs, expected_kernels, options, output, false)?
+            .image)
     }
 
     /// Link LTOIR while collecting non-semantic ptxas resource diagnostics.
@@ -113,20 +126,34 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Result<LinkReport, FinalizerError> {
-        self.link_ltoir_impl(inputs, options, output, true)
+        self.link_ltoir_with_report_and_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Link LTOIR with diagnostics while rooting and verifying expected kernels.
+    pub fn link_ltoir_with_report_and_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Result<LinkReport, FinalizerError> {
+        self.link_ltoir_impl(inputs, expected_kernels, options, output, true)
     }
 
     fn link_ltoir_impl(
         &self,
         inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
     ) -> Result<LinkReport, FinalizerError> {
         validate_inputs(inputs)?;
+        validate_expected_kernels(expected_kernels)?;
         self.link_inputs(
             inputs,
             InputType::Ltoir,
+            expected_kernels,
             options,
             output,
             collect_resource_usage,
@@ -149,6 +176,7 @@ impl LtoLinker {
             .link_inputs(
                 std::slice::from_ref(&input),
                 InputType::Ptx,
+                &[],
                 options,
                 FinalizerOutput::Cubin,
                 false,
@@ -160,6 +188,7 @@ impl LtoLinker {
         &self,
         inputs: &[NamedInput<'_>],
         input_type: InputType,
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
@@ -169,7 +198,14 @@ impl LtoLinker {
             self.tool.digest,
             || current_linker_tool_digest(&self.tool),
             || {
-                match self.run_link(inputs, input_type, options, output, collect_resource_usage) {
+                match self.run_link(
+                    inputs,
+                    input_type,
+                    expected_kernels,
+                    options,
+                    output,
+                    collect_resource_usage,
+                ) {
                     // Older nvJitLink versions reject the diagnostic-only
                     // reporting options with NVJITLINK_ERROR_UNRECOGNIZED_OPTION.
                     // The caller asked for the same program plus a best-effort
@@ -178,7 +214,7 @@ impl LtoLinker {
                     Err(FinalizerError::NvJitLink(error))
                         if collect_resource_usage && error.is_unrecognized_option() =>
                     {
-                        self.run_link(inputs, input_type, options, output, false)
+                        self.run_link(inputs, input_type, expected_kernels, options, output, false)
                     }
                     result => result,
                 }
@@ -190,6 +226,7 @@ impl LtoLinker {
         &self,
         inputs: &[NamedInput<'_>],
         input_type: InputType,
+        expected_kernels: &[&str],
         options: &FinalizationOptions,
         output: FinalizerOutput,
         collect_resource_usage: bool,
@@ -199,6 +236,9 @@ impl LtoLinker {
         } else {
             options.nvjitlink_ltoir_options(output)
         };
+        if input_type == InputType::Ltoir {
+            option_storage.extend(expected_kernel_options(expected_kernels));
+        }
         if collect_resource_usage {
             option_storage.extend(options.nvjitlink_diagnostic_options(output));
         }
@@ -221,6 +261,7 @@ impl LtoLinker {
         if output == FinalizerOutput::Ptx && image.is_empty() {
             return Err(FinalizerError::EmptyPtx);
         }
+        verify_expected_kernels(&image, output, expected_kernels)?;
 
         let resource_usage = if collect_resource_usage {
             info_log
@@ -244,9 +285,24 @@ impl LtoLinker {
         options: &FinalizationOptions,
         output: FinalizerOutput,
     ) -> Option<[u8; 32]> {
+        self.artifact_digest_with_expected_kernels(inputs, &[], options, output)
+    }
+
+    /// Digest an LTOIR link including the complete expected-kernel root set.
+    pub fn artifact_digest_with_expected_kernels(
+        &self,
+        inputs: &[NamedInput<'_>],
+        expected_kernels: &[&str],
+        options: &FinalizationOptions,
+        output: FinalizerOutput,
+    ) -> Option<[u8; 32]> {
         let nvjitlink = self.nvjitlink_digest()?;
         Some(ltoir_artifact_digest_parts(
-            inputs, options, output, &nvjitlink,
+            inputs,
+            expected_kernels,
+            options,
+            output,
+            &nvjitlink,
         ))
     }
 
@@ -266,6 +322,65 @@ impl LtoLinker {
             options,
             &nvjitlink,
         )))
+    }
+}
+
+fn validate_expected_kernels(expected_kernels: &[&str]) -> Result<(), FinalizerError> {
+    for kernel in expected_kernels {
+        if kernel.is_empty() || kernel.as_bytes().contains(&0) {
+            return Err(FinalizerError::InvalidExpectedKernelName {
+                name: (*kernel).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn normalized_expected_kernels<'a>(expected_kernels: &[&'a str]) -> Vec<&'a str> {
+    let mut kernels = expected_kernels.to_vec();
+    kernels.sort_unstable();
+    kernels.dedup();
+    kernels
+}
+
+fn expected_kernel_options(expected_kernels: &[&str]) -> Vec<String> {
+    normalized_expected_kernels(expected_kernels)
+        .into_iter()
+        .map(|kernel| format!("-kernels-used={kernel}"))
+        .collect()
+}
+
+fn verify_expected_kernels(
+    image: &[u8],
+    output: FinalizerOutput,
+    expected_kernels: &[&str],
+) -> Result<(), FinalizerError> {
+    if expected_kernels.is_empty() {
+        return Ok(());
+    }
+    let actual = match output {
+        FinalizerOutput::Cubin => cubin_kernel_entries(image),
+        FinalizerOutput::Ptx => ptx_kernel_entries(image),
+    }
+    .ok_or(FinalizerError::LinkedKernelInventoryUnavailable {
+        output: match output {
+            FinalizerOutput::Cubin => "cubin",
+            FinalizerOutput::Ptx => "PTX",
+        },
+    })?;
+    let missing = normalized_expected_kernels(expected_kernels)
+        .into_iter()
+        .filter(|kernel| {
+            actual
+                .binary_search_by(|entry| entry.as_str().cmp(kernel))
+                .is_err()
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(FinalizerError::MissingExpectedKernels { missing })
     }
 }
 
@@ -341,6 +456,7 @@ fn load_linker_tool(
 
 pub(crate) fn ltoir_artifact_digest_parts(
     inputs: &[NamedInput<'_>],
+    expected_kernels: &[&str],
     options: &FinalizationOptions,
     output: FinalizerOutput,
     nvjitlink_digest: &[u8; 32],
@@ -357,6 +473,9 @@ pub(crate) fn ltoir_artifact_digest_parts(
         digest = digest
             .field("ltoir-name", input.name.as_bytes())
             .field("ltoir", input.bytes);
+    }
+    for kernel in normalized_expected_kernels(expected_kernels) {
+        digest = digest.field("expected-kernel", kernel.as_bytes());
     }
     for option in options.nvjitlink_ltoir_options(output) {
         digest = digest.field("nvjitlink-option", option.as_bytes());
@@ -394,15 +513,16 @@ mod tests {
         let a = NamedInput::new("a.ltoir", b"a");
         let b = NamedInput::new("b.ltoir", b"b");
         let baseline =
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[7; 32]);
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Cubin, &[7; 32]);
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[b, a], &options, FinalizerOutput::Cubin, &[7; 32])
+            ltoir_artifact_digest_parts(&[b, a], &[], &options, FinalizerOutput::Cubin, &[7; 32])
         );
         assert_ne!(
             baseline,
             ltoir_artifact_digest_parts(
                 &[NamedInput::new("renamed.ltoir", b"a"), b],
+                &[],
                 &options,
                 FinalizerOutput::Cubin,
                 &[7; 32]
@@ -412,6 +532,7 @@ mod tests {
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &FinalizationOptions::new("sm_90".parse().unwrap()),
                 FinalizerOutput::Cubin,
                 &[7; 32]
@@ -421,6 +542,7 @@ mod tests {
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &options
                     .clone()
                     .with_debug_policy(crate::DebugPolicy::LineTables),
@@ -430,21 +552,89 @@ mod tests {
         );
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Cubin, &[8; 32])
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Cubin, &[8; 32])
         );
         assert_ne!(
             baseline,
-            ltoir_artifact_digest_parts(&[a, b], &options, FinalizerOutput::Ptx, &[7; 32])
+            ltoir_artifact_digest_parts(&[a, b], &[], &options, FinalizerOutput::Ptx, &[7; 32])
         );
         assert_ne!(
             baseline,
             ltoir_artifact_digest_parts(
                 &[a, b],
+                &[],
                 &options.clone().with_fma_contraction(false),
                 FinalizerOutput::Cubin,
                 &[7; 32]
             )
         );
+    }
+
+    #[test]
+    fn link_digest_covers_expected_kernel_set_without_order_or_duplicate_noise() {
+        let options = FinalizationOptions::new("sm_120".parse().unwrap());
+        let input = [NamedInput::new("a.ltoir", b"a")];
+        let baseline = ltoir_artifact_digest_parts(
+            &input,
+            &["kernel_a", "kernel_b"],
+            &options,
+            FinalizerOutput::Cubin,
+            &[7; 32],
+        );
+        assert_eq!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &input,
+                &["kernel_b", "kernel_a", "kernel_a"],
+                &options,
+                FinalizerOutput::Cubin,
+                &[7; 32],
+            )
+        );
+        assert_ne!(
+            baseline,
+            ltoir_artifact_digest_parts(
+                &input,
+                &["kernel_a"],
+                &options,
+                FinalizerOutput::Cubin,
+                &[7; 32],
+            )
+        );
+    }
+
+    #[test]
+    fn expected_kernel_options_are_complete_canonical_roots() {
+        assert_eq!(
+            expected_kernel_options(&["kernel_b", "kernel_a", "kernel_a"]),
+            vec![
+                "-kernels-used=kernel_a".to_string(),
+                "-kernels-used=kernel_b".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn expected_kernel_validation_and_missing_inventory_fail_closed() {
+        assert!(matches!(
+            validate_expected_kernels(&[""]),
+            Err(FinalizerError::InvalidExpectedKernelName { .. })
+        ));
+        assert!(matches!(
+            validate_expected_kernels(&["bad\0kernel"]),
+            Err(FinalizerError::InvalidExpectedKernelName { .. })
+        ));
+        let error = verify_expected_kernels(
+            b".version 8.9\n.visible .entry kernel_a() { ret; }\n",
+            FinalizerOutput::Ptx,
+            &["kernel_a", "kernel_b"],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            FinalizerError::MissingExpectedKernels { ref missing }
+                if missing == &["kernel_b".to_string()]
+        ));
     }
 
     #[test]

--- a/crates/cuda-artifact-finalizer/src/validation.rs
+++ b/crates/cuda-artifact-finalizer/src/validation.rs
@@ -9,6 +9,11 @@ const ELF64_SECTION_HEADER_LENGTH: u16 = 64;
 const ELF_VERSION_CURRENT: u32 = 1;
 const CUDA_ABI_RUNTIME_JIT_LINK: u8 = 7;
 const CUDA_12_TOOLKIT_VERSIONS: std::ops::RangeInclusive<u32> = 120..=129;
+const ELF_SECTION_TYPE_SYMTAB: u32 = 2;
+const ELF_SECTION_TYPE_DYNSYM: u32 = 11;
+const ELF_SYMBOL_TYPE_FUNCTION: u8 = 2;
+const CUDA_SYMBOL_OTHER_ENTRY: u8 = 0x10;
+const ELF64_SYMBOL_LENGTH: u64 = 24;
 
 /// Check that bytes are a complete 64-bit little-endian CUDA executable ELF.
 ///
@@ -148,6 +153,184 @@ pub fn is_valid_cubin(bytes: &[u8]) -> bool {
     }
 
     has_meaningful_contents
+}
+
+/// Collect kernel entry names from linked PTX.
+///
+/// This is intentionally a small structural lexer rather than a substring
+/// search: comments and quoted strings cannot satisfy the final-link guard.
+pub(crate) fn ptx_kernel_entries(bytes: &[u8]) -> Option<Vec<String>> {
+    let bytes = bytes.strip_suffix(b"\0").unwrap_or(bytes);
+    if bytes.contains(&0) {
+        return None;
+    }
+    let text = std::str::from_utf8(bytes).ok()?;
+    let tokens = ptx_tokens(text)?;
+    let mut entries = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index] == ".entry" {
+            let name = tokens.get(index + 1)?;
+            if name.is_empty() {
+                return None;
+            }
+            entries.push((*name).to_string());
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    entries.sort();
+    entries.dedup();
+    Some(entries)
+}
+
+fn ptx_tokens(text: &str) -> Option<Vec<&str>> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b if b.is_ascii_whitespace() => index += 1,
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index += 2;
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index += 2;
+                let mut closed = false;
+                while index + 1 < bytes.len() {
+                    if bytes[index] == b'*' && bytes[index + 1] == b'/' {
+                        index += 2;
+                        closed = true;
+                        break;
+                    }
+                    index += 1;
+                }
+                if !closed {
+                    return None;
+                }
+            }
+            b'"' => {
+                index += 1;
+                let mut escaped = false;
+                let mut closed = false;
+                while index < bytes.len() {
+                    let byte = bytes[index];
+                    index += 1;
+                    if escaped {
+                        escaped = false;
+                    } else if byte == b'\\' {
+                        escaped = true;
+                    } else if byte == b'"' {
+                        closed = true;
+                        break;
+                    }
+                }
+                if !closed {
+                    return None;
+                }
+            }
+            b'(' | b')' | b'{' | b'}' | b',' | b';' => index += 1,
+            _ => {
+                let start = index;
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b if b.is_ascii_whitespace() => break,
+                        b'(' | b')' | b'{' | b'}' | b',' | b';' | b'"' => break,
+                        b'/' if matches!(bytes.get(index + 1), Some(b'/') | Some(b'*')) => {
+                            break;
+                        }
+                        _ => index += 1,
+                    }
+                }
+                if start == index {
+                    return None;
+                }
+                tokens.push(&text[start..index]);
+            }
+        }
+    }
+    Some(tokens)
+}
+
+/// Collect CUDA kernel entry symbols from a linked cubin.
+///
+/// nvdisasm represents kernel entries as defined `STT_FUNC` symbols carrying
+/// `STO_CUDA_ENTRY` in `st_other`. Walking `.symtab`/`.dynsym` therefore
+/// distinguishes real entries from device functions and incidental strings.
+pub(crate) fn cubin_kernel_entries(bytes: &[u8]) -> Option<Vec<String>> {
+    if !is_valid_cubin(bytes) {
+        return None;
+    }
+    let section_offset = usize::try_from(read_u64(bytes, 40)?).ok()?;
+    let section_entry_size = usize::from(read_u16(bytes, 58)?);
+    let section_count = usize::from(read_u16(bytes, 60)?);
+    if section_count == 0 || section_entry_size != usize::from(ELF64_SECTION_HEADER_LENGTH) {
+        return None;
+    }
+
+    let mut entries = Vec::new();
+    let mut found_symbol_table = false;
+    for section_index in 0..section_count {
+        let header = section_offset.checked_add(section_index.checked_mul(section_entry_size)?)?;
+        let section_type = read_u32(bytes, header + 4)?;
+        if !matches!(
+            section_type,
+            ELF_SECTION_TYPE_SYMTAB | ELF_SECTION_TYPE_DYNSYM
+        ) {
+            continue;
+        }
+        found_symbol_table = true;
+        let symbols_offset = usize::try_from(read_u64(bytes, header + 24)?).ok()?;
+        let symbols_size = usize::try_from(read_u64(bytes, header + 32)?).ok()?;
+        let string_section_index = usize::try_from(read_u32(bytes, header + 40)?).ok()?;
+        let symbol_entry_size = read_u64(bytes, header + 56)?;
+        if symbol_entry_size < ELF64_SYMBOL_LENGTH
+            || symbols_size % usize::try_from(symbol_entry_size).ok()? != 0
+            || string_section_index >= section_count
+        {
+            return None;
+        }
+        let strings_header =
+            section_offset.checked_add(string_section_index.checked_mul(section_entry_size)?)?;
+        let strings_offset = usize::try_from(read_u64(bytes, strings_header + 24)?).ok()?;
+        let strings_size = usize::try_from(read_u64(bytes, strings_header + 32)?).ok()?;
+        let strings = bytes.get(strings_offset..strings_offset.checked_add(strings_size)?)?;
+        let symbol_entry_size = usize::try_from(symbol_entry_size).ok()?;
+        let symbols = bytes.get(symbols_offset..symbols_offset.checked_add(symbols_size)?)?;
+        for symbol in symbols.chunks_exact(symbol_entry_size) {
+            let name_offset = usize::try_from(read_u32(symbol, 0)?).ok()?;
+            let info = *symbol.get(4)?;
+            let other = *symbol.get(5)?;
+            let section_index = read_u16(symbol, 6)?;
+            if info & 0x0f != ELF_SYMBOL_TYPE_FUNCTION
+                || other & CUDA_SYMBOL_OTHER_ENTRY == 0
+                || section_index == 0
+                || name_offset == 0
+            {
+                continue;
+            }
+            let name = read_c_string(strings, name_offset)?;
+            if !name.is_empty() {
+                entries.push(name.to_string());
+            }
+        }
+    }
+    if !found_symbol_table {
+        return None;
+    }
+    entries.sort();
+    entries.dedup();
+    Some(entries)
+}
+
+fn read_c_string(bytes: &[u8], offset: usize) -> Option<&str> {
+    let tail = bytes.get(offset..)?;
+    let length = tail.iter().position(|&byte| byte == 0)?;
+    std::str::from_utf8(&tail[..length]).ok()
 }
 
 fn has_supported_cuda_elf_version(abi_version: u8, file_version: Option<u32>) -> bool {
@@ -301,5 +484,94 @@ mod tests {
                 "ABI version {abi_version}, file version {file_version}"
             );
         }
+    }
+
+    fn cubin_with_kernel_symbols(symbols: &[(&str, bool)]) -> Vec<u8> {
+        const SECTION_COUNT: usize = 4;
+        let section_table_length = SECTION_COUNT * usize::from(ELF64_SECTION_HEADER_LENGTH);
+        let strings = {
+            let mut strings = vec![0_u8];
+            for (name, _) in symbols {
+                strings.extend_from_slice(name.as_bytes());
+                strings.push(0);
+            }
+            strings
+        };
+        let symbol_table_length = (symbols.len() + 1) * ELF64_SYMBOL_LENGTH as usize;
+        let strings_offset = ELF64_HEADER_LENGTH + section_table_length;
+        let symbols_offset = strings_offset + strings.len();
+        let text_offset = symbols_offset + symbol_table_length;
+        let mut bytes = vec![0_u8; text_offset + 4];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[6] = 1;
+        bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&190_u16.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[40..48].copy_from_slice(&(ELF64_HEADER_LENGTH as u64).to_le_bytes());
+        bytes[52..54].copy_from_slice(&(ELF64_HEADER_LENGTH as u16).to_le_bytes());
+        bytes[58..60].copy_from_slice(&ELF64_SECTION_HEADER_LENGTH.to_le_bytes());
+        bytes[60..62].copy_from_slice(&(SECTION_COUNT as u16).to_le_bytes());
+
+        let strtab = ELF64_HEADER_LENGTH + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[strtab + 4..strtab + 8].copy_from_slice(&3_u32.to_le_bytes());
+        bytes[strtab + 24..strtab + 32].copy_from_slice(&(strings_offset as u64).to_le_bytes());
+        bytes[strtab + 32..strtab + 40].copy_from_slice(&(strings.len() as u64).to_le_bytes());
+
+        let symtab = strtab + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[symtab + 4..symtab + 8].copy_from_slice(&ELF_SECTION_TYPE_SYMTAB.to_le_bytes());
+        bytes[symtab + 24..symtab + 32].copy_from_slice(&(symbols_offset as u64).to_le_bytes());
+        bytes[symtab + 32..symtab + 40]
+            .copy_from_slice(&(symbol_table_length as u64).to_le_bytes());
+        bytes[symtab + 40..symtab + 44].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[symtab + 56..symtab + 64].copy_from_slice(&ELF64_SYMBOL_LENGTH.to_le_bytes());
+
+        let text = symtab + usize::from(ELF64_SECTION_HEADER_LENGTH);
+        bytes[text + 4..text + 8].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[text + 24..text + 32].copy_from_slice(&(text_offset as u64).to_le_bytes());
+        bytes[text + 32..text + 40].copy_from_slice(&4_u64.to_le_bytes());
+        bytes[text_offset..text_offset + 4].copy_from_slice(b"CUDA");
+        bytes[strings_offset..strings_offset + strings.len()].copy_from_slice(&strings);
+
+        let mut name_offset = 1_u32;
+        for (index, (name, is_kernel)) in symbols.iter().enumerate() {
+            let symbol = symbols_offset + (index + 1) * ELF64_SYMBOL_LENGTH as usize;
+            bytes[symbol..symbol + 4].copy_from_slice(&name_offset.to_le_bytes());
+            bytes[symbol + 4] = 0x12;
+            bytes[symbol + 5] = if *is_kernel {
+                CUDA_SYMBOL_OTHER_ENTRY
+            } else {
+                0
+            };
+            bytes[symbol + 6..symbol + 8].copy_from_slice(&3_u16.to_le_bytes());
+            name_offset += u32::try_from(name.len() + 1).unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn ptx_entry_inventory_ignores_comments_and_strings() {
+        let ptx = br#"
+.version 8.9
+// .entry fake_comment() {}
+.const .b8 text[] = {0}; // ".entry fake_string"
+.visible .entry kernel_a() { ret; }
+.entry
+kernel_b() { ret; }
+"#;
+        assert_eq!(
+            ptx_kernel_entries(ptx).unwrap(),
+            vec!["kernel_a".to_string(), "kernel_b".to_string()]
+        );
+        assert!(ptx_kernel_entries(b".entry kernel() {}\0").is_some());
+        assert!(ptx_kernel_entries(b".entry kernel() {}\0garbage").is_none());
+    }
+
+    #[test]
+    fn cubin_entry_inventory_uses_cuda_entry_symbol_flag() {
+        let cubin = cubin_with_kernel_symbols(&[("kernel_a", true), ("helper", false)]);
+        assert!(is_valid_cubin(&cubin));
+        assert_eq!(cubin_kernel_entries(&cubin).unwrap(), vec!["kernel_a"]);
     }
 }

--- a/crates/cuda-core/src/embedded.rs
+++ b/crates/cuda-core/src/embedded.rs
@@ -8,8 +8,9 @@
 use crate::{CudaContext, CudaModule, DriverError};
 use oxide_artifacts::ArtifactError;
 pub use oxide_artifacts::{
-    ArtifactCompileOptions, ArtifactDebugPolicy, ArtifactPayloadKind,
-    COMPILE_OPTIONS_TARGET_MARKER, OwnedArtifactBundle,
+    ArtifactCompileOptions, ArtifactDebugPolicy, ArtifactEntryKind, ArtifactPayloadKind,
+    COMPILE_OPTIONS_TARGET_MARKER, KERNEL_ENTRIES_TARGET_MARKER, OwnedArtifactBundle,
+    build_kernel_entries_sidecar, parse_kernel_entries_sidecar,
 };
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -15,6 +15,10 @@ use cuda_core::{CudaContext, CudaModule, DriverError};
 use std::sync::Arc;
 use thiserror::Error;
 
+// ArtifactEntryKind::Kernel wire tag. cuda-core re-exports OwnedArtifactBundle
+// but not the enum itself, so deferred loading reads the stable encoded tag.
+const ARTIFACT_ENTRY_KIND_KERNEL: u16 = 1;
+
 /// Errors while discovering, building, or loading an embedded CUDA module.
 #[derive(Debug, Error)]
 pub enum EmbeddedModuleError {
@@ -155,6 +159,12 @@ fn load_bundle(
     ctx: &Arc<CudaContext>,
     bundle: &OwnedArtifactBundle,
 ) -> Result<Arc<CudaModule>, EmbeddedModuleError> {
+    let expected_kernels = bundle
+        .entries
+        .iter()
+        .filter(|entry| entry.kind.to_u16() == ARTIFACT_ENTRY_KIND_KERNEL)
+        .map(|entry| entry.symbol.as_str())
+        .collect::<Vec<_>>();
     if let Some(cubin) = bundle.payload(ArtifactPayloadKind::Cubin) {
         return Ok(ctx.load_module_from_image(cubin)?);
     }
@@ -167,18 +177,24 @@ fn load_bundle(
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::build_cubin_from_nvvm_ir_with_compile_options(
-                nvvm_ir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::build_ptx_from_nvvm_ir_with_compile_options(
-                nvvm_ir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
+            ltoir::ExecutionRoute::Cubin => {
+                ltoir::build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+                    nvvm_ir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
+            ltoir::ExecutionRoute::PtxBridge => {
+                ltoir::build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+                    nvvm_ir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }
@@ -187,18 +203,24 @@ fn load_bundle(
         let emitted = target_arch_for_bundle(bundle)?;
         let execution = ltoir::execution_arch_for_context(ctx)?;
         let image = match ltoir::execution_route(&emitted, &execution)? {
-            ltoir::ExecutionRoute::Cubin => ltoir::link_ltoir_to_cubin_with_compile_options(
-                ltoir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
-            ltoir::ExecutionRoute::PtxBridge => ltoir::link_ltoir_to_ptx_with_compile_options(
-                ltoir,
-                &bundle.name,
-                &emitted.sm(),
-                bundle.compile_options,
-            )?,
+            ltoir::ExecutionRoute::Cubin => {
+                ltoir::link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+                    ltoir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
+            ltoir::ExecutionRoute::PtxBridge => {
+                ltoir::link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+                    ltoir,
+                    &bundle.name,
+                    &expected_kernels,
+                    &emitted.sm(),
+                    bundle.compile_options,
+                )?
+            }
         };
         return Ok(ctx.load_module_from_image(&image)?);
     }

--- a/crates/cuda-host/src/embedded.rs
+++ b/crates/cuda-host/src/embedded.rs
@@ -7,17 +7,13 @@
 
 use crate::ltoir;
 pub use cuda_core::embedded::{
-    ArtifactCompileOptions, ArtifactPayloadKind, EmbeddedModule, OwnedArtifactBundle,
-    artifact_bundles_from_binary_path, artifact_bundles_from_current_exe,
+    ArtifactCompileOptions, ArtifactEntryKind, ArtifactPayloadKind, EmbeddedModule,
+    OwnedArtifactBundle, artifact_bundles_from_binary_path, artifact_bundles_from_current_exe,
     embedded_modules_from_current_exe,
 };
 use cuda_core::{CudaContext, CudaModule, DriverError};
 use std::sync::Arc;
 use thiserror::Error;
-
-// ArtifactEntryKind::Kernel wire tag. cuda-core re-exports OwnedArtifactBundle
-// but not the enum itself, so deferred loading reads the stable encoded tag.
-const ARTIFACT_ENTRY_KIND_KERNEL: u16 = 1;
 
 /// Errors while discovering, building, or loading an embedded CUDA module.
 #[derive(Debug, Error)]
@@ -162,7 +158,7 @@ fn load_bundle(
     let expected_kernels = bundle
         .entries
         .iter()
-        .filter(|entry| entry.kind.to_u16() == ARTIFACT_ENTRY_KIND_KERNEL)
+        .filter(|entry| entry.kind == ArtifactEntryKind::Kernel)
         .map(|entry| entry.symbol.as_str())
         .collect::<Vec<_>>();
     if let Some(cubin) = bundle.payload(ArtifactPayloadKind::Cubin) {

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -85,6 +85,7 @@ use cuda_artifact_finalizer::{
 };
 use cuda_core::embedded::{
     ArtifactCompileOptions, ArtifactDebugPolicy, COMPILE_OPTIONS_TARGET_MARKER,
+    KERNEL_ENTRIES_TARGET_MARKER, parse_kernel_entries_sidecar,
 };
 use cuda_core::{CudaContext, CudaModule, DriverError};
 #[cfg(test)]
@@ -127,6 +128,15 @@ pub enum LtoirError {
         /// Path to the malformed sidecar.
         path: PathBuf,
         /// Trimmed sidecar contents.
+        value: String,
+    },
+
+    /// A required kernel-entry sidecar was absent or malformed.
+    #[error("invalid cuda-oxide kernel metadata in {path}: {value}")]
+    InvalidKernelEntries {
+        /// Path to the missing or malformed sidecar.
+        path: PathBuf,
+        /// Specific metadata failure.
         value: String,
     },
 
@@ -273,6 +283,11 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
         source,
     })?;
     let compile_options = read_compile_options(ll_path)?;
+    let expected_kernels = read_kernel_entries(ll_path)?;
+    let expected_kernel_refs = expected_kernels
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
     validate_ir_target_sidecar(ll_path, arch)?;
     // Record the supplied target for older or manually created `.ll` files.
     // The sibling `.ltoir` can then be loaded after the `.ll` is removed.
@@ -293,6 +308,7 @@ fn build_cubin_from_ll_file(ll_path: &Path, arch: &CudaArch) -> Result<FileCubin
         &ltoir_path.display().to_string(),
         arch,
         compile_options,
+        &expected_kernel_refs,
     )?;
     let ltoir = cached
         .ltoir
@@ -666,6 +682,7 @@ fn cached_nvvm_ir_to_cubin(
         ltoir_module_name,
         arch,
         ArtifactCompileOptions::new(),
+        &[],
     )
 }
 
@@ -676,13 +693,15 @@ fn cached_nvvm_ir_to_cubin_with_compile_options(
     ltoir_module_name: &str,
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
+    expected_kernels: &[&str],
 ) -> Result<CacheResult, LtoirError> {
     let finalizer = Finalizer::discover()?;
     let options = finalization_options(arch, compile_options);
-    let key = finalizer.nvvm_ir_artifact_digest(
+    let key = finalizer.nvvm_ir_artifact_digest_with_expected_kernels(
         nvvm_module_name,
         ltoir_module_name,
         nvvm_ir,
+        expected_kernels,
         &options,
         FinalizerOutput::Cubin,
     );
@@ -692,8 +711,9 @@ fn cached_nvvm_ir_to_cubin_with_compile_options(
             finalizer
                 .compiler()
                 .compile_nvvm_ir_to_ltoir(nvvm_module_name, nvvm_ir, &options)?;
-        let cubin = finalizer.link_ltoir(
+        let cubin = finalizer.link_ltoir_with_expected_kernels(
             &[NamedInput::new(ltoir_module_name, &ltoir)],
+            expected_kernels,
             &options,
             FinalizerOutput::Cubin,
         )?;
@@ -721,6 +741,7 @@ fn cached_ltoir_to_cubin(
         module_name,
         arch,
         ArtifactCompileOptions::new(),
+        &[],
     )
 }
 
@@ -730,14 +751,25 @@ fn cached_ltoir_to_cubin_with_compile_options(
     module_name: &str,
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
+    expected_kernels: &[&str],
 ) -> Result<CacheResult, LtoirError> {
     let linker = LtoLinker::discover()?;
     let options = finalization_options(arch, compile_options);
     let inputs = [NamedInput::new(module_name, ltoir)];
-    let key = linker.artifact_digest(&inputs, &options, FinalizerOutput::Cubin);
+    let key = linker.artifact_digest_with_expected_kernels(
+        &inputs,
+        expected_kernels,
+        &options,
+        FinalizerOutput::Cubin,
+    );
     let build = || -> Result<BuiltArtifacts, LtoirError> {
         Ok(BuiltArtifacts::new(
-            linker.link_ltoir(&inputs, &options, FinalizerOutput::Cubin)?,
+            linker.link_ltoir_with_expected_kernels(
+                &inputs,
+                expected_kernels,
+                &options,
+                FinalizerOutput::Cubin,
+            )?,
             None,
         ))
     };
@@ -954,9 +986,15 @@ pub fn load_kernel_module(
                 ExecutionRoute::PtxBridge => {
                     let nvvm_ir = read_artifact(&ll)?;
                     let compile_options = read_compile_options(&ll)?;
-                    let ptx = build_ptx_from_nvvm_ir_with_compile_options(
+                    let expected_kernels = read_kernel_entries(&ll)?;
+                    let expected_kernel_refs = expected_kernels
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>();
+                    let ptx = build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
                         &nvvm_ir,
                         &ll.display().to_string(),
+                        &expected_kernel_refs,
                         &emitted.sm(),
                         compile_options,
                     )?;
@@ -969,6 +1007,11 @@ pub fn load_kernel_module(
             let execution = execution_arch_for_context(ctx)?;
             let bytes = read_artifact(&ltoir)?;
             let compile_options = read_compile_options(&ltoir)?;
+            let expected_kernels = read_kernel_entries(&ltoir)?;
+            let expected_kernel_refs = expected_kernels
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
             let image = match execution_route(&emitted, &execution)? {
                 ExecutionRoute::Cubin => {
                     cached_ltoir_to_cubin_with_compile_options(
@@ -977,13 +1020,14 @@ pub fn load_kernel_module(
                         &ltoir.display().to_string(),
                         &emitted,
                         compile_options,
+                        &expected_kernel_refs,
                     )?
                     .cubin
                 }
                 ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_compile_options(
                     &bytes,
                     &ltoir.display().to_string(),
-                    &[],
+                    &expected_kernel_refs,
                     &emitted,
                     compile_options,
                 )?,
@@ -1143,6 +1187,10 @@ fn emitted_compile_options_path(ll_path: &Path) -> PathBuf {
     ll_path.with_extension("options")
 }
 
+fn emitted_kernel_entries_path(artifact_path: &Path) -> PathBuf {
+    artifact_path.with_extension("kernels")
+}
+
 fn read_compile_options(ll_path: &Path) -> Result<ArtifactCompileOptions, LtoirError> {
     let path = emitted_compile_options_path(ll_path);
     match std::fs::read_to_string(&path) {
@@ -1159,15 +1207,30 @@ fn read_compile_options(ll_path: &Path) -> Result<ArtifactCompileOptions, LtoirE
     }
 }
 
+fn read_kernel_entries(artifact_path: &Path) -> Result<Vec<String>, LtoirError> {
+    let path = emitted_kernel_entries_path(artifact_path);
+    match std::fs::read(&path) {
+        Ok(bytes) => parse_kernel_entries_sidecar(&bytes)
+            .map(|kernels| kernels.into_iter().map(str::to_string).collect())
+            .map_err(|error| LtoirError::InvalidKernelEntries {
+                path,
+                value: error.to_string(),
+            }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(source) => Err(LtoirError::Io { path, source }),
+    }
+}
+
 fn read_emitted_target(ll_path: &Path) -> Result<Option<CudaArch>, LtoirError> {
     let path = emitted_target_path(ll_path);
     match std::fs::read_to_string(&path) {
         Ok(target) => {
             let mut lines = target.lines();
             let arch = lines.next().unwrap_or_default().parse()?;
-            match (lines.next(), lines.next()) {
-                (None, None) => Ok(Some(arch)),
-                (Some(marker), None) if marker == COMPILE_OPTIONS_TARGET_MARKER => {
+            let markers = lines.collect::<Vec<_>>();
+            match markers.as_slice() {
+                [] => Ok(Some(arch)),
+                [marker] if *marker == COMPILE_OPTIONS_TARGET_MARKER => {
                     let options_path = emitted_compile_options_path(ll_path);
                     if !options_path.try_exists().map_err(|source| LtoirError::Io {
                         path: options_path.clone(),
@@ -1179,6 +1242,34 @@ fn read_emitted_target(ll_path: &Path) -> Result<Option<CudaArch>, LtoirError> {
                         });
                     }
                     read_compile_options(ll_path)?;
+                    Ok(Some(arch))
+                }
+                [options_marker, kernels_marker]
+                    if *options_marker == COMPILE_OPTIONS_TARGET_MARKER
+                        && *kernels_marker == KERNEL_ENTRIES_TARGET_MARKER =>
+                {
+                    let options_path = emitted_compile_options_path(ll_path);
+                    if !options_path.try_exists().map_err(|source| LtoirError::Io {
+                        path: options_path.clone(),
+                        source,
+                    })? {
+                        return Err(LtoirError::InvalidCompileOptions {
+                            path: options_path,
+                            value: "required sidecar is missing".to_string(),
+                        });
+                    }
+                    read_compile_options(ll_path)?;
+                    let kernels_path = emitted_kernel_entries_path(ll_path);
+                    if !kernels_path.try_exists().map_err(|source| LtoirError::Io {
+                        path: kernels_path.clone(),
+                        source,
+                    })? {
+                        return Err(LtoirError::InvalidKernelEntries {
+                            path: kernels_path,
+                            value: "required sidecar is missing".to_string(),
+                        });
+                    }
+                    read_kernel_entries(ll_path)?;
                     Ok(Some(arch))
                 }
                 _ => Err(LtoirError::InvalidCompileOptions {
@@ -1212,12 +1303,30 @@ fn write_artifact_target_sidecar(
 ) -> Result<(), LtoirError> {
     let path = emitted_target_path(artifact_path);
     let options_path = emitted_compile_options_path(artifact_path);
-    let contents = if options_path.try_exists().map_err(|source| LtoirError::Io {
+    let kernels_path = emitted_kernel_entries_path(artifact_path);
+    let has_options = options_path.try_exists().map_err(|source| LtoirError::Io {
         path: options_path.clone(),
         source,
-    })? {
+    })?;
+    let has_kernels = kernels_path.try_exists().map_err(|source| LtoirError::Io {
+        path: kernels_path.clone(),
+        source,
+    })?;
+    let contents = if has_options && has_kernels {
+        read_compile_options(artifact_path)?;
+        read_kernel_entries(artifact_path)?;
+        format!(
+            "{}\n{COMPILE_OPTIONS_TARGET_MARKER}\n{KERNEL_ENTRIES_TARGET_MARKER}\n",
+            target.sm()
+        )
+    } else if has_options {
         read_compile_options(artifact_path)?;
         format!("{}\n{COMPILE_OPTIONS_TARGET_MARKER}\n", target.sm())
+    } else if has_kernels {
+        return Err(LtoirError::InvalidCompileOptions {
+            path: options_path,
+            value: "kernel metadata requires the compile-options sidecar".to_string(),
+        });
     } else {
         format!("{}\n", target.sm())
     };
@@ -1283,6 +1392,7 @@ pub(crate) fn execution_route(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cuda_core::embedded::build_kernel_entries_sidecar;
 
     fn temp_dir(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
@@ -1381,6 +1491,45 @@ mod tests {
             ArtifactCompileOptions::new(),
             "legacy artifacts default to FMA enabled with no debug information"
         );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn kernel_entry_marker_requires_and_validates_its_sidecar() {
+        let dir = temp_dir("versioned_kernel_entries");
+        std::fs::create_dir_all(&dir).unwrap();
+        let ll = dir.join("kernel.ll");
+        std::fs::write(&ll, "; test\n").unwrap();
+        std::fs::write(
+            dir.join("kernel.options"),
+            ArtifactCompileOptions::new().sidecar_text(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("kernel.target"),
+            format!("sm_86\n{COMPILE_OPTIONS_TARGET_MARKER}\n{KERNEL_ENTRIES_TARGET_MARKER}\n"),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            read_emitted_target(&ll),
+            Err(LtoirError::InvalidKernelEntries { .. })
+        ));
+
+        std::fs::write(
+            dir.join("kernel.kernels"),
+            build_kernel_entries_sidecar(["kernel_b", "kernel_a"]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(read_emitted_target(&ll).unwrap().unwrap().sm(), "sm_86");
+        assert_eq!(read_kernel_entries(&ll).unwrap(), ["kernel_a", "kernel_b"]);
+
+        std::fs::write(dir.join("kernel.kernels"), b"invalid").unwrap();
+        assert!(matches!(
+            read_emitted_target(&ll),
+            Err(LtoirError::InvalidKernelEntries { .. })
+        ));
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/cuda-host/src/ltoir.rs
+++ b/crates/cuda-host/src/ltoir.rs
@@ -358,9 +358,32 @@ pub fn build_cubin_from_nvvm_ir_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+        nvvm_ir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn build_cubin_from_nvvm_ir_with_compile_options_and_expected_kernels(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
     let options = finalization_options(&arch, compile_options);
-    Ok(Finalizer::discover()?.materialize_nvvm_ir(module_name, nvvm_ir, &options)?)
+    Ok(
+        Finalizer::discover()?.materialize_nvvm_ir_with_expected_kernels(
+            module_name,
+            nvvm_ir,
+            expected_kernels,
+            &options,
+        )?,
+    )
 }
 
 /// Compile NVVM IR bytes to forward-compatible PTX.
@@ -404,6 +427,22 @@ pub fn build_ptx_from_nvvm_ir_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+        nvvm_ir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn build_ptx_from_nvvm_ir_with_compile_options_and_expected_kernels(
+    nvvm_ir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
     let finalizer = Finalizer::discover()?;
     let options = finalization_options(&arch, compile_options);
@@ -411,8 +450,9 @@ pub fn build_ptx_from_nvvm_ir_with_compile_options(
         .compiler()
         .compile_nvvm_ir_to_ltoir(module_name, nvvm_ir, &options)?;
     let ltoir_name = format!("{module_name}.ltoir");
-    Ok(finalizer.link_ltoir(
+    Ok(finalizer.link_ltoir_with_expected_kernels(
         &[NamedInput::new(&ltoir_name, &ltoir)],
+        expected_kernels,
         &options,
         FinalizerOutput::Ptx,
     )?)
@@ -454,8 +494,30 @@ pub fn link_ltoir_to_cubin_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+        ltoir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn link_ltoir_to_cubin_with_compile_options_and_expected_kernels(
+    ltoir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_cubin_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
+    link_ltoir_to_cubin_parsed_with_compile_options(
+        ltoir,
+        module_name,
+        expected_kernels,
+        &arch,
+        compile_options,
+    )
 }
 
 /// Link one LTOIR payload to forward-compatible PTX.
@@ -498,19 +560,43 @@ pub fn link_ltoir_to_ptx_with_compile_options(
     arch: &str,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
+    link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+        ltoir,
+        module_name,
+        &[],
+        arch,
+        compile_options,
+    )
+}
+
+pub(crate) fn link_ltoir_to_ptx_with_compile_options_and_expected_kernels(
+    ltoir: &[u8],
+    module_name: &str,
+    expected_kernels: &[&str],
+    arch: &str,
+    compile_options: ArtifactCompileOptions,
+) -> Result<Vec<u8>, LtoirError> {
     let arch: CudaArch = arch.parse()?;
-    link_ltoir_to_ptx_parsed_with_compile_options(ltoir, module_name, &arch, compile_options)
+    link_ltoir_to_ptx_parsed_with_compile_options(
+        ltoir,
+        module_name,
+        expected_kernels,
+        &arch,
+        compile_options,
+    )
 }
 
 fn link_ltoir_to_cubin_parsed_with_compile_options(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
     link_ltoir_with_shared_finalizer(
         ltoir,
         module_name,
+        expected_kernels,
         arch,
         compile_options,
         FinalizerOutput::Cubin,
@@ -520,12 +606,14 @@ fn link_ltoir_to_cubin_parsed_with_compile_options(
 fn link_ltoir_to_ptx_parsed_with_compile_options(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
 ) -> Result<Vec<u8>, LtoirError> {
     link_ltoir_with_shared_finalizer(
         ltoir,
         module_name,
+        expected_kernels,
         arch,
         compile_options,
         FinalizerOutput::Ptx,
@@ -535,13 +623,15 @@ fn link_ltoir_to_ptx_parsed_with_compile_options(
 fn link_ltoir_with_shared_finalizer(
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     arch: &CudaArch,
     compile_options: ArtifactCompileOptions,
     output: FinalizerOutput,
 ) -> Result<Vec<u8>, LtoirError> {
     let options = finalization_options(arch, compile_options);
-    Ok(LtoLinker::discover()?.link_ltoir(
+    Ok(LtoLinker::discover()?.link_ltoir_with_expected_kernels(
         &[NamedInput::new(module_name, ltoir)],
+        expected_kernels,
         &options,
         output,
     )?)
@@ -893,6 +983,7 @@ pub fn load_kernel_module(
                 ExecutionRoute::PtxBridge => link_ltoir_to_ptx_parsed_with_compile_options(
                     &bytes,
                     &ltoir.display().to_string(),
+                    &[],
                     &emitted,
                     compile_options,
                 )?,

--- a/crates/mir-importer/src/pipeline.rs
+++ b/crates/mir-importer/src/pipeline.rs
@@ -559,8 +559,9 @@ pub fn run_pipeline(
                 config.allow_fma_contraction,
                 config.debug_kind,
             )?;
+            write_kernel_entries_sidecar(&config.output_dir, &config.output_name, functions)?;
             // Publish the target last: its version marker is the completion record
-            // that says the sibling options file is required.
+            // that says the sibling options and kernel-entry files are required.
             write_nvvm_target_sidecar(&config.output_dir, &config.output_name, &generated.target)?;
             Ok(CompilationResult {
                 artifact_path: ll_path.clone(),
@@ -637,13 +638,42 @@ fn write_nvvm_target_sidecar(
     std::fs::write(
         &path,
         format!(
-            "{target}\n{}\n",
-            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+            "{target}\n{}\n{}\n",
+            oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER,
+            oxide_artifacts::KERNEL_ENTRIES_TARGET_MARKER,
         ),
     )
     .map_err(|error| {
         PipelineError::Export(format!(
             "failed to record NVVM target in {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Records the complete host-visible kernel set used to root and verify the
+/// later nvJitLink operation. Device functions are deliberately excluded.
+fn write_kernel_entries_sidecar(
+    output_dir: &Path,
+    output_name: &str,
+    functions: &[CollectedFunction],
+) -> Result<(), PipelineError> {
+    let path = output_dir.join(format!("{output_name}.kernels"));
+    let bytes = oxide_artifacts::build_kernel_entries_sidecar(
+        functions
+            .iter()
+            .filter(|function| function.is_kernel)
+            .map(|function| function.export_name.as_str()),
+    )
+    .map_err(|error| {
+        PipelineError::Export(format!(
+            "failed to encode NVVM kernel entries for {}: {error}",
+            path.display()
+        ))
+    })?;
+    std::fs::write(&path, bytes).map_err(|error| {
+        PipelineError::Export(format!(
+            "failed to record NVVM kernel entries in {}: {error}",
             path.display()
         ))
     })
@@ -685,6 +715,7 @@ fn stale_compilation_artifact_paths(
         "ptx",
         "target",
         "options",
+        "kernels",
         "ltoir",
         "cubin",
         "cubin.target",
@@ -1170,8 +1201,9 @@ fn adversarial_export_name() -> u64 {
         assert_eq!(
             fs::read_to_string(output_dir.join("empty.target")).unwrap(),
             format!(
-                "sm_86\n{}\n",
-                oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER
+                "sm_86\n{}\n{}\n",
+                oxide_artifacts::COMPILE_OPTIONS_TARGET_MARKER,
+                oxide_artifacts::KERNEL_ENTRIES_TARGET_MARKER,
             )
         );
         assert_eq!(
@@ -1179,6 +1211,13 @@ fn adversarial_export_name() -> u64 {
             oxide_artifacts::ArtifactCompileOptions::new()
                 .with_fma_contraction(true)
                 .sidecar_text()
+        );
+        assert!(
+            oxide_artifacts::parse_kernel_entries_sidecar(
+                &fs::read(output_dir.join("empty.kernels")).unwrap()
+            )
+            .unwrap()
+            .is_empty()
         );
 
         fs::remove_dir_all(&root).expect("clean up temp output dir");

--- a/crates/oxide-artifacts/src/lib.rs
+++ b/crates/oxide-artifacts/src/lib.rs
@@ -35,6 +35,15 @@ const KNOWN_COMPILE_OPTIONS: u64 = OPTION_NO_FMA_CONTRACTION | OPTION_DEBUG_MASK
 /// format header.
 pub const COMPILE_OPTIONS_TARGET_MARKER: &str = "compile-options=v1";
 
+/// Marker written after [`COMPILE_OPTIONS_TARGET_MARKER`] in a versioned
+/// NVVM/LTOIR `.target` sidecar. It makes older consumers reject artifacts
+/// whose sibling `.kernels` retention contract they do not understand.
+pub const KERNEL_ENTRIES_TARGET_MARKER: &str = "kernel-entries=v1";
+
+const KERNEL_ENTRIES_MAGIC: [u8; 8] = *b"OXKERNL\0";
+const KERNEL_ENTRIES_VERSION: u16 = 1;
+const KERNEL_ENTRIES_HEADER_BYTES: usize = 16;
+
 const COMPILE_OPTIONS_SIDECAR_HEADER: &str = "cuda-oxide-compile-options-v1";
 const COMPILE_OPTIONS_FMA_ON: &str = "cuda-oxide-compile-options-v1\nfma-contraction=on\n";
 const COMPILE_OPTIONS_FMA_OFF: &str = "cuda-oxide-compile-options-v1\nfma-contraction=off\n";
@@ -208,6 +217,101 @@ impl ArtifactEntryKind {
             _ => None,
         }
     }
+}
+
+/// Encode the normalized kernel-entry set for a sibling `.kernels` sidecar.
+///
+/// The length-prefixed format preserves arbitrary UTF-8 symbol names without
+/// introducing escaping rules. Sorting and de-duplication make the sidecar a
+/// stable semantic record rather than a reflection of collection order.
+pub fn build_kernel_entries_sidecar<'a>(
+    kernels: impl IntoIterator<Item = &'a str>,
+) -> Result<Vec<u8>, ArtifactError> {
+    let mut kernels = kernels.into_iter().collect::<Vec<_>>();
+    kernels.sort_unstable();
+    kernels.dedup();
+    if kernels.iter().any(|kernel| kernel.is_empty()) {
+        return Err(ArtifactError::EmptyEntrySymbol);
+    }
+
+    let mut bytes = vec![0; KERNEL_ENTRIES_HEADER_BYTES];
+    bytes[..8].copy_from_slice(&KERNEL_ENTRIES_MAGIC);
+    write_u16(&mut bytes, 8, KERNEL_ENTRIES_VERSION);
+    write_u32(
+        &mut bytes,
+        12,
+        checked_u32(kernels.len(), "kernel entry count")?,
+    );
+    for kernel in kernels {
+        let length = checked_u32(kernel.len(), "kernel entry length")?;
+        bytes.extend_from_slice(&length.to_le_bytes());
+        bytes.extend_from_slice(kernel.as_bytes());
+    }
+    Ok(bytes)
+}
+
+/// Decode a complete sibling `.kernels` sidecar.
+pub fn parse_kernel_entries_sidecar(bytes: &[u8]) -> Result<Vec<&str>, ArtifactError> {
+    if bytes.len() < KERNEL_ENTRIES_HEADER_BYTES {
+        return Err(ArtifactError::Truncated("kernel entries header"));
+    }
+    if bytes[..8] != KERNEL_ENTRIES_MAGIC {
+        return Err(ArtifactError::Malformed(
+            "kernel entries sidecar has bad magic".to_string(),
+        ));
+    }
+    let version = read_u16(bytes, 8)?;
+    if version != KERNEL_ENTRIES_VERSION {
+        return Err(ArtifactError::UnsupportedVersion(version));
+    }
+    if read_u16(bytes, 10)? != 0 {
+        return Err(ArtifactError::Malformed(
+            "kernel entries sidecar has nonzero reserved bits".to_string(),
+        ));
+    }
+    let count = usize::try_from(read_u32(bytes, 12)?)
+        .map_err(|_| ArtifactError::TooLarge("kernel entry count"))?;
+    let minimum_entry_bytes = count
+        .checked_mul(5)
+        .ok_or(ArtifactError::TooLarge("kernel entry count"))?;
+    if minimum_entry_bytes > bytes.len() - KERNEL_ENTRIES_HEADER_BYTES {
+        return Err(ArtifactError::Truncated("kernel entries"));
+    }
+    let mut cursor = KERNEL_ENTRIES_HEADER_BYTES;
+    let mut kernels = Vec::with_capacity(count);
+    for _ in 0..count {
+        let length_end = cursor
+            .checked_add(4)
+            .ok_or(ArtifactError::TooLarge("kernel entry length"))?;
+        let length = usize::try_from(read_u32(bytes, cursor)?)
+            .map_err(|_| ArtifactError::TooLarge("kernel entry length"))?;
+        cursor = length_end;
+        let end = cursor
+            .checked_add(length)
+            .ok_or(ArtifactError::TooLarge("kernel entry"))?;
+        let kernel = std::str::from_utf8(
+            bytes
+                .get(cursor..end)
+                .ok_or(ArtifactError::Truncated("kernel entry"))?,
+        )
+        .map_err(|_| ArtifactError::InvalidUtf8("kernel entry"))?;
+        if kernel.is_empty() {
+            return Err(ArtifactError::EmptyEntrySymbol);
+        }
+        kernels.push(kernel);
+        cursor = end;
+    }
+    if cursor != bytes.len() {
+        return Err(ArtifactError::Malformed(
+            "kernel entries sidecar has trailing bytes".to_string(),
+        ));
+    }
+    if kernels.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(ArtifactError::Malformed(
+            "kernel entries sidecar is not a normalized set".to_string(),
+        ));
+    }
+    Ok(kernels)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -983,6 +1087,49 @@ mod tests {
 
     fn sample_payload_record_start() -> usize {
         HEADER_BYTES + "demo".len() + "sm_90".len()
+    }
+
+    #[test]
+    fn kernel_entries_sidecar_round_trips_a_normalized_set() {
+        let sidecar = build_kernel_entries_sidecar(["kernel_b", "kernel_a", "kernel_a"])
+            .expect("valid kernel names");
+
+        assert_eq!(
+            parse_kernel_entries_sidecar(&sidecar).unwrap(),
+            ["kernel_a", "kernel_b"]
+        );
+    }
+
+    #[test]
+    fn kernel_entries_sidecar_rejects_incomplete_or_noncanonical_input() {
+        assert!(matches!(
+            build_kernel_entries_sidecar([""]),
+            Err(ArtifactError::EmptyEntrySymbol)
+        ));
+
+        let sidecar = build_kernel_entries_sidecar(["kernel_a", "kernel_b"]).unwrap();
+        assert!(matches!(
+            parse_kernel_entries_sidecar(&sidecar[..sidecar.len() - 1]),
+            Err(ArtifactError::Truncated("kernel entry"))
+        ));
+
+        let mut duplicate = sidecar;
+        let second_name = KERNEL_ENTRIES_HEADER_BYTES + 4 + "kernel_a".len() + 4;
+        duplicate[second_name..].copy_from_slice(b"kernel_a");
+        assert!(matches!(
+            parse_kernel_entries_sidecar(&duplicate),
+            Err(ArtifactError::Malformed(message))
+                if message.contains("normalized set")
+        ));
+
+        let mut impossible_count = vec![0; KERNEL_ENTRIES_HEADER_BYTES];
+        impossible_count[..8].copy_from_slice(&KERNEL_ENTRIES_MAGIC);
+        write_u16(&mut impossible_count, 8, KERNEL_ENTRIES_VERSION);
+        write_u32(&mut impossible_count, 12, u32::MAX);
+        assert!(matches!(
+            parse_kernel_entries_sidecar(&impossible_count),
+            Err(ArtifactError::Truncated("kernel entries"))
+        ));
     }
 
     #[test]

--- a/crates/rustc-codegen-cuda/src/lib.rs
+++ b/crates/rustc-codegen-cuda/src/lib.rs
@@ -846,6 +846,7 @@ fn write_device_artifact_object(
         &bundle_name,
         result,
         artifact,
+        functions,
     )?;
     if let Some(materialized) = materialized_artifact.as_ref() {
         emit_launch_bounds_spill_warnings(tcx, result, functions, &materialized.resource_usage);
@@ -978,10 +979,16 @@ fn materialize_artifact_for_embedding(
     bundle_name: &str,
     result: &device_codegen::DeviceCodegenResult,
     artifact: &device_codegen::DeviceCodegenArtifact,
+    functions: &[collector::CollectedFunction<'_>],
 ) -> Result<Option<MaterializedDeviceArtifact>, Box<dyn std::error::Error>> {
     let Some(request) = request else {
         return Ok(None);
     };
+    let expected_kernels = functions
+        .iter()
+        .filter(|function| function.is_kernel)
+        .map(|function| function.export_name.as_str())
+        .collect::<Vec<_>>();
     let debug_policy = match result.debug_kind {
         llvm_export::export::DebugKind::Off => cuda_artifact_finalizer::DebugPolicy::None,
         llvm_export::export::DebugKind::LineTables => {
@@ -994,6 +1001,7 @@ fn materialize_artifact_for_embedding(
             request,
             &artifact.bytes,
             bundle_name,
+            &expected_kernels,
             &result.target,
             result.allow_fma_contraction,
             debug_policy,
@@ -1002,6 +1010,7 @@ fn materialize_artifact_for_embedding(
             request,
             &artifact.bytes,
             &artifact.name,
+            &expected_kernels,
             &result.target,
             result.allow_fma_contraction,
             debug_policy,

--- a/crates/rustc-codegen-cuda/src/materialize.rs
+++ b/crates/rustc-codegen-cuda/src/materialize.rs
@@ -194,13 +194,19 @@ pub(crate) fn nvvm_ir_to_cubin(
     request: MaterializationRequest,
     nvvm_ir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     target: &str,
     allow_fma_contraction: bool,
     debug_policy: DebugPolicy,
 ) -> Result<MaterializedCubin, MaterializeError> {
     let options = options(target, allow_fma_contraction, debug_policy)?;
     let finalizer = checked_finalizer(request)?;
-    let report = finalizer.materialize_nvvm_ir_with_report(module_name, nvvm_ir, &options)?;
+    let report = finalizer.materialize_nvvm_ir_with_report_and_expected_kernels(
+        module_name,
+        nvvm_ir,
+        expected_kernels,
+        &options,
+    )?;
     Ok(MaterializedCubin {
         bytes: report.image,
         resource_usage: report.resource_usage,
@@ -211,14 +217,16 @@ pub(crate) fn ltoir_to_cubin(
     request: MaterializationRequest,
     ltoir: &[u8],
     module_name: &str,
+    expected_kernels: &[&str],
     target: &str,
     allow_fma_contraction: bool,
     debug_policy: DebugPolicy,
 ) -> Result<MaterializedCubin, MaterializeError> {
     let options = options(target, allow_fma_contraction, debug_policy)?;
     let finalizer = checked_finalizer(request)?;
-    let report = finalizer.link_ltoir_with_report(
+    let report = finalizer.link_ltoir_with_report_and_expected_kernels(
         &[NamedInput::new(module_name, ltoir)],
+        expected_kernels,
         &options,
         FinalizerOutput::Cubin,
     )?;


### PR DESCRIPTION
## Summary

Prevent a successful nvJitLink result from silently publishing an image that dropped a declared CUDA kernel. This continues #1167, preserving Raul Estrada's original authored commit, and closes the three cross-path gaps identified in that review.

## Changes

- root expected kernels with `-kernels-used` and structurally verify the linked PTX/cubin inventory
- use `ArtifactEntryKind` as the shared entry-kind source of truth
- carry a versioned, normalized kernel-entry sidecar through NVVM IR, LTOIR, cargo-oxide compatibility finalization, file loading, PTX bridging, and cache identity
- add a live negative nvJitLink regression that first reproduces a successful empty link, then proves the expected root is retained

## Testing

- [ ] `just check` passes (upstream CI in progress)
- [ ] live CUDA Toolkit regression passes (in progress)
- [x] `cargo test -p oxide-artifacts --all-targets --features object`
- [x] `cargo test -p cuda-artifact-finalizer --all-targets`
- [x] `cargo test -p cargo-oxide`
- [x] `cargo test -p mir-importer`
- [x] `cargo test --lib` in `crates/rustc-codegen-cuda`

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (no new source files)

Fixes #1166.
