### PR TITLE
[do not merge] CodeQL PR-attribution probe

### DIFF
--- a/crates/rustc-codegen-cuda/examples/const_bool_dead_branch/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_bool_dead_branch/src/main.rs
@@ -394,3 +394,5 @@ fn main() {
         std::process::exit(1);
     }
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.

--- a/crates/rustc-codegen-cuda/examples/const_generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/const_generic/src/main.rs
@@ -186,3 +186,5 @@ mod tests {
         println!("VALUE=8 host lookup: {value_8}");
     }
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.

--- a/crates/rustc-codegen-cuda/examples/generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/generic/src/main.rs
@@ -235,3 +235,5 @@ fn main() {
 
     println!("\n✓ SUCCESS: typed generic launches and captured closures worked for f32 and i32");
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.

--- a/crates/rustc-codegen-cuda/examples/host_closure/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/host_closure/src/main.rs
@@ -615,3 +615,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.

--- a/crates/rustc-codegen-cuda/examples/manual_launch_generic/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/manual_launch_generic/src/main.rs
@@ -144,3 +144,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nSUCCESS: manual type- and const-generic launches passed");
     Ok(())
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.

--- a/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/unchecked_indexing/src/main.rs
@@ -393,3 +393,5 @@ fn has_guarded_branch(definition: ptx_parse::CallableDefinition<'_, '_>) -> bool
         .instructions()
         .any(|instruction| instruction.base_opcode() == "bra" && instruction.predicate().is_some())
 }
+
+// CodeQL PR-attribution probe: comment-only change, no code modified.


### PR DESCRIPTION
Comment-only touches of the six example files whose pre-existing kernel code CodeQL flags on #1102. If this PR's CodeQL check passes, the alerts are already in main's baseline and #1102's failures are attribution artifacts of the large diff; if it fails with the same alerts, the PR gate attributes them to any PR touching these files. Will be closed once the check reports.