### PR TITLE
Restore ptxas SASS loop unrolling under LLVM 23 (disable llc's late branch folding); assemble every compile-only PTX in CI

### DIFF
--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -273,9 +273,13 @@ const DISABLE_SWITCH_LOOKUP_TABLES: &str = "-switch-to-lookup=false";
 /// - Measured on gemm_views' sgemm_naive_raw (RTX 5090, live benches,
 ///   bit-identical numerics): folded layout drops 38 -> 26 registers and
 ///   FFMA 18 -> 4, costing 26% throughput (7218 -> 5708 GFLOPS). With
-///   these flags: 38 registers, 7226 GFLOPS. Zero register movement on
-///   the 16 other kernels across 6 examples; PTX grows 1-6% in lines,
-///   all redundant jumps ptxas discards.
+///   these flags: 38 registers, 7226 GFLOPS. Full-suite sweep (890
+///   kernels, 197 modules): 45 kernels change registers, every one the
+///   SASS unroller re-enabling (register counts and SASS bodies grow,
+///   e.g. the table-lookup scan loops now fully unroll) or an exact
+///   return to the pre-LLVM-23 baseline; zero unexplained movers, all
+///   affected examples numerically verified on hardware. PTX grows
+///   +2.6% in lines suite-wide, all redundant jumps ptxas discards.
 ///
 /// Permanent until ptxas learns to unroll both layouts or upstream adds
 /// an opt-out for the NVPTX folding; an internal NVBug and an LLVM issue

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -8,7 +8,7 @@ use crate::generated::GeneratedModuleRequirements;
 use crate::llvm_tools::LlvmToolchain;
 use crate::options::BackendOptions;
 use crate::target::{
-    ModuleRequirements, detect_module_requirements_in_llvm_file,
+    ModuleRequirements, PtxIsaRequirement, detect_module_requirements_in_llvm_file,
     merge_generated_module_requirements, merge_generated_module_requirements_for_target,
     required_ptx_feature, resolve_ptx_target_with_generated, validate_ptx_isa_for_llvm_major,
     validate_target_features, validate_target_for_llvm_major,
@@ -302,6 +302,38 @@ fn base_llc_args(target: &str) -> Vec<String> {
         DISABLE_BRANCH_FOLD.to_string(),
         DISABLE_BLOCK_PLACEMENT.to_string(),
     ]
+}
+
+/// Full-debug modules need PTX ISA 7.5 or newer declared, whatever the
+/// target's own floor is.
+///
+/// llc's DWARF emission writes label-difference expressions into debug
+/// sections:
+///
+/// ```text
+/// .section .debug_pubnames
+/// {
+/// .b32 $L__pubNames_end0-$L__pubNames_start0   ← "labels1 - labels2
+///                                                 expression in .section"
+///                                                 = PTX ISA 7.5 feature
+/// ```
+///
+/// but still declares the target's default `.version` (7.0 at sm_80), so
+/// ptxas rejects the module. Observed with llc-22 (CI's floor pin); llc-23
+/// emits its debug sections differently and dodges it. There is no 7.5
+/// requirement spelling in the supported set, so raise to the nearest one,
+/// 7.8; [`required_ptx_feature`] already refuses to downgrade targets whose
+/// floor is at or above it. Caught by the all-examples compile-only ptxas
+/// gate; line-tables debug emits no such expressions and stays untouched.
+fn ptx_isa_with_debug_floor(
+    requirement: PtxIsaRequirement,
+    debug_kind: DebugKind,
+) -> PtxIsaRequirement {
+    if debug_kind.variables_enabled() {
+        requirement.max(PtxIsaRequirement::Ptx78)
+    } else {
+        requirement
+    }
 }
 
 /// Build the middle-end arguments for a self-contained PTX module.
@@ -642,8 +674,11 @@ fn generate_ptx_impl(
 
     let mut llc_cmd = std::process::Command::new(&toolchain.llc_path);
     llc_cmd.args(base_llc_args(&target));
-    if let Some(feature) =
-        required_ptx_feature(&target, requirements.ptx_isa).map_err(PipelineError::PtxGeneration)?
+    if let Some(feature) = required_ptx_feature(
+        &target,
+        ptx_isa_with_debug_floor(requirements.ptx_isa, debug_kind),
+    )
+    .map_err(PipelineError::PtxGeneration)?
     {
         llc_cmd.arg(format!("-mattr={feature}"));
     }
@@ -1059,6 +1094,52 @@ mod tests {
         assert_eq!(
             optimization_args(&[]).unwrap(),
             ["-O2", "-switch-to-lookup=false"]
+        );
+    }
+
+    /// Full-debug DWARF uses label-difference expressions (a PTX ISA 7.5
+    /// feature), so the requirement floor rises to the nearest supported
+    /// spelling, 7.8; targets already at or above it are untouched, and
+    /// line-tables/off never raise (see [`ptx_isa_with_debug_floor`]).
+    #[test]
+    fn full_debug_raises_the_ptx_isa_floor_only_when_below() {
+        assert_eq!(
+            ptx_isa_with_debug_floor(PtxIsaRequirement::Default, DebugKind::Full),
+            PtxIsaRequirement::Ptx78
+        );
+        assert_eq!(
+            ptx_isa_with_debug_floor(PtxIsaRequirement::Ptx70, DebugKind::Full),
+            PtxIsaRequirement::Ptx78
+        );
+        assert_eq!(
+            ptx_isa_with_debug_floor(PtxIsaRequirement::Ptx86, DebugKind::Full),
+            PtxIsaRequirement::Ptx86
+        );
+        assert_eq!(
+            ptx_isa_with_debug_floor(PtxIsaRequirement::Default, DebugKind::LineTables),
+            PtxIsaRequirement::Default
+        );
+        assert_eq!(
+            ptx_isa_with_debug_floor(PtxIsaRequirement::Default, DebugKind::Off),
+            PtxIsaRequirement::Default
+        );
+        // End to end: at sm_80 (floor 7.0) the raised requirement emits the
+        // feature; at sm_90a (floor 8.0) it is already satisfied.
+        assert_eq!(
+            required_ptx_feature(
+                "sm_80",
+                ptx_isa_with_debug_floor(PtxIsaRequirement::Default, DebugKind::Full)
+            )
+            .unwrap(),
+            Some("+ptx78")
+        );
+        assert_eq!(
+            required_ptx_feature(
+                "sm_90a",
+                ptx_isa_with_debug_floor(PtxIsaRequirement::Default, DebugKind::Full)
+            )
+            .unwrap(),
+            None
         );
     }
 

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -239,6 +239,67 @@ fn optimize_ll(
 /// path for a few uniform ALU ops.
 const DISABLE_SWITCH_LOOKUP_TABLES: &str = "-switch-to-lookup=false";
 
+/// Disable llc's late branch folding so loops keep the two-jump layout
+/// ptxas's SASS unroller recognizes.
+///
+/// LLVM 23's NVPTX backend gained `reverseBranchCondition`
+/// (llvm/llvm-project PR #191889, commit d55166c23bf1, follow-up PR
+/// #191890, commit 205f4bf6cc03), which lets BranchFolding and
+/// MachineBlockPlacement collapse the classic loop branch idiom into a
+/// single negated conditional with fallthrough:
+///
+/// ```text
+/// LLVM 22 layout (ptxas unrolls)       LLVM 23 layout (ptxas gives up)
+///
+/// guard:  @%p bra body;    ─┐          guard:  @!%p bra exit;
+///         bra.uni exit;     │ taken            (falls through to body)
+/// body:   ...             ◄─┘          body:   ...
+/// latch:  @%p bra exit;                latch:  @%p bra body;
+///         bra.uni body;   ← continue           (falls through to exit)
+/// exit:                                exit:
+/// ```
+///
+/// Why we turn it off:
+///
+/// - ptxas's SASS loop unroller keys on the taken-target orientation at
+///   both ends of the loop: the guard's conditional taken-target must
+///   enter the preheader/body, and the latch must be "conditional exit +
+///   `bra.uni` continue". The folded negated forms defeat it.
+/// - Upstream enabled the folding with no opt-out (PR #191889), so the
+///   only supported control is disabling the two late machine passes.
+/// - Both flags are generic disable-only cl::opts: they skip layout
+///   transforms and change no semantics, so there is no correctness
+///   surface. llc 21.1.8, 22.1.2, 22.1.7, and 23.1.0 all accept them.
+/// - Measured on gemm_views' sgemm_naive_raw (RTX 5090, live benches,
+///   bit-identical numerics): folded layout drops 38 -> 26 registers and
+///   FFMA 18 -> 4, costing 26% throughput (7218 -> 5708 GFLOPS). With
+///   these flags: 38 registers, 7226 GFLOPS. Zero register movement on
+///   the 16 other kernels across 6 examples; PTX grows 1-6% in lines,
+///   all redundant jumps ptxas discards.
+///
+/// Permanent until ptxas learns to unroll both layouts or upstream adds
+/// an opt-out for the NVPTX folding; an internal NVBug and an LLVM issue
+/// are to be filed to track both ends.
+const DISABLE_BRANCH_FOLD: &str = "-disable-branch-fold";
+
+/// Companion to [`DISABLE_BRANCH_FOLD`]: MachineBlockPlacement performs
+/// the same rotation and tail layout on its own, so both passes must be
+/// off or the folded form comes back.
+const DISABLE_BLOCK_PLACEMENT: &str = "-disable-block-placement";
+
+/// The unconditional head of every `llc` invocation: target selection plus
+/// the branch-layout controls ptxas depends on (see
+/// [`DISABLE_BRANCH_FOLD`]). Kept as a function so the tests can assert
+/// the argument list verbatim.
+fn base_llc_args(target: &str) -> Vec<String> {
+    vec![
+        "-march=nvptx64".to_string(),
+        format!("-mcpu={target}"),
+        DISABLE_BRANCH_FOLD.to_string(),
+        DISABLE_BLOCK_PLACEMENT.to_string(),
+    ]
+}
+
 /// Build the middle-end arguments for a self-contained PTX module.
 ///
 /// The LLVM exporter returns the module's externally consumed definitions as
@@ -576,9 +637,7 @@ fn generate_ptx_impl(
     }
 
     let mut llc_cmd = std::process::Command::new(&toolchain.llc_path);
-    llc_cmd
-        .arg("-march=nvptx64")
-        .arg(format!("-mcpu={}", target));
+    llc_cmd.args(base_llc_args(&target));
     if let Some(feature) =
         required_ptx_feature(&target, requirements.ptx_isa).map_err(PipelineError::PtxGeneration)?
     {
@@ -996,6 +1055,23 @@ mod tests {
         assert_eq!(
             optimization_args(&[]).unwrap(),
             ["-O2", "-switch-to-lookup=false"]
+        );
+    }
+
+    /// Every llc invocation must carry the branch-layout controls: without
+    /// them LLVM 23's BranchFolding/MachineBlockPlacement rewrite loop
+    /// branches into a form ptxas's SASS unroller does not recognize (see
+    /// [`DISABLE_BRANCH_FOLD`]).
+    #[test]
+    fn llc_base_args_keep_the_ptxas_friendly_branch_layout() {
+        assert_eq!(
+            base_llc_args("sm_90"),
+            [
+                "-march=nvptx64",
+                "-mcpu=sm_90",
+                "-disable-branch-fold",
+                "-disable-block-placement",
+            ]
         );
     }
 

--- a/crates/rustc-codegen-cuda/examples/gemm_views/README.md
+++ b/crates/rustc-codegen-cuda/examples/gemm_views/README.md
@@ -85,10 +85,16 @@ identical global-memory load/store instruction sets.
 
 | kernel             | time     | GFLOPS |
 | ------------------ | -------- | ------ |
-| naive views (safe) | 0.300 ms | 7159   |
-| naive raw (unsafe) | 0.300 ms | 7161   |
-| tiled views (safe) | 0.232 ms | 9272   |
-| tiled raw (unsafe) | 0.231 ms | 9286   |
+| naive views (safe) | 0.298 ms | 7201   |
+| naive raw (unsafe) | 0.298 ms | 7201   |
+| tiled views (safe) | 0.229 ms | 9370   |
+| tiled raw (unsafe) | 0.230 ms | 9337   |
+
+These numbers depend on the pipeline disabling llc's late branch folding:
+LLVM 23 started rewriting loop branches into a single negated conditional,
+which ptxas's SASS unroller does not recognize, and the naive kernels lose
+about a quarter of their throughput. The rationale and measurements live
+on `DISABLE_BRANCH_FOLD` in `crates/cuda-oxide-codegen/src/ptx.rs`.
 
 For scale: the `gemm` example (plain `a[i]`, checked on every read) runs
 the same problem at roughly 2940 GFLOPS. Removing the per-read checks

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -178,7 +178,10 @@ OPTIONS
                        `cargo oxide build`; designated NVVM regressions use
                        `emit-ltoir` to include real libNVVM verification.
                        Non-error categories must leave a fresh artifact;
-                       error examples must still fail. Works on GPU-less CI.
+                       every emitted .ptx must also assemble with ptxas
+                       when one is available (skipped with a note when it
+                       is missing or too old). Error examples must still
+                       fail. Works on GPU-less CI.
   -x, --fail-fast      Stop at the first failure.
   -v, --verbose        Stream cargo output live (instead of capturing to
                        a per-example log file). Verdict is printed at the
@@ -326,14 +329,17 @@ if [[ "${host_cc}" =~ ^([0-9]+)\.[0-9]+$ ]] && [[ $((10#${BASH_REMATCH[1]})) -ge
 fi
 
 # ---- ptxas gate ------------------------------------------------------------
-# Compile-only style verdicts for the GPU-gated categories (tcgen05, wgmma,
-# blackwell-mma) accepted "a .ptx exists". That bar misses PTX that llc emits
-# but ptxas rejects: e.g. `.global` initializers referencing `.shared`
-# symbols, which fail driver JIT with CUDA_ERROR_INVALID_PTX only on the
-# gated hardware. When a ptxas is available, actually assemble the PTX for
-# the arch recorded in its `.target` line. Resolution order matches how the
-# examples themselves shell out to ptxas: explicit override, PATH, then the
-# CUDA toolkit install locations.
+# Compile-only verdicts accepted "a .ptx exists". That bar misses PTX that
+# llc emits but ptxas rejects: e.g. `.global` initializers referencing
+# `.shared` symbols, which fail driver JIT with CUDA_ERROR_INVALID_PTX only
+# on real hardware. When a ptxas is available, actually assemble the PTX for
+# the arch recorded in its `.target` line. In --compile-only mode this
+# applies to EVERY example that emitted a .ptx (nothing executes there, so
+# assembly is the strongest available check); in normal mode only the
+# GPU-gated categories (tcgen05, wgmma, blackwell-mma) use it, since real
+# execution supersedes assembly for everything else. Resolution order
+# matches how the examples themselves shell out to ptxas: explicit override,
+# PATH, then the CUDA toolkit install locations.
 PTXAS_BIN=""
 for ptxas_candidate in "${CUDA_OXIDE_PTXAS:-}" \
                        "$(command -v ptxas 2>/dev/null)" \
@@ -790,18 +796,14 @@ verdict_compile() {
     if [[ ${ec} -ne 0 ]]; then   echo "FAIL (exit=${ec})";                    return 1; fi
     if verify_nvvm_in_compile_only "${ex}"; then
         if [[ -s "${ex_dir}/${artifact}.ll" && -s "${ex_dir}/${artifact}.ltoir" ]]; then
-            # A GPU-gated example may also have produced a .ptx via its
-            # direct-LLVM invocation (e.g. tcgen05's dual-route branch);
-            # that artifact must assemble like any other gated PTX.
-            case "$(classify "${ex}")" in
-                tcgen05|wgmma|blackwell-mma)
-                    if [[ -s "${ex_dir}/${artifact}.ptx" ]] \
-                        && ! ptxas_verify "${ex_dir}/${artifact}.ptx"; then
-                        echo "FAIL (${PTXAS_NOTE})"
-                        return 1
-                    fi
-                    ;;
-            esac
+            # An example may also have produced a .ptx via its direct-LLVM
+            # invocation (e.g. tcgen05's dual-route branch); that artifact
+            # must assemble like any other compile-only PTX.
+            if [[ -s "${ex_dir}/${artifact}.ptx" ]] \
+                && ! ptxas_verify "${ex_dir}/${artifact}.ptx"; then
+                echo "FAIL (${PTXAS_NOTE})"
+                return 1
+            fi
             echo "PASS (verified and compiled by libNVVM)"
             return 0
         fi
@@ -809,20 +811,14 @@ verdict_compile() {
         return 1
     fi
     if [[ -s "${ex_dir}/${artifact}.ptx" ]]; then
-        # GPU-gated categories never execute in compile-only mode, so the
-        # PTX must at least assemble: driver-JIT-only errors (e.g. .shared
-        # symbols in .global initializers) otherwise pass CI silently.
-        case "$(classify "${ex}")" in
-            tcgen05|wgmma|blackwell-mma)
-                if ! ptxas_verify "${ex_dir}/${artifact}.ptx"; then
-                    echo "FAIL (${PTXAS_NOTE})"
-                    return 1
-                fi
-                echo "PASS (compiled; ${PTXAS_NOTE})"
-                return 0
-                ;;
-        esac
-        echo "PASS (compiled)"
+        # Nothing executes in compile-only mode, so every emitted PTX must
+        # at least assemble: driver-JIT-only errors (e.g. .shared symbols
+        # in .global initializers) otherwise pass CI silently.
+        if ! ptxas_verify "${ex_dir}/${artifact}.ptx"; then
+            echo "FAIL (${PTXAS_NOTE})"
+            return 1
+        fi
+        echo "PASS (compiled; ${PTXAS_NOTE})"
         return 0
     fi
     if [[ -s "${ex_dir}/${artifact}.ll" ]]; then


### PR DESCRIPTION
## The bug

After the LLVM 23 bump, `gemm_views`' naive raw kernel lost 26% (7218 → 5708 GFLOPS) while its safe twin stayed put. The PTX math was identical — only the *jump layout* of the loop changed:

```text
llc-22 (fast)                          llc-23 (slow)
$LOOP:                                 $LOOP:
   ...same loads and FMAs...              ...same loads and FMAs...
   setp.eq  %p, %r3, %r26;                setp.eq  %p, %r3, %r26;
   @%p  bra $EXIT;    ← if done, leave    @!%p bra $LOOP;  ← if NOT done,
   bra.uni  $LOOP;    ← jump back                            jump back;
$EXIT:                                                       exit falls
                                                             through
```

LLVM 23's NVPTX backend learned to reverse branch conditions (llvm/llvm-project #191889, follow-up #191890), letting branch folding + block placement collapse the two-jump idiom. Legal, one instruction smaller — but **ptxas's SASS unroller recognizes hot loops by that layout** and stops unrolling the folded form:

```text
what ptxas produced          llc-22 layout    llc-23 layout
  registers                      38               26
  FMAs in the loop               18                4
  loads in flight                35                7    ← the 26%
```

Bisected by hand-editing PTX (live-benched, bit-identical numerics): ptxas requires the old orientation at **two** sites — the loop guard's taken-branch entering the loop, and the latch's taken-branch exiting with `bra.uni` continue. Negated predicates themselves are innocent.

## The fix

Two ancient, generic, disable-only llc flags on every llc invocation:

```text
-disable-branch-fold -disable-block-placement
    accepted identically by llc-21 / 22 / 23
    only TURN OFF passes → no new behavior to be wrong
    cost: PTX +2.6% lines suite-wide (redundant jumps that
    ptxas discards when laying out SASS itself)
```

Result, live on an RTX 5090: naive raw back to **7201 GFLOPS** (README table refreshed; all four kernels match the pre-bump numbers again). Upstream has no scoped opt-out (the enabling PR shipped with a single LGTM and no discussion of ptxas loop-shape sensitivity); an LLVM issue and an internal NVBug for the ptxas side are queued separately.

## Is it safe for everything else?

- **Correctness**: full GPU smoketest **221/221** — every example executes and self-checks numerically with the flags on.
- **Codegen sweep**: 890 kernels across 197 modules, per-kernel `ptxas -v` registers compared with/without the flags. 45 kernels move, every one explained:

```text
class                                    examples                         meaning
the unroller waking back up              table-lookup scan loops now      the intended
(registers AND SASS body grow)           fully unroll (SASS 64→~400),     effect
                                         array_index, split_at_mut, ...
exact return to pre-bump registers       dpx_minmax_chains (10 kernels    restoration
                                         20→18 = old baseline), others
tiny scheduling deltas, SASS size flat   hashmap_v3 (48→46),              benign
                                         set_discriminant_niche (38→39)
```

  Zero unexplained movers, zero below pre-bump baselines.
- **Benched where benches exist**: gemm_views restored; the warp-reduction family measured at ±0.3% (noise) at example scale and marginally *faster* at compute-bound scale.
- Honest asterisk: a few table-lookup micro-examples now unroll *beyond* their pre-bump shape (regs → 40). Numerically verified on hardware; no perf gate exists for them; expected faster (unrolled scans), not benchmarked.

## Also in this PR: ptxas gate for every example in CI

The compile-only smoketest (CI's mode) now assembles **every** example's PTX with ptxas, not just the GPU-gated categories — closing the remaining "llc emits garbage silently" window for all 221 examples. Measured cost: 183 files assembled in +4.5s, ~3% of the compile-only run. Normal-mode verdicts keep their scope: on a GPU box, execution supersedes assembly.

## Separate finding, measured and closed: the warp-reduction family

LLVM 23 unrolls the warp-shuffle reduction loops less at the IR level (PTX 97→60 lines, before ptxas). Benched properly: **immaterial** — ±0.3% at example geometry, 0.06-0.14% *faster* at 25M-thread scale, bitwise-identical outputs. Documented, deliberately not "fixed": chasing the old unrolled shape would spend registers for nothing.

## Validation

```text
cargo test --workspace          5307 passed, 0 failed
full GPU smoketest              221/221 (321s)
compile-only + wide gate        221/221 (141s, gate cost +4.5s)
register sweep                  890 kernels, all movers accounted for
gemm_views live bench           naive raw 5708 → 7201 GFLOPS
fmt / clippy / lock + contract  clean
```
