### PR TITLE
docs(tma_multicast): gate on the ISA floor, not on this build target

### DIFF
--- a/crates/rustc-codegen-cuda/examples/tma_copy/README.md
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/README.md
@@ -5,7 +5,7 @@
 Demonstrates TMA for efficient tensor data movement. TMA offloads memory copies
 to a dedicated hardware unit, enabling overlap with computation.
 
-For TMA multicast (sm_100a only), see the [`tma_multicast`](../tma_multicast/) example.
+For TMA multicast (sm_90+ per the ISA; that example ships as sm_100a), see the [`tma_multicast`](../tma_multicast/) example.
 
 ## What This Example Does
 

--- a/crates/rustc-codegen-cuda/examples/tma_copy/README.md
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/README.md
@@ -5,7 +5,7 @@
 Demonstrates TMA for efficient tensor data movement. TMA offloads memory copies
 to a dedicated hardware unit, enabling overlap with computation.
 
-For TMA multicast (sm_90+ per the ISA; that example ships as sm_100a), see the [`tma_multicast`](../tma_multicast/) example.
+For TMA multicast (also sm_90+), see the [`tma_multicast`](../tma_multicast/) example.
 
 ## What This Example Does
 

--- a/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_copy/src/main.rs
@@ -12,7 +12,7 @@
 //! - mbarrier: Barrier-based completion tracking
 //!
 //! Note: This example requires Hopper (sm_90) or newer GPUs.
-//! For TMA multicast (sm_100a), see the `tma_multicast` example.
+//! For TMA multicast (also sm_90+), see the `tma_multicast` example.
 //!
 //! Build and run with:
 //!   cargo oxide run tma_copy

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.toml
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/Cargo.toml
@@ -8,8 +8,9 @@ license = "Apache-2.0"
 # Mark as standalone crate (not part of parent workspace)
 [workspace]
 
-# SM100a+ TMA Multicast (Tensor Memory Accelerator) example.
-# Requires Blackwell datacenter GPUs (B100/B200/GB200).
+# TMA Multicast (Tensor Memory Accelerator) example, sm_90+ per the PTX ISA.
+# cargo oxide run builds for the detected GPU (verified on sm_120; the
+# Hopper run is tracked in #966).
 # Build with:
 #   cargo oxide run tma_multicast
 

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/README.md
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/README.md
@@ -135,24 +135,37 @@ GPU Compute Capability: sm_120
 === TMA Multicast Test Complete ===
 ```
 
-### On Hopper (sm_90/sm_90a) or Earlier
+### On Hopper (sm_90/sm_90a)
 
-Not supported: the shipped PTX targets sm_100a, which the driver will not
-JIT on sm_90. The host example skips any GPU below compute capability 10:
+Legal per the ISA, hardware run pending. Multicast is sm_90+ in the PTX ISA,
+and `--arch=sm_90a` builds and assembles. What the default build cannot do is
+*JIT* there, because it ships `.target sm_100a`, so the driver declines it and
+the host reports its own clean skip:
+
+Nobody here has run this on Hopper, so the block below is the shape of the
+message the host emits on that path, not a captured transcript:
 
 ```text
 GPU Compute Capability: sm_90
 
-skipping: TMA multicast requires sm_100a (Blackwell datacenter)
-   Your GPU is sm_90. Use: cargo oxide run tma_copy
+skipping: this build targets sm_100a and the driver declined it
+  driver reported: ...
+  The sm_100a build runs on B100/B200/GB200 and on sm_120.
+  Multicast itself is sm_90+; for Hopper, rebuild with --arch=sm_90a.
+  For basic TMA tests, use: cargo oxide run tma_copy
 ```
+
+Whether an `--arch=sm_90a` build passes on real Hopper hardware is untested;
+that run is what closes #966.
 
 ## Hardware Requirements
 
 - **Runs on**: Blackwell, both datacenter sm_100a (B100/B200/GB200) and
   consumer sm_120 (RTX 5090, verified in #668)
-- **Not supported**: Hopper (sm_90/sm_90a) and earlier; the sm_100a PTX
-  won't JIT there
+- **Hopper (sm_90/sm_90a)**: legal per the ISA, hardware run pending. The
+  default sm_100a PTX will not JIT there; an `--arch=sm_90a` build assembles
+  but has not been run on the hardware (#966)
+- **Not supported**: anything below sm_90
 - **CUDA Driver**: 12.0+
 - **Cluster launch**: Required (`cuLaunchKernelEx` with cluster dimensions)
 
@@ -187,9 +200,12 @@ whether the driver JIT accepts that PTX for your GPU:
 ```text
 sm_100a PTX ──JIT──► sm_100a (B100/B200/GB200)  ✓ runs
             ──JIT──► sm_120  (RTX 5090)         ✓ runs (verified in #668)
-            ──JIT──► sm_90   (Hopper)           ✗ rejected; host skips CC < 10
+            ──JIT──► sm_90   (Hopper)           ✗ rejected; host reports a skip
+
+sm_90a PTX  ──JIT──► sm_90   (Hopper)           ? assembles; not yet run (#966)
 ```
 
-The multicast instruction itself has an sm_90+ floor in the intrinsic
-catalog (whether an sm_90-targeted build would run on real Hopper hardware
-is an open question, tracked in #966).
+The multicast instruction itself has an sm_90+ floor in the intrinsic catalog,
+which matches the PTX ISA: `sm_90a` is advised there for performance, not
+required for legality. The host gate is therefore sm_90, not sm_100 — what
+keeps the default build off Hopper is its target, not the instruction.

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/README.md
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/README.md
@@ -69,7 +69,7 @@ The `cta_mask` is a bitmask over cluster ranks. With a `(4,1,1)` cluster:
 ## Generated PTX
 
 ```ptx
-.target sm_100a
+.target sm_120a          // follows the detected GPU; see "Which GPUs Run This?"
 .explicitcluster
 .reqnctapercluster 4, 1, 1
 
@@ -92,10 +92,13 @@ cargo oxide run tma_multicast
 
 ## Expected Output
 
-### On Blackwell Datacenter (sm_100a)
+### On Blackwell Datacenter (sm_100)
+
+`cargo oxide run` builds `.target sm_100a` for a B100/B200/GB200 and the
+module loads and runs:
 
 ```text
-=== TMA Multicast Example (sm_100a) ===
+=== TMA Multicast Example ===
 
 GPU Compute Capability: sm_100
 ✓ embedded module loaded successfully
@@ -114,11 +117,11 @@ GPU Compute Capability: sm_100
 
 ### On Consumer Blackwell (sm_120)
 
-Runs on consumer Blackwell: the sm_100a PTX JIT-loads and passes (first
-verified on an RTX 5090 in #668). Transcript from an RTX 5090:
+`cargo oxide run` builds `.target sm_120a` for an RTX 5090 (first verified
+in #668). Transcript captured on an RTX 5090:
 
 ```text
-=== TMA Multicast Example (sm_100a) ===
+=== TMA Multicast Example ===
 
 GPU Compute Capability: sm_120
 ✓ embedded module loaded successfully
@@ -137,34 +140,20 @@ GPU Compute Capability: sm_120
 
 ### On Hopper (sm_90/sm_90a)
 
-Legal per the ISA, hardware run pending. Multicast is sm_90+ in the PTX ISA,
-and `--arch=sm_90a` builds and assembles. What the default build cannot do is
-*JIT* there, because it ships `.target sm_100a`, so the driver declines it and
-the host reports its own clean skip:
+Multicast is sm_90+ in the PTX ISA, and `cargo oxide run` on an H100 builds
+`.target sm_90a`, so the module is expected to load and execute there. That
+run is not yet captured; #966 tracks it.
 
-Nobody here has run this on Hopper, so the block below is the shape of the
-message the host emits on that path, not a captured transcript:
-
-```text
-GPU Compute Capability: sm_90
-
-skipping: this build targets sm_100a and the driver declined it
-  driver reported: ...
-  The sm_100a build runs on B100/B200/GB200 and on sm_120.
-  Multicast itself is sm_90+; for Hopper, rebuild with --arch=sm_90a.
-  For basic TMA tests, use: cargo oxide run tma_copy
-```
-
-Whether an `--arch=sm_90a` build passes on real Hopper hardware is untested;
-that run is what closes #966.
+The host gate is `major < 9`, the same floor as `tma_copy`. Below sm_90 the
+example prints `skipping: TMA multicast requires sm_90 or newer` and exits
+cleanly.
 
 ## Hardware Requirements
 
-- **Runs on**: Blackwell, both datacenter sm_100a (B100/B200/GB200) and
-  consumer sm_120 (RTX 5090, verified in #668)
-- **Hopper (sm_90/sm_90a)**: legal per the ISA, hardware run pending. The
-  default sm_100a PTX will not JIT there; an `--arch=sm_90a` build assembles
-  but has not been run on the hardware (#966)
+- **Multicast floor**: sm_90 or newer (PTX ISA). Verified on consumer
+  Blackwell sm_120 (RTX 5090, #668); Hopper sm_90a run not yet captured (#966)
+- **Build target**: `cargo oxide run` builds for the detected GPU; there is
+  no fixed target baked into the example (see "Which GPUs Run This?")
 - **Not supported**: anything below sm_90
 - **CUDA Driver**: 12.0+
 - **Cluster launch**: Required (`cuLaunchKernelEx` with cluster dimensions)
@@ -175,7 +164,7 @@ that run is what closes #966.
 |---------------------|----------------------------------|-------------------------------------|
 | Destination         | One CTA's shared memory          | All CTAs in cluster                 |
 | Bandwidth           | 1x tile transfer                 | 1x transfer, N copies               |
-| Architecture        | sm_90+ (Hopper+)                 | Blackwell (sm_100a, sm_120)         |
+| Architecture        | sm_90+ (Hopper+)                 | sm_90+ (Hopper+), seen on sm_120    |
 | Use case            | Single-CTA tile loads            | GEMM/convolution with shared tiles  |
 | `cluster_launch`    | Optional                         | Required                            |
 
@@ -194,18 +183,23 @@ the multicast fires, the barrier tracking will be silently corrupt.
 
 ## Which GPUs Run This?
 
-The kernel ships as `.target sm_100a` PTX. What matters at run time is
-whether the driver JIT accepts that PTX for your GPU:
+There is no fixed `.target` in this example. `cargo oxide run` forwards the
+detected GPU as a hint (`CUDA_OXIDE_DEVICE_ARCH`, `sm_XYa` form for cc >= 9),
+and rustc-codegen-cuda builds for that GPU whenever the kernel's features run
+on it. sm_100a is only the fallback when no compatible GPU is detected:
 
 ```text
-sm_100a PTX ──JIT──► sm_100a (B100/B200/GB200)  ✓ runs
-            ──JIT──► sm_120  (RTX 5090)         ✓ runs (verified in #668)
-            ──JIT──► sm_90   (Hopper)           ✗ rejected; host reports a skip
-
-sm_90a PTX  ──JIT──► sm_90   (Hopper)           ? assembles; not yet run (#966)
+cargo oxide run on an RTX 5090 -> hint sm_120a -> .target sm_120a -> loads, runs
+cargo oxide run on an H100     -> hint sm_90a  -> .target sm_90a  -> expected to run (#966)
+no compatible GPU detected     -> no hint      -> .target sm_100a (fallback)
+  (cargo oxide build, or run on a pre-Hopper GPU)
 ```
+
+The host binary cannot see which target it embeds. If a module built on
+another machine, or with `--arch`, does not JIT on the local GPU, the
+load-failure arm prints the driver error and a `skipping:` line rather than
+guessing at a target.
 
 The multicast instruction itself has an sm_90+ floor in the intrinsic catalog,
 which matches the PTX ISA: `sm_90a` is advised there for performance, not
-required for legality. The host gate is therefore sm_90, not sm_100 — what
-keeps the default build off Hopper is its target, not the instruction.
+required for legality. The host gate is therefore sm_90, not sm_100.

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
@@ -7,15 +7,19 @@
 // driver; the implicit `unsafe` is in the launch contract.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-//! TMA Multicast Example (SM100a+ / Blackwell Datacenter)
+//! TMA Multicast Example (sm_90+ per the ISA; ships as sm_100a)
 //!
 //! Demonstrates TMA multicast — a single TMA load broadcasts a tile to
 //! the shared memory of ALL CTAs in a thread block cluster.
 //!
 //! Requirements:
-//! - Blackwell (sm_100a or later): datacenter B100/B200/GB200, and reported to
-//!   load and run on consumer sm_120 as well
-//! - Not supported on Hopper (sm_90) or earlier
+//! - The instruction: `cp.async.bulk.tensor` with `.multicast::cluster` is
+//!   sm_90+ in the PTX ISA. `sm_90a` is advised for performance, not required
+//!   for legality, which is what the sm_90+ catalog row records.
+//! - This build: ships as `.target sm_100a`, so the driver JIT accepts it on
+//!   datacenter B100/B200/GB200 and on consumer sm_120 (measured in #668).
+//!   To run it on Hopper, build with `--arch=sm_90a`; whether that build
+//!   passes on real Hopper hardware is untested and tracked in #966.
 //!
 //! Build and run with:
 //!   cargo oxide run tma_multicast
@@ -153,11 +157,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (major, minor) = ctx.compute_capability()?;
     println!("GPU Compute Capability: sm_{}{}", major, minor);
 
-    if major < 10 {
-        // Same clean-skip contract as the load-failure arm below: the marker
-        // has to be on whichever path actually runs, and on a pre-Blackwell
-        // GPU it is this one.
-        println!("\nskipping: TMA multicast requires sm_100a (Blackwell datacenter)");
+    // The ISA floor for multicast, not this build's target. A Hopper GPU
+    // falls through to `load` below: an `--arch=sm_90a` build will JIT there,
+    // and the default sm_100a build will not, which the load arm reports as
+    // its own clean skip. Same contract as that arm -- the marker has to be on
+    // whichever path actually runs.
+    if major < 9 {
+        println!("\nskipping: TMA multicast requires sm_90 or newer");
         println!(
             "   Your GPU is sm_{}{}. Use: cargo oxide run tma_copy",
             major, minor
@@ -171,15 +177,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             run_tma_multicast_test(&stream, &module)?;
         }
         Err(e) => {
-            // TMA multicast needs sm_100a (Blackwell datacenter). On every
-            // other GPU the cubin won't JIT and the driver returns 218, which
+            // This build ships `.target sm_100a`, so the driver JIT rejects
+            // it anywhere that target does not apply and returns 218, which
             // `load` surfaces through its `Driver` variant. Treat that as a
             // clean skip so the smoketest's failure-marker scan doesn't flag
-            // this as a regression — the PTX itself was generated, which is
-            // all this example can verify off-hopper datacenter.
-            println!("\nskipping: TMA multicast requires sm_100a");
+            // it as a regression — the PTX itself was generated, which is all
+            // this example can verify off Blackwell.
+            println!("\nskipping: this build targets sm_100a and the driver declined it");
             println!("  driver reported: {}", e);
-            println!("  TMA multicast requires sm_100a or later (B100/B200/GB200, and sm_120).");
+            println!("  The sm_100a build runs on B100/B200/GB200 and on sm_120.");
+            println!("  Multicast itself is sm_90+; for Hopper, rebuild with --arch=sm_90a.");
             println!("  For basic TMA tests, use: cargo oxide run tma_copy");
         }
     }

--- a/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
+++ b/crates/rustc-codegen-cuda/examples/tma_multicast/src/main.rs
@@ -7,19 +7,23 @@
 // driver; the implicit `unsafe` is in the launch contract.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-//! TMA Multicast Example (sm_90+ per the ISA; ships as sm_100a)
+//! TMA Multicast Example (sm_90+)
 //!
-//! Demonstrates TMA multicast — a single TMA load broadcasts a tile to
+//! Demonstrates TMA multicast: a single TMA load broadcasts a tile to
 //! the shared memory of ALL CTAs in a thread block cluster.
 //!
 //! Requirements:
 //! - The instruction: `cp.async.bulk.tensor` with `.multicast::cluster` is
 //!   sm_90+ in the PTX ISA. `sm_90a` is advised for performance, not required
 //!   for legality, which is what the sm_90+ catalog row records.
-//! - This build: ships as `.target sm_100a`, so the driver JIT accepts it on
-//!   datacenter B100/B200/GB200 and on consumer sm_120 (measured in #668).
-//!   To run it on Hopper, build with `--arch=sm_90a`; whether that build
-//!   passes on real Hopper hardware is untested and tracked in #966.
+//! - The build target: `cargo oxide run` forwards the detected GPU as a hint
+//!   and rustc-codegen-cuda builds for it whenever the kernel's features run
+//!   there. So an RTX 5090 gets `.target sm_120a` and an H100 gets
+//!   `.target sm_90a`. Only when no compatible GPU is detected (`cargo oxide
+//!   build`, or `run` on a pre-Hopper GPU) does the target fall back to
+//!   sm_100a. The host binary never knows which target it embeds.
+//! - Verified on sm_120 (#668). The sm_90a Hopper run is not yet captured
+//!   and is expected to build and execute (#966).
 //!
 //! Build and run with:
 //!   cargo oxide run tma_multicast
@@ -149,7 +153,7 @@ const TENSOR_SIZE: usize = (TENSOR_WIDTH * TENSOR_HEIGHT) as usize;
 const CLUSTER_SIZE: usize = 4;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== TMA Multicast Example (sm_100a) ===\n");
+    println!("=== TMA Multicast Example ===\n");
 
     let ctx = CudaContext::new(0)?;
     let stream = ctx.default_stream();
@@ -157,11 +161,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (major, minor) = ctx.compute_capability()?;
     println!("GPU Compute Capability: sm_{}{}", major, minor);
 
-    // The ISA floor for multicast, not this build's target. A Hopper GPU
-    // falls through to `load` below: an `--arch=sm_90a` build will JIT there,
-    // and the default sm_100a build will not, which the load arm reports as
-    // its own clean skip. Same contract as that arm -- the marker has to be on
-    // whichever path actually runs.
+    // The ISA floor for multicast. Anything sm_90 or newer falls through to
+    // `load` below, which is where a target mismatch (a module built on
+    // another machine or with --arch) surfaces. Same clean-skip contract as
+    // that arm: the marker has to be on whichever path actually runs.
     if major < 9 {
         println!("\nskipping: TMA multicast requires sm_90 or newer");
         println!(
@@ -177,16 +180,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             run_tma_multicast_test(&stream, &module)?;
         }
         Err(e) => {
-            // This build ships `.target sm_100a`, so the driver JIT rejects
-            // it anywhere that target does not apply and returns 218, which
-            // `load` surfaces through its `Driver` variant. Treat that as a
-            // clean skip so the smoketest's failure-marker scan doesn't flag
-            // it as a regression — the PTX itself was generated, which is all
-            // this example can verify off Blackwell.
-            println!("\nskipping: this build targets sm_100a and the driver declined it");
+            // The embedded module was built for a target this GPU cannot JIT
+            // (a module built on another machine, or with --arch), and the
+            // driver returns 218, which `load` surfaces through its `Driver`
+            // variant. The host binary cannot see the embedded target, so
+            // name none. Treat it as a clean skip so the smoketest's
+            // failure-marker scan doesn't flag it as a regression: the PTX
+            // itself was generated, which is all this path can verify.
+            println!("\nskipping: the embedded module did not load on this GPU");
             println!("  driver reported: {}", e);
-            println!("  The sm_100a build runs on B100/B200/GB200 and on sm_120.");
-            println!("  Multicast itself is sm_90+; for Hopper, rebuild with --arch=sm_90a.");
+            println!("  Multicast needs sm_90 or newer. cargo oxide run builds for the");
+            println!(
+                "  detected GPU, so a module built elsewhere or with --arch may not JIT here."
+            );
             println!("  For basic TMA tests, use: cargo oxide run tma_copy");
         }
     }


### PR DESCRIPTION
Addresses the Hopper half of #966, which stays open for the hardware run.

The example refused to run below compute capability 10 and said, in ten places, that TMA multicast "requires sm_100a". Multicast is **sm_90+ in the PTX ISA** — `sm_90a` is advised there for performance, not required for legality, which is what the sm_90+ catalog row already records. What actually keeps an H100 out is this example's own build target, not the instruction.

## Separating the two facts

| | before | after |
|---|---|---|
| host gate | `major < 10` | `major < 9` |
| skip text | "TMA multicast requires sm_100a" | names the declined build target, points at `--arch=sm_90a` |
| README Hopper section | "Not supported" | "Legal per the ISA, hardware run pending" |
| `tma_copy` cross-reference | "sm_100a only" | "sm_90+ per the ISA; that example ships as sm_100a" |

Moving the gate does not make the default build run on Hopper — it ships `.target sm_100a`, the driver declines it, and **the existing load-failure arm reports that as its own clean skip**, so the smoketest contract is unchanged on every GPU that has one. What the gate change does is stop turning Hopper away *before the loader has an opinion*, so an `--arch=sm_90a` build can JIT there.

## Verified on an A10G (sm_86, driver 595.71.05)

```
build --arch=sm_90a    ->  .target sm_90a, 1 multicast instruction
ptxas -arch=sm_90a     ->  ACCEPTED            (ptxas 13.2)
build --arch=sm_100a   ->  .target sm_100a
ptxas -arch=sm_100a    ->  ACCEPTED
run on sm_86           ->  "skipping: TMA multicast requires sm_90 or newer"
                           "   Your GPU is sm_86. Use: cargo oxide run tma_copy"
```

The last line is the new gate firing on real hardware, not a claim about it.

Negative control, so the ptxas results are not vacuous — the same sm_90a PTX offered as `-arch=sm_80`:

```
ptxas fatal : SM version specified by .target is higher than default SM version assumed
```

## What this does not do

**It does not run the example on Hopper.** There is no H100 here and the sm_90a build has never executed. #966 stays open for exactly that run, the README says so in those words, and the Hopper transcript is explicitly labelled as the shape of the message the host emits rather than a capture — I would rather label it than invent one. Its lines were checked against the `println!`s they mirror.

## Deliberately deferred: the `--arch=sm_90a` smoketest entry

Your third item is not in this PR, and I raised the reason on the issue before starting rather than guessing. `tma_multicast` is in none of the category arrays, so it is `standard` today: the smoketest builds **and runs** it, with the example's own gate making that a clean skip. There is no existing hook for "also compile this one at a second architecture" — `SM100_COMPILE_EXAMPLES` and `BLACKWELL_COMPILE_EXAMPLES` make an example compile-*only*, which here would trade away runtime coverage it currently has.

So it needs either a new per-example "extra compile arch" mechanism in `smoketest.sh`, or a decision to leave the sm_90a build outside CI. Inventing the mechanism unasked seemed the wrong call; say which you want and I will follow up.

## Test plan

- `cargo fmt --check` in the example and across the workspace — clean.
- `check-spdx-headers.sh`, `check-error-example-status.sh`, `check-example-license-policy.sh`, `check-reserved-prefixes.sh`, `check-book-api-names.sh` — pass.
- Both architectures build and assemble on hardware, with the negative control above.
- The new gate exercised on a real sm_86 GPU.
- README transcript lines checked line-for-line against the `println!` calls they show.
