### PR TITLE
fix(nix): advance the rust-overlay pin to the toolchain's nightly, and gate the flake in CI

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,37 @@
+---
+name: flake
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # flake.nix derives its toolchain from rust-toolchain.toml, so flake.lock has
+  # to know every nightly that file names. #1201 moved the pin without moving
+  # the lock, and every flake output stopped evaluating. The toolchain-pin
+  # parity guard does not cover this: it compares copies of the pin text, not
+  # the lock's capacity to resolve it.
+  evaluation:
+    name: flake evaluation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.1
+
+      - name: Evaluate development shell and cargo-oxide package
+        run: |
+          nix eval .#devShells.x86_64-linux.default.drvPath
+          nix eval .#packages.x86_64-linux.cargo-oxide.drvPath

--- a/Justfile
+++ b/Justfile
@@ -131,6 +131,14 @@ check-intrinsics base_ref="HEAD^":
     cargo run -p cuda-intrinsics-gen -- probe --all --skip-terminal
     cargo run -p cuda-intrinsics-gen -- check-abi-history --base-ref {{base_ref}}
 
+# flake.lock has to be able to resolve the pin in rust-toolchain.toml, and
+# nothing else checks that. Kept out of `check` and `check-guards` so those
+# stay runnable without Nix.
+# Evaluate the dev shell and cargo-oxide package against flake.lock (needs Nix)
+check-flake:
+    nix eval .#devShells.x86_64-linux.default.drvPath
+    nix eval .#packages.x86_64-linux.cargo-oxide.drvPath
+
 # Build docs warning-free + run doctests (mirrors the docs CI gate). The `test`
 # recipe uses `--all-targets`, which skips doctests, so this covers them.
 # cuda-bindings is excluded from doctests (its generated C doc comments are not
@@ -221,9 +229,12 @@ check-errors:
 # failed. Keep this list in step when a guard is added to any of the three
 # workflows -- the crate-inventory and toolchain-parity jobs were added to CI
 # without being added here, which is the same drift this recipe exists to
-# prevent. Prerequisites: `cargo-deny` on PATH (`cargo install cargo-deny
-# --locked`) and `python3` (most of the scripts drive it). The scripts are
-# invoked via `bash` as CI does, since not all of them carry an exec bit.
+# prevent. The flake evaluation gate has its own `check-flake` recipe and is
+# deliberately not part of `check-guards`, so contributors without Nix can
+# still run this list. Prerequisites: `cargo-deny` on PATH (`cargo install
+# cargo-deny --locked`) and `python3` (most of the scripts drive it). The
+# scripts are invoked via `bash` as CI does, since not all of them carry an
+# exec bit.
 # Run the status-guard, naming-guard and cargo-deny CI jobs (needs cargo-deny, python3)
 check-guards:
     bash scripts/check-error-example-status.sh

--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778296574,
-        "narHash": "sha256-DVmg1JCjG0VJTa+FF6tH6tkQChaxzK1EzPL98RiRWU0=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1d634a90dffb59ec9ba52652de311b15528c1595",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Fixes #1209. Every flake output fails to evaluate on `main`: `flake.nix` derives its toolchain from `rust-toolchain.toml`, but `fe616639d` (#1201) moved the pin to `nightly-2026-08-28` without updating the 2026-05-09 `rust-overlay` lock revision. That revision predates the nightly, so both the dev shell `CONTRIBUTING.md:123` recommends and the `cargo-oxide` package fail with `error: Nightly 2026-08-28 is not available`.

This advances only `rust-overlay` and adds the gate that would have caught the drift.

## Changes

- `flake.lock`: advance `rust-overlay` from `1d634a90` (2026-05-09) to `89e26eea` (2026-08-30). No other node moves; `nixpkgs`, CUDA, LLVM, and support packages remain pinned. Advancing that one input is sufficient; a whole-lock bump is not needed.
- `.github/workflows/flake.yml`: evaluate both public outputs without building the toolchain. No existing workflow evaluated the flake.
- `Justfile`: mirror the gate as `check-flake`, outside `check` and `check-guards` so contributors without Nix can still run them.

### Why a flake evaluation and not an extension of `check-toolchain-parity.sh`

`check-toolchain-parity.sh` compares copies of the pin text: the nested `rustc-codegen-cuda` pin, the `cargo oxide new` scaffold, the devcontainer, and the book's quoted `[toolchain]` blocks. `flake.lock` is not another copy; its overlay must resolve the pin. Comparing `lastModified` with the nightly date could pass when the dates align even if the flake does not work. Evaluating both output derivations tests the property that broke and builds no toolchain; the cost is installing Nix and fetching inputs, with evaluation taking about a second once cached.

## Testing

Before, on `8b41ac1b5`:

```console
$ nix eval .#devShells.x86_64-linux.default.drvPath
error: Nightly 2026-08-28 is not available
$ nix eval .#packages.x86_64-linux.cargo-oxide.drvPath
error: Nightly 2026-08-28 is not available
```

After, on this branch (`just check-flake`; the store hashes depend on the source tree, the point is that both resolve):

```console
$ nix eval .#devShells.x86_64-linux.default.drvPath
"/nix/store/0jbdhnhg28fmaa7x0l5gf5mly8n7yra4-nix-shell.drv"
$ nix eval .#packages.x86_64-linux.cargo-oxide.drvPath
"/nix/store/b9xq9d7w8yqd9cshkc9xkl8j8risqam9-cargo-oxide-0.2.1.drv"
```

The shell also supplies the pinned rustc 1.100 / LLVM 23 toolchain and CUDA, and completes a workspace check:

```console
$ nix develop --command rustc --version --verbose
rustc 1.100.0-nightly (e457a7b0d 2026-08-27)
commit-date: 2026-08-27
release: 1.100.0-nightly
LLVM version: 23.1.0

$ nix develop --command cargo --version
cargo 1.100.0-nightly (e8cb624d5 2026-08-22)

$ nix develop --command bash -c 'nvcc --version | tail -2'
Cuda compilation tools, release 13.2, V13.2.51

$ nix develop --command cargo check --workspace --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.00s
```

`just check` runs in the restored shell and gets through `fmt-check`, `clippy`, `test`, `test-cuda`, and all of `check-guards`. It stops in `check-intrinsics`:

```console
$ nix develop --command just check
error: validate probe backend for abs_bf16x2: rust-toolchain llc SHA-256 mismatch:
selected evidence records 2e5bc688...f921, found ca7af83e...7b49
```

That is not this change and not a missing `llc`. `intrinsics/catalog.json` pins the probe backend by binary hash, and the recorded `2e5bc688...` is byte-for-byte the `llc` that rustup ships for `nightly-2026-08-28`. The shell's `llc` is the same nightly and reports the same `LLVM version 23.1.0-rust-1.100.0-nightly`, but nixpkgs rewrites its ELF interpreter and RPATH into the store, so its hash cannot match. Any `nix develop` shell hits this, before and after this PR. It does mean the environment `CONTRIBUTING.md` recommends cannot run the repo's own probe validation; that is a separate problem and I have not touched it here.

One standard example end to end in the same shell, on an RTX 5080:

```console
$ nix develop --command cargo oxide run vecadd
Detected GPU arch: sm_120a (via nvidia-smi)
    Finished `release` profile [optimized] target(s) in 10.79s
     Running `target/release/vecadd`
✓ SUCCESS: All 1024 elements correct!
```

The new workflow has never run on GitHub Actions; this PR's runs are `action_required` pending maintainer approval. Locally, its two commands pass through `just check-flake`. `cachix/install-nix-action` enables `nix-command flakes` by default, so no `extra_nix_config` is needed. The action uses the exact `v31.11.1` release because no floating `v31` tag exists, matching the `Jimver/cuda-toolkit@v0.2.35` precedent.

- [ ] `just check` passes (the local mirror of CI: fmt, clippy, tests, guards, docs) (fmt, clippy, tests, CUDA tests and guards pass; `check-intrinsics` cannot pass inside any `nix develop` shell, for the pre-existing reason above)
- [x] `cargo oxide run <example>` passes, or `scripts/smoketest.sh -o '^<example>$'` (`vecadd`, in the restored shell, on hardware)
- [ ] New example added (not applicable)

## Checklist

- [x] All commits signed off (`git commit -s`)
- [x] SPDX headers on new source files (the new file is a workflow; workflows here carry none)

## Out of scope, noted for the record

`flake.nix:85` still selects `pkgs.llvmPackages_22` while the pin uses rustc 1.100 with LLVM 23. It does not block evaluation and remains separate from this lock fix; #1209 records it.
