### PR TITLE
[WIP - Please do not review] feat(intrinsics): validate PTX floors from evidence

### DIFF
--- a/crates/cuda-intrinsics-gen/src/main.rs
+++ b/crates/cuda-intrinsics-gen/src/main.rs
@@ -94,6 +94,26 @@ fn try_main() -> Result<()> {
             },
             ProbeInvocation::Candidate(options) => probe::run_candidate(&repo_root, options),
         },
+        "probe-floors" => {
+            let llc = take_option(&mut arguments, "--llc")?
+                .map(PathBuf::from)
+                .context("probe-floors requires --llc FILE")?;
+            let ptxas = take_option(&mut arguments, "--ptxas")?
+                .map(PathBuf::from)
+                .context("probe-floors requires --ptxas FILE")?;
+            let intrinsic_id = take_option(&mut arguments, "--intrinsic")?;
+            let declared_floor = take_option(&mut arguments, "--declared-floor")?;
+            reject_extra(arguments)?;
+            probe::run_floors(
+                &repo_root,
+                probe::FloorProbeOptions {
+                    llc,
+                    ptxas,
+                    intrinsic_id,
+                    declared_floor,
+                },
+            )
+        }
         "check-abi-history" => {
             let base_ref = take_option(&mut arguments, "--base-ref")?
                 .context("check-abi-history requires --base-ref REF")?;
@@ -198,6 +218,7 @@ fn print_usage() {
          cuda-intrinsics-gen coverage [--family NAME] [--repo-root DIR]\n  \
          cuda-intrinsics-gen check-abi-history --base-ref REF [--repo-root DIR]\n  \
          cuda-intrinsics-gen probe [--all | --intrinsic ID] [--llc FILE] [--skip-terminal] [--per-target] [--repo-root DIR]\n  \
+         cuda-intrinsics-gen probe-floors --llc FILE --ptxas FILE [--intrinsic ID --declared-floor VERSION] [--repo-root DIR]\n  \
          cuda-intrinsics-gen probe --candidate --intrinsic ID --llc FILE --gpu-target TARGET --ptx-feature FEATURE (--ptxas FILE | --skip-terminal) [--repo-root DIR]"
     );
 }

--- a/crates/cuda-intrinsics-gen/src/probe.rs
+++ b/crates/cuda-intrinsics-gen/src/probe.rs
@@ -12,6 +12,10 @@ use crate::ptx::{
     InstructionPattern, OperandPattern, instructions_with_matching_head, matching_instructions,
 };
 use crate::render::render_probe;
+use crate::resolve::{
+    FloorEvidenceFile, FloorEvidenceRecord, MINIMUM_PROBEABLE_PTX, evidence_path,
+    floor_policy_declarations, parse_version, resolve_without_floor_evidence,
+};
 use crate::resolve::{resolve, resolve_candidate};
 use crate::util::{pretty_json, sha256_bytes, sha256_file};
 use anyhow::{Context, Result, ensure};
@@ -43,6 +47,179 @@ pub(crate) struct CandidateProbeOptions {
     pub ptx_feature: String,
     pub ptxas: Option<PathBuf>,
     pub skip_terminal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FloorProbeOptions {
+    pub llc: PathBuf,
+    pub ptxas: PathBuf,
+    pub intrinsic_id: Option<String>,
+    pub declared_floor: Option<String>,
+}
+
+pub(crate) fn run_floors(repo_root: &Path, options: FloorProbeOptions) -> Result<()> {
+    const SPELLINGS: &[&str] = &[
+        "1.0", "1.1", "1.2", "1.3", "1.4", "2.0", "2.1", "2.2", "2.3", "3.0", "3.1", "3.2", "4.0",
+        "4.1", "4.2", "4.3", "5.0", "6.0", "6.1", "6.2", "6.3", "6.4", "6.5", "7.0", "7.1", "7.2",
+        "7.3", "7.4", "7.5", "7.6", "7.7", "7.8", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5", "8.6",
+        "8.7", "8.8", "9.0",
+    ];
+    let catalog = resolve_without_floor_evidence(repo_root)?;
+    ensure!(
+        options.intrinsic_id.is_some() == options.declared_floor.is_some(),
+        "floor-probe overrides require both --intrinsic and --declared-floor"
+    );
+    let mut declarations = floor_policy_declarations(repo_root)?;
+    if let (Some(id), Some(floor)) = (&options.intrinsic_id, &options.declared_floor) {
+        let declaration = declarations
+            .iter_mut()
+            .find(|declaration| declaration.0 == *id)
+            .with_context(|| format!("unknown floor-probe intrinsic {id}"))?;
+        declaration.1 = floor.clone();
+        declarations.retain(|declaration| declaration.0 == *id);
+    }
+    let llc_identity = llc_identity(&options.llc)?;
+    let ptxas_identity = ptxas_identity(&options.ptxas)?;
+    let output_dir = repo_root.join("target/intrinsics/floor-probes");
+    fs::create_dir_all(&output_dir)?;
+    let catalog_hash = sha256_bytes(pretty_json(&catalog)?.as_bytes());
+    let minimum_probeable = parse_version(MINIMUM_PROBEABLE_PTX)?;
+    let mut records = Vec::with_capacity(declarations.len());
+
+    for (index, (id, minimum_ptx, _minimum_sm)) in declarations.iter().enumerate() {
+        eprintln!(
+            "[{}/{}] probing PTX floor for {id}",
+            index + 1,
+            declarations.len()
+        );
+        let encoded = parse_version(minimum_ptx)?;
+        if encoded < minimum_probeable {
+            records.push(FloorEvidenceRecord::Unverifiable {
+                id: id.clone(),
+                minimum_ptx: minimum_ptx.clone(),
+                reason: format!(
+                    "PTX {minimum_ptx} cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+                ),
+            });
+            continue;
+        }
+        let record = catalog
+            .intrinsics
+            .iter()
+            .find(|record| record.id == *id)
+            .with_context(|| format!("catalog has no exact-ID representative for {id}"))?;
+        let target = floor_probe_target(&record.backend.gpu_target)?;
+        let input = output_dir.join(format!("{id}.ll"));
+        let positive_ptx = output_dir.join(format!("{id}.ptx"));
+        let positive_cubin = output_dir.join(format!("{id}.cubin"));
+        fs::write(&input, render_probe(&catalog, record, &catalog_hash))?;
+        let ptx = lower_candidate_ptx(
+            &options.llc,
+            &input,
+            &target,
+            &format!("+ptx{}", minimum_ptx.replace('.', "")),
+            &positive_ptx,
+        )?;
+        validate_probe_instructions(record, &ptx)?;
+        assemble_candidate_ptx(&options.ptxas, &target, &positive_ptx, &positive_cubin)
+            .with_context(|| format!("declared PTX floor {minimum_ptx} was rejected for {id}"))?;
+
+        let rejected_ptx = previous_spelling(SPELLINGS, minimum_ptx)?;
+        let negative_source = replace_ptx_version(&ptx, minimum_ptx, rejected_ptx)?;
+        let negative_ptx = output_dir.join(format!("{id}.below.ptx"));
+        let negative_cubin = output_dir.join(format!("{id}.below.cubin"));
+        fs::write(&negative_ptx, negative_source)?;
+        remove_if_present(&negative_cubin)?;
+        let output = Command::new(&options.ptxas)
+            .arg(format!("-arch={target}"))
+            .arg(&negative_ptx)
+            .arg("-o")
+            .arg(&negative_cubin)
+            .output()
+            .with_context(|| format!("run {}", options.ptxas.display()))?;
+        ensure!(
+            !output.status.success(),
+            "below-floor positive control failed: ptxas accepted {id} at PTX {rejected_ptx}, below declared PTX {minimum_ptx}"
+        );
+        let rejection_detail = String::from_utf8_lossy(&output.stderr)
+            .lines()
+            .take(4)
+            .collect::<Vec<_>>()
+            .join("\n")
+            .replace(&output_dir.display().to_string(), "<floor-probe>");
+        ensure!(
+            !rejection_detail.trim().is_empty(),
+            "ptxas rejected {id} without a diagnostic"
+        );
+        records.push(FloorEvidenceRecord::Verified {
+            id: id.clone(),
+            minimum_ptx: minimum_ptx.clone(),
+            target,
+            accepted_ptx: minimum_ptx.clone(),
+            rejected_ptx: rejected_ptx.into(),
+            rejection_detail,
+        });
+    }
+    records.sort_by(|left, right| left.id().cmp(right.id()));
+    let evidence = FloorEvidenceFile {
+        schema: 1,
+        profile: "cuda-13.2.51-ptxas".into(),
+        tool_path: options.ptxas.display().to_string(),
+        tool_version: ptxas_identity.version,
+        tool_sha256: ptxas_identity.sha256,
+        llvm_tool_path: options.llc.display().to_string(),
+        llvm_tool_version: llc_identity.version.clone(),
+        llvm_tool_sha256: llc_identity.sha256.clone(),
+        minimum_supported_target: "sm_75".into(),
+        minimum_probeable_ptx: MINIMUM_PROBEABLE_PTX.into(),
+        records,
+    };
+    if options.intrinsic_id.is_some() {
+        println!("targeted floor probe succeeded; committed evidence was not changed");
+        return Ok(());
+    }
+    let path = evidence_path(repo_root);
+    fs::create_dir_all(path.parent().unwrap())?;
+    fs::write(&path, pretty_json(&evidence)?)?;
+    println!("recorded floor evidence: {}", path.display());
+    println!(
+        "measurement LLVM: {} ({})",
+        llc_identity.version, llc_identity.sha256
+    );
+    Ok(())
+}
+
+fn floor_probe_target(target: &str) -> Result<String> {
+    let digits: String = target
+        .strip_prefix("sm_")
+        .with_context(|| format!("invalid probe target {target}"))?
+        .chars()
+        .take_while(|character| character.is_ascii_digit())
+        .collect();
+    let sm: u16 = digits.parse()?;
+    Ok(if sm < 75 {
+        "sm_75".into()
+    } else {
+        target.into()
+    })
+}
+
+fn previous_spelling<'a>(spellings: &'a [&str], version: &str) -> Result<&'a str> {
+    let index = spellings
+        .iter()
+        .position(|candidate| *candidate == version)
+        .with_context(|| format!("PTX {version} is absent from the floor-probe spelling table"))?;
+    ensure!(index > 0, "PTX {version} has no lower spelling");
+    Ok(spellings[index - 1])
+}
+
+fn replace_ptx_version(ptx: &str, expected: &str, replacement: &str) -> Result<String> {
+    let directive = format!(".version {expected}");
+    ensure!(
+        ptx.matches(&directive).count() == 1,
+        "generated PTX does not contain exactly one {directive}"
+    );
+    Ok(ptx.replacen(&directive, &format!(".version {replacement}"), 1))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/crates/cuda-intrinsics-gen/src/resolve/driver.rs
+++ b/crates/cuda-intrinsics-gen/src/resolve/driver.rs
@@ -26,6 +26,7 @@ use std::path::Path;
 use super::abi_ledger::*;
 use super::evidence::*;
 use super::families::*;
+use super::floor_evidence::*;
 use super::materialize::*;
 use super::overlay::*;
 use super::policy::*;
@@ -70,6 +71,25 @@ pub(super) fn primary_evidence_profile<'a>(
 }
 
 pub fn resolve(repo_root: &Path) -> Result<CatalogFile> {
+    resolve_impl(repo_root, true)
+}
+
+pub(crate) fn resolve_without_floor_evidence(repo_root: &Path) -> Result<CatalogFile> {
+    resolve_impl(repo_root, false)
+}
+
+pub(crate) fn floor_policy_declarations(
+    repo_root: &Path,
+) -> Result<Vec<(String, String, Option<String>)>> {
+    Ok(load_resolution_base(repo_root)?
+        .overlay
+        .intrinsics
+        .into_iter()
+        .map(|policy| (policy.id, policy.minimum_ptx, policy.minimum_sm))
+        .collect())
+}
+
+fn resolve_impl(repo_root: &Path, validate_floors: bool) -> Result<CatalogFile> {
     let base = load_resolution_base(repo_root)?;
     let ResolutionBase {
         overlay,
@@ -82,6 +102,9 @@ pub fn resolve(repo_root: &Path) -> Result<CatalogFile> {
     let imported_by_record = index_imported_intrinsics(&imported)?;
     let llvm_revision = source.llvm_revision.clone();
     let (evidence_files, evidence_hashes) = read_evidence(repo_root)?;
+    if validate_floors {
+        validate_floor_evidence(repo_root, &overlay.intrinsics)?;
+    }
     let evidence_by_profile_id = index_evidence(&evidence_files, &llvm_revision)?;
 
     let mut intrinsics = Vec::with_capacity(overlay.intrinsics.len());

--- a/crates/cuda-intrinsics-gen/src/resolve/floor_evidence.rs
+++ b/crates/cuda-intrinsics-gen/src/resolve/floor_evidence.rs
@@ -1,0 +1,193 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::model::OverlayIntrinsic;
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) const FLOOR_EVIDENCE_SCHEMA: u32 = 1;
+pub(crate) const MINIMUM_PROBEABLE_PTX: &str = "6.3";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FloorEvidenceFile {
+    pub schema: u32,
+    pub profile: String,
+    pub tool_path: String,
+    pub tool_version: String,
+    pub tool_sha256: String,
+    pub llvm_tool_path: String,
+    pub llvm_tool_version: String,
+    pub llvm_tool_sha256: String,
+    pub minimum_supported_target: String,
+    pub minimum_probeable_ptx: String,
+    pub records: Vec<FloorEvidenceRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum FloorEvidenceRecord {
+    Verified {
+        id: String,
+        minimum_ptx: String,
+        target: String,
+        accepted_ptx: String,
+        rejected_ptx: String,
+        rejection_detail: String,
+    },
+    Unverifiable {
+        id: String,
+        minimum_ptx: String,
+        reason: String,
+    },
+}
+
+impl FloorEvidenceRecord {
+    pub(crate) fn id(&self) -> &str {
+        match self {
+            Self::Verified { id, .. } | Self::Unverifiable { id, .. } => id,
+        }
+    }
+
+    pub(crate) fn minimum_ptx(&self) -> &str {
+        match self {
+            Self::Verified { minimum_ptx, .. } | Self::Unverifiable { minimum_ptx, .. } => {
+                minimum_ptx
+            }
+        }
+    }
+}
+
+pub(crate) fn evidence_path(repo_root: &Path) -> PathBuf {
+    repo_root.join("intrinsics/floor-evidence/cuda-13.2.51-ptxas.json")
+}
+
+pub(super) fn validate_floor_evidence(
+    repo_root: &Path,
+    policies: &[OverlayIntrinsic],
+) -> Result<()> {
+    let path = evidence_path(repo_root);
+    let bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+    let file: FloorEvidenceFile = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse floor evidence {}", path.display()))?;
+    ensure!(
+        file.schema == FLOOR_EVIDENCE_SCHEMA,
+        "unsupported floor evidence schema"
+    );
+    ensure!(
+        file.minimum_supported_target == "sm_75",
+        "floor evidence must record sm_75 as the CUDA 13.2 minimum target"
+    );
+    ensure!(
+        file.minimum_probeable_ptx == MINIMUM_PROBEABLE_PTX,
+        "floor evidence must record PTX {MINIMUM_PROBEABLE_PTX} as its measurement boundary"
+    );
+    ensure!(
+        !file.tool_version.trim().is_empty() && file.tool_sha256.len() == 64,
+        "floor evidence does not pin a concrete ptxas"
+    );
+    ensure!(
+        !file.llvm_tool_version.trim().is_empty() && file.llvm_tool_sha256.len() == 64,
+        "floor evidence does not pin the LLVM tool that produced its PTX"
+    );
+
+    let mut indexed = BTreeMap::new();
+    for record in &file.records {
+        ensure!(
+            indexed.insert(record.id(), record).is_none(),
+            "duplicate floor evidence for {}",
+            record.id()
+        );
+    }
+    ensure!(
+        indexed.len() == policies.len(),
+        "floor evidence has {} records, catalog policy has {}",
+        indexed.len(),
+        policies.len()
+    );
+    let policy_ids: BTreeSet<_> = policies.iter().map(|policy| policy.id.as_str()).collect();
+    ensure!(
+        indexed.keys().copied().collect::<BTreeSet<_>>() == policy_ids,
+        "floor evidence IDs do not exactly cover catalog policy IDs"
+    );
+
+    for policy in policies {
+        let record = indexed[policy.id.as_str()];
+        ensure!(
+            record.minimum_ptx() == policy.minimum_ptx,
+            "{} floor evidence records PTX {}, catalog declares PTX {}",
+            policy.id,
+            record.minimum_ptx(),
+            policy.minimum_ptx
+        );
+        let encoded = parse_version(&policy.minimum_ptx)?;
+        match record {
+            FloorEvidenceRecord::Verified {
+                accepted_ptx,
+                rejected_ptx,
+                rejection_detail,
+                ..
+            } => {
+                ensure!(
+                    encoded >= 63,
+                    "{} claims a measured floor below the CUDA 13.2 measurement boundary",
+                    policy.id
+                );
+                ensure!(
+                    accepted_ptx == &policy.minimum_ptx,
+                    "{} accepted floor does not match its declaration",
+                    policy.id
+                );
+                ensure!(
+                    parse_version(rejected_ptx)? < encoded,
+                    "{} rejected spelling is not below its accepted spelling",
+                    policy.id
+                );
+                ensure!(
+                    !rejection_detail.trim().is_empty(),
+                    "{} verified verdict omits the negative-control diagnostic",
+                    policy.id
+                );
+            }
+            FloorEvidenceRecord::Unverifiable { reason, .. } => {
+                ensure!(
+                    encoded < 63,
+                    "{} is marked unverifiable even though CUDA 13.2 can express its floor",
+                    policy.id
+                );
+                ensure!(
+                    !reason.trim().is_empty(),
+                    "{} unverifiable verdict has no reason",
+                    policy.id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_ptx_versions() {
+        assert_eq!(parse_version("6.3").unwrap(), 63);
+        assert_eq!(parse_version("8.7").unwrap(), 87);
+        assert!(parse_version("63").is_err());
+        assert!(parse_version("6.30").is_err());
+    }
+}
+
+pub(crate) fn parse_version(value: &str) -> Result<u16> {
+    let (major, minor) = value
+        .split_once('.')
+        .with_context(|| format!("invalid PTX version {value}"))?;
+    ensure!(minor.len() == 1, "invalid PTX version {value}");
+    Ok(major.parse::<u16>()? * 10 + minor.parse::<u16>()?)
+}

--- a/crates/cuda-intrinsics-gen/src/resolve/mod.rs
+++ b/crates/cuda-intrinsics-gen/src/resolve/mod.rs
@@ -7,6 +7,7 @@ mod abi_ledger;
 mod driver;
 mod evidence;
 mod families;
+mod floor_evidence;
 mod guards;
 mod materialize;
 mod overlay;
@@ -18,6 +19,10 @@ mod tests;
 pub(crate) use abi_ledger::validate_operation_key;
 pub use driver::resolve;
 pub(crate) use driver::resolve_candidate;
+pub(crate) use driver::{floor_policy_declarations, resolve_without_floor_evidence};
+pub(crate) use floor_evidence::{
+    FloorEvidenceFile, FloorEvidenceRecord, MINIMUM_PROBEABLE_PTX, evidence_path, parse_version,
+};
 // The remaining pre-split surface: nothing outside `resolve` names these
 // today, so the re-exports would otherwise trip `unused_imports`.
 #[allow(unused_imports)]

--- a/intrinsics/floor-evidence/cuda-13.2.51-ptxas.json
+++ b/intrinsics/floor-evidence/cuda-13.2.51-ptxas.json
@@ -1,0 +1,8990 @@
+{
+  "schema": 1,
+  "profile": "cuda-13.2.51-ptxas",
+  "tool_path": "/nix/store/224kd1xyrzym6pcwxbvh1dlgcs0v2ch0-cuda-symlinked/bin/ptxas",
+  "tool_version": "Cuda compilation tools, release 13.2, V13.2.51",
+  "tool_sha256": "c0a7c9752d1a1b29310ffbb453e8b895fb09e909dcf7436fef5c2c986c1a658e",
+  "llvm_tool_path": "/nix/store/pjqx0w003mjz5wq9kwx2x84dq7pc67km-rust-default-1.100.0-nightly-2026-08-28/lib/rustlib/x86_64-unknown-linux-gnu/bin/llc",
+  "llvm_tool_version": "LLVM version 23.1.0-rust-1.100.0-nightly",
+  "llvm_tool_sha256": "ca7af83e237af640fe337faff2eff49055988921933186ab5535b38addeb7b49",
+  "minimum_supported_target": "sm_75",
+  "minimum_probeable_ptx": "6.3",
+  "records": [
+    {
+      "verdict": "verified",
+      "id": "abs_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/abs_bf16x2.below.ptx, line 20; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/abs_bf16x2.below.ptx, line 20; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/abs_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "abs_f16x2",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/abs_f16x2.below.ptx, line 20; error   : Feature 'abs.f16 or abs.f16x2' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "active_mask",
+      "minimum_ptx": "6.2",
+      "reason": "PTX 6.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_bf16x2",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/add_bf16x2.below.ptx, line 22; error   : Feature 'add.bf16x2' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/add_bf16x2.below.ptx, line 22; error   : Feature 'add.bf16x2' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/add_bf16x2.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "add_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/add_f32x2.below.ptx, line 22; error   : Feature 'add.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/add_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_ftz_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/add_ftz_f32x2.below.ptx, line 22; error   : Feature 'add.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/add_ftz_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rm_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rm_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rm_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rm_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rm_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rm_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rm_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rn_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rn_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rn_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rn_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rn_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rn_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rn_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rp_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rp_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rp_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rp_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rp_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rp_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rp_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rz_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rz_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rz_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rz_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "add_rz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/add_rz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "all_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "any_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "ballot_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_arrive",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_arrive.below.ptx, line 16; error   : Feature 'barrier.cluster.arrive' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/barrier_cluster_arrive.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_arrive_aligned",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_arrive_aligned.below.ptx, line 16; error   : Feature 'barrier.cluster.arrive' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/barrier_cluster_arrive_aligned.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_arrive_relaxed",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_arrive_relaxed.below.ptx, line 16; error   : Modifier '.relaxed' on 'barrier.cluster.arrive' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_arrive_relaxed_aligned",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_arrive_relaxed_aligned.below.ptx, line 16; error   : Modifier '.relaxed' on 'barrier.cluster.arrive' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_wait",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_wait.below.ptx, line 16; error   : Feature 'barrier.cluster.wait' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/barrier_cluster_wait.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "barrier_cluster_wait_aligned",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/barrier_cluster_wait_aligned.below.ptx, line 16; error   : Feature 'barrier.cluster.wait' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/barrier_cluster_wait_aligned.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "barrier_cta_arrive",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "barrier_cta_arrive_aligned",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "barrier_cta_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "barrier_cta_sync_aligned",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_dim_x",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_dim_y",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_dim_z",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_idx_x",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_idx_y",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "block_idx_z",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "breakpoint",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_query_get_first_ctaid_x",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_query_get_first_ctaid_x.below.ptx, line 25; error   : Feature '.get_first_ctaid::x' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_x.below.ptx, line 25; error   : Feature 'clusterlaunchcontrol.query_cancel' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_x.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_query_get_first_ctaid_y",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_query_get_first_ctaid_y.below.ptx, line 25; error   : Feature '.get_first_ctaid::y' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_y.below.ptx, line 25; error   : Feature 'clusterlaunchcontrol.query_cancel' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_y.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_query_get_first_ctaid_z",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_query_get_first_ctaid_z.below.ptx, line 25; error   : Feature '.get_first_ctaid::z' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_z.below.ptx, line 25; error   : Feature 'clusterlaunchcontrol.query_cancel' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_get_first_ctaid_z.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_query_is_canceled",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_query_is_canceled.below.ptx, line 26; error   : Feature '.is_canceled' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_is_canceled.below.ptx, line 26; error   : Feature 'clusterlaunchcontrol.query_cancel' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_query_is_canceled.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_try_cancel",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_try_cancel.below.ptx, line 23; error   : Feature 'clusterlaunchcontrol.try_cancel.async' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_try_cancel.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "clc_try_cancel_multicast",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/clc_try_cancel_multicast.below.ptx, line 23; error   : Feature 'clusterlaunchcontrol.try_cancel.async' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_try_cancel_multicast.below.ptx, line 23; error   : Feature '.multicast::cluster::all' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/clc_try_cancel_multicast.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "clock",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "clock64",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_block_count",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_block_count.below.ptx, line 16; error   : Feature '%cluster_nctarank' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_block_count.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_block_idx_x",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_block_idx_x.below.ptx, line 16; error   : Feature '%cluster_ctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_block_idx_x.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_block_idx_y",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_block_idx_y.below.ptx, line 16; error   : Feature '%cluster_ctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_block_idx_y.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_block_idx_z",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_block_idx_z.below.ptx, line 16; error   : Feature '%cluster_ctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_block_idx_z.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_block_rank",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_block_rank.below.ptx, line 16; error   : Feature '%cluster_ctarank' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_block_rank.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_dim_x",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_dim_x.below.ptx, line 16; error   : Feature '%cluster_nctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_dim_x.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_dim_y",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_dim_y.below.ptx, line 16; error   : Feature '%cluster_nctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_dim_y.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_dim_z",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_dim_z.below.ptx, line 16; error   : Feature '%cluster_nctaid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_dim_z.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_grid_dim_x",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_grid_dim_x.below.ptx, line 16; error   : Feature '%nclusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_grid_dim_x.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_grid_dim_y",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_grid_dim_y.below.ptx, line 16; error   : Feature '%nclusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_grid_dim_y.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_grid_dim_z",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_grid_dim_z.below.ptx, line 16; error   : Feature '%nclusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_grid_dim_z.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_idx_x",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_idx_x.below.ptx, line 16; error   : Feature '%clusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_idx_x.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_idx_y",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_idx_y.below.ptx, line 16; error   : Feature '%clusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_idx_y.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cluster_idx_z",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cluster_idx_z.below.ptx, line 16; error   : Feature '%clusterid' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cluster_idx_z.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cos_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cos_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cos_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cos_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_commit_group",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_commit_group.below.ptx, line 16; error   : Feature 'cp.async.bulk.commit_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_1d_l2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_1d_l2.below.ptx, line 23; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_1d_l2.below.ptx, line 23; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_1d_l2_cache_hint",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_1d_l2_cache_hint.below.ptx, line 24; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_1d_l2_cache_hint.below.ptx, line 24; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_2d_l2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_2d_l2.below.ptx, line 25; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_2d_l2.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_2d_l2_cache_hint",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_2d_l2_cache_hint.below.ptx, line 26; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_2d_l2_cache_hint.below.ptx, line 26; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_3d_l2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_3d_l2.below.ptx, line 27; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_3d_l2.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_3d_l2_cache_hint",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_3d_l2_cache_hint.below.ptx, line 28; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_3d_l2_cache_hint.below.ptx, line 28; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_4d_l2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_4d_l2.below.ptx, line 29; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_4d_l2.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_4d_l2_cache_hint",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_4d_l2_cache_hint.below.ptx, line 30; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_4d_l2_cache_hint.below.ptx, line 30; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_5d_l2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_5d_l2.below.ptx, line 31; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_5d_l2.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_5d_l2_cache_hint",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_5d_l2_cache_hint.below.ptx, line 32; error   : Feature 'cp.async.bulk.prefetch.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_5d_l2_cache_hint.below.ptx, line 32; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_gather4_2d_l2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_gather4_2d_l2.below.ptx, line 31; error   : Feature '.tile::gather4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_gather4_2d_l2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_prefetch_tensor_gather4_2d_l2_cache_hint",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_prefetch_tensor_gather4_2d_l2_cache_hint.below.ptx, line 32; error   : Feature '.tile::gather4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cp_async_bulk_prefetch_tensor_gather4_2d_l2_cache_hint.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_1d_g2s",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_1d_g2s.below.ptx, line 31; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_1d_g2s.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_1d_g2s.below.ptx, line 31; error   : Feature '.mbarrier::complete_tx::bytes' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_1d_s2g",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_1d_s2g.below.ptx, line 26; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_1d_s2g.below.ptx, line 26; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_1d_s2g.below.ptx, line 26; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_2d_g2s",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s.below.ptx, line 33; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s.below.ptx, line 33; error   : Feature '.mbarrier::complete_tx::bytes' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_2d_g2s_multicast",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast.below.ptx, line 34; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast.below.ptx, line 34; error   : Modifier '.multicast::cluster' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast.below.ptx, line 34; warning : Advisory: '.multicast::cluster' modifier on instruction 'cp.async.bulk{.tensor}' should be used on .target 'sm_90a/sm_100a/sm_100f/sm_103a/sm_103f/sm_110a/sm_110f' instead of .target 'sm_90' as this feature is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast.below.ptx, line 34; error   : Feature '.tile' requires PTX ISA .version 8.0 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_2d_g2s_multicast_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast_cg2.below.ptx, line 34; error   : Modifier '.cta_group::2' on 'cp.async.bulk.tensor' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast_cg2.below.ptx, line 34; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_g2s_multicast_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_2d_s2g",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_2d_s2g.below.ptx, line 28; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_s2g.below.ptx, line 28; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_2d_s2g.below.ptx, line 28; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_3d_g2s",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_3d_g2s.below.ptx, line 35; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_3d_g2s.below.ptx, line 35; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_3d_g2s.below.ptx, line 35; error   : Feature '.mbarrier::complete_tx::bytes' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_3d_s2g",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_3d_s2g.below.ptx, line 30; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_3d_s2g.below.ptx, line 30; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_3d_s2g.below.ptx, line 30; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_4d_g2s",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_4d_g2s.below.ptx, line 37; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_4d_g2s.below.ptx, line 37; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_4d_g2s.below.ptx, line 37; error   : Feature '.mbarrier::complete_tx::bytes' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_4d_s2g",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_4d_s2g.below.ptx, line 32; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_4d_s2g.below.ptx, line 32; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_4d_s2g.below.ptx, line 32; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_5d_g2s",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_5d_g2s.below.ptx, line 39; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_5d_g2s.below.ptx, line 39; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_5d_g2s.below.ptx, line 39; error   : Feature '.mbarrier::complete_tx::bytes' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_5d_s2g",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_5d_s2g.below.ptx, line 34; error   : Feature 'cp.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_5d_s2g.below.ptx, line 34; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_5d_s2g.below.ptx, line 34; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_add_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_add_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_and_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_and_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_dec_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_dec_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_inc_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_inc_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_max_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_max_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_min_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_min_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_or_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_or_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_im2col_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_3d.below.ptx, line 29; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_im2col_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_4d.below.ptx, line 31; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_im2col_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_5d.below.ptx, line 33; error   : Feature '.im2col_no_offs' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_im2col_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_tile_1d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_1d.below.ptx, line 25; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_1d.below.ptx, line 25; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_1d.below.ptx, line 25; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_tile_2d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_2d.below.ptx, line 27; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_2d.below.ptx, line 27; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_2d.below.ptx, line 27; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_tile_3d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_3d.below.ptx, line 29; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_3d.below.ptx, line 29; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_3d.below.ptx, line 29; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_tile_4d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_4d.below.ptx, line 31; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_4d.below.ptx, line 31; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_4d.below.ptx, line 31; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_tensor_reduce_xor_tile_5d",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_5d.below.ptx, line 33; error   : Feature 'cp.reduce.async.bulk.tensor' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_5d.below.ptx, line 33; error   : Feature '.tile' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_tensor_reduce_xor_tile_5d.below.ptx, line 33; error   : Feature '.bulk_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_wait_group",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_wait_group.below.ptx, line 16; error   : Feature 'cp.async.bulk.wait_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_bulk_wait_group_read",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_bulk_wait_group_read.below.ptx, line 16; error   : Modifier '.read' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/cp_async_bulk_wait_group_read.below.ptx, line 16; error   : Feature 'cp.async.bulk.wait_group' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_16.below.ptx, line 23; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_4.below.ptx, line 23; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_8.below.ptx, line 23; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_zfill_16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_zfill_16.below.ptx, line 26; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_16.below.ptx, line 43; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_zfill_4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_zfill_4.below.ptx, line 26; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_4.below.ptx, line 43; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_ca_zfill_8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_ca_zfill_8.below.ptx, line 26; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_8.below.ptx, line 43; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_ca_zfill_8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_cg_16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_cg_16.below.ptx, line 23; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_cg_16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_cg_zfill_16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_cg_zfill_16.below.ptx, line 26; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_cg_zfill_16.below.ptx, line 43; error   : Feature 'cp.async' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_cg_zfill_16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_commit_group",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_commit_group.below.ptx, line 16; error   : Feature 'cp.async.commit_group' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_commit_group.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_mbarrier_arrive",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_mbarrier_arrive.below.ptx, line 19; error   : Feature 'cp.async.mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_mbarrier_arrive.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_mbarrier_arrive_noinc",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_mbarrier_arrive_noinc.below.ptx, line 19; error   : Feature 'cp.async.mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_mbarrier_arrive_noinc.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_mbarrier_arrive_noinc_shared",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_mbarrier_arrive_noinc_shared.below.ptx, line 20; error   : Feature 'cp.async.mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_mbarrier_arrive_noinc_shared.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_mbarrier_arrive_shared",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_mbarrier_arrive_shared.below.ptx, line 20; error   : Feature 'cp.async.mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_mbarrier_arrive_shared.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_wait_all",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_wait_all.below.ptx, line 16; error   : Feature 'cp.async.wait_all' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_wait_all.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cp_async_wait_group",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cp_async_wait_group.below.ptx, line 16; error   : Feature 'cp.async.wait_group' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cp_async_wait_group.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_f16x2_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_f16x2_f32.below.ptx, line 22; error   : Feature 'cvt.f16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_f16x2_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_f32x2_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_f32x2_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_f32x2_bf16x2.below.ptx, line 22; error   : Feature 'cvt.bf16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_f32x2_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_f16x2_e4m3x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_f16x2_e4m3x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e4m3x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_f16x2_e4m3x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e4m3x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_f16x2_e5m2x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_f16x2_e5m2x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e5m2x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_f16x2_e5m2x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e5m2x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_bf16x2_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_bf16x2_f32.below.ptx, line 22; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_bf16x2_f32.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_bf16x2_f32.below.ptx, line 22; error   : Feature 'cvt.bf16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_bf16x2_f32.below.ptx, line 22; error   : Feature '.relu' requires PTX ISA .version 7.0 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_f16x2_e4m3x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_f16x2_e4m3x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e4m3x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_relu_f16x2_e4m3x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e4m3x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_f16x2_e5m2x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_f16x2_e5m2x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e5m2x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_relu_f16x2_e5m2x2.below.ptx, line 21; error   : Feature 'cvt.f16x2.e5m2x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_f16x2_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_f16x2_f32.below.ptx, line 22; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_f16x2_f32.below.ptx, line 22; error   : Feature 'cvt.f16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_f16x2_f32.below.ptx, line 22; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rn_relu_f16x2_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_satfinite_tf32_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_satfinite_tf32_f32.below.ptx, line 19; error   : Modifier '.satfinite' on 'cvt.tf32.f32.rn' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cvt_rn_relu_satfinite_tf32_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_relu_tf32_f32",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_relu_tf32_f32.below.ptx, line 19; error   : Feature 'cvt with .tf32.f32.rn' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cvt_rn_relu_tf32_f32.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_e4m3x2_f16x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_e4m3x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e4m3x2.f16x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_e4m3x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e4m3x2.f16x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_e4m3x2_f32",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_e4m3x2_f32.below.ptx, line 22; error   : Feature 'cvt.e4m3x2.f32' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_e4m3x2_f32.below.ptx, line 22; error   : Feature 'cvt.e4m3x2.f32 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_e5m2x2_f16x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_e5m2x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e5m2x2.f16x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_e5m2x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e5m2x2.f16x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_e5m2x2_f32",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_e5m2x2_f32.below.ptx, line 22; error   : Feature 'cvt.e5m2x2.f32' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_e5m2x2_f32.below.ptx, line 22; error   : Feature 'cvt.e5m2x2.f32 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_relu_e4m3x2_f16x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_relu_e4m3x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e4m3x2.f16x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_relu_e4m3x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e4m3x2.f16x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_relu_e4m3x2_f32",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_relu_e4m3x2_f32.below.ptx, line 22; error   : Feature 'cvt.e4m3x2.f32' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_relu_e4m3x2_f32.below.ptx, line 22; error   : Feature 'cvt.e4m3x2.f32 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_relu_e5m2x2_f16x2",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_relu_e5m2x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e5m2x2.f16x2' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_relu_e5m2x2_f16x2.below.ptx, line 21; error   : Feature 'cvt.e5m2x2.f16x2 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_relu_e5m2x2_f32",
+      "minimum_ptx": "8.1",
+      "target": "sm_89",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_relu_e5m2x2_f32.below.ptx, line 22; error   : Feature 'cvt.e5m2x2.f32' requires .target sm_90 or higher\nptxas <floor-probe>/cvt_rn_satfinite_relu_e5m2x2_f32.below.ptx, line 22; error   : Feature 'cvt.e5m2x2.f32 on sm_89' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_satfinite_tf32_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_satfinite_tf32_f32.below.ptx, line 19; error   : Modifier '.satfinite' on 'cvt.tf32.f32.rn' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cvt_rn_satfinite_tf32_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rn_tf32_f32",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rn_tf32_f32.below.ptx, line 19; error   : Feature 'cvt with .tf32.f32.rn' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cvt_rn_tf32_f32.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rna_satfinite_tf32_f32",
+      "minimum_ptx": "8.1",
+      "target": "sm_80",
+      "accepted_ptx": "8.1",
+      "rejected_ptx": "8.0",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rna_satfinite_tf32_f32.below.ptx, line 19; error   : Modifier '.satfinite' on 'cvt.tf32.f32.rna' requires PTX ISA .version 8.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rna_tf32_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rna_tf32_f32.below.ptx, line 19; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rna_tf32_f32.below.ptx, line 19; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rna_tf32_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_bf16x2_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_bf16x2_f32.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rz_bf16x2_f32.below.ptx, line 22; error   : Feature 'cvt.bf16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rz_bf16x2_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_f16x2_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_f16x2_f32.below.ptx, line 22; error   : Feature 'cvt.f16x2.f32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/cvt_rz_f16x2_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_relu_satfinite_tf32_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_relu_satfinite_tf32_f32.below.ptx, line 19; error   : Modifier '.satfinite' on 'cvt.tf32.f32.rz' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cvt_rz_relu_satfinite_tf32_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_relu_tf32_f32",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_relu_tf32_f32.below.ptx, line 19; error   : Feature 'cvt with .tf32.f32.rz' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cvt_rz_relu_tf32_f32.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_satfinite_tf32_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_satfinite_tf32_f32.below.ptx, line 19; error   : Modifier '.satfinite' on 'cvt.tf32.f32.rz' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/cvt_rz_satfinite_tf32_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "cvt_rz_tf32_f32",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/cvt_rz_tf32_f32.below.ptx, line 19; error   : Feature 'cvt with .tf32.f32.rz' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/cvt_rz_tf32_f32.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "div_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "dp2a_s32",
+      "minimum_ptx": "5.0",
+      "reason": "PTX 5.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "dp2a_u32",
+      "minimum_ptx": "5.0",
+      "reason": "PTX 5.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "dp4a_s32",
+      "minimum_ptx": "5.0",
+      "reason": "PTX 5.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "dp4a_u32",
+      "minimum_ptx": "5.0",
+      "reason": "PTX 5.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "dsmem_read_u32",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/dsmem_read_u32.below.ptx, line 24; error   : Feature 'mapa' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/dsmem_read_u32.below.ptx, line 24; error   : Feature '::cluster' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/dsmem_read_u32.below.ptx, line 24; error   : Feature '::cluster' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/dsmem_read_u32.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "dynamic_smem_size",
+      "minimum_ptx": "4.1",
+      "reason": "PTX 4.1 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "elect_sync",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/elect_sync.below.ptx, line 21; error   : Feature 'elect' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/elect_sync.below.ptx, line 36; error   : Feature 'elect' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "envreg1",
+      "minimum_ptx": "2.1",
+      "reason": "PTX 2.1 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "envreg2",
+      "minimum_ptx": "2.1",
+      "reason": "PTX 2.1 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "ex2_approx_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_75",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/ex2_approx_f16.below.ptx, line 21; error   : Feature 'ex2.f16/f16x2' requires PTX ISA .version 7.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ex2_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/ex2_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ex2_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/ex2_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_mbarrier_init_release_cluster",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/fence_mbarrier_init_release_cluster.below.ptx, line 17; error   : Feature '.op_restrict' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/fence_mbarrier_init_release_cluster.below.ptx, line 17; error   : Modifier '.mbarrier_init' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_async_generic_acquire_shared_cluster_cluster",
+      "minimum_ptx": "8.6",
+      "target": "sm_90",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_async_generic_acquire_shared_cluster_cluster.below.ptx, line 17; error   : Feature '.sync_restrict' requires PTX ISA .version 8.6 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_async_generic_release_shared_cta_cluster",
+      "minimum_ptx": "8.6",
+      "target": "sm_90",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_async_generic_release_shared_cta_cluster.below.ptx, line 17; error   : Feature '.sync_restrict' requires PTX ISA .version 8.6 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_async_shared_cta",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_async_shared_cta.below.ptx, line 17; error   : Modifier '.async' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_acquire_cluster",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_cluster.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_cluster.below.ptx, line 19; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_acquire_cta",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_cta.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_cta.below.ptx, line 19; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_acquire_gpu",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_gpu.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_gpu.below.ptx, line 19; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_acquire_system",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_system.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/fence_proxy_tensormap_generic_acquire_system.below.ptx, line 19; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_release_cluster",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_release_cluster.below.ptx, line 16; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_release_cta",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_release_cta.below.ptx, line 16; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_release_gpu",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_release_gpu.below.ptx, line 16; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fence_proxy_tensormap_generic_release_system",
+      "minimum_ptx": "8.3",
+      "target": "sm_90",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/fence_proxy_tensormap_generic_release_system.below.ptx, line 16; error   : Feature 'fence.proxy with unidirection proxy fence' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_bf16x2.below.ptx, line 24; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_bf16x2.below.ptx, line 24; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "fma_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_f32x2.below.ptx, line 24; error   : Feature 'fma.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/fma_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "fma_ftz_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_ftz_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_ftz_f32x2.below.ptx, line 24; error   : Feature 'fma.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/fma_ftz_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_ftz_relu_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_ftz_relu_f16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_ftz_relu_f16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_ftz_relu_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "fma_ftz_sat_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_relu_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_relu_bf16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_relu_bf16x2.below.ptx, line 24; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_relu_bf16x2.below.ptx, line 24; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_relu_bf16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_relu_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_relu_f16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_relu_f16x2.below.ptx, line 24; error   : Feature '.relu' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/fma_relu_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rm_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rm_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rm_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rm_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rm_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rm_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rm_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rn_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rn_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rn_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rn_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rn_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rn_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rn_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rp_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rp_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rp_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rp_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rp_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rp_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rp_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rz_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rz_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rz_ftz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rz_ftz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "fma_rz_sat_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/fma_rz_sat_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "fma_sat_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "globaltimer",
+      "minimum_ptx": "3.1",
+      "reason": "PTX 3.1 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "grid_dependency_launch_dependents",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/grid_dependency_launch_dependents.below.ptx, line 16; error   : Modifier '.launch_dependents' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/grid_dependency_launch_dependents.below.ptx, line 16; error   : Feature 'griddepcontrol' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/grid_dependency_launch_dependents.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "grid_dependency_wait",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/grid_dependency_wait.below.ptx, line 16; error   : Modifier '.wait' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/grid_dependency_wait.below.ptx, line 16; error   : Feature 'griddepcontrol' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/grid_dependency_wait.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "grid_dim_x",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "grid_dim_y",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "grid_dim_z",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "gridid",
+      "minimum_ptx": "3.0",
+      "reason": "PTX 3.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lane_id",
+      "minimum_ptx": "1.3",
+      "reason": "PTX 1.3 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lanemask_eq",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lanemask_ge",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lanemask_gt",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lanemask_le",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "lanemask_lt",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x1_trans_b8",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8.below.ptx, line 21; error   : Feature 'ldmatrix.b8' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x1_trans_b8x16_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x1_trans_b8x16_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x1_trans_b8x16_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x2_trans_b8",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8.below.ptx, line 21; error   : Feature 'ldmatrix.b8' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x2_trans_b8x16_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m16n16_x2_trans_b8x16_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier '.m16n16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m16n16_x2_trans_b8x16_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x1_b8x16_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x1_b8x16_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x1_b8x16_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x2_b8x16_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x2_b8x16_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x2_b8x16_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x4_b8x16_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b4x16_p64.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n16_x4_b8x16_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier '.m8n16' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b6x16_p32.below.ptx, line 21; error   : Modifier 'format conversion' on 'ldmatrix' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/ldmatrix_m8n16_x4_b8x16_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x1_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x1_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x1_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x1_trans_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x1_trans_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x1_trans_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x2_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x2_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x2_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x2_trans_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x2_trans_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x2_trans_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x4_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x4_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x4_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "ldmatrix_m8n8_x4_trans_b16",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/ldmatrix_m8n8_x4_trans_b16.below.ptx, line 21; error   : Feature 'ldmatrix' requires PTX ISA .version 6.5 or later\nptxas <floor-probe>/ldmatrix_m8n8_x4_trans_b16.below.ptx, line 21; error   : Feature '.m8n8' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "lg2_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/lg2_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "lg2_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/lg2_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "map_shared_rank",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/map_shared_rank.below.ptx, line 24; error   : Feature 'mapa' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/map_shared_rank.below.ptx, line 24; error   : Feature '::cluster' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/map_shared_rank.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "match_all_i64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "match_all_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "match_any_i64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "match_any_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_f16.below.ptx, line 23; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_f16x2.below.ptx, line 22; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_f16.below.ptx, line 23; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_f16x2.below.ptx, line 22; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_nan_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_nan_f16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_nan_f16.below.ptx, line 23; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_nan_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_nan_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_nan_f16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_nan_f16x2.below.ptx, line 22; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_ftz_nan_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_nan_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_nan_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_nan_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_ftz_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_ftz_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_ftz_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_f16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_f16.below.ptx, line 23; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_f16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_f16x2.below.ptx, line 22; error   : Feature 'max.f16 or max.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/max_nan_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_xorsign_abs_bf16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_nan_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_xorsign_abs_bf16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_nan_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_nan_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_relu_s16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/max_relu_s16x2.below.ptx, line 22; error   : Feature 'max.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_relu_s16x2.below.ptx, line 22; error   : Feature 'max.s16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_relu_s16x2.below.ptx, line 22; error   : Feature 'max.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_relu_s16x2.below.ptx, line 22; error   : Feature 'max.s16x2' requires PTX ISA .version 8.0 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_relu_s32",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/max_relu_s32.below.ptx, line 22; error   : Feature 'max.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_relu_s32.below.ptx, line 22; error   : Feature 'max.relu' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_s16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/max_s16x2.below.ptx, line 22; error   : Feature 'max.s16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_s16x2.below.ptx, line 22; error   : Feature 'max.s16x2' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_u16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/max_u16x2.below.ptx, line 22; error   : Feature 'max.u16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/max_u16x2.below.ptx, line 22; error   : Feature 'max.u16x2' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_xorsign_abs_bf16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_xorsign_abs_bf16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "max_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/max_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/max_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_arrive",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_arrive.below.ptx, line 20; error   : Feature 'mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mbarrier_arrive.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_arrive_cluster",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_arrive_cluster.below.ptx, line 20; error   : Feature '.shared::cluster' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/mbarrier_arrive_cluster.below.ptx, line 20; error   : Modifier '.release' on 'mbarrier.arrive' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/mbarrier_arrive_cluster.below.ptx, line 20; error   : Feature 'scopes on mbarrier operations' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_arrive_expect_tx",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_arrive_expect_tx.below.ptx, line 24; error   : Feature 'mbarrier.arrive.expect_tx' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/mbarrier_arrive_expect_tx.below.ptx, line 24; error   : Modifier '.release' on 'mbarrier.arrive.expect_tx' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/mbarrier_arrive_expect_tx.below.ptx, line 24; error   : Feature 'scopes on mbarrier operations' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_arrive_expect_tx_cluster",
+      "minimum_ptx": "8.6",
+      "target": "sm_90",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_arrive_expect_tx_cluster.below.ptx, line 24; error   : Modifier '.relaxed' on 'mbarrier.arrive.expect_tx' requires PTX ISA .version 8.6 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_arrive_no_complete",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_arrive_no_complete.below.ptx, line 23; error   : Feature 'mbarrier.arrive' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mbarrier_arrive_no_complete.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_init",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_init.below.ptx, line 23; error   : Feature 'mbarrier.init' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mbarrier_init.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_inval",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_inval.below.ptx, line 20; error   : Feature 'mbarrier.inval' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mbarrier_inval.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_test_wait",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_test_wait.below.ptx, line 24; error   : Feature 'mbarrier.test_wait' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mbarrier_test_wait.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_try_wait",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_try_wait.below.ptx, line 24; error   : Feature 'mbarrier.try_wait' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/mbarrier_try_wait.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_try_wait_parity",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_try_wait_parity.below.ptx, line 24; error   : Feature 'mbarrier.try_wait.parity' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/mbarrier_try_wait_parity.below.ptx, line 24; error   : Feature '::cta' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/mbarrier_try_wait_parity.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mbarrier_try_wait_parity_cluster",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/mbarrier_try_wait_parity_cluster.below.ptx, line 24; error   : Modifier '.acquire' on 'mbarrier.try_wait.parity' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/mbarrier_try_wait_parity_cluster.below.ptx, line 24; error   : Feature 'scopes on mbarrier operations' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_f16.below.ptx, line 23; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_f16x2.below.ptx, line 22; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_f16.below.ptx, line 23; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_f16x2.below.ptx, line 22; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_nan_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_nan_f16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_nan_f16.below.ptx, line 23; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_nan_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_nan_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_nan_f16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_nan_f16x2.below.ptx, line 22; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_ftz_nan_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_nan_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_nan_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_nan_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_ftz_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_ftz_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_ftz_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16.below.ptx, line 23; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16x2.below.ptx, line 22; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_f16.below.ptx, line 23; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_f16.below.ptx, line 23; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_f16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_f16x2.below.ptx, line 22; error   : Feature '.NaN' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_f16x2.below.ptx, line 22; error   : Feature 'min.f16 or min.f16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/min_nan_f16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_xorsign_abs_bf16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_nan_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_xorsign_abs_bf16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_nan_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_nan_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_nan_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_nan_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_nan_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_relu_s16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/min_relu_s16x2.below.ptx, line 22; error   : Feature 'min.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_relu_s16x2.below.ptx, line 22; error   : Feature 'min.s16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_relu_s16x2.below.ptx, line 22; error   : Feature 'min.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_relu_s16x2.below.ptx, line 22; error   : Feature 'min.s16x2' requires PTX ISA .version 8.0 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_relu_s32",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/min_relu_s32.below.ptx, line 22; error   : Feature 'min.relu' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_relu_s32.below.ptx, line 22; error   : Feature 'min.relu' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_s16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/min_s16x2.below.ptx, line 22; error   : Feature 'min.s16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_s16x2.below.ptx, line 22; error   : Feature 'min.s16x2' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_u16x2",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/min_u16x2.below.ptx, line 22; error   : Feature 'min.u16x2' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/min_u16x2.below.ptx, line 22; error   : Feature 'min.u16x2' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_xorsign_abs_bf16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_xorsign_abs_bf16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_xorsign_abs_bf16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_xorsign_abs_bf16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_xorsign_abs_f16",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_xorsign_abs_f16.below.ptx, line 23; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_xorsign_abs_f16x2",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_xorsign_abs_f16x2.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "min_xorsign_abs_f32",
+      "minimum_ptx": "7.2",
+      "target": "sm_86",
+      "accepted_ptx": "7.2",
+      "rejected_ptx": "7.1",
+      "rejection_detail": "ptxas <floor-probe>/min_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.abs' requires PTX ISA .version 7.2 or later\nptxas <floor-probe>/min_xorsign_abs_f32.below.ptx, line 22; error   : Feature '.xorsign' requires PTX ISA .version 7.2 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k128_s32_b1_and_popc",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k128_s32_b1_and_popc.below.ptx, line 32; error   : Modifier '.and' on 'mma' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k128_s32_b1_xor_popc",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k128_s32_b1_xor_popc.below.ptx, line 32; error   : Feature '.m16n8k128' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k128_s32_b1_xor_popc.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_f16_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_f16_f16.below.ptx, line 34; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_f16_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_f32_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_f32_bf16.below.ptx, line 38; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_f32_bf16.below.ptx, line 38; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_f32_bf16.below.ptx, line 38; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_f32_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_f32_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_f32_f16.below.ptx, line 38; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_f32_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f16_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f16_e4m3_e4m3.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k16_fp8_f16_e4m3_e4m3.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f16_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f16_e4m3_e5m2.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k16_fp8_f16_e4m3_e5m2.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f16_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f16_e5m2_e4m3.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k16_fp8_f16_e5m2_e4m3.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f16_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f16_e5m2_e5m2.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k16_fp8_f16_e5m2_e5m2.below.ptx, line 28; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f32_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f32_e4m3_e4m3.below.ptx, line 32; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f32_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f32_e4m3_e5m2.below.ptx, line 32; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f32_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f32_e5m2_e4m3.below.ptx, line 32; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_fp8_f32_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_fp8_f32_e5m2_e5m2.below.ptx, line 32; error   : Feature 'mma with FP8 floating point type and .m16n8k16 shape' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_s8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_s8.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_s8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_s8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_s8_satfinite.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_s8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_s8_u8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_s8_u8.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_s8_u8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_s8_u8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_s8_u8_satfinite.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_s8_u8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_u8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_u8.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_u8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_u8_s8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_u8_s8.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_u8_s8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_u8_s8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_u8_s8_satfinite.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_u8_s8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k16_s32_u8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k16_s32_u8_satfinite.below.ptx, line 32; error   : Feature '.m16n8k16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k16_s32_u8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k256_s32_b1_and_popc",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k256_s32_b1_and_popc.below.ptx, line 38; error   : Modifier '.and' on 'mma' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k256_s32_b1_xor_popc",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k256_s32_b1_xor_popc.below.ptx, line 38; error   : Feature '.m16n8k256' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k256_s32_b1_xor_popc.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m1_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e2m1.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m1_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e2m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m1_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e3m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m1_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e4m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m1_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e5m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m1_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e2m1.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e2m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e3m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e4m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e2m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e5m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e2m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e3m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e2m1.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e3m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e2m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e3m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e3m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e3m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e4m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e3m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e5m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e3m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e4m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e2m1.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e4m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e2m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e4m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e3m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e4m3.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e5m2.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e4m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e5m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e2m1.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e5m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e2m3.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e5m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e3m2.below.ptx, line 34; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e4m3.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f16_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e5m2.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f16_e5m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m1_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e2m1.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m1_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e2m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m1_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e3m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m1_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e4m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m1_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e5m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m1_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e2m1.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e2m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e3m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e4m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e2m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e5m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e2m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e3m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e2m1.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e3m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e2m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e3m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e3m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e3m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e4m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e3m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e5m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e3m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e4m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e2m1.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e4m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e2m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e4m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e3m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e4m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e5m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e2m1.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e5m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e2m3.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e5m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e3m2.below.ptx, line 38; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_f32_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_f32_e5m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f16_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f16_e4m3_e4m3.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f16_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f16_e4m3_e5m2.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f16_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f16_e5m2_e4m3.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f16_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_89",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f16_e5m2_e5m2.below.ptx, line 34; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f32_e4m3_e4m3",
+      "minimum_ptx": "8.4",
+      "target": "sm_89",
+      "accepted_ptx": "8.4",
+      "rejected_ptx": "8.3",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f32_e4m3_e4m3.below.ptx, line 38; error   : Feature 'mma with FP8 floating point type' requires PTX ISA .version 8.4 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f32_e4m3_e5m2",
+      "minimum_ptx": "8.4",
+      "target": "sm_89",
+      "accepted_ptx": "8.4",
+      "rejected_ptx": "8.3",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f32_e4m3_e5m2.below.ptx, line 38; error   : Feature 'mma with FP8 floating point type' requires PTX ISA .version 8.4 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f32_e5m2_e4m3",
+      "minimum_ptx": "8.4",
+      "target": "sm_89",
+      "accepted_ptx": "8.4",
+      "rejected_ptx": "8.3",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f32_e5m2_e4m3.below.ptx, line 38; error   : Feature 'mma with FP8 floating point type' requires PTX ISA .version 8.4 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_fp8_f32_e5m2_e5m2",
+      "minimum_ptx": "8.4",
+      "target": "sm_89",
+      "accepted_ptx": "8.4",
+      "rejected_ptx": "8.3",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_fp8_f32_e5m2_e5m2.below.ptx, line 38; error   : Feature 'mma with FP8 floating point type' requires PTX ISA .version 8.4 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m1.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m1_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e3m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m1_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e4m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m1_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e5m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m1_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m1.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e3m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e4m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e2m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e5m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e2m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m1.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e3m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e3m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e3m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e4m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e3m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e5m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e3m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m1.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e4m3_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e3m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e4m3_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e4m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e4m3_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e5m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e4m3_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m1",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m1.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m1.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e2m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e5m2_e3m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e3m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e3m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e5m2_e4m3",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e4m3.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e4m3.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_mxf8f6f4_f32_e5m2_e5m2",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e5m2.below.ptx, line 51; error   : Feature 'mma with block scale' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_m16n8k32_mxf8f6f4_f32_e5m2_e5m2.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s4.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s4_satfinite.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s4_u4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s4_u4.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s4_u4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s4_u4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s4_u4_satfinite.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s4_u4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s8.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s8_satfinite.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s8_u8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s8_u8.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s8_u8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_s8_u8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u4.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u4_s4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u4_s4.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u4_s4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u4_s4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u4_s4_satfinite.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u4_s4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u4_satfinite.below.ptx, line 32; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u8.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u8_s8",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u8_s8.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u8_s8.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u8_s8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k32_s32_u8_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k32_s32_u8_satfinite.below.ptx, line 38; error   : Feature '.m16n8k32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k32_s32_u8_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k4_f32_tf32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k4_f32_tf32.below.ptx, line 32; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k4_f32_tf32.below.ptx, line 32; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k4_f32_tf32.below.ptx, line 32; error   : Feature '.m16n8k4' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k4_f32_tf32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_s4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_s4.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_s4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_s4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_s4_satfinite.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_s4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_s4_u4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_s4_u4.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_s4_u4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_s4_u4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_u4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_u4.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_u4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_u4_s4",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_u4_s4.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_u4_s4.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_u4_s4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k64_s32_u4_satfinite",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k64_s32_u4_satfinite.below.ptx, line 38; error   : Feature '.m16n8k64' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k64_s32_u4_satfinite.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k8_f16_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k8_f16_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k8_f32_bf16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k8_f32_bf16.below.ptx, line 32; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_bf16.below.ptx, line 32; error   : Feature '.bf16' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_bf16.below.ptx, line 32; error   : Feature '.m16n8k8' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_bf16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k8_f32_f16",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k8_f32_f16.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m16n8k8_f32_tf32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m16n8k8_f32_tf32.below.ptx, line 38; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_tf32.below.ptx, line 38; error   : Feature '.tf32' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_tf32.below.ptx, line 38; error   : Feature '.m16n8k8' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m16n8k8_f32_tf32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k128_s32_b1_and_popc",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k128_s32_b1_and_popc.below.ptx, line 26; error   : Modifier '.and' on 'mma' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k128_s32_b1_xor_popc",
+      "minimum_ptx": "7.0",
+      "target": "sm_75",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k128_s32_b1_xor_popc.below.ptx, line 26; error   : Feature '.m8n8k128' requires PTX ISA .version 7.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_s8",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_s8.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_s8_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_s8_satfinite.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_s8_u8",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_s8_u8.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_s8_u8_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_s8_u8_satfinite.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_u8",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_u8.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_u8_s8",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_u8_s8.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_u8_s8_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_u8_s8_satfinite.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k16_s32_u8_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k16_s32_u8_satfinite.below.ptx, line 26; error   : Feature '.m8n8k16' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_s4",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_s4.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_s4_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_s4_satfinite.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_s4_u4",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_s4_u4.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_s4_u4_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_s4_u4_satfinite.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_u4",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_u4.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_u4_s4",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_u4_s4.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_u4_s4_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_u4_s4_satfinite.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k32_s32_u4_satfinite",
+      "minimum_ptx": "6.5",
+      "target": "sm_75",
+      "accepted_ptx": "6.5",
+      "rejected_ptx": "6.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k32_s32_u4_satfinite.below.ptx, line 26; error   : Feature '.m8n8k32' requires PTX ISA .version 6.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_m8n8k4_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mma_m8n8k4_f64.below.ptx, line 26; error   : Feature '.m8n8k4 with double types' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/mma_m8n8k4_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_s4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_s4.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_s4.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_s4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_s4_u4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_u4.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_u4.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_s4_u4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_u4_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_s4_u4_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_u4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_u4.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_u4.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_u4_s4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_s4.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_s4.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_u4_s4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_s4_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_s4_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k128_s32_u4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k128_s32_u4_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_s8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_s8.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_s8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_s8_u8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_s8_u8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_u8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_u8.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_u8_s8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_u8_s8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k32_s32_u8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k32_s32_u8_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s4.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s4_u4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s4_u4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s8.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s8.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s8_u8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_u8.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_u8.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_s8_u8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_u8_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_s8_u8_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u4.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u4_s4",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u4_s4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u4_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_satfinite.below.ptx, line 36; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_satfinite.below.ptx, line 36; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_satfinite.below.ptx, line 71; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u4_satfinite.below.ptx, line 71; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u8.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u8.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u8_s8",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_s8.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_s8.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u8_s8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_s8_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_s8_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_m16n8k64_s32_u8_satfinite",
+      "minimum_ptx": "7.1",
+      "target": "sm_80",
+      "accepted_ptx": "7.1",
+      "rejected_ptx": "7.0",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_satfinite.below.ptx, line 44; info    : Advisory: Modifier '.sp::ordered_metadata' should be used on instruction 'mma' instead of modifier '.sp' as it is expected to have substantially reduced performance on some future architectures\nptxas <floor-probe>/mma_sp_m16n8k64_s32_u8_satfinite.below.ptx, line 44; error   : Feature 'Sparse MMA' requires PTX ISA .version 7.1 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_s4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_s4.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_s4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_s4_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_s4_u4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_s4_u4.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_s4_u4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_s4_u4_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_u4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_u4.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_u4_s4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_u4_s4.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_u4_s4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_u4_s4_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k128_s32_u4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k128_s32_u4_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k16_f16_f16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f16_f16.below.ptx, line 32; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f16_f16.below.ptx, line 61; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f16_f16.below.ptx, line 90; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f16_f16.below.ptx, line 119; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k16_f32_bf16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_bf16.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_bf16.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_bf16.below.ptx, line 106; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_bf16.below.ptx, line 141; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k16_f32_f16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_f16.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_f16.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_f16.below.ptx, line 106; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_f16.below.ptx, line 141; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k16_f32_tf32",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_tf32.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k16_f32_tf32.below.ptx, line 87; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_f16_f16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f16_f16.below.ptx, line 40; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f16_f16.below.ptx, line 77; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_f32_bf16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f32_bf16.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f32_bf16.below.ptx, line 87; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_f32_f16",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f32_f16.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_f32_f16.below.ptx, line 87; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_s8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_s8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_s8_u8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_u8.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_u8.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_s8_u8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_s8_u8_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_u8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_u8_s8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_s8.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_s8.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_u8_s8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_s8_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k32_s32_u8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k32_s32_u8_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m1_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m1_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e2m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e3m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e3m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e4m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e4m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e5m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m1_e5m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m1_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m1_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e2m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e3m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e3m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e4m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e4m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e5m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e2m3_e5m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m1_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m1_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e2m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e3m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e3m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e4m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e4m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e5m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e3m2_e5m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m1_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m1_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e2m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e3m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e3m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e4m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e4m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e5m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e4m3_e5m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m1_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m1_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m1_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e2m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e3m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e3m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e3m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e4m3_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e4m3_f16.below.ptx, line 40; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e4m3_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e5m2_f16",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with with F16 accumulator and F8 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e5m2_f16.below.ptx, line 40; error   : Feature 'mma with FP8 floating point type and FP16 accumulation' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f16_e5m2_e5m2_f16.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m1_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m1_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m1_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e2m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e3m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e3m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e3m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e4m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e4m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e4m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e5m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e5m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m1_e5m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m1_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m1_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m1_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e2m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e3m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e3m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e3m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e4m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e4m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e4m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e5m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e5m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e2m3_e5m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m1_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m1_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m1_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e2m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e3m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e3m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e3m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e4m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e4m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e4m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e5m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e5m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e3m2_e5m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m1_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m1_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m1_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e2m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e3m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e3m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e3m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e4m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e4m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e5m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e4m3_e5m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m1_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m1_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m1_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m3_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e2m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e3m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e3m2_f32.below.ptx, line 44; error   : Feature 'mma with with FP6/FP4 floating point type' requires PTX ISA .version 8.7 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e3m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e4m3_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e4m3_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e5m2_f32",
+      "minimum_ptx": "8.7",
+      "target": "sm_120a",
+      "accepted_ptx": "8.7",
+      "rejected_ptx": "8.6",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_kind_f8f6f4_f32_e5m2_e5m2_f32.below.ptx, line 6; error   : PTX .version 8.6 does not support .target sm_120a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s4_u4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_u4.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_u4.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s4_u4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s4_u4_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s8.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s8_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s8_u8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s8_u8.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_s8_u8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_s8_u8_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u4_s4",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_s4.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_s4.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u4_s4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_s4_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u4_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_satfinite.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u4_satfinite.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u8.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u8_s8",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u8_s8.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u8_s8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u8_s8_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k64_s32_u8_satfinite",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k64_s32_u8_satfinite.below.ptx, line 44; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mma_sp_ordered_metadata_m16n8k8_f32_tf32",
+      "minimum_ptx": "8.5",
+      "target": "sm_80",
+      "accepted_ptx": "8.5",
+      "rejected_ptx": "8.4",
+      "rejection_detail": "ptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k8_f32_tf32.below.ptx, line 36; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k8_f32_tf32.below.ptx, line 71; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k8_f32_tf32.below.ptx, line 106; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later\nptxas <floor-probe>/mma_sp_ordered_metadata_m16n8k8_f32_tf32.below.ptx, line 141; error   : Feature '.sp::ordered_metadata' requires PTX ISA .version 8.5 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "movmatrix_trans_b16",
+      "minimum_ptx": "7.8",
+      "target": "sm_75",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/movmatrix_trans_b16.below.ptx, line 20; error   : Feature 'movmatrix' requires PTX ISA .version 7.8 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_bf16x2",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/mul_bf16x2.below.ptx, line 22; error   : Feature 'mul.bf16x2' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/mul_bf16x2.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "mul_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_f32x2.below.ptx, line 22; error   : Feature 'mul.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/mul_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_ftz_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_ftz_f32x2.below.ptx, line 22; error   : Feature 'mul.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/mul_ftz_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rm_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rm_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rm_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rn_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rn_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rn_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rp_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rp_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rp_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rz_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "mul_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/mul_rz_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "nanosleep",
+      "minimum_ptx": "6.3",
+      "target": "sm_75",
+      "accepted_ptx": "6.3",
+      "rejected_ptx": "6.2",
+      "rejection_detail": "ptxas <floor-probe>/nanosleep.below.ptx, line 6; error   : PTX .version 6.2 does not support .target sm_75\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "neg_bf16x2",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/neg_bf16x2.below.ptx, line 20; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/neg_bf16x2.below.ptx, line 20; error   : Feature '.bf16x2' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/neg_bf16x2.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "neg_f16x2",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "nsmid",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "nwarpid",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "packed_atomic_add_bf16x2",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/packed_atomic_add_bf16x2.below.ptx, line 23; error   : Instruction 'atom.add.bf16x2.global' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/packed_atomic_add_bf16x2.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "packed_atomic_add_f16x2",
+      "minimum_ptx": "6.2",
+      "reason": "PTX 6.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "pmevent",
+      "minimum_ptx": "1.4",
+      "reason": "PTX 1.4 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "prefetch_tma_descriptor",
+      "minimum_ptx": "8.0",
+      "target": "sm_90",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/prefetch_tma_descriptor.below.ptx, line 19; error   : Modifier '.tensormap' requires PTX ISA .version 8.0 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_b4e",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_ecl",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_ecr",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_f4e",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_rc16",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "prmt_rc8",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/rcp_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_approx_ftz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/rcp_approx_ftz_f64.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rcp_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_add",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_add.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_add.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_and",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_and.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_and.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_abs_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_abs_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_max_abs_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_abs_nan_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_abs_nan_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_max_abs_nan_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_max_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_i32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_i32.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_max_i32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_nan_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_nan_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_max_nan_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_max_u32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_max_u32.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_max_u32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_abs_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_abs_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_min_abs_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_abs_nan_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_abs_nan_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_min_abs_nan_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_min_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_i32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_i32.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_min_i32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_nan_f32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_nan_f32.below.ptx, line 21; error   : Feature 'redux.f32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/redux_sync_min_nan_f32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_min_u32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_min_u32.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_min_u32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_or",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_or.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_or.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "redux_sync_xor",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/redux_sync_xor.below.ptx, line 21; error   : Feature 'redux' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/redux_sync_xor.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rsqrt_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/rsqrt_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rsqrt_approx_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "rsqrt_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/rsqrt_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "setmaxnreg_dec",
+      "minimum_ptx": "8.0",
+      "target": "sm_90a",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/setmaxnreg_dec.below.ptx, line 16; error   : Feature 'setmaxnreg.dec' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/setmaxnreg_dec.below.ptx, line 6; error   : PTX .version 7.8 does not support .target sm_90a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "setmaxnreg_inc",
+      "minimum_ptx": "8.0",
+      "target": "sm_90a",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/setmaxnreg_inc.below.ptx, line 16; error   : Feature 'setmaxnreg.inc' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/setmaxnreg_inc.below.ptx, line 6; error   : PTX .version 7.8 does not support .target sm_90a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_down_f32_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_down_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_down_u64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_f32_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_u64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_up_f32_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_up_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_up_u64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_xor_f32_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_xor_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "shuffle_xor_u64_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "sin_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/sin_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sin_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/sin_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "smid",
+      "minimum_ptx": "1.3",
+      "reason": "PTX 1.3 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/sqrt_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_approx_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/sqrt_approx_ftz_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rm_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rm_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rm_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rn_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rn_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rn_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rp_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rp_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rp_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rz_f64",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sqrt_rz_ftz_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <macro util>, line 2; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "stmatrix_m8n8_x2_b16",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/stmatrix_m8n8_x2_b16.below.ptx, line 25; error   : Feature 'stmatrix' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/stmatrix_m8n8_x2_b16.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "stmatrix_m8n8_x2_trans_b16",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/stmatrix_m8n8_x2_trans_b16.below.ptx, line 25; error   : Feature 'stmatrix' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/stmatrix_m8n8_x2_trans_b16.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "stmatrix_m8n8_x4_b16",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/stmatrix_m8n8_x4_b16.below.ptx, line 29; error   : Feature 'stmatrix' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/stmatrix_m8n8_x4_b16.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "stmatrix_m8n8_x4_trans_b16",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/stmatrix_m8n8_x4_trans_b16.below.ptx, line 29; error   : Feature 'stmatrix' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/stmatrix_m8n8_x4_trans_b16.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sub_bf16x2",
+      "minimum_ptx": "7.8",
+      "target": "sm_90",
+      "accepted_ptx": "7.8",
+      "rejected_ptx": "7.7",
+      "rejection_detail": "ptxas <floor-probe>/sub_bf16x2.below.ptx, line 22; error   : Feature 'sub.bf16x2' requires PTX ISA .version 7.8 or later\nptxas <floor-probe>/sub_bf16x2.below.ptx, line 6; error   : PTX .version 7.7 does not support .target sm_90\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "sub_f16x2",
+      "minimum_ptx": "4.2",
+      "reason": "PTX 4.2 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "sub_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/sub_f32x2.below.ptx, line 22; error   : Feature 'sub.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/sub_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "sub_ftz_f32x2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/sub_ftz_f32x2.below.ptx, line 22; error   : Feature 'sub.f32x2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/sub_ftz_f32x2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "sync_mask",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "sync_threads",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "tanh_approx_f32",
+      "minimum_ptx": "7.0",
+      "target": "sm_80",
+      "accepted_ptx": "7.0",
+      "rejected_ptx": "6.5",
+      "rejection_detail": "ptxas <floor-probe>/tanh_approx_f32.below.ptx, line 20; error   : Feature 'tanh' requires PTX ISA .version 7.0 or later\nptxas <floor-probe>/tanh_approx_f32.below.ptx, line 6; error   : PTX .version 6.5 does not support .target sm_80\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_alloc",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_alloc.below.ptx, line 23; error   : Feature 'tcgen05.alloc' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_alloc.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_alloc.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_alloc_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_alloc_cg2.below.ptx, line 23; error   : Feature 'tcgen05.alloc' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_alloc_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_alloc_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit.below.ptx, line 20; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit.below.ptx, line 20; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit.below.ptx, line 20; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit_cg2.below.ptx, line 20; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_cg2.below.ptx, line 20; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_cg2.below.ptx, line 20; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit_multicast",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit_multicast.below.ptx, line 23; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast.below.ptx, line 23; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit_multicast_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit_multicast_cg2.below.ptx, line 23; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast_cg2.below.ptx, line 23; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_multicast_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit_shared_cluster",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit_shared_cluster.below.ptx, line 20; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster.below.ptx, line 20; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster.below.ptx, line 20; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_commit_shared_cluster_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_commit_shared_cluster_cg2.below.ptx, line 20; error   : Feature 'tcgen05.commit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster_cg2.below.ptx, line 20; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster_cg2.below.ptx, line 20; error   : Feature '.zoneevre::neevir::bar' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_commit_shared_cluster_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b4x16_p64_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_b6x16_p32_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x128b_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x128b_cg2.below.ptx, line 23; error   : Modifier '.128x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x128b_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x256b_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x256b_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b4x16_p64_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x256b_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_128x256b_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_128x256b_b6x16_p32_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_32x128b_warpx4_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_cg2.below.ptx, line 23; error   : Modifier '.32x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_cg2.below.ptx, line 23; error   : Feature '.warpx4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_32x128b_warpx4_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b4x16_p64_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_b6x16_p32_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_4x256b_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_4x256b_cg2.below.ptx, line 23; error   : Modifier '.4x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_4x256b_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_01_23_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_cg2.below.ptx, line 23; error   : Feature '.warpx2::01_23' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_01_23_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b4x16_p64_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_b6x16_p32_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_64x128b_warpx2_02_13_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_cg2.below.ptx, line 23; error   : Modifier '.64x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_cg2.below.ptx, line 23; error   : Feature '.warpx2::02_13' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_64x128b_warpx2_02_13_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_smem_to_tmem",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_smem_to_tmem.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem.below.ptx, line 23; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_cp_smem_to_tmem_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_cp_smem_to_tmem_cg2.below.ptx, line 23; error   : Modifier '.128x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem_cg2.below.ptx, line 23; error   : Feature 'tcgen05.cp' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem_cg2.below.ptx, line 23; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_cp_smem_to_tmem_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_dealloc",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_dealloc.below.ptx, line 22; error   : Feature 'tcgen05.dealloc' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_dealloc.below.ptx, line 22; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_dealloc.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_dealloc_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_dealloc_cg2.below.ptx, line 22; error   : Feature 'tcgen05.dealloc' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_dealloc_cg2.below.ptx, line 22; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_dealloc_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_fence_after_thread_sync",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_fence_after_thread_sync.below.ptx, line 17; error   : Feature 'tcgen05.fence' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_fence_after_thread_sync.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_fence_before_thread_sync",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_fence_before_thread_sync.below.ptx, line 17; error   : Feature 'tcgen05.fence' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_fence_before_thread_sync.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x16_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x16_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x16_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x16_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x16_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x16_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x16_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x1_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x1_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x1_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x1_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x1_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x1_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x1_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x2_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x2_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x2_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x2_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x2_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x2_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x2_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x32_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x32_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x32_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x32_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x32_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x32_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x32_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x4_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x4_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x4_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x4_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x4_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x4_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x4_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x64_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x64_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x64_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x64_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x64_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x64_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x64_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x8_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x8_pack16.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x8_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x8_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x8_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x128b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x128b_x8_raw.below.ptx, line 20; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x8_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x128b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_pure",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_pure.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_pure.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_pure.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x16_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x16_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x16_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x16_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x16_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x16_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x16_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x1_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x1_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x1_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x1_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x1_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x1_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x1_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x2_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x2_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x2_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x2_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x2_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x2_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x2_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x32_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x32_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x32_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x32_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x32_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x32_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x32_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x4_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x4_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x4_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x4_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x4_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x4_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x4_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x8_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x8_pack16.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x8_pure",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x8_pure.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_pure.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_pure.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x256b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x256b_x8_raw.below.ptx, line 20; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x256b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x128_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x16_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x1_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x2_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x32_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x4_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x64_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x8_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_pack16.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x32bx2_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_raw.below.ptx, line 20; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x32bx2_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x128_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x128_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x128_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x128_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x128_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x128_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x128_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x16_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x16_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x16_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x16_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x16_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x16_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x16_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x1_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x1_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x1_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x1_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x1_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x1_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x1_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x2_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x2_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x2_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x2_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x2_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x2_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x2_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x32_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x32_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x32_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x32_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x32_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x32_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x32_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x4_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x4_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x4_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x4_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x4_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x4_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x4_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x64_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x64_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x64_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x64_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x64_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x64_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x64_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x8_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x8_pack16.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x8_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x8_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x8_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_16x64b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_16x64b_x8_raw.below.ptx, line 20; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x8_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_16x64b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x128_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x128_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x128_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x128_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x128_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x128_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x128_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x16_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x16_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x16_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x16_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x16_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x16_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x16_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x1_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x1_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x1_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x1_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x1_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x1_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x1_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x2_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x2_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x2_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x2_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x2_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x2_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x2_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x32_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x32_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x32_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x32_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x32_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x32_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x32_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x4_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x4_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x4_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x4_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x4_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x4_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x4_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x64_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x64_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x64_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x64_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x64_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x64_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x64_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x8_pack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x8_pack16.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x8_pack16.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x8_pack16.below.ptx, line 20; error   : Feature '.pack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x8_pack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_ld_32x32b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_ld_32x32b_x8_raw.below.ptx, line 20; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x8_raw.below.ptx, line 20; error   : Feature 'tcgen05.ld' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_ld_32x32b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_load_wait",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_load_wait.below.ptx, line 17; error   : Feature 'tcgen05.wait' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_load_wait.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_e2m1",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_e2m1.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m1.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m1.below.ptx, line 29; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m1.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_e2m3",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_e2m3.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m3.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m3.below.ptx, line 29; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e2m3.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_e3m2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_e3m2.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e3m2.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e3m2.below.ptx, line 29; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e3m2.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_e4m3",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_e4m3.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e4m3.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e4m3.below.ptx, line 29; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e4m3.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_e5m2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_e5m2.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e5m2.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e5m2.below.ptx, line 29; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_e5m2.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_f16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_f16.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_f16_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_f16_cg2.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16_cg2.below.ptx, line 29; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16_cg2.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_f16_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_shared",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_shared.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_shared.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_shared.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_shared.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_sp_shared",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_sp_shared.below.ptx, line 31; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_shared.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_shared.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_shared.below.ptx, line 31; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_sp_tensor",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_sp_tensor.below.ptx, line 31; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor.below.ptx, line 31; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_sp_tensor_ashift",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_sp_tensor_ashift.below.ptx, line 31; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor_ashift.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor_ashift.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_sp_tensor_ashift.below.ptx, line 31; error   : Feature '.ashift' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_tensor",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_tensor.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor.below.ptx, line 29; error   : Feature '.collector::a::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_tensor_ashift",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_tensor_ashift.below.ptx, line 29; error   : Feature 'tcgen05.mma' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor_ashift.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor_ashift.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_tensor_ashift.below.ptx, line 29; error   : Feature '.ashift' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_bf16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_bf16.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_bf16.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_bf16.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_bf16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_e2m1",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_e2m1.below.ptx, line 30; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m1.below.ptx, line 30; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m1.below.ptx, line 30; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m1.below.ptx, line 30; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_e2m3",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_e2m3.below.ptx, line 30; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m3.below.ptx, line 30; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m3.below.ptx, line 30; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e2m3.below.ptx, line 30; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_e3m2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_e3m2.below.ptx, line 30; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e3m2.below.ptx, line 30; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e3m2.below.ptx, line 30; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e3m2.below.ptx, line 30; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_e4m3",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_e4m3.below.ptx, line 30; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e4m3.below.ptx, line 30; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e4m3.below.ptx, line 30; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e4m3.below.ptx, line 30; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_e5m2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_e5m2.below.ptx, line 30; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e5m2.below.ptx, line 30; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e5m2.below.ptx, line 30; error   : Feature '.kind::f8f6f4' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_e5m2.below.ptx, line 30; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_f16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_f16.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_f16.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_f16.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_f16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_shared",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_shared.below.ptx, line 29; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared.below.ptx, line 29; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_shared_zero_col_mask",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_shared_zero_col_mask.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared_zero_col_mask.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared_zero_col_mask.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_shared_zero_col_mask.below.ptx, line 31; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_sp_shared",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_sp_shared.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared.below.ptx, line 31; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_sp_shared_zero_col_mask",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_sp_shared_zero_col_mask.below.ptx, line 33; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared_zero_col_mask.below.ptx, line 33; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared_zero_col_mask.below.ptx, line 33; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_shared_zero_col_mask.below.ptx, line 33; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_sp_tensor",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_sp_tensor.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor.below.ptx, line 31; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_sp_tensor_zero_col_mask",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_sp_tensor_zero_col_mask.below.ptx, line 33; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor_zero_col_mask.below.ptx, line 33; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor_zero_col_mask.below.ptx, line 33; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_sp_tensor_zero_col_mask.below.ptx, line 33; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_tensor",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_tensor.below.ptx, line 29; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor.below.ptx, line 29; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor.below.ptx, line 29; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor.below.ptx, line 29; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_tensor_zero_col_mask",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_tensor_zero_col_mask.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor_zero_col_mask.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor_zero_col_mask.below.ptx, line 31; error   : Feature '.kind::f16' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tensor_zero_col_mask.below.ptx, line 31; error   : Feature '.collector::b0::discard' requires PTX ISA .version 8.6 or later"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_mma_ws_tf32",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_mma_ws_tf32.below.ptx, line 31; error   : Feature 'tcgen05.mma.ws' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tf32.below.ptx, line 31; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tf32.below.ptx, line 31; error   : Feature '.kind::tf32' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_mma_ws_tf32.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_relinquish_alloc_permit",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_relinquish_alloc_permit.below.ptx, line 17; error   : Feature 'tcgen05.relinquish_alloc_permit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_relinquish_alloc_permit.below.ptx, line 17; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_relinquish_alloc_permit.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_relinquish_alloc_permit_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_relinquish_alloc_permit_cg2.below.ptx, line 17; error   : Feature 'tcgen05.relinquish_alloc_permit' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_relinquish_alloc_permit_cg2.below.ptx, line 17; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_relinquish_alloc_permit_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_shift_down",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_shift_down.below.ptx, line 20; error   : Feature 'tcgen05.shift' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_shift_down.below.ptx, line 20; error   : Feature '.cta_group::1' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_shift_down.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_shift_down_cg2",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_shift_down_cg2.below.ptx, line 20; error   : Feature 'tcgen05.shift' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_shift_down_cg2.below.ptx, line 20; error   : Feature '.cta_group::2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_shift_down_cg2.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x16_raw.below.ptx, line 84; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x16_raw.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x16_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x16_unpack16.below.ptx, line 84; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x16_unpack16.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x16_unpack16.below.ptx, line 84; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x16_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x1_raw.below.ptx, line 24; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x1_raw.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x1_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x1_unpack16.below.ptx, line 24; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x1_unpack16.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x1_unpack16.below.ptx, line 24; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x1_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x2_raw.below.ptx, line 28; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x2_raw.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x2_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x2_unpack16.below.ptx, line 28; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x2_unpack16.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x2_unpack16.below.ptx, line 28; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x2_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x32_raw.below.ptx, line 148; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x32_raw.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x32_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x32_unpack16.below.ptx, line 148; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x32_unpack16.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x32_unpack16.below.ptx, line 148; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x32_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x4_raw.below.ptx, line 36; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x4_raw.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x4_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x4_unpack16.below.ptx, line 36; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x4_unpack16.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x4_unpack16.below.ptx, line 36; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x4_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x64_raw.below.ptx, line 276; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x64_raw.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x64_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x64_unpack16.below.ptx, line 276; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x64_unpack16.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x64_unpack16.below.ptx, line 276; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x64_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x8_raw.below.ptx, line 52; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x8_raw.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x128b_x8_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x128b_x8_unpack16.below.ptx, line 52; error   : Modifier '.16x128b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x8_unpack16.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x8_unpack16.below.ptx, line 52; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x128b_x8_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x16_raw.below.ptx, line 148; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x16_raw.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x16_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x16_unpack16.below.ptx, line 148; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x16_unpack16.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x16_unpack16.below.ptx, line 148; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x16_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x1_raw.below.ptx, line 28; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x1_raw.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x1_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x1_unpack16.below.ptx, line 28; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x1_unpack16.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x1_unpack16.below.ptx, line 28; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x1_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x2_raw.below.ptx, line 36; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x2_raw.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x2_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x2_unpack16.below.ptx, line 36; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x2_unpack16.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x2_unpack16.below.ptx, line 36; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x2_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x32_raw.below.ptx, line 276; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x32_raw.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x32_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x32_unpack16.below.ptx, line 276; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x32_unpack16.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x32_unpack16.below.ptx, line 276; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x32_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x4_raw.below.ptx, line 52; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x4_raw.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x4_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x4_unpack16.below.ptx, line 52; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x4_unpack16.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x4_unpack16.below.ptx, line 52; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x4_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x8_raw.below.ptx, line 84; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x8_raw.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x256b_x8_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x256b_x8_unpack16.below.ptx, line 84; error   : Modifier '.16x256b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x8_unpack16.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x8_unpack16.below.ptx, line 84; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x256b_x8_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x128_raw.below.ptx, line 276; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x128_raw.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x128_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x128_unpack16.below.ptx, line 276; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x128_unpack16.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x128_unpack16.below.ptx, line 276; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x128_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x16_raw.below.ptx, line 52; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x16_raw.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x16_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x16_unpack16.below.ptx, line 52; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x16_unpack16.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x16_unpack16.below.ptx, line 52; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x16_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x1_raw.below.ptx, line 22; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x1_raw.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x1_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x1_unpack16.below.ptx, line 22; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x1_unpack16.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x1_unpack16.below.ptx, line 22; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x1_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x2_raw.below.ptx, line 24; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x2_raw.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x2_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x2_unpack16.below.ptx, line 24; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x2_unpack16.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x2_unpack16.below.ptx, line 24; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x2_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x32_raw.below.ptx, line 84; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x32_raw.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x32_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x32_unpack16.below.ptx, line 84; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x32_unpack16.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x32_unpack16.below.ptx, line 84; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x32_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x4_raw.below.ptx, line 28; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x4_raw.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x4_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x4_unpack16.below.ptx, line 28; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x4_unpack16.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x4_unpack16.below.ptx, line 28; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x4_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x64_raw.below.ptx, line 148; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x64_raw.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x64_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x64_unpack16.below.ptx, line 148; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x64_unpack16.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x64_unpack16.below.ptx, line 148; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x64_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x8_raw.below.ptx, line 36; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x8_raw.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x32bx2_x8_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x32bx2_x8_unpack16.below.ptx, line 36; error   : Modifier '.16x32bx2' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x8_unpack16.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x8_unpack16.below.ptx, line 36; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x32bx2_x8_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x128_raw.below.ptx, line 276; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x128_raw.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x128_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x128_unpack16.below.ptx, line 276; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x128_unpack16.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x128_unpack16.below.ptx, line 276; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x128_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x16_raw.below.ptx, line 52; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x16_raw.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x16_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x16_unpack16.below.ptx, line 52; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x16_unpack16.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x16_unpack16.below.ptx, line 52; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x16_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x1_raw.below.ptx, line 22; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x1_raw.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x1_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x1_unpack16.below.ptx, line 22; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x1_unpack16.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x1_unpack16.below.ptx, line 22; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x1_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x2_raw.below.ptx, line 24; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x2_raw.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x2_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x2_unpack16.below.ptx, line 24; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x2_unpack16.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x2_unpack16.below.ptx, line 24; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x2_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x32_raw.below.ptx, line 84; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x32_raw.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x32_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x32_unpack16.below.ptx, line 84; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x32_unpack16.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x32_unpack16.below.ptx, line 84; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x32_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x4_raw.below.ptx, line 28; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x4_raw.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x4_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x4_unpack16.below.ptx, line 28; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x4_unpack16.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x4_unpack16.below.ptx, line 28; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x4_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x64_raw.below.ptx, line 148; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x64_raw.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x64_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x64_unpack16.below.ptx, line 148; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x64_unpack16.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x64_unpack16.below.ptx, line 148; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x64_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x8_raw.below.ptx, line 36; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x8_raw.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_16x64b_x8_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_16x64b_x8_unpack16.below.ptx, line 36; error   : Modifier '.16x64b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x8_unpack16.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x8_unpack16.below.ptx, line 36; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_16x64b_x8_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x128_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x128_raw.below.ptx, line 276; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x128_raw.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x128_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x128_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x128_unpack16.below.ptx, line 276; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x128_unpack16.below.ptx, line 276; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x128_unpack16.below.ptx, line 276; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x128_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x16_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x16_raw.below.ptx, line 52; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x16_raw.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x16_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x16_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x16_unpack16.below.ptx, line 52; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x16_unpack16.below.ptx, line 52; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x16_unpack16.below.ptx, line 52; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x16_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x1_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x1_raw.below.ptx, line 22; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x1_raw.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x1_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x1_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x1_unpack16.below.ptx, line 22; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x1_unpack16.below.ptx, line 22; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x1_unpack16.below.ptx, line 22; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x1_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x2_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x2_raw.below.ptx, line 24; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x2_raw.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x2_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x2_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x2_unpack16.below.ptx, line 24; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x2_unpack16.below.ptx, line 24; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x2_unpack16.below.ptx, line 24; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x2_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x32_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x32_raw.below.ptx, line 84; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x32_raw.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x32_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x32_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x32_unpack16.below.ptx, line 84; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x32_unpack16.below.ptx, line 84; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x32_unpack16.below.ptx, line 84; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x32_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x4_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x4_raw.below.ptx, line 28; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x4_raw.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x4_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x4_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x4_unpack16.below.ptx, line 28; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x4_unpack16.below.ptx, line 28; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x4_unpack16.below.ptx, line 28; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x4_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x64_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x64_raw.below.ptx, line 148; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x64_raw.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x64_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x64_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x64_unpack16.below.ptx, line 148; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x64_unpack16.below.ptx, line 148; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x64_unpack16.below.ptx, line 148; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x64_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x8_raw",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x8_raw.below.ptx, line 36; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x8_raw.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x8_raw.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_st_32x32b_x8_unpack16",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_st_32x32b_x8_unpack16.below.ptx, line 36; error   : Modifier '.32x32b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x8_unpack16.below.ptx, line 36; error   : Feature 'tcgen05.st' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x8_unpack16.below.ptx, line 36; error   : Feature '.unpack::16b' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_st_32x32b_x8_unpack16.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a"
+    },
+    {
+      "verdict": "verified",
+      "id": "tcgen05_store_wait",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tcgen05_store_wait.below.ptx, line 17; error   : Feature 'tcgen05.wait' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tcgen05_store_wait.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_box_dim",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_box_dim.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_box_dim.below.ptx, line 21; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_box_dim.below.ptx, line 23; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_element_stride",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_element_stride.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_element_stride.below.ptx, line 21; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_element_stride.below.ptx, line 23; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_element_type",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_element_type.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_element_type.below.ptx, line 20; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_fill_mode",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_fill_mode.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_fill_mode.below.ptx, line 20; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_global_address",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_global_address.below.ptx, line 19; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_address.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_address.below.ptx, line 22; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_global_dim",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_global_dim.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_dim.below.ptx, line 21; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_dim.below.ptx, line 23; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_global_stride",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_global_stride.below.ptx, line 19; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_stride.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_global_stride.below.ptx, line 22; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_interleave_layout",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_interleave_layout.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_interleave_layout.below.ptx, line 20; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_rank",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_rank.below.ptx, line 20; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_rank.below.ptx, line 21; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_rank.below.ptx, line 23; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_swizzle_atomicity",
+      "minimum_ptx": "8.6",
+      "target": "sm_100a",
+      "accepted_ptx": "8.6",
+      "rejected_ptx": "8.5",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_swizzle_atomicity.below.ptx, line 20; error   : Feature 'tensormap.replace.swizzle_atomicity' requires PTX ISA .version 8.6 or later\nptxas <floor-probe>/tensormap_replace_swizzle_atomicity.below.ptx, line 6; error   : PTX .version 8.5 does not support .target sm_100a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "tensormap_replace_swizzle_mode",
+      "minimum_ptx": "8.3",
+      "target": "sm_90a",
+      "accepted_ptx": "8.3",
+      "rejected_ptx": "8.2",
+      "rejection_detail": "ptxas <floor-probe>/tensormap_replace_swizzle_mode.below.ptx, line 18; error   : Feature '::func' requires PTX ISA .version 8.3 or later\nptxas <floor-probe>/tensormap_replace_swizzle_mode.below.ptx, line 20; error   : Feature 'tensormap.replace' requires PTX ISA .version 8.3 or later\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "thread_idx_x",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "thread_idx_y",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "thread_idx_z",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "threadfence",
+      "minimum_ptx": "1.4",
+      "reason": "PTX 1.4 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "threadfence_block",
+      "minimum_ptx": "1.4",
+      "reason": "PTX 1.4 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "threadfence_system",
+      "minimum_ptx": "2.0",
+      "reason": "PTX 2.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "total_smem_size",
+      "minimum_ptx": "4.1",
+      "reason": "PTX 4.1 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "trap",
+      "minimum_ptx": "1.0",
+      "reason": "PTX 1.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "uni_sync",
+      "minimum_ptx": "6.0",
+      "reason": "PTX 6.0 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "unverifiable",
+      "id": "warpid",
+      "minimum_ptx": "1.3",
+      "reason": "PTX 1.3 cannot name sm_75, the oldest target accepted by CUDA 13.2 ptxas"
+    },
+    {
+      "verdict": "verified",
+      "id": "wgmma_commit_group",
+      "minimum_ptx": "8.0",
+      "target": "sm_90a",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/wgmma_commit_group.below.ptx, line 16; error   : Feature 'WGMMA' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/wgmma_commit_group.below.ptx, line 6; error   : PTX .version 7.8 does not support .target sm_90a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "wgmma_fence",
+      "minimum_ptx": "8.0",
+      "target": "sm_90a",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/wgmma_fence.below.ptx, line 16; error   : Feature 'WGMMA' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/wgmma_fence.below.ptx, line 6; error   : PTX .version 7.8 does not support .target sm_90a\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "verdict": "verified",
+      "id": "wgmma_wait_group",
+      "minimum_ptx": "8.0",
+      "target": "sm_90a",
+      "accepted_ptx": "8.0",
+      "rejected_ptx": "7.8",
+      "rejection_detail": "ptxas <floor-probe>/wgmma_wait_group.below.ptx, line 16; error   : Feature 'WGMMA' requires PTX ISA .version 8.0 or later\nptxas <floor-probe>/wgmma_wait_group.below.ptx, line 6; error   : PTX .version 7.8 does not support .target sm_90a\nptxas fatal   : Ptx assembly aborted due to errors"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a CUDA 13.2.51 `ptxas` floor probe that lowers each resolved intrinsic at its declared PTX floor, requires assembly success there, and requires rejection at the immediately preceding PTX spelling
- record the accepted/rejected boundary, target, rejection diagnostic, and SHA-256 identities of both `ptxas` and the Rust LLVM `llc`
- represent floors below the live toolchain boundary as `unverifiable` instead of manufacturing a verdict
- make normal catalog resolution require exact floor-evidence coverage and equality with every resolved policy floor; CI therefore checks committed evidence without needing `ptxas`

## Population and measurement

The 160 literal `minimum_ptx` declarations in `intrinsics/overlay/*.toml` split into 102 probeable and 58 unprobeable declarations. Resolution expands compact admission matrices, so the generator's actual validation population is larger:

- 1,025 resolved intrinsic policies total
- 942 measured: CUDA 13.2.51 accepted the declared floor and rejected the immediately preceding PTX spelling
- 83 explicitly unverifiable: their floor is below PTX 6.3

The measurement used:

- `ptxas` CUDA 13.2 V13.2.51, SHA-256 `c0a7c9752d1a1b29310ffbb453e8b895fb09e909dcf7436fef5c2c986c1a658e`
- Rust LLVM 23.1.0 from nightly 2026-08-28, `llc` SHA-256 `ca7af83e237af640fe337faff2eff49055988921933186ab5535b38addeb7b49`
- no GPU execution

CUDA 13.2 `ptxas` accepts no target below `sm_75`, and PTX 6.2 cannot name `sm_75`; PTX 6.3 can. The negative diagnostic is retained per record, including cases where instruction and target floors are coupled. This also means `PtxIsaRequirement::Ptx62` appears unreachable with this current assembler, but this PR does not change requirement lowering.

CI does not rerun this experiment. It follows the existing recorded-evidence model: the live toolkit produces committed evidence, while stock runners validate the resolved catalog against that evidence. `probe --all --skip-terminal --per-target` continues to work without `ptxas`.

## Positive control

I deliberately probed `abs_bf16x2` with a false PTX 7.1 declaration. The command failed because CUDA 13.2 accepted the PTX 7.0 negative probe:

```text
error: below-floor positive control failed: ptxas accepted abs_bf16x2 at PTX 7.0, below declared PTX 7.1
```

## Legacy barrier note

The NVIDIA PTX ISA states exactly:

> `bar.sync` without a thread count introduced in PTX ISA version 1.0.
>
> Register operands, thread count, and `bar.{arrive,red}` introduced in PTX ISA version 2.0.

It also states that those register/count/arrive/red forms require `sm_20` or higher. Source: [NVIDIA PTX ISA 9.3, bar/barrier notes](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar-barrier).

Accordingly, the fixed-immediate `sync.toml` declaration appears correct at PTX 1.0, while counted `bar.sync` and `bar.arrive` declarations appear under-declared. They are in the unprobeable population, and this PR intentionally does not edit `counted_barrier.toml` or `sync.toml` because those files are being changed concurrently.

## Not verified here

- CUDA 13.3 is not installed on this machine, so the new evidence has its own CUDA 13.2.51 profile and does not modify or claim to refresh the existing CUDA 13.3 evidence.
- Floors below PTX 6.3 cannot be measured by this supported assembler/target combination and remain explicitly `unverifiable`.
- No runtime behavior was tested; the GPU is currently unavailable, and floor validation requires only PTX assembly.

## Verification

- `cargo test -p cuda-intrinsics-gen` — 311 passed
- `cargo run -p cuda-intrinsics-gen -- check`
- `git diff --check`
- full live `probe-floors` run using CUDA 13.2.51
- false-floor positive control described above
