### PR TITLE
cuda-macros: keep generic kernel specializations alive with black_box, not a null-pointer volatile pair

### DIFF
--- a/crates/cuda-macros/src/kernel/codegen.rs
+++ b/crates/cuda-macros/src/kernel/codegen.rs
@@ -405,8 +405,6 @@ fn generate_generic_cuda_kernel_impl(
     };
     let (impl_generics, _, _) = generics.split_for_impl();
     let hash = internal_ident("__cuda_oxide_kernel_hash");
-    let kernel_ptr = internal_ident("__cuda_oxide_kernel_ptr");
-    let force_mono = internal_ident("__cuda_oxide_force_mono");
 
     quote! {
         /// Marker type for a generic kernel; implements `GenericCudaKernel`.
@@ -431,15 +429,14 @@ fn generate_generic_cuda_kernel_impl(
         }
 
         /// Retains this concrete kernel specialization and returns its PTX entry name.
+        ///
+        /// The reify cast is what makes rustc collect the monomorphized kernel
+        /// item for the device backend; `black_box` keeps the otherwise unused
+        /// cast from being optimized away without touching any pointer.
         #(#cfg_attrs)*
         #[inline(never)]
         #vis fn #ptx_name_fn #generics () -> &'static str #where_clause {
-            let #kernel_ptr = #kernel_name #kernel_turbofish as *const ();
-            unsafe {
-                let mut #force_mono: *const () = ::core::ptr::null();
-                ::core::ptr::write_volatile(&mut #force_mono, #kernel_ptr);
-                let _ = ::core::ptr::read_volatile(&#force_mono);
-            }
+            ::core::hint::black_box(#kernel_name #kernel_turbofish as *const ());
             <#marker_type as ::cuda_host::GenericCudaKernel>::ptx_name()
         }
     }


### PR DESCRIPTION
Every generic `#[kernel]` expands a `ptx_name()` helper whose only job is to make rustc collect the concrete kernel instantiation for the device backend. It did that with a null pointer and a volatile write/read:

```rust
let p = kernel::<T> as *const ();
let mut force_mono: *const () = ::core::ptr::null();
::core::ptr::write_volatile(&mut force_mono, p);
let _ = ::core::ptr::read_volatile(&force_mono);
```

CodeQL's `rust/access-invalid-pointer` follows `null -> local -> volatile access` and reports it at every `#[cuda_module]` / `#[kernel]` site. That is all 13 open alerts on main, and the same 13 come back as "new" on any large PR (#1102).

```text
before:  null() ──► force_mono ──► write_volatile / read_volatile     13 alerts
after:   core::hint::black_box(kernel::<T> as *const ())              0 alerts
```

`black_box` keeps the reify cast alive just as well (the `#[cuda_module]` loader already uses it for the same reason) and touches no pointer. The two internal idents go away with it; the hygiene probes that name them still compile, they just probe a name the macro no longer introduces.

Validated on an RTX 5090:
- cuda-macros and cuda-host suites
- smoketest over the eleven alerted examples plus vecadd, async_vecadd, cluster, cuda_module_in_lib: 15/15, generic kernels included

The 13 alerts close on the next main scan; the CodeQL check on this PR is the proof.
