### PR TITLE
cargo-oxide: build the backend from the project's cuda-oxide dependency commit

### DIFF
--- a/crates/cargo-oxide/README.md
+++ b/crates/cargo-oxide/README.md
@@ -378,10 +378,13 @@ Explicitly builds (or rebuilds) the codegen backend. Normally this happens autom
 
 ### `cargo oxide update [--force]`
 
-Refreshes the shared codegen backend cache used by projects outside this
-repository (`~/.cargo/cuda-oxide/`). Inside the cuda-oxide workspace the local
-source tree is authoritative, so the default path prints how to run
-`cargo oxide setup`; pass `--force` to run setup from this command.
+Rebuilds the shared codegen backend cache used by projects outside this
+repository (`~/.cargo/cuda-oxide/`) from the commit the project's cuda-oxide
+dependency resolves to (see [Backend Discovery](#backend-discovery)). You
+rarely need it: a changed dependency rebuilds the cache on the next build by
+itself. Inside the cuda-oxide workspace the local source tree is
+authoritative, so the default path prints how to run `cargo oxide setup`;
+pass `--force` to run setup from this command.
 
 ```bash
 cargo oxide update
@@ -392,11 +395,34 @@ cargo oxide update --force
 
 When `cargo oxide` needs the `librustc_codegen_cuda.so` backend, it searches in this order:
 
-1. **`CUDA_OXIDE_BACKEND` env var** — explicit path override
-2. **Project config** — `.cargo/cuda-oxide.toml`
-3. **Local repo** — detects `crates/rustc-codegen-cuda` relative to workspace root, builds from source
-4. **Cached `.so`** — checks `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`
-5. **Auto-fetch** — clones the cuda-oxide repo, builds, and caches (one-time)
+1. **`CUDA_OXIDE_BACKEND` env var**: explicit path override
+2. **Project config**: `.cargo/cuda-oxide.toml`
+3. **Local repo**: detects `crates/rustc-codegen-cuda` relative to workspace root, builds from source
+4. **Cached `.so`**: `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`, when it was built from the commit the project's cuda-oxide dependency resolves to
+5. **Build from the dependency**: builds `crates/rustc-codegen-cuda` out of the checkout Cargo already made for the project's `cuda-device` / `cuda-host` dependency, and caches it
+
+Outside the repository the backend follows the project's `Cargo.lock`:
+
+```text
+Cargo.lock   cuda-device = git+https://github.com/NVlabs/cuda-oxide.git#a1b4f118...
+                 │
+                 ▼
+~/.cargo/git/checkouts/cuda-oxide-*/a1b4f11/        Cargo's checkout of that commit
+                 │  crates/rustc-codegen-cuda  →  cargo build
+                 ▼
+~/.cargo/cuda-oxide/librustc_codegen_cuda.so         + source-rev.txt = a1b4f118...
+```
+
+The kernels compile against the crates at that commit and the backend that
+lowers them is built from the same commit, so the two cannot drift. Changing
+the dependency (`cargo update`, a new `rev = ...`) rebuilds the cache on the
+next build. The checkout's `rust-toolchain.toml` names the nightly that commit
+needs; if the project pins a different one, the build stops before compiling
+and tells you which channel to set. A path dependency on a local checkout
+builds in place, like step 3. Projects with no cuda-oxide dependency fall back
+to a one-time clone of `main`. The backend's build tree lives at
+`~/.cargo/cuda-oxide/target` (shared by every commit's builds; delete it to
+reclaim the space).
 
 Project config can also provide the default architecture, extra rustc flags,
 and child-process environment:

--- a/crates/cargo-oxide/src/backend.rs
+++ b/crates/cargo-oxide/src/backend.rs
@@ -10,9 +10,13 @@
 //! 1. `CUDA_OXIDE_BACKEND` env var (explicit override)
 //! 2. Project config (`.cargo/cuda-oxide.toml`)
 //! 3. Local repo (detected by presence of `crates/rustc-codegen-cuda`)
-//! 4. Cached `.so` at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`,
-//!    but only when it isn't older than the running `cargo-oxide` binary
-//! 5. Auto-fetch from git and build (one-time, or after a stale-cache miss)
+//! 4. Cached `.so` at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`, but
+//!    only when it was built from the commit the project's cuda-oxide
+//!    dependency resolves to (see "The backend follows the dependency" below)
+//!    and none of the staleness checks fire
+//! 5. Build from the dependency's checkout and cache the result. A project
+//!    with no cuda-oxide dependency falls back to cloning `main` (one-time,
+//!    or after a stale-cache miss)
 //!
 //! ## Cache staleness (issue #49)
 //!
@@ -73,10 +77,37 @@
 //! identities with guidance and exits instead of rebuilding. Any lookup that
 //! passes the fingerprint check deletes the marker, so a genuinely healed
 //! cache clears the memory.
+//!
+//! ## The backend follows the dependency
+//!
+//! Outside the repository, the backend source is the checkout Cargo made for
+//! the project's `cuda-device` / `cuda-host` dependency (see
+//! [`crate::backend_source`]), so the crates a kernel compiles against and
+//! the backend that lowers it always come from one commit. That commit is
+//! recorded next to the cached `.so` (`source-rev.txt`) and compared on every
+//! lookup; a project resolving a different commit rebuilds the cache from its
+//! own checkout. A path dependency is a local checkout and builds in place,
+//! the same way step 3 does. Dependency checkouts build into
+//! `~/.cargo/cuda-oxide/target`, one tree cargo-oxide owns (delete it to
+//! reclaim the space) that consecutive commits share their dependency builds
+//! in, rather than into Cargo's checkout.
+//!
+//! Under `cargo oxide` the rustup proxy exports `RUSTUP_TOOLCHAIN` for the
+//! project's toolchain, and every child `cargo`/`rustc`, the backend build
+//! included, uses it; a checkout's own `rust-toolchain.toml` gets no say.
+//! That file still states the nightly the commit was written for, and
+//! rustc_private APIs change between nightlies, so before any build the
+//! project's active toolchain is compared with that channel and a mismatch is
+//! reported up front, naming the channel to set, instead of spending minutes
+//! on a backend that fails to compile or to load. The toolchain heal marker
+//! above guards only the `main` clone path: a rebuild from a pinned
+//! dependency's checkout converges by construction.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::SystemTime;
+
+use crate::backend_source::{self, CODEGEN_CRATE_SUBDIR, DependencySource};
 
 /// Finds the workspace root by walking up from CWD looking for Cargo.toml
 /// with a `crates/rustc-codegen-cuda` directory.
@@ -98,8 +129,10 @@ pub fn find_workspace_root() -> Option<PathBuf> {
 /// 1. `CUDA_OXIDE_BACKEND` env var
 /// 2. Project config (`.cargo/cuda-oxide.toml`)
 /// 3. Local repo build (crates/rustc-codegen-cuda)
-/// 4. Cached build at ~/.cargo/cuda-oxide/
-/// 5. Auto-fetch + build from git
+/// 4. Cached build at ~/.cargo/cuda-oxide/, when built from the commit the
+///    project's cuda-oxide dependency resolves to
+/// 5. Build from the dependency's checkout (or, without one, from a `main`
+///    clone) and cache the result
 pub fn find_or_build_backend(workspace_root: &Path, configured_backend: Option<&Path>) -> PathBuf {
     // 1. Explicit override
     if let Ok(path) = std::env::var("CUDA_OXIDE_BACKEND") {
@@ -132,32 +165,199 @@ pub fn find_or_build_backend(workspace_root: &Path, configured_backend: Option<&
         return build_backend_from_source(&codegen_crate);
     }
 
-    // 4. Cached .so. Only honored when it isn't older than the running
-    //    cargo-oxide binary; see the module-level comment about issue #49.
-    if let Some(cache_dir) = cache_directory()
-        && let Some(cached_so) = consult_backend_cache(&cache_dir)
-    {
-        return cached_so;
-    }
+    // 4 + 5. Standalone project: the backend follows the project's cuda-oxide
+    //        dependency.
+    standalone_backend(workspace_root)
+}
 
-    // 5. Auto-fetch from git
-    auto_fetch_and_build()
+/// Backend for a project outside the repository (discovery steps 4 and 5).
+///
+/// The project's `Cargo.lock` decides the commit: the backend is built from
+/// the checkout Cargo made for the `cuda-device` / `cuda-host` dependency, and
+/// the shared cache is reused only when it records that same commit. See the
+/// module-level comment ("The backend follows the dependency").
+fn standalone_backend(project_dir: &Path) -> PathBuf {
+    let source = match backend_source::resolve_dependency_source(project_dir, false) {
+        Ok(source) => source,
+        Err(error) => {
+            eprintln!("Error: could not resolve this project's cuda-oxide dependency: {error}");
+            eprintln!(
+                "Every cuda-oxide crate in Cargo.toml must come from one git commit or one \
+                 local checkout. To bypass this, point CUDA_OXIDE_BACKEND at a backend built \
+                 for this project."
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let Some(source) = source else {
+        // No cuda-oxide crate in the graph, so nothing pins a commit: the
+        // shared cache and the `main` clone are all there is.
+        if let Some(cache_dir) = cache_directory()
+            && let Some(cached) = consult_backend_cache(
+                &cache_dir,
+                Some(&cache_dir.join("src").join(CODEGEN_CRATE_SUBDIR)),
+                None,
+            )
+        {
+            return cached;
+        }
+        return auto_fetch_and_build();
+    };
+
+    // A project on a toolchain other than the one this commit was written for
+    // cannot build or load a backend from it, so settle that before touching
+    // the cache: the refusal comes first, and whatever valid cache another
+    // project left stays put.
+    refuse_unloadable_backend(source.checkout(), &source.describe());
+
+    let Some(rev) = source.rev() else {
+        // A path dependency is a local checkout: build it in place, the same
+        // way step 3 does inside the repository.
+        return build_backend_from_source(&source.codegen_crate());
+    };
+
+    // The checkout holds one commit and never changes, so the commit record
+    // replaces the source-mtime check: a checkout Cargo re-creates after a
+    // cache sweep has fresh mtimes but identical content and must not force a
+    // rebuild.
+    if let Some(cache_dir) = cache_directory()
+        && let Some(cached) = consult_backend_cache(&cache_dir, None, Some(rev))
+    {
+        return cached;
+    }
+    build_and_cache(&source)
+}
+
+/// Builds the backend from the dependency's checkout and installs it into the
+/// shared cache with its commit recorded. The caller has already run
+/// [`refuse_unloadable_backend`] for this checkout.
+fn build_and_cache(source: &DependencySource) -> PathBuf {
+    let cache_dir = cache_directory().unwrap_or_else(|| {
+        eprintln!("Error: Cannot determine cache directory.");
+        eprintln!("Set CARGO_HOME or HOME environment variable.");
+        std::process::exit(1);
+    });
+    eprintln!(
+        "Building the cuda-oxide backend from {}...",
+        source.describe()
+    );
+    let codegen_crate = source.codegen_crate();
+    // The build tree goes beside the cache, not into Cargo's checkout: one
+    // place cargo-oxide owns, shared by every commit's dependency builds.
+    let built_so = build_backend_from_source_in(&codegen_crate, Some(&cache_dir.join("target")));
+    let so_path = install_backend_into(&cache_dir, &built_so, &codegen_crate, source.rev())
+        .unwrap_or_else(|error| {
+            eprintln!(
+                "Error: could not copy the backend into {}: {error}",
+                cache_dir.display()
+            );
+            std::process::exit(1);
+        });
+    eprintln!("✓ Backend cached at {}", so_path.display());
+    so_path
+}
+
+/// Refuses to build a backend the project could not build or load.
+///
+/// Under `cargo oxide` the rustup proxy exports `RUSTUP_TOOLCHAIN` for the
+/// project's toolchain, so every child `cargo`/`rustc`, the backend build
+/// included, uses that toolchain and the checkout's nested
+/// `rust-toolchain.toml` gets no say (it would with a bare `cargo-oxide`
+/// binary, which is not how users run it). That file still names the nightly
+/// the commit was written for, and rustc_private APIs change between
+/// nightlies: any other toolchain fails to compile the backend or builds one
+/// its rustc cannot load. So compare the active toolchain with that channel
+/// first and say which channel to set. Conservative: without rustup or
+/// without a toolchain file in the checkout, let the build proceed and surface
+/// its own errors.
+fn refuse_unloadable_backend(checkout: &Path, description: &str) {
+    let Some(report) = unloadable_backend_report(
+        description,
+        active_toolchain().as_deref(),
+        backend_source::pinned_channel(checkout).as_deref(),
+    ) else {
+        return;
+    };
+    eprint!("{report}");
+    std::process::exit(1);
+}
+
+/// `rustup show active-toolchain` from the process cwd: the toolchain the
+/// application build and every child process will use (`RUSTUP_TOOLCHAIN`
+/// from the proxy, else the project's `rust-toolchain.toml`, else rustup's
+/// default). `None` without rustup.
+fn active_toolchain() -> Option<String> {
+    let output = Command::new("rustup")
+        .args(["show", "active-toolchain"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|active| !active.is_empty())
+}
+
+/// The refusal text for a project whose active toolchain does not match the
+/// channel the checkout needs, or `None` when it does or either side is
+/// unknown. Pure, so the decision and the wording are testable without a
+/// process exit.
+fn unloadable_backend_report(
+    description: &str,
+    active: Option<&str>,
+    needed_channel: Option<&str>,
+) -> Option<String> {
+    let (Some(active), Some(channel)) = (active, needed_channel) else {
+        return None;
+    };
+    if crate::commands::active_toolchain_matches_channel(active, channel) {
+        return None;
+    }
+    let active_name = active
+        .lines()
+        .next()
+        .unwrap_or(active)
+        .split_whitespace()
+        .next()
+        .unwrap_or(active);
+    let lines = [
+        format!(
+            "Error: {description} needs Rust `{channel}` (its rust-toolchain.toml), but this \
+             project is using `{active_name}`."
+        ),
+        "The backend is a rustc plugin: it is built with, and only loads into, the toolchain \
+         this project uses, and rustc_private APIs change between nightlies."
+            .to_string(),
+        format!(
+            "Set `channel = \"{channel}\"` in this project's rust-toolchain.toml to match \
+             {description}, then re-run. To use a backend built some other way, point \
+             CUDA_OXIDE_BACKEND at it."
+        ),
+    ];
+    Some(format!("{}\n", lines.join("\n")))
 }
 
 /// Consults the shared backend cache at `cache_dir` (discovery step 4).
 ///
-/// Returns the cached `.so` when it is fresh. Returns `None` when the caller
-/// should fall through to the auto-fetch step, after performing whichever
-/// invalidation the staleness verdict calls for. Exits the process with
-/// guidance when a toolchain mismatch already failed one heal attempt and
-/// rebuilding again cannot converge (see [`toolchain_heal_decision`]).
-fn consult_backend_cache(cache_dir: &Path) -> Option<PathBuf> {
+/// `source_dir` is the backend source the cache was built from when that
+/// source can change in place (the `main` clone); `expected_rev` is the commit
+/// the project's dependency resolves to, when it has one. Returns the cached
+/// `.so` when it is fresh. Returns `None` when the caller should fall through
+/// to a rebuild, after performing whichever invalidation the staleness verdict
+/// calls for. Exits the process with guidance when a toolchain mismatch
+/// already failed one heal attempt and rebuilding again cannot converge (see
+/// [`toolchain_heal_decision`]).
+fn consult_backend_cache(
+    cache_dir: &Path,
+    source_dir: Option<&Path>,
+    expected_rev: Option<&str>,
+) -> Option<PathBuf> {
     let cached_so = cache_dir.join("librustc_codegen_cuda.so");
     if !cached_so.exists() {
         return None;
     }
-    let source_dir = cache_dir.join("src/crates/rustc-codegen-cuda");
-    match cached_backend_status(&cached_so, Some(&source_dir)) {
+    match cached_backend_status(&cached_so, source_dir, expected_rev) {
         CacheStatus::Fresh => {
             // The fingerprint check passed: end any heal cycle, so a future,
             // unrelated mismatch gets its own one-shot heal attempt.
@@ -166,6 +366,19 @@ fn consult_backend_cache(cache_dir: &Path) -> Option<PathBuf> {
         }
         CacheStatus::StaleVsBinary => {
             invalidate_cache(cache_dir);
+            None
+        }
+        CacheStatus::StaleVsToolchain if expected_rev.is_some() => {
+            // The rebuild source is the project's own checkout, and the caller
+            // already confirmed the project's toolchain is the one that commit
+            // needs, so this rebuild converges. The heal marker guards only
+            // the `main` clone path; drop any it left behind. The old `.so`
+            // stays until the replacement is installed over it.
+            eprintln!(
+                "Cached backend was built against a different Rust toolchain; rebuilding \
+                 from the project's dependency."
+            );
+            clear_heal_marker(cache_dir);
             None
         }
         CacheStatus::StaleVsToolchain => match toolchain_heal_decision(cache_dir) {
@@ -183,6 +396,21 @@ fn consult_backend_cache(cache_dir: &Path) -> Option<PathBuf> {
                 std::process::exit(1);
             }
         },
+        CacheStatus::StaleVsDependency => {
+            // Fall through to a rebuild without deleting anything: the old
+            // `.so` and its record stay consistent for whichever project they
+            // belong to until `install_backend_into` replaces both, so a
+            // failed build never leaves the cache empty.
+            let recorded = recorded_source_rev(cache_dir)
+                .map(|rev| format!("cuda-oxide {}", backend_source::short_rev(&rev)))
+                .unwrap_or_else(|| "an unrecorded cuda-oxide commit".to_string());
+            eprintln!(
+                "Cached backend was built from {recorded}, but this project depends on \
+                 cuda-oxide {}; rebuilding from the project's dependency.",
+                backend_source::short_rev(expected_rev.unwrap_or("?"))
+            );
+            None
+        }
         CacheStatus::StaleVsSource => {
             // The cached source advanced; rebuild the `.so` from it in
             // place. We do NOT invalidate the cache here, so the
@@ -191,7 +419,9 @@ fn consult_backend_cache(cache_dir: &Path) -> Option<PathBuf> {
             eprintln!(
                 "Cached backend source at {} is newer than the cached \
                  library; rebuilding from it in place.",
-                source_dir.display()
+                source_dir
+                    .map(|dir| dir.display().to_string())
+                    .unwrap_or_default()
             );
             None
         }
@@ -210,7 +440,9 @@ fn consult_backend_cache(cache_dir: &Path) -> Option<PathBuf> {
 ///    so the caller can report the configured-but-absent path.
 /// 3. Local repo host build path
 ///    (`crates/rustc-codegen-cuda/target/<host>/debug/...`).
-/// 4. Cache path at `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`.
+/// 4. For a path dependency on a cuda-oxide checkout, that checkout's host
+///    build path (it builds in place); otherwise the cache path at
+///    `~/.cargo/cuda-oxide/librustc_codegen_cuda.so`.
 ///
 /// `cargo oxide doctor` uses this so that a diagnostic run never triggers a
 /// multi-minute backend build or a git clone before it can print anything.
@@ -226,6 +458,16 @@ pub fn backend_so_candidate(workspace_root: &Path, configured_backend: Option<&P
     let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");
     if codegen_crate.is_dir() {
         return backend_so_path_candidate(&codegen_crate);
+    }
+
+    // A path dependency builds in place (see `standalone_backend`), so its
+    // artifact is that checkout's own host build, not the shared cache.
+    // Read-only resolution: never fetches or writes; any failure (no
+    // Cargo.lock yet, no cargo) falls through to the cache path.
+    if let Ok(Some(source)) = backend_source::resolve_dependency_source(workspace_root, true)
+        && source.rev().is_none()
+    {
+        return backend_so_path_candidate(&source.codegen_crate());
     }
 
     cache_directory()
@@ -251,19 +493,31 @@ enum CacheStatus {
     /// so it must be re-cloned and rebuilt. Highest precedence: an unloadable
     /// `.so` is stale regardless of mtimes.
     StaleVsToolchain,
+    /// The cached `.so` was built from a different cuda-oxide commit than the
+    /// one the project's dependency resolves to (or from an unrecorded one).
+    /// It loads fine but lowers the project's kernels with the wrong backend,
+    /// so it must be rebuilt from the project's own checkout.
+    StaleVsDependency,
 }
 
-/// Classifies the cached backend `.so` against the running `cargo-oxide`
-/// binary (the user upgraded the binary) and the newest backend source input
-/// (the developer advanced the source). When `source_dir` is `None`, or no
-/// source inputs can be found under it, only the binary check applies.
-/// Binary staleness takes precedence when both fire, since a binary upgrade
-/// wants a fresh clone (which also picks up the newest source).
+/// Classifies the cached backend `.so` against the active toolchain, the
+/// commit the project's dependency resolves to (`expected_rev`), the running
+/// `cargo-oxide` binary (the user upgraded the binary) and the newest backend
+/// source input (the developer advanced the source). When `source_dir` is
+/// `None`, or no source inputs can be found under it, the source check is
+/// skipped; when `expected_rev` is `None`, the commit check is skipped.
+/// Precedence when several fire: toolchain, dependency, binary, source. The
+/// first two make the cache wrong for this project outright; the binary check
+/// wants a fresh build regardless of source mtimes.
 ///
 /// Conservative on errors: if we can't stat the cached `.so`, we report
 /// [`CacheStatus::Fresh`] so a working cache is never invalidated on a failed
 /// metadata read.
-fn cached_backend_status(cached_so: &Path, source_dir: Option<&Path>) -> CacheStatus {
+fn cached_backend_status(
+    cached_so: &Path,
+    source_dir: Option<&Path>,
+    expected_rev: Option<&str>,
+) -> CacheStatus {
     let Ok(so_meta) = std::fs::metadata(cached_so) else {
         return CacheStatus::Fresh;
     };
@@ -278,6 +532,14 @@ fn cached_backend_status(cached_so: &Path, source_dir: Option<&Path>) -> CacheSt
         && toolchain_fingerprint_mismatch(cache_dir)
     {
         return CacheStatus::StaleVsToolchain;
+    }
+
+    // Dependency check: the cache must come from the commit this project
+    // compiles its kernels against.
+    if let (Some(cache_dir), Some(expected)) = (cached_so.parent(), expected_rev)
+        && dependency_rev_mismatch(cache_dir, expected)
+    {
+        return CacheStatus::StaleVsDependency;
     }
 
     let self_mtime = std::env::current_exe()
@@ -387,6 +649,65 @@ fn write_toolchain_fingerprint(cache_dir: &Path, build_dir: &Path) {
     if let Some(fp) = toolchain_fingerprint_in(build_dir) {
         let _ = std::fs::write(cache_dir.join(TOOLCHAIN_FINGERPRINT_FILE), fp);
     }
+}
+
+/// File next to the cached `.so` recording the cuda-oxide commit it was built
+/// from (the full hash).
+const SOURCE_REV_FILE: &str = "source-rev.txt";
+
+/// The commit recorded next to the cached `.so`, if any.
+fn recorded_source_rev(cache_dir: &Path) -> Option<String> {
+    std::fs::read_to_string(cache_dir.join(SOURCE_REV_FILE))
+        .ok()
+        .map(|rev| rev.trim().to_string())
+        .filter(|rev| !rev.is_empty())
+}
+
+/// The commit the shared cache's backend was built from, for `doctor`.
+pub fn cached_backend_source_rev() -> Option<String> {
+    cache_directory().and_then(|dir| recorded_source_rev(&dir))
+}
+
+/// True when the cache was not built from `expected`. An unrecorded commit
+/// counts as a mismatch: such a cache predates this check (it was cloned from
+/// `main` at an unknown commit), and the one rebuild this triggers records
+/// the commit, so it cannot thrash.
+fn dependency_rev_mismatch(cache_dir: &Path, expected: &str) -> bool {
+    recorded_source_rev(cache_dir).as_deref() != Some(expected)
+}
+
+/// Records the commit the installed `.so` was built from, or forgets a stale
+/// record when the commit is unknown (a `main` clone, a checkout without git),
+/// so a later project can never match against a commit the cache did not come
+/// from. Best effort, like the fingerprint: a lost record costs one rebuild.
+fn record_source_rev(cache_dir: &Path, source_rev: Option<&str>) {
+    let path = cache_dir.join(SOURCE_REV_FILE);
+    match source_rev {
+        Some(rev) => {
+            let _ = std::fs::write(path, rev);
+        }
+        None => {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// `HEAD` of the git repository containing `dir`, when there is one.
+///
+/// Used when the in-repo build is published to the shared cache. A dirty tree
+/// is recorded under its HEAD on purpose: the developer who runs `cargo oxide
+/// setup` wants projects on that commit to pick up the build they just made.
+fn repository_head(dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|rev| !rev.is_empty())
 }
 
 /// File next to the cached `.so` recording the (active, recorded) fingerprint
@@ -555,18 +876,47 @@ pub fn clear_cached_backend() -> Option<PathBuf> {
 fn clear_cache_contents(cache_dir: &Path) {
     let _ = std::fs::remove_file(cache_dir.join("librustc_codegen_cuda.so"));
     let _ = std::fs::remove_dir_all(cache_dir.join("src"));
+    // The record describes the `.so` just removed; without it, `doctor` would
+    // still report the commit of a backend that no longer exists.
+    let _ = std::fs::remove_file(cache_dir.join(SOURCE_REV_FILE));
 }
 
-/// Invalidate the shared cache and rebuild via auto-fetch (external projects).
+/// Rebuild the backend for the project in `project_dir` (external projects):
+/// from the commit its cuda-oxide dependency resolves to, in place for a path
+/// dependency, or from a fresh `main` clone without any dependency. The shared
+/// cache is cleared first whenever the project uses it.
 ///
-/// Returns the path to the freshly cached `.so`.
-pub fn refresh_cached_backend() -> PathBuf {
-    let _ = clear_cached_backend();
-    auto_fetch_and_build()
+/// Returns the path to the freshly built `.so`.
+pub fn refresh_cached_backend(project_dir: &Path) -> PathBuf {
+    // A path dependency builds in place and never touches the shared cache;
+    // clearing it would only cost other projects a rebuild. Read-only
+    // resolution here; the real one, which may fetch, runs in
+    // `standalone_backend`.
+    let builds_in_place = matches!(
+        backend_source::resolve_dependency_source(project_dir, true),
+        Ok(Some(ref source)) if source.rev().is_none()
+    );
+    if !builds_in_place {
+        let _ = clear_cached_backend();
+    }
+    standalone_backend(project_dir)
 }
 
-/// Builds the backend from a local source tree.
+/// Builds the backend from a local source tree, with the build tree at
+/// `<codegen_crate>/target`: the layout the in-repo path, `cargo oxide setup`
+/// and the passive [`backend_so_path_candidate`] expect.
 pub fn build_backend_from_source(codegen_crate: &Path) -> PathBuf {
+    build_backend_from_source_in(codegen_crate, None)
+}
+
+/// Builds the backend from `codegen_crate`, with the build tree at
+/// `target_dir` when given and at `<codegen_crate>/target` otherwise.
+/// Dependency checkouts pass `~/.cargo/cuda-oxide/target`: one tree that
+/// cargo-oxide owns, that consecutive commits share their dependency builds
+/// in (pliron and friends rebuild only when they change), and that a user can
+/// delete to reclaim the space, instead of a build tree inside Cargo's
+/// checkout that nothing ever cleans up.
+pub fn build_backend_from_source_in(codegen_crate: &Path, target_dir: Option<&Path>) -> PathBuf {
     println!("Building rustc-codegen-cuda backend...");
     // The application build still honors these (codegen_env.rs folds them
     // into the composed flags), so say once why the backend build does not.
@@ -589,7 +939,7 @@ pub fn build_backend_from_source(codegen_crate: &Path) -> PathBuf {
     let rustc_sysroot = get_rustc_sysroot();
     let lib_path = rustc_sysroot.as_ref().map(|s| format!("{}/lib", s));
 
-    let mut cmd = backend_build_command(codegen_crate, lib_path.as_deref());
+    let mut cmd = backend_build_command_in(codegen_crate, target_dir, lib_path.as_deref());
     let output = cmd.output().unwrap_or_else(|error| {
         eprintln!("Failed to run cargo build for rustc-codegen-cuda: {error}");
         std::process::exit(1);
@@ -622,9 +972,18 @@ pub fn build_backend_from_source(codegen_crate: &Path) -> PathBuf {
     so_path
 }
 
-fn backend_build_command(codegen_crate: &Path, rustc_lib_path: Option<&str>) -> Command {
+/// The `cargo build` invocation for the backend crate, with the build tree at
+/// `target_dir` when given and at `<codegen_crate>/target` otherwise (see
+/// [`build_backend_from_source_in`]).
+fn backend_build_command_in(
+    codegen_crate: &Path,
+    target_dir: Option<&Path>,
+    rustc_lib_path: Option<&str>,
+) -> Command {
     let codegen_crate = absolute_path(codegen_crate);
-    let target_dir = codegen_crate.join("target");
+    let target_dir = target_dir
+        .map(absolute_path)
+        .unwrap_or_else(|| codegen_crate.join("target"));
     let mut cmd = Command::new("cargo");
     cmd.args([
         "build",
@@ -843,11 +1202,12 @@ fn dirs_path() -> Option<PathBuf> {
         })
 }
 
-/// Clones the cuda-oxide repo into the cache directory and builds the backend.
+/// Clones cuda-oxide `main` into the cache directory and builds the backend.
 ///
-/// This is the last-resort discovery path for external users who don't have
-/// the repo checked out locally. The clone is shallow (`--depth 1`) to keep
-/// the download small.
+/// This is the last-resort path for a project with no cuda-oxide dependency
+/// to pin a commit (projects with one build from that checkout instead; see
+/// [`standalone_backend`]). The clone is shallow (`--depth 1`) to keep the
+/// download small.
 fn auto_fetch_and_build() -> PathBuf {
     let cache_dir = cache_directory().unwrap_or_else(|| {
         eprintln!("Error: Cannot determine cache directory.");
@@ -861,7 +1221,10 @@ fn auto_fetch_and_build() -> PathBuf {
     std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
 
     if !src_dir.join("Cargo.toml").exists() {
-        eprintln!("Backend not found. Fetching cuda-oxide source (one-time setup)...");
+        eprintln!(
+            "Backend not found, and no cuda-device/cuda-host dependency pins a commit for \
+             this project. Fetching cuda-oxide main (one-time setup)..."
+        );
         eprintln!();
         let status = Command::new("git")
             .args([
@@ -881,10 +1244,13 @@ fn auto_fetch_and_build() -> PathBuf {
         }
     }
 
-    let codegen_crate = src_dir.join("crates/rustc-codegen-cuda");
+    refuse_unloadable_backend(&src_dir, "the cuda-oxide main clone");
+    let codegen_crate = src_dir.join(CODEGEN_CRATE_SUBDIR);
     let built_so = build_backend_from_source(&codegen_crate);
     if built_so.exists() {
-        install_backend_into(&cache_dir, &built_so, &codegen_crate)
+        // A `main` clone pins nothing, so no commit is recorded: a project
+        // that does pin one must never match this cache.
+        install_backend_into(&cache_dir, &built_so, &codegen_crate, None)
             .expect("Failed to copy backend to cache");
         eprintln!("✓ Backend cached at {}", so_path.display());
     }
@@ -893,12 +1259,14 @@ fn auto_fetch_and_build() -> PathBuf {
 }
 
 /// Copies a freshly built backend into `cache_dir` and records the toolchain
-/// fingerprint beside it.
+/// fingerprint and the source commit beside it.
 ///
 /// The fingerprint must be written whenever the `.so` is. A `.so` installed
 /// without one falls back to the mtime checks, which cannot see a toolchain
 /// swap, so the next lookup would load a backend linked against the wrong
-/// `librustc_driver`.
+/// `librustc_driver`. The commit record follows the same rule: written with
+/// the `.so`, or removed when the commit is unknown (see
+/// [`record_source_rev`]).
 ///
 /// Takes the directories explicitly so it can be exercised without touching
 /// `CARGO_HOME`. `build_dir` is the backend source crate the `.so` was built
@@ -908,12 +1276,26 @@ fn install_backend_into(
     cache_dir: &Path,
     built_so: &Path,
     build_dir: &Path,
+    source_rev: Option<&str>,
 ) -> std::io::Result<PathBuf> {
     std::fs::create_dir_all(cache_dir)?;
     let so_path = cache_dir.join("librustc_codegen_cuda.so");
+    // Drop the old record before the copy and write the new one after it, so
+    // the only intermediate state is "no record", which counts as stale: a
+    // copy interrupted halfway can never be handed out under the old commit.
+    record_source_rev(cache_dir, None);
     std::fs::copy(built_so, &so_path)?;
     write_toolchain_fingerprint(cache_dir, build_dir);
+    record_source_rev(cache_dir, source_rev);
     Ok(so_path)
+}
+
+/// What [`publish_to_cache`] installed.
+pub struct PublishedBackend {
+    /// The cached `.so`.
+    pub path: PathBuf,
+    /// The commit recorded beside it, when the checkout is a git repository.
+    pub source_rev: Option<String>,
 }
 
 /// Publishes a freshly built backend to the shared cache at
@@ -922,14 +1304,19 @@ fn install_backend_into(
 /// That path is what step 4 of the discovery order resolves to, and it is the
 /// only one a project outside this repository can reach: `find_workspace_root`
 /// walks up from the current directory looking for `crates/rustc-codegen-cuda`
-/// and finds nothing from an unrelated crate.
+/// and finds nothing from an unrelated crate. The checkout's HEAD is recorded
+/// beside the `.so`, so only projects whose dependency resolves to that commit
+/// reuse it.
 ///
 /// Returns `None` when the cache directory cannot be determined or the copy
 /// fails. Callers treat this as best effort: a failure leaves the in-repo build
 /// usable and costs external projects only a rebuild.
-pub fn publish_to_cache(built_so: &Path, codegen_crate: &Path) -> Option<PathBuf> {
+pub fn publish_to_cache(built_so: &Path, codegen_crate: &Path) -> Option<PublishedBackend> {
     let cache_dir = cache_directory()?;
-    install_backend_into(&cache_dir, built_so, codegen_crate).ok()
+    let source_rev = repository_head(codegen_crate);
+    let path =
+        install_backend_into(&cache_dir, built_so, codegen_crate, source_rev.as_deref()).ok()?;
+    Some(PublishedBackend { path, source_rev })
 }
 
 /// Returns the active rustc sysroot path (e.g., `~/.rustup/toolchains/nightly-...`).
@@ -981,7 +1368,8 @@ mod tests {
     /// cargo-oxide builds or looks for `librustc_codegen_cuda.so`.
     #[test]
     fn backend_build_command_isolates_target_dir_and_forces_the_host() {
-        let command = backend_build_command(Path::new("/tmp/codegen"), Some("/tmp/rustc/lib"));
+        let command =
+            backend_build_command_in(Path::new("/tmp/codegen"), None, Some("/tmp/rustc/lib"));
 
         let cargo_target_dir = command
             .get_envs()
@@ -1091,7 +1479,7 @@ mod tests {
         );
 
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::StaleVsBinary,
             "cache backdated by 1y must be stale vs the running binary"
         );
@@ -1111,7 +1499,7 @@ mod tests {
         );
 
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::Fresh,
             "cache postdating the test binary must be reported fresh"
         );
@@ -1124,22 +1512,27 @@ mod tests {
     fn not_stale_when_cache_file_missing() {
         let dir = tempdir();
         let so = dir.join("does_not_exist.so");
-        assert_eq!(cached_backend_status(&so, None), CacheStatus::Fresh);
+        assert_eq!(cached_backend_status(&so, None, None), CacheStatus::Fresh);
     }
 
     #[test]
-    fn clear_cache_contents_removes_so_and_src_tree() {
+    fn clear_cache_contents_removes_so_src_tree_and_commit_record() {
         let dir = tempdir();
         let so = dir.join("librustc_codegen_cuda.so");
         let src = dir.join("src/crates/rustc-codegen-cuda");
         std::fs::create_dir_all(&src).unwrap();
         std::fs::write(&so, b"old").unwrap();
         std::fs::write(src.join("lib.rs"), b"fn main() {}").unwrap();
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111").unwrap();
 
         clear_cache_contents(&dir);
 
         assert!(!so.exists());
         assert!(!dir.join("src").exists());
+        assert!(
+            !dir.join(SOURCE_REV_FILE).exists(),
+            "a record without its .so would misreport a backend that is gone"
+        );
     }
 
     /// A backend source input newer than the cached `.so` must report
@@ -1168,7 +1561,7 @@ mod tests {
         write_with_mtime(&dir.join("Cargo.toml"), b"[package]", SystemTime::now());
 
         assert_eq!(
-            cached_backend_status(&so, Some(&dir)),
+            cached_backend_status(&so, Some(&dir), None),
             CacheStatus::StaleVsSource,
             "source newer than cached .so must be stale vs source (rebuild in place)"
         );
@@ -1198,7 +1591,7 @@ mod tests {
         );
 
         assert_eq!(
-            cached_backend_status(&so, Some(&dir)),
+            cached_backend_status(&so, Some(&dir), None),
             CacheStatus::Fresh,
             "source older than cached .so must be reported fresh"
         );
@@ -1217,7 +1610,7 @@ mod tests {
         );
         let absent = dir.join("no-such-src-tree");
         assert_eq!(
-            cached_backend_status(&so, Some(&absent)),
+            cached_backend_status(&so, Some(&absent), None),
             CacheStatus::Fresh,
             "absent source tree must fall back to binary-only (fresh here)"
         );
@@ -1244,7 +1637,7 @@ mod tests {
         );
 
         assert_eq!(
-            cached_backend_status(&so, Some(&dir)),
+            cached_backend_status(&so, Some(&dir), None),
             CacheStatus::StaleVsBinary,
             "binary staleness must win over source staleness"
         );
@@ -1383,7 +1776,8 @@ mod tests {
         std::fs::write(&source, b"built").unwrap();
 
         let cache = dir.join("cache");
-        let installed = install_backend_into(&cache, &source, &dir).expect("install must succeed");
+        let installed =
+            install_backend_into(&cache, &source, &dir, None).expect("install must succeed");
 
         assert_eq!(
             installed,
@@ -1419,7 +1813,8 @@ mod tests {
         let source = dir.join("built.so");
         std::fs::write(&source, b"fresh").unwrap();
 
-        let installed = install_backend_into(&cache, &source, &dir).expect("install must succeed");
+        let installed =
+            install_backend_into(&cache, &source, &dir, None).expect("install must succeed");
 
         assert_eq!(
             std::fs::read(&installed).unwrap(),
@@ -1448,7 +1843,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::StaleVsToolchain,
             "a recorded fingerprint differing from the active toolchain must be stale"
         );
@@ -1468,7 +1863,7 @@ mod tests {
         std::fs::write(dir.join(TOOLCHAIN_FINGERPRINT_FILE), fp).unwrap();
 
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::Fresh,
             "a matching fingerprint with fresh mtimes must be fresh"
         );
@@ -1485,7 +1880,7 @@ mod tests {
         write_with_mtime(&so, b"built", SystemTime::now() + year);
         // No fingerprint file written.
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::Fresh,
             "absent fingerprint must defer to mtime checks (fresh here)"
         );
@@ -1508,7 +1903,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            cached_backend_status(&so, None),
+            cached_backend_status(&so, None, None),
             CacheStatus::StaleVsToolchain,
             "toolchain mismatch must win over binary staleness"
         );
@@ -1579,7 +1974,7 @@ mod tests {
         std::fs::write(dir.join(TOOLCHAIN_HEAL_MARKER_FILE), "stale heal memory").unwrap();
 
         assert_eq!(
-            consult_backend_cache(&dir),
+            consult_backend_cache(&dir, None, None),
             Some(so),
             "a matching fingerprint with fresh mtimes must reuse the cache"
         );
@@ -1587,6 +1982,403 @@ mod tests {
             !dir.join(TOOLCHAIN_HEAL_MARKER_FILE).exists(),
             "a passing fingerprint check must clear the heal marker"
         );
+    }
+
+    /// The cache records the cuda-oxide commit it was built from. A project
+    /// whose dependency resolves to another commit must not load it, however
+    /// fresh the mtimes look: its kernels compile against `cuda-device` at one
+    /// commit and would be lowered by a backend from another.
+    #[test]
+    fn stale_when_cache_was_built_from_another_commit() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            cached_backend_status(&so, None, Some("bbbb2222")),
+            CacheStatus::StaleVsDependency,
+            "a cache from another commit must be stale for this project"
+        );
+    }
+
+    #[test]
+    fn fresh_when_cache_matches_the_dependency_commit() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            cached_backend_status(&so, None, Some("aaaa1111")),
+            CacheStatus::Fresh,
+            "a cache from the project's own commit must be reused"
+        );
+    }
+
+    /// A cache with no recorded commit predates this check: it came from a
+    /// `main` clone at an unknown commit. When the project pins one, rebuild
+    /// once; the rebuild records the commit, so this fires once, not forever.
+    #[test]
+    fn unrecorded_commit_is_stale_when_the_project_pins_one() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+
+        assert_eq!(
+            cached_backend_status(&so, None, Some("aaaa1111")),
+            CacheStatus::StaleVsDependency,
+            "an unrecorded commit cannot be trusted to match the project's"
+        );
+    }
+
+    /// A project with no cuda-oxide dependency pins nothing, so whatever
+    /// commit the cache records is no reason to rebuild.
+    #[test]
+    fn recorded_commit_is_ignored_when_the_project_pins_none() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            cached_backend_status(&so, None, None),
+            CacheStatus::Fresh,
+            "no expected commit means no commit check"
+        );
+    }
+
+    /// An unloadable `.so` is stale whichever commit it came from, so the
+    /// toolchain verdict (and its heal guard) keeps the highest precedence.
+    #[test]
+    fn toolchain_staleness_takes_precedence_over_dependency() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(
+            dir.join(TOOLCHAIN_FINGERPRINT_FILE),
+            "rustc 0.0.0 (deadbeef 1970-01-01)",
+        )
+        .unwrap();
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            cached_backend_status(&so, None, Some("bbbb2222")),
+            CacheStatus::StaleVsToolchain,
+            "toolchain mismatch must win over a commit mismatch"
+        );
+    }
+
+    /// A binary upgrade and a commit change both rebuild from the project's
+    /// checkout; the commit verdict wins so the message names the real cause.
+    #[test]
+    fn dependency_staleness_takes_precedence_over_binary() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        // Backdate the `.so` so binary-staleness would otherwise fire.
+        write_with_mtime(&so, b"built", SystemTime::now() - year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            cached_backend_status(&so, None, Some("bbbb2222")),
+            CacheStatus::StaleVsDependency,
+            "commit mismatch must win over binary staleness"
+        );
+    }
+
+    /// Installing writes the commit beside the `.so`, and installing a build
+    /// of unknown origin removes any earlier record: a stale record would let
+    /// a later project match a cache that did not come from its commit.
+    #[test]
+    fn installing_records_the_source_commit_and_forgets_an_unknown_one() {
+        let dir = tempdir();
+        let source = dir.join("built.so");
+        std::fs::write(&source, b"built").unwrap();
+        let cache = dir.join("cache");
+
+        install_backend_into(&cache, &source, &dir, Some("aaaa1111")).expect("install");
+        assert_eq!(
+            std::fs::read_to_string(cache.join(SOURCE_REV_FILE)).unwrap(),
+            "aaaa1111",
+            "installing must record the source commit"
+        );
+
+        install_backend_into(&cache, &source, &dir, None).expect("install");
+        assert!(
+            !cache.join(SOURCE_REV_FILE).exists(),
+            "a build of unknown origin must not keep the previous commit record"
+        );
+    }
+
+    /// A commit mismatch falls through to a rebuild without deleting anything:
+    /// the old `.so` and its record stay consistent for the project they
+    /// belong to until the replacement is installed over them, so a failed
+    /// build never empties the cache. It must not touch the heal marker
+    /// machinery either, which belongs to toolchain mismatches.
+    #[test]
+    fn dependency_mismatch_keeps_the_old_cache_until_replaced() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+
+        assert_eq!(
+            consult_backend_cache(&dir, None, Some("bbbb2222")),
+            None,
+            "a cache from another commit must not be handed out"
+        );
+        assert!(
+            so.exists(),
+            "the old backend stays until the replacement lands"
+        );
+        assert_eq!(
+            recorded_source_rev(&dir).as_deref(),
+            Some("aaaa1111"),
+            "the old record stays with the old backend"
+        );
+        assert!(
+            !dir.join(TOOLCHAIN_HEAL_MARKER_FILE).exists(),
+            "a commit mismatch is not a toolchain heal attempt"
+        );
+    }
+
+    /// A toolchain mismatch with a pinned dependency must not consult the
+    /// heal-marker gate: the rebuild comes from the project's own checkout and
+    /// converges, so a marker left by the `main` clone path (or by the
+    /// previous cargo-oxide, whose users this fix targets) is dropped rather
+    /// than turned into a "cannot converge" exit. The old `.so` stays until
+    /// the replacement is installed. Without a pinned dependency the gate
+    /// still applies.
+    #[test]
+    fn toolchain_mismatch_with_a_pinned_dependency_rebuilds_instead_of_giving_up() {
+        let Some(current) = current_toolchain_fingerprint() else {
+            return; // no rustc here; nothing to observe
+        };
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        let recorded = "rustc 0.0.0 (deadbeef 1970-01-01)";
+        std::fs::write(dir.join(TOOLCHAIN_FINGERPRINT_FILE), recorded).unwrap();
+        std::fs::write(
+            dir.join(TOOLCHAIN_HEAL_MARKER_FILE),
+            heal_marker_content(&current, recorded),
+        )
+        .unwrap();
+
+        assert_eq!(
+            consult_backend_cache(&dir, None, Some("aaaa1111")),
+            None,
+            "a toolchain mismatch must fall through to a rebuild from the dependency"
+        );
+        assert!(
+            so.exists(),
+            "the old backend stays until the replacement lands"
+        );
+        assert!(
+            !dir.join(TOOLCHAIN_HEAL_MARKER_FILE).exists(),
+            "the heal marker belongs to the main-clone path and must be dropped"
+        );
+
+        std::fs::write(
+            dir.join(TOOLCHAIN_HEAL_MARKER_FILE),
+            heal_marker_content(&current, recorded),
+        )
+        .unwrap();
+        assert_eq!(
+            toolchain_heal_decision(&dir),
+            ToolchainHealDecision::GiveUp {
+                current,
+                recorded: recorded.to_string(),
+            },
+            "without a pinned dependency the same marker still means \"already tried\""
+        );
+    }
+
+    /// Dependency checkouts build into the shared cache's `target`, not into
+    /// Cargo's checkout; the in-repo default stays `<crate>/target`.
+    #[test]
+    fn backend_build_command_honours_a_target_dir_override() {
+        let command = backend_build_command_in(
+            Path::new("/tmp/codegen"),
+            Some(Path::new("/tmp/cache/target")),
+            None,
+        );
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--target-dir", "/tmp/cache/target"])
+        );
+        let cargo_target_dir = command
+            .get_envs()
+            .find_map(|(key, value)| (key == OsStr::new("CARGO_TARGET_DIR")).then_some(value));
+        assert_eq!(
+            cargo_target_dir.flatten(),
+            Some(OsStr::new("/tmp/cache/target"))
+        );
+        assert_eq!(command.get_current_dir(), Some(Path::new("/tmp/codegen")));
+
+        let default = backend_build_command_in(Path::new("/tmp/codegen"), None, None);
+        let args = default
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--target-dir", "/tmp/codegen/target"])
+        );
+    }
+
+    /// The refusal compares the ACTIVE toolchain (what the proxy exported and
+    /// what will build and load the backend) with the channel the checkout
+    /// needs, fires only when both are known and differ, tolerates rustup's
+    /// host-suffixed names, and names the channel to set plus the escape
+    /// hatch. Comparing two `rustc -vV` fingerprints instead would never fire
+    /// under `cargo oxide`, where `RUSTUP_TOOLCHAIN` makes both resolve alike.
+    #[test]
+    fn unloadable_backend_report_compares_channels_and_names_the_fix() {
+        let dep = "cuda-oxide 596a6353de (git dependency)";
+        let april = "nightly-2026-04-03-x86_64-unknown-linux-gnu (overridden by environment \
+                     variable RUSTUP_TOOLCHAIN)";
+        let august =
+            "nightly-2026-08-28-x86_64-unknown-linux-gnu (overridden by '/p/rust-toolchain.toml')";
+
+        assert_eq!(
+            unloadable_backend_report(dep, None, Some("nightly-2026-08-28")),
+            None,
+            "no rustup means no verdict; let the build proceed"
+        );
+        assert_eq!(
+            unloadable_backend_report(dep, Some(april), None),
+            None,
+            "a checkout without a toolchain file pins nothing to compare with"
+        );
+        assert_eq!(
+            unloadable_backend_report(dep, Some(august), Some("nightly-2026-08-28")),
+            None,
+            "the host-suffixed active name matches its channel"
+        );
+
+        let report = unloadable_backend_report(dep, Some(april), Some("nightly-2026-08-28"))
+            .expect("a different channel must be refused");
+        assert!(
+            report.contains("needs Rust `nightly-2026-08-28`"),
+            "{report}"
+        );
+        assert!(
+            report.contains("using `nightly-2026-04-03-x86_64-unknown-linux-gnu`"),
+            "the active toolchain must be named without rustup's trailing reason: {report}"
+        );
+        assert!(
+            report.contains(
+                "Set `channel = \"nightly-2026-08-28\"` in this project's rust-toolchain.toml"
+            ),
+            "{report}"
+        );
+        assert!(report.contains("CUDA_OXIDE_BACKEND"), "{report}");
+    }
+
+    /// The commit verdict outranks the source-mtime verdict: the wrong commit
+    /// is the wrong backend whatever the mtimes say.
+    #[test]
+    fn dependency_staleness_takes_precedence_over_source() {
+        let year = Duration::from_secs(365 * 24 * 60 * 60);
+        let dir = tempdir();
+        let so = dir.join("librustc_codegen_cuda.so");
+        write_with_mtime(&so, b"built", SystemTime::now() + year);
+        std::fs::write(dir.join(SOURCE_REV_FILE), "aaaa1111\n").unwrap();
+        let src = dir.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        write_with_mtime(
+            &src.join("lib.rs"),
+            b"// newer",
+            SystemTime::now() + year + year,
+        );
+
+        assert_eq!(
+            cached_backend_status(&so, Some(&dir), Some("bbbb2222")),
+            CacheStatus::StaleVsDependency,
+            "commit mismatch must win over source staleness"
+        );
+    }
+
+    /// `setup` records the repository HEAD beside the published `.so`, and
+    /// `dependency_rev_mismatch` compares it byte for byte with the 40-hex
+    /// commit Cargo reports. So it must be the full hash, trimmed, resolved
+    /// from a directory inside the repository, and unaffected by a dirty tree.
+    #[test]
+    fn repository_head_is_the_full_commit_of_the_enclosing_repo() {
+        let repo = tempdir();
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .args(["-c", "commit.gpgsign=false"])
+                .args(args)
+                .current_dir(&repo)
+                .output()
+        };
+        if !git(&["init", "-q"]).is_ok_and(|output| output.status.success()) {
+            return; // no git here; nothing to observe
+        }
+        let committed = git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .unwrap();
+        assert!(
+            committed.status.success(),
+            "{}",
+            String::from_utf8_lossy(&committed.stderr)
+        );
+        let expected = String::from_utf8_lossy(&git(&["rev-parse", "HEAD"]).unwrap().stdout)
+            .trim()
+            .to_string();
+        assert_eq!(expected.len(), 40, "git must report the full hash");
+
+        let nested = repo.join(CODEGEN_CRATE_SUBDIR);
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(
+            repository_head(&nested),
+            Some(expected.clone()),
+            "HEAD must resolve from the backend crate directory inside the repo"
+        );
+
+        std::fs::write(repo.join("dirty.txt"), b"uncommitted").unwrap();
+        assert_eq!(
+            repository_head(&nested),
+            Some(expected),
+            "a dirty tree is recorded under its HEAD"
+        );
+
+        let outside = tempdir();
+        let in_a_repo = Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(&outside)
+            .output()
+            .is_ok_and(|output| output.status.success());
+        if !in_a_repo {
+            assert_eq!(
+                repository_head(&outside),
+                None,
+                "outside any repository there is nothing to record"
+            );
+        }
     }
 
     fn tempdir() -> PathBuf {

--- a/crates/cargo-oxide/src/backend_source.rs
+++ b/crates/cargo-oxide/src/backend_source.rs
@@ -1,0 +1,685 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Where a project outside the repository gets its backend source.
+//!
+//! Kernels compile against the `cuda-device` / `cuda-host` crates at the commit
+//! Cargo resolved for them. The backend that lowers those kernels,
+//! `librustc_codegen_cuda`, lives in the same repository and has to come from
+//! the same commit: `cuda-device` only declares stubs (every method body is
+//! `unreachable!()`), and the backend recognises each stub by its path and
+//! supplies the whole lowering. A backend from another commit compiles the
+//! kernels differently, or not at all, with no error pointing at the cause.
+//!
+//! So the backend is built from the checkout Cargo already made for the
+//! dependency instead of from a separately cloned `main`:
+//!
+//! ```text
+//! Cargo.lock   cuda-device = git+https://github.com/NVlabs/cuda-oxide.git#<sha>
+//!                  │  cargo metadata: package.manifest_path
+//!                  ▼
+//! ~/.cargo/git/checkouts/cuda-oxide-<hash>/<sha>/crates/cuda-device/Cargo.toml
+//!                  │  walk up to the repository root
+//!                  ▼
+//! ~/.cargo/git/checkouts/cuda-oxide-<hash>/<sha>/crates/rustc-codegen-cuda   built
+//! ~/.cargo/git/checkouts/cuda-oxide-<hash>/<sha>/rust-toolchain.toml         nightly it needs
+//! ```
+//!
+//! The checkout's `rust-toolchain.toml` matters as much as the code: the
+//! backend is a rustc plugin and only loads into the toolchain that built it,
+//! so that file names the nightly the project itself has to use.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The cuda-oxide crates a project depends on directly. Any one of them
+/// identifies the checkout: they ship in a single repository.
+const CUDA_OXIDE_CRATES: &[&str] = &["cuda-device", "cuda-host", "cuda-macros"];
+
+/// The backend crate, relative to a cuda-oxide checkout root.
+pub const CODEGEN_CRATE_SUBDIR: &str = "crates/rustc-codegen-cuda";
+
+/// The cuda-oxide checkout a project's dependency resolves to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencySource {
+    /// A git dependency: Cargo's checkout of the repository at `rev`.
+    Git {
+        /// Repository root of the checkout.
+        checkout: PathBuf,
+        /// Full commit hash Cargo resolved (the `#<sha>` of the package source).
+        rev: String,
+    },
+    /// A path dependency: a local checkout of the repository.
+    Path {
+        /// Repository root of the checkout.
+        checkout: PathBuf,
+    },
+}
+
+impl DependencySource {
+    /// Repository root of the checkout.
+    pub fn checkout(&self) -> &Path {
+        match self {
+            Self::Git { checkout, .. } | Self::Path { checkout } => checkout,
+        }
+    }
+
+    /// The backend crate inside the checkout.
+    pub fn codegen_crate(&self) -> PathBuf {
+        self.checkout().join(CODEGEN_CRATE_SUBDIR)
+    }
+
+    /// The commit the checkout is at, for git dependencies.
+    pub fn rev(&self) -> Option<&str> {
+        match self {
+            Self::Git { rev, .. } => Some(rev),
+            Self::Path { .. } => None,
+        }
+    }
+
+    /// One-line identity for messages.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Git { rev, .. } => format!("cuda-oxide {} (git dependency)", short_rev(rev)),
+            Self::Path { checkout } => format!(
+                "cuda-oxide checkout {} (path dependency)",
+                checkout.display()
+            ),
+        }
+    }
+}
+
+/// Abbreviated commit hash for messages.
+pub fn short_rev(rev: &str) -> &str {
+    rev.get(..10).unwrap_or(rev)
+}
+
+/// The nightly a checkout pins in its `rust-toolchain.toml`, when readable.
+pub fn pinned_channel(checkout: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(checkout.join("rust-toolchain.toml")).ok()?;
+    crate::commands::parse_rust_toolchain_toml(&contents)
+        .ok()
+        .map(|pin| pin.channel)
+}
+
+/// Resolves the cuda-oxide checkout the project in `project_dir` depends on.
+///
+/// Returns `Ok(None)` when no cuda-oxide crate is in the dependency graph.
+/// With `read_only`, Cargo may neither fetch nor write `Cargo.lock`
+/// (`--offline --locked`); passive commands such as `doctor` use this so a
+/// diagnostic never touches the network or the project.
+pub fn resolve_dependency_source(
+    project_dir: &Path,
+    read_only: bool,
+) -> Result<Option<DependencySource>, String> {
+    let metadata = cargo_metadata(project_dir, read_only)?;
+    dependency_source_from_metadata(&metadata)
+}
+
+/// Reads the dependency checkout out of `cargo metadata` output.
+///
+/// Every cuda-oxide crate in the graph must resolve to one checkout; two
+/// checkouts would mean two commits and no single backend to build for them.
+pub fn dependency_source_from_metadata(
+    metadata: &serde_json::Value,
+) -> Result<Option<DependencySource>, String> {
+    let packages = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "`cargo metadata` output has no packages".to_string())?;
+
+    let mut sources: Vec<DependencySource> = Vec::new();
+    for package in packages {
+        let Some(name) = package.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if !CUDA_OXIDE_CRATES.contains(&name) {
+            continue;
+        }
+        let manifest = package
+            .get("manifest_path")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| format!("`cargo metadata` lists `{name}` without a manifest_path"))?;
+        let rev = match package.get("source").and_then(serde_json::Value::as_str) {
+            None => None,
+            Some(source) => Some(
+                git_source_rev(source)
+                    .ok_or_else(|| {
+                        format!(
+                            "`{name}` comes from `{source}`; only git and path dependencies \
+                             carry the cuda-oxide checkout the backend is built from"
+                        )
+                    })?
+                    .to_string(),
+            ),
+        };
+        let checkout = checkout_root(Path::new(manifest)).ok_or_else(|| {
+            format!(
+                "`{name}` at {manifest} is not inside a cuda-oxide checkout (no \
+                 `{CODEGEN_CRATE_SUBDIR}` above it), so there is no backend to build"
+            )
+        })?;
+        let source = match rev {
+            Some(rev) => DependencySource::Git { checkout, rev },
+            None => DependencySource::Path { checkout },
+        };
+        if !sources.contains(&source) {
+            sources.push(source);
+        }
+    }
+
+    match sources.as_slice() {
+        [] => Ok(None),
+        [source] => Ok(Some(source.clone())),
+        several => Err(format!(
+            "cuda-oxide crates resolve from more than one checkout, so there is no single \
+             backend to build:\n{}",
+            several
+                .iter()
+                .map(|source| format!("  {}", source.describe()))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )),
+    }
+}
+
+/// The resolved commit of a git package source.
+///
+/// Cargo writes git sources as `git+<url>?<rev|branch|tag>=<spec>#<sha>`; the
+/// fragment is always the full commit hash, whatever the spec was.
+fn git_source_rev(source: &str) -> Option<&str> {
+    let rest = source.strip_prefix("git+")?;
+    let (_, rev) = rest.rsplit_once('#')?;
+    (!rev.is_empty()).then_some(rev)
+}
+
+/// Walks up from a crate manifest to the repository root, recognised by the
+/// backend crate living under it.
+///
+/// The walk never leaves the repository the manifest belongs to: it stops at
+/// the first directory that is itself a repository root (`.git`, or the
+/// `.cargo-ok` marker Cargo writes into every git checkout). Without that
+/// boundary a trimmed checkout would keep climbing and could latch onto an
+/// unrelated cuda-oxide tree higher up, such as a developer's own clone.
+fn checkout_root(manifest: &Path) -> Option<PathBuf> {
+    let mut dir = manifest.parent()?;
+    loop {
+        if dir.join(CODEGEN_CRATE_SUBDIR).join("Cargo.toml").is_file() {
+            return Some(dir.to_path_buf());
+        }
+        if dir.join(".git").exists() || dir.join(".cargo-ok").exists() {
+            return None;
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// `cargo metadata` for the project, with dependencies.
+///
+/// `--all-features`, so a cuda-oxide crate declared `optional = true` behind
+/// a feature is still found: the backend must follow that commit whichever
+/// features the build enables. Read-only (`doctor`): `--offline --locked`, so
+/// a missing or stale `Cargo.lock` is reported instead of being resolved
+/// against whatever the local git database holds and written to disk, and
+/// stderr is captured so the caller can fold Cargo's reason into its report.
+/// Otherwise the user's own lock discipline (`--locked` / `--frozen` /
+/// `--offline`, which cargo-oxide passes through to cargo) is honoured, so
+/// resolving here never writes a lockfile the build was told to refuse to
+/// touch, and Cargo's progress ("Updating git repository ...") streams to the
+/// terminal since a first fetch can take a while.
+fn cargo_metadata(project_dir: &Path, read_only: bool) -> Result<serde_json::Value, String> {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["metadata", "--format-version=1", "--all-features"])
+        .current_dir(project_dir);
+    if read_only {
+        cmd.args(["--offline", "--locked"]);
+    } else {
+        cmd.args(lock_discipline_flags(std::env::args()));
+        cmd.stderr(Stdio::inherit());
+    }
+    let output = cmd
+        .output()
+        .map_err(|error| format!("could not start `cargo metadata`: {error}"))?;
+    if !output.status.success() {
+        // Cargo's diagnostic, not its first chatter: a concurrent cargo can
+        // put "Blocking waiting for file lock on package cache" ahead of the
+        // `error:` line, and `doctor` prints this reason verbatim.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let lines = || {
+            stderr
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+        };
+        let reason = lines()
+            .find(|line| line.starts_with("error"))
+            .or_else(|| lines().next())
+            .map(|line| format!(": {line}"))
+            .unwrap_or_default();
+        return Err(format!(
+            "`cargo metadata` failed ({}){reason}",
+            output.status
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("could not parse `cargo metadata` output: {error}"))
+}
+
+/// The lock-discipline flags in a `cargo oxide` command line, to repeat on the
+/// `cargo metadata` call. cargo-oxide defines none of these itself, so any
+/// occurrence before a bare `--` is a passthrough argument for cargo; after
+/// `--` they belong to the program being run and are ignored.
+fn lock_discipline_flags(args: impl IntoIterator<Item = String>) -> Vec<String> {
+    args.into_iter()
+        .take_while(|arg| arg != "--")
+        .filter(|arg| matches!(arg.as_str(), "--locked" | "--frozen" | "--offline"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::SystemTime;
+
+    const REPO: &str = "https://github.com/NVlabs/cuda-oxide.git";
+    const SHA: &str = "a1b4f11882592fae9d022c86a9d8d1a4c9426980";
+
+    /// Lays out what Cargo's checkout of the repository looks like: the crate
+    /// the project depends on plus the backend crate beside it.
+    fn checkout_with_backend(root: &Path, crate_name: &str) -> PathBuf {
+        for sub in [CODEGEN_CRATE_SUBDIR, &format!("crates/{crate_name}")] {
+            let dir = root.join(sub);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("Cargo.toml"), "[package]\n").unwrap();
+        }
+        root.join("crates").join(crate_name).join("Cargo.toml")
+    }
+
+    fn package(name: &str, source: Option<&str>, manifest: &Path) -> serde_json::Value {
+        json!({
+            "name": name,
+            "source": source,
+            "manifest_path": manifest,
+        })
+    }
+
+    fn metadata(packages: Vec<serde_json::Value>) -> serde_json::Value {
+        json!({ "packages": packages })
+    }
+
+    /// The common case: `cuda-device = { git = ..., rev = ... }`. The backend
+    /// must come from Cargo's checkout of that same commit, located by walking
+    /// up from the crate's manifest.
+    #[test]
+    fn git_dependency_resolves_to_cargos_checkout_and_commit() {
+        let root = tempdir();
+        let checkout = root.join("checkouts/cuda-oxide-6d394bb0/a1b4f11");
+        let manifest = checkout_with_backend(&checkout, "cuda-device");
+        let source = format!("git+{REPO}?rev=a1b4f118#{SHA}");
+        let md = metadata(vec![
+            package("maxproj", None, &root.join("Cargo.toml")),
+            package("cuda-device", Some(&source), &manifest),
+        ]);
+
+        let resolved = dependency_source_from_metadata(&md).unwrap().unwrap();
+        assert_eq!(
+            resolved,
+            DependencySource::Git {
+                checkout: checkout.clone(),
+                rev: SHA.to_string(),
+            }
+        );
+        assert_eq!(
+            resolved.codegen_crate(),
+            checkout.join(CODEGEN_CRATE_SUBDIR)
+        );
+        assert_eq!(resolved.rev(), Some(SHA));
+    }
+
+    /// A project pulls in several cuda-oxide crates (`cuda-device` brings
+    /// `cuda-macros`). They share one checkout, so they resolve to one source
+    /// rather than tripping the "more than one checkout" error.
+    #[test]
+    fn several_crates_from_one_checkout_resolve_once() {
+        let root = tempdir();
+        let checkout = root.join("a1b4f11");
+        let device = checkout_with_backend(&checkout, "cuda-device");
+        let macros = checkout_with_backend(&checkout, "cuda-macros");
+        let source = format!("git+{REPO}#{SHA}");
+        let md = metadata(vec![
+            package("cuda-device", Some(&source), &device),
+            package("cuda-macros", Some(&source), &macros),
+        ]);
+
+        let resolved = dependency_source_from_metadata(&md).unwrap().unwrap();
+        assert_eq!(resolved.rev(), Some(SHA));
+        assert_eq!(resolved.checkout(), checkout);
+    }
+
+    /// `cuda-device = { path = "../cuda-oxide/crates/cuda-device" }`: a local
+    /// checkout with no commit to record; the backend builds in place there.
+    #[test]
+    fn path_dependency_resolves_to_the_local_checkout() {
+        let root = tempdir();
+        let checkout = root.join("dev/cuda-oxide");
+        let manifest = checkout_with_backend(&checkout, "cuda-host");
+        let md = metadata(vec![package("cuda-host", None, &manifest)]);
+
+        let resolved = dependency_source_from_metadata(&md).unwrap().unwrap();
+        assert_eq!(resolved, DependencySource::Path { checkout });
+        assert_eq!(resolved.rev(), None);
+    }
+
+    /// No cuda-oxide crate in the graph means nothing pins a commit; the
+    /// caller falls back to the shared cache and the `main` clone.
+    #[test]
+    fn no_cuda_oxide_crates_means_no_source() {
+        let root = tempdir();
+        let md = metadata(vec![
+            package("maxproj", None, &root.join("Cargo.toml")),
+            package(
+                "serde",
+                Some("registry+https://github.com/rust-lang/crates.io-index"),
+                &root.join("registry/serde/Cargo.toml"),
+            ),
+        ]);
+        assert_eq!(dependency_source_from_metadata(&md).unwrap(), None);
+    }
+
+    /// Two different commits in one graph cannot share a backend. Refusing
+    /// beats silently picking one: kernels from the other crate would be
+    /// lowered by a backend that never saw them.
+    #[test]
+    fn crates_from_two_commits_are_an_error() {
+        let root = tempdir();
+        let old = checkout_with_backend(&root.join("b22efa9"), "cuda-device");
+        let new = checkout_with_backend(&root.join("a1b4f11"), "cuda-host");
+        let md = metadata(vec![
+            package(
+                "cuda-device",
+                Some(&format!(
+                    "git+{REPO}#b22efa99e000000000000000000000000000000000"
+                )),
+                &old,
+            ),
+            package("cuda-host", Some(&format!("git+{REPO}#{SHA}")), &new),
+        ]);
+
+        let error = dependency_source_from_metadata(&md).unwrap_err();
+        assert!(error.contains("more than one checkout"), "{error}");
+        assert!(error.contains("b22efa99e0"), "{error}");
+        assert!(error.contains("a1b4f11882"), "{error}");
+    }
+
+    /// A registry tarball ships one crate, not the repository, so no backend
+    /// source exists for it. Say so instead of walking up into `~/.cargo`.
+    #[test]
+    fn registry_dependency_is_an_error() {
+        let root = tempdir();
+        let manifest = root.join("registry/src/cuda-device-0.2.1/Cargo.toml");
+        std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        std::fs::write(&manifest, "[package]\n").unwrap();
+        let md = metadata(vec![package(
+            "cuda-device",
+            Some("registry+https://github.com/rust-lang/crates.io-index"),
+            &manifest,
+        )]);
+
+        let error = dependency_source_from_metadata(&md).unwrap_err();
+        assert!(error.contains("only git and path dependencies"), "{error}");
+    }
+
+    /// A checkout without the backend crate (a trimmed fork, a partial copy)
+    /// has nothing to build; the error names what was expected where.
+    #[test]
+    fn checkout_without_the_backend_crate_is_an_error() {
+        let root = tempdir();
+        if checkout_root(&root.join("Cargo.toml")).is_some() {
+            return; // the temp dir itself sits inside a cuda-oxide checkout
+        }
+        let manifest = root.join("somewhere/crates/cuda-device/Cargo.toml");
+        std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        std::fs::write(&manifest, "[package]\n").unwrap();
+        let md = metadata(vec![package(
+            "cuda-device",
+            Some(&format!("git+{REPO}#{SHA}")),
+            &manifest,
+        )]);
+
+        let error = dependency_source_from_metadata(&md).unwrap_err();
+        assert!(error.contains(CODEGEN_CRATE_SUBDIR), "{error}");
+    }
+
+    /// The walk stops at the repository the manifest belongs to. A trimmed
+    /// checkout (marked `.cargo-ok` like every Cargo git checkout) nested under
+    /// a directory that does hold a full cuda-oxide tree must NOT resolve to
+    /// that outer tree: it is somebody else's checkout at some other commit.
+    #[test]
+    fn checkout_root_never_climbs_out_of_the_repository() {
+        let outer = tempdir();
+        checkout_with_backend(&outer, "cuda-device");
+        let trimmed = outer.join("nested/cuda-oxide-abcd/0123456");
+        let manifest = trimmed.join("crates/cuda-device/Cargo.toml");
+        std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        std::fs::write(&manifest, "[package]\n").unwrap();
+
+        // Without a repository marker the walk climbs to the outer tree.
+        assert_eq!(checkout_root(&manifest), Some(outer.clone()));
+
+        // With one it stops there and reports nothing.
+        std::fs::write(trimmed.join(".cargo-ok"), b"").unwrap();
+        assert_eq!(checkout_root(&manifest), None);
+
+        // A plain git clone is bounded the same way.
+        std::fs::remove_file(trimmed.join(".cargo-ok")).unwrap();
+        std::fs::create_dir_all(trimmed.join(".git")).unwrap();
+        assert_eq!(checkout_root(&manifest), None);
+
+        // The marker directory itself is still eligible when it has the crate.
+        checkout_with_backend(&trimmed, "cuda-device");
+        assert_eq!(checkout_root(&manifest), Some(trimmed));
+    }
+
+    /// The parser is fed real `cargo metadata` output, not only hand-built
+    /// JSON: a package with no cuda-oxide dependency resolves to nothing, and
+    /// a path dependency on a checkout resolves to it with `source: null` the
+    /// way Cargo emits it. Skipped when no `cargo` is on PATH.
+    #[test]
+    fn real_cargo_metadata_resolves_a_path_dependency() {
+        if Command::new("cargo").arg("--version").output().is_err() {
+            return; // no cargo here; nothing to observe
+        }
+        let root = tempdir();
+        let checkout = root.join("cuda-oxide");
+        checkout_with_backend(&checkout, "cuda-device");
+        let device = checkout.join("crates/cuda-device");
+        std::fs::create_dir_all(device.join("src")).unwrap();
+        std::fs::write(
+            device.join("Cargo.toml"),
+            "[package]\nname = \"cuda-device\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(device.join("src/lib.rs"), "").unwrap();
+
+        let plain = root.join("plain");
+        std::fs::create_dir_all(plain.join("src")).unwrap();
+        std::fs::write(
+            plain.join("Cargo.toml"),
+            "[package]\nname = \"plain\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(plain.join("src/lib.rs"), "").unwrap();
+        assert_eq!(
+            resolve_dependency_source(&plain, false).unwrap(),
+            None,
+            "a project without cuda-oxide crates pins no commit"
+        );
+
+        let user = root.join("user");
+        std::fs::create_dir_all(user.join("src")).unwrap();
+        std::fs::write(
+            user.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"user\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\
+                 [dependencies]\ncuda-device = {{ path = {:?} }}\n",
+                device.display().to_string()
+            ),
+        )
+        .unwrap();
+        std::fs::write(user.join("src/lib.rs"), "").unwrap();
+        // Read-only first: with no Cargo.lock yet, `--locked` must refuse
+        // rather than write one (this is what keeps `doctor` from silently
+        // resolving a fresh scaffold against a stale local git database).
+        let error = resolve_dependency_source(&user, true).unwrap_err();
+        assert!(error.contains("--locked"), "{error}");
+        assert!(
+            !user.join("Cargo.lock").exists(),
+            "read-only must not write"
+        );
+
+        let resolved = resolve_dependency_source(&user, false)
+            .unwrap()
+            .expect("the path dependency must resolve to its checkout");
+        assert_eq!(resolved.rev(), None, "a path dependency has no commit");
+        assert_eq!(
+            resolved.checkout().canonicalize().unwrap(),
+            checkout.canonicalize().unwrap()
+        );
+
+        // Once the lockfile exists, read-only resolution agrees with it.
+        assert!(user.join("Cargo.lock").exists());
+        assert_eq!(
+            resolve_dependency_source(&user, true).unwrap(),
+            Some(resolved)
+        );
+
+        // `--all-features`: a cuda-oxide crate behind an optional feature is
+        // still the commit the backend must follow.
+        let gated = root.join("gated");
+        std::fs::create_dir_all(gated.join("src")).unwrap();
+        std::fs::write(
+            gated.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"gated\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\
+                 [features]\ngpu = [\"dep:cuda-device\"]\n\
+                 [dependencies]\ncuda-device = {{ path = {:?}, optional = true }}\n",
+                device.display().to_string()
+            ),
+        )
+        .unwrap();
+        std::fs::write(gated.join("src/lib.rs"), "").unwrap();
+        let resolved = resolve_dependency_source(&gated, false)
+            .unwrap()
+            .expect("an optional cuda-oxide dependency must still be found");
+        assert_eq!(
+            resolved.checkout().canonicalize().unwrap(),
+            checkout.canonicalize().unwrap()
+        );
+    }
+
+    /// Only the flags meant for cargo count: anything after a bare `--` is
+    /// for the program `cargo oxide run` launches.
+    #[test]
+    fn lock_discipline_flags_are_taken_from_the_cargo_side_only() {
+        let args = |list: &[&str]| list.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            lock_discipline_flags(args(&["cargo-oxide", "build", "--locked", "--release"])),
+            ["--locked"]
+        );
+        assert_eq!(
+            lock_discipline_flags(args(&[
+                "cargo-oxide",
+                "run",
+                "x",
+                "--frozen",
+                "--offline",
+                "--",
+                "--offline"
+            ])),
+            ["--frozen", "--offline"]
+        );
+        assert!(lock_discipline_flags(args(&["cargo-oxide", "run", "--", "--locked"])).is_empty());
+    }
+
+    /// `doctor` prints this error verbatim, so a broken manifest must yield
+    /// the exit status plus Cargo's own first line, not an empty reason.
+    #[test]
+    fn real_cargo_metadata_failure_carries_cargos_reason() {
+        if Command::new("cargo").arg("--version").output().is_err() {
+            return; // no cargo here; nothing to observe
+        }
+        let broken = tempdir();
+        std::fs::write(broken.join("Cargo.toml"), "[package]\n").unwrap();
+
+        let error = resolve_dependency_source(&broken, true).unwrap_err();
+        assert!(error.starts_with("`cargo metadata` failed ("), "{error}");
+        assert!(
+            error.contains("): error"),
+            "the reason must carry Cargo's first stderr line: {error}"
+        );
+    }
+
+    /// The fragment is the resolved commit no matter how the dependency was
+    /// spelled (`rev`, `branch`, `tag`, or nothing).
+    #[test]
+    fn git_source_rev_reads_the_fragment() {
+        assert_eq!(
+            git_source_rev(&format!("git+{REPO}?rev=a1b4f118#{SHA}")),
+            Some(SHA)
+        );
+        assert_eq!(
+            git_source_rev(&format!("git+{REPO}?branch=main#{SHA}")),
+            Some(SHA)
+        );
+        assert_eq!(git_source_rev(&format!("git+{REPO}#{SHA}")), Some(SHA));
+        assert_eq!(git_source_rev(&format!("git+{REPO}")), None);
+        assert_eq!(
+            git_source_rev("registry+https://github.com/rust-lang/crates.io-index"),
+            None
+        );
+    }
+
+    /// The nightly a commit needs is whatever its `rust-toolchain.toml` says;
+    /// that is what the mismatch message tells the user to set.
+    #[test]
+    fn pinned_channel_reads_the_checkout_toolchain_file() {
+        let checkout = tempdir();
+        std::fs::write(
+            checkout.join("rust-toolchain.toml"),
+            "[toolchain]\nchannel = \"nightly-2026-08-28\"\ncomponents = [\"rustc-dev\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            pinned_channel(&checkout),
+            Some("nightly-2026-08-28".to_string())
+        );
+        assert_eq!(pinned_channel(&checkout.join("absent")), None);
+    }
+
+    #[test]
+    fn describe_abbreviates_the_commit() {
+        let source = DependencySource::Git {
+            checkout: PathBuf::from("/x"),
+            rev: SHA.to_string(),
+        };
+        assert_eq!(source.describe(), "cuda-oxide a1b4f11882 (git dependency)");
+        assert_eq!(short_rev("abc"), "abc");
+    }
+
+    fn tempdir() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "cargo-oxide-backend-source-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/crates/cargo-oxide/src/commands/context.rs
+++ b/crates/cargo-oxide/src/commands/context.rs
@@ -48,8 +48,10 @@ pub struct Context {
 ///   `crates/rustc-codegen-cuda` directory). Examples are resolved from the
 ///   workspace examples directory.
 /// - **Standalone mode**: CWD has a `Cargo.toml` but is not inside the
-///   workspace. The backend is located via cache or auto-fetch. Commands
-///   like `run` operate on the current directory directly.
+///   workspace. The backend is built from the commit the project's cuda-oxide
+///   dependency resolves to, or taken from the shared cache when that already
+///   holds it (see `backend::standalone_backend`). Commands like `run`
+///   operate on the current directory directly.
 pub fn resolve_context() -> Context {
     if let Some(workspace_root) = backend::find_workspace_root() {
         let codegen_crate = workspace_root.join("crates/rustc-codegen-cuda");

--- a/crates/cargo-oxide/src/commands/doctor.rs
+++ b/crates/cargo-oxide/src/commands/doctor.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::backend;
+use crate::backend_source::{self, DependencySource, short_rev};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -15,9 +16,9 @@ use super::*;
 
 /// Parsed contents of a `rust-toolchain.toml` pin.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct RustToolchainPin {
-    pub(super) channel: String,
-    pub(super) components: Vec<String>,
+pub(crate) struct RustToolchainPin {
+    pub(crate) channel: String,
+    pub(crate) components: Vec<String>,
 }
 
 /// Components that doctor treats as hard requirements for the cuda-oxide
@@ -45,7 +46,7 @@ pub(super) fn doctor_verified_components(pin: &RustToolchainPin) -> Vec<String> 
 }
 
 /// Parse a `rust-toolchain.toml` document for channel and components.
-pub(super) fn parse_rust_toolchain_toml(contents: &str) -> Result<RustToolchainPin, String> {
+pub(crate) fn parse_rust_toolchain_toml(contents: &str) -> Result<RustToolchainPin, String> {
     let value: toml::Value =
         toml::from_str(contents).map_err(|error| format!("invalid TOML: {error}"))?;
     let toolchain = value
@@ -91,7 +92,7 @@ pub(super) fn parse_rust_toolchain_toml(contents: &str) -> Result<RustToolchainP
 ///   (verified against rustup 1.29.0);
 /// - 1.28.x: the bare name on the first line with the reason on a second
 ///   `active because: ...` line.
-pub(super) fn active_toolchain_matches_channel(active_toolchain: &str, channel: &str) -> bool {
+pub(crate) fn active_toolchain_matches_channel(active_toolchain: &str, channel: &str) -> bool {
     let active = active_toolchain
         .lines()
         .next()
@@ -239,6 +240,107 @@ fn doctor_report_toolchain_pin(ctx: &Context, ok: &mut bool) {
     }
 }
 
+/// Reports whether the cached backend came from the commit this project's
+/// cuda-oxide dependency resolves to.
+///
+/// Resolves offline: doctor must not fetch, and the dependency is already
+/// checked out once the project has resolved its lockfile. Informational,
+/// never fatal: a mismatch heals itself on the next build.
+fn doctor_report_backend_source(ctx: &Context) {
+    print!("Backend source (cuda-oxide commit)... ");
+    // Both pins sit above the dependency in backend discovery, so the
+    // dependency's commit plays no part while either is set.
+    if std::env::var_os("CUDA_OXIDE_BACKEND").is_some() || ctx.config.backend.is_some() {
+        println!(
+            "- backend pinned by CUDA_OXIDE_BACKEND or `.cargo/cuda-oxide.toml`; the \
+             dependency's commit is not consulted"
+        );
+        return;
+    }
+    // Read-only resolution needs a lockfile to read; a fresh project has none
+    // until its first build, which is the normal state, not a fault.
+    if !ctx.workspace_root.join("Cargo.lock").is_file() {
+        println!(
+            "- no Cargo.lock yet; run `cargo oxide build` once, then doctor can compare the \
+             cache with the dependency"
+        );
+        return;
+    }
+    let check = backend_source_check(
+        backend_source::resolve_dependency_source(&ctx.workspace_root, true),
+        backend::cached_backend_source_rev(),
+    );
+    println!("{}", check.headline);
+    for line in check.details {
+        println!("  {line}");
+    }
+}
+
+/// The backend-source verdict, from the resolved dependency and the commit
+/// recorded in the shared cache. Reuses the config check's struct so doctor
+/// prints it the same way; pure, so every branch is testable.
+pub(super) fn backend_source_check(
+    source: Result<Option<DependencySource>, String>,
+    recorded: Option<String>,
+) -> OxideConfigCheck {
+    let check = |headline: String, details: Vec<String>| OxideConfigCheck {
+        headline,
+        details,
+        failed: false,
+    };
+    let source = match source {
+        Ok(source) => source,
+        Err(error) => {
+            return check(
+                format!("- could not resolve the cuda-oxide dependency offline ({error})"),
+                Vec::new(),
+            );
+        }
+    };
+    let Some(source) = source else {
+        return check(
+            "- no cuda-device/cuda-host dependency; the cache follows cuda-oxide main".to_string(),
+            Vec::new(),
+        );
+    };
+    let Some(expected) = source.rev() else {
+        return check(
+            format!("✓ {} builds in place", source.describe()),
+            Vec::new(),
+        );
+    };
+    match recorded {
+        Some(recorded) if recorded == expected => check(
+            format!(
+                "✓ cache built from {}, matching this project's dependency",
+                short_rev(expected)
+            ),
+            Vec::new(),
+        ),
+        Some(recorded) => check(
+            format!(
+                "⚠ cache built from {} but this project depends on {}",
+                short_rev(&recorded),
+                short_rev(expected)
+            ),
+            vec![
+                "The next `cargo oxide build` or `run` rebuilds the cache from the dependency."
+                    .to_string(),
+            ],
+        ),
+        None => check(
+            format!(
+                "⚠ cache records no commit (built by an older cargo-oxide); this project depends on {}",
+                short_rev(expected)
+            ),
+            vec![
+                "The next `cargo oxide build` or `run` rebuilds the cache and records it."
+                    .to_string(),
+            ],
+        ),
+    }
+}
+
 /// Validate the development environment.
 ///
 /// Checks for: Rust nightly toolchain, `rust-toolchain.toml`, the codegen
@@ -315,6 +417,14 @@ pub fn doctor(ctx: &Context) {
             }
         },
         None => println!("- cache directory unknown (set CARGO_HOME or HOME)"),
+    }
+
+    // 3c. Backend source. Outside the repository the backend is built from
+    // the commit Cargo resolved for the project's cuda-oxide dependency, and
+    // the cache records which commit it came from. Informational: a mismatch
+    // heals itself on the next build.
+    if !ctx.is_workspace {
+        doctor_report_backend_source(ctx);
     }
 
     // 4. CUDA headers (cuda.h). The host `cuda-bindings` crate cannot build

--- a/crates/cargo-oxide/src/commands/setup_update.rs
+++ b/crates/cargo-oxide/src/commands/setup_update.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::backend;
+use crate::backend_source;
 
 use super::*;
 
@@ -31,12 +32,22 @@ pub fn setup(ctx: &Context) {
     // shared cache, since `find_workspace_root` finds no
     // `crates/rustc-codegen-cuda` above it. Publishing the build there keeps
     // those projects on the backend that was just built instead of on whatever
-    // the cache last held.
+    // the cache last held. The cache records the commit it came from, so only
+    // projects whose cuda-oxide dependency resolves to this checkout's HEAD
+    // pick it up; any other project rebuilds from its own dependency.
     match backend::publish_to_cache(&built_so, &ctx.codegen_crate) {
-        Some(path) => {
+        Some(published) => {
             println!();
-            println!("✓ Published to {}", path.display());
-            println!("  Projects outside this repo will now use this build.");
+            println!("✓ Published to {}", published.path.display());
+            match published.source_rev {
+                Some(rev) => println!(
+                    "  Projects outside this repo whose cuda-oxide dependency resolves to {} will use this build.",
+                    backend_source::short_rev(&rev)
+                ),
+                None => println!(
+                    "  Projects outside this repo without a cuda-oxide dependency will use this build."
+                ),
+            }
         }
         None => {
             eprintln!();
@@ -71,7 +82,8 @@ pub fn plan_update(is_workspace: bool, force: bool) -> UpdatePlan {
 /// Inside the cuda-oxide workspace the authoritative backend is the local
 /// source tree, so the default path points at `cargo oxide setup`. Outside
 /// the workspace, the shared `~/.cargo/cuda-oxide/` cache is cleared and
-/// rebuilt via the auto-fetch path.
+/// rebuilt from the commit the project's cuda-oxide dependency resolves to
+/// (or from a fresh `main` clone when the project has no such dependency).
 /// The backend pin that outranks the shared cache `update` refreshes, if any.
 ///
 /// Both the `CUDA_OXIDE_BACKEND` env var and a `.cargo/cuda-oxide.toml`
@@ -131,11 +143,14 @@ pub fn update(ctx: &Context, force: bool) {
             setup(ctx);
         }
         UpdatePlan::RefreshCache => {
-            println!("Refreshing the shared codegen backend cache for external projects...");
+            // Each route prints its own specific line (cached from the
+            // dependency, built in place for a path dependency, or fetched
+            // from main), so the framing here stays route-neutral.
+            println!("Rebuilding the codegen backend for this project...");
             println!();
-            let so = backend::refresh_cached_backend();
+            let so = backend::refresh_cached_backend(&ctx.workspace_root);
             println!();
-            println!("✓ Cached backend ready at {}", so.display());
+            println!("✓ Backend ready at {}", so.display());
         }
     }
 }

--- a/crates/cargo-oxide/src/commands/tests.rs
+++ b/crates/cargo-oxide/src/commands/tests.rs
@@ -4317,3 +4317,97 @@ fn explicit_line_tables_override_inherited_full_debug_for_mir_optimization() {
 
     assert_eq!(decoded_rustflags(&encoded), ["base"]);
 }
+
+// ---------------------------------------------------------------------------
+// doctor: "Backend source (cuda-oxide commit)" line
+// ---------------------------------------------------------------------------
+
+/// Every branch of the backend-source line, from the resolved dependency and
+/// the commit recorded in the shared cache. The line is informational, so no
+/// branch may flip doctor's exit status.
+#[test]
+fn doctor_backend_source_check_covers_every_branch() {
+    use crate::backend_source::DependencySource;
+    let sha_a = "a1b4f11882592fae9d022c86a9d8d1a4c9426980";
+    let sha_b = "596a6353de480662bbc03cb2d3c0f92e88f1e6c6";
+    let git = |rev: &str| {
+        Some(DependencySource::Git {
+            checkout: PathBuf::from("/checkouts/x"),
+            rev: rev.to_string(),
+        })
+    };
+
+    let check = backend_source_check(
+        Err("`cargo metadata` failed (exit status: 101)".into()),
+        None,
+    );
+    assert!(
+        check
+            .headline
+            .starts_with("- could not resolve the cuda-oxide dependency offline ("),
+        "{}",
+        check.headline
+    );
+    assert!(
+        check.headline.contains("exit status: 101"),
+        "{}",
+        check.headline
+    );
+
+    let check = backend_source_check(Ok(None), Some(sha_a.into()));
+    assert!(
+        check
+            .headline
+            .starts_with("- no cuda-device/cuda-host dependency"),
+        "{}",
+        check.headline
+    );
+
+    let check = backend_source_check(
+        Ok(Some(DependencySource::Path {
+            checkout: PathBuf::from("/dev/cuda-oxide"),
+        })),
+        None,
+    );
+    assert_eq!(
+        check.headline,
+        "✓ cuda-oxide checkout /dev/cuda-oxide (path dependency) builds in place"
+    );
+
+    let check = backend_source_check(Ok(git(sha_a)), Some(sha_a.into()));
+    assert_eq!(
+        check.headline,
+        "✓ cache built from a1b4f11882, matching this project's dependency"
+    );
+    assert!(check.details.is_empty());
+
+    // The mismatch line must put the CACHE's commit first and the PROJECT's
+    // second; swapped, it would send the user chasing the wrong commit.
+    let check = backend_source_check(Ok(git(sha_a)), Some(sha_b.into()));
+    assert_eq!(
+        check.headline,
+        "⚠ cache built from 596a6353de but this project depends on a1b4f11882"
+    );
+    assert_eq!(check.details.len(), 1, "{:?}", check.details);
+    assert!(
+        check.details[0].contains("rebuilds the cache"),
+        "{:?}",
+        check.details
+    );
+
+    let check = backend_source_check(Ok(git(sha_a)), None);
+    assert!(
+        check.headline.starts_with("⚠ cache records no commit"),
+        "{}",
+        check.headline
+    );
+    assert!(check.headline.ends_with("a1b4f11882"), "{}", check.headline);
+    assert_eq!(check.details.len(), 1, "{:?}", check.details);
+
+    for source in [Err("x".to_string()), Ok(None), Ok(git(sha_a))] {
+        assert!(
+            !backend_source_check(source, Some(sha_b.into())).failed,
+            "the backend-source line is informational and must never fail doctor"
+        );
+    }
+}

--- a/crates/cargo-oxide/src/main.rs
+++ b/crates/cargo-oxide/src/main.rs
@@ -35,6 +35,7 @@ use std::path::PathBuf;
 
 mod artifact_identity;
 mod backend;
+mod backend_source;
 mod commands;
 
 /// Top-level CLI structure parsed by clap.


### PR DESCRIPTION
## What this fixes

A user bumped their `cuda-oxide` dependency and a kernel got 2x slower. Bisecting was impossible: three separately versioned things had moved at once, and one of them was nobody's choice.

```
 (A) crates you compile against   cuda-device = { git = ..., rev = "a1b4f118" }   your Cargo.toml
 (B) backend that lowers them     librustc_codegen_cuda.so                        cargo oxide: git clone main
 (C) rustc nightly                rust-toolchain.toml                              your project

        A ──── nothing ────► B      B was whatever main HEAD was the day cargo oxide first ran
        B ──── fingerprint ─► C     already checked
```

- `cuda-device` only declares stubs (every body is `unreachable!()`). The backend recognises each one by path and supplies the whole lowering.
- So A and B **must** come from the same commit, and today nothing made that true. `cargo oxide update` made it worse: it re-cloned `main`.
- The user's workaround was a shell script that finds Cargo's checkout, builds the backend from it, and a `build.rs` that asserts the revs match. That is what `cargo oxide` should have been doing.

## What changes

Outside the repo, the backend now follows `Cargo.lock`:

```
Cargo.lock   cuda-device = git+https://github.com/NVlabs/cuda-oxide.git#a1b4f118...
                 │  cargo metadata → manifest_path
                 ▼
~/.cargo/git/checkouts/cuda-oxide-*/a1b4f11/       Cargo already downloaded this
                 │  crates/rustc-codegen-cuda → cargo build
                 ▼
~/.cargo/cuda-oxide/librustc_codegen_cuda.so        + source-rev.txt = a1b4f118...
```

- **No new clone.** The backend is built from the checkout Cargo made for the dependency.
- **Commit recorded next to the `.so`** (`source-rev.txt`), same pattern as the existing `toolchain-fingerprint.txt`. A project on a different commit gets one rebuild from its own checkout.
- **Toolchain checked before building, and before touching the cache.** The checkout's `rust-toolchain.toml` says which nightly the commit needs; `rustup show active-toolchain` says what the project is using (under `cargo oxide` the rustup proxy exports `RUSTUP_TOOLCHAIN`, so that is also what builds the backend). If they differ, the build stops up front and names the channel to set, instead of a wall of rustc_private compile errors or a `.so` that cannot load.
- **Nothing is deleted before its replacement exists.** A stale cache falls through to the rebuild and is overwritten on install; the commit record is dropped before the copy and written after it, so the only intermediate state is "no record" (treated as stale). A failed build never empties the cache.
- **Build tree out of Cargo's checkout.** Dependency builds go to `~/.cargo/cuda-oxide/target`: one tree cargo-oxide owns, shared by every commit's dependency builds (switching commits rebuilds only the cuda-oxide crates), deletable to reclaim space.
- **`cargo metadata` discipline.** `--all-features` so an optional cuda-oxide dependency is still found; `doctor` resolves `--offline --locked` so it never writes a lockfile (a fresh scaffold would otherwise get silently pinned to whatever stale commit the local git database held); the build path forwards the user's own `--locked` / `--frozen` / `--offline`.
- **The checkout walk is bounded.** Locating the repository root from the crate's `manifest_path` stops at the first `.git` / `.cargo-ok`, so a trimmed checkout can never latch onto an unrelated cuda-oxide tree higher up.
- **`cargo oxide update`** rebuilds from the dependency, not from `main`.
- **`cargo oxide doctor`** gains one line: `Backend source (cuda-oxide commit)... ✓ cache built from a1b4f11882, matching this project's dependency`.

Nothing above rung 4 moves: `CUDA_OXIDE_BACKEND`, `.cargo/cuda-oxide.toml`, and the in-repo build still outrank all of this.

## Case by case

| Project depends on | Backend comes from | Cache |
| :-- | :-- | :-- |
| `cuda-device = { git = ..., rev = X }` (or unpinned git, resolved in `Cargo.lock`) | Cargo's checkout of X | shared `.so` + `source-rev.txt = X` |
| `cuda-device = { path = "../cuda-oxide/crates/cuda-device" }` | that local checkout, built in place | none, like the in-repo path |
| no cuda-oxide crate at all | one-time clone of `main` (old behaviour) | shared `.so`, no commit recorded |
| two different cuda-oxide commits in one graph | refused with both commits listed | |

## Before / after on the reporter's setup

```
before   Cargo.toml rev a1b4f118  +  cache built from main HEAD (596a6353)  →  silently mixed, CAS-loop PTX
after    Cargo.toml rev a1b4f118  →  "Cached backend was built from an unrecorded cuda-oxide commit,
                                      but this project depends on cuda-oxide a1b4f11882; rebuilding
                                      from the project's dependency."
         cargo update → 596a6353  →  "Cached backend was built from cuda-oxide a1b4f11882, but this
                                      project depends on cuda-oxide 596a6353de; rebuilding ..."
         wrong nightly            →  "cuda-oxide 596a6353de (git dependency) needs Rust
                                      `nightly-2026-08-28` (its rust-toolchain.toml), but this
                                      project is using `nightly-2026-04-03-x86_64-unknown-linux-gnu`.
                                      ... Set `channel = "nightly-2026-08-28"` in this project's
                                      rust-toolchain.toml to match cuda-oxide 596a6353de ..."
                                     (exit 1 before any build; cache left intact)
```

## One behaviour change to know about

`cargo oxide setup` inside the repo still publishes to the shared cache, but now records the repo's `HEAD` beside it. External projects pick that build up only when their dependency resolves to that commit; any other project rebuilds from its own checkout. To force a specific backend on a project regardless of commit, use `CUDA_OXIDE_BACKEND` or the `backend =` config entry, which exist for that.

## Validation

- `cargo test` in `crates/cargo-oxide`: 190 → 218 tests, all passing. New: metadata parsing (git/path/registry/two-commits/no-dep), the walk's repository boundary, real `cargo metadata` round trips (path dep, optional dep, `--locked` refusal, broken manifest), lock-flag passthrough, staleness precedence (toolchain > dependency > binary > source), record/forget, keep-until-replaced, the heal-marker bypass, the refusal text, target-dir override, `repository_head`, every doctor branch.
- `cargo clippy --all-targets -D warnings`, `cargo fmt --check`: clean.
- End to end, on a scratch project pinned to the reporter's rev (`a1b4f118`):
  - cold: unrecorded cache → rebuilt from `~/.cargo/git/checkouts/cuda-oxide-*/a1b4f11/`, `source-rev.txt` written; warm: 0.36s cache hit.
  - drift to `596a6353`: recorded-vs-expected message, rebuilt from the new checkout.
  - `cargo oxide update`: rebuilt from the dependency, no clone of `main`.
  - project pinned to `nightly-2026-04-03` while the dependency needs `2026-08-28`: refused before building, channel named, cache left intact.
  - `doctor` shows the new line.

## Not in this PR

- The cache is still one slot. Switching between two projects on different commits rebuilds (~30s here). Keying it by commit is a follow-up if anyone hits that.
- The reporter's actual perf regression (`atom.global.add.f32` becoming a CAS loop) is a separate investigation; this PR only makes it bisectable.
