### PR TITLE
debug: fix LLVM 23 silently dropping device debug info for kernel-local statics

### DIFF
--- a/crates/cuda-oxide-codegen/src/export.rs
+++ b/crates/cuda-oxide-codegen/src/export.rs
@@ -10,7 +10,9 @@ use crate::target::{
     select_target_with_generated, validate_generated_target, validate_target_features,
 };
 use libnvvm_sys::CudaArch;
-use llvm_export::export::{DebugKind, DeviceExternType, ExportBackendConfig, NvvmIrDialect};
+use llvm_export::export::{
+    DebugKind, DeviceExternType, ExportBackendConfig, FunctionLocalStaticPlacement, NvvmIrDialect,
+};
 use pliron::builtin::op_interfaces::{CallOpCallable, CallOpInterface, SymbolOpInterface};
 use pliron::context::{Context, Ptr};
 use pliron::linked_list::ContainsLinkedList;
@@ -195,6 +197,33 @@ pub fn validate_nvvm_debug_support(
     Ok(())
 }
 
+/// The function-local static placement the resolved `llc` accepts.
+///
+/// An unparseable `llc --version` falls back to the LLVM 22 form. If that
+/// guess is wrong, PTX generation fails closed when `llc` reports the
+/// rejected debug graph, instead of shipping PTX without debug info.
+// mir-importer pipeline plumbing; not part of the frontend contract.
+#[doc(hidden)]
+pub fn function_local_static_placement_for_llc(
+    llc_major: Option<u32>,
+) -> FunctionLocalStaticPlacement {
+    llc_major.map_or(
+        FunctionLocalStaticPlacement::CompileUnitGlobals,
+        FunctionLocalStaticPlacement::for_llvm_major,
+    )
+}
+
+/// Debug metadata settings for one export.
+// mir-importer pipeline plumbing; not part of the frontend contract.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DebugExport {
+    /// Which debug metadata tier to emit.
+    pub kind: DebugKind,
+    /// Where function-local statics are retained, per the consuming LLVM.
+    pub function_local_static_placement: FunctionLocalStaticPlacement,
+}
+
 /// Exports an LLVM dialect module to textual LLVM IR (`.ll` file).
 ///
 /// Backend configuration is selected based on flags:
@@ -211,7 +240,7 @@ pub fn export_llvm_ir(
     path: &Path,
     emit_nvvm_ir: bool,
     nvvm_dialect: Option<NvvmIrDialect>,
-    debug_kind: DebugKind,
+    debug: DebugExport,
 ) -> Result<llvm_export::export::ExportedModule, PipelineError> {
     let exported = render_exported_llvm_ir(
         ctx,
@@ -219,7 +248,7 @@ pub fn export_llvm_ir(
         device_externs,
         emit_nvvm_ir,
         nvvm_dialect,
-        debug_kind,
+        debug,
     )?;
 
     std::fs::write(path, &exported.llvm_ir).map_err(|e| PipelineError::Export(e.to_string()))?;
@@ -240,7 +269,7 @@ pub fn render_llvm_ir(
     device_externs: &[DeviceExternDecl],
     emit_nvvm_ir: bool,
     nvvm_dialect: Option<NvvmIrDialect>,
-    debug_kind: DebugKind,
+    debug: DebugExport,
 ) -> Result<String, PipelineError> {
     render_exported_llvm_ir(
         ctx,
@@ -248,7 +277,7 @@ pub fn render_llvm_ir(
         device_externs,
         emit_nvvm_ir,
         nvvm_dialect,
-        debug_kind,
+        debug,
     )
     .map(|exported| exported.llvm_ir)
 }
@@ -259,7 +288,7 @@ fn render_exported_llvm_ir(
     device_externs: &[DeviceExternDecl],
     emit_nvvm_ir: bool,
     nvvm_dialect: Option<NvvmIrDialect>,
-    debug_kind: DebugKind,
+    debug: DebugExport,
 ) -> Result<llvm_export::export::ExportedModule, PipelineError> {
     let module_op = Operation::get_op::<pliron::builtin::ops::ModuleOp>(module_op_ptr, ctx)
         .ok_or_else(|| PipelineError::Export("Not a module op".to_string()))?;
@@ -270,7 +299,7 @@ fn render_exported_llvm_ir(
         })?;
         let config = PipelineExportConfig {
             inner: llvm_export::export::NvvmExportConfig::new(dialect),
-            debug_kind,
+            debug,
         };
         llvm_export::export::export_module_with_externs_and_roots(
             ctx,
@@ -282,7 +311,7 @@ fn render_exported_llvm_ir(
     } else {
         let config = PipelineExportConfig {
             inner: llvm_export::export::PtxExportConfig,
-            debug_kind,
+            debug,
         };
         llvm_export::export::export_module_with_externs_and_roots(
             ctx,
@@ -298,7 +327,7 @@ fn render_exported_llvm_ir(
 
 struct PipelineExportConfig<C> {
     inner: C,
-    debug_kind: DebugKind,
+    debug: DebugExport,
 }
 
 impl<C: ExportBackendConfig> ExportBackendConfig for PipelineExportConfig<C> {
@@ -331,7 +360,11 @@ impl<C: ExportBackendConfig> ExportBackendConfig for PipelineExportConfig<C> {
     }
 
     fn debug_kind(&self) -> DebugKind {
-        self.debug_kind
+        self.debug.kind
+    }
+
+    fn function_local_static_placement(&self) -> FunctionLocalStaticPlacement {
+        self.debug.function_local_static_placement
     }
 }
 
@@ -741,7 +774,18 @@ mod tests {
         let mut ctx = Context::new();
         let module_ptr = build_module_with_func_decl(&mut ctx, "llvm_nvvm_tcgen05_alloc");
 
-        let preview = render_llvm_ir(&ctx, module_ptr, &[], false, None, DebugKind::Off).unwrap();
+        let preview = render_llvm_ir(
+            &ctx,
+            module_ptr,
+            &[],
+            false,
+            None,
+            DebugExport {
+                kind: DebugKind::Off,
+                function_local_static_placement: FunctionLocalStaticPlacement::CompileUnitGlobals,
+            },
+        )
+        .unwrap();
 
         assert!(preview.contains("@llvm.nvvm.tcgen05.alloc"), "{preview}");
         assert_eq!(
@@ -836,6 +880,39 @@ mod tests {
             unresolved_libdevice_ptx_declarations(ptx)
                 .unwrap()
                 .is_empty()
+        );
+    }
+}
+
+#[cfg(test)]
+mod function_local_static_placement_tests {
+    use super::function_local_static_placement_for_llc;
+    use llvm_export::export::FunctionLocalStaticPlacement;
+
+    /// LLVM 23 moved function-local statics from the compile unit's globals
+    /// to the owning subprogram's retained nodes; an unknown major takes the
+    /// older form and relies on the fail-closed llc check.
+    #[test]
+    fn placement_follows_the_resolved_llc_major() {
+        assert_eq!(
+            function_local_static_placement_for_llc(Some(21)),
+            FunctionLocalStaticPlacement::CompileUnitGlobals
+        );
+        assert_eq!(
+            function_local_static_placement_for_llc(Some(22)),
+            FunctionLocalStaticPlacement::CompileUnitGlobals
+        );
+        assert_eq!(
+            function_local_static_placement_for_llc(Some(23)),
+            FunctionLocalStaticPlacement::SubprogramRetainedNodes
+        );
+        assert_eq!(
+            function_local_static_placement_for_llc(Some(24)),
+            FunctionLocalStaticPlacement::SubprogramRetainedNodes
+        );
+        assert_eq!(
+            function_local_static_placement_for_llc(None),
+            FunctionLocalStaticPlacement::CompileUnitGlobals
         );
     }
 }

--- a/crates/cuda-oxide-codegen/src/llvm_tools.rs
+++ b/crates/cuda-oxide-codegen/src/llvm_tools.rs
@@ -56,7 +56,7 @@ pub struct OptTool {
 }
 
 /// The `opt` / `llc` / `llvm-link` set the pipeline will use, resolved once
-/// per compilation so `optimize_ll`, `generate_ptx`, and `link_libdevice`
+/// per compilation so `optimize_ll`, `generate_ptx_discovered`, and `link_libdevice`
 /// agree on it. Future version-conditional IR emission should key off
 /// `llc_major` here rather than re-probing binaries.
 // mir-importer pipeline plumbing; not part of the frontend contract.

--- a/crates/cuda-oxide-codegen/src/pipeline.rs
+++ b/crates/cuda-oxide-codegen/src/pipeline.rs
@@ -11,9 +11,10 @@
 
 use crate::error::PipelineError;
 use crate::export::{
-    DeviceExternDecl, export_llvm_ir, module_uses_libdevice, render_llvm_ir,
-    resolve_nvvm_target_with_generated, unresolved_external_symbols,
-    unresolved_libdevice_ptx_declarations, validate_nvvm_debug_support,
+    DebugExport, DeviceExternDecl, export_llvm_ir, function_local_static_placement_for_llc,
+    module_uses_libdevice, render_llvm_ir, resolve_nvvm_target_with_generated,
+    unresolved_external_symbols, unresolved_libdevice_ptx_declarations,
+    validate_nvvm_debug_support,
 };
 use crate::generated::{
     GeneratedMarkerPolicy, collect_generated_intrinsic_requirements_for_backend,
@@ -24,10 +25,12 @@ use crate::llvm_tools::LlvmToolchain;
 use crate::lower::{add_device_extern_declarations, lower_to_llvm};
 use crate::options::{BackendOptions, IketInstrumentation};
 use crate::prep::{MirPreparation, prepare_mir_module};
-use crate::ptx::{PtxModule, generate_ptx, generate_ptx_with_toolchain};
+use crate::ptx::{
+    PtxModule, discover_llvm_toolchain, generate_ptx_discovered, generate_ptx_with_toolchain,
+};
 use crate::target::detect_features_in_llvm_text;
 use crate::verify::verify_operation;
-use llvm_export::export::{DebugKind, NvvmIrDialect};
+use llvm_export::export::{DebugKind, FunctionLocalStaticPlacement, NvvmIrDialect};
 use pliron::context::{Context, Ptr};
 use pliron::linked_list::ContainsLinkedList;
 use pliron::operation::Operation;
@@ -193,7 +196,7 @@ pub fn compile_translated_module(
 
     // IKET's placeholder ABI is keyed by the concrete sm_* family, but the
     // definitive target is normally resolved only after LLVM lowering
-    // (`generate_ptx` on the PTX path, `resolve_nvvm_target_with_generated`
+    // (`generate_ptx_discovered` on the PTX path, `resolve_nvvm_target_with_generated`
     // on the NVVM path), where a device hint that cannot lower a detected
     // feature is silently raised to the feature floor. Materializing from
     // the pre-resolution hint could then bake a placeholder shape for a
@@ -368,7 +371,10 @@ pub fn compile_translated_module(
             request.device_externs,
             false,
             None,
-            request.debug_kind,
+            DebugExport {
+                kind: request.debug_kind,
+                function_local_static_placement: FunctionLocalStaticPlacement::CompileUnitGlobals,
+            },
         )?;
         Some(detect_features_in_llvm_text(&preview))
     } else {
@@ -448,6 +454,26 @@ pub fn compile_translated_module(
             .trace
             .emit(format!("\n=== Exporting to LLVM IR ({mode} mode) ==="));
     }
+    // A function-local static has one verifier-accepted home per LLVM major
+    // (see `FunctionLocalStaticPlacement`), so the PTX path resolves the
+    // `llc` that will assemble this module before the debug graph is
+    // exported. libNVVM's LLVM takes the compile-unit form.
+    let mut discovered_toolchain: Option<LlvmToolchain> = None;
+    let ptx_toolchain: Option<&LlvmToolchain> = if emit_nvvm_ir {
+        None
+    } else {
+        Some(match request.toolchain {
+            ToolchainPolicy::Explicit(toolchain) => toolchain,
+            ToolchainPolicy::Discover => {
+                &*discovered_toolchain.insert(discover_llvm_toolchain(backend)?)
+            }
+        })
+    };
+    let function_local_static_placement = ptx_toolchain.map_or(
+        FunctionLocalStaticPlacement::CompileUnitGlobals,
+        |toolchain| function_local_static_placement_for_llc(toolchain.llc_major),
+    );
+
     remove_stale_files(request.files.stale_before_export)?;
     let exported = export_llvm_ir(
         ctx,
@@ -456,7 +482,10 @@ pub fn compile_translated_module(
         request.files.llvm_ir,
         emit_nvvm_ir,
         nvvm_dialect,
-        request.debug_kind,
+        DebugExport {
+            kind: request.debug_kind,
+            function_local_static_placement,
+        },
     )?;
     if request.trace.verbose {
         request.trace.emit(format!(
@@ -498,16 +527,18 @@ pub fn compile_translated_module(
         output: request.files.ptx,
         public_symbols: &exported.public_symbols,
     };
+    let toolchain = ptx_toolchain.expect("the PTX toolchain is resolved before export");
     let generated = match request.toolchain {
-        ToolchainPolicy::Discover => generate_ptx(
+        ToolchainPolicy::Discover => generate_ptx_discovered(
             ptx_module,
             request.debug_kind,
             backend,
+            toolchain,
             request.trace.sink,
             &generated_requirements,
             ptx_libdevice,
         )?,
-        ToolchainPolicy::Explicit(toolchain) => generate_ptx_with_toolchain(
+        ToolchainPolicy::Explicit(_) => generate_ptx_with_toolchain(
             ptx_module,
             request.debug_kind,
             backend,

--- a/crates/cuda-oxide-codegen/src/ptx.rs
+++ b/crates/cuda-oxide-codegen/src/ptx.rs
@@ -113,12 +113,44 @@ fn link_libdevice(
 ///
 /// Returns the optimized path plus caller-owned diagnostics. Experimental v1
 /// is strict; the legacy rustc path retains its warn-and-continue behavior.
+/// LLVM's verifier prints this when a module's debug metadata is malformed.
+/// It then strips every debug node instead of failing, so `opt` and `llc`
+/// exit 0 and emit an artifact with no `.loc`, no `.file`, and no DWARF.
+const LLVM_INVALID_DEBUG_INFO_WARNING: &str = "ignoring invalid debug info";
+
+/// Fail when a tool that exited successfully reported that it discarded the
+/// module's debug metadata.
+///
+/// A debug build whose debug graph is silently dropped is worse than a failed
+/// build: cuda-gdb then resolves every source breakpoint to its host shadow
+/// and never stops in the kernel. Debug-off builds carry no graph to reject,
+/// so their stderr is left alone.
+fn reject_dropped_debug_info(
+    tool: &str,
+    stderr: &[u8],
+    debug_kind: DebugKind,
+) -> Result<(), String> {
+    if !debug_kind.line_tables_enabled() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(stderr);
+    if !stderr.contains(LLVM_INVALID_DEBUG_INFO_WARNING) {
+        return Ok(());
+    }
+    Err(format!(
+        "{tool} rejected the module's debug metadata and would have emitted an artifact \
+         without it, but device debug information was requested:\n{}",
+        stderr.trim()
+    ))
+}
+
 fn optimize_ll(
     ll_path: &Path,
     public_symbols: &[String],
     toolchain: &LlvmToolchain,
     opts: &BackendOptions,
     strict: bool,
+    debug_kind: DebugKind,
 ) -> Result<(Option<PathBuf>, Vec<String>), PipelineError> {
     if opts.no_opt {
         return Ok((None, Vec::new()));
@@ -146,6 +178,8 @@ fn optimize_ll(
         .output()
     {
         Ok(output) if output.status.success() => {
+            reject_dropped_debug_info(&format!("opt ({})", opt.path), &output.stderr, debug_kind)
+                .map_err(PipelineError::Optimization)?;
             let diagnostics = opts
                 .verbose
                 .then(|| {
@@ -411,7 +445,8 @@ pub struct PtxModule<'a> {
 /// GPU can run the kernel, else the minimum arch the IR's features require.
 // mir-importer pipeline plumbing; not part of the frontend contract.
 #[doc(hidden)]
-pub fn generate_ptx(
+#[cfg(test)]
+pub(crate) fn generate_ptx(
     module: PtxModule<'_>,
     debug_kind: DebugKind,
     opts: &BackendOptions,
@@ -419,8 +454,28 @@ pub fn generate_ptx(
     generated: &GeneratedModuleRequirements,
     libdevice_path: Option<&Path>,
 ) -> Result<GeneratedPtx, PipelineError> {
-    let Some(toolchain) = LlvmToolchain::resolve(opts) else {
-        return Err(PipelineError::PtxGeneration(
+    let toolchain = discover_llvm_toolchain(opts)?;
+    generate_ptx_discovered(
+        module,
+        debug_kind,
+        opts,
+        &toolchain,
+        diagnostic_sink,
+        generated,
+        libdevice_path,
+    )
+}
+
+/// Resolve the `llc` / `opt` / `llvm-link` set the PTX path will use.
+///
+/// Split from [`generate_ptx`] so the pipeline can learn the `llc` major
+/// before it exports the debug graph, whose function-local static placement
+/// depends on that major.
+pub(crate) fn discover_llvm_toolchain(
+    opts: &BackendOptions,
+) -> Result<LlvmToolchain, PipelineError> {
+    LlvmToolchain::resolve(opts).ok_or_else(|| {
+        PipelineError::PtxGeneration(
             "No working llc found.\n\
              cuda-oxide tries (in order): opts.llc_override (CUDA_OXIDE_LLC), the \
              Rust toolchain's llvm-tools llc, then llc-23 / llc-22 / llc-21 on PATH. \
@@ -430,8 +485,21 @@ pub fn generate_ptx(
              Alternative: `sudo apt install llvm-21` (or `llvm-22`).\n\
              Or set opts.llc_override (CUDA_OXIDE_LLC) to a specific binary."
                 .to_string(),
-        ));
-    };
+        )
+    })
+}
+
+/// Generate PTX with a toolchain from [`discover_llvm_toolchain`], reporting
+/// its selection diagnostics through `diagnostic_sink`.
+pub(crate) fn generate_ptx_discovered(
+    module: PtxModule<'_>,
+    debug_kind: DebugKind,
+    opts: &BackendOptions,
+    toolchain: &LlvmToolchain,
+    diagnostic_sink: Option<fn(&str)>,
+    generated: &GeneratedModuleRequirements,
+    libdevice_path: Option<&Path>,
+) -> Result<GeneratedPtx, PipelineError> {
     let mut diagnostics = toolchain.diagnostics.clone();
     if !opts.no_opt && toolchain.opt.is_none() {
         diagnostics.push(
@@ -458,7 +526,7 @@ pub fn generate_ptx(
         debug_kind,
         PtxBackend {
             options: opts,
-            toolchain: &toolchain,
+            toolchain,
             generated,
         },
         false,
@@ -600,6 +668,7 @@ fn generate_ptx_impl(
             toolchain,
             opts,
             strict_optimization,
+            debug_kind,
         )?;
         for diagnostic in opt_diagnostics.drain(..) {
             record_diagnostic(&mut diagnostics, diagnostic_sink, diagnostic);
@@ -714,6 +783,8 @@ fn generate_ptx_impl(
 
     match result {
         Ok(output) if output.status.success() => {
+            reject_dropped_debug_info(&llc_desc, &output.stderr, debug_kind)
+                .map_err(PipelineError::PtxGeneration)?;
             verify_no_shared_symbols_in_initializers(module.output)?;
             verify_no_leaked_intrinsic_externs(module.output)?;
             if matches!(debug_kind, DebugKind::LineTables) {
@@ -1056,11 +1127,12 @@ mod tests {
         let opts = BackendOptions::default();
         let input = Path::new("unused.ll");
 
-        let (optimized, diagnostics) = optimize_ll(input, &[], &toolchain, &opts, false).unwrap();
+        let (optimized, diagnostics) =
+            optimize_ll(input, &[], &toolchain, &opts, false, DebugKind::Off).unwrap();
         assert!(optimized.is_none());
         assert!(diagnostics[0].contains("continuing with unoptimized IR"));
 
-        let error = optimize_ll(input, &[], &toolchain, &opts, true).unwrap_err();
+        let error = optimize_ll(input, &[], &toolchain, &opts, true, DebugKind::Off).unwrap_err();
         assert!(matches!(&error, PipelineError::Optimization(_)));
         assert!(
             error
@@ -1326,6 +1398,143 @@ mod tests {
             "{diagnostics:?}"
         );
         drop(diagnostics);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Writes an executable stand-in for `llc`/`opt` that answers `--version`
+    /// with LLVM 23, writes a minimal artifact to its `-o` path, and reports
+    /// on stderr that it discarded the module's debug metadata.
+    #[cfg(unix)]
+    fn write_debug_dropping_tool(path: &Path, artifact: &str) {
+        std::fs::write(
+            path,
+            format!(
+                "#!/bin/sh\n\
+                 if [ \"${{1:-}}\" = \"--version\" ]; then echo 'LLVM version 23.1.0'; exit 0; fi\n\
+                 out=''\n\
+                 while [ $# -gt 0 ]; do if [ \"$1\" = \"-o\" ]; then out=\"$2\"; shift; fi; shift; done\n\
+                 printf '%s' '{artifact}' > \"$out\"\n\
+                 echo 'warning: ignoring invalid debug info in module.ll' >&2\n\
+                 exit 0\n"
+            ),
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    /// llc exits 0 after LLVM's verifier strips a malformed debug graph, so
+    /// a debug build must treat that warning as a failure rather than ship
+    /// PTX with no line table (the 2026-09 LLVM 23 function-local static
+    /// regression, where cuda-gdb could only stop at host shadow lines).
+    #[test]
+    #[cfg(unix)]
+    fn debug_builds_fail_when_llc_drops_the_debug_graph() {
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_llc_dropped_debug_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&root).unwrap();
+        let ll_path = root.join("module.ll");
+        let ptx_path = root.join("module.ptx");
+        let llc_path = root.join("llc-fake");
+        std::fs::write(&ll_path, "define void @kernel() { ret void }\n").unwrap();
+        write_debug_dropping_tool(&llc_path, ".version 8.7\n.target sm_80\n.address_size 64\n");
+        let opts = BackendOptions {
+            target_arch: Some("sm_80".to_string()),
+            no_opt: true,
+            llc_override: Some(llc_path),
+            ..BackendOptions::default()
+        };
+        let module = || PtxModule {
+            llvm_ir: &ll_path,
+            output: &ptx_path,
+            public_symbols: &[],
+        };
+
+        for debug_kind in [DebugKind::Full, DebugKind::LineTables] {
+            let error = generate_ptx(
+                module(),
+                debug_kind,
+                &opts,
+                None,
+                &GeneratedModuleRequirements::default(),
+                None,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(&error, PipelineError::PtxGeneration(message)
+                    if message.contains("rejected the module's debug metadata")
+                        && message.contains(LLVM_INVALID_DEBUG_INFO_WARNING)),
+                "{debug_kind:?}: {error}"
+            );
+        }
+
+        // Without debug information there is no graph to lose; the same
+        // warning is not a failure.
+        generate_ptx(
+            module(),
+            DebugKind::Off,
+            &opts,
+            None,
+            &GeneratedModuleRequirements::default(),
+            None,
+        )
+        .expect("debug-off builds ignore the verifier's debug warning");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Line-table builds run `opt -O2`, which prints the same warning and
+    /// exits 0 when it strips the debug graph; that must fail even in the
+    /// lenient (non-strict) optimization mode.
+    #[test]
+    #[cfg(unix)]
+    fn debug_builds_fail_when_opt_drops_the_debug_graph() {
+        let root = std::env::temp_dir().join(format!(
+            "cuda_oxide_opt_dropped_debug_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&root).unwrap();
+        let ll_path = root.join("module.ll");
+        let opt_path = root.join("opt-fake");
+        std::fs::write(&ll_path, "define void @kernel() { ret void }\n").unwrap();
+        write_debug_dropping_tool(&opt_path, "define void @kernel() { ret void }\n");
+        let toolchain = LlvmToolchain {
+            llc_path: posix_utility("true"),
+            llc_major: Some(23),
+            llc_from_env: false,
+            opt: Some(crate::llvm_tools::OptTool {
+                path: opt_path.to_string_lossy().into_owned(),
+                major: Some(23),
+            }),
+            llvm_link: None,
+            diagnostics: Vec::new(),
+        };
+        let opts = BackendOptions::default();
+
+        let error = optimize_ll(
+            &ll_path,
+            &[],
+            &toolchain,
+            &opts,
+            false,
+            DebugKind::LineTables,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&error, PipelineError::Optimization(message)
+                if message.contains("rejected the module's debug metadata")),
+            "{error}"
+        );
+
+        let (optimized, _) =
+            optimize_ll(&ll_path, &[], &toolchain, &opts, false, DebugKind::Off).unwrap();
+        assert!(
+            optimized.is_some(),
+            "debug-off optimization keeps opt's output"
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/llvm-export/src/export/config.rs
+++ b/crates/llvm-export/src/export/config.rs
@@ -61,6 +61,55 @@ impl DebugKind {
     }
 }
 
+/// Where a function-local static's `DIGlobalVariableExpression` is retained.
+///
+/// A `static` declared inside a kernel (a shared-memory tile, say) is a
+/// global with a `DISubprogram` scope. LLVM's verifier accepts exactly one
+/// home for such a variable, and the accepted home changed in LLVM 23:
+///
+/// ```text
+/// LLVM 21 / 22                          LLVM 23+
+///
+/// !DICompileUnit(..., globals: !{!E})   !DISubprogram(..., retainedNodes: !{!E})
+///   !E = !DIGlobalVariableExpression      !E = !DIGlobalVariableExpression
+///        (var: !V ...)                         (var: !V ...)
+///   !V = !DIGlobalVariable(scope: !SP)    !V = !DIGlobalVariable(scope: !SP)
+///
+/// LLVM 23 rejects the left form ("function-local variables are not allowed
+/// in a DICompileUnit's global variables list"); LLVM 21/22 reject the right
+/// form ("invalid retained nodes, expected DILocalVariable, DILabel or
+/// DIImportedEntity"). Either rejection makes llc/opt drop the module's
+/// entire debug graph with only a warning.
+/// ```
+///
+/// Module-level globals are unaffected: they always live in the compile
+/// unit's `globals:` tuple.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FunctionLocalStaticPlacement {
+    /// List the expression in the compile unit's `globals:` tuple, scoped to
+    /// its owning `DISubprogram`. Required by LLVM 22 and older, and by
+    /// libNVVM's LLVM.
+    #[default]
+    CompileUnitGlobals,
+    /// List the expression in the owning `DISubprogram`'s `retainedNodes:`
+    /// tuple. Required by LLVM 23 and newer.
+    SubprogramRetainedNodes,
+}
+
+impl FunctionLocalStaticPlacement {
+    /// The first LLVM major whose verifier requires the retained-nodes form.
+    pub const FIRST_RETAINED_NODES_MAJOR: u32 = 23;
+
+    /// The placement the given LLVM major's verifier accepts.
+    pub fn for_llvm_major(major: u32) -> Self {
+        if major >= Self::FIRST_RETAINED_NODES_MAJOR {
+            Self::SubprogramRetainedNodes
+        } else {
+            Self::CompileUnitGlobals
+        }
+    }
+}
+
 /// Configuration trait for export backends (PTX, LTOIR, etc.).
 ///
 /// This trait allows different backends to customize IR generation without
@@ -95,6 +144,16 @@ pub trait ExportBackendConfig {
     /// Which device debug metadata tier to emit.
     fn debug_kind(&self) -> DebugKind {
         DebugKind::Off
+    }
+
+    /// Where function-local statics are retained in the debug graph.
+    ///
+    /// The default is the LLVM 22 form because it is also what libNVVM's
+    /// LLVM accepts; a backend feeding `llc` must select the form for the
+    /// `llc` major it resolved (see
+    /// [`FunctionLocalStaticPlacement::for_llvm_major`]).
+    fn function_local_static_placement(&self) -> FunctionLocalStaticPlacement {
+        FunctionLocalStaticPlacement::default()
     }
 }
 
@@ -192,5 +251,32 @@ impl ExportBackendConfig for NvvmExportConfig {
 
     fn nvvm_ir_dialect(&self) -> Option<NvvmIrDialect> {
         Some(self.dialect)
+    }
+}
+
+#[cfg(test)]
+mod function_local_static_placement_tests {
+    use super::FunctionLocalStaticPlacement;
+
+    #[test]
+    fn retained_nodes_start_at_llvm_23() {
+        for major in [21, 22] {
+            assert_eq!(
+                FunctionLocalStaticPlacement::for_llvm_major(major),
+                FunctionLocalStaticPlacement::CompileUnitGlobals,
+                "LLVM {major}"
+            );
+        }
+        for major in [23, 24] {
+            assert_eq!(
+                FunctionLocalStaticPlacement::for_llvm_major(major),
+                FunctionLocalStaticPlacement::SubprogramRetainedNodes,
+                "LLVM {major}"
+            );
+        }
+        assert_eq!(
+            FunctionLocalStaticPlacement::default(),
+            FunctionLocalStaticPlacement::CompileUnitGlobals
+        );
     }
 }

--- a/crates/llvm-export/src/export/debug.rs
+++ b/crates/llvm-export/src/export/debug.rs
@@ -26,6 +26,7 @@ use crate::ops::{
     DebugProjectedVariableInfo, DebugSourcePosition,
 };
 
+use super::config::FunctionLocalStaticPlacement;
 use super::state::{ModuleExportState, ResolvedDebugScope};
 
 impl<'a> ModuleExportState<'a> {
@@ -286,7 +287,21 @@ impl<'a> ModuleExportState<'a> {
             expression_id,
             format!("!DIGlobalVariableExpression(var: !{variable_id}, expr: {expression})"),
         ));
-        self.debug_global_expressions.push(expression_id);
+        // A function-local static has exactly one verifier-accepted home,
+        // and which one depends on the consuming LLVM (see
+        // [`FunctionLocalStaticPlacement`]). Module globals always belong to
+        // the compile unit.
+        if info.is_function_local
+            && self.debug_function_local_static_placement
+                == FunctionLocalStaticPlacement::SubprogramRetainedNodes
+        {
+            self.debug_subprogram_retained_globals
+                .entry(scope_id)
+                .or_default()
+                .push(expression_id);
+        } else {
+            self.debug_global_expressions.push(expression_id);
+        }
         self.debug_global_variables.insert(
             linkage_name.to_string(),
             (info.clone(), address_space, owner_function, expression_id),
@@ -328,6 +343,7 @@ impl<'a> ModuleExportState<'a> {
             return;
         }
         self.debug_globals_finalized = true;
+        self.finalize_debug_retained_globals();
         if self.debug_global_expressions.is_empty() {
             return;
         }
@@ -352,6 +368,41 @@ impl<'a> ModuleExportState<'a> {
             return;
         };
         *compile_unit = format!("{prefix}, globals: !{globals_id})");
+    }
+
+    /// Splice function-local static expressions into their owning
+    /// `DISubprogram`'s `retainedNodes` tuple.
+    ///
+    /// Owners are written with an empty tuple when the function is exported,
+    /// because AS3 globals are emitted before functions and the complete
+    /// retained set is only known after top-level export (the same forward
+    /// dependency `finalize_debug_globals` resolves for the compile unit).
+    /// Owners are visited in metadata-id order so the output is
+    /// deterministic; the map is drained, so a repeated call is a no-op.
+    fn finalize_debug_retained_globals(&mut self) {
+        let mut owners: Vec<(usize, Vec<usize>)> =
+            self.debug_subprogram_retained_globals.drain().collect();
+        owners.sort_by_key(|(owner, _)| *owner);
+        for (owner, expressions) in owners {
+            let Some((_, subprogram)) = self.debug_nodes.iter_mut().find(|(id, _)| *id == owner)
+            else {
+                debug_assert!(false, "retained-node owner DISubprogram must exist");
+                continue;
+            };
+            let Some(prefix) = subprogram.strip_suffix("retainedNodes: !{})") else {
+                debug_assert!(
+                    false,
+                    "retained-node owner must be a DISubprogram with an empty retainedNodes tuple"
+                );
+                continue;
+            };
+            let retained = expressions
+                .iter()
+                .map(|id| format!("!{id}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            *subprogram = format!("{prefix}retainedNodes: !{{{retained}}})");
+        }
     }
 
     pub(super) fn debug_local_variable_for_scope(
@@ -1230,6 +1281,7 @@ mod tests {
             true,
             super::super::config::DebugKind::LineTables,
             None,
+            super::super::config::FunctionLocalStaticPlacement::CompileUnitGlobals,
         );
 
         let (path, pos) = state
@@ -1244,8 +1296,13 @@ mod tests {
     #[test]
     fn global_expressions_and_namespaces_are_uniqued_and_conflicts_rejected() {
         let ctx = Context::new();
-        let mut state =
-            ModuleExportState::new(&ctx, true, super::super::config::DebugKind::Full, None);
+        let mut state = ModuleExportState::new(
+            &ctx,
+            true,
+            super::super::config::DebugKind::Full,
+            None,
+            super::super::config::FunctionLocalStaticPlacement::CompileUnitGlobals,
+        );
         let info = global_info();
 
         let first = state

--- a/crates/llvm-export/src/export/metadata.rs
+++ b/crates/llvm-export/src/export/metadata.rs
@@ -182,7 +182,13 @@ mod tests {
     use pliron::context::Context;
 
     fn test_state<'a>(ctx: &'a Context) -> ModuleExportState<'a> {
-        ModuleExportState::new(ctx, false, DebugKind::Off, None)
+        ModuleExportState::new(
+            ctx,
+            false,
+            DebugKind::Off,
+            None,
+            super::super::config::FunctionLocalStaticPlacement::CompileUnitGlobals,
+        )
     }
 
     #[test]

--- a/crates/llvm-export/src/export/mod.rs
+++ b/crates/llvm-export/src/export/mod.rs
@@ -49,7 +49,8 @@ mod state;
 mod types;
 
 pub use config::{
-    DebugKind, ExportBackendConfig, NvvmExportConfig, NvvmIrDialect, PtxExportConfig,
+    DebugKind, ExportBackendConfig, FunctionLocalStaticPlacement, NvvmExportConfig, NvvmIrDialect,
+    PtxExportConfig,
 };
 pub use externs::{AsDeviceExtern, DeviceExternAttrs, DeviceExternDecl, DeviceExternType};
 

--- a/crates/llvm-export/src/export/module.rs
+++ b/crates/llvm-export/src/export/module.rs
@@ -561,6 +561,7 @@ pub(super) fn export_module_with_externs_impl(
         emit_ptx_kernel_keyword,
         config.debug_kind(),
         config.nvvm_ir_dialect(),
+        config.function_local_static_placement(),
     );
     index_module_symbols(&mut state, module)?;
     prepare_debug_shared_function_scopes(&mut state, module)?;
@@ -751,6 +752,7 @@ pub(super) fn export_module_to_string_with_config(
         emit_ptx_kernel_keyword,
         config.debug_kind(),
         config.nvvm_ir_dialect(),
+        config.function_local_static_placement(),
     );
     index_module_symbols(&mut state, module)?;
     prepare_debug_shared_function_scopes(&mut state, module)?;

--- a/crates/llvm-export/src/export/state.rs
+++ b/crates/llvm-export/src/export/state.rs
@@ -15,7 +15,7 @@ use crate::ops::{
 };
 
 use super::{
-    config::{DebugKind, NvvmIrDialect},
+    config::{DebugKind, FunctionLocalStaticPlacement, NvvmIrDialect},
     externs::DeviceExternDecl,
 };
 
@@ -139,6 +139,8 @@ pub(super) struct ModuleExportState<'a> {
     next_metadata_id: usize,
     /// Which debug metadata tier this export should emit.
     pub(super) debug_kind: DebugKind,
+    /// Where function-local statics are retained (per the consuming LLVM).
+    pub(super) debug_function_local_static_placement: FunctionLocalStaticPlacement,
     /// NVVM textual dialect, or `None` for the ordinary PTX/llc path.
     pub(super) nvvm_ir_dialect: Option<NvvmIrDialect>,
     /// The single compile unit used for Stage 2 line-table debug info.
@@ -179,6 +181,10 @@ pub(super) struct ModuleExportState<'a> {
         FxHashMap<String, (DebugGlobalVariableInfo, u32, Option<String>, usize)>,
     /// Module globals retained by the compile unit.
     pub(super) debug_global_expressions: Vec<usize>,
+    /// Function-local static expressions retained by their owning
+    /// `DISubprogram` (keyed by its metadata id), under the
+    /// [`FunctionLocalStaticPlacement::SubprogramRetainedNodes`] placement.
+    pub(super) debug_subprogram_retained_globals: FxHashMap<usize, Vec<usize>>,
     /// Whether the compile unit's immutable globals tuple has been finalized.
     pub(super) debug_globals_finalized: bool,
     /// `DILocalVariable` nodes keyed by scope, source line, and local identity.
@@ -210,6 +216,7 @@ impl<'a> ModuleExportState<'a> {
         emit_ptx_kernel_keyword: bool,
         debug_kind: DebugKind,
         nvvm_ir_dialect: Option<NvvmIrDialect>,
+        debug_function_local_static_placement: FunctionLocalStaticPlacement,
     ) -> Self {
         Self {
             ctx,
@@ -230,6 +237,7 @@ impl<'a> ModuleExportState<'a> {
             global_sources: FxHashMap::default(),
             next_metadata_id: 0,
             debug_kind,
+            debug_function_local_static_placement,
             nvvm_ir_dialect,
             debug_compile_unit: None,
             debug_files: FxHashMap::default(),
@@ -248,6 +256,7 @@ impl<'a> ModuleExportState<'a> {
             debug_namespaces: FxHashMap::default(),
             debug_global_variables: FxHashMap::default(),
             debug_global_expressions: Vec::new(),
+            debug_subprogram_retained_globals: FxHashMap::default(),
             debug_globals_finalized: false,
             debug_local_variables: FxHashMap::default(),
             debug_nodes: Vec::new(),

--- a/crates/llvm-export/tests/export_test/common.rs
+++ b/crates/llvm-export/tests/export_test/common.rs
@@ -4,7 +4,7 @@
  */
 
 use combine::stream::position::SourcePosition;
-use llvm_export::export::{DebugKind, ExportBackendConfig};
+use llvm_export::export::{DebugKind, ExportBackendConfig, FunctionLocalStaticPlacement};
 use pliron::{
     basic_block::BasicBlock,
     builtin::ops::ModuleOp,
@@ -51,6 +51,51 @@ impl<C: ExportBackendConfig> ExportBackendConfig for DebugConfig<C> {
 
     fn debug_kind(&self) -> DebugKind {
         self.debug_kind
+    }
+}
+
+/// Selects where function-local statics are retained, delegating everything
+/// else (including the debug tier) to the wrapped config.
+pub(super) struct PlacementConfig<C> {
+    pub(super) inner: C,
+    pub(super) placement: FunctionLocalStaticPlacement,
+}
+
+impl<C: ExportBackendConfig> ExportBackendConfig for PlacementConfig<C> {
+    fn datalayout(&self) -> &str {
+        self.inner.datalayout()
+    }
+
+    fn emit_llvm_used(&self) -> bool {
+        self.inner.emit_llvm_used()
+    }
+
+    fn emit_nvvmir_version(&self) -> bool {
+        self.inner.emit_nvvmir_version()
+    }
+
+    fn nvvmir_version(&self) -> [i32; 4] {
+        self.inner.nvvmir_version()
+    }
+
+    fn emit_all_kernel_annotations(&self) -> bool {
+        self.inner.emit_all_kernel_annotations()
+    }
+
+    fn emit_ptx_kernel_keyword(&self) -> bool {
+        self.inner.emit_ptx_kernel_keyword()
+    }
+
+    fn nvvm_ir_dialect(&self) -> Option<llvm_export::export::NvvmIrDialect> {
+        self.inner.nvvm_ir_dialect()
+    }
+
+    fn debug_kind(&self) -> DebugKind {
+        self.inner.debug_kind()
+    }
+
+    fn function_local_static_placement(&self) -> FunctionLocalStaticPlacement {
+        self.placement
     }
 }
 

--- a/crates/llvm-export/tests/export_test/debug_info.rs
+++ b/crates/llvm-export/tests/export_test/debug_info.rs
@@ -5,7 +5,7 @@
 
 use llvm_export::{
     export::{
-        DebugKind, NvvmExportConfig, NvvmIrDialect, PtxExportConfig,
+        DebugKind, FunctionLocalStaticPlacement, NvvmExportConfig, NvvmIrDialect, PtxExportConfig,
         export_module_to_string_with_config,
     },
     ops::{
@@ -34,7 +34,7 @@ use pliron::{
 };
 use std::{num::NonZero, path::PathBuf};
 
-use crate::common::{DebugConfig, metadata_id, module_top_block, src_location};
+use crate::common::{DebugConfig, PlacementConfig, metadata_id, module_top_block, src_location};
 
 #[test]
 fn legacy_export_rejects_debug_metadata() {
@@ -651,7 +651,7 @@ fn full_debug_metadata_emits_dbg_declare_for_tagged_allocas() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let _ = std::fs::remove_file(&ll_path);
     assert!(
-        output.status.success(),
+        output.status.success() && !stderr.contains("invalid debug info"),
         "{llvm_as} rejected pointer debug metadata:\n{stderr}\n--- module ---\n{ir}"
     );
 }
@@ -1327,7 +1327,7 @@ fn full_debug_globals_preserve_qualified_identity_visibility_and_relocations() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let _ = std::fs::remove_file(&ll_path);
     assert!(
-        output.status.success(),
+        output.status.success() && !stderr.contains("invalid debug info"),
         "{llvm_as} rejected global debug metadata:\n{stderr}\n--- module ---\n{full}"
     );
 }
@@ -1832,7 +1832,7 @@ fn full_debug_metadata_emits_diarglist_for_multi_value_locations() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let _ = std::fs::remove_file(&ll_path);
     assert!(
-        output.status.success(),
+        output.status.success() && !stderr.contains("invalid debug info"),
         "{llvm_as} rejected the emitted multi-value debug module:\n{stderr}\n--- module ---\n{ir}"
     );
 }
@@ -2280,7 +2280,7 @@ fn full_debug_metadata_emits_scalarized_fragment_dbg_declares() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let _ = std::fs::remove_file(&ll_path);
     assert!(
-        output.status.success(),
+        output.status.success() && !stderr.contains("invalid debug info"),
         "{llvm_as} rejected scalarized fragment debug metadata:\n{stderr}\n--- module ---\n{ir}"
     );
 }
@@ -2455,4 +2455,343 @@ fn full_debug_metadata_emits_projected_dbg_declares() {
         ir.contains("!DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32)"),
         "missing dereference-plus-field debug expression:\n{ir}"
     );
+}
+
+/// A kernel `shared_kernel` owning the function-local AS3 static `TILE`,
+/// optionally next to the module-level AS1 static `GLOBAL_COUNTER`.
+fn function_local_shared_static_module(ctx: &mut Context, with_module_global: bool) -> ModuleOp {
+    let module = ModuleOp::new(ctx, "shared_placement".try_into().unwrap());
+    let module_block = module_top_block(ctx, &module);
+    let raw_owner = reserved_oxide_symbols::device_symbol("shared_kernel");
+
+    let i32_ty = IntegerType::get(ctx, 32, Signedness::Signless);
+    let storage_ty = ArrayType::get(ctx, i32_ty.into(), 32);
+    let shared = GlobalOp::new_with_alignment(
+        ctx,
+        "__shared_mem_0".try_into().unwrap(),
+        storage_ty.into(),
+        4,
+    );
+    shared.set_address_space(ctx, llvm_export::types::address_space::SHARED);
+    llvm_export::ops::set_debug_global_variable(
+        ctx,
+        shared.get_operation(),
+        &DebugGlobalVariableInfo {
+            name: "TILE".to_string(),
+            namespace: vec![
+                "debuginfo".to_string(),
+                "kernels".to_string(),
+                "shared_kernel".to_string(),
+            ],
+            ty: DebugLocalTypeKind::Array {
+                name: "[i32; 32]".to_string(),
+                size_bits: 1024,
+                element: Box::new(DebugLocalTypeKind::Basic {
+                    name: "i32".to_string(),
+                    size_bits: 32,
+                    encoding: "DW_ATE_signed",
+                }),
+                count: 32,
+            },
+            declaration: DebugSourcePosition {
+                file: PathBuf::from("/tmp/cuda-oxide/tests/shared.rs"),
+                line: 40,
+                column: 9,
+            },
+            is_local_to_unit: true,
+            is_function_local: true,
+        },
+    );
+    llvm_export::ops::set_debug_global_owner_function(ctx, shared.get_operation(), &raw_owner);
+    shared.get_operation().insert_at_back(module_block, ctx);
+
+    if with_module_global {
+        let i8_ty = IntegerType::get(ctx, 8, Signedness::Signless);
+        let bytes_ty = ArrayType::get(ctx, i8_ty.into(), 8);
+        let global = GlobalOp::new_with_alignment(
+            ctx,
+            "__device_global_0".try_into().unwrap(),
+            bytes_ty.into(),
+            8,
+        );
+        global.set_address_space(ctx, llvm_export::types::address_space::GLOBAL);
+        global.set_initializer_hex(ctx, "0000000000000000");
+        llvm_export::ops::set_debug_global_variable(
+            ctx,
+            global.get_operation(),
+            &DebugGlobalVariableInfo {
+                name: "GLOBAL_COUNTER".to_string(),
+                namespace: vec!["debuginfo".to_string(), "state".to_string()],
+                ty: DebugLocalTypeKind::Basic {
+                    name: "u64".to_string(),
+                    size_bits: 64,
+                    encoding: "DW_ATE_unsigned",
+                },
+                declaration: DebugSourcePosition {
+                    file: PathBuf::from("/tmp/cuda-oxide/tests/shared.rs"),
+                    line: 9,
+                    column: 1,
+                },
+                is_local_to_unit: true,
+                is_function_local: false,
+            },
+        );
+        global.get_operation().insert_at_back(module_block, ctx);
+    }
+
+    let void_ty = VoidType::get(ctx);
+    let func_ty = FuncType::get(ctx, void_ty.to_handle(), vec![], false);
+    let function = FuncOp::new(ctx, raw_owner.as_str().try_into().unwrap(), func_ty);
+    let function_loc = src_location(ctx, "/tmp/cuda-oxide/tests/shared.rs", 35, 1);
+    function
+        .get_operation()
+        .deref_mut(ctx)
+        .set_loc(function_loc);
+    let entry = function.get_or_create_entry_block(ctx);
+    ReturnOp::new(ctx, None)
+        .get_operation()
+        .insert_at_back(entry, ctx);
+    function.get_operation().insert_at_back(module_block, ctx);
+    module
+}
+
+fn export_full_debug_with_placement(
+    ctx: &Context,
+    module: &ModuleOp,
+    placement: FunctionLocalStaticPlacement,
+) -> String {
+    export_module_to_string_with_config(
+        ctx,
+        module,
+        &PlacementConfig {
+            inner: DebugConfig {
+                inner: PtxExportConfig,
+                debug_kind: DebugKind::Full,
+            },
+            placement,
+        },
+    )
+    .expect("full debug export succeeds")
+}
+
+fn line_containing<'a>(ir: &'a str, needle: &str) -> &'a str {
+    ir.lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("missing line containing {needle:?}:\n{ir}"))
+}
+
+/// LLVM 23's verifier rejects a function-scoped variable in the compile
+/// unit's `globals:` list and then drops the whole debug graph, so the
+/// retained-nodes placement must move the expression onto its owner and
+/// leave the compile unit without a `globals:` tuple when nothing else
+/// needs one.
+#[test]
+fn retained_node_placement_moves_function_local_static_onto_its_owner() {
+    let mut ctx = Context::new();
+    let module = function_local_shared_static_module(&mut ctx, false);
+
+    let retained = export_full_debug_with_placement(
+        &ctx,
+        &module,
+        FunctionLocalStaticPlacement::SubprogramRetainedNodes,
+    );
+    let expression = metadata_id(&retained, "!DIGlobalVariableExpression(var: !");
+    let owner = metadata_id(&retained, "distinct !DISubprogram(name: \"shared_kernel\"");
+    let subprogram = line_containing(&retained, "distinct !DISubprogram(name: \"shared_kernel\"");
+    assert!(
+        subprogram.ends_with(&format!("retainedNodes: !{{{expression}}})")),
+        "the owning subprogram must retain the static's expression:\n{retained}"
+    );
+    assert!(
+        line_containing(&retained, "!DIGlobalVariable(name: \"TILE\"")
+            .contains(&format!("scope: {owner},")),
+        "the variable stays scoped to its owning subprogram:\n{retained}"
+    );
+    assert!(
+        !line_containing(&retained, "!DICompileUnit(").contains("globals:"),
+        "a function-local static must not appear in the compile unit's globals:\n{retained}"
+    );
+    assert!(
+        retained.contains("!DIExpression(DW_OP_constu, 8, DW_OP_swap, DW_OP_xderef)"),
+        "the shared address class is unchanged by the placement:\n{retained}"
+    );
+
+    // The LLVM 21/22 form is the pre-existing output: the compile unit
+    // retains the expression and the owner's tuple stays empty.
+    let compile_unit = export_full_debug_with_placement(
+        &ctx,
+        &module,
+        FunctionLocalStaticPlacement::CompileUnitGlobals,
+    );
+    assert!(
+        line_containing(
+            &compile_unit,
+            "distinct !DISubprogram(name: \"shared_kernel\""
+        )
+        .ends_with("retainedNodes: !{})"),
+        "{compile_unit}"
+    );
+    assert!(
+        line_containing(&compile_unit, "!DICompileUnit(").contains("globals: !"),
+        "{compile_unit}"
+    );
+}
+
+/// Module-level statics always belong to the compile unit; only the
+/// function-local one moves under the retained-nodes placement.
+#[test]
+fn retained_node_placement_leaves_module_globals_in_the_compile_unit() {
+    let mut ctx = Context::new();
+    let module = function_local_shared_static_module(&mut ctx, true);
+    let ir = export_full_debug_with_placement(
+        &ctx,
+        &module,
+        FunctionLocalStaticPlacement::SubprogramRetainedNodes,
+    );
+
+    let shared_expression = metadata_id(
+        &ir,
+        "expr: !DIExpression(DW_OP_constu, 8, DW_OP_swap, DW_OP_xderef))",
+    );
+    let global_expression = metadata_id(&ir, "expr: !DIExpression())");
+    assert_ne!(shared_expression, global_expression);
+
+    let subprogram = line_containing(&ir, "distinct !DISubprogram(name: \"shared_kernel\"");
+    assert!(
+        subprogram.ends_with(&format!("retainedNodes: !{{{shared_expression}}})")),
+        "{ir}"
+    );
+
+    let compile_unit = line_containing(&ir, "!DICompileUnit(");
+    let globals_id = compile_unit
+        .split("globals: !")
+        .nth(1)
+        .and_then(|rest| rest.strip_suffix(')'))
+        .expect("compile-unit globals tuple");
+    let globals_tuple = line_containing(&ir, &format!("!{globals_id} = !{{"));
+    assert_eq!(
+        globals_tuple,
+        format!("!{globals_id} = !{{{global_expression}}}"),
+        "only the module-level static stays in the compile unit:\n{ir}"
+    );
+}
+
+/// Every `llvm-as` reachable from the test, with its LLVM major: the
+/// `llvm-as-NN` / `llvm-as` names on `PATH` plus the Rust sysroot's
+/// llvm-tools copy, deduplicated by major.
+fn discover_llvm_as_tools() -> Vec<(String, u32)> {
+    let mut candidates: Vec<String> = ["llvm-as-23", "llvm-as-22", "llvm-as-21", "llvm-as"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    if let Some(sysroot) = std::process::Command::new("rustc")
+        .args(["--print", "sysroot"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_owned())
+        && let Some(host) = std::process::Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+            .and_then(|out| {
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .find_map(|line| line.strip_prefix("host: ").map(str::to_owned))
+            })
+    {
+        candidates.push(format!("{sysroot}/lib/rustlib/{host}/bin/llvm-as"));
+    }
+    let mut tools: Vec<(String, u32)> = Vec::new();
+    for tool in candidates {
+        let Some(output) = std::process::Command::new(&tool)
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+        else {
+            continue;
+        };
+        let text = String::from_utf8_lossy(&output.stdout);
+        let Some(major) = text
+            .split("LLVM version ")
+            .nth(1)
+            .and_then(|rest| rest.split('.').next())
+            .and_then(|major| major.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if tools.iter().all(|(_, seen)| *seen != major) {
+            tools.push((tool, major));
+        }
+    }
+    tools
+}
+
+fn run_llvm_as(tool: &str, ir: &str, tag: &str) -> std::process::Output {
+    let ll_path = std::env::temp_dir().join(format!(
+        "cuda_oxide_placement_gate_{}_{tag}.ll",
+        std::process::id()
+    ));
+    std::fs::write(&ll_path, ir).expect("write temp .ll");
+    let output = std::process::Command::new(tool)
+        .arg("-o")
+        .arg("/dev/null")
+        .arg(&ll_path)
+        .output()
+        .expect("run llvm-as");
+    let _ = std::fs::remove_file(&ll_path);
+    output
+}
+
+/// Checks the LLVM 23 boundary in `FunctionLocalStaticPlacement::for_llvm_major`
+/// against every reachable `llvm-as`: the form selected for its major must
+/// verify, and the other form must be rejected with the verifier's known
+/// message. Like `opt` and `llc`, `llvm-as` strips a broken debug graph and
+/// still exits 0, so the verdict is read from its stderr: an accepted module
+/// produces no "invalid debug info" warning at all.
+#[test]
+fn llvm_as_verifies_the_placement_selected_for_its_major() {
+    let mut ctx = Context::new();
+    let module = function_local_shared_static_module(&mut ctx, true);
+    let tools = discover_llvm_as_tools();
+    if tools.is_empty() {
+        eprintln!("skipping placement verifier gate: no llvm-as on PATH or in the sysroot");
+        return;
+    }
+    for (tool, major) in tools {
+        let selected = FunctionLocalStaticPlacement::for_llvm_major(major);
+        let (rejected, rejection) = match selected {
+            FunctionLocalStaticPlacement::CompileUnitGlobals => (
+                FunctionLocalStaticPlacement::SubprogramRetainedNodes,
+                "invalid retained nodes",
+            ),
+            FunctionLocalStaticPlacement::SubprogramRetainedNodes => (
+                FunctionLocalStaticPlacement::CompileUnitGlobals,
+                "function-local variables are not allowed in a DICompileUnit's global variables list",
+            ),
+        };
+
+        let accepted_ir = export_full_debug_with_placement(&ctx, &module, selected);
+        let output = run_llvm_as(&tool, &accepted_ir, &format!("{major}_selected"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success() && !stderr.contains("invalid debug info"),
+            "{tool} (LLVM {major}) rejected the {selected:?} form:\n{stderr}\n--- module ---\n{accepted_ir}"
+        );
+
+        let rejected_ir = export_full_debug_with_placement(&ctx, &module, rejected);
+        let output = run_llvm_as(&tool, &rejected_ir, &format!("{major}_rejected"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("ignoring invalid debug info"),
+            "{tool} (LLVM {major}) accepted the {rejected:?} form, so the boundary in \
+             FunctionLocalStaticPlacement::for_llvm_major is stale:\n{stderr}\n{rejected_ir}"
+        );
+        assert!(
+            stderr.contains(rejection),
+            "{tool} (LLVM {major}) rejected the {rejected:?} form for an unexpected reason:\n{stderr}"
+        );
+    }
 }

--- a/crates/rustc-codegen-cuda/examples/shared_debug/verify-debug-info.sh
+++ b/crates/rustc-codegen-cuda/examples/shared_debug/verify-debug-info.sh
@@ -24,16 +24,36 @@ linkage_name() {
     sed -E 's/.*linkageName: "([^"]+)".*/\1/'
 }
 
+# A function-local static's expression has one verifier-accepted home per
+# LLVM major: LLVM 23+ retains it on the owning DISubprogram's retainedNodes
+# tuple, LLVM 21/22 list it in the compile unit's globals tuple. The exporter
+# picks the form for the llc it resolved, so accept either here.
 require_retained_class8() {
-    local die="$1" die_id expression expression_id cu globals_id tuple
+    local die="$1" die_id expression expression_id owner_id cu globals_id tuple
     die_id="$(printf '%s\n' "${die}" | sed -E 's/^!([0-9]+) = .*/\1/')"
     expression="$(grep -F "!DIGlobalVariableExpression(var: !${die_id}, expr: !DIExpression(DW_OP_constu, 8, DW_OP_swap, DW_OP_xderef))" "${llvm_ir}")"
     [[ "$(printf '%s\n' "${expression}" | wc -l)" -eq 1 ]]
     expression_id="$(printf '%s\n' "${expression}" | sed -E 's/^!([0-9]+) = .*/\1/')"
+    owner_id="$(printf '%s\n' "${die}" | sed -E 's/.*scope: !([0-9]+).*/\1/')"
+    if grep -Eq "^!${owner_id} = distinct !DISubprogram\\(.*retainedNodes: !\\{([^}]*[{ ])?!${expression_id}[,}]" "${llvm_ir}"; then
+        record_placement retained
+        return 0
+    fi
     cu="$(grep -F '!DICompileUnit(' "${llvm_ir}")"
     globals_id="$(printf '%s\n' "${cu}" | sed -E 's/.*globals: !([0-9]+)\).*/\1/')"
     tuple="$(grep -E "^!${globals_id} = !\\{" "${llvm_ir}")"
-    grep -Fq "!${expression_id}" <<<"${tuple}"
+    grep -Eq "[{ ]!${expression_id}[,}]" <<<"${tuple}"
+    record_placement compile-unit
+}
+
+# Every function-local static must use the same placement.
+placement=""
+record_placement() {
+    if [[ -n "${placement}" && "${placement}" != "$1" ]]; then
+        echo "mixed function-local static placements: ${placement} and $1" >&2
+        exit 1
+    fi
+    placement="$1"
 }
 
 require_physical() {
@@ -94,39 +114,81 @@ right_linkage="$(printf '%s\n' "${same_right_die}" | linkage_name)"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-if command -v llvm-as >/dev/null 2>&1; then
-    llvm-as -o "${tmpdir}/shared-debug.bc" "${llvm_ir}"
-    if command -v opt >/dev/null 2>&1; then
-        opt -passes=verify -disable-output "${tmpdir}/shared-debug.bc"
+# Verify the graph with LLVM tools whose major accepts the placement the
+# exporter chose: LLVM 23+ for the retained-nodes form, LLVM 21/22 for the
+# compile-unit form (the other major's verifier rejects the graph by design
+# and, like llc, strips it with an exit status of 0, so stderr is checked
+# too). Candidates are the `-NN`-suffixed tools on PATH and the Rust
+# sysroot's llvm-tools. ptxas's cubin is authoritative for the NVPTX
+# address-class translation; llvm-dwarfdump reads it, with readelf as the
+# fallback when the toolset ships no dwarfdump.
+toolsets=()
+for version in 21 22 23 24 25; do
+    if command -v "llc-${version}" >/dev/null 2>&1; then
+        toolsets+=("|-${version}")
+    fi
+done
+if command -v rustc >/dev/null 2>&1; then
+    sysroot_bin="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin"
+    if [[ -x "${sysroot_bin}/llc" ]]; then
+        toolsets+=("${sysroot_bin}/|")
     fi
 fi
 
-# Validate the supported LLVM floor and current LLVM independently. PTXAS's
-# final cubin is authoritative for the NVPTX address-class translation.
-for version in 21 22; do
-    llvm_as="llvm-as-${version}"
-    opt="opt-${version}"
-    llc="llc-${version}"
-    dwarfdump="llvm-dwarfdump-${version}"
+reject_stripped_debug_info() {
+    if grep -q 'invalid debug info' "$1"; then
+        echo "$2 rejected the debug graph:" >&2
+        cat "$1" >&2
+        exit 1
+    fi
+}
+
+validated=0
+for entry in "${toolsets[@]}"; do
+    prefix="${entry%%|*}"
+    suffix="${entry##*|}"
+    llvm_as="${prefix}llvm-as${suffix}"
+    opt="${prefix}opt${suffix}"
+    llc="${prefix}llc${suffix}"
+    dwarfdump="${prefix}llvm-dwarfdump${suffix}"
     if ! command -v "${llvm_as}" >/dev/null 2>&1 \
         || ! command -v "${opt}" >/dev/null 2>&1 \
         || ! command -v "${llc}" >/dev/null 2>&1 \
-        || ! command -v "${dwarfdump}" >/dev/null 2>&1 \
         || ! command -v ptxas >/dev/null 2>&1; then
         continue
     fi
+    major="$("${llc}" --version | sed -nE 's/.*LLVM version ([0-9]+)\..*/\1/p' | head -n 1)"
+    [[ -n "${major}" ]] || continue
+    if [[ "${placement}" == retained && "${major}" -lt 23 ]] \
+        || [[ "${placement}" == compile-unit && "${major}" -ge 23 ]]; then
+        continue
+    fi
 
-    bitcode="${tmpdir}/shared-debug-${version}.bc"
-    ptx="${tmpdir}/shared-debug-${version}.ptx"
-    cubin="${tmpdir}/shared-debug-${version}.cubin"
-    dwarf="${tmpdir}/shared-debug-${version}.dwarf"
-    "${llvm_as}" -o "${bitcode}" "${llvm_ir}"
-    "${opt}" -passes=verify -disable-output "${bitcode}"
+    bitcode="${tmpdir}/shared-debug-${major}.bc"
+    ptx="${tmpdir}/shared-debug-${major}.ptx"
+    cubin="${tmpdir}/shared-debug-${major}.cubin"
+    dwarf="${tmpdir}/shared-debug-${major}.dwarf"
+    "${llvm_as}" -o "${bitcode}" "${llvm_ir}" 2>"${tmpdir}/as.err"
+    reject_stripped_debug_info "${tmpdir}/as.err" "${llvm_as}"
+    "${opt}" -passes=verify -disable-output "${bitcode}" 2>"${tmpdir}/opt.err"
+    reject_stripped_debug_info "${tmpdir}/opt.err" "${opt}"
     "${llc}" -march=nvptx64 -mcpu=sm_90 -mattr=+ptx80 -O0 \
-        -filetype=asm "${bitcode}" -o "${ptx}"
+        -filetype=asm "${bitcode}" -o "${ptx}" 2>"${tmpdir}/llc.err"
+    reject_stripped_debug_info "${tmpdir}/llc.err" "${llc}"
+    grep -Eq '^\.target sm_90, debug$' "${ptx}"
     ptxas -arch=sm_90 -g "${ptx}" -o "${cubin}"
-    "${dwarfdump}" --debug-info "${cubin}" >"${dwarf}"
-    [[ "$(grep -c 'DW_AT_address_class.*0x08' "${dwarf}")" -eq 6 ]]
+    if command -v "${dwarfdump}" >/dev/null 2>&1; then
+        "${dwarfdump}" --debug-info "${cubin}" >"${dwarf}"
+        [[ "$(grep -c 'DW_AT_address_class.*0x08' "${dwarf}")" -eq 6 ]]
+    else
+        readelf --debug-dump=info "${cubin}" >"${dwarf}"
+        [[ "$(grep -c 'DW_AT_address_class: 8$' "${dwarf}")" -eq 6 ]]
+    fi
+    validated=$((validated + 1))
 done
 
-echo "shared-static AS3 debug-info shape verified"
+if [[ "${validated}" -eq 0 ]]; then
+    echo "note: no LLVM toolset matching the ${placement} placement was found; graph shape verified from the text only" >&2
+fi
+
+echo "shared-static AS3 debug-info shape verified (placement: ${placement}; LLVM toolsets exercised: ${validated})"

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -1655,6 +1655,14 @@ run_cargo() {
         # exist when the example is compiled with full device debug metadata.
         args+=("--device-debug")
     fi
+    if [[ "${ex}" == "shared_debug" ]]; then
+        # Its kernel-local shared statics become function-scoped DWARF
+        # variables, whose accepted placement differs across LLVM majors.
+        # Only a full-debug build makes llc verify that graph, and the
+        # backend now fails the build when llc rejects it instead of
+        # silently emitting PTX without debug info.
+        args+=("--device-debug")
+    fi
     if [[ "${ex}" == "reborrow" ]]; then
         # Regression coverage for the importer's Rvalue::Reborrow arm. GVN
         # folds the Mutability::Mut variant into plain copies at


### PR DESCRIPTION
## Problem

Since the nightly bump to LLVM 23 (#1201), every module that contains a kernel-local `static` (a shared-memory tile, a `Barrier`, ...) loses **all** device debug info under `CUDA_OXIDE_DEBUG=full`: no `.file`, no `.loc`, no DWARF sections, and the PTX `.target` loses its `debug` modifier. cuda-gdb then binds a source breakpoint only to the host shadow of the line and never stops in the kernel. Reported by Dmitry (cuda-devtools) against his debugger assessment example; `vecadd` was unaffected because it has no kernel-local static.

The exporter (#1129) describes a kernel-local static as a `DIGlobalVariable` scoped to the kernel's `DISubprogram` and lists its `DIGlobalVariableExpression` in the compile unit's `globals:` tuple. LLVM 21 and 22 require that form. LLVM 23's verifier rejects it:

```text
function-local variables are not allowed in a DICompileUnit's global variables list
warning: ignoring invalid debug info in debuginfo.ll
```

and, rather than failing, strips every debug node in the module. `llc` still exits 0, and the pipeline never read its stderr, so the stripped PTX shipped.

```text
LLVM 21 / 22 (required)                 LLVM 23+ (required)

!DICompileUnit(..., globals: !{!E})     !DISubprogram(..., retainedNodes: !{!E})
  !E = !DIGlobalVariableExpression        !E = !DIGlobalVariableExpression
       (var: !V ...)                           (var: !V ...)
  !V = !DIGlobalVariable(scope: !SP)      !V = !DIGlobalVariable(scope: !SP)
```

Each version rejects the other form (LLVM 21/22: `invalid retained nodes, expected DILocalVariable, DILabel or DIImportedEntity`), so no single form works for both the CI floor (llc-22) and the pinned toolchain (LLVM 23).

## Fix

- **llvm-export**: new `FunctionLocalStaticPlacement` config option (`CompileUnitGlobals` | `SubprogramRetainedNodes`, `for_llvm_major(23) => SubprogramRetainedNodes`). Under the retained-nodes placement the exporter splices function-local static expressions into the owning `DISubprogram`'s `retainedNodes:` tuple at finalize time; module-level globals always stay in the compile unit.
- **cuda-oxide-codegen**: the PTX path resolves the LLVM toolchain *before* export (`discover_llvm_toolchain` split out of `generate_ptx`) and derives the placement from `llc_major`; libNVVM output keeps the compile-unit form. `llc` and `opt` stderr is now checked: `ignoring invalid debug info` under a debug build is a hard `PipelineError` instead of a silently stripped artifact.
- **shared_debug**: smoketest builds it with `--device-debug`; `verify-debug-info.sh` accepts both placements and validates with LLVM tools whose major matches (previously it drove a PATH `llvm-as` regardless of version).

## Before / after (`debuginfo` example, `b main.rs:174`, RTX 5090, cuda-gdb 13.3)

| build | PTX `.target` | `.file` | `.section .debug_*` | cuda-gdb |
|---|---|---|---|---|
| main @ 97f8b2b7, llc 23 | `sm_120a` | 0 | 0 | stops on host `main.rs:216` only, `No CUDA kernels` |
| this PR, llc 23 | `sm_120a, debug` | 13 | 3 | `CUDA thread hit Breakpoint 1, debuginfo_scalars<<<...>>> at src/main.rs:174` |
| this PR, `CUDA_OXIDE_LLC` = llc 22 | `sm_120a, debug` | 13 | 5 | same device hit |

Cross-check: main's IR through llc 22 is fine, and main's tree through llc 23 with only the IR form swapped is fine, so the placement is the whole cause. The retained-nodes form nests TILE as a `DW_TAG_variable` child of its kernel with `DW_AT_address_class 8` in the ptxas cubin.

## Tests

- `llvm-export`: both placements for a function-local AS3 static, module-level globals staying in the compile unit, and an `llvm-as` boundary test that exports both forms through every reachable `llvm-as` (LLVM 22 and 23 locally, `llvm-as-22` on CI) and asserts the selected form verifies while the other is rejected with the known message. The three pre-existing `llvm-as` parse gates now read stderr: exit status alone is 0 even when the graph is stripped.
- `cuda-oxide-codegen`: `for_llvm_major` mapping; fake `llc`/`opt` that print the warning and exit 0 must fail full-debug and line-tables builds and pass debug-off builds.
- Existing suites: `cargo test --workspace`, clippy `-D warnings`, fmt, and all nine status-guard scripts pass; `debug`, `shared_debug`, `device_global` run with `--device-debug` and their verify scripts pass under both llc 22 and llc 23; `scripts/debug-smoketest.sh` (cuda-gdb consumption of the DWARF, incl. the closure/enum/projection passes) passes.

## Follow-ups

- Forcing `CUDA_OXIDE_DEBUG=full` on all 222 examples (not a CI configuration) fails 77 of them on unpatched main and on this branch alike: a dozen `verify-code-shape.sh` gates that assert on optimized output, the rest importer/lowering gaps that only appear at `-Zmir-opt-level=0`. None involve debug metadata (the fail-closed check never fires there). Worth its own issue.

- libNVVM output keeps the compile-unit form and has no fail-closed check; when libNVVM moves to LLVM 23 the same break would recur on that path.
- The nightly-bump runbook should include "build a full-debug example that owns a kernel-local static and grep llc stderr for `invalid debug info`".
