### PR TITLE
refactor(llvm): use upstream GEP no-wrap flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "awint",
  "combine",
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "combine",
  "convert_case",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,14 +48,14 @@ repository = "https://github.com/NVlabs/cuda-oxide.git"
 # Examples are in: crates/rustc-codegen-cuda/examples/
 
 [workspace.dependencies]
-# Pliron MLIR framework, pinned to the upstream revision containing explicit LLVM struct layouts (#232).
-# pliron-llvm uses default-features = false to keep llvm-sys (LLVM 22) out:
+# Pliron MLIR framework, pinned to upstream struct-layout and GEP no-wrap semantics.
+# pliron-llvm uses default-features = false to keep llvm-sys (LLVM 23) out:
 # cuda-oxide consumes the dialect modeling only, not the FFI bridge.
 # `crates/rustc-codegen-cuda/Cargo.toml` MUST stay on this same rev, or pliron
 # resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
-pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564", default-features = false, features = [
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "8e4500e16d96926a91751a505e3d8b4ef9c4f7c8" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "8e4500e16d96926a91751a505e3d8b4ef9c4f7c8" }
+pliron-llvm = { git = "https://github.com/pliron-org/pliron", rev = "8e4500e16d96926a91751a505e3d8b4ef9c4f7c8", default-features = false, features = [
     "std",
 ] }
 

--- a/crates/llvm-export/src/export/ops.rs
+++ b/crates/llvm-export/src/export/ops.rs
@@ -27,7 +27,7 @@ use pliron::{
 use crate::{
     attributes::{
         AtomicOrderingAttr, AtomicRmwKindAttr, FCmpPredicateAttr, FPHalfAttr, FastmathFlags,
-        FastmathFlagsAttr, GepIndexAttr, ICmpPredicateAttr, SyncScopeAttr,
+        FastmathFlagsAttr, GepIndexAttr, GepNoWrapFlags, ICmpPredicateAttr, SyncScopeAttr,
     },
     op_interfaces::{ATTR_KEY_FAST_MATH_FLAGS, PointerTypeResult, SyncScopeInterface},
     ops,
@@ -1161,8 +1161,14 @@ impl<'a> ModuleExportState<'a> {
         };
 
         write!(output, "  {gep_name} = getelementptr").unwrap();
-        if ops::gep_inbounds(self.ctx, op.get_operation()) {
+        let no_wrap_flags = op.no_wrap_flags(self.ctx);
+        if no_wrap_flags.contains(GepNoWrapFlags::INBOUNDS) {
             write!(output, " inbounds").unwrap();
+        } else if no_wrap_flags.contains(GepNoWrapFlags::NUSW) {
+            write!(output, " nusw").unwrap();
+        }
+        if no_wrap_flags.contains(GepNoWrapFlags::NUW) {
+            write!(output, " nuw").unwrap();
         }
         write!(output, " ").unwrap();
         self.export_type(elem_ty, output)?;

--- a/crates/llvm-export/src/lib.rs
+++ b/crates/llvm-export/src/lib.rs
@@ -440,10 +440,6 @@ pub mod ops {
     /// and emitted as `align N` during export.
     const OP_ALIGNMENT_KEY: &str = "cuda_oxide_op_alignment";
 
-    /// Op-attribute key controlling whether a GEP is emitted with LLVM's
-    /// `inbounds` promise. Absence denotes an in-bounds GEP.
-    const GEP_INBOUNDS_KEY: &str = "cuda_oxide_gep_inbounds";
-
     /// Op-attribute key controlling whether an inline asm op is emitted with
     /// LLVM's `sideeffect` marker. Absent means true, matching the conservative
     /// default for user-authored inline PTX.
@@ -466,24 +462,6 @@ pub mod ops {
             .get::<BoolAttr>(&key)
             .map(|attr| bool::from((*attr).clone()))
             .unwrap_or(false)
-    }
-
-    /// Stamp the source pointer arithmetic contract onto an LLVM GEP.
-    pub fn set_gep_inbounds(ctx: &mut Context, op: Ptr<Operation>, inbounds: bool) {
-        let key = Identifier::try_new(GEP_INBOUNDS_KEY.to_string()).expect("valid identifier");
-        op.deref_mut(ctx)
-            .attributes
-            .set(key, BoolAttr::new(inbounds));
-    }
-
-    /// Return whether an LLVM GEP carries the `inbounds` promise.
-    pub fn gep_inbounds(ctx: &Context, op: Ptr<Operation>) -> bool {
-        let key = Identifier::try_new(GEP_INBOUNDS_KEY.to_string()).expect("valid identifier");
-        op.deref(ctx)
-            .attributes
-            .get::<BoolAttr>(&key)
-            .map(|attr| bool::from(attr.clone()))
-            .unwrap_or(true)
     }
 
     /// Debug type metadata for a local variable described by `llvm.dbg.declare`.

--- a/crates/llvm-export/tests/export_test/calls_and_addresses.rs
+++ b/crates/llvm-export/tests/export_test/calls_and_addresses.rs
@@ -342,7 +342,7 @@ fn export_addressof_uses_symbol_when_definition_block_prints_later() {
     // The GEP base operand must be the global symbol, not a stale `%vN`.
     let gep_line = ir
         .lines()
-        .find(|line| line.contains("getelementptr inbounds"))
+        .find(|line| line.contains("getelementptr"))
         .expect("exported GEP line");
     assert!(
         gep_line.contains("@__shared_mem_20"),

--- a/crates/llvm-export/tests/export_test/instructions.rs
+++ b/crates/llvm-export/tests/export_test/instructions.rs
@@ -4,6 +4,7 @@
  */
 
 use llvm_export::{
+    attributes::GepNoWrapFlags,
     export::{
         NvvmExportConfig, NvvmIrDialect, export_module_to_string,
         export_module_to_string_with_config,
@@ -238,7 +239,7 @@ fn legacy_gep_rejects_a_result_address_space_different_from_its_base() {
 }
 
 #[test]
-fn gep_inbounds_marker_controls_exported_pointer_semantics() {
+fn gep_no_wrap_flags_control_exported_pointer_semantics() {
     let mut ctx = Context::new();
     let module = ModuleOp::new(&mut ctx, "gep_semantics".try_into().unwrap());
     let module_block = module_top_block(&mut ctx, &module);
@@ -251,12 +252,23 @@ fn gep_inbounds_marker_controls_exported_pointer_semantics() {
     let entry = func.get_or_create_entry_block(&mut ctx);
     let base = entry.deref(&ctx).get_argument(0);
 
-    let ordinary = GetElementPtrOp::new(&mut ctx, base, vec![GepIndex::Constant(1)], i32_ty.into());
-    ordinary.get_operation().insert_at_back(entry, &ctx);
-
-    let wrapping = GetElementPtrOp::new(&mut ctx, base, vec![GepIndex::Constant(2)], i32_ty.into());
-    llvm_export::ops::set_gep_inbounds(&mut ctx, wrapping.get_operation(), false);
-    wrapping.get_operation().insert_at_back(entry, &ctx);
+    let cases = [
+        (1, GepNoWrapFlags::empty()),
+        (2, GepNoWrapFlags::NUSW),
+        (3, GepNoWrapFlags::NUW),
+        (4, GepNoWrapFlags::INBOUNDS),
+        (5, GepNoWrapFlags::INBOUNDS | GepNoWrapFlags::NUW),
+    ];
+    for (index, flags) in cases {
+        let gep = GetElementPtrOp::new_with_no_wrap_flags(
+            &mut ctx,
+            base,
+            vec![GepIndex::Constant(index)],
+            i32_ty.into(),
+            flags,
+        );
+        gep.get_operation().insert_at_back(entry, &ctx);
+    }
 
     ReturnOp::new(&mut ctx, None)
         .get_operation()
@@ -268,12 +280,29 @@ fn gep_inbounds_marker_controls_exported_pointer_semantics() {
         .lines()
         .filter(|line| line.contains("getelementptr"))
         .collect();
-    assert_eq!(gep_lines.len(), 2, "{ir}");
-    assert!(gep_lines[0].contains("getelementptr inbounds"), "{ir}");
+    assert_eq!(gep_lines.len(), 5, "{ir}");
+
+    assert!(gep_lines[0].contains("getelementptr i32"), "{ir}");
     assert!(
-        gep_lines[1].contains("getelementptr i32")
-            && !gep_lines[1].contains("getelementptr inbounds"),
+        !gep_lines[0].contains("inbounds")
+            && !gep_lines[0].contains("nusw")
+            && !gep_lines[0].contains("nuw"),
         "{ir}"
+    );
+    assert!(gep_lines[1].contains("getelementptr nusw i32"), "{ir}");
+    assert!(gep_lines[2].contains("getelementptr nuw i32"), "{ir}");
+    assert!(gep_lines[3].contains("getelementptr inbounds i32"), "{ir}");
+    assert!(
+        !gep_lines[3].contains("nusw"),
+        "inbounds must not redundantly print implied nusw:\n{ir}"
+    );
+    assert!(
+        gep_lines[4].contains("getelementptr inbounds nuw i32"),
+        "{ir}"
+    );
+    assert!(
+        !gep_lines[4].contains("nusw"),
+        "inbounds nuw must not redundantly print implied nusw:\n{ir}"
     );
 }
 

--- a/crates/mir-lower/src/convert/ops/aggregate/addressing.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate/addressing.rs
@@ -11,6 +11,7 @@ use crate::convert::types::{
 };
 use dialect_mir::ops::{MirConstantOp, MirFieldAddrOp};
 use dialect_mir::types::{MirEnumType, MirPtrType, MirStructType, MirTupleType, MirUnionType};
+use llvm_export::attributes::GepNoWrapFlags;
 use llvm_export::ops as llvm;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -91,7 +92,13 @@ pub(crate) fn convert_field_addr(
         // for repeated field accesses and for `union.struct_field.inner`.
         use llvm_export::ops::GepIndex;
         let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
-        let gep = llvm::GetElementPtrOp::new(ctx, ptr_operand, vec![GepIndex::Constant(0)], i8_ty);
+        let gep = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+            ctx,
+            ptr_operand,
+            vec![GepIndex::Constant(0)],
+            i8_ty,
+            GepNoWrapFlags::INBOUNDS,
+        );
         rewriter.insert_operation(ctx, gep.get_operation());
         rewriter.replace_operation(ctx, op, gep.get_operation());
         return Ok(());
@@ -144,11 +151,12 @@ pub(crate) fn convert_field_addr(
 
         use llvm_export::ops::GepIndex;
         let gep = match slot_entry {
-            Some(slot) => llvm::GetElementPtrOp::new(
+            Some(slot) => llvm::GetElementPtrOp::new_with_no_wrap_flags(
                 ctx,
                 ptr_operand,
                 vec![GepIndex::Constant(0), GepIndex::Constant(slot)],
                 map.llvm_struct_ty,
+                GepNoWrapFlags::INBOUNDS,
             ),
             None => {
                 // No slot of its own: address the bytes directly, off the
@@ -167,11 +175,12 @@ pub(crate) fn convert_field_addr(
                     )
                 })?;
                 let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
-                llvm::GetElementPtrOp::new(
+                llvm::GetElementPtrOp::new_with_no_wrap_flags(
                     ctx,
                     ptr_operand,
                     vec![GepIndex::Constant(offset)],
                     i8_ty,
+                    GepNoWrapFlags::INBOUNDS,
                 )
             }
         };
@@ -217,8 +226,13 @@ pub(crate) fn convert_field_addr(
             // that captures other ZST closures, like iter map_fold).
             use llvm_export::ops::GepIndex;
             let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
-            let gep =
-                llvm::GetElementPtrOp::new(ctx, ptr_operand, vec![GepIndex::Constant(0)], i8_ty);
+            let gep = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+                ctx,
+                ptr_operand,
+                vec![GepIndex::Constant(0)],
+                i8_ty,
+                GepNoWrapFlags::INBOUNDS,
+            );
             rewriter.insert_operation(ctx, gep.get_operation());
             rewriter.replace_operation(ctx, op, gep.get_operation());
             return Ok(());
@@ -266,7 +280,13 @@ pub(crate) fn convert_field_addr(
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Constant(slot)];
 
-    let gep_op = llvm::GetElementPtrOp::new(ctx, ptr_operand, gep_indices, map.llvm_struct_ty);
+    let gep_op = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+        ctx,
+        ptr_operand,
+        gep_indices,
+        map.llvm_struct_ty,
+        GepNoWrapFlags::INBOUNDS,
+    );
     rewriter.insert_operation(ctx, gep_op.get_operation());
     stamp_field_address_alignment(
         ctx,
@@ -396,7 +416,13 @@ pub(crate) fn convert_array_element_addr(
 
     let element_align = element_address_provable_alignment(ctx, arr_ptr, element_ty, index);
 
-    let gep_op = llvm::GetElementPtrOp::new(ctx, arr_ptr, gep_indices, llvm_element_ty);
+    let gep_op = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+        ctx,
+        arr_ptr,
+        gep_indices,
+        llvm_element_ty,
+        GepNoWrapFlags::INBOUNDS,
+    );
     rewriter.insert_operation(ctx, gep_op.get_operation());
     if let Some(align) = element_align {
         llvm_export::ops::set_address_alignment(ctx, gep_op.get_operation(), align);

--- a/crates/mir-lower/src/convert/ops/aggregate/array_extract.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate/array_extract.rs
@@ -6,7 +6,7 @@
 use super::common::anyhow_to_pliron;
 use crate::convert::types::{convert_type, mir_type_abi_align};
 use dialect_mir::types::MirArrayType;
-use llvm_export::attributes::ICmpPredicateAttr;
+use llvm_export::attributes::{GepNoWrapFlags, ICmpPredicateAttr};
 use llvm_export::ops as llvm;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -161,7 +161,13 @@ pub(crate) fn convert_extract_array_element(
 
     use llvm_export::ops::GepIndex;
     let gep_indices = vec![GepIndex::Constant(0), GepIndex::Value(index_val)];
-    let gep_op = llvm::GetElementPtrOp::new(ctx, array_ptr, gep_indices, llvm_array_ty.into());
+    let gep_op = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+        ctx,
+        array_ptr,
+        gep_indices,
+        llvm_array_ty.into(),
+        GepNoWrapFlags::INBOUNDS,
+    );
     rewriter.insert_operation(ctx, gep_op.get_operation());
     let element_ptr = gep_op.get_operation().deref(ctx).get_result(0);
 

--- a/crates/mir-lower/src/convert/ops/aggregate/common.rs
+++ b/crates/mir-lower/src/convert/ops/aggregate/common.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use llvm_export::attributes::GepNoWrapFlags;
 use llvm_export::ops as llvm;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::Context;
@@ -77,7 +78,13 @@ pub(super) fn byte_offset_gep(
     use llvm_export::ops::GepIndex;
     let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
     let offset = emit_integer_constant(ctx, rewriter, 64, u128::from(offset));
-    let gep_op = llvm::GetElementPtrOp::new(ctx, base, vec![GepIndex::Value(offset)], i8_ty);
+    let gep_op = llvm::GetElementPtrOp::new_with_no_wrap_flags(
+        ctx,
+        base,
+        vec![GepIndex::Value(offset)],
+        i8_ty,
+        GepNoWrapFlags::INBOUNDS,
+    );
     rewriter.insert_operation(ctx, gep_op.get_operation());
     gep_op.get_operation().deref(ctx).get_result(0)
 }

--- a/crates/mir-lower/src/convert/ops/memory/access.rs
+++ b/crates/mir-lower/src/convert/ops/memory/access.rs
@@ -12,6 +12,7 @@ use super::common::{
 use super::debug::copy_debug_local_variable;
 use crate::convert::types::{convert_type, mir_type_abi_align};
 use dialect_mir::types::MirPtrType;
+use llvm_export::attributes::GepNoWrapFlags;
 use llvm_export::ops as llvm;
 use pliron::builtin::types::{IntegerType, Signedness};
 use pliron::context::{Context, Ptr};
@@ -259,14 +260,18 @@ pub(crate) fn convert_ptr_offset(
         })?;
     let elem_ty = convert_type(ctx, pointee).map_err(anyhow_to_pliron)?;
 
-    let llvm_gep = llvm::GetElementPtrOp::new(
+    let no_wrap_flags = if dialect_mir::ops::MirPtrOffsetOp::new(op).is_inbounds(ctx) {
+        GepNoWrapFlags::INBOUNDS
+    } else {
+        GepNoWrapFlags::empty()
+    };
+    let llvm_gep = llvm::GetElementPtrOp::new_with_no_wrap_flags(
         ctx,
         ptr,
         vec![llvm_export::ops::GepIndex::Value(offset)],
         elem_ty,
+        no_wrap_flags,
     );
-    let inbounds = dialect_mir::ops::MirPtrOffsetOp::new(op).is_inbounds(ctx);
-    llvm::set_gep_inbounds(ctx, llvm_gep.get_operation(), inbounds);
     rewriter.insert_operation(ctx, llvm_gep.get_operation());
     rewriter.replace_operation(ctx, op, llvm_gep.get_operation());
 

--- a/crates/mir-lower/src/convert/ops/memory/extern_shared.rs
+++ b/crates/mir-lower/src/convert/ops/memory/extern_shared.rs
@@ -103,6 +103,10 @@ pub fn convert_extern_shared_dc(
         let offset_value = offset_const.get_operation().deref(ctx).get_result(0);
 
         let i8_ty = IntegerType::get(ctx, 8, Signedness::Signless);
+        // Keep this GEP unflagged. The LLVM symbol is nominally `[0 x i8]`,
+        // while the actual dynamic shared-memory allocation is supplied at
+        // kernel launch, so this lowering cannot prove LLVM's `inbounds`
+        // allocated-object contract for a nonzero byte offset.
         let gep_op = llvm::GetElementPtrOp::new(
             ctx,
             base_ptr,

--- a/crates/mir-lower/src/convert/ops/memory/tests/access.rs
+++ b/crates/mir-lower/src/convert/ops/memory/tests/access.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use super::*;
+use llvm_export::attributes::GepNoWrapFlags;
 
 #[test]
 fn convert_alloca_lowers_to_llvm_alloca() {
@@ -434,7 +435,7 @@ fn convert_ptr_offset_lowers_to_gep_with_pointee_elem_type() {
         .expect("gep src_elem_type should be IntegerType");
     assert_eq!(int_ty.width(), 32, "gep elem type must be i32 (pointee)");
     assert!(
-        llvm::gep_inbounds(&ctx, gep.get_operation()),
+        gep.no_wrap_flags(&ctx).contains(GepNoWrapFlags::INBOUNDS),
         "ordinary pointer offsets retain the in-bounds contract"
     );
 }
@@ -467,7 +468,7 @@ fn convert_wrapping_ptr_offset_lowers_to_non_inbounds_gep() {
     let body = kernel_blocks(&ctx, module_ptr);
     let gep = find_first::<llvm::GetElementPtrOp>(&ctx, &body).expect("expected one llvm.gep");
     assert!(
-        !llvm::gep_inbounds(&ctx, gep.get_operation()),
+        gep.no_wrap_flags(&ctx).is_empty(),
         "wrapping pointer offsets must not promise in-bounds arithmetic"
     );
 }

--- a/crates/mir-lower/src/convert/ops/memory/tests/shared.rs
+++ b/crates/mir-lower/src/convert/ops/memory/tests/shared.rs
@@ -558,3 +558,106 @@ fn shared_and_device_global_indices_are_per_module_not_process_global() {
         );
     }
 }
+
+/// Append a `mir.extern_shared` (dynamic shared memory) to `block` with the
+/// given launch-contract alignment and byte offset into the pool.
+fn append_extern_shared(
+    ctx: &mut Context,
+    block: Ptr<BasicBlock>,
+    alignment: u64,
+    byte_offset: u64,
+) -> Ptr<Operation> {
+    let i8_ty: TypeHandle = IntegerType::get(ctx, 8, Signedness::Signless).into();
+    let shared_i8 = MirPtrType::get_shared(ctx, i8_ty, true);
+    let op = Operation::new(
+        ctx,
+        mir::MirExternSharedOp::get_concrete_op_info(),
+        vec![shared_i8.into()],
+        vec![],
+        vec![],
+        0,
+    );
+    let extern_shared = mir::MirExternSharedOp::new(op);
+    extern_shared.set_alignment_value(ctx, alignment);
+    extern_shared.set_byte_offset_value(ctx, byte_offset);
+    op.insert_at_back(block, ctx);
+    op
+}
+
+/// A `mir.extern_shared` with a nonzero byte offset addresses into an extern
+/// `[0 x i8]` addrspace(3) global whose real size only exists at launch, so
+/// the lowering cannot promise LLVM's `inbounds` allocated-object contract
+/// for that GEP:
+///
+/// ```text
+/// @__dynamic_smem_*  external addrspace(3) global [0 x i8]      size known at launch only
+///        |
+///        +-- getelementptr i8, ptr addrspace(3) @__dynamic_smem_*, i64 64     plain: fine
+///        +-- getelementptr inbounds i8, ...                                    promise we cannot keep
+/// ```
+///
+/// Before the upstream no-wrap flags, the exporter treated an unset attribute
+/// as `inbounds`, so this GEP shipped as `getelementptr inbounds`. It must
+/// stay a plain `getelementptr`.
+///
+/// Scope: today the importer only sets `byte_offset = 0` on this op (that is
+/// `DynamicSharedArray::get()`); `offset(N)` goes through a separate
+/// `mir.ptr_offset`. So this locks the op's own contract; the `offset(N)`
+/// path real kernels take is a separate follow-up.
+#[test]
+fn extern_shared_byte_offset_gep_carries_no_no_wrap_flags() {
+    use llvm_export::attributes::GepNoWrapFlags;
+
+    let mut ctx = make_ctx();
+    let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+    append_extern_shared(&mut ctx, block, 16, 64);
+    append_mir_return(&mut ctx, block, vec![]);
+
+    crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+    let body = kernel_blocks(&ctx, module_ptr);
+    let gep = find_first::<llvm::GetElementPtrOp>(&ctx, &body)
+        .expect("a nonzero byte offset must lower to one llvm.gep");
+    assert_eq!(
+        gep.no_wrap_flags(&ctx),
+        GepNoWrapFlags::empty(),
+        "the dynamic shared-memory GEP must not claim inbounds, nusw, or nuw"
+    );
+
+    let module = Operation::get_op::<pliron::builtin::ops::ModuleOp>(module_ptr, &ctx)
+        .expect("lowered top-level op is a module");
+    let ir = llvm_export::export::export_module_to_string(&ctx, &module).expect("export");
+    assert!(
+        ir.contains("getelementptr i8,"),
+        "the byte-offset GEP must export as a plain i8 getelementptr:\n{ir}"
+    );
+    assert!(
+        !ir.contains("getelementptr inbounds"),
+        "the dynamic shared-memory GEP must not export as inbounds:\n{ir}"
+    );
+}
+
+/// Control for the test above: `DynamicSharedArray::get()` (offset 0) is
+/// just the pool base, so the lowering hands back the `llvm.addressof`
+/// directly and there is no GEP whose flags could be wrong.
+#[test]
+fn extern_shared_zero_byte_offset_is_the_bare_address_of() {
+    let mut ctx = make_ctx();
+    let (module_ptr, block) = build_kernel(&mut ctx, vec![], vec![]);
+    append_extern_shared(&mut ctx, block, 16, 0);
+    append_mir_return(&mut ctx, block, vec![]);
+
+    crate::lower_mir_to_llvm(&mut ctx, module_ptr).expect("lowering failed");
+
+    let body = kernel_blocks(&ctx, module_ptr);
+    assert_eq!(
+        count_ops::<llvm::GetElementPtrOp>(&ctx, &body),
+        0,
+        "a zero byte offset must not emit a GEP at all"
+    );
+    assert_eq!(
+        count_ops::<llvm::AddressOfOp>(&ctx, &body),
+        1,
+        "a zero byte offset lowers to exactly one llvm.addressof of the pool"
+    );
+}

--- a/crates/rustc-codegen-cuda/Cargo.lock
+++ b/crates/rustc-codegen-cuda/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "awint",
  "combine",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "combine",
  "convert_case",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "git+https://github.com/pliron-org/pliron?rev=823d9d8087652cd3f2d006a7ea534df921a23564#823d9d8087652cd3f2d006a7ea534df921a23564"
+source = "git+https://github.com/pliron-org/pliron?rev=8e4500e16d96926a91751a505e3d8b4ef9c4f7c8#8e4500e16d96926a91751a505e3d8b4ef9c4f7c8"
 dependencies = [
  "bitflags",
  "log",

--- a/crates/rustc-codegen-cuda/Cargo.toml
+++ b/crates/rustc-codegen-cuda/Cargo.toml
@@ -33,8 +33,8 @@ cuda-artifact-finalizer = { path = "../cuda-artifact-finalizer" }
 # `{ workspace = true }`. Keep these versions synchronized with root Cargo.toml
 # [workspace.dependencies] section. Source MUST match the root (same git + rev),
 # or pliron resolves to two distinct crates and types stop unifying.
-pliron = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
-pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "823d9d8087652cd3f2d006a7ea534df921a23564" }
+pliron = { git = "https://github.com/pliron-org/pliron", rev = "8e4500e16d96926a91751a505e3d8b4ef9c4f7c8" }
+pliron-derive = { git = "https://github.com/pliron-org/pliron", rev = "8e4500e16d96926a91751a505e3d8b4ef9c4f7c8" }
 linkme = "0.3"            # must match workspace
 combine = "4.6"           # must match workspace
 once_cell = "1.18"        # must match workspace


### PR DESCRIPTION
Closes #1231 

## What this is

Replace CUDA_OXIDE's private LLVM GEP `inbounds` metadata with the first-class GEP no-wrap representation added upstream in pliron-org/pliron#244.

The Rust-level distinction introduced for wrapping pointer offsets remains unchanged:

```text
ordinary pointer offset  -> GEP INBOUNDS
wrapping pointer offset  -> plain GEP
```

What changes is where that information is represented after MIR lowering.

Before:

```text
MIR mir_ptr_offset_inbounds
        |
        v
private cuda_oxide_gep_inbounds metadata
        |
        v
llvm-export conditionally prints `inbounds`
```

After:

```text
MIR mir_ptr_offset_inbounds
        |
        v
Pliron GepNoWrapFlags
        |
        v
llvm-export emits the corresponding LLVM GEP flags
```

This removes the CUDA_OXIDE-specific LLVM shim and uses the upstream dialect model directly.

## GEP semantics

`mir_ptr_offset_inbounds` stays in MIR because it represents a Rust semantic distinction rather than an LLVM implementation detail.

During MIR lowering:

* ordinary pointer offsets use `GepNoWrapFlags::INBOUNDS`;
* wrapping pointer offsets use `GepNoWrapFlags::empty()`.

Production GEP sites that previously depended on CUDA_OXIDE's implicit `inbounds` behavior now request `INBOUNDS` explicitly.

Dynamic shared-memory addressing deliberately remains unflagged.

CUDA dynamic shared memory is represented through an external `[0 x i8]` object in shared address space. Although the launch supplies backing storage at runtime, that declaration does not establish LLVM's allocated-object `inbounds` contract for arbitrary non-zero runtime byte offsets. Those GEPs therefore continue to use plain `GetElementPtrOp::new`.

## LLVM export

`llvm-export` now consumes Pliron's `GepNoWrapFlags` directly and emits:

```text
plain
nusw
nuw
inbounds
inbounds nuw
```

`inbounds` implies `nusw` in Pliron, matching LLVM semantics, but the implied `nusw` is not redundantly printed.

The private:

```text
cuda_oxide_gep_inbounds
```

attribute and its getter/setter helpers are removed.

## Why this Pliron revision

This PR moves the Pliron dependency from:

```text
823d9d8087652cd3f2d006a7ea534df921a23564
```

to:

```text
8e4500e16d96926a91751a505e3d8b4ef9c4f7c8
```

The revision range contains five upstream commits:

* pliron-org/pliron#241: preserve LLVM data layout and target triple;
* pliron-org/pliron#242: LLVM metadata support;
* pliron-org/pliron#243: upgrade the optional LLVM bridge to LLVM 23;
* pliron-org/pliron#244: add GEP no-wrap support;
* `8e4500e`: address the GEP no-wrap review comments for pliron-org/pliron#244.

Only the GEP no-wrap support requires CUDA_OXIDE source changes in this PR. The preceding commits are rides-along from the upstream revision range. CUDA_OXIDE continues to consume `pliron-llvm` with `default-features = false`, so its `llvm-sys` bridge remains disabled.

The merged pliron-org/pliron#244 revision is intentionally not used here. pliron-org/pliron#249 landed on Pliron `master` before pliron-org/pliron#244 was merged, so the eventual pliron-org/pliron#244 merge also carries the unrelated `ConstantOp` API changes from pliron-org/pliron#249. Adopting that revision would require a separate CUDA_OXIDE-wide compatibility migration.

Pinning `8e4500e` isolates the GEP migration from that unrelated `ConstantOp` refactor. The full CUDA_OXIDE workspace tests and the 222/222 compile-only example sweep pass with this revision.

## Tests

Added/updated regression coverage verifies:

* plain GEP export;
* `nusw`;
* `nuw`;
* `inbounds`;
* `inbounds nuw`;
* ordinary pointer offsets retain `INBOUNDS`;
* wrapping pointer offsets lower without `INBOUNDS`;
* unrelated address-of export tests do not depend on GEP no-wrap semantics.

## Validation

```text
cargo fmt --all -- --check
    PASS

cargo test --workspace
    PASS

cargo clippy --workspace --all-targets -- -D warnings
    PASS

scripts/smoketest.sh --compile-only
    222 / 222 PASS

targeted compile-only smoke:
    dynamic_smem       PASS
    ptr_offset_from    PASS

targeted GPU execution:
    dynamic_smem       PASS
    ptr_offset_from    PASS
```

`dynamic_smem` was also exercised through its alignment and partitioning cases on real hardware, and `ptr_offset_from` verified pointer distance, wrapping, and provenance behavior.

The private GEP metadata is no longer present in the tree.
