### PR TITLE
ptx-schedule: classify tensor-map mutations as schedule sites

### DIFF
--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -31,6 +31,7 @@ places where another thread's progress can be observed:
 | `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
 | `AsyncProxy` | the asynchronous proxy pipeline: `cp.async.*`, `cp.reduce.async.*`, `wgmma.*`, `tcgen05.*` and `clusterlaunchcontrol.*` -- the bulk-copy, bulk-reduce and matrix issues and the commit/wait pairs that order them |
+| `GridDependency` | programmatic dependent-launch ordering: `griddepcontrol.launch_dependents` / `griddepcontrol.wait` |
 | `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |
 
 Each site keeps its ordinal, enclosing callable, byte span, the instruction

--- a/crates/ptx-schedule/README.md
+++ b/crates/ptx-schedule/README.md
@@ -31,6 +31,7 @@ places where another thread's progress can be observed:
 | `OrderedMemory` | a load or store carrying an explicit ordering qualifier (`.volatile`, `.acquire`, `.relaxed`, ...) |
 | `WarpCollective` | `shfl`, `vote`, `match`, `redux` and friends |
 | `AsyncProxy` | the asynchronous proxy pipeline: `cp.async.*`, `cp.reduce.async.*`, `wgmma.*`, `tcgen05.*` and `clusterlaunchcontrol.*` -- the bulk-copy, bulk-reduce and matrix issues and the commit/wait pairs that order them |
+| `TensorMapMutation` | `tensormap.replace.*` generic-proxy tensor-map descriptor mutation, published by `fence.proxy.tensormap::*` |
 | `Backedge` | a `bra` back to the same or an earlier block -- a conservative loop detector |
 
 Each site keeps its ordinal, enclosing callable, byte span, the instruction

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -832,7 +832,12 @@ L_loop:
 
     /// Both spellings are emitted by mir-lower for programmatic dependent
     /// launch. They order one grid against another and must remain distinct
-    /// from the asynchronous proxy pipeline.
+    /// from the asynchronous proxy pipeline. The trailing `fence.acq_rel.gpu`
+    /// is an unaffected control: a neighbouring kind that must keep its kind.
+    /// No in-tree example emits `griddepcontrol` yet, so the spellings come
+    /// from the mir-lower lowering (inline asm on the libNVVM path, the
+    /// `llvm.nvvm.griddepcontrol.*` intrinsics otherwise), as the AsyncProxy
+    /// fixture does for `cp.reduce.async`.
     const GRID_DEPENDENCY: &str = r#".version 8.7
 .target sm_90
 .address_size 64
@@ -841,6 +846,7 @@ L_loop:
 {
     griddepcontrol.launch_dependents;
     griddepcontrol.wait;
+    fence.acq_rel.gpu;
     ret;
 }
 "#;
@@ -854,10 +860,21 @@ L_loop:
             .filter(|site| site.kind == SiteKind::GridDependency)
             .collect();
 
-        assert_eq!(analysis.sites().len(), 2, "{:?}", analysis.sites());
+        assert_eq!(analysis.sites().len(), 3, "{:?}", analysis.sites());
         assert_eq!(sites.len(), 2, "{:?}", sites);
         assert_eq!(sites[0].head, "griddepcontrol.launch_dependents");
         assert_eq!(sites[1].head, "griddepcontrol.wait");
+
+        let control = analysis
+            .sites()
+            .iter()
+            .find(|site| site.head.starts_with("fence."))
+            .expect("the control fence must still be a site");
+        assert_eq!(
+            control.kind,
+            SiteKind::Fence,
+            "a neighbouring kind must keep its kind: {control:?}"
+        );
     }
 
     #[test]

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -42,6 +42,7 @@ pub enum SiteKind {
     OrderedMemory,
     WarpCollective,
     AsyncProxy,
+    GridDependency,
     Backedge,
 }
 
@@ -368,6 +369,13 @@ fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
     .any(|prefix| head.starts_with(prefix))
     {
         return Some(SiteKind::AsyncProxy);
+    }
+
+    // Programmatic dependent launch orders one grid against another. It is a
+    // schedule boundary like a barrier or fence, but belongs to neither the
+    // synchronous thread/CTA primitives nor the asynchronous proxy pipeline.
+    if head.starts_with("griddepcontrol.") {
+        return Some(SiteKind::GridDependency);
     }
 
     let mut parts = head.split('.');
@@ -820,5 +828,58 @@ L_loop:
                 .count()
                 >= 15
         );
+    }
+
+    /// Both spellings are emitted by mir-lower for programmatic dependent
+    /// launch. They order one grid against another and must remain distinct
+    /// from the asynchronous proxy pipeline.
+    const GRID_DEPENDENCY: &str = r#".version 8.7
+.target sm_90
+.address_size 64
+
+.visible .entry grid_dependency()
+{
+    griddepcontrol.launch_dependents;
+    griddepcontrol.wait;
+    ret;
+}
+"#;
+
+    #[test]
+    fn grid_dependency_instructions_are_sites() {
+        let analysis = analyze_ptx(GRID_DEPENDENCY).unwrap();
+        let sites: Vec<_> = analysis
+            .sites()
+            .iter()
+            .filter(|site| site.kind == SiteKind::GridDependency)
+            .collect();
+
+        assert_eq!(analysis.sites().len(), 2, "{:?}", analysis.sites());
+        assert_eq!(sites.len(), 2, "{:?}", sites);
+        assert_eq!(sites[0].head, "griddepcontrol.launch_dependents");
+        assert_eq!(sites[1].head, "griddepcontrol.wait");
+    }
+
+    #[test]
+    fn a_grid_dependency_site_can_be_perturbed() {
+        let rewrite = perturb_ptx(
+            GRID_DEPENDENCY,
+            &InjectionOptions {
+                seed: 7,
+                intensity: 1.0,
+                focus: Some("griddepcontrol".to_string()),
+                ..InjectionOptions::default()
+            },
+        )
+        .unwrap();
+        let injected = rewrite
+            .report
+            .decisions
+            .iter()
+            .filter(|decision| decision.site.kind == SiteKind::GridDependency)
+            .filter(|decision| decision.before_ns > 0 || decision.after_ns > 0)
+            .count();
+        assert!(injected > 0, "{:?}", rewrite.report.decisions);
+        assert!(rewrite.ptx.contains("nanosleep.u32"));
     }
 }

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -42,6 +42,7 @@ pub enum SiteKind {
     OrderedMemory,
     WarpCollective,
     AsyncProxy,
+    TensorMapMutation,
     Backedge,
 }
 
@@ -368,6 +369,14 @@ fn classify_instruction(instruction: &Instruction<'_>) -> Option<SiteKind> {
     .any(|prefix| head.starts_with(prefix))
     {
         return Some(SiteKind::AsyncProxy);
+    }
+
+    // Tensor-map replacement mutates a descriptor through the generic proxy.
+    // Its ordering edge is `fence.proxy.tensormap::generic.*`, so keep it
+    // separate from `AsyncProxy`: a campaign must be able to delay the
+    // mutation independently from the fence that publishes it.
+    if head.starts_with("tensormap.replace.") {
+        return Some(SiteKind::TensorMapMutation);
     }
 
     let mut parts = head.split('.');
@@ -819,6 +828,106 @@ L_loop:
                 .filter(|site| site.kind == SiteKind::AsyncProxy)
                 .count()
                 >= 15
+        );
+    }
+
+    /// Both spellings are emitted by the TMA lowering. The release
+    /// fence is the publication edge that orders the generic-proxy descriptor
+    /// mutation before a tensor-map consumer.
+    const TENSORMAP_MUTATIONS: &str = r#".version 8.7
+.target sm_90a
+.address_size 64
+
+.visible .entry tensormap_mutations()
+{
+    .reg .b32 %r0;
+    .reg .b64 %rd0;
+    tensormap.replace.tile.global_address.global.b1024.b64 [%rd0], %rd0;
+    tensormap.replace.tile.global_dim.global.b1024.b32 [%rd0], 0, %r0;
+    fence.proxy.tensormap::generic.release.gpu;
+    ret;
+}
+"#;
+
+    #[test]
+    fn tensormap_replace_instructions_are_sites() {
+        let analysis = analyze_ptx(TENSORMAP_MUTATIONS).unwrap();
+        let mutations: Vec<_> = analysis
+            .sites()
+            .iter()
+            .filter(|site| site.kind == SiteKind::TensorMapMutation)
+            .collect();
+
+        assert_eq!(mutations.len(), 2, "{mutations:?}");
+        assert!(
+            mutations
+                .iter()
+                .any(|site| site.head.contains(".global_address."))
+        );
+        assert!(
+            mutations
+                .iter()
+                .any(|site| site.head.contains(".global_dim."))
+        );
+    }
+
+    #[test]
+    fn tensormap_mutation_classification_leaves_proxy_fence_alone() {
+        let analysis = analyze_ptx(TENSORMAP_MUTATIONS).unwrap();
+        let kind_of = |prefix: &str| {
+            analysis
+                .sites()
+                .iter()
+                .find(|site| site.head.starts_with(prefix))
+                .map(|site| site.kind)
+        };
+
+        assert_eq!(
+            kind_of("tensormap.replace.tile.global_address"),
+            Some(SiteKind::TensorMapMutation)
+        );
+        assert_eq!(
+            kind_of("tensormap.replace.tile.global_dim"),
+            Some(SiteKind::TensorMapMutation)
+        );
+        assert_eq!(kind_of("fence.proxy.tensormap"), Some(SiteKind::Fence));
+    }
+
+    /// A focused campaign must be able to insert a delay after the descriptor
+    /// mutation and before the release fence that publishes it.
+    #[test]
+    fn a_tensormap_mutation_can_be_delayed_before_its_publish_fence() {
+        let rewrite = perturb_ptx(
+            TENSORMAP_MUTATIONS,
+            &InjectionOptions {
+                seed: 7,
+                intensity: 1.0,
+                focus: Some("global_dim".to_string()),
+                ..InjectionOptions::default()
+            },
+        )
+        .unwrap();
+
+        let decision = rewrite
+            .report
+            .decisions
+            .iter()
+            .find(|decision| decision.site.head.contains(".global_dim."))
+            .expect("global_dim tensor-map mutation must be a schedule site");
+        assert_eq!(decision.site.kind, SiteKind::TensorMapMutation);
+        assert!(decision.after_ns > 0, "{:?}", rewrite.report.decisions);
+
+        let mutation = rewrite
+            .ptx
+            .find("tensormap.replace.tile.global_dim")
+            .expect("rewritten PTX must retain the mutation");
+        let fence = rewrite
+            .ptx
+            .find("fence.proxy.tensormap")
+            .expect("rewritten PTX must retain the publish fence");
+        assert!(
+            rewrite.ptx[mutation..fence].contains("nanosleep.u32"),
+            "focused perturbation must delay the mutation before the fence"
         );
     }
 }

--- a/crates/ptx-schedule/src/lib.rs
+++ b/crates/ptx-schedule/src/lib.rs
@@ -831,9 +831,14 @@ L_loop:
         );
     }
 
-    /// Both spellings are emitted by the TMA lowering. The release
-    /// fence is the publication edge that orders the generic-proxy descriptor
-    /// mutation before a tensor-map consumer.
+    /// The three operand forms the TMA lowering emits: a register value
+    /// (`global_address`), an ordinal plus register (`global_dim`), and an
+    /// immediate (`swizzle_mode`). The release fence is the publication edge
+    /// that orders the generic-proxy descriptor mutation before a tensor-map
+    /// consumer. No in-tree example emits `tensormap.replace` yet, so the
+    /// spellings come from the mir-lower template
+    /// (`convert/intrinsics/tma.rs`), as the AsyncProxy fixture does for
+    /// `cp.reduce.async`.
     const TENSORMAP_MUTATIONS: &str = r#".version 8.7
 .target sm_90a
 .address_size 64
@@ -844,6 +849,7 @@ L_loop:
     .reg .b64 %rd0;
     tensormap.replace.tile.global_address.global.b1024.b64 [%rd0], %rd0;
     tensormap.replace.tile.global_dim.global.b1024.b32 [%rd0], 0, %r0;
+    tensormap.replace.tile.swizzle_mode.global.b1024.b32 [%rd0], 3;
     fence.proxy.tensormap::generic.release.gpu;
     ret;
 }
@@ -858,7 +864,7 @@ L_loop:
             .filter(|site| site.kind == SiteKind::TensorMapMutation)
             .collect();
 
-        assert_eq!(mutations.len(), 2, "{mutations:?}");
+        assert_eq!(mutations.len(), 3, "{mutations:?}");
         assert!(
             mutations
                 .iter()
@@ -868,6 +874,11 @@ L_loop:
             mutations
                 .iter()
                 .any(|site| site.head.contains(".global_dim."))
+        );
+        assert!(
+            mutations
+                .iter()
+                .any(|site| site.head.contains(".swizzle_mode."))
         );
     }
 
@@ -888,6 +899,10 @@ L_loop:
         );
         assert_eq!(
             kind_of("tensormap.replace.tile.global_dim"),
+            Some(SiteKind::TensorMapMutation)
+        );
+        assert_eq!(
+            kind_of("tensormap.replace.tile.swizzle_mode"),
             Some(SiteKind::TensorMapMutation)
         );
         assert_eq!(kind_of("fence.proxy.tensormap"), Some(SiteKind::Fence));


### PR DESCRIPTION
Closes #1208.

## Summary

Classify `tensormap.replace.*` instructions as schedule-sensitive sites in `ptx-schedule`.

Tensor-map replacement operations mutate the tensor-map descriptor through the generic proxy. They must be observable by schedule perturbation independently from the `fence.proxy.tensormap::*` operation that publishes those mutations.

This adds a dedicated `SiteKind::TensorMapMutation` rather than classifying these instructions as `AsyncProxy` or `OrderedMemory`.

## Changes

* Add `SiteKind::TensorMapMutation`.
* Classify `tensormap.replace.*` instructions as `TensorMapMutation`.
* Keep `fence.proxy.tensormap::*` classified as `Fence`.
* Add coverage for emitted tensor-map replacement spellings.
* Add a perturbation test verifying that a tensor-map mutation can be delayed before its publish fence.
* Document the new site kind in the `ptx-schedule` README.

## Validation

Validated with:

```text
cargo fmt --all -- --check
cargo test -p ptx-schedule tensormap -- --nocapture
cargo test -p ptx-schedule
cargo clippy -p ptx-schedule --all-targets -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ptx-schedule
git diff --check
```

Results:

* 3 tensor-map-specific tests passed.
* 22 `ptx-schedule` unit tests passed.
* 3 CLI integration tests passed.
* Clippy passed with warnings denied.
* Rustdoc passed with warnings denied.

The original and perturbed PTX were also assembled successfully with `ptxas`.

`--list-sites` reports:

```text
tensormap.replace.*       -> TensorMapMutation
fence.proxy.tensormap::*  -> Fence
```
