### PR TITLE
docs(examples): correct stale tcgen05 consumer Blackwell claims (carries #1202)

### DIFF
--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -70,8 +70,11 @@
 //!
 //! # Hardware Support
 //!
-//! - **sm_100/sm_100a**: B100, B200 (Data Center)
-//! - **sm_120/sm_120a**: RTX 5090 (Consumer)
+//! - **sm_100/sm_100a**: B100, B200 (Datacenter Blackwell)
+//! - **sm_103a, sm_110a**: B300 (Blackwell Ultra), Jetson Thor (Thor robotics/embedded); supported via the `compute_100` TMEM-capable architecture family
+//!
+//! Note: Consumer Blackwell (sm_120, RTX 50 series) does not implement TMEM or
+//! the tcgen05 instruction set; tensor operations on sm_120 use register-based `mma.sync`.
 
 use core::marker::PhantomData;
 

--- a/crates/cuda-device/src/tcgen05.rs
+++ b/crates/cuda-device/src/tcgen05.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Tensor Core Gen 5 (tcgen05) for Blackwell architectures (sm_100+).
+//! Tensor Core Gen 5 (tcgen05) for datacenter Blackwell architectures (sm_100a family).
 //!
 //! tcgen05 is Blackwell's tensor core instruction set, replacing WGMMA from Hopper.
 //! The key architectural change is **single-thread MMA semantics** - one thread can
@@ -71,7 +71,10 @@
 //! # Hardware Support
 //!
 //! - **sm_100/sm_100a**: B100, B200 (Datacenter Blackwell)
-//! - **sm_103a, sm_110a**: B300 (Blackwell Ultra), Jetson Thor (Thor robotics/embedded); supported via the `compute_100` TMEM-capable architecture family
+//! - **sm_101a, sm_103a, sm_110a**: B300 (Blackwell Ultra), Jetson Thor
+//!   (robotics/embedded); rest of the TMEM-capable `compute_100` family
+//!   (same set the tcgen05 examples gate execution on: cc 10.0 / 10.1 /
+//!   10.3 / 11.0)
 //!
 //! Note: Consumer Blackwell (sm_120, RTX 50 series) does not implement TMEM or
 //! the tcgen05 instruction set; tensor operations on sm_120 use register-based `mma.sync`.

--- a/crates/rustc-codegen-cuda/examples/tcgen05/README.md
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/README.md
@@ -1,6 +1,6 @@
 # tcgen05
 
-## tcgen05 - Blackwell (sm_100+) 5th Gen Tensor Cores
+## tcgen05 - Datacenter Blackwell (sm_100a) 5th Gen Tensor Cores
 
 Tests tcgen05 (Tensor Core Gen 5) infrastructure for Blackwell GPUs. This is the next generation of tensor core instructions, replacing Hopper's WGMMA.
 
@@ -117,8 +117,6 @@ cargo oxide run tcgen05
 === Unified tcgen05 Example ===
 
 GPU Compute Capability: sm_100
-
-Loading PTX from: tcgen05.ptx
 ✓ PTX loaded successfully
 
 --- Test: tcgen05 Fence Primitives ---
@@ -153,7 +151,7 @@ TMEM address: 0x00000000
 ## Hardware Requirements
 
 - **Required GPU**: Blackwell datacenter B100, B200 or newer (sm_100a)
-- **NOT supported**: Hopper (sm_90 — uses WGMMA), Ada (sm_89), Consumer Blackwell (sm_120)
+- **NOT supported**: Hopper (sm_90, uses WGMMA), Ada (sm_89), Consumer Blackwell (sm_120)
 - **CUDA Driver**: 12.x with Blackwell support
 
 ## tcgen05 vs WGMMA (Hopper)

--- a/crates/rustc-codegen-cuda/examples/tcgen05/README.md
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/README.md
@@ -152,15 +152,15 @@ TMEM address: 0x00000000
 
 ## Hardware Requirements
 
-- **Required GPU**: Blackwell B100, B200 or newer (sm_100/sm_120)
-- **NOT supported**: Hopper (sm_90 — uses WGMMA), Ada (sm_89)
+- **Required GPU**: Blackwell datacenter B100, B200 or newer (sm_100a)
+- **NOT supported**: Hopper (sm_90 — uses WGMMA), Ada (sm_89), Consumer Blackwell (sm_120)
 - **CUDA Driver**: 12.x with Blackwell support
 
 ## tcgen05 vs WGMMA (Hopper)
 
-| Feature              | WGMMA (Hopper)       | tcgen05 (Blackwell)       |
+| Feature              | WGMMA (Hopper)       | tcgen05 (Blackwell DC)    |
 |----------------------|----------------------|---------------------------|
-| Architecture         | sm_90                | sm_100/sm_120             |
+| Architecture         | sm_90                | sm_100a                   |
 | Accumulator storage  | Register file        | TMEM (separate memory)    |
 | Accumulator capacity | Limited by registers | Larger (TMEM)             |
 | Issue model          | 128-thread warpgroup | Single thread             |

--- a/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tcgen05/src/main.rs
@@ -24,7 +24,7 @@
 //! MMA tiles. All tcgen05 instructions in a kernel must use the same
 //! cta_group value.
 //!
-//! NOTE: tcgen05 is Blackwell-only (sm_100/sm_120).
+//! NOTE: tcgen05 is Blackwell datacenter-only (sm_100a).
 //!
 //! Build and run with:
 //!   cargo oxide run tcgen05

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/README.md
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/README.md
@@ -104,12 +104,12 @@ cargo oxide run tcgen05_matmul
 
 ## Expected Output
 
-### On Blackwell (sm_100/sm_120):
+### On Blackwell Datacenter (sm_100a):
 
 ```text
 === Unified tcgen05 Matmul Example ===
 
-GPU Compute Capability: sm_120
+GPU Compute Capability: sm_100
 Loading PTX from: tcgen05_matmul.ptx
 ✓ PTX loaded successfully
 
@@ -136,12 +136,14 @@ SUM CHECK:
 === tcgen05 Matmul Test Complete ===
 ```
 
-### On Pre-Blackwell:
+### On Non-Datacenter GPUs (Consumer Blackwell, Hopper, Ada):
 
 ```text
-GPU Compute Capability: sm_90
+GPU Compute Capability: sm_120
 
-⚠️  WARNING: tcgen05 requires sm_100/sm_120 (Blackwell) or newer!
+⚠️  tcgen05 (5th gen tensor cores) requires sm_100 (datacenter Blackwell only).
+   Your GPU is sm_120 (consumer Blackwell has no tcgen05).
+   PTX was generated successfully; run on sm_100 to execute kernels.
 
 📝 PTX Verification:
    PTX file generated at: tcgen05_matmul.ptx
@@ -149,7 +151,8 @@ GPU Compute Capability: sm_90
 
 ## Hardware Requirements
 
-- **Required GPU**: Blackwell B100, B200 or newer (sm_100/sm_120)
+- **Required GPU**: Blackwell datacenter B100, B200 or newer (sm_100a)
+- **NOT supported**: Consumer Blackwell (sm_120), Hopper (sm_90), Ada (sm_89)
 - **CUDA Driver**: 12.x with Blackwell support
 - **Memory**: ~32KB shared memory per block
 

--- a/crates/rustc-codegen-cuda/examples/tcgen05_matmul/README.md
+++ b/crates/rustc-codegen-cuda/examples/tcgen05_matmul/README.md
@@ -1,6 +1,6 @@
 # tcgen05_matmul
 
-## tcgen05 Matrix Multiplication - Blackwell (sm_100+) Tensor Core GEMM
+## tcgen05 Matrix Multiplication - Datacenter Blackwell (sm_100a) Tensor Core GEMM
 
 128×128×16 matrix multiplication using Blackwell's 5th generation tensor cores with TMA for data loading and pre-tiled input matrices.
 
@@ -110,7 +110,6 @@ cargo oxide run tcgen05_matmul
 === Unified tcgen05 Matmul Example ===
 
 GPU Compute Capability: sm_100
-Loading PTX from: tcgen05_matmul.ptx
 ✓ PTX loaded successfully
 
 --- Test: tcgen05_matmul_128x128_tiled ---
@@ -139,14 +138,21 @@ SUM CHECK:
 ### On Non-Datacenter GPUs (Consumer Blackwell, Hopper, Ada):
 
 ```text
+=== Unified tcgen05 Matmul Example ===
+
 GPU Compute Capability: sm_120
 
-⚠️  tcgen05 (5th gen tensor cores) requires sm_100 (datacenter Blackwell only).
+⚠️  WARNING: tcgen05 requires sm_100 (datacenter Blackwell)!
    Your GPU is sm_120 (consumer Blackwell has no tcgen05).
    PTX was generated successfully; run on sm_100 to execute kernels.
 
 📝 PTX Verification:
-   PTX file generated at: tcgen05_matmul.ptx
+   PTX file generated at: .../tcgen05_matmul/tcgen05_matmul.ptx
+
+📝 To inspect generated PTX:
+   cat .../tcgen05_matmul/tcgen05_matmul.ptx
+
+   Look for: tcgen05.mma instructions
 ```
 
 ## Hardware Requirements

--- a/cuda-oxide-book/gpu-safety/the-safety-model.md
+++ b/cuda-oxide-book/gpu-safety/the-safety-model.md
@@ -531,14 +531,14 @@ architectures. Every call is `unsafe`, the safety contracts are complex
 and architecture-dependent, and the documentation lives in the PTX ISA
 manual more than in Rust doc comments.
 
-| Feature                              | Key APIs                                                      | Architectures      |
-|:-------------------------------------|:--------------------------------------------------------------|:-------------------|
-| **TMA** (Tensor Memory Accelerator)  | `tma_load_2d`, `tma_store_2d`, `TmaDescriptor`                | sm_90+ (Hopper)    |
-| **tcgen05** (Tensor Core Gen 5)      | `tcgen05_mma`, `tcgen05_commit`, `TensorMemoryHandle`         | sm_120 (Blackwell) |
-| **WGMMA** (Warpgroup MMA)            | `wgmma_mma_async`, `wgmma_commit_group`, `wgmma_wait_group`   | sm_90+ (Hopper)    |
-| **Cluster**                          | `cluster_rank`, `map_shared_rank`, `cluster_barrier_arrive`   | sm_90+ (Hopper)    |
-| **CLC** (Cluster Launch Control)     | `clc_prefetch`, `clc_query_channel`                           | sm_120 (Blackwell) |
-| **TMEM** (Tensor Memory)             | `TmemGuard` (typestate), `tmem_alloc`, `tmem_dealloc`         | sm_120 (Blackwell) |
+| Feature                              | Key APIs                                                      | Architectures          |
+|:-------------------------------------|:--------------------------------------------------------------|:-----------------------|
+| **TMA** (Tensor Memory Accelerator)  | `tma_load_2d`, `tma_store_2d`, `TmaDescriptor`                | sm_90+ (Hopper)        |
+| **tcgen05** (Tensor Core Gen 5)      | `tcgen05_mma`, `tcgen05_commit`, `TensorMemoryHandle`         | sm_100a (Blackwell DC) |
+| **WGMMA** (Warpgroup MMA)            | `wgmma_mma_async`, `wgmma_commit_group`, `wgmma_wait_group`   | sm_90+ (Hopper)        |
+| **Cluster**                          | `cluster_rank`, `map_shared_rank`, `cluster_barrier_arrive`   | sm_90+ (Hopper)        |
+| **CLC** (Cluster Launch Control)     | `clc_prefetch`, `clc_query_channel`                           | sm_100+ (Blackwell)    |
+| **TMEM** (Tensor Memory)             | `TmemGuard` (typestate), `tmem_alloc`, `tmem_dealloc`         | sm_100a (Blackwell DC) |
 
 If you are writing application-level kernels, you should not need Tier 3
 APIs. They exist for the people building the next CUTLASS -- and for those


### PR DESCRIPTION
Carries @pedrozaz's docs fix from #1202, rebased past #1203. His commit and authorship are preserved; a maintainer slip while force-pushing the rebase to his branch auto-closed the original PR (details there), so this branch re-hosts it. Fixes #1194.

**The problem**

Several docs claimed consumer Blackwell (sm_120, RTX 50 series) runs tcgen05. It doesn't; tcgen05 and TMEM exist only on datacenter Blackwell:

```
docs said:                          hardware reality:
  tcgen05: sm_100/sm_120             tcgen05: sm_100a family only
                                       (sm_100a/sm_101a/sm_103a/sm_110a)
$ ptxas -arch=sm_120a tcgen05.ptx
  error: Instruction 'tcgen05.alloc' not supported on .target 'sm_120a'
```

@pedrozaz verified the ptxas rejection on a real RTX 5060 Ti.

**What this changes** (docs only; #1203 already landed the runtime gate)

- both tcgen05 example READMEs: sm_100a family, explicit "NOT supported: Consumer Blackwell (sm_120)" notes
- `cuda-device` tcgen05 rustdoc: drops "sm_120/sm_120a: RTX 5090 (Consumer)", lists the real family incl. sm_101a to match the runtime allowlist
- book safety-model Tier 3 table: tcgen05/TMEM rows to "sm_100a (Blackwell DC)", CLC row to "sm_100+ (Blackwell)"
- tcgen05 crate-doc line: "Blackwell datacenter-only (sm_100a)"
- README "expected output" transcripts re-synced to what the post-#1203 code literally prints

**What it deliberately does not change**

The PR's original runtime half (compute-capability pre-check, ptxas retarget) was superseded by #1203's stronger version on main (loud `CUDA_ERROR_INVALID_PTX` classification, `.target`-parsed ptxas arch). Main's code is kept wholesale.

**Validation**

- `cargo fmt --check` clean, book builds with zero warnings
- diff touches only the five doc sites; both examples' `src/main.rs` byte-identical to main except one crate-doc comment line
- transcripts compared line-by-line against every `println!` in both examples
